### PR TITLE
`Development`: Improve LTI URL validation

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiDynamicRegistrationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiDynamicRegistrationService.java
@@ -27,6 +27,21 @@ import de.tum.cit.aet.artemis.lti.dto.Lti13ClientRegistrationFactory;
 import de.tum.cit.aet.artemis.lti.dto.Lti13PlatformConfiguration;
 import de.tum.cit.aet.artemis.lti.repository.LtiPlatformConfigurationRepository;
 
+/**
+ * Handles LTI 1.3 Dynamic Registration as defined in
+ * <a href="https://www.imsglobal.org/spec/lti-dr/v1p0">IMS LTI Dynamic Registration 1.0</a>.
+ * <p>
+ * The registration flow consists of three steps:
+ * <ol>
+ * <li>Fetch the platform's OpenID Connect configuration from the provided URL.</li>
+ * <li>POST Artemis' tool registration to the platform's registration endpoint.</li>
+ * <li>Persist the resulting {@link LtiPlatformConfiguration} and generate a JWKS key pair.</li>
+ * </ol>
+ * <p>
+ * Every URL used for outbound HTTP requests — both the initial configuration URL provided by the caller
+ * and all endpoint URLs returned by the platform — is validated via {@link #validateExternalUrl(String)}
+ * before use. This ensures the server only connects to legitimate, publicly routable HTTPS hosts.
+ */
 @Lazy
 @Service
 @Conditional(LtiEnabled.class)
@@ -50,31 +65,46 @@ public class LtiDynamicRegistrationService {
     }
 
     /**
-     * Performs dynamic registration.
+     * Performs the full LTI 1.3 dynamic registration flow.
+     * <p>
+     * Steps:
+     * <ol>
+     * <li>Fetch the platform's OpenID Connect configuration from {@code openIdConfigurationUrl}.</li>
+     * <li>Validate all endpoint URLs the platform returned (authorization, token, JWKS, registration).</li>
+     * <li>POST Artemis' client registration to the platform's registration endpoint.</li>
+     * <li>Persist the resulting {@link LtiPlatformConfiguration} and generate a JWKS key pair for the new registration.</li>
+     * </ol>
      *
-     * @param openIdConfigurationUrl the url to get the configuration from
-     * @param registrationToken      the token to be used to authenticate the POST request
+     * @param openIdConfigurationUrl the platform-provided URL that serves the OpenID Connect discovery document
+     * @param registrationToken      a one-time bearer token used to authenticate the registration POST request (may be {@code null})
+     * @throws BadRequestAlertException if any URL is invalid, any required field is missing, or the platform rejects the registration
+     * @throws IllegalStateException    if the platform returns an HTTP error during the flow
      */
     public void performDynamicRegistration(String openIdConfigurationUrl, String registrationToken) {
         try {
-            // Get platform's configuration
+            // Step 1: Fetch the platform's OpenID configuration (the URL is validated inside getLti13PlatformConfiguration)
             Lti13PlatformConfiguration platformConfiguration = getLti13PlatformConfiguration(openIdConfigurationUrl);
 
             String clientRegistrationId = "artemis-" + UUID.randomUUID();
 
+            // Verify that all required endpoint URLs are present in the platform response
             if (platformConfiguration.authorizationEndpoint() == null || platformConfiguration.tokenEndpoint() == null || platformConfiguration.jwksUri() == null
                     || platformConfiguration.registrationEndpoint() == null) {
                 throw new BadRequestAlertException("Invalid platform configuration", "LTI", "invalidPlatformConfiguration");
             }
 
-            // Validate all URLs from the platform configuration to prevent delayed SSRF
+            // Step 2: Validate all platform-provided URLs before using them for outbound requests or persisting them.
+            // This is critical because the platform response is untrusted external input — each URL could potentially
+            // point to an internal service if not checked.
             validateExternalUrl(platformConfiguration.authorizationEndpoint());
             validateExternalUrl(platformConfiguration.tokenEndpoint());
             validateExternalUrl(platformConfiguration.jwksUri());
             validateExternalUrl(platformConfiguration.registrationEndpoint());
 
+            // Step 3: Register Artemis as an LTI tool on the platform
             var clientRegistrationResponse = postClientRegistrationToPlatform(platformConfiguration.registrationEndpoint(), clientRegistrationId, registrationToken);
 
+            // Step 4: Persist configuration and generate JWKS key pair
             LtiPlatformConfiguration ltiPlatformConfiguration = updateLtiPlatformConfiguration(clientRegistrationId, platformConfiguration, clientRegistrationResponse);
             ltiPlatformConfigurationRepository.save(ltiPlatformConfiguration);
 
@@ -87,11 +117,20 @@ public class LtiDynamicRegistrationService {
     }
 
     /**
-     * Validates that the given URL uses HTTPS and does not point to a private, internal, or reserved network address.
-     * This prevents SSRF attacks where an attacker could make the server request internal resources.
+     * Validates that the given URL is safe for outbound HTTP requests during LTI registration.
      * <p>
+     * Enforces the following rules:
+     * <ul>
+     * <li>The URL must be syntactically valid.</li>
+     * <li>Only the {@code https} scheme is permitted.</li>
+     * <li>The URL must contain a non-null host.</li>
+     * <li><strong>All</strong> IP addresses the host resolves to (via {@link InetAddress#getAllByName})
+     * must be public — none may be loopback, site-local, link-local, multicast, or otherwise
+     * reserved (see {@link #isPrivateOrReservedAddress}).</li>
+     * </ul>
      *
      * @param url the URL to validate
+     * @throws BadRequestAlertException if the URL fails any of the above checks
      */
     private void validateExternalUrl(String url) {
         URI uri;
@@ -112,8 +151,9 @@ public class LtiDynamicRegistrationService {
         }
 
         try {
-            // Use getAllByName to check ALL resolved addresses, not just the first one.
-            // A hostname may resolve to multiple IPs; an attacker could mix public and private addresses.
+            // Resolve all addresses for the host and reject if any points to a non-public range.
+            // Using getAllByName (not getByName) is important: a hostname may resolve to multiple
+            // IPs via DNS round-robin, and every single one must be checked.
             InetAddress[] addresses = InetAddress.getAllByName(host);
             for (InetAddress address : addresses) {
                 if (isPrivateOrReservedAddress(address)) {
@@ -127,42 +167,59 @@ public class LtiDynamicRegistrationService {
     }
 
     /**
-     * Checks whether the given address belongs to a private, loopback, link-local, or other reserved range
-     * that should not be targeted by outbound HTTP requests.
+     * Determines whether the given {@link InetAddress} belongs to a non-public IP range.
+     * <p>
+     * The following ranges are treated as non-public:
+     * <ul>
+     * <li>Loopback (127.0.0.0/8, ::1)</li>
+     * <li>Site-local / private (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)</li>
+     * <li>Link-local (169.254.0.0/16, fe80::/10)</li>
+     * <li>Any-local / wildcard (0.0.0.0, ::)</li>
+     * <li>Multicast (224.0.0.0/4, ff00::/8)</li>
+     * <li>Shared / CGN address space (100.64.0.0/10, RFC 6598)</li>
+     * <li>"This" network (0.0.0.0/8)</li>
+     * <li>IPv6 Unique Local Addresses (fc00::/7)</li>
+     * <li>IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) — the embedded IPv4 address is extracted
+     * and re-checked recursively</li>
+     * <li>Deprecated IPv4-compatible IPv6 addresses (::x.x.x.x, RFC 4291) — handled the same way</li>
+     * </ul>
      *
      * @param address the resolved address to check
-     * @return true if the address is private or reserved
+     * @return {@code true} if the address falls into any non-public range listed above
      */
     private boolean isPrivateOrReservedAddress(InetAddress address) {
+        // Standard JDK checks cover loopback, site-local (RFC 1918), link-local, wildcard, and multicast
         if (address.isLoopbackAddress() || address.isSiteLocalAddress() || address.isLinkLocalAddress() || address.isAnyLocalAddress() || address.isMulticastAddress()) {
             return true;
         }
 
         byte[] addr = address.getAddress();
 
+        // --- IPv4-specific checks ---
         if (addr.length == 4) {
             int firstOctet = addr[0] & 0xFF;
             int secondOctet = addr[1] & 0xFF;
-            // 100.64.0.0/10 - Shared Address Space (CGN, used by some cloud providers)
+            // 100.64.0.0/10 — Shared Address Space (CGN / RFC 6598), used by some cloud providers
             if (firstOctet == 100 && (secondOctet & 0xC0) == 64) {
                 return true;
             }
-            // 0.0.0.0/8 - "This" network
+            // 0.0.0.0/8 — "This" network (RFC 791)
             if (firstOctet == 0) {
                 return true;
             }
         }
 
+        // --- IPv6-specific checks ---
         if (addr.length == 16) {
-            // IPv4-mapped IPv6 (::ffff:x.x.x.x) - extract the IPv4 portion and re-check
-            boolean isV4Mapped = true;
+            // Check for IPv4-mapped IPv6 (::ffff:x.x.x.x) — extract the IPv4 portion and re-check
+            boolean prefixAllZeros = true;
             for (int i = 0; i < 10; i++) {
                 if (addr[i] != 0) {
-                    isV4Mapped = false;
+                    prefixAllZeros = false;
                     break;
                 }
             }
-            if (isV4Mapped && (addr[10] & 0xFF) == 0xFF && (addr[11] & 0xFF) == 0xFF) {
+            if (prefixAllZeros && (addr[10] & 0xFF) == 0xFF && (addr[11] & 0xFF) == 0xFF) {
                 byte[] v4Addr = new byte[] { addr[12], addr[13], addr[14], addr[15] };
                 try {
                     return isPrivateOrReservedAddress(InetAddress.getByAddress(v4Addr));
@@ -171,9 +228,9 @@ public class LtiDynamicRegistrationService {
                     return true;
                 }
             }
-            // IPv4-compatible IPv6 (::x.x.x.x) - deprecated (RFC 4291) but still parsed by Java
-            if (isV4Mapped) {
-                // bytes 0-9 are zero but bytes 10-11 are not 0xFF, so this is an IPv4-compatible address
+            // Deprecated IPv4-compatible IPv6 (::x.x.x.x, RFC 4291) — bytes 0-9 are zero
+            // but bytes 10-11 are not 0xFF, still parsed by Java
+            if (prefixAllZeros) {
                 byte[] v4Addr = new byte[] { addr[12], addr[13], addr[14], addr[15] };
                 try {
                     return isPrivateOrReservedAddress(InetAddress.getByAddress(v4Addr));
@@ -182,7 +239,7 @@ public class LtiDynamicRegistrationService {
                     return true;
                 }
             }
-            // fc00::/7 - IPv6 Unique Local Addresses
+            // fc00::/7 — IPv6 Unique Local Addresses (RFC 4193)
             if ((addr[0] & 0xFE) == 0xFC) {
                 return true;
             }
@@ -191,6 +248,17 @@ public class LtiDynamicRegistrationService {
         return false;
     }
 
+    /**
+     * Fetches the LTI 1.3 platform's OpenID Connect configuration from the given URL.
+     * <p>
+     * The URL is validated before the request is made. The response is deserialized into an
+     * {@link Lti13PlatformConfiguration} containing the platform's authorization, token, JWKS,
+     * and registration endpoints.
+     *
+     * @param openIdConfigurationUrl the platform-provided OpenID Connect discovery URL
+     * @return the deserialized platform configuration
+     * @throws BadRequestAlertException if the URL is invalid or the platform does not return a valid configuration
+     */
     private Lti13PlatformConfiguration getLti13PlatformConfiguration(String openIdConfigurationUrl) {
         validateExternalUrl(openIdConfigurationUrl);
 
@@ -210,6 +278,18 @@ public class LtiDynamicRegistrationService {
         return platformConfiguration;
     }
 
+    /**
+     * Registers Artemis as an LTI 1.3 tool on the external platform by POSTing a client registration.
+     * <p>
+     * The registration endpoint URL is validated before the request is made. If a {@code registrationToken}
+     * is provided, it is sent as a Bearer token in the Authorization header.
+     *
+     * @param registrationEndpoint the platform's registration endpoint URL
+     * @param clientRegistrationId the unique client registration ID generated for this registration (e.g. "artemis-&lt;uuid&gt;")
+     * @param registrationToken    the one-time bearer token for authenticating the request (may be {@code null})
+     * @return the platform's response containing the assigned client ID and other registration details
+     * @throws BadRequestAlertException if the URL is invalid or the platform rejects/does not respond to the registration
+     */
     private Lti13ClientRegistration postClientRegistrationToPlatform(String registrationEndpoint, String clientRegistrationId, String registrationToken) {
         validateExternalUrl(registrationEndpoint);
 
@@ -228,8 +308,7 @@ public class LtiDynamicRegistrationService {
             registrationResponse = response.getBody();
         }
         catch (HttpClientErrorException e) {
-            String message = "Could not register new client in external LMS at " + registrationEndpoint;
-            log.error(message);
+            log.error("Could not register new client in external LMS at {}", registrationEndpoint);
         }
 
         if (registrationResponse == null) {
@@ -238,6 +317,17 @@ public class LtiDynamicRegistrationService {
         return registrationResponse;
     }
 
+    /**
+     * Creates a new {@link LtiPlatformConfiguration} entity from the platform's OpenID configuration
+     * and the client registration response.
+     * <p>
+     * Maps the platform's endpoint URLs and the assigned client ID into a persistable entity.
+     *
+     * @param registrationId             the unique registration ID generated for this registration
+     * @param platformConfiguration      the platform's OpenID Connect configuration (source of endpoint URLs)
+     * @param clientRegistrationResponse the platform's response to the client registration POST (source of client ID)
+     * @return a fully populated {@link LtiPlatformConfiguration} ready to be persisted
+     */
     private LtiPlatformConfiguration updateLtiPlatformConfiguration(String registrationId, Lti13PlatformConfiguration platformConfiguration,
             Lti13ClientRegistration clientRegistrationResponse) {
         LtiPlatformConfiguration ltiPlatformConfiguration = new LtiPlatformConfiguration();

--- a/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiDynamicRegistrationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiDynamicRegistrationService.java
@@ -111,16 +111,18 @@ public class LtiDynamicRegistrationService {
             throw new BadRequestAlertException("URL must contain a valid host", "LTI", "invalidUrl");
         }
 
-        InetAddress address;
         try {
-            address = InetAddress.getByName(host);
+            // Use getAllByName to check ALL resolved addresses, not just the first one.
+            // A hostname may resolve to multiple IPs; an attacker could mix public and private addresses.
+            InetAddress[] addresses = InetAddress.getAllByName(host);
+            for (InetAddress address : addresses) {
+                if (isPrivateOrReservedAddress(address)) {
+                    throw new BadRequestAlertException("URLs pointing to internal or loopback addresses are not allowed", "LTI", "invalidUrl");
+                }
+            }
         }
         catch (UnknownHostException e) {
             throw new BadRequestAlertException("URL host could not be resolved", "LTI", "invalidUrl");
-        }
-
-        if (isPrivateOrReservedAddress(address)) {
-            throw new BadRequestAlertException("URLs pointing to internal or loopback addresses are not allowed", "LTI", "invalidUrl");
         }
     }
 
@@ -187,61 +189,6 @@ public class LtiDynamicRegistrationService {
         }
 
         return false;
-    }
-
-    /**
-     * Validates that the given URL is a safe external URL for outbound HTTP requests.
-     * <p>
-     * The URL must:
-     * <ul>
-     *     <li>Use the {@code http} or {@code https} scheme.</li>
-     *     <li>Have a non-null host component.</li>
-     *     <li>Resolve to at least one IP address that is not private, loopback, link-local, multicast,
-     *     or otherwise reserved as determined by {@link #isPrivateOrReservedAddress(InetAddress)}.</li>
-     * </ul>
-     *
-     * @param url the URL string to validate
-     * @throws BadRequestAlertException if the URL is invalid or not allowed
-     */
-    private void validateExternalUrl(String url) {
-        if (url == null || url.isBlank()) {
-            throw new BadRequestAlertException("Missing external URL", "LTI", "missingExternalUrl");
-        }
-
-        final URI uri;
-        try {
-            uri = URI.create(url);
-        }
-        catch (IllegalArgumentException ex) {
-            log.warn("Rejected external URL due to invalid syntax: {}", url, ex);
-            throw new BadRequestAlertException("Invalid external URL", "LTI", "invalidExternalUrl");
-        }
-
-        String scheme = uri.getScheme();
-        if (scheme == null || (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme))) {
-            log.warn("Rejected external URL due to unsupported scheme: {}", url);
-            throw new BadRequestAlertException("Unsupported URL scheme", "LTI", "invalidExternalUrl");
-        }
-
-        String host = uri.getHost();
-        if (host == null || host.isBlank()) {
-            log.warn("Rejected external URL due to missing host: {}", url);
-            throw new BadRequestAlertException("URL must include a host", "LTI", "invalidExternalUrl");
-        }
-
-        try {
-            InetAddress[] addresses = InetAddress.getAllByName(host);
-            for (InetAddress address : addresses) {
-                if (isPrivateOrReservedAddress(address)) {
-                    log.warn("Rejected external URL because it resolves to a private or reserved address: {} -> {}", url, address);
-                    throw new BadRequestAlertException("URL points to a disallowed address", "LTI", "invalidExternalUrl");
-                }
-            }
-        }
-        catch (UnknownHostException ex) {
-            log.warn("Rejected external URL because host could not be resolved: {}", url, ex);
-            throw new BadRequestAlertException("Unknown host in external URL", "LTI", "invalidExternalUrl");
-        }
     }
 
     private Lti13PlatformConfiguration getLti13PlatformConfiguration(String openIdConfigurationUrl) {

--- a/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiDynamicRegistrationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiDynamicRegistrationService.java
@@ -189,6 +189,61 @@ public class LtiDynamicRegistrationService {
         return false;
     }
 
+    /**
+     * Validates that the given URL is a safe external URL for outbound HTTP requests.
+     * <p>
+     * The URL must:
+     * <ul>
+     *     <li>Use the {@code http} or {@code https} scheme.</li>
+     *     <li>Have a non-null host component.</li>
+     *     <li>Resolve to at least one IP address that is not private, loopback, link-local, multicast,
+     *     or otherwise reserved as determined by {@link #isPrivateOrReservedAddress(InetAddress)}.</li>
+     * </ul>
+     *
+     * @param url the URL string to validate
+     * @throws BadRequestAlertException if the URL is invalid or not allowed
+     */
+    private void validateExternalUrl(String url) {
+        if (url == null || url.isBlank()) {
+            throw new BadRequestAlertException("Missing external URL", "LTI", "missingExternalUrl");
+        }
+
+        final URI uri;
+        try {
+            uri = URI.create(url);
+        }
+        catch (IllegalArgumentException ex) {
+            log.warn("Rejected external URL due to invalid syntax: {}", url, ex);
+            throw new BadRequestAlertException("Invalid external URL", "LTI", "invalidExternalUrl");
+        }
+
+        String scheme = uri.getScheme();
+        if (scheme == null || (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme))) {
+            log.warn("Rejected external URL due to unsupported scheme: {}", url);
+            throw new BadRequestAlertException("Unsupported URL scheme", "LTI", "invalidExternalUrl");
+        }
+
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            log.warn("Rejected external URL due to missing host: {}", url);
+            throw new BadRequestAlertException("URL must include a host", "LTI", "invalidExternalUrl");
+        }
+
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(host);
+            for (InetAddress address : addresses) {
+                if (isPrivateOrReservedAddress(address)) {
+                    log.warn("Rejected external URL because it resolves to a private or reserved address: {} -> {}", url, address);
+                    throw new BadRequestAlertException("URL points to a disallowed address", "LTI", "invalidExternalUrl");
+                }
+            }
+        }
+        catch (UnknownHostException ex) {
+            log.warn("Rejected external URL because host could not be resolved: {}", url, ex);
+            throw new BadRequestAlertException("Unknown host in external URL", "LTI", "invalidExternalUrl");
+        }
+    }
+
     private Lti13PlatformConfiguration getLti13PlatformConfiguration(String openIdConfigurationUrl) {
         validateExternalUrl(openIdConfigurationUrl);
 


### PR DESCRIPTION
### Summary

Improve LTI URL validation in `LtiDynamicRegistrationService` by checking all resolved IP addresses for a hostname (not just the first one) and add comprehensive JavaDoc throughout the service.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

The existing `validateExternalUrl` method in `LtiDynamicRegistrationService` used `InetAddress.getByName()`, which only resolves and checks the **first** IP address for a given hostname. Since a hostname can resolve to multiple IP addresses (e.g. via DNS round-robin), this left a gap where a hostname resolving to a mix of public and non-public addresses would only have the first address validated.

Additionally, the service lacked class-level and method-level JavaDoc, making it harder to understand the registration flow, the validation rules, and the blocked IP ranges at a glance.

### Description

**Improved URL validation:**
- Changed `InetAddress.getByName()` to `InetAddress.getAllByName()` in `validateExternalUrl` so that **every** resolved IP address for a hostname is checked against the blocked ranges before allowing the outbound request.

**Comprehensive JavaDoc and inline documentation:**
- Added class-level JavaDoc describing the LTI 1.3 Dynamic Registration flow (with link to the IMS spec) and the URL validation strategy.
- Expanded `performDynamicRegistration` JavaDoc with numbered steps, `@throws` tags, and inline step comments explaining the rationale behind each phase.
- Expanded `validateExternalUrl` JavaDoc with an explicit list of all enforced rules and `@throws` tag.
- Expanded `isPrivateOrReservedAddress` JavaDoc with a complete list of all blocked IP ranges (loopback, site-local, link-local, wildcard, multicast, CGN/RFC 6598, "this" network, IPv6 ULA, IPv4-mapped IPv6, deprecated IPv4-compatible IPv6) with RFC references.
- Added JavaDoc to `getLti13PlatformConfiguration`, `postClientRegistrationToPlatform`, and `updateLtiPlatformConfiguration` documenting their purpose, parameters, return values, and exceptions.
- Improved inline comments with RFC references and section headers for IPv4/IPv6-specific checks.
- Minor: replaced string concatenation with `{}` placeholder in a `log.error` call.

### Steps for Testing
Prerequisites:
- 1 Admin

1. Log in to Artemis as admin
2. Navigate to LTI configuration
3. Attempt a dynamic registration with a valid external LMS platform URL — should succeed as before
4. Verify that the server starts and compiles without errors

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 
#### Manual Tests
- [x] Test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling during dynamic registration processes to catch and properly respond to both client and server error scenarios.
  * Added comprehensive URL validation and IP address range verification for all registration endpoints, preventing unauthorized access attempts to internal or non-public network addresses.

* **Documentation**
  * Improved operational logging with clearer messages and enhanced documentation for the complete registration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->