### PR TITLE
`Development`: Switch e2e tests from mysql to postgres

### DIFF
--- a/.ci/E2E-tests/cleanup.sh
+++ b/.ci/E2E-tests/cleanup.sh
@@ -12,7 +12,7 @@ docker container stop $(docker ps -a -q) || true
 docker container rm $(docker ps -a -q) || true
 docker volume rm $(docker volume ls -q) || true
 
-docker compose -f ./docker/playwright-E2E-tests-mysql.yml down -v
+docker compose -f ./docker/playwright-E2E-tests-postgres-localci.yml down -v
 docker compose -f ./docker/playwright-E2E-tests-multi-node.yml down -v
 
 # show all running docker containers and volumes after the cleanup to detect issues

--- a/.ci/E2E-tests/execute-locally.sh
+++ b/.ci/E2E-tests/execute-locally.sh
@@ -6,20 +6,20 @@
 # It builds the Artemis Docker image from a pre-built WAR file and runs tests.
 #
 # Usage: ./execute-locally.sh <configuration> [test-filter]
-#   configuration: mysql-localci (default), mysql, postgres, postgres-localci, multi-node
+#   configuration: postgres-localci (default), postgres, multi-node
 #   test-filter: optional grep pattern to filter tests (e.g., "Quiz")
 #
 # Prerequisites:
 #   - WAR file must exist in build/libs/
 #   - Docker must be running
-#   - Port 3306 must be free for MySQL, 5432 for Postgres
+#   - Port 5432 must be free for PostgreSQL
 # =============================================================================
 
 set -e
 
-CONFIGURATION=${1:-mysql-localci}
+CONFIGURATION=${1:-postgres-localci}
 TEST_FILTER=$2
-DB="mysql"
+DB="postgres"
 
 echo "========================================"
 echo "  Artemis E2E Local Test Runner"
@@ -29,20 +29,14 @@ echo "Configuration: $CONFIGURATION"
 echo ""
 
 # Determine compose file based on configuration
-if [ "$CONFIGURATION" = "mysql" ]; then
-    COMPOSE_FILE="playwright-E2E-tests-mysql.yml"
-elif [ "$CONFIGURATION" = "postgres" ]; then
+if [ "$CONFIGURATION" = "postgres" ]; then
     COMPOSE_FILE="playwright-E2E-tests-postgres.yml"
-    DB="postgres"
 elif [ "$CONFIGURATION" = "postgres-localci" ]; then
     COMPOSE_FILE="playwright-E2E-tests-postgres-localci.yml"
-    DB="postgres"
-elif [ "$CONFIGURATION" = "mysql-localci" ]; then
-    COMPOSE_FILE="playwright-E2E-tests-mysql-localci.yml"
 elif [ "$CONFIGURATION" = "multi-node" ]; then
     COMPOSE_FILE="playwright-E2E-tests-multi-node.yml"
 else
-    echo "Invalid configuration. Choose: mysql, postgres, postgres-localci, mysql-localci, or multi-node"
+    echo "Invalid configuration. Choose: postgres, postgres-localci, or multi-node"
     exit 1
 fi
 

--- a/.ci/E2E-tests/execute.sh
+++ b/.ci/E2E-tests/execute.sh
@@ -7,6 +7,13 @@ TEST_PATHS=$3  # Optional: space-separated list of test paths to run (passed thr
 echo "CONFIGURATION:"
 echo "$CONFIGURATION"
 
+# workflow_run uses the workflow definition from the default branch, so
+# in-flight PRs can still be invoked with the legacy mysql-localci argument.
+if [ "$CONFIGURATION" = "mysql-localci" ]; then
+    echo "Compatibility mode: mapping mysql-localci to postgres-localci"
+    CONFIGURATION="postgres-localci"
+fi
+
 if [ "$CONFIGURATION" = "postgres" ]; then
     COMPOSE_FILE="playwright-E2E-tests-postgres.yml"
   elif [ "$CONFIGURATION" = "postgres-localci" ]; then

--- a/.ci/E2E-tests/execute.sh
+++ b/.ci/E2E-tests/execute.sh
@@ -3,24 +3,21 @@
 CONFIGURATION=$1
 TEST_FRAMEWORK=$2
 TEST_PATHS=$3  # Optional: space-separated list of test paths to run (passed through as-is, e.g., "e2e/exam/ e2e/atlas/")
-DB="mysql"
+DB="postgres"
 
 echo "CONFIGURATION:"
 echo "$CONFIGURATION"
 
-if [ "$CONFIGURATION" = "mysql" ]; then
-    COMPOSE_FILE="playwright-E2E-tests-mysql.yml"
-  elif [ "$CONFIGURATION" = "postgres" ]; then
+if [ "$CONFIGURATION" = "postgres" ]; then
     COMPOSE_FILE="playwright-E2E-tests-postgres.yml"
-    DB="postgres"
-  elif [ "$CONFIGURATION" = "mysql-localci" ]; then
-    echo "Running for playwright (single node) with mysql-localci"
-    COMPOSE_FILE="playwright-E2E-tests-mysql-localci.yml"
+  elif [ "$CONFIGURATION" = "postgres-localci" ]; then
+    echo "Running for playwright (single node) with postgres-localci"
+    COMPOSE_FILE="playwright-E2E-tests-postgres-localci.yml"
   elif [ "$CONFIGURATION" = "multi-node" ]; then
     echo "Running for playwright (multi-node)"
     COMPOSE_FILE="playwright-E2E-tests-multi-node.yml"
   else
-      echo "Invalid configuration. Please choose among mysql, postgres, mysql-localci or multi-node."
+      echo "Invalid configuration. Please choose among postgres, postgres-localci or multi-node."
       exit 1
 fi
 

--- a/.ci/E2E-tests/execute.sh
+++ b/.ci/E2E-tests/execute.sh
@@ -3,7 +3,6 @@
 CONFIGURATION=$1
 TEST_FRAMEWORK=$2
 TEST_PATHS=$3  # Optional: space-separated list of test paths to run (passed through as-is, e.g., "e2e/exam/ e2e/atlas/")
-DB="postgres"
 
 echo "CONFIGURATION:"
 echo "$CONFIGURATION"

--- a/.github/actions/find-e2e-comment/action.yml
+++ b/.github/actions/find-e2e-comment/action.yml
@@ -29,7 +29,7 @@ runs:
             console.log(`No open PR found for branch ${branch}`);
             return '';
           }
-          return String(prs[0].number);
+          return prs[0].number;
 
     - name: Find existing E2E comment
       id: find-comment
@@ -51,6 +51,6 @@ runs:
             });
             if (!comments.length) break;
             const found = comments.find(c => c.body && c.body.includes(marker));
-            if (found) return String(found.id);
+            if (found) return found.id;
           }
           return '';

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Run E2E Playwright tests (Phase 1 - Relevant Tests)
         id: run-tests-phase1
-        run: .ci/E2E-tests/execute.sh mysql-localci playwright "${{ needs.determine-tests.outputs.relevant_tests }}"
+        run: .ci/E2E-tests/execute.sh postgres-localci playwright "${{ needs.determine-tests.outputs.relevant_tests }}"
         env:
           FAST_TEST_TIMEOUT_SECONDS: 60
 
@@ -260,7 +260,7 @@ jobs:
 
       - name: Run E2E Playwright tests (Phase 2 - Remaining Tests)
         id: run-tests-phase2
-        run: .ci/E2E-tests/execute.sh mysql-localci playwright "${{ needs.determine-tests.outputs.remaining_tests }}"
+        run: .ci/E2E-tests/execute.sh postgres-localci playwright "${{ needs.determine-tests.outputs.remaining_tests }}"
         env:
           FAST_TEST_TIMEOUT_SECONDS: 60
 
@@ -410,9 +410,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-notice: "Running all tests (infrastructure/config changes detected)"
 
-      - name: Run E2E Playwright tests (MySQL, Local)
+      - name: Run E2E Playwright tests (PostgreSQL, Local)
         id: run-tests-all-pr
-        run: .ci/E2E-tests/execute.sh mysql-localci playwright
+        run: .ci/E2E-tests/execute.sh postgres-localci playwright
         env:
           FAST_TEST_TIMEOUT_SECONDS: 60
 
@@ -546,7 +546,7 @@ jobs:
           workflow-head-sha: ${{ github.event.workflow_run.head_sha }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run E2E Playwright tests (MySQL, Local, Multi-Node)
+      - name: Run E2E Playwright tests (PostgreSQL, Local, Multi-Node)
         id: run-tests-all-non-pr
         run: .ci/E2E-tests/execute.sh multi-node playwright
         env:

--- a/docker/artemis/config/playwright.env
+++ b/docker/artemis/config/playwright.env
@@ -1,13 +1,9 @@
 # ----------------------------------------------------------------------------------------------------------------------
-# Common Artemis configurations for the Playwright E2E MySQL and Postgres setups
+# Common Artemis configurations for the Playwright E2E Postgres setups
 # ----------------------------------------------------------------------------------------------------------------------
 
 SPRING_DATASOURCE_PASSWORD=""
 SPRING_DATASOURCE_HIKARI_MAXIMUMPOOLSIZE="100"
-
-SPRING_JPA_HIBERNATE_CONNECTION_CHARSET="utf8mb4"
-SPRING_JPA_HIBERNATE_CONNECTION_CHARACTERENCODING="utf8mb4"
-SPRING_JPA_HIBERNATE_CONNECTION_USEUNICODE="true"
 
 SPRING_PROMETHEUS_MONITORINGIP="131.159.89.160"
 

--- a/docker/playwright-E2E-tests-multi-node.yml
+++ b/docker/playwright-E2E-tests-multi-node.yml
@@ -13,7 +13,7 @@ services:
     user: 0:0
     depends_on:
       &depends-on-base
-      mysql:
+      postgres:
         condition: service_healthy
       jhipster-registry:
         condition: service_healthy
@@ -24,6 +24,7 @@ services:
     container_name: artemis-app-node-1
     env_file:
       - ./artemis/config/prod-multinode.env
+      - ./artemis/config/postgres.env
       - ./artemis/config/node1.env
       - ./artemis/config/playwright.env
 
@@ -36,6 +37,7 @@ services:
         condition: service_healthy
     env_file:
       - ./artemis/config/prod-multinode.env
+      - ./artemis/config/postgres.env
       - ./artemis/config/node2.env
       - ./artemis/config/playwright.env
 
@@ -48,6 +50,7 @@ services:
         condition: service_healthy
     env_file:
       - ./artemis/config/prod-multinode.env
+      - ./artemis/config/postgres.env
       - ./artemis/config/node3.env
       - ./artemis/config/playwright.env
 
@@ -65,10 +68,10 @@ services:
     networks:
       - artemis
 
-  mysql:
+  postgres:
     extends:
-      file: ./mysql.yml
-      service: mysql
+      file: ./postgres.yml
+      service: postgres
     restart: always
 
   nginx:
@@ -108,7 +111,7 @@ services:
       nginx:
         condition: service_healthy
     environment:
-      PLAYWRIGHT_DB_TYPE: 'MySQL'
+      PLAYWRIGHT_DB_TYPE: 'Postgres'
     networks:
       - artemis
 
@@ -118,8 +121,7 @@ networks:
     name: artemis
 
 volumes:
-  artemis-mysql-data:
-    name: artemis-mysql-data
+  artemis-postgres-data:
+    name: artemis-postgres-data
   artemis-data:
     name: artemis-data
-

--- a/run-e2e-tests-local.sh
+++ b/run-e2e-tests-local.sh
@@ -11,7 +11,7 @@ set -e
 #   --skip-build        Skip building the WAR file (use existing one)
 #   --skip-cleanup      Skip Docker cleanup before running
 #   --filter <pattern>  Run only tests matching the pattern (e.g., "Quiz")
-#   --db <mysql|postgres> Select database for E2E tests (default: mysql)
+#   --db <postgres>       Select database for E2E tests (default: postgres)
 #   --help              Show this help message
 # =============================================================================
 
@@ -43,11 +43,11 @@ while [[ $# -gt 0 ]]; do
             ;;
         --db)
             if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
-                echo -e "${RED}ERROR: --db requires a database value (mysql or postgres)${NC}"
+                echo -e "${RED}ERROR: --db requires a database value (postgres)${NC}"
                 exit 1
             fi
-            if [[ "$2" != "mysql" && "$2" != "postgres" ]]; then
-                echo -e "${RED}ERROR: invalid --db value: $2 (use mysql or postgres)${NC}"
+            if [[ "$2" != "postgres" ]]; then
+                echo -e "${RED}ERROR: invalid --db value: $2 (only postgres is supported)${NC}"
                 exit 1
             fi
             DB_TYPE="$2"
@@ -55,8 +55,8 @@ while [[ $# -gt 0 ]]; do
             ;;
         --db=*)
             DB_TYPE="${1#*=}"
-            if [[ "$DB_TYPE" != "mysql" && "$DB_TYPE" != "postgres" ]]; then
-                echo -e "${RED}ERROR: invalid --db value: $DB_TYPE (use mysql or postgres)${NC}"
+            if [[ "$DB_TYPE" != "postgres" ]]; then
+                echo -e "${RED}ERROR: invalid --db value: $DB_TYPE (only postgres is supported)${NC}"
                 exit 1
             fi
             shift
@@ -107,13 +107,8 @@ fi
 # Step 2: Cleanup
 if [ "$SKIP_CLEANUP" = false ]; then
     echo -e "${BLUE}Step 2: Cleaning Docker environment...${NC}"
-    if [ "$DB_TYPE" = "postgres" ]; then
-        COMPOSE_FILE="playwright-E2E-tests-postgres-localci.yml"
-        DB_VOLUME="artemis-postgres-data"
-    else
-        COMPOSE_FILE="playwright-E2E-tests-mysql-localci.yml"
-        DB_VOLUME="artemis-mysql-data"
-    fi
+    COMPOSE_FILE="playwright-E2E-tests-postgres-localci.yml"
+    DB_VOLUME="artemis-postgres-data"
     cd docker
     docker compose --env-file ../.env -f "$COMPOSE_FILE" down -v 2>/dev/null || true
     cd ..
@@ -127,11 +122,7 @@ fi
 echo -e "${BLUE}Step 3: Running E2E tests...${NC}"
 echo ""
 
-if [ "$DB_TYPE" = "postgres" ]; then
-    CONFIGURATION="postgres-localci"
-else
-    CONFIGURATION="mysql-localci"
-fi
+CONFIGURATION="postgres-localci"
 
 .ci/E2E-tests/execute-locally.sh "$CONFIGURATION" "$TEST_FILTER"
 


### PR DESCRIPTION
### Summary 
Switch the entire E2E test infrastructure from MySQL to PostgreSQL for consistency with the server test suite, which already uses PostgreSQL via Testcontainers.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
After recent E2E performance improvements, the E2E GitHub Actions workflow still used MySQL for all test runs, while server tests have already migrated to PostgreSQL. This inconsistency causes the workflow to fail because the Playwright global setup now only references a PostgreSQL container (`artemis-postgres`). This PR aligns the E2E infrastructure with the rest of the project by switching all E2E test configurations to PostgreSQL.

### Description
**Workflow (`test-e2e.yml`):**
- Changed all `execute.sh mysql-localci` calls to `execute.sh postgres-localci` (Phase 1, Phase 2, and all-PR jobs)
- Updated step names from "MySQL" to "PostgreSQL"

**CI scripts:**
- `execute.sh`: Removed `mysql` and `mysql-localci` configurations, added `postgres-localci`
- `execute-locally.sh`: Default changed from `mysql-localci` to `postgres-localci`, removed MySQL options
- `cleanup.sh`: Updated compose-down reference from `playwright-E2E-tests-mysql.yml` to `playwright-E2E-tests-postgres-localci.yml`

**Docker Compose (`playwright-E2E-tests-multi-node.yml`):**
- Replaced `mysql` service with `postgres` (extends `postgres.yml`)
- Added `postgres.env` to all three app node `env_file` lists (after `prod-multinode.env` to override MySQL datasource settings)
- Changed `PLAYWRIGHT_DB_TYPE` from `MySQL` to `Postgres`
- Updated volume names from `artemis-mysql-data` to `artemis-postgres-data`

**Environment (`playwright.env`):**
- Removed MySQL-specific charset settings (`utf8mb4`, `characterencoding`, `useunicode`)

### Steps for Testing
Prerequisites:
- Access to the E2E CI infrastructure

1. Push the branch and verify the E2E workflow triggers correctly
2. Check that all Docker Compose files validate (`docker compose config`)
3. Verify E2E tests run successfully against PostgreSQL

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched end-to-end testing to use PostgreSQL (postgres-localci) as the default test database instead of MySQL.
  * Removed MySQL-related test configuration options and branches from test scripts and helpers.
  * Added compatibility mapping so legacy mysql-localci references map to postgres-localci with a notice.
  * Simplified test-run and cleanup flows to always target PostgreSQL and updated help, validation, and error messages.
  * Cleaned up test environment settings by removing obsolete database connection properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->