### PR TITLE
`Lectures`: Create deep linking for HLS video player

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -337,8 +337,8 @@ dependencies {
     implementation "org.redisson:redisson-spring-boot-starter:${redisson_version}"
 
 
-    implementation "org.hibernate.orm:hibernate-core:${hibernate_version}"
-    implementation "org.hibernate.orm:hibernate-envers:${hibernate_version}"
+    implementation "org.hibernate.orm:hibernate-core"
+    implementation "org.hibernate.orm:hibernate-envers"
 
     // Required for jdbc connection pooling to databases
     implementation "com.zaxxer:HikariCP:7.0.2"
@@ -465,8 +465,8 @@ dependencies {
     implementation("net.bytebuddy:byte-buddy-agent") { version {        strictly byte_buddy_version } }
     annotationProcessor("net.bytebuddy:byte-buddy-agent") { version {   strictly byte_buddy_version } }
 
-    annotationProcessor "org.hibernate.orm:hibernate-jpamodelgen:${hibernate_version}"
-    annotationProcessor "org.hibernate.orm:hibernate-core:${hibernate_version}"
+    annotationProcessor "org.hibernate.orm:hibernate-jpamodelgen"
+    annotationProcessor "org.hibernate.orm:hibernate-core"
     annotationProcessor "org.glassfish.jaxb:jaxb-runtime:${jaxb_runtime_version}"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,6 @@ npm_version=11.5.1
 jhipster_dependencies_version=8.12.0
 spring_boot_version=3.5.11
 spring_cloud_version=4.3.1
-# TODO: upgrading to 6.6.x currently leads to issues due to internal changes in Hibernate and potentially wrong use in Artemis server code. See https://hibernate.atlassian.net/browse/HHH-19249
-hibernate_version=6.5.3.Final
 opensaml_version=5.2.1
 jwt_version=0.13.0
 jaxb_runtime_version=4.0.7

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/dto/GradingScaleUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/dto/GradingScaleUpdateDTO.java
@@ -1,0 +1,104 @@
+package de.tum.cit.aet.artemis.assessment.dto;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.BonusStrategy;
+import de.tum.cit.aet.artemis.assessment.domain.GradeStep;
+import de.tum.cit.aet.artemis.assessment.domain.GradeType;
+import de.tum.cit.aet.artemis.assessment.domain.GradingScale;
+
+/**
+ * DTO for updating a grading scale.
+ * Contains all fields needed for updating a grading scale without requiring the full entity.
+ *
+ * @param gradeType               the type of grading (GRADE, BONUS, NONE)
+ * @param bonusStrategy           the bonus strategy to use
+ * @param plagiarismGrade         the grade for plagiarism cases
+ * @param noParticipationGrade    the grade for no participation
+ * @param presentationsNumber     the number of presentations
+ * @param presentationsWeight     the weight of presentations
+ * @param gradeSteps              the grade steps for this scale (can be null or empty)
+ * @param courseMaxPoints         optional: max points for the course (for course grading scales)
+ * @param coursePresentationScore optional: presentation score for the course
+ * @param examMaxPoints           optional: max points for the exam (for exam grading scales)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record GradingScaleUpdateDTO(@NotNull GradeType gradeType, @Nullable BonusStrategy bonusStrategy, @Nullable @Size(max = 100) String plagiarismGrade,
+        @Nullable @Size(max = 100) String noParticipationGrade, @Nullable Integer presentationsNumber, @Nullable Double presentationsWeight, @Nullable Set<GradeStepDTO> gradeSteps,
+        @Nullable Integer courseMaxPoints, @Nullable Integer coursePresentationScore, @Nullable Integer examMaxPoints) {
+
+    /**
+     * Returns the grade steps, defaulting to an empty set if null.
+     */
+    public Set<GradeStepDTO> gradeStepsOrEmpty() {
+        return gradeSteps != null ? gradeSteps : new HashSet<>();
+    }
+
+    /**
+     * DTO for a grade step within a grading scale.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public record GradeStepDTO(double lowerBoundPercentage, boolean lowerBoundInclusive, double upperBoundPercentage, boolean upperBoundInclusive, @NotNull String gradeName,
+            boolean isPassingGrade) {
+
+        /**
+         * Creates a GradeStep entity from this DTO.
+         *
+         * @param gradingScale the grading scale to associate with
+         * @return a new GradeStep entity
+         */
+        public GradeStep toEntity(GradingScale gradingScale) {
+            GradeStep gradeStep = new GradeStep();
+            gradeStep.setGradingScale(gradingScale);
+            gradeStep.setLowerBoundPercentage(lowerBoundPercentage);
+            gradeStep.setLowerBoundInclusive(lowerBoundInclusive);
+            gradeStep.setUpperBoundPercentage(upperBoundPercentage);
+            gradeStep.setUpperBoundInclusive(upperBoundInclusive);
+            gradeStep.setGradeName(gradeName);
+            gradeStep.setIsPassingGrade(isPassingGrade);
+            return gradeStep;
+        }
+    }
+
+    /**
+     * Applies this DTO's values to an existing GradingScale entity.
+     *
+     * @param gradingScale the grading scale to update
+     */
+    public void applyTo(GradingScale gradingScale) {
+        gradingScale.setGradeType(gradeType);
+        gradingScale.setBonusStrategy(bonusStrategy);
+        gradingScale.setPlagiarismGrade(plagiarismGrade);
+        gradingScale.setNoParticipationGrade(noParticipationGrade);
+        gradingScale.setPresentationsNumber(presentationsNumber);
+        gradingScale.setPresentationsWeight(presentationsWeight);
+
+        // Clear existing grade steps and add new ones
+        gradingScale.getGradeSteps().clear();
+        for (GradeStepDTO gradeStepDTO : gradeStepsOrEmpty()) {
+            GradeStep gradeStep = gradeStepDTO.toEntity(gradingScale);
+            gradingScale.getGradeSteps().add(gradeStep);
+        }
+    }
+
+    /**
+     * Creates a new GradingScale entity from this DTO.
+     *
+     * @return a new GradingScale entity
+     */
+    public GradingScale toEntity() {
+        GradingScale gradingScale = new GradingScale();
+        applyTo(gradingScale);
+        return gradingScale;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/web/GradingScaleResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/web/GradingScaleResource.java
@@ -4,7 +4,6 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Objects;
 import java.util.Optional;
 
 import jakarta.validation.Valid;
@@ -25,6 +24,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.cit.aet.artemis.assessment.domain.GradingScale;
+import de.tum.cit.aet.artemis.assessment.dto.GradingScaleUpdateDTO;
 import de.tum.cit.aet.artemis.assessment.repository.GradingScaleRepository;
 import de.tum.cit.aet.artemis.assessment.service.GradingScaleService;
 import de.tum.cit.aet.artemis.core.domain.Course;
@@ -130,52 +130,55 @@ public class GradingScaleResource {
     /**
      * POST /courses/{courseId}/grading-scale : Create grading scale for course
      *
-     * @param courseId     the course to which the grading scale belongs
-     * @param gradingScale the grading scale which will be created
+     * @param courseId the course to which the grading scale belongs
+     * @param dto      the DTO containing the grading scale values
      * @return ResponseEntity with status 201 (Created) with body the new grading scale if no such exists for the course
      *         and if it is correctly formatted and 400 (Bad request) otherwise
      */
     @PostMapping("courses/{courseId}/grading-scale")
     @EnforceAtLeastInstructor
-    public ResponseEntity<GradingScale> createGradingScaleForCourse(@PathVariable Long courseId, @Valid @RequestBody GradingScale gradingScale) throws URISyntaxException {
+    public ResponseEntity<GradingScale> createGradingScaleForCourse(@PathVariable Long courseId, @Valid @RequestBody GradingScaleUpdateDTO dto) throws URISyntaxException {
         log.debug("REST request to create a grading scale for course: {}", courseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
         Optional<GradingScale> existingGradingScale = gradingScaleRepository.findByCourseId(courseId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
-        validateGradingScale(existingGradingScale, gradingScale);
+        validateGradingScaleForCreate(existingGradingScale, dto);
 
+        // Create grading scale from DTO
+        GradingScale gradingScale = dto.toEntity();
+        gradingScale.setCourse(course);
+
+        // Apply DTO values to course before validation so that presentation config is validated correctly
+        applyCourseValuesFromDTO(dto, course);
         validatePresentationsConfiguration(gradingScale);
-        updateCourseForGradingScale(gradingScale, course);
+        saveCourseIfChanged(dto, course);
 
         GradingScale savedGradingScale = gradingScaleService.saveGradingScale(gradingScale);
         return ResponseEntity.created(new URI("/api/assessment/courses/" + courseId + "/grading-scale/"))
                 .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, "")).body(savedGradingScale);
     }
 
-    private void validateGradingScale(Optional<GradingScale> existingGradingScale, GradingScale gradingScale) {
+    private void validateGradingScaleForCreate(Optional<GradingScale> existingGradingScale, GradingScaleUpdateDTO dto) {
         if (existingGradingScale.isPresent()) {
             throw new BadRequestAlertException("A grading scale already exists", ENTITY_NAME, "gradingScaleAlreadyExists");
         }
-        else if (gradingScale.getGradeSteps() == null || gradingScale.getGradeSteps().isEmpty()) {
+        else if (dto.gradeSteps() == null || dto.gradeSteps().isEmpty()) {
             throw new BadRequestAlertException("A grading scale must contain grade steps", ENTITY_NAME, "emptyGradeSteps");
-        }
-        else if (gradingScale.getId() != null) {
-            throw new BadRequestAlertException("A grading scale can't contain a predefined id", ENTITY_NAME, "gradingScaleHasId");
         }
     }
 
     /**
      * POST /courses/{courseId}/exams/{examId}grading-scale : Create grading scale for exam
      *
-     * @param courseId     the course to which the exam belongs
-     * @param examId       the exam to which the grading scale belongs
-     * @param gradingScale the grading scale which will be created
+     * @param courseId the course to which the exam belongs
+     * @param examId   the exam to which the grading scale belongs
+     * @param dto      the DTO containing the grading scale values
      * @return ResponseEntity with status 201 (Created) with body the new grading scale if no such exists for the course
      *         and if it is correctly formatted and 400 (Bad request) otherwise
      */
     @PostMapping("courses/{courseId}/exams/{examId}/grading-scale")
     @EnforceAtLeastInstructor
-    public ResponseEntity<GradingScale> createGradingScaleForExam(@PathVariable Long courseId, @PathVariable Long examId, @Valid @RequestBody GradingScale gradingScale)
+    public ResponseEntity<GradingScale> createGradingScaleForExam(@PathVariable Long courseId, @PathVariable Long examId, @Valid @RequestBody GradingScaleUpdateDTO dto)
             throws URISyntaxException {
         log.debug("REST request to create a grading scale for exam: {}", examId);
         ExamRepositoryApi api = examRepositoryApi.orElseThrow(() -> new ExamApiNotPresentException(ExamRepositoryApi.class));
@@ -183,12 +186,16 @@ public class GradingScaleResource {
         Course course = courseRepository.findByIdElseThrow(courseId);
         Optional<GradingScale> existingGradingScale = gradingScaleRepository.findByExamId(examId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
-        validateGradingScale(existingGradingScale, gradingScale);
+        validateGradingScaleForCreate(existingGradingScale, dto);
+
         Exam exam = api.findByIdElseThrow(examId);
-        if (gradingScale.getExam().getExamMaxPoints() != exam.getExamMaxPoints()) {
-            exam.setExamMaxPoints(gradingScale.getExam().getExamMaxPoints());
+        if (dto.examMaxPoints() != null && !dto.examMaxPoints().equals(exam.getExamMaxPoints())) {
+            exam.setExamMaxPoints(dto.examMaxPoints());
             api.save(exam);
         }
+
+        // Create grading scale from DTO
+        GradingScale gradingScale = dto.toEntity();
         gradingScale.setExam(exam);
 
         GradingScale savedGradingScale = gradingScaleService.saveGradingScale(gradingScale);
@@ -199,53 +206,67 @@ public class GradingScaleResource {
     /**
      * PUT /courses/{courseId}/grading-scale : Update grading scale for course
      *
-     * @param courseId     the course to which the grading scale belongs
-     * @param gradingScale the grading scale which will be updated
+     * @param courseId the course to which the grading scale belongs
+     * @param dto      the DTO containing the grading scale update values
      * @return ResponseEntity with status 200 (Ok) with body the newly updated grading scale if it is correctly formatted and 400 (Bad request) otherwise
      */
     @PutMapping("courses/{courseId}/grading-scale")
     @EnforceAtLeastInstructor
-    public ResponseEntity<GradingScale> updateGradingScaleForCourse(@PathVariable Long courseId, @Valid @RequestBody GradingScale gradingScale) {
+    public ResponseEntity<GradingScale> updateGradingScaleForCourse(@PathVariable Long courseId, @Valid @RequestBody GradingScaleUpdateDTO dto) {
         log.debug("REST request to update a grading scale for course: {}", courseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
-        GradingScale oldGradingScale = gradingScaleRepository.findByCourseIdOrElseThrow(courseId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
-        gradingScale.setId(oldGradingScale.getId());
-        gradingScale.setBonusFrom(oldGradingScale.getBonusFrom()); // bonusFrom should not be affected by this endpoint.
 
-        validatePresentationsConfiguration(gradingScale);
-        updateCourseForGradingScale(gradingScale, course);
+        // Fetch the existing grading scale from the database (this is the managed entity)
+        // Note: gradeSteps are eagerly fetched due to FetchType.EAGER
+        GradingScale existingGradingScale = gradingScaleRepository.findByCourseIdOrElseThrow(courseId);
 
-        GradingScale savedGradingScale = gradingScaleService.saveGradingScale(gradingScale);
+        // Apply DTO values to the managed entity
+        dto.applyTo(existingGradingScale);
+        existingGradingScale.setCourse(course);
+
+        // Apply DTO values to course before validation so that presentation config is validated correctly
+        applyCourseValuesFromDTO(dto, course);
+        validatePresentationsConfiguration(existingGradingScale);
+        saveCourseIfChanged(dto, course);
+
+        GradingScale savedGradingScale = gradingScaleService.saveGradingScale(existingGradingScale);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, "")).body(savedGradingScale);
     }
 
     /**
      * PUT /courses/{courseId}/exams/{examId}/grading-scale : Update grading scale for exam
      *
-     * @param courseId     the course to which the exam belongs
-     * @param examId       the exam to which the grading scale belongs
-     * @param gradingScale the grading scale which will be updated
+     * @param courseId the course to which the exam belongs
+     * @param examId   the exam to which the grading scale belongs
+     * @param dto      the DTO containing the grading scale update values
      * @return ResponseEntity with status 200 (Ok) with body the newly updated grading scale if it is correctly formatted and 400 (Bad request) otherwise
      */
     @PutMapping("courses/{courseId}/exams/{examId}/grading-scale")
     @EnforceAtLeastInstructor
-    public ResponseEntity<GradingScale> updateGradingScaleForExam(@PathVariable Long courseId, @PathVariable Long examId, @Valid @RequestBody GradingScale gradingScale) {
+    public ResponseEntity<GradingScale> updateGradingScaleForExam(@PathVariable Long courseId, @PathVariable Long examId, @Valid @RequestBody GradingScaleUpdateDTO dto) {
         log.debug("REST request to update a grading scale for exam: {}", examId);
         ExamRepositoryApi api = examRepositoryApi.orElseThrow(() -> new ExamApiNotPresentException(ExamRepositoryApi.class));
 
         Course course = courseRepository.findByIdElseThrow(courseId);
         Exam exam = api.findByIdElseThrow(examId);
-        GradingScale oldGradingScale = gradingScaleRepository.findByExamIdOrElseThrow(examId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
-        gradingScale.setId(oldGradingScale.getId());
-        gradingScale.setBonusFrom(oldGradingScale.getBonusFrom()); // bonusFrom should not be affected by this endpoint.
-        if (gradingScale.getExam().getExamMaxPoints() != exam.getExamMaxPoints()) {
-            exam.setExamMaxPoints(gradingScale.getExam().getExamMaxPoints());
+
+        // Fetch the existing grading scale from the database (this is the managed entity)
+        // Note: gradeSteps are eagerly fetched due to FetchType.EAGER
+        GradingScale existingGradingScale = gradingScaleRepository.findByExamIdOrElseThrow(examId);
+
+        // Update exam max points if provided
+        if (dto.examMaxPoints() != null && dto.examMaxPoints() != exam.getExamMaxPoints()) {
+            exam.setExamMaxPoints(dto.examMaxPoints());
             api.save(exam);
         }
-        gradingScale.setExam(exam);
-        GradingScale savedGradingScale = gradingScaleService.saveGradingScale(gradingScale);
+
+        // Apply DTO values to the managed entity
+        dto.applyTo(existingGradingScale);
+        existingGradingScale.setExam(exam);
+
+        GradingScale savedGradingScale = gradingScaleService.saveGradingScale(existingGradingScale);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, "")).body(savedGradingScale);
     }
 
@@ -284,18 +305,36 @@ public class GradingScaleResource {
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, "")).build();
     }
 
-    private void updateCourseForGradingScale(GradingScale gradingScale, Course course) {
-        if (gradingScale == null) {
+    /**
+     * Applies course properties from DTO to the course object (in memory, does not save).
+     * This should be called before validation so that the validation uses the intended values.
+     */
+    private void applyCourseValuesFromDTO(GradingScaleUpdateDTO dto, Course course) {
+        if (dto == null || course == null) {
             return;
         }
 
-        if (course != null && gradingScale.getCourse() != null && (!Objects.equals(gradingScale.getCourse().getMaxPoints(), course.getMaxPoints())
-                || !Objects.equals(gradingScale.getCourse().getPresentationScore(), course.getPresentationScore()))) {
-            course.setMaxPoints(gradingScale.getCourse().getMaxPoints());
-            course.setPresentationScore(gradingScale.getCourse().getPresentationScore());
+        if (dto.courseMaxPoints() != null) {
+            course.setMaxPoints(dto.courseMaxPoints());
+        }
+        if (dto.coursePresentationScore() != null) {
+            course.setPresentationScore(dto.coursePresentationScore());
+        }
+    }
+
+    /**
+     * Saves the course if it was modified by DTO values.
+     * Should be called after validation succeeds.
+     */
+    private void saveCourseIfChanged(GradingScaleUpdateDTO dto, Course course) {
+        if (dto == null || course == null) {
+            return;
+        }
+
+        // If either value was provided in the DTO, we need to save
+        if (dto.courseMaxPoints() != null || dto.coursePresentationScore() != null) {
             courseRepository.save(course);
         }
-        gradingScale.setCourse(course);
     }
 
     private void validatePresentationsConfiguration(GradingScale gradingScale) {

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/api/CompetencyRelationApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/api/CompetencyRelationApi.java
@@ -1,6 +1,11 @@
 package de.tum.cit.aet.artemis.atlas.api;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Lazy;
@@ -9,9 +14,11 @@ import org.springframework.stereotype.Controller;
 import de.tum.cit.aet.artemis.atlas.config.AtlasEnabled;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyLectureUnitLink;
+import de.tum.cit.aet.artemis.atlas.domain.competency.CourseCompetency;
 import de.tum.cit.aet.artemis.atlas.repository.CompetencyExerciseLinkRepository;
 import de.tum.cit.aet.artemis.atlas.repository.CompetencyLectureUnitLinkRepository;
 import de.tum.cit.aet.artemis.atlas.repository.CompetencyRelationRepository;
+import de.tum.cit.aet.artemis.atlas.repository.CourseCompetencyRepository;
 
 @Controller
 @Conditional(AtlasEnabled.class)
@@ -24,11 +31,14 @@ public class CompetencyRelationApi extends AbstractAtlasApi {
 
     private final CompetencyLectureUnitLinkRepository lectureUnitLinkRepository;
 
+    private final CourseCompetencyRepository courseCompetencyRepository;
+
     public CompetencyRelationApi(CompetencyRelationRepository competencyRelationRepository, CompetencyExerciseLinkRepository competencyExerciseLinkRepository,
-            CompetencyLectureUnitLinkRepository lectureUnitLinkRepository) {
+            CompetencyLectureUnitLinkRepository lectureUnitLinkRepository, CourseCompetencyRepository courseCompetencyRepository) {
         this.competencyRelationRepository = competencyRelationRepository;
         this.competencyExerciseLinkRepository = competencyExerciseLinkRepository;
         this.lectureUnitLinkRepository = lectureUnitLinkRepository;
+        this.courseCompetencyRepository = courseCompetencyRepository;
     }
 
     public void deleteAllByCourseId(Long courseId) {
@@ -40,7 +50,23 @@ public class CompetencyRelationApi extends AbstractAtlasApi {
     }
 
     public List<CompetencyExerciseLink> saveAllExerciseLinks(Iterable<CompetencyExerciseLink> competencyExerciseLinks) {
-        return competencyExerciseLinkRepository.saveAll(competencyExerciseLinks);
+        List<CompetencyExerciseLink> links = StreamSupport.stream(competencyExerciseLinks.spliterator(), false).toList();
+
+        // Load all competencies from database to ensure they are managed entities
+        // Hibernate 6.6+ requires all referenced entities to be managed during persist/merge
+        Set<Long> competencyIds = links.stream().map(link -> link.getCompetency().getId()).collect(Collectors.toSet());
+        Map<Long, CourseCompetency> competencyMap = courseCompetencyRepository.findAllById(competencyIds).stream()
+                .collect(Collectors.toMap(CourseCompetency::getId, Function.identity()));
+
+        // Replace detached competencies with managed entities
+        links.forEach(link -> {
+            CourseCompetency managedCompetency = competencyMap.get(link.getCompetency().getId());
+            if (managedCompetency != null) {
+                link.setCompetency(managedCompetency);
+            }
+        });
+
+        return competencyExerciseLinkRepository.saveAll(links);
     }
 
     public List<CompetencyLectureUnitLink> saveAllLectureUnitLinks(Iterable<CompetencyLectureUnitLink> lectureUnitLinks) {

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/api/CompetencyRepositoryApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/api/CompetencyRepositoryApi.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.artemis.atlas.api;
 
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.context.annotation.Conditional;
@@ -32,5 +33,9 @@ public class CompetencyRepositoryApi extends AbstractAtlasApi {
 
     public CourseCompetency findCompetencyOrPrerequisiteByIdElseThrow(long competencyId) {
         return courseCompetencyRepository.findByIdElseThrow(competencyId);
+    }
+
+    public List<CourseCompetency> findAllCompetenciesById(Iterable<Long> ids) {
+        return courseCompetencyRepository.findAllById(ids);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/domain/competency/CompetencyExerciseLink.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/domain/competency/CompetencyExerciseLink.java
@@ -4,7 +4,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
@@ -28,7 +27,7 @@ public class CompetencyExerciseLink extends CompetencyLearningObjectLink {
     @JsonIgnore
     protected CompetencyExerciseId id = new CompetencyExerciseId();
 
-    @ManyToOne(optional = false, cascade = CascadeType.PERSIST)
+    @ManyToOne(optional = false)
     @MapsId("exerciseId")
     private Exercise exercise;
 

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/domain/competency/CompetencyLearningObjectLink.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/domain/competency/CompetencyLearningObjectLink.java
@@ -2,7 +2,6 @@ package de.tum.cit.aet.artemis.atlas.domain.competency;
 
 import java.io.Serializable;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
@@ -11,7 +10,7 @@ import jakarta.persistence.MapsId;
 @MappedSuperclass
 public abstract class CompetencyLearningObjectLink implements Serializable {
 
-    @ManyToOne(optional = false, cascade = CascadeType.PERSIST)
+    @ManyToOne(optional = false)
     @MapsId("competencyId")
     protected CourseCompetency competency;
 

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/domain/competency/CompetencyLectureUnitLink.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/domain/competency/CompetencyLectureUnitLink.java
@@ -4,7 +4,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
@@ -30,7 +29,7 @@ public class CompetencyLectureUnitLink extends CompetencyLearningObjectLink {
     protected CompetencyLectureUnitId id = new CompetencyLectureUnitId();
 
     @JsonIgnoreProperties("competencyLinks")
-    @ManyToOne(optional = false, cascade = CascadeType.PERSIST)
+    @ManyToOne(optional = false)
     @MapsId("lectureUnitId")
     private LectureUnit lectureUnit;
 

--- a/src/main/java/de/tum/cit/aet/artemis/communication/dto/SystemNotificationUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/dto/SystemNotificationUpdateDTO.java
@@ -1,0 +1,62 @@
+package de.tum.cit.aet.artemis.communication.dto;
+
+import java.time.ZonedDateTime;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.communication.domain.SystemNotificationType;
+import de.tum.cit.aet.artemis.communication.domain.notification.SystemNotification;
+
+/**
+ * DTO for creating and updating SystemNotifications.
+ * Uses DTOs instead of entity classes to avoid Hibernate detached entity issues.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record SystemNotificationUpdateDTO(@Nullable Long id, @Nullable String title, @Nullable String text, @Nullable ZonedDateTime notificationDate,
+        @Nullable ZonedDateTime expireDate, @Nullable SystemNotificationType type) {
+
+    /**
+     * Creates a SystemNotificationUpdateDTO from the given SystemNotification domain object.
+     *
+     * @param notification the SystemNotification to convert
+     * @return the corresponding DTO
+     */
+    public static SystemNotificationUpdateDTO of(SystemNotification notification) {
+        return new SystemNotificationUpdateDTO(notification.getId(), notification.getTitle(), notification.getText(), notification.getNotificationDate(),
+                notification.getExpireDate(), notification.getType());
+    }
+
+    /**
+     * Creates a new SystemNotification entity from this DTO.
+     * Used for create operations.
+     *
+     * @return a new SystemNotification entity
+     */
+    public SystemNotification toEntity() {
+        SystemNotification notification = new SystemNotification();
+        notification.setTitle(title);
+        notification.setText(text);
+        notification.setNotificationDate(notificationDate);
+        notification.setExpireDate(expireDate);
+        notification.setType(type);
+        return notification;
+    }
+
+    /**
+     * Applies the DTO values to an existing SystemNotification entity.
+     * This updates the managed entity with values from the DTO.
+     *
+     * @param notification the existing notification to update
+     */
+    public void applyTo(SystemNotification notification) {
+        notification.setTitle(title);
+        notification.setText(text);
+        notification.setNotificationDate(notificationDate);
+        notification.setExpireDate(expireDate);
+        notification.setType(type);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/admin/AdminSystemNotificationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/admin/AdminSystemNotificationResource.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.cit.aet.artemis.communication.domain.notification.SystemNotification;
+import de.tum.cit.aet.artemis.communication.dto.SystemNotificationUpdateDTO;
 import de.tum.cit.aet.artemis.communication.repository.SystemNotificationRepository;
 import de.tum.cit.aet.artemis.communication.service.SystemNotificationService;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
@@ -57,18 +58,19 @@ public class AdminSystemNotificationResource {
     /**
      * POST /system-notifications : Create a new system notification.
      *
-     * @param systemNotification   the system notification to create
+     * @param dto                  the system notification DTO to create
      * @param sendMaintenanceEmail whether to send maintenance email to instructors of ongoing courses
      * @return the ResponseEntity with status 201 (Created) and with body the new system notification, or with status 400 (Bad Request) if the system notification has already an ID
      * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PostMapping("system-notifications")
-    public ResponseEntity<SystemNotification> createSystemNotification(@RequestBody SystemNotification systemNotification,
+    public ResponseEntity<SystemNotification> createSystemNotification(@RequestBody SystemNotificationUpdateDTO dto,
             @RequestParam(defaultValue = "false") boolean sendMaintenanceEmail) throws URISyntaxException {
-        log.debug("REST request to save SystemNotification : {}", systemNotification);
-        if (systemNotification.getId() != null) {
+        log.debug("REST request to save SystemNotification : {}", dto);
+        if (dto.id() != null) {
             throw new BadRequestAlertException("A new system notification cannot already have an ID", ENTITY_NAME, "idExists");
         }
+        SystemNotification systemNotification = dto.toEntity();
         this.systemNotificationService.validateDatesElseThrow(systemNotification);
         SystemNotification result = systemNotificationRepository.save(systemNotification);
         systemNotificationService.distributeActiveAndFutureNotificationsToClients();
@@ -100,23 +102,28 @@ public class AdminSystemNotificationResource {
     /**
      * PUT /system-notifications : Updates an existing system notification.
      *
-     * @param systemNotification the system notification to update
+     * @param updateDTO the system notification update DTO containing the new values
      * @return the ResponseEntity with status 200 (OK) and with body the updated notification, or with status 400 (Bad Request) if the system notification is not valid, or with
      *         status 500 (Internal Server Error) if the system notification couldn't be updated
      */
     @PutMapping("system-notifications")
-    public ResponseEntity<SystemNotification> updateSystemNotification(@RequestBody SystemNotification systemNotification) {
-        log.debug("REST request to update SystemNotification : {}", systemNotification);
-        if (systemNotification.getId() == null) {
+    public ResponseEntity<SystemNotification> updateSystemNotification(@RequestBody SystemNotificationUpdateDTO updateDTO) {
+        log.debug("REST request to update SystemNotification : {}", updateDTO);
+        if (updateDTO.id() == null) {
             throw new BadRequestAlertException("ID must not be null", ENTITY_NAME, "idNull");
         }
-        this.systemNotificationService.validateDatesElseThrow(systemNotification);
-        if (!systemNotificationRepository.existsById(systemNotification.getId())) {
-            throw new BadRequestAlertException("No system notification with this ID found", ENTITY_NAME, "idNull");
-        }
-        SystemNotification result = systemNotificationRepository.save(systemNotification);
+
+        // Fetch the existing notification from the database (this is the managed entity)
+        SystemNotification existingNotification = systemNotificationRepository.findById(updateDTO.id())
+                .orElseThrow(() -> new BadRequestAlertException("No system notification with this ID found", ENTITY_NAME, "idNull"));
+
+        // Apply DTO values to the managed entity
+        updateDTO.applyTo(existingNotification);
+
+        this.systemNotificationService.validateDatesElseThrow(existingNotification);
+        SystemNotification result = systemNotificationRepository.save(existingNotification);
         systemNotificationService.distributeActiveAndFutureNotificationsToClients();
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, systemNotification.getId().toString())).body(result);
+        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, result.getId().toString())).body(result);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/CourseUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/CourseUpdateDTO.java
@@ -1,0 +1,146 @@
+package de.tum.cit.aet.artemis.core.dto;
+
+import java.time.ZonedDateTime;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.core.domain.Course;
+import de.tum.cit.aet.artemis.core.domain.CourseInformationSharingConfiguration;
+import de.tum.cit.aet.artemis.core.domain.Language;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage;
+
+/**
+ * Data Transfer Object for updating an existing course.
+ * <p>
+ * This DTO is used instead of directly deserializing to a Course entity to prevent
+ * potential issues with entity state management, particularly:
+ * <ul>
+ * <li>Avoiding unintended orphan removal of child entities (e.g., tutorial groups)</li>
+ * <li>The server controls which fields can be updated</li>
+ * <li>Internal entity state (e.g., relationships, computed fields) is not exposed</li>
+ * </ul>
+ * <p>
+ * The {@link #applyTo(Course)} method applies the DTO values to an existing Course entity.
+ *
+ * @see de.tum.cit.aet.artemis.core.web.course.CourseUpdateResource#updateCourse
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record CourseUpdateDTO(
+        // ID is required for update
+        @NotNull Long id,
+
+        // Basic info
+        @NotBlank @Size(max = 255) String title, @NotBlank @Size(max = 255) String shortName, @Size(max = 2000) String description, String semester,
+
+        // Group names
+        String studentGroupName, String teachingAssistantGroupName, String editorGroupName, String instructorGroupName,
+
+        // Dates
+        ZonedDateTime startDate, ZonedDateTime endDate, ZonedDateTime enrollmentStartDate, ZonedDateTime enrollmentEndDate, ZonedDateTime unenrollmentEndDate,
+
+        // Configuration flags
+        boolean testCourse, Boolean onlineCourse, Language language, ProgrammingLanguage defaultProgrammingLanguage,
+
+        // Complaint settings
+        Integer maxComplaints, Integer maxTeamComplaints, int maxComplaintTimeDays, int maxRequestMoreFeedbackTimeDays, int maxComplaintTextLimit,
+        int maxComplaintResponseTextLimit,
+
+        // UI settings
+        String color, String courseIcon, Boolean enrollmentEnabled, @Size(max = 2000) String enrollmentConfirmationMessage, boolean unenrollmentEnabled,
+        String courseInformationSharingMessagingCodeOfConduct,
+
+        // Course features
+        boolean faqEnabled, boolean learningPathsEnabled, boolean studentCourseAnalyticsDashboardEnabled, Integer presentationScore, Integer maxPoints,
+        @Min(0) @Max(5) Integer accuracyOfScores, boolean restrictedAthenaModulesAccess, String timeZone,
+        CourseInformationSharingConfiguration courseInformationSharingConfiguration) {
+
+    /**
+     * Applies the DTO values to an existing Course entity.
+     * <p>
+     * This method updates only the fields that are part of the DTO, leaving
+     * other entity state (like tutorial groups, exercises, etc.) untouched.
+     *
+     * @param course the existing course entity to update
+     * @return the updated course entity
+     */
+    public Course applyTo(Course course) {
+        // Basic info
+        course.setTitle(title);
+        course.setShortName(shortName);
+        course.setDescription(description);
+        course.setSemester(semester);
+
+        // Group names
+        course.setStudentGroupName(studentGroupName);
+        course.setTeachingAssistantGroupName(teachingAssistantGroupName);
+        course.setEditorGroupName(editorGroupName);
+        course.setInstructorGroupName(instructorGroupName);
+
+        // Dates
+        course.setStartDate(startDate);
+        course.setEndDate(endDate);
+        course.setEnrollmentStartDate(enrollmentStartDate);
+        course.setEnrollmentEndDate(enrollmentEndDate);
+        course.setUnenrollmentEndDate(unenrollmentEndDate);
+
+        // Configuration flags
+        course.setTestCourse(testCourse);
+        course.setOnlineCourse(onlineCourse != null && onlineCourse);
+        course.setLanguage(language);
+        course.setDefaultProgrammingLanguage(defaultProgrammingLanguage);
+
+        // Complaint settings
+        course.setMaxComplaints(maxComplaints);
+        course.setMaxTeamComplaints(maxTeamComplaints);
+        course.setMaxComplaintTimeDays(maxComplaintTimeDays);
+        course.setMaxRequestMoreFeedbackTimeDays(maxRequestMoreFeedbackTimeDays);
+        course.setMaxComplaintTextLimit(maxComplaintTextLimit);
+        course.setMaxComplaintResponseTextLimit(maxComplaintResponseTextLimit);
+
+        // UI settings
+        course.setColor(color);
+        course.setCourseIcon(courseIcon);
+        course.setEnrollmentEnabled(enrollmentEnabled);
+        course.setEnrollmentConfirmationMessage(enrollmentConfirmationMessage);
+        course.setUnenrollmentEnabled(unenrollmentEnabled);
+        course.setCourseInformationSharingMessagingCodeOfConduct(courseInformationSharingMessagingCodeOfConduct);
+
+        // Course features
+        course.setFaqEnabled(faqEnabled);
+        course.setLearningPathsEnabled(learningPathsEnabled);
+        course.setStudentCourseAnalyticsDashboardEnabled(studentCourseAnalyticsDashboardEnabled);
+        course.setPresentationScore(presentationScore);
+        course.setMaxPoints(maxPoints);
+        course.setAccuracyOfScores(accuracyOfScores);
+        course.setRestrictedAthenaModulesAccess(restrictedAthenaModulesAccess);
+        course.setTimeZone(timeZone);
+        course.setCourseInformationSharingConfiguration(courseInformationSharingConfiguration);
+
+        return course;
+    }
+
+    /**
+     * Creates a CourseUpdateDTO from an existing Course entity.
+     *
+     * @param course the course entity to convert
+     * @return a new CourseUpdateDTO with values from the course
+     */
+    public static CourseUpdateDTO of(Course course) {
+        return new CourseUpdateDTO(course.getId(), course.getTitle(), course.getShortName(), course.getDescription(), course.getSemester(), course.getStudentGroupName(),
+                course.getTeachingAssistantGroupName(), course.getEditorGroupName(), course.getInstructorGroupName(), course.getStartDate(), course.getEndDate(),
+                course.getEnrollmentStartDate(), course.getEnrollmentEndDate(), course.getUnenrollmentEndDate(), course.isTestCourse(), course.isOnlineCourse(),
+                course.getLanguage(), course.getDefaultProgrammingLanguage(), course.getMaxComplaints(), course.getMaxTeamComplaints(), course.getMaxComplaintTimeDays(),
+                course.getMaxRequestMoreFeedbackTimeDays(), course.getMaxComplaintTextLimit(), course.getMaxComplaintResponseTextLimit(), course.getColor(), course.getCourseIcon(),
+                course.isEnrollmentEnabled(), course.getEnrollmentConfirmationMessage(), course.isUnenrollmentEnabled(), course.getCourseInformationSharingMessagingCodeOfConduct(),
+                course.isFaqEnabled(), course.getLearningPathsEnabled(), course.getStudentCourseAnalyticsDashboardEnabled(), course.getPresentationScore(), course.getMaxPoints(),
+                course.getAccuracyOfScores(), course.getRestrictedAthenaModulesAccess(), course.getTimeZone(), course.getCourseInformationSharingConfiguration());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/course/CourseUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/course/CourseUpdateResource.java
@@ -31,6 +31,7 @@ import de.tum.cit.aet.artemis.communication.service.ConductAgreementService;
 import de.tum.cit.aet.artemis.core.FilePathType;
 import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.core.dto.CourseUpdateDTO;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.repository.CourseRepository;
 import de.tum.cit.aet.artemis.core.repository.UserRepository;
@@ -92,42 +93,42 @@ public class CourseUpdateResource {
         this.userRepository = userRepository;
     }
 
-    private static Set<String> getChangedGroupNames(Course courseUpdate, Course existingCourse) {
+    private static Set<String> getChangedGroupNames(CourseUpdateDTO courseUpdateDTO, Course existingCourse) {
         Set<String> existingGroupNames = new HashSet<>(List.of(existingCourse.getStudentGroupName(), existingCourse.getTeachingAssistantGroupName(),
                 existingCourse.getEditorGroupName(), existingCourse.getInstructorGroupName()));
-        Set<String> newGroupNames = new HashSet<>(List.of(courseUpdate.getStudentGroupName(), courseUpdate.getTeachingAssistantGroupName(), courseUpdate.getEditorGroupName(),
-                courseUpdate.getInstructorGroupName()));
+        Set<String> newGroupNames = new HashSet<>(List.of(courseUpdateDTO.studentGroupName(), courseUpdateDTO.teachingAssistantGroupName(), courseUpdateDTO.editorGroupName(),
+                courseUpdateDTO.instructorGroupName()));
         Set<String> changedGroupNames = new HashSet<>(newGroupNames);
         changedGroupNames.removeAll(existingGroupNames);
         return changedGroupNames;
     }
 
     /**
-     * PUT /courses/:courseId : Updates an existing updatedCourse.
+     * PUT /courses/:courseId : Updates an existing course.
      *
-     * @param courseId     the id of the course to update
-     * @param courseUpdate the course to update
-     * @param file         the optional course icon file
+     * @param courseId        the id of the course to update
+     * @param courseUpdateDTO the DTO containing the course update data
+     * @param file            the optional course icon file
      * @return the ResponseEntity with status 200 (OK) and with body the updated course
      */
     @PutMapping(value = "courses/{courseId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @EnforceAtLeastInstructor
-    public ResponseEntity<Course> updateCourse(@PathVariable Long courseId, @RequestPart("course") Course courseUpdate, @RequestPart(required = false) MultipartFile file)
-            throws URISyntaxException {
-        log.debug("REST request to update Course : {}", courseUpdate);
+    public ResponseEntity<Course> updateCourse(@PathVariable Long courseId, @RequestPart("course") CourseUpdateDTO courseUpdateDTO,
+            @RequestPart(required = false) MultipartFile file) throws URISyntaxException {
+        log.debug("REST request to update Course : {}", courseUpdateDTO);
         User user = userRepository.getUserWithGroupsAndAuthorities();
 
-        var existingCourse = courseRepository.findByIdForUpdateElseThrow(courseUpdate.getId());
+        var existingCourse = courseRepository.findByIdForUpdateElseThrow(courseUpdateDTO.id());
 
-        if (existingCourse.getTimeZone() != null && courseUpdate.getTimeZone() == null) {
+        if (existingCourse.getTimeZone() != null && courseUpdateDTO.timeZone() == null) {
             throw new IllegalArgumentException("You can not remove the time zone of a course");
         }
 
-        var timeZoneChanged = (existingCourse.getTimeZone() != null && courseUpdate.getTimeZone() != null && !existingCourse.getTimeZone().equals(courseUpdate.getTimeZone()));
+        var timeZoneChanged = (existingCourse.getTimeZone() != null && courseUpdateDTO.timeZone() != null && !existingCourse.getTimeZone().equals(courseUpdateDTO.timeZone()));
 
-        var athenaModuleAccessChanged = existingCourse.getRestrictedAthenaModulesAccess() != courseUpdate.getRestrictedAthenaModulesAccess();
+        var athenaModuleAccessChanged = existingCourse.getRestrictedAthenaModulesAccess() != courseUpdateDTO.restrictedAthenaModulesAccess();
 
-        if (!Objects.equals(existingCourse.getShortName(), courseUpdate.getShortName())) {
+        if (!Objects.equals(existingCourse.getShortName(), courseUpdateDTO.shortName())) {
             throw new BadRequestAlertException("The course short name cannot be changed", Course.ENTITY_NAME, "shortNameCannotChange", true);
         }
 
@@ -138,7 +139,7 @@ public class CourseUpdateResource {
         if (!authCheckService.isAdmin(user)) {
             // this means the user must be an instructor, who has NO Admin rights.
             // instructors are not allowed to change group names, because this would lead to security problems
-            final var changedGroupNames = getChangedGroupNames(courseUpdate, existingCourse);
+            final var changedGroupNames = getChangedGroupNames(courseUpdateDTO, existingCourse);
             if (!changedGroupNames.isEmpty()) {
                 throw new BadRequestAlertException("You are not allowed to change the group names of a course", Course.ENTITY_NAME, "groupNamesCannotChange", true);
             }
@@ -148,62 +149,62 @@ public class CourseUpdateResource {
                         "restrictedAthenaModulesAccessCannotChange", true);
             }
             // instructors are not allowed to change the dashboard settings
-            if (existingCourse.getStudentCourseAnalyticsDashboardEnabled() != courseUpdate.getStudentCourseAnalyticsDashboardEnabled()) {
+            if (existingCourse.getStudentCourseAnalyticsDashboardEnabled() != courseUpdateDTO.studentCourseAnalyticsDashboardEnabled()) {
                 throw new BadRequestAlertException("You are not allowed to change the dashboard settings of a course", Course.ENTITY_NAME, "dashboardSettingsCannotChange", true);
             }
         }
 
-        // Make sure to preserve associations in updated entity
-        courseUpdate.setId(courseId);
-        courseUpdate.setPrerequisites(existingCourse.getPrerequisites());
-        courseUpdate.setTutorialGroupsConfiguration(existingCourse.getTutorialGroupsConfiguration());
-        courseUpdate.setOnlineCourseConfiguration(existingCourse.getOnlineCourseConfiguration());
-
-        if (courseUpdate.getTitle().length() > MAX_TITLE_LENGTH) {
+        if (courseUpdateDTO.title().length() > MAX_TITLE_LENGTH) {
             throw new BadRequestAlertException("The course title is too long", Course.ENTITY_NAME, "courseTitleTooLong");
         }
 
-        courseUpdate.validateEnrollmentConfirmationMessage();
-        courseUpdate.validateComplaintsAndRequestMoreFeedbackConfig();
-        courseUpdate.validateOnlineCourseAndEnrollmentEnabled();
-        courseUpdate.validateShortName();
-        courseUpdate.validateAccuracyOfScores();
-        courseUpdate.validateStartAndEndDate();
-        courseUpdate.validateEnrollmentStartAndEndDate();
-        courseUpdate.validateUnenrollmentEndDate();
+        // Save the existing course icon path before applying DTO changes
+        String existingCourseIcon = existingCourse.getCourseIcon();
 
+        // Apply DTO values to the existing course entity - this preserves all relationships
+        courseUpdateDTO.applyTo(existingCourse);
+        existingCourse.setId(courseId); // Ensure the ID is correct
+
+        existingCourse.validateEnrollmentConfirmationMessage();
+        existingCourse.validateComplaintsAndRequestMoreFeedbackConfig();
+        existingCourse.validateOnlineCourseAndEnrollmentEnabled();
+        existingCourse.validateShortName();
+        existingCourse.validateAccuracyOfScores();
+        existingCourse.validateStartAndEndDate();
+        existingCourse.validateEnrollmentStartAndEndDate();
+        existingCourse.validateUnenrollmentEndDate();
         if (file != null) {
             Path basePath = FilePathConverter.getCourseIconFilePath();
             Path savePath = FileUtil.saveFile(file, basePath, FilePathType.COURSE_ICON, false);
-            courseUpdate.setCourseIcon(FilePathConverter.externalUriForFileSystemPath(savePath, FilePathType.COURSE_ICON, courseId).toString());
-            if (existingCourse.getCourseIcon() != null) {
+            existingCourse.setCourseIcon(FilePathConverter.externalUriForFileSystemPath(savePath, FilePathType.COURSE_ICON, courseId).toString());
+            if (existingCourseIcon != null) {
                 // delete old course icon
-                fileService.schedulePathForDeletion(FilePathConverter.fileSystemPathForExternalUri(new URI(existingCourse.getCourseIcon()), FilePathType.COURSE_ICON), 0);
+                fileService.schedulePathForDeletion(FilePathConverter.fileSystemPathForExternalUri(new URI(existingCourseIcon), FilePathType.COURSE_ICON), 0);
             }
         }
-        else if (courseUpdate.getCourseIcon() == null && existingCourse.getCourseIcon() != null) {
+        else if (courseUpdateDTO.courseIcon() == null && existingCourseIcon != null) {
             // delete old course icon
-            fileService.schedulePathForDeletion(FilePathConverter.fileSystemPathForExternalUri(new URI(existingCourse.getCourseIcon()), FilePathType.COURSE_ICON), 0);
+            fileService.schedulePathForDeletion(FilePathConverter.fileSystemPathForExternalUri(new URI(existingCourseIcon), FilePathType.COURSE_ICON), 0);
         }
 
-        if (courseUpdate.isOnlineCourse() != existingCourse.isOnlineCourse()) {
-            if (courseUpdate.isOnlineCourse() && ltiApi.isPresent()) {
-                ltiApi.get().createOnlineCourseConfiguration(courseUpdate);
+        boolean wasOnlineCourse = existingCourse.getOnlineCourseConfiguration() != null;
+        if (courseUpdateDTO.onlineCourse() != null && courseUpdateDTO.onlineCourse() != wasOnlineCourse) {
+            if (courseUpdateDTO.onlineCourse() && ltiApi.isPresent()) {
+                ltiApi.get().createOnlineCourseConfiguration(existingCourse);
             }
             else {
-                courseUpdate.setOnlineCourseConfiguration(null);
+                existingCourse.setOnlineCourseConfiguration(null);
             }
         }
 
-        if (!Objects.equals(courseUpdate.getCourseInformationSharingMessagingCodeOfConduct(), existingCourse.getCourseInformationSharingMessagingCodeOfConduct())) {
+        if (!Objects.equals(courseUpdateDTO.courseInformationSharingMessagingCodeOfConduct(), existingCourse.getCourseInformationSharingMessagingCodeOfConduct())) {
             conductAgreementService.resetUsersAgreeToCodeOfConductInCourse(existingCourse);
         }
 
-        courseUpdate.setId(courseId); // Don't persist a wrong ID
-        Course result = courseRepository.save(courseUpdate);
+        Course result = courseRepository.save(existingCourse);
 
         // if learning paths got enabled, generate learning paths for students
-        if (existingCourse.getLearningPathsEnabled() != courseUpdate.getLearningPathsEnabled() && courseUpdate.getLearningPathsEnabled() && learningPathApi.isPresent()) {
+        if (!existingCourse.getLearningPathsEnabled() && courseUpdateDTO.learningPathsEnabled() && learningPathApi.isPresent()) {
             Course courseWithCompetencies = courseRepository.findWithEagerCompetenciesAndPrerequisitesByIdElseThrow(result.getId());
             Set<User> students = userRepository.getStudentsWithLearnerProfile(courseWithCompetencies);
             learnerProfileApi.ifPresent(api -> api.createCourseLearnerProfiles(courseWithCompetencies, students));
@@ -211,7 +212,7 @@ public class CourseUpdateResource {
         }
 
         // if access to restricted athena modules got disabled for the course, we need to set all exercises that use restricted modules to null
-        if (athenaModuleAccessChanged && !courseUpdate.getRestrictedAthenaModulesAccess()) {
+        if (athenaModuleAccessChanged && !courseUpdateDTO.restrictedAthenaModulesAccess()) {
             athenaApi.ifPresent(api -> api.revokeAccessToRestrictedFeedbackSuggestionModules(result));
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExamImportDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExamImportDTO.java
@@ -1,0 +1,107 @@
+package de.tum.cit.aet.artemis.exam.dto;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.core.domain.Course;
+import de.tum.cit.aet.artemis.exam.domain.Exam;
+import de.tum.cit.aet.artemis.exam.domain.ExerciseGroup;
+
+/**
+ * DTO for importing exams with exercise groups and exercises.
+ * Uses DTOs instead of entity classes to avoid Hibernate detached entity issues.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ExamImportDTO(@NotNull String title, boolean testExam, boolean examWithAttendanceCheck, @NotNull ZonedDateTime visibleDate, @NotNull ZonedDateTime startDate,
+        @NotNull ZonedDateTime endDate, @Nullable ZonedDateTime publishResultsDate, @Nullable ZonedDateTime examStudentReviewStart, @Nullable ZonedDateTime examStudentReviewEnd,
+        @Nullable Integer gracePeriod, int workingTime, @Nullable String startText, @Nullable String endText, @Nullable String confirmationStartText,
+        @Nullable String confirmationEndText, @Nullable Integer examMaxPoints, @Nullable Boolean randomizeExerciseOrder, @Nullable Integer numberOfExercisesInExam,
+        @Nullable Integer numberOfCorrectionRoundsInExam, @Nullable String examiner, @Nullable String moduleNumber, @Nullable String courseName,
+        @Nullable ZonedDateTime exampleSolutionPublicationDate, @Nullable String channelName, @NotNull Long courseId, @Nullable List<ExerciseGroupImportDTO> exerciseGroups) {
+
+    /**
+     * Creates an ExamImportDTO from an existing Exam entity.
+     * Useful for tests and converting existing exams to the import format.
+     *
+     * @param exam     the exam to convert
+     * @param courseId the target course ID
+     * @return the DTO representation
+     */
+    public static ExamImportDTO of(Exam exam, Long courseId) {
+        List<ExerciseGroupImportDTO> exerciseGroupDTOs = null;
+        if (exam.getExerciseGroups() != null && !exam.getExerciseGroups().isEmpty()) {
+            exerciseGroupDTOs = exam.getExerciseGroups().stream().map(ExerciseGroupImportDTO::of).toList();
+        }
+
+        return new ExamImportDTO(exam.getTitle(), exam.isTestExam(), exam.isExamWithAttendanceCheck(), exam.getVisibleDate(), exam.getStartDate(), exam.getEndDate(),
+                exam.getPublishResultsDate(), exam.getExamStudentReviewStart(), exam.getExamStudentReviewEnd(), exam.getGracePeriod(), exam.getWorkingTime(), exam.getStartText(),
+                exam.getEndText(), exam.getConfirmationStartText(), exam.getConfirmationEndText(), exam.getExamMaxPoints(), exam.getRandomizeExerciseOrder(),
+                exam.getNumberOfExercisesInExam(), exam.getNumberOfCorrectionRoundsInExam(), exam.getExaminer(), exam.getModuleNumber(), exam.getCourseName(),
+                exam.getExampleSolutionPublicationDate(), exam.getChannelName(), courseId, exerciseGroupDTOs);
+    }
+
+    /**
+     * Creates a new Exam entity from this DTO.
+     *
+     * @param course the course to associate with the exam
+     * @return a new Exam entity with exercise groups
+     */
+    public Exam toEntity(Course course) {
+        Exam exam = new Exam();
+        exam.setTitle(title);
+        exam.setTestExam(testExam);
+        exam.setExamWithAttendanceCheck(examWithAttendanceCheck);
+        exam.setVisibleDate(visibleDate);
+        exam.setStartDate(startDate);
+        exam.setEndDate(endDate);
+        exam.setPublishResultsDate(publishResultsDate);
+        exam.setExamStudentReviewStart(examStudentReviewStart);
+        exam.setExamStudentReviewEnd(examStudentReviewEnd);
+        if (gracePeriod != null) {
+            exam.setGracePeriod(gracePeriod);
+        }
+        exam.setWorkingTime(workingTime);
+        exam.setStartText(startText);
+        exam.setEndText(endText);
+        exam.setConfirmationStartText(confirmationStartText);
+        exam.setConfirmationEndText(confirmationEndText);
+        exam.setExamMaxPoints(examMaxPoints);
+        exam.setRandomizeExerciseOrder(randomizeExerciseOrder);
+        exam.setNumberOfExercisesInExam(numberOfExercisesInExam);
+        exam.setNumberOfCorrectionRoundsInExam(numberOfCorrectionRoundsInExam);
+        exam.setExaminer(examiner);
+        exam.setModuleNumber(moduleNumber);
+        exam.setCourseName(courseName);
+        exam.setExampleSolutionPublicationDate(exampleSolutionPublicationDate);
+        exam.setChannelName(channelName);
+        exam.setCourse(course);
+
+        // Add exercise groups with exercises
+        if (exerciseGroups != null) {
+            for (ExerciseGroupImportDTO groupDTO : exerciseGroups) {
+                ExerciseGroup group = groupDTO.toEntity();
+                exam.addExerciseGroup(group);
+            }
+        }
+
+        return exam;
+    }
+
+    /**
+     * Gets the list of exercise groups or an empty list if null.
+     *
+     * @return the exercise groups or empty list
+     */
+    public List<ExerciseGroupImportDTO> exerciseGroupsOrEmpty() {
+        return exerciseGroups != null ? exerciseGroups : new ArrayList<>();
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExamUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExamUpdateDTO.java
@@ -1,0 +1,112 @@
+package de.tum.cit.aet.artemis.exam.dto;
+
+import java.time.ZonedDateTime;
+
+import jakarta.validation.constraints.NotNull;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.exam.domain.Exam;
+
+/**
+ * DTO for creating and updating exams.
+ * Uses DTOs instead of entity classes to avoid Hibernate detached entity issues.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ExamUpdateDTO(@Nullable Long id, @NotNull String title, boolean testExam, boolean examWithAttendanceCheck, @NotNull ZonedDateTime visibleDate,
+        @NotNull ZonedDateTime startDate, @NotNull ZonedDateTime endDate, @Nullable ZonedDateTime publishResultsDate, @Nullable ZonedDateTime examStudentReviewStart,
+        @Nullable ZonedDateTime examStudentReviewEnd, @Nullable Integer gracePeriod, int workingTime, @Nullable String startText, @Nullable String endText,
+        @Nullable String confirmationStartText, @Nullable String confirmationEndText, @Nullable Integer examMaxPoints, @Nullable Boolean randomizeExerciseOrder,
+        @Nullable Integer numberOfExercisesInExam, @Nullable Integer numberOfCorrectionRoundsInExam, @Nullable String examiner, @Nullable String moduleNumber,
+        @Nullable String courseName, @Nullable ZonedDateTime exampleSolutionPublicationDate, @Nullable String channelName) {
+
+    /**
+     * Creates an ExamUpdateDTO from the given Exam domain object.
+     *
+     * @param exam the exam to convert
+     * @return the corresponding DTO
+     */
+    public static ExamUpdateDTO of(Exam exam) {
+        return new ExamUpdateDTO(exam.getId(), exam.getTitle(), exam.isTestExam(), exam.isExamWithAttendanceCheck(), exam.getVisibleDate(), exam.getStartDate(), exam.getEndDate(),
+                exam.getPublishResultsDate(), exam.getExamStudentReviewStart(), exam.getExamStudentReviewEnd(), exam.getGracePeriod(), exam.getWorkingTime(), exam.getStartText(),
+                exam.getEndText(), exam.getConfirmationStartText(), exam.getConfirmationEndText(), exam.getExamMaxPoints(), exam.getRandomizeExerciseOrder(),
+                exam.getNumberOfExercisesInExam(), exam.getNumberOfCorrectionRoundsInExam(), exam.getExaminer(), exam.getModuleNumber(), exam.getCourseName(),
+                exam.getExampleSolutionPublicationDate(), exam.getChannelName());
+    }
+
+    /**
+     * Creates a new Exam entity from this DTO.
+     * Used for create operations.
+     *
+     * @return a new Exam entity
+     */
+    public Exam toEntity() {
+        Exam exam = new Exam();
+        exam.setTitle(title);
+        exam.setTestExam(testExam);
+        exam.setExamWithAttendanceCheck(examWithAttendanceCheck);
+        exam.setVisibleDate(visibleDate);
+        exam.setStartDate(startDate);
+        exam.setEndDate(endDate);
+        exam.setPublishResultsDate(publishResultsDate);
+        exam.setExamStudentReviewStart(examStudentReviewStart);
+        exam.setExamStudentReviewEnd(examStudentReviewEnd);
+        if (gracePeriod != null) {
+            exam.setGracePeriod(gracePeriod);
+        }
+        exam.setWorkingTime(workingTime);
+        exam.setStartText(startText);
+        exam.setEndText(endText);
+        exam.setConfirmationStartText(confirmationStartText);
+        exam.setConfirmationEndText(confirmationEndText);
+        exam.setExamMaxPoints(examMaxPoints);
+        exam.setRandomizeExerciseOrder(randomizeExerciseOrder);
+        exam.setNumberOfExercisesInExam(numberOfExercisesInExam);
+        exam.setNumberOfCorrectionRoundsInExam(numberOfCorrectionRoundsInExam);
+        exam.setExaminer(examiner);
+        exam.setModuleNumber(moduleNumber);
+        exam.setCourseName(courseName);
+        exam.setExampleSolutionPublicationDate(exampleSolutionPublicationDate);
+        exam.setChannelName(channelName);
+        return exam;
+    }
+
+    /**
+     * Applies the DTO values to an existing Exam entity.
+     * This updates the managed entity with values from the DTO.
+     *
+     * @param exam the existing exam to update
+     */
+    public void applyTo(Exam exam) {
+        exam.setTitle(title);
+        // testExam cannot be changed after creation, so we don't set it here
+        exam.setExamWithAttendanceCheck(examWithAttendanceCheck);
+        exam.setVisibleDate(visibleDate);
+        exam.setStartDate(startDate);
+        exam.setEndDate(endDate);
+        exam.setPublishResultsDate(publishResultsDate);
+        exam.setExamStudentReviewStart(examStudentReviewStart);
+        exam.setExamStudentReviewEnd(examStudentReviewEnd);
+        if (gracePeriod != null) {
+            exam.setGracePeriod(gracePeriod);
+        }
+        exam.setWorkingTime(workingTime);
+        exam.setStartText(startText);
+        exam.setEndText(endText);
+        exam.setConfirmationStartText(confirmationStartText);
+        exam.setConfirmationEndText(confirmationEndText);
+        exam.setExamMaxPoints(examMaxPoints);
+        exam.setRandomizeExerciseOrder(randomizeExerciseOrder);
+        exam.setNumberOfExercisesInExam(numberOfExercisesInExam);
+        exam.setNumberOfCorrectionRoundsInExam(numberOfCorrectionRoundsInExam);
+        exam.setExaminer(examiner);
+        exam.setModuleNumber(moduleNumber);
+        exam.setCourseName(courseName);
+        exam.setExampleSolutionPublicationDate(exampleSolutionPublicationDate);
+        exam.setChannelName(channelName);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExerciseGroupImportDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExerciseGroupImportDTO.java
@@ -1,0 +1,66 @@
+package de.tum.cit.aet.artemis.exam.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.exam.domain.ExerciseGroup;
+import de.tum.cit.aet.artemis.exercise.domain.Exercise;
+
+/**
+ * DTO for importing exercise groups.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ExerciseGroupImportDTO(@Nullable String title, boolean isMandatory, @Nullable List<ExerciseImportDTO> exercises) {
+
+    /**
+     * Creates an ExerciseGroupImportDTO from an existing ExerciseGroup entity.
+     *
+     * @param group the exercise group to convert
+     * @return the DTO representation
+     */
+    public static ExerciseGroupImportDTO of(ExerciseGroup group) {
+        List<ExerciseImportDTO> exerciseDTOs = null;
+        if (group.getExercises() != null && !group.getExercises().isEmpty()) {
+            exerciseDTOs = group.getExercises().stream().map(ExerciseImportDTO::of).toList();
+        }
+        return new ExerciseGroupImportDTO(group.getTitle(), group.getIsMandatory(), exerciseDTOs);
+    }
+
+    /**
+     * Creates a new ExerciseGroup entity from this DTO.
+     *
+     * @return a new ExerciseGroup entity
+     */
+    public ExerciseGroup toEntity() {
+        ExerciseGroup group = new ExerciseGroup();
+        group.setTitle(title);
+        group.setIsMandatory(isMandatory);
+
+        // Add exercises
+        if (exercises != null) {
+            for (ExerciseImportDTO exerciseDTO : exercises) {
+                Exercise exercise = exerciseDTO.toEntity();
+                if (exercise != null) {
+                    group.addExercise(exercise);
+                }
+            }
+        }
+
+        return group;
+    }
+
+    /**
+     * Gets the list of exercises or an empty list if null.
+     *
+     * @return the exercises or empty list
+     */
+    public List<ExerciseImportDTO> exercisesOrEmpty() {
+        return exercises != null ? exercises : new ArrayList<>();
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExerciseGroupUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExerciseGroupUpdateDTO.java
@@ -1,0 +1,40 @@
+package de.tum.cit.aet.artemis.exam.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.exam.domain.ExerciseGroup;
+
+/**
+ * DTO for updating exercise groups.
+ * Uses DTOs instead of entity classes to avoid Hibernate detached entity issues.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ExerciseGroupUpdateDTO(@NotNull Long id, @Nullable String title, @NotNull Boolean isMandatory) {
+
+    /**
+     * Creates an ExerciseGroupUpdateDTO from the given ExerciseGroup domain object.
+     *
+     * @param exerciseGroup the exercise group to convert
+     * @return the corresponding DTO
+     */
+    public static ExerciseGroupUpdateDTO of(ExerciseGroup exerciseGroup) {
+        return new ExerciseGroupUpdateDTO(exerciseGroup.getId(), exerciseGroup.getTitle(), exerciseGroup.getIsMandatory());
+    }
+
+    /**
+     * Applies the DTO values to an existing ExerciseGroup entity.
+     * This updates the managed entity with values from the DTO.
+     *
+     * @param exerciseGroup the existing exercise group to update
+     */
+    public void applyTo(ExerciseGroup exerciseGroup) {
+        exerciseGroup.setTitle(title);
+        exerciseGroup.setIsMandatory(isMandatory);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExerciseImportDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExerciseImportDTO.java
@@ -1,0 +1,81 @@
+package de.tum.cit.aet.artemis.exam.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.exercise.domain.Exercise;
+import de.tum.cit.aet.artemis.exercise.domain.ExerciseType;
+import de.tum.cit.aet.artemis.fileupload.domain.FileUploadExercise;
+import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
+import de.tum.cit.aet.artemis.quiz.domain.QuizExercise;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
+
+/**
+ * DTO for importing exercises. Contains the source exercise ID and optional overrides.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ExerciseImportDTO(@NotNull Long id, @NotNull ExerciseType exerciseType, @Nullable String title, @Nullable String shortName, @Nullable Double maxPoints,
+        @Nullable Double bonusPoints) {
+
+    /**
+     * Creates an ExerciseImportDTO from an existing Exercise entity.
+     *
+     * @param exercise the exercise to convert
+     * @return the DTO representation
+     */
+    public static ExerciseImportDTO of(Exercise exercise) {
+        return new ExerciseImportDTO(exercise.getId(), exercise.getExerciseType(), exercise.getTitle(), exercise.getShortName(), exercise.getMaxPoints(),
+                exercise.getBonusPoints());
+    }
+
+    /**
+     * Creates a skeleton Exercise entity from this DTO.
+     * The actual exercise import will use the ID to look up the source exercise.
+     *
+     * @return a new Exercise entity with basic properties set
+     */
+    public Exercise toEntity() {
+        Exercise exercise = createExerciseByType(exerciseType);
+
+        exercise.setId(id);
+        if (title != null) {
+            exercise.setTitle(title);
+        }
+        if (shortName != null) {
+            exercise.setShortName(shortName);
+        }
+        if (maxPoints != null) {
+            exercise.setMaxPoints(maxPoints);
+        }
+        if (bonusPoints != null) {
+            exercise.setBonusPoints(bonusPoints);
+        }
+
+        return exercise;
+    }
+
+    private static Exercise createExerciseByType(ExerciseType type) {
+        if (type == ExerciseType.MODELING) {
+            return new ModelingExercise();
+        }
+        else if (type == ExerciseType.TEXT) {
+            return new TextExercise();
+        }
+        else if (type == ExerciseType.PROGRAMMING) {
+            return new ProgrammingExercise();
+        }
+        else if (type == ExerciseType.FILE_UPLOAD) {
+            return new FileUploadExercise();
+        }
+        else if (type == ExerciseType.QUIZ) {
+            return new QuizExercise();
+        }
+        throw new IllegalArgumentException("Unknown exercise type: " + type);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamImportService.java
@@ -325,12 +325,18 @@ public class ExamImportService {
                 }
 
                 case QUIZ -> {
-                    final Optional<QuizExercise> optionalOriginalQuizExercise = quizExerciseRepository.findById(exerciseToCopy.getId());
+                    // Use a query that eagerly loads quiz questions, grading criteria, and other needed associations
+                    final Optional<QuizExercise> optionalOriginalQuizExercise = quizExerciseRepository
+                            .findWithEagerQuestionsAndStatisticsAndCompetenciesAndBatchesAndGradingCriteriaById(exerciseToCopy.getId());
                     if (optionalOriginalQuizExercise.isEmpty()) {
                         yield Optional.empty();
                     }
+                    // The import service copies questions from the second parameter (importedExercise),
+                    // so we need to pass the original quiz with questions but set the new exercise group on it
+                    var originalQuizExercise = optionalOriginalQuizExercise.get();
+                    originalQuizExercise.setExerciseGroup(exerciseToCopy.getExerciseGroup());
                     // We don't allow a modification of the exercise at this point, so we can just pass an empty list of files.
-                    yield Optional.of(quizExerciseImportService.importQuizExercise(optionalOriginalQuizExercise.get(), (QuizExercise) exerciseToCopy, null));
+                    yield Optional.of(quizExerciseImportService.importQuizExercise(originalQuizExercise, originalQuizExercise, null));
                 }
             };
             // Attach the newly created Exercise to the new Exercise Group only if the importing was successful

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamImportService.java
@@ -285,24 +285,28 @@ public class ExamImportService {
         for (Exercise exerciseToCopy : exerciseGroupToCopy.getExercises()) {
             // We need to set the new Exercise Group to the old exercise, so the new exercise group is correctly set for the new exercise
             exerciseToCopy.setExerciseGroup(exerciseGroupCopied);
+            // Extract the source exercise ID and clear it from the skeleton exercise to avoid
+            // Hibernate conflicts with managed entities that have the same ID in the persistence context
+            Long sourceExerciseId = exerciseToCopy.getId();
+            exerciseToCopy.setId(null);
             Optional<? extends Exercise> exerciseCopied = switch (exerciseToCopy.getExerciseType()) {
                 case MODELING -> {
                     if (modelingExerciseImportApi.isEmpty()) {
                         yield Optional.empty();
                     }
-                    yield modelingExerciseImportApi.get().importModelingExercise(exerciseToCopy.getId(), (ModelingExercise) exerciseToCopy);
+                    yield modelingExerciseImportApi.get().importModelingExercise(sourceExerciseId, (ModelingExercise) exerciseToCopy);
                 }
 
                 case TEXT -> {
                     if (textExerciseImportApi.isEmpty()) {
                         yield Optional.empty();
                     }
-                    yield textExerciseImportApi.get().importTextExercise(exerciseToCopy.getId(), (TextExercise) exerciseToCopy);
+                    yield textExerciseImportApi.get().importTextExercise(sourceExerciseId, (TextExercise) exerciseToCopy);
                 }
 
                 case PROGRAMMING -> {
                     final Optional<ProgrammingExercise> optionalOriginalProgrammingExercise = programmingExerciseRepository
-                            .findByIdWithEagerTestCasesStaticCodeAnalysisCategoriesHintsAndTemplateAndSolutionParticipationsAndAuxReposAndBuildConfig(exerciseToCopy.getId());
+                            .findByIdWithEagerTestCasesStaticCodeAnalysisCategoriesHintsAndTemplateAndSolutionParticipationsAndAuxReposAndBuildConfig(sourceExerciseId);
                     if (optionalOriginalProgrammingExercise.isEmpty()) {
                         yield Optional.empty();
                     }
@@ -321,13 +325,13 @@ public class ExamImportService {
                     if (fileUploadImportApi.isEmpty()) {
                         yield Optional.empty();
                     }
-                    yield fileUploadImportApi.get().importFileUploadExercise(exerciseToCopy.getId(), (FileUploadExercise) exerciseToCopy);
+                    yield fileUploadImportApi.get().importFileUploadExercise(sourceExerciseId, (FileUploadExercise) exerciseToCopy);
                 }
 
                 case QUIZ -> {
                     // Use a query that eagerly loads quiz questions, grading criteria, and other needed associations
                     final Optional<QuizExercise> optionalOriginalQuizExercise = quizExerciseRepository
-                            .findWithEagerQuestionsAndStatisticsAndCompetenciesAndBatchesAndGradingCriteriaById(exerciseToCopy.getId());
+                            .findWithEagerQuestionsAndStatisticsAndCompetenciesAndBatchesAndGradingCriteriaById(sourceExerciseId);
                     if (optionalOriginalQuizExercise.isEmpty()) {
                         yield Optional.empty();
                     }

--- a/src/main/java/de/tum/cit/aet/artemis/exam/web/ExamResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/web/ExamResource.java
@@ -90,9 +90,11 @@ import de.tum.cit.aet.artemis.exam.domain.SuspiciousSessionsAnalysisOptions;
 import de.tum.cit.aet.artemis.exam.dto.ActiveExamDTO;
 import de.tum.cit.aet.artemis.exam.dto.ExamChecklistDTO;
 import de.tum.cit.aet.artemis.exam.dto.ExamDeletionSummaryDTO;
+import de.tum.cit.aet.artemis.exam.dto.ExamImportDTO;
 import de.tum.cit.aet.artemis.exam.dto.ExamInformationDTO;
 import de.tum.cit.aet.artemis.exam.dto.ExamScoresDTO;
 import de.tum.cit.aet.artemis.exam.dto.ExamSidebarDataDTO;
+import de.tum.cit.aet.artemis.exam.dto.ExamUpdateDTO;
 import de.tum.cit.aet.artemis.exam.dto.ExamUserDTO;
 import de.tum.cit.aet.artemis.exam.dto.ExamWithIdAndCourseDTO;
 import de.tum.cit.aet.artemis.exam.dto.SuspiciousExamSessionsDTO;
@@ -215,28 +217,30 @@ public class ExamResource {
      * POST /courses/{courseId}/exams : Create a new exam.
      *
      * @param courseId the course to which the exam belongs
-     * @param exam     the exam to create
+     * @param examDTO  the exam DTO to create
      * @return the ResponseEntity with status 201 (Created) and with body the new exam, or with status 400 (Bad Request) if the exam has already an ID
      * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PostMapping("courses/{courseId}/exams")
     @EnforceAtLeastInstructor
-    public ResponseEntity<Exam> createExam(@PathVariable Long courseId, @RequestBody Exam exam) throws URISyntaxException {
-        log.debug("REST request to create an exam : {}", exam);
-        if (exam.getId() != null) {
+    public ResponseEntity<Exam> createExam(@PathVariable Long courseId, @RequestBody ExamUpdateDTO examDTO) throws URISyntaxException {
+        log.debug("REST request to create an exam : {}", examDTO);
+        if (examDTO.id() != null) {
             throw new BadRequestAlertException("A new exam cannot already have an ID", ENTITY_NAME, "idExists");
         }
 
+        examAccessService.checkCourseAccessForInstructorElseThrow(courseId);
+
+        Course course = courseRepository.findByIdElseThrow(courseId);
+        Exam exam = examDTO.toEntity();
+        exam.setCourse(course);
+
         checkForExamConflictsElseThrow(courseId, exam);
 
-        // Check that exerciseGroups are not set to prevent manipulation of associated exerciseGroups
-        if (!exam.getExerciseGroups().isEmpty()) {
-            throw new ConflictException("A new exam cannot have exercise groups yet", ENTITY_NAME, "groupsExist");
-        }
+        // New exams don't have exercise groups, so no need to check
 
-        examAccessService.checkCourseAccessForInstructorElseThrow(courseId);
         Exam savedExam = examRepository.save(exam);
-        channelService.createExamChannel(savedExam, Optional.ofNullable(exam.getChannelName()));
+        channelService.createExamChannel(savedExam, Optional.ofNullable(examDTO.channelName()));
         return ResponseEntity.created(new URI("/api/exam/courses/" + courseId + "/exams/" + savedExam.getId())).body(savedExam);
     }
 
@@ -244,43 +248,42 @@ public class ExamResource {
      * PUT /courses/{courseId}/exams : Updates an existing exam.
      * This route does not save changes to the exercise groups. This should be done via the ExerciseGroupResource.
      *
-     * @param courseId    the course to which the exam belongs
-     * @param updatedExam the exam to update
+     * @param courseId      the course to which the exam belongs
+     * @param examUpdateDTO the exam update DTO containing the new values
      * @return the ResponseEntity with status 200 (OK) and with body the updated exam
-     * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PutMapping("courses/{courseId}/exams")
     @EnforceAtLeastInstructor
-    // TODO: use a DTO here
-    public ResponseEntity<Exam> updateExam(@PathVariable Long courseId, @RequestBody Exam updatedExam) throws URISyntaxException {
-        log.debug("REST request to update an exam : {}", updatedExam);
+    public ResponseEntity<Exam> updateExam(@PathVariable Long courseId, @RequestBody ExamUpdateDTO examUpdateDTO) {
+        log.debug("REST request to update an exam : {}", examUpdateDTO);
 
-        if (updatedExam.getId() == null) {
-            return createExam(courseId, updatedExam);
+        if (examUpdateDTO.id() == null) {
+            throw new BadRequestAlertException("An exam update must have an ID", ENTITY_NAME, "idMissing");
         }
 
-        checkForExamConflictsElseThrow(courseId, updatedExam);
+        examAccessService.checkCourseAndExamAccessForInstructorElseThrow(courseId, examUpdateDTO.id());
 
-        examAccessService.checkCourseAndExamAccessForInstructorElseThrow(courseId, updatedExam.getId());
-
-        // Make sure that the original references are preserved.
-        Exam originalExam = examRepository.findByIdElseThrow(updatedExam.getId());
+        // Fetch the original exam from the database (this is the managed entity)
+        Exam originalExam = examRepository.findByIdElseThrow(examUpdateDTO.id());
         var originalExamDuration = originalExam.getDuration();
+        ZonedDateTime originalVisibleDate = originalExam.getVisibleDate();
+        ZonedDateTime originalStartDate = originalExam.getStartDate();
+        ZonedDateTime originalEndDate = originalExam.getEndDate();
 
         // The Exam Mode cannot be changed after creation -> Compare request with version in the database
-        if (updatedExam.isTestExam() != originalExam.isTestExam()) {
+        if (examUpdateDTO.testExam() != originalExam.isTestExam()) {
             throw new ConflictException("The Exam Mode cannot be changed after creation", ENTITY_NAME, "examModeMismatch");
         }
 
-        // NOTE: Make sure that all references are preserved here
-        updatedExam.setExerciseGroups(originalExam.getExerciseGroups());
-        updatedExam.setStudentExams(originalExam.getStudentExams());
-        updatedExam.setExamUsers(originalExam.getExamUsers());
-        updatedExam.setExamRoomAssignments(originalExam.getExamRoomAssignments());
+        // Apply DTO values to the managed entity
+        examUpdateDTO.applyTo(originalExam);
 
-        Channel updatedChannel = channelService.updateExamChannel(originalExam, updatedExam);
+        // Validate the updated exam
+        checkForExamConflictsElseThrow(courseId, originalExam);
 
-        Exam savedExam = examRepository.save(updatedExam);
+        Channel updatedChannel = channelService.updateExamChannel(originalExam, originalExam);
+
+        Exam savedExam = examRepository.save(originalExam);
 
         User instructor = userRepository.getUser();
         final var auditEvent = new AuditEvent(instructor.getLogin(), Constants.UPDATE_EXAM, "exam=" + savedExam.getId());
@@ -290,9 +293,9 @@ public class ExamResource {
         Exam examWithExercises = examService.findByIdWithExerciseGroupsAndExercisesElseThrow(savedExam.getId(), false);
 
         Comparator<ZonedDateTime> comparator = ExamDateUtil.truncatedComparator();
-        boolean visibleOrStartDateChanged = comparator.compare(originalExam.getVisibleDate(), updatedExam.getVisibleDate()) != 0
-                || comparator.compare(originalExam.getStartDate(), updatedExam.getStartDate()) != 0;
-        boolean endDateChanged = comparator.compare(originalExam.getEndDate(), updatedExam.getEndDate()) != 0;
+        boolean visibleOrStartDateChanged = comparator.compare(originalVisibleDate, savedExam.getVisibleDate()) != 0
+                || comparator.compare(originalStartDate, savedExam.getStartDate()) != 0;
+        boolean endDateChanged = comparator.compare(originalEndDate, savedExam.getEndDate()) != 0;
         if (visibleOrStartDateChanged) {
             // for all programming exercises in the exam, send their ids for scheduling
             examWithExercises.getExerciseGroups().stream().flatMap(group -> group.getExercises().stream()).filter(ProgrammingExercise.class::isInstance).map(Exercise::getId)
@@ -309,7 +312,7 @@ public class ExamResource {
         examService.syncExamExercisesMetadata(examWithExercises, visibleOrStartDateChanged, endDateChanged);
 
         if (updatedChannel != null) {
-            savedExam.setChannelName(updatedExam.getChannelName());
+            savedExam.setChannelName(examUpdateDTO.channelName());
         }
 
         return ResponseEntity.ok(savedExam);
@@ -381,27 +384,26 @@ public class ExamResource {
     /**
      * POST /courses/{courseId}/exam-import : Imports a new exam with exercises.
      *
-     * @param courseId         the course to which the exam belongs
-     * @param examToBeImported the exam to import / create
+     * @param courseId      the course to which the exam belongs
+     * @param examImportDTO the exam import DTO containing the exam data and exercise group references
      * @return the ResponseEntity with status 201 (Created) and with body the newly imported exam, or with status 400 (Bad Request) if the exam has already an ID
      * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PostMapping("courses/{courseId}/exam-import")
     @EnforceAtLeastInstructor
-    public ResponseEntity<Exam> importExamWithExercises(@PathVariable Long courseId, @RequestBody Exam examToBeImported) throws URISyntaxException, IOException {
-        log.debug("REST request to import an exam : {}", examToBeImported);
-
-        // Step 1: Check if Exam has an ID
-        if (examToBeImported.getId() != null) {
-            throw new BadRequestAlertException("A imported exam cannot already have an ID", ENTITY_NAME, "idexists");
-        }
+    public ResponseEntity<Exam> importExamWithExercises(@PathVariable Long courseId, @RequestBody ExamImportDTO examImportDTO) throws URISyntaxException, IOException {
+        log.debug("REST request to import an exam : {}", examImportDTO);
 
         examAccessService.checkCourseAccessForInstructorElseThrow(courseId);
 
-        // Step 3: Validate the Exam dates
+        // Load the course and create the Exam entity from the DTO
+        Course course = courseRepository.findByIdElseThrow(courseId);
+        Exam examToBeImported = examImportDTO.toEntity(course);
+
+        // Validate the Exam dates and configuration
         checkForExamConflictsElseThrow(courseId, examToBeImported);
 
-        // Step 4: Import Exam with Exercises and create a channel for the exam
+        // Import Exam with Exercises and create a channel for the exam
         Exam examCopied = examImportService.importExamWithExercises(examToBeImported, courseId);
 
         return ResponseEntity.created(new URI("/api/exam/courses/" + courseId + "/exams/" + examCopied.getId()))

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/CompetencyLinksHolderDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/CompetencyLinksHolderDTO.java
@@ -1,0 +1,10 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.util.Set;
+
+import de.tum.cit.aet.artemis.lecture.dto.CompetencyLinkDTO;
+
+public interface CompetencyLinksHolderDTO {
+
+    Set<CompetencyLinkDTO> competencyLinks();
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationDueDateUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationDueDateUpdateDTO.java
@@ -1,0 +1,33 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.time.ZonedDateTime;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+
+/**
+ * DTO for updating a participation's individual due date.
+ *
+ * @param id                the ID of the participation to update
+ * @param exerciseId        the ID of the exercise the participation belongs to
+ * @param individualDueDate the new individual due date (can be null to remove)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ParticipationDueDateUpdateDTO(@NotNull Long id, @NotNull Long exerciseId, ZonedDateTime individualDueDate) {
+
+    /**
+     * Creates a ParticipationDueDateUpdateDTO from a StudentParticipation.
+     *
+     * @param participation the participation to convert
+     * @return the DTO representation
+     */
+    public static ParticipationDueDateUpdateDTO of(StudentParticipation participation) {
+        Long exerciseId = participation.getExercise() != null ? participation.getExercise().getId() : null;
+        return new ParticipationDueDateUpdateDTO(participation.getId(), exerciseId, participation.getIndividualDueDate());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationUpdateDTO.java
@@ -1,0 +1,18 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * DTO for updating a participation's presentation score.
+ *
+ * @param id                the ID of the participation to update
+ * @param exerciseId        the ID of the exercise the participation belongs to
+ * @param presentationScore the new presentation score (can be null to remove score)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ParticipationUpdateDTO(@NotNull Long id, @NotNull Long exerciseId, Double presentationScore) {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/TeamImportDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/TeamImportDTO.java
@@ -1,0 +1,81 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.exercise.domain.Team;
+
+/**
+ * DTO for importing teams from a list.
+ * Students are identified by login or registration number (not database IDs).
+ *
+ * @param name      the name of the team
+ * @param shortName the short name of the team
+ * @param image     the image URL of the team
+ * @param students  the set of student identifiers (login or registration number)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record TeamImportDTO(@NotNull @Size(max = 250) String name, @NotNull @Size(max = 10) String shortName, @Nullable @Size(max = 500) String image,
+        @Nullable Set<StudentIdentifierDTO> students) {
+
+    /**
+     * Returns the students, defaulting to an empty set if null.
+     */
+    public Set<StudentIdentifierDTO> studentsOrEmpty() {
+        return students != null ? students : new HashSet<>();
+    }
+
+    /**
+     * DTO for identifying a student by login or registration number.
+     *
+     * @param login                     the login of the student
+     * @param visibleRegistrationNumber the visible registration number of the student
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public record StudentIdentifierDTO(@Nullable String login, @Nullable String visibleRegistrationNumber) {
+
+        /**
+         * Converts this identifier to a User object for lookup.
+         *
+         * @return a User with login or registration number set
+         */
+        public User toUser() {
+            User user = new User();
+            user.setLogin(login);
+            user.setVisibleRegistrationNumber(visibleRegistrationNumber);
+            return user;
+        }
+    }
+
+    /**
+     * Converts this DTO to a Team entity.
+     * Note: The resulting team has students with only login/registration numbers set,
+     * which need to be resolved to actual users later.
+     *
+     * @return a new Team entity
+     */
+    public Team toTeam() {
+        Team team = new Team();
+        team.setName(name);
+        team.setShortName(shortName);
+        team.setImage(image);
+
+        Set<User> studentUsers = new HashSet<>();
+        for (StudentIdentifierDTO studentId : studentsOrEmpty()) {
+            studentUsers.add(studentId.toUser());
+        }
+        team.setStudents(studentUsers);
+
+        return team;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/TeamInputDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/TeamInputDTO.java
@@ -1,0 +1,51 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.exercise.domain.Team;
+
+/**
+ * DTO for creating and updating teams.
+ * Uses user IDs for students and owner references.
+ *
+ * @param id        the id of the team (null for creation)
+ * @param name      the name of the team
+ * @param shortName the short name of the team
+ * @param image     the image URL of the team
+ * @param students  the set of student user IDs
+ * @param ownerId   the owner user ID
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record TeamInputDTO(@Nullable Long id, @NotNull @Size(max = 250) String name, @NotNull @Size(max = 10) String shortName, @Nullable @Size(max = 500) String image,
+        @Nullable Set<Long> students, @Nullable Long ownerId) {
+
+    /**
+     * Returns the students, defaulting to an empty set if null.
+     */
+    public Set<Long> studentsOrEmpty() {
+        return students != null ? students : new HashSet<>();
+    }
+
+    /**
+     * Creates a TeamInputDTO from a Team entity.
+     *
+     * @param team the team entity to convert
+     * @return a new TeamInputDTO with data from the team
+     */
+    public static TeamInputDTO of(Team team) {
+        Set<Long> studentIds = team.getStudents() != null ? team.getStudents().stream().map(User::getId).collect(java.util.stream.Collectors.toSet()) : null;
+        Long ownerId = team.getOwner() != null ? team.getOwner().getId() : null;
+        return new TeamInputDTO(team.getId(), team.getName(), team.getShortName(), team.getImage(), studentIds, ownerId);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseImportService.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.exercise.service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -63,7 +64,8 @@ public abstract class ExerciseImportService {
         newExercise.setDifficulty(importedExercise.getDifficulty());
         newExercise.setGradingInstructions(importedExercise.getGradingInstructions());
         newExercise.setGradingCriteria(importedExercise.copyGradingCriteria(gradingInstructionCopyTracker));
-        newExercise.setCompetencyLinks(importedExercise.getCompetencyLinks());
+        // Create a new set to avoid sharing the collection reference with the managed entity (Hibernate orphan removal protection)
+        newExercise.setCompetencyLinks(new HashSet<>(importedExercise.getCompetencyLinks()));
 
         if (importedExercise.getPlagiarismDetectionConfig() != null) {
             newExercise.setPlagiarismDetectionConfig(new PlagiarismDetectionConfig(importedExercise.getPlagiarismDetectionConfig()));

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseImportService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +15,7 @@ import de.tum.cit.aet.artemis.assessment.domain.Result;
 import de.tum.cit.aet.artemis.assessment.repository.ExampleSubmissionRepository;
 import de.tum.cit.aet.artemis.assessment.repository.ResultRepository;
 import de.tum.cit.aet.artemis.assessment.service.FeedbackService;
+import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.ExerciseMode;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
@@ -64,8 +66,13 @@ public abstract class ExerciseImportService {
         newExercise.setDifficulty(importedExercise.getDifficulty());
         newExercise.setGradingInstructions(importedExercise.getGradingInstructions());
         newExercise.setGradingCriteria(importedExercise.copyGradingCriteria(gradingInstructionCopyTracker));
-        // Create a new set to avoid sharing the collection reference with the managed entity (Hibernate orphan removal protection)
-        newExercise.setCompetencyLinks(new HashSet<>(importedExercise.getCompetencyLinks()));
+        // Copy competency links as NEW unmanaged objects (not sharing managed entities from the template)
+        Set<CompetencyExerciseLink> copiedLinks = new HashSet<>();
+        for (CompetencyExerciseLink link : importedExercise.getCompetencyLinks()) {
+            // Create a new link with just the competency reference and weight (exercise will be set later)
+            copiedLinks.add(new CompetencyExerciseLink(link.getCompetency(), newExercise, link.getWeight()));
+        }
+        newExercise.setCompetencyLinks(copiedLinks);
 
         if (importedExercise.getPlagiarismDetectionConfig() != null) {
             newExercise.setPlagiarismDetectionConfig(new PlagiarismDetectionConfig(importedExercise.getPlagiarismDetectionConfig()));

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseService.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.Strings;
-import org.hibernate.Hibernate;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -832,39 +831,6 @@ public class ExerciseService {
     }
 
     /**
-     * Saves the exercise and links it to the competencies.
-     *
-     * @param exercise     exercise to save
-     * @param saveFunction function to save the exercise
-     * @param <T>          type of the exercise
-     * @return saved exercise
-     */
-    public <T extends Exercise> T saveWithCompetencyLinks(T exercise, Function<T, T> saveFunction) {
-        // persist exercise before linking it to the competency
-        Set<CompetencyExerciseLink> links = exercise.getCompetencyLinks();
-        exercise.setCompetencyLinks(new HashSet<>());
-
-        T savedExercise = saveFunction.apply(exercise);
-
-        if (Hibernate.isInitialized(links) && !links.isEmpty()) {
-            savedExercise.setCompetencyLinks(links);
-            reconnectCompetencyExerciseLinks(savedExercise);
-            competencyRelationApi.ifPresent(api -> savedExercise.setCompetencyLinks(new HashSet<>(api.saveAllExerciseLinks(links))));
-        }
-
-        return savedExercise;
-    }
-
-    /**
-     * Reconnects the competency exercise links to the exercise after the cycle was broken by the deserialization.
-     *
-     * @param exercise exercise to reconnect the links
-     */
-    public void reconnectCompetencyExerciseLinks(Exercise exercise) {
-        exercise.getCompetencyLinks().forEach(link -> link.setExercise(exercise));
-    }
-
-    /**
      * Retrieves a {@link NonQuizExerciseCalendarEventDTO} for each {@link FileUploadExercise}, {@link TextExercise}, {@link ModelingExercise}
      * and {@link ProgrammingExercise} associated to the given courseId. Each DTO encapsulates the releaseDate, startDate, dueDate and assessmentDueDate
      * of the respective exercise.
@@ -990,8 +956,12 @@ public class ExerciseService {
     }
 
     /**
-     * Restores competency links to a saved exercise.
-     * Must be called AFTER the exercise has been saved and has an ID.
+     * Restores competency links to a saved exercise and persists them.
+     * <p>
+     * This method must be called AFTER the exercise has been saved and has an ID.
+     * It sets the proper exercise reference on each link (required for @MapsId) and
+     * adds them to the exercise. The caller must save the exercise again after this call
+     * to persist the links via cascade.
      *
      * @param exercise        the saved exercise (must have an ID)
      * @param competencyLinks the links previously extracted via extractCompetencyLinksForCreation
@@ -1000,9 +970,21 @@ public class ExerciseService {
         if (competencyLinks == null || competencyLinks.isEmpty()) {
             return;
         }
-        for (CompetencyExerciseLink link : competencyLinks) {
-            link.setExercise(exercise);
+        if (competencyRepositoryApi.isEmpty()) {
+            return;
         }
-        exercise.setCompetencyLinks(competencyLinks);
+        // Batch-load all competencies as managed entities to avoid detached entity issues with Hibernate 6.6+
+        Set<Long> competencyIds = competencyLinks.stream().map(link -> link.getCompetency().getId()).collect(Collectors.toSet());
+        Map<Long, CourseCompetency> managedCompetencies = competencyRepositoryApi.get().findAllCompetenciesById(competencyIds).stream()
+                .collect(Collectors.toMap(CourseCompetency::getId, Function.identity()));
+
+        Set<CompetencyExerciseLink> resolvedLinks = new HashSet<>();
+        for (CompetencyExerciseLink link : competencyLinks) {
+            CourseCompetency managedCompetency = managedCompetencies.get(link.getCompetency().getId());
+            if (managedCompetency != null) {
+                resolvedLinks.add(new CompetencyExerciseLink(managedCompetency, exercise, link.getWeight()));
+            }
+        }
+        exercise.setCompetencyLinks(resolvedLinks);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseService.java
@@ -48,6 +48,7 @@ import de.tum.cit.aet.artemis.assessment.repository.ResultRepository;
 import de.tum.cit.aet.artemis.assessment.service.RatingService;
 import de.tum.cit.aet.artemis.assessment.service.TutorLeaderboardService;
 import de.tum.cit.aet.artemis.atlas.api.CompetencyRelationApi;
+import de.tum.cit.aet.artemis.atlas.api.CompetencyRepositoryApi;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CourseCompetency;
 import de.tum.cit.aet.artemis.communication.service.notifications.GroupNotificationScheduleService;
@@ -71,6 +72,7 @@ import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.ExerciseMode;
 import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.CompetencyLinksHolderDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.repository.SubmissionRepository;
@@ -143,6 +145,8 @@ public class ExerciseService {
 
     private final ParticipationFilterService participationFilterService;
 
+    private final Optional<CompetencyRepositoryApi> competencyRepositoryApi;
+
     public ExerciseService(ExerciseRepository exerciseRepository, AuthorizationCheckService authCheckService, AuditEventRepository auditEventRepository,
             TeamRepository teamRepository, ProgrammingExerciseRepository programmingExerciseRepository, StudentParticipationRepository studentParticipationRepository,
             ResultRepository resultRepository, SubmissionRepository submissionRepository, ParticipantScoreRepository participantScoreRepository, Optional<LtiApi> ltiApi,
@@ -150,7 +154,7 @@ public class ExerciseService {
             ComplaintResponseRepository complaintResponseRepository, GradingCriterionRepository gradingCriterionRepository, FeedbackRepository feedbackRepository,
             RatingService ratingService, ExerciseDateService exerciseDateService, ExampleSubmissionRepository exampleSubmissionRepository, QuizBatchService quizBatchService,
             Optional<ExamLiveEventsApi> examLiveEventsApi, GroupNotificationScheduleService groupNotificationScheduleService, Optional<CompetencyRelationApi> competencyRelationApi,
-            ParticipationFilterService participationFilterService) {
+            ParticipationFilterService participationFilterService, Optional<CompetencyRepositoryApi> competencyRepositoryApi) {
         this.exerciseRepository = exerciseRepository;
         this.resultRepository = resultRepository;
         this.authCheckService = authCheckService;
@@ -175,6 +179,7 @@ public class ExerciseService {
         this.groupNotificationScheduleService = groupNotificationScheduleService;
         this.competencyRelationApi = competencyRelationApi;
         this.participationFilterService = participationFilterService;
+        this.competencyRepositoryApi = competencyRepositoryApi;
     }
 
     /**
@@ -927,5 +932,77 @@ public class ExerciseService {
             }
         }
         return events;
+    }
+
+    /**
+     * Updates the competency links of an exercise based on the DTO values.
+     * Reuses existing managed links where possible, creates new ones for new competencies,
+     * and removes links that are no longer present.
+     *
+     * @param dto    the DTO containing the new competency link state
+     * @param entity the exercise entity to update
+     */
+    public void updateCompetencyLinks(CompetencyLinksHolderDTO dto, Exercise entity) {
+        if (competencyRepositoryApi.isEmpty()) {
+            return;
+        }
+        if (dto.competencyLinks() == null || dto.competencyLinks().isEmpty()) {
+            entity.getCompetencyLinks().clear();
+        }
+        else {
+            final var existingLinksByCompetencyId = entity.getCompetencyLinks().stream().collect(Collectors.toMap(link -> link.getCompetency().getId(), Function.identity()));
+
+            Set<CompetencyExerciseLink> updatedLinks = new HashSet<>();
+
+            for (var dtoLink : dto.competencyLinks()) {
+                long competencyId = dtoLink.competency().id();
+                double weight = dtoLink.weight();
+
+                var existingLink = existingLinksByCompetencyId.get(competencyId);
+                if (existingLink != null) {
+                    existingLink.setWeight(weight);
+                    updatedLinks.add(existingLink);
+                }
+                else {
+                    var competency = competencyRepositoryApi.get().findCompetencyOrPrerequisiteByIdElseThrow(competencyId);
+                    var newLink = new CompetencyExerciseLink(competency, entity, weight);
+                    updatedLinks.add(newLink);
+                }
+            }
+
+            entity.getCompetencyLinks().clear();
+            entity.getCompetencyLinks().addAll(updatedLinks);
+        }
+    }
+
+    /**
+     * Extracts competency links from a new exercise before its first save.
+     * The links are cleared from the exercise so it can be saved without them
+     * (since they need the exercise ID which doesn't exist yet).
+     *
+     * @param exercise the new exercise (not yet saved) from which to extract competency links
+     * @return the extracted competency links (may be empty)
+     */
+    public Set<CompetencyExerciseLink> extractCompetencyLinksForCreation(Exercise exercise) {
+        Set<CompetencyExerciseLink> competencyLinks = new HashSet<>(exercise.getCompetencyLinks());
+        exercise.getCompetencyLinks().clear();
+        return competencyLinks;
+    }
+
+    /**
+     * Restores competency links to a saved exercise.
+     * Must be called AFTER the exercise has been saved and has an ID.
+     *
+     * @param exercise        the saved exercise (must have an ID)
+     * @param competencyLinks the links previously extracted via extractCompetencyLinksForCreation
+     */
+    public void addCompetencyLinksForCreation(Exercise exercise, Set<CompetencyExerciseLink> competencyLinks) {
+        if (competencyLinks == null || competencyLinks.isEmpty()) {
+            return;
+        }
+        for (CompetencyExerciseLink link : competencyLinks) {
+            link.setExercise(exercise);
+        }
+        exercise.setCompetencyLinks(competencyLinks);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationService.java
@@ -32,6 +32,7 @@ import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participant;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.ParticipationDueDateUpdateDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.repository.SubmissionRepository;
@@ -709,6 +710,41 @@ public class ParticipationService {
             }
             else {
                 newIndividualDueDate = toBeUpdated.getIndividualDueDate();
+            }
+
+            if (!Objects.equals(originalParticipation.getIndividualDueDate(), newIndividualDueDate)) {
+                originalParticipation.setIndividualDueDate(newIndividualDueDate);
+                changedParticipations.add(originalParticipation);
+            }
+        }
+
+        return changedParticipations;
+    }
+
+    /**
+     * Updates individual due dates for participations based on DTOs.
+     * Similar to updateIndividualDueDates but accepts DTOs instead of entities.
+     *
+     * @param exercise       the exercise the participations belong to.
+     * @param dueDateUpdates the DTOs containing participation IDs and new individual due dates.
+     * @return all participations where the individual due date actually changed.
+     */
+    public List<StudentParticipation> updateIndividualDueDatesFromDTOs(final Exercise exercise, final List<ParticipationDueDateUpdateDTO> dueDateUpdates) {
+        final List<StudentParticipation> changedParticipations = new ArrayList<>();
+
+        for (final ParticipationDueDateUpdateDTO dto : dueDateUpdates) {
+            final Optional<StudentParticipation> optionalOriginalParticipation = studentParticipationRepository.findById(dto.id());
+            if (optionalOriginalParticipation.isEmpty()) {
+                continue;
+            }
+            final StudentParticipation originalParticipation = optionalOriginalParticipation.get();
+
+            final ZonedDateTime newIndividualDueDate;
+            if (exercise.getDueDate() == null || (dto.individualDueDate() != null && dto.individualDueDate().isBefore(exercise.getDueDate()))) {
+                newIndividualDueDate = null;
+            }
+            else {
+                newIndividualDueDate = dto.individualDueDate();
             }
 
             if (!Objects.equals(originalParticipation.getIndividualDueDate(), newIndividualDueDate)) {

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationResource.java
@@ -170,7 +170,7 @@ public class ParticipationResource {
             participant = teamRepository.findOneByExerciseIdAndUserId(exercise.getId(), user.getId())
                     .orElseThrow(() -> new BadRequestAlertException("Team exercise cannot be started without assigned team.", "participation", "teamExercise.cannotStart"));
         }
-        StudentParticipation participation = null;
+        StudentParticipation participation;
         try {
             participation = participationService.startExercise(exercise, participant, true);
         }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationUpdateResource.java
@@ -33,6 +33,8 @@ import de.tum.cit.aet.artemis.core.util.HeaderUtil;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.ParticipationDueDateUpdateDTO;
+import de.tum.cit.aet.artemis.exercise.dto.ParticipationUpdateDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.service.ExerciseDateService;
@@ -86,78 +88,83 @@ public class ParticipationUpdateResource {
     }
 
     /**
-     * PUT /participations : Updates an existing participation.
+     * PUT /participations : Updates an existing participation's presentation score.
      *
-     * @param exerciseId    the id of the exercise, the participation belongs to
-     * @param participation the participation to update
+     * @param exerciseId the id of the exercise, the participation belongs to
+     * @param dto        the DTO containing the participation update information
      * @return the ResponseEntity with status 200 (OK) and with body the updated participation, or with status 400 (Bad Request) if the participation is not valid, or with status
      *         500 (Internal Server Error) if the participation couldn't be updated
      */
     @PutMapping("exercises/{exerciseId}/participations")
     @EnforceAtLeastTutor
-    public ResponseEntity<Participation> updateParticipation(@PathVariable long exerciseId, @RequestBody StudentParticipation participation) {
-        log.debug("REST request to update Participation : {}", participation);
-        if (participation.getId() == null) {
-            throw new BadRequestAlertException("The participation object needs to have an id to be changed", ENTITY_NAME, "idmissing");
-        }
-        if (participation.getExercise() == null || participation.getExercise().getId() == null) {
-            throw new BadRequestAlertException("The participation needs to be connected to an exercise", ENTITY_NAME, "exerciseidmissing");
-        }
-        if (participation.getExercise().getId() != exerciseId) {
+    public ResponseEntity<Participation> updateParticipation(@PathVariable long exerciseId, @RequestBody ParticipationUpdateDTO dto) {
+        log.debug("REST request to update Participation : {}", dto);
+        if (dto.exerciseId() != exerciseId) {
             throw new ConflictException("The exercise of the participation does not match the exercise id in the URL", ENTITY_NAME, "noidmatch");
         }
-        var originalParticipation = studentParticipationRepository.findByIdElseThrow(participation.getId());
-        var user = userRepository.getUserWithGroupsAndAuthorities();
-        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, originalParticipation.getExercise(), null);
 
-        Course course = findCourseFromParticipation(participation);
-        if (participation.getPresentationScore() != null && participation.getExercise().getPresentationScoreEnabled() != null
-                && participation.getExercise().getPresentationScoreEnabled()) {
-            Optional<GradingScale> gradingScale = gradingScaleService.findGradingScaleByCourseId(participation.getExercise().getCourseViaExerciseGroupOrCourseMember().getId());
+        // Load the existing participation from database to avoid orphan removal issues with detached entities
+        StudentParticipation existingParticipation = studentParticipationRepository.findByIdElseThrow(dto.id());
+        if (existingParticipation.getExercise().getId() != exerciseId) {
+            throw new ConflictException("The participation does not belong to the specified exercise", ENTITY_NAME, "noidmatch");
+        }
+
+        var user = userRepository.getUserWithGroupsAndAuthorities();
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, existingParticipation.getExercise(), null);
+
+        Course course = existingParticipation.getExercise().getCourseViaExerciseGroupOrCourseMember();
+        Double newPresentationScore = dto.presentationScore();
+
+        if (newPresentationScore != null && existingParticipation.getExercise().getPresentationScoreEnabled() != null
+                && existingParticipation.getExercise().getPresentationScoreEnabled()) {
+            Optional<GradingScale> gradingScale = gradingScaleService.findGradingScaleByCourseId(course.getId());
 
             // Presentation Score is only valid for non practice participations
-            if (participation.isPracticeMode()) {
+            if (existingParticipation.isPracticeMode()) {
                 throw new BadRequestAlertException("Presentation score is not allowed for practice participations", ENTITY_NAME, "presentationScoreInvalid");
             }
 
             // Validity of presentationScore for basic presentations
             if (course.getPresentationScore() != null && course.getPresentationScore() > 0) {
-                if (participation.getPresentationScore() >= 1.) {
-                    participation.setPresentationScore(1.);
+                if (newPresentationScore >= 1.) {
+                    newPresentationScore = 1.;
                 }
                 else {
-                    participation.setPresentationScore(null);
+                    newPresentationScore = null;
                 }
             }
             // Validity of presentationScore for graded presentations
             if (gradingScale.isPresent() && gradingScale.get().getPresentationsNumber() != null) {
-                if ((participation.getPresentationScore() > 100. || participation.getPresentationScore() < 0.)) {
+                if (newPresentationScore != null && (newPresentationScore > 100. || newPresentationScore < 0.)) {
                     throw new BadRequestAlertException("The presentation grade must be between 0 and 100", ENTITY_NAME, "presentationGradeInvalid");
                 }
 
-                long presentationCountForParticipant = studentParticipationRepository.countPresentationScoresForParticipant(course.getId(), participation.getParticipant().getId(),
-                        participation.getId());
+                long presentationCountForParticipant = studentParticipationRepository.countPresentationScoresForParticipant(course.getId(),
+                        existingParticipation.getParticipant().getId(), existingParticipation.getId());
                 if (presentationCountForParticipant >= gradingScale.get().getPresentationsNumber()) {
                     throw new BadRequestAlertException("Participant already gave the maximum number of presentations", ENTITY_NAME,
                             "invalid.presentations.maxNumberOfPresentationsExceeded",
-                            Map.of("name", participation.getParticipant().getName(), "presentationsNumber", gradingScale.get().getPresentationsNumber()));
+                            Map.of("name", existingParticipation.getParticipant().getName(), "presentationsNumber", gradingScale.get().getPresentationsNumber()));
                 }
             }
         }
         // Validity of presentationScore for no presentations
         else {
-            participation.setPresentationScore(null);
+            newPresentationScore = null;
         }
 
-        StudentParticipation currentParticipation = studentParticipationRepository.findByIdElseThrow(participation.getId());
-        if (currentParticipation.getPresentationScore() != null && participation.getPresentationScore() == null || course.getPresentationScore() != null
-                && currentParticipation.getPresentationScore() != null && currentParticipation.getPresentationScore() > participation.getPresentationScore()) {
-            log.info("{} removed the presentation score of {} for exercise with participationId {}", user.getLogin(), originalParticipation.getParticipantIdentifier(),
-                    originalParticipation.getExercise().getId());
+        // Log if presentation score was removed or reduced
+        if (existingParticipation.getPresentationScore() != null && newPresentationScore == null || course.getPresentationScore() != null
+                && existingParticipation.getPresentationScore() != null && newPresentationScore != null && existingParticipation.getPresentationScore() > newPresentationScore) {
+            log.info("{} removed the presentation score of {} for exercise with participationId {}", user.getLogin(), existingParticipation.getParticipantIdentifier(),
+                    existingParticipation.getExercise().getId());
         }
 
-        Participation updatedParticipation = studentParticipationRepository.saveAndFlush(participation);
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, participation.getParticipant().getName()))
+        // Apply the update to the managed entity
+        existingParticipation.setPresentationScore(newPresentationScore);
+
+        Participation updatedParticipation = studentParticipationRepository.saveAndFlush(existingParticipation);
+        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, existingParticipation.getParticipant().getName()))
                 .body(updatedParticipation);
     }
 
@@ -167,17 +174,17 @@ public class ParticipationUpdateResource {
      * If the exercise is a programming exercise, also triggers a scheduling
      * update for the participations where the individual due date has changed.
      *
-     * @param exerciseId     of the exercise the participations belong to.
-     * @param participations for which the individual due date should be updated.
+     * @param exerciseId        of the exercise the participations belong to.
+     * @param dueDateUpdateDTOs the DTOs containing participation IDs and new due dates.
      * @return all participations where the individual due date actually changed.
      */
     @PutMapping("exercises/{exerciseId}/participations/update-individual-due-date")
     @EnforceAtLeastInstructor
-    public ResponseEntity<List<StudentParticipation>> updateParticipationDueDates(@PathVariable long exerciseId, @RequestBody List<StudentParticipation> participations) {
-        final boolean anyInvalidExerciseId = participations.stream()
-                .anyMatch(participation -> participation.getExercise() == null || participation.getExercise().getId() == null || exerciseId != participation.getExercise().getId());
+    public ResponseEntity<List<StudentParticipation>> updateParticipationDueDates(@PathVariable long exerciseId,
+            @RequestBody List<ParticipationDueDateUpdateDTO> dueDateUpdateDTOs) {
+        final boolean anyInvalidExerciseId = dueDateUpdateDTOs.stream().anyMatch(dto -> dto.exerciseId() != exerciseId);
         if (anyInvalidExerciseId) {
-            throw new BadRequestAlertException("The participation needs to be connected to an exercise", ENTITY_NAME, "exerciseidmissing");
+            throw new BadRequestAlertException("The participation needs to be connected to the specified exercise", ENTITY_NAME, "exerciseidmismatch");
         }
 
         final Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
@@ -190,7 +197,7 @@ public class ParticipationUpdateResource {
             throw new BadRequestAlertException("Cannot set individual due dates for quiz exercises", ENTITY_NAME, "quizexercise");
         }
 
-        final List<StudentParticipation> changedParticipations = participationService.updateIndividualDueDates(exercise, participations);
+        final List<StudentParticipation> changedParticipations = participationService.updateIndividualDueDatesFromDTOs(exercise, dueDateUpdateDTOs);
         final List<StudentParticipation> updatedParticipations = studentParticipationRepository.saveAllAndFlush(changedParticipations);
 
         if (!updatedParticipations.isEmpty() && exercise instanceof ProgrammingExercise programmingExercise) {
@@ -208,11 +215,4 @@ public class ParticipationUpdateResource {
         return ResponseEntity.ok().body(updatedParticipations);
     }
 
-    private Course findCourseFromParticipation(StudentParticipation participation) {
-        if (participation.getExercise() != null && participation.getExercise().getCourseViaExerciseGroupOrCourseMember() != null) {
-            return participation.getExercise().getCourseViaExerciseGroupOrCourseMember();
-        }
-
-        return studentParticipationRepository.findByIdElseThrow(participation.getId()).getExercise().getCourseViaExerciseGroupOrCourseMember();
-    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/service/FileUploadExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/service/FileUploadExerciseImportService.java
@@ -61,7 +61,13 @@ public class FileUploadExerciseImportService extends ExerciseImportService {
         log.debug("Creating a new Exercise based on exercise {}", templateExercise);
         FileUploadExercise newExercise = copyFileUploadExerciseBasis(importedExercise);
 
-        FileUploadExercise newFileUploadExercise = exerciseService.saveWithCompetencyLinks(newExercise, fileUploadExerciseRepository::save);
+        var competencyLinks = exerciseService.extractCompetencyLinksForCreation(newExercise);
+        FileUploadExercise savedExercise = fileUploadExerciseRepository.save(newExercise);
+        if (!competencyLinks.isEmpty()) {
+            exerciseService.addCompetencyLinksForCreation(savedExercise, competencyLinks);
+            savedExercise = fileUploadExerciseRepository.save(savedExercise);
+        }
+        final FileUploadExercise newFileUploadExercise = savedExercise;
 
         channelService.createExerciseChannel(newFileUploadExercise, Optional.ofNullable(importedExercise.getChannelName()));
 

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/web/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/web/FileUploadExerciseResource.java
@@ -192,7 +192,13 @@ public class FileUploadExerciseResource {
         // Validate plagiarism detection config
         PlagiarismDetectionConfigHelper.validatePlagiarismDetectionConfigOrThrow(fileUploadExercise, ENTITY_NAME);
 
-        FileUploadExercise result = exerciseService.saveWithCompetencyLinks(fileUploadExercise, fileUploadExerciseRepository::save);
+        var competencyLinks = exerciseService.extractCompetencyLinksForCreation(fileUploadExercise);
+        FileUploadExercise savedExercise = fileUploadExerciseRepository.save(fileUploadExercise);
+        if (!competencyLinks.isEmpty()) {
+            exerciseService.addCompetencyLinksForCreation(savedExercise, competencyLinks);
+            savedExercise = fileUploadExerciseRepository.save(savedExercise);
+        }
+        final FileUploadExercise result = savedExercise;
 
         channelService.createExerciseChannel(result, Optional.ofNullable(fileUploadExercise.getChannelName()));
         groupNotificationScheduleService.checkNotificationsForNewExerciseAsync(fileUploadExercise);
@@ -408,7 +414,7 @@ public class FileUploadExerciseResource {
         channelService.updateExerciseChannel(originalExercise, updatedExercise);
 
         // ========== 3. Persist changes ==========
-        var persistedExercise = exerciseService.saveWithCompetencyLinks(updatedExercise, fileUploadExerciseRepository::save);
+        var persistedExercise = fileUploadExerciseRepository.save(updatedExercise);
         exerciseService.logUpdate(persistedExercise, persistedExercise.getCourseViaExerciseGroupOrCourseMember(), user);
 
         // ========== 4. Handle side effects based on what changed ==========

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/dto/AttachmentVideoUnitDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/dto/AttachmentVideoUnitDTO.java
@@ -1,0 +1,13 @@
+package de.tum.cit.aet.artemis.lecture.dto;
+
+import java.time.ZonedDateTime;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record AttachmentVideoUnitDTO(Long id, String name, ZonedDateTime releaseDate, String description, String videoSource, Set<CompetencyLinkDTO> competencyLinks)
+        implements LectureUnitDTO {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/dto/CompetencyDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/dto/CompetencyDTO.java
@@ -3,8 +3,13 @@ package de.tum.cit.aet.artemis.lecture.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import de.tum.cit.aet.artemis.atlas.domain.competency.CourseCompetency;
+
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record CompetencyDTO(long id) {
 
+    public static CompetencyDTO of(CourseCompetency competency) {
+        return new CompetencyDTO(competency.getId());
+    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/dto/CompetencyLinkDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/dto/CompetencyLinkDTO.java
@@ -3,8 +3,13 @@ package de.tum.cit.aet.artemis.lecture.dto;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyLearningObjectLink;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record CompetencyLinkDTO(CompetencyDTO competency, double weight) {
 
+    public static CompetencyLinkDTO of(CompetencyLearningObjectLink link) {
+        return new CompetencyLinkDTO(CompetencyDTO.of(link.getCompetency()), link.getWeight());
+    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/dto/LectureUnitDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/dto/LectureUnitDTO.java
@@ -5,8 +5,10 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import de.tum.cit.aet.artemis.exercise.dto.CompetencyLinksHolderDTO;
+
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public interface LectureUnitDTO {
+public interface LectureUnitDTO extends CompetencyLinksHolderDTO {
 
     Long id();
 

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentVideoUnitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentVideoUnitService.java
@@ -3,10 +3,8 @@ package de.tum.cit.aet.artemis.lecture.service;
 import java.net.URI;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -16,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import de.tum.cit.aet.artemis.atlas.api.CompetencyProgressApi;
-import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyLectureUnitLink;
 import de.tum.cit.aet.artemis.core.FilePathType;
 import de.tum.cit.aet.artemis.core.service.FileService;
 import de.tum.cit.aet.artemis.core.util.FilePathConverter;
@@ -24,6 +21,7 @@ import de.tum.cit.aet.artemis.core.util.FileUtil;
 import de.tum.cit.aet.artemis.lecture.config.LectureEnabled;
 import de.tum.cit.aet.artemis.lecture.domain.Attachment;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
+import de.tum.cit.aet.artemis.lecture.dto.AttachmentVideoUnitDTO;
 import de.tum.cit.aet.artemis.lecture.dto.HiddenPageInfoDTO;
 import de.tum.cit.aet.artemis.lecture.dto.SlideOrderDTO;
 import de.tum.cit.aet.artemis.lecture.repository.AttachmentRepository;
@@ -71,7 +69,7 @@ public class AttachmentVideoUnitService {
      */
     public AttachmentVideoUnit saveAttachmentVideoUnit(AttachmentVideoUnit attachmentVideoUnit, Attachment attachment, MultipartFile file, boolean keepFilename) {
         // TODO: switch to the new mechanism of lectureUnitService.updateCompetencyLinks
-        AttachmentVideoUnit savedAttachmentVideoUnit = lectureUnitService.saveWithCompetencyLinks(attachmentVideoUnit, attachmentVideoUnitRepository::saveAndFlush);
+        AttachmentVideoUnit savedAttachmentVideoUnit = attachmentVideoUnitRepository.save(attachmentVideoUnit);
 
         if (attachment != null && file != null) {
             createAttachment(attachment, savedAttachmentVideoUnit, file, keepFilename);
@@ -85,9 +83,10 @@ public class AttachmentVideoUnitService {
 
     /**
      * Updates the provided attachment video unit with an optional file.
+     * Note: Competency links must be updated by the caller before invoking this method.
      *
      * @param existingAttachmentVideoUnit The attachment video unit to update.
-     * @param updateUnit                  The new attachment video unit data.
+     * @param updateUnitDTO               The DTO with the new attachment video unit data.
      * @param updateAttachment            The new attachment data.
      * @param updateFile                  The optional file.
      * @param keepFilename                Whether to keep the original filename or not.
@@ -95,15 +94,13 @@ public class AttachmentVideoUnitService {
      * @param pageOrder                   The new order of the edited attachment video unit
      * @return The updated attachment video unit.
      */
-    public AttachmentVideoUnit updateAttachmentVideoUnit(AttachmentVideoUnit existingAttachmentVideoUnit, AttachmentVideoUnit updateUnit, Attachment updateAttachment,
+    public AttachmentVideoUnit updateAttachmentVideoUnit(AttachmentVideoUnit existingAttachmentVideoUnit, AttachmentVideoUnitDTO updateUnitDTO, Attachment updateAttachment,
             MultipartFile updateFile, boolean keepFilename, List<HiddenPageInfoDTO> hiddenPages, List<SlideOrderDTO> pageOrder) {
-        Set<CompetencyLectureUnitLink> existingCompetencyLinks = new HashSet<>(existingAttachmentVideoUnit.getCompetencyLinks());
-
-        existingAttachmentVideoUnit.setDescription(updateUnit.getDescription());
-        existingAttachmentVideoUnit.setName(updateUnit.getName());
-        existingAttachmentVideoUnit.setReleaseDate(updateUnit.getReleaseDate());
-        existingAttachmentVideoUnit.setCompetencyLinks(updateUnit.getCompetencyLinks());
-        existingAttachmentVideoUnit.setVideoSource(updateUnit.getVideoSource());
+        existingAttachmentVideoUnit.setDescription(updateUnitDTO.description());
+        existingAttachmentVideoUnit.setName(updateUnitDTO.name());
+        existingAttachmentVideoUnit.setReleaseDate(updateUnitDTO.releaseDate());
+        existingAttachmentVideoUnit.setVideoSource(updateUnitDTO.videoSource());
+        // Note: competency links are updated by the resource layer using lectureUnitService.updateCompetencyLinks
 
         Attachment existingAttachment = existingAttachmentVideoUnit.getAttachment();
         boolean createdNewAttachment = false;
@@ -113,12 +110,9 @@ public class AttachmentVideoUnitService {
             createdNewAttachment = true;
         }
 
-        // TODO: switch to the new mechanism of lectureUnitService.updateCompetencyLinks
-        AttachmentVideoUnit savedAttachmentVideoUnit = lectureUnitService.saveWithCompetencyLinks(existingAttachmentVideoUnit, attachmentVideoUnitRepository::saveAndFlush);
+        AttachmentVideoUnit savedAttachmentVideoUnit = attachmentVideoUnitRepository.save(existingAttachmentVideoUnit);
 
-        // Set the original competencies back to the attachment video unit so that the competencyProgressService can determine which competencies changed
-        existingAttachmentVideoUnit.setCompetencyLinks(existingCompetencyLinks);
-        competencyProgressApi.ifPresent(api -> api.updateProgressForUpdatedLearningObjectAsync(existingAttachmentVideoUnit, Optional.of(updateUnit)));
+        competencyProgressApi.ifPresent(api -> api.updateProgressForUpdatedLearningObjectAsync(existingAttachmentVideoUnit, Optional.of(savedAttachmentVideoUnit)));
 
         if (updateAttachment == null) {
             // Trigger processing for video-only updates (video source change detection is done inside the service)

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureUnitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureUnitService.java
@@ -218,6 +218,39 @@ public class LectureUnitService {
     }
 
     /**
+     * Reconnects the competency exercise links to the exercise after the cycle was broken by the deserialization.
+     *
+     * @param lectureUnit The lecture unit to reconnect the competency links
+     */
+    public void reconnectCompetencyLectureUnitLinks(LectureUnit lectureUnit) {
+        lectureUnit.getCompetencyLinks().forEach(link -> link.setLectureUnit(lectureUnit));
+    }
+
+    /**
+     * Saves the exercise and links it to the competencies.
+     *
+     * @param lectureUnit  the lecture unit to save
+     * @param saveFunction function to save the exercise
+     * @param <T>          type of the lecture unit
+     * @return saved exercise
+     */
+    public <T extends LectureUnit> T saveWithCompetencyLinks(T lectureUnit, Function<T, T> saveFunction) {
+        // persist lecture Unit before linking it to the competency
+        Set<CompetencyLectureUnitLink> links = lectureUnit.getCompetencyLinks();
+        lectureUnit.setCompetencyLinks(new HashSet<>());
+
+        T savedLectureUnit = saveFunction.apply(lectureUnit);
+
+        if (Hibernate.isInitialized(links) && links != null && !links.isEmpty()) {
+            savedLectureUnit.setCompetencyLinks(links);
+            reconnectCompetencyLectureUnitLinks(savedLectureUnit);
+            competencyRelationApi.ifPresent(api -> savedLectureUnit.setCompetencyLinks(new HashSet<>(api.saveAllLectureUnitLinks(links))));
+        }
+
+        return savedLectureUnit;
+    }
+
+    /**
      * Update the competency links of an existing text unit based on the provided DTO.
      * Supports removing links, updating weights of existing ones, and adding new links.
      * This method ensures that the managed entity's collection is updated correctly to avoid JPA issues and unnecessary database operations.

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureUnitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureUnitService.java
@@ -5,7 +5,6 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -28,6 +27,7 @@ import de.tum.cit.aet.artemis.core.FilePathType;
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.service.FileService;
 import de.tum.cit.aet.artemis.core.util.FilePathConverter;
+import de.tum.cit.aet.artemis.exercise.dto.CompetencyLinksHolderDTO;
 import de.tum.cit.aet.artemis.lecture.api.LectureContentProcessingApi;
 import de.tum.cit.aet.artemis.lecture.config.LectureEnabled;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
@@ -35,7 +35,6 @@ import de.tum.cit.aet.artemis.lecture.domain.ExerciseUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnitCompletion;
-import de.tum.cit.aet.artemis.lecture.dto.LectureUnitDTO;
 import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureUnitCompletionRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureUnitRepository;
@@ -57,15 +56,15 @@ public class LectureUnitService {
 
     private final Optional<CourseCompetencyApi> courseCompetencyApi;
 
-    private final Optional<CompetencyRelationApi> competencyRelationApi;
-
     private final Optional<CompetencyRepositoryApi> competencyRepositoryApi;
+
+    private final Optional<CompetencyRelationApi> competencyRelationApi;
 
     private final Optional<LectureContentProcessingApi> contentProcessingApi;
 
     public LectureUnitService(LectureUnitRepository lectureUnitRepository, LectureRepository lectureRepository, LectureUnitCompletionRepository lectureUnitCompletionRepository,
             FileService fileService, Optional<CompetencyProgressApi> competencyProgressApi, Optional<CourseCompetencyApi> courseCompetencyApi,
-            Optional<CompetencyRelationApi> competencyRelationApi, Optional<CompetencyRepositoryApi> competencyRepositoryApi,
+            Optional<CompetencyRepositoryApi> competencyRepositoryApi, Optional<CompetencyRelationApi> competencyRelationApi,
             Optional<LectureContentProcessingApi> contentProcessingApi) {
         this.lectureUnitRepository = lectureUnitRepository;
         this.lectureRepository = lectureRepository;
@@ -73,8 +72,8 @@ public class LectureUnitService {
         this.fileService = fileService;
         this.courseCompetencyApi = courseCompetencyApi;
         this.competencyProgressApi = competencyProgressApi;
-        this.competencyRelationApi = competencyRelationApi;
         this.competencyRepositoryApi = competencyRepositoryApi;
+        this.competencyRelationApi = competencyRelationApi;
         this.contentProcessingApi = contentProcessingApi;
     }
 
@@ -186,18 +185,19 @@ public class LectureUnitService {
     }
 
     /**
-     * Link the competency to a set of lecture units
+     * Link the competency to a set of lecture units.
+     * Note: Since we use CascadeType.REMOVE only (not PERSIST), links must be saved explicitly.
      *
      * @param competency       The competency to be linked
      * @param lectureUnitLinks New set of lecture unit links to associate with the competency
      */
     public void linkLectureUnitsToCompetency(CourseCompetency competency, Set<CompetencyLectureUnitLink> lectureUnitLinks) {
-        if (courseCompetencyApi.isEmpty()) {
+        if (competencyRelationApi.isEmpty()) {
             return;
         }
         lectureUnitLinks.forEach(link -> link.setCompetency(competency));
-        competency.setLectureUnitLinks(lectureUnitLinks);
-        courseCompetencyApi.get().save(competency);
+        // Save links explicitly since cascade does not include PERSIST
+        competencyRelationApi.get().saveAllLectureUnitLinks(lectureUnitLinks);
     }
 
     /**
@@ -218,65 +218,32 @@ public class LectureUnitService {
     }
 
     /**
-     * Reconnects the competency exercise links to the exercise after the cycle was broken by the deserialization.
-     *
-     * @param lectureUnit The lecture unit to reconnect the competency links
-     */
-    public void reconnectCompetencyLectureUnitLinks(LectureUnit lectureUnit) {
-        lectureUnit.getCompetencyLinks().forEach(link -> link.setLectureUnit(lectureUnit));
-    }
-
-    /**
-     * Saves the exercise and links it to the competencies.
-     *
-     * @param lectureUnit  the lecture unit to save
-     * @param saveFunction function to save the exercise
-     * @param <T>          type of the lecture unit
-     * @return saved exercise
-     */
-    public <T extends LectureUnit> T saveWithCompetencyLinks(T lectureUnit, Function<T, T> saveFunction) {
-        // persist lecture Unit before linking it to the competency
-        Set<CompetencyLectureUnitLink> links = lectureUnit.getCompetencyLinks();
-        lectureUnit.setCompetencyLinks(new HashSet<>());
-
-        T savedLectureUnit = saveFunction.apply(lectureUnit);
-
-        if (Hibernate.isInitialized(links) && links != null && !links.isEmpty()) {
-            savedLectureUnit.setCompetencyLinks(links);
-            reconnectCompetencyLectureUnitLinks(savedLectureUnit);
-            competencyRelationApi.ifPresent(api -> savedLectureUnit.setCompetencyLinks(new HashSet<>(api.saveAllLectureUnitLinks(links))));
-        }
-
-        return savedLectureUnit;
-    }
-
-    /**
      * Update the competency links of an existing text unit based on the provided DTO.
      * Supports removing links, updating weights of existing ones, and adding new links.
      * This method ensures that the managed entity's collection is updated correctly to avoid JPA issues and unnecessary database operations.
      * It makes sure to be Hibernate compliant by modifying the existing collection rather than replacing it.
      *
-     * @param lectureUnitDto      the DTO (from the client) containing the new state of competency links (new, existing or removed ones)
-     * @param existingLectureUnit the existing DB entity to update
+     * @param dto    the DTO (from the client) containing the new state of competency links (new, existing or removed ones)
+     * @param entity the existing DB entity to update
      */
-    public void updateCompetencyLinks(LectureUnitDTO lectureUnitDto, LectureUnit existingLectureUnit) {
+    // TODO: duplicated code, try to unify with ExerciseService.updateCompetencyLinks
+    public void updateCompetencyLinks(CompetencyLinksHolderDTO dto, LectureUnit entity) {
         if (competencyRepositoryApi.isEmpty()) {
             return;
         }
         // TODO: think about optimizing this by loading all new competencies in a single query
-        if (lectureUnitDto.competencyLinks() == null || lectureUnitDto.competencyLinks().isEmpty()) {
+        if (dto.competencyLinks() == null || dto.competencyLinks().isEmpty()) {
             // this handles the case where all competency links were removed
-            existingLectureUnit.getCompetencyLinks().clear();
+            entity.getCompetencyLinks().clear();
         }
         else {
             // 1) Existing links indexed by competency id
-            Map<Long, CompetencyLectureUnitLink> existingLinksByCompetencyId = existingLectureUnit.getCompetencyLinks().stream()
-                    .collect(Collectors.toMap(link -> link.getCompetency().getId(), Function.identity()));
+            final var existingLinksByCompetencyId = entity.getCompetencyLinks().stream().collect(Collectors.toMap(link -> link.getCompetency().getId(), Function.identity()));
 
             // 2) New state of links (reusing existing ones where possible)
             Set<CompetencyLectureUnitLink> updatedLinks = new HashSet<>();
 
-            for (var dtoLink : lectureUnitDto.competencyLinks()) {
+            for (var dtoLink : dto.competencyLinks()) {
                 long competencyId = dtoLink.competency().id();
                 double weight = dtoLink.weight();
 
@@ -289,16 +256,15 @@ public class LectureUnitService {
                 else {
                     // no existing link → create a new one
                     var competency = competencyRepositoryApi.get().findCompetencyOrPrerequisiteByIdElseThrow(competencyId);
-                    var newLink = new CompetencyLectureUnitLink(competency, existingLectureUnit, weight);
+                    var newLink = new CompetencyLectureUnitLink(competency, entity, weight);
 
                     updatedLinks.add(newLink);
                 }
             }
 
             // 3) Replace the contents of the managed collection, NOT the collection itself
-            var managedSet = existingLectureUnit.getCompetencyLinks();
-            managedSet.clear();
-            managedSet.addAll(updatedLinks);
+            entity.getCompetencyLinks().clear();
+            entity.getCompetencyLinks().addAll(updatedLinks);
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/AttachmentResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/AttachmentResource.java
@@ -94,23 +94,31 @@ public class AttachmentResource {
     public ResponseEntity<Attachment> updateAttachment(@PathVariable Long attachmentId, @RequestPart Attachment attachment, @RequestPart(required = false) MultipartFile file,
             @RequestParam(value = "notificationText", required = false) String notificationText) {
         log.debug("REST request to update Attachment : {}", attachment);
-        attachment.setId(attachmentId);
 
-        // Make sure that the original references are preserved.
-        Attachment originalAttachment = attachmentRepository.findByIdOrElseThrow(attachment.getId());
-        attachment.setAttachmentVideoUnit(originalAttachment.getAttachmentVideoUnit());
+        // Load existing attachment from DB to preserve relationships and avoid detached entity issues
+        Attachment existingAttachment = attachmentRepository.findByIdOrElseThrow(attachmentId);
+
+        // Update only the fields that should be changed from client data
+        existingAttachment.setName(attachment.getName());
+        existingAttachment.setReleaseDate(attachment.getReleaseDate());
+        existingAttachment.setUploadDate(attachment.getUploadDate());
+        existingAttachment.setVersion(attachment.getVersion());
+        existingAttachment.setAttachmentType(attachment.getAttachmentType());
+        existingAttachment.setStudentVersion(attachment.getStudentVersion());
 
         if (file != null) {
-            Path basePath = FilePathConverter.getLectureAttachmentFileSystemPath().resolve(originalAttachment.getLecture().getId().toString());
+            Path basePath = FilePathConverter.getLectureAttachmentFileSystemPath().resolve(existingAttachment.getLecture().getId().toString());
             Path savePath = FileUtil.saveFile(file, basePath, FilePathType.LECTURE_ATTACHMENT, true);
-            attachment.setLink(FilePathConverter.externalUriForFileSystemPath(savePath, FilePathType.LECTURE_ATTACHMENT, originalAttachment.getLecture().getId()).toString());
             // Delete the old file
-            URI oldPath = URI.create(originalAttachment.getLink());
+            URI oldPath = URI.create(existingAttachment.getLink());
             fileService.schedulePathForDeletion(FilePathConverter.fileSystemPathForExternalUri(oldPath, FilePathType.LECTURE_ATTACHMENT), 0);
             this.fileService.evictCacheForPath(FilePathConverter.fileSystemPathForExternalUri(oldPath, FilePathType.LECTURE_ATTACHMENT));
+            // Set the new link
+            existingAttachment
+                    .setLink(FilePathConverter.externalUriForFileSystemPath(savePath, FilePathType.LECTURE_ATTACHMENT, existingAttachment.getLecture().getId()).toString());
         }
 
-        Attachment result = attachmentRepository.save(attachment);
+        Attachment result = attachmentRepository.save(existingAttachment);
         if (notificationText != null) {
             groupNotificationService.notifyStudentGroupAboutAttachmentChange(result);
         }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/AttachmentVideoUnitResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/AttachmentVideoUnitResource.java
@@ -45,6 +45,7 @@ import de.tum.cit.aet.artemis.lecture.config.LectureEnabled;
 import de.tum.cit.aet.artemis.lecture.domain.Attachment;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
+import de.tum.cit.aet.artemis.lecture.dto.AttachmentVideoUnitDTO;
 import de.tum.cit.aet.artemis.lecture.dto.HiddenPageInfoDTO;
 import de.tum.cit.aet.artemis.lecture.dto.LectureUnitSplitInformationDTO;
 import de.tum.cit.aet.artemis.lecture.dto.SlideOrderDTO;
@@ -53,6 +54,7 @@ import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureUnitRepository;
 import de.tum.cit.aet.artemis.lecture.service.AttachmentVideoUnitService;
 import de.tum.cit.aet.artemis.lecture.service.LectureUnitProcessingService;
+import de.tum.cit.aet.artemis.lecture.service.LectureUnitService;
 import de.tum.cit.aet.artemis.lecture.service.SlideSplitterService;
 
 @Conditional(LectureEnabled.class)
@@ -85,10 +87,12 @@ public class AttachmentVideoUnitResource {
 
     private final LectureUnitRepository lectureUnitRepository;
 
+    private final LectureUnitService lectureUnitService;
+
     public AttachmentVideoUnitResource(AttachmentVideoUnitRepository attachmentVideoUnitRepository, LectureRepository lectureRepository,
             LectureUnitProcessingService lectureUnitProcessingService, AuthorizationCheckService authorizationCheckService, GroupNotificationService groupNotificationService,
             AttachmentVideoUnitService attachmentVideoUnitService, Optional<CompetencyProgressApi> competencyProgressApi, SlideSplitterService slideSplitterService,
-            FileService fileService, LectureUnitRepository lectureUnitRepository) {
+            FileService fileService, LectureUnitRepository lectureUnitRepository, LectureUnitService lectureUnitService) {
         this.attachmentVideoUnitRepository = attachmentVideoUnitRepository;
         this.lectureUnitProcessingService = lectureUnitProcessingService;
         this.lectureRepository = lectureRepository;
@@ -99,6 +103,7 @@ public class AttachmentVideoUnitResource {
         this.slideSplitterService = slideSplitterService;
         this.fileService = fileService;
         this.lectureUnitRepository = lectureUnitRepository;
+        this.lectureUnitService = lectureUnitService;
     }
 
     /**
@@ -121,38 +126,42 @@ public class AttachmentVideoUnitResource {
     /**
      * PUT lectures/:lectureId/attachment-video-units/:attachmentVideoUnitId : Updates an existing attachment video unit
      *
-     * @param lectureId             the id of the lecture to which the attachment video unit belongs to update
-     * @param attachmentVideoUnitId the id of the attachment video unit to update
-     * @param attachmentVideoUnit   the attachment video unit with updated content
-     * @param attachment            the attachment with updated content
-     * @param file                  the optional file to upload
-     * @param hiddenPages           the pages to be hidden in the attachment video unit
-     * @param pageOrder             the new order of the edited attachment video unit
-     * @param keepFilename          specifies if the original filename should be kept or not
-     * @param notificationText      the text to be used for the notification. No notification will be sent if the parameter is not set
+     * @param lectureId              the id of the lecture to which the attachment video unit belongs to update
+     * @param attachmentVideoUnitId  the id of the attachment video unit to update
+     * @param attachmentVideoUnitDTO the attachment video unit DTO with updated content
+     * @param attachment             the attachment with updated content
+     * @param file                   the optional file to upload
+     * @param hiddenPages            the pages to be hidden in the attachment video unit
+     * @param pageOrder              the new order of the edited attachment video unit
+     * @param keepFilename           specifies if the original filename should be kept or not
+     * @param notificationText       the text to be used for the notification. No notification will be sent if the parameter is not set
      * @return the ResponseEntity with status 200 (OK) and with body the updated attachmentVideoUnit
      */
     @PutMapping(value = "lectures/{lectureId}/attachment-video-units/{attachmentVideoUnitId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @EnforceAtLeastEditorInLectureUnit(resourceIdFieldName = "attachmentVideoUnitId")
+    // TODO: we should use a DTO here for @RequestPart(required = false) Attachment attachment
     public ResponseEntity<AttachmentVideoUnit> updateAttachmentVideoUnit(@PathVariable Long lectureId, @PathVariable Long attachmentVideoUnitId,
-            @RequestPart AttachmentVideoUnit attachmentVideoUnit, @RequestPart(required = false) Attachment attachment, @RequestPart(required = false) MultipartFile file,
-            @RequestPart(required = false) List<HiddenPageInfoDTO> hiddenPages, @RequestPart(required = false) List<SlideOrderDTO> pageOrder,
-            @RequestParam(defaultValue = "false") boolean keepFilename, @RequestParam(value = "notificationText", required = false) String notificationText) {
-        log.debug("REST request to update an attachment video unit : {}", attachmentVideoUnit);
+            @RequestPart("attachmentVideoUnit") AttachmentVideoUnitDTO attachmentVideoUnitDTO, @RequestPart(required = false) Attachment attachment,
+            @RequestPart(required = false) MultipartFile file, @RequestPart(required = false) List<HiddenPageInfoDTO> hiddenPages,
+            @RequestPart(required = false) List<SlideOrderDTO> pageOrder, @RequestParam(defaultValue = "false") boolean keepFilename,
+            @RequestParam(value = "notificationText", required = false) String notificationText) {
+        log.debug("REST request to update an attachment video unit : {}", attachmentVideoUnitDTO);
         AttachmentVideoUnit existingAttachmentVideoUnit = attachmentVideoUnitRepository.findWithSlidesAndCompetenciesByIdElseThrow(attachmentVideoUnitId);
         checkAttachmentVideoUnitCourseAndLecture(existingAttachmentVideoUnit, lectureId);
 
         if (!validateHiddenSlidesDates(hiddenPages)) {
             throw new BadRequestAlertException("Hidden slide dates cannot be in the past", ENTITY_NAME, "invalidHiddenDates");
         }
-        AttachmentVideoUnit savedAttachmentVideoUnit = attachmentVideoUnitService.updateAttachmentVideoUnit(existingAttachmentVideoUnit, attachmentVideoUnit, attachment, file,
+
+        // Update competency links using the proper mechanism
+        lectureUnitService.updateCompetencyLinks(attachmentVideoUnitDTO, existingAttachmentVideoUnit);
+
+        AttachmentVideoUnit savedAttachmentVideoUnit = attachmentVideoUnitService.updateAttachmentVideoUnit(existingAttachmentVideoUnit, attachmentVideoUnitDTO, attachment, file,
                 keepFilename, hiddenPages, pageOrder);
 
         if (notificationText != null && attachment != null) {
             groupNotificationService.notifyStudentGroupAboutAttachmentChange(savedAttachmentVideoUnit.getAttachment());
         }
-
-        log.debug("REST request to update an attachment video unit 4: {}", attachmentVideoUnit);
 
         return ResponseEntity.ok(savedAttachmentVideoUnit);
     }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/OnlineUnitResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/OnlineUnitResource.java
@@ -175,7 +175,7 @@ public class OnlineUnitResource {
 
         OnlineUnit persistedUnit = (OnlineUnit) updatedLecture.getLectureUnits().getLast();
         // From now on, only use persistedUnit
-        lectureUnitService.saveWithCompetencyLinks(persistedUnit, onlineUnitRepository::saveAndFlush);
+        onlineUnitRepository.save(persistedUnit);
         competencyProgressApi.ifPresent(api -> api.updateProgressByLearningObjectAsync(persistedUnit));
 
         // TODO: return a DTO instead to avoid manipulation of the entity before sending it to the client

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/TextUnitResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/TextUnitResource.java
@@ -162,7 +162,7 @@ public class TextUnitResource {
         Lecture updatedLecture = lectureRepository.saveAndFlush(lecture);
         TextUnit persistedUnit = (TextUnit) updatedLecture.getLectureUnits().getLast();
         // From now on, only use persistedUnit
-        lectureUnitService.saveWithCompetencyLinks(persistedUnit, textUnitRepository::saveAndFlush);
+        textUnitRepository.save(persistedUnit);
         competencyProgressApi.ifPresent(api -> api.updateProgressByLearningObjectAsync(persistedUnit));
 
         // TODO: return a DTO instead to avoid manipulation of the entity before sending it to the client

--- a/src/main/java/de/tum/cit/aet/artemis/lti/dto/LtiPlatformConfigurationUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/dto/LtiPlatformConfigurationUpdateDTO.java
@@ -1,0 +1,64 @@
+package de.tum.cit.aet.artemis.lti.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
+
+/**
+ * DTO for creating and updating LtiPlatformConfiguration.
+ * Uses DTOs instead of entity classes to avoid Hibernate detached entity issues.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record LtiPlatformConfigurationUpdateDTO(@Nullable Long id, @Nullable String registrationId, @NotNull String clientId, @Nullable String originalUrl,
+        @Nullable String customName, @NotNull String authorizationUri, @NotNull String jwkSetUri, @NotNull String tokenUri) {
+
+    /**
+     * Creates a LtiPlatformConfigurationUpdateDTO from the given LtiPlatformConfiguration domain object.
+     *
+     * @param config the LtiPlatformConfiguration to convert
+     * @return the corresponding DTO
+     */
+    public static LtiPlatformConfigurationUpdateDTO of(LtiPlatformConfiguration config) {
+        return new LtiPlatformConfigurationUpdateDTO(config.getId(), config.getRegistrationId(), config.getClientId(), config.getOriginalUrl(), config.getCustomName(),
+                config.getAuthorizationUri(), config.getJwkSetUri(), config.getTokenUri());
+    }
+
+    /**
+     * Creates a new LtiPlatformConfiguration entity from this DTO.
+     * Used for create operations.
+     *
+     * @return a new LtiPlatformConfiguration entity
+     */
+    public LtiPlatformConfiguration toEntity() {
+        LtiPlatformConfiguration config = new LtiPlatformConfiguration();
+        config.setClientId(clientId);
+        config.setOriginalUrl(originalUrl);
+        config.setCustomName(customName);
+        config.setAuthorizationUri(authorizationUri);
+        config.setJwkSetUri(jwkSetUri);
+        config.setTokenUri(tokenUri);
+        return config;
+    }
+
+    /**
+     * Applies the DTO values to an existing LtiPlatformConfiguration entity.
+     * This updates the managed entity with values from the DTO.
+     * Note: registrationId is NOT updated as it should remain immutable after creation.
+     *
+     * @param config the existing configuration to update
+     */
+    public void applyTo(LtiPlatformConfiguration config) {
+        config.setClientId(clientId);
+        config.setOriginalUrl(originalUrl);
+        config.setCustomName(customName);
+        config.setAuthorizationUri(authorizationUri);
+        config.setJwkSetUri(jwkSetUri);
+        config.setTokenUri(tokenUri);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/lti/web/admin/AdminLtiConfigurationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/web/admin/AdminLtiConfigurationResource.java
@@ -24,6 +24,7 @@ import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
 import de.tum.cit.aet.artemis.core.util.HeaderUtil;
 import de.tum.cit.aet.artemis.lti.config.LtiEnabled;
 import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
+import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationUpdateDTO;
 import de.tum.cit.aet.artemis.lti.repository.LtiPlatformConfigurationRepository;
 import de.tum.cit.aet.artemis.lti.service.LtiDynamicRegistrationService;
 import de.tum.cit.aet.artemis.lti.service.OAuth2JWKSService;
@@ -103,24 +104,28 @@ public class AdminLtiConfigurationResource {
     /**
      * Updates an existing LTI platform configuration.
      *
-     * @param platform the updated LTI platform configuration to be saved.
+     * @param updateDTO the LTI platform configuration update DTO containing the new values.
      * @return a {@link ResponseEntity} with status 200 (OK) if the update was successful,
      *         or with status 400 (Bad Request) if the provided platform configuration is invalid (e.g., missing ID)
      */
     @PutMapping("lti-platform")
-    public ResponseEntity<Void> updateLtiPlatformConfiguration(@RequestBody LtiPlatformConfiguration platform) {
+    public ResponseEntity<Void> updateLtiPlatformConfiguration(@RequestBody LtiPlatformConfigurationUpdateDTO updateDTO) {
         log.debug("REST request to update configured LTI platform");
 
-        if (platform.getId() == null) {
+        if (updateDTO.id() == null) {
             return ResponseEntity.badRequest().build();
         }
 
-        LtiPlatformConfiguration existingPlatform = ltiPlatformConfigurationRepository.findByIdElseThrow(platform.getId());
-        if (!existingPlatform.getRegistrationId().equals(platform.getRegistrationId())) {
+        // Fetch the existing configuration from the database (this is the managed entity)
+        LtiPlatformConfiguration existingPlatform = ltiPlatformConfigurationRepository.findByIdElseThrow(updateDTO.id());
+        if (!existingPlatform.getRegistrationId().equals(updateDTO.registrationId())) {
             return ResponseEntity.badRequest().build();
         }
 
-        ltiPlatformConfigurationRepository.save(platform);
+        // Apply DTO values to the managed entity
+        updateDTO.applyTo(existingPlatform);
+
+        ltiPlatformConfigurationRepository.save(existingPlatform);
 
         return ResponseEntity.ok().build();
     }
@@ -128,13 +133,14 @@ public class AdminLtiConfigurationResource {
     /**
      * Adds a new LTI platform configuration.
      *
-     * @param platform the new LTI platform configuration to be saved.
+     * @param dto the LTI platform configuration DTO containing the new values.
      * @return a {@link ResponseEntity} with status 200 (OK) if the creation was successful
      */
     @PostMapping("lti-platform")
-    public ResponseEntity<Void> addLtiPlatformConfiguration(@RequestBody LtiPlatformConfiguration platform) {
+    public ResponseEntity<Void> addLtiPlatformConfiguration(@RequestBody LtiPlatformConfigurationUpdateDTO dto) {
         log.debug("REST request to add new LTI platform");
 
+        LtiPlatformConfiguration platform = dto.toEntity();
         String clientRegistrationId = "artemis-" + UUID.randomUUID();
         platform.setRegistrationId(clientRegistrationId);
 

--- a/src/main/java/de/tum/cit/aet/artemis/modeling/dto/ApollonDiagramUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/dto/ApollonDiagramUpdateDTO.java
@@ -1,0 +1,58 @@
+package de.tum.cit.aet.artemis.modeling.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.modeling.domain.ApollonDiagram;
+import de.tum.cit.aet.artemis.modeling.domain.DiagramType;
+
+/**
+ * DTO for creating and updating ApollonDiagrams.
+ * Uses DTOs instead of entity classes to avoid Hibernate detached entity issues.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ApollonDiagramUpdateDTO(@Nullable Long id, @Nullable String title, @Nullable String jsonRepresentation, @Nullable DiagramType diagramType, @NotNull Long courseId) {
+
+    /**
+     * Creates an ApollonDiagramUpdateDTO from the given ApollonDiagram domain object.
+     *
+     * @param diagram the ApollonDiagram to convert
+     * @return the corresponding DTO
+     */
+    public static ApollonDiagramUpdateDTO of(ApollonDiagram diagram) {
+        return new ApollonDiagramUpdateDTO(diagram.getId(), diagram.getTitle(), diagram.getJsonRepresentation(), diagram.getDiagramType(), diagram.getCourseId());
+    }
+
+    /**
+     * Creates a new ApollonDiagram entity from this DTO.
+     * Used for create operations.
+     *
+     * @return a new ApollonDiagram entity
+     */
+    public ApollonDiagram toEntity() {
+        ApollonDiagram diagram = new ApollonDiagram();
+        diagram.setTitle(title);
+        diagram.setJsonRepresentation(jsonRepresentation);
+        diagram.setDiagramType(diagramType);
+        diagram.setCourseId(courseId);
+        return diagram;
+    }
+
+    /**
+     * Applies the DTO values to an existing ApollonDiagram entity.
+     * This updates the managed entity with values from the DTO.
+     *
+     * @param diagram the existing diagram to update
+     */
+    public void applyTo(ApollonDiagram diagram) {
+        diagram.setTitle(title);
+        diagram.setJsonRepresentation(jsonRepresentation);
+        diagram.setDiagramType(diagramType);
+        diagram.setCourseId(courseId);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/modeling/service/ModelingExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/service/ModelingExerciseImportService.java
@@ -72,7 +72,13 @@ public class ModelingExerciseImportService extends ExerciseImportService {
         Map<Long, GradingInstruction> gradingInstructionCopyTracker = new HashMap<>();
         ModelingExercise newExercise = copyModelingExerciseBasis(importedExercise, gradingInstructionCopyTracker);
 
-        ModelingExercise newModelingExercise = exerciseService.saveWithCompetencyLinks(newExercise, modelingExerciseRepository::save);
+        var competencyLinks = exerciseService.extractCompetencyLinksForCreation(newExercise);
+        ModelingExercise savedExercise = modelingExerciseRepository.save(newExercise);
+        if (!competencyLinks.isEmpty()) {
+            exerciseService.addCompetencyLinksForCreation(savedExercise, competencyLinks);
+            savedExercise = modelingExerciseRepository.save(savedExercise);
+        }
+        final ModelingExercise newModelingExercise = savedExercise;
 
         channelService.createExerciseChannel(newModelingExercise, Optional.ofNullable(importedExercise.getChannelName()));
         newModelingExercise.setExampleSubmissions(copyExampleSubmission(templateExercise, newExercise, gradingInstructionCopyTracker));

--- a/src/main/java/de/tum/cit/aet/artemis/modeling/web/ApollonDiagramResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/web/ApollonDiagramResource.java
@@ -5,6 +5,8 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Objects;
 
+import jakarta.validation.Valid;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Conditional;
@@ -30,6 +32,7 @@ import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastTutor;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
 import de.tum.cit.aet.artemis.modeling.config.ModelingEnabled;
 import de.tum.cit.aet.artemis.modeling.domain.ApollonDiagram;
+import de.tum.cit.aet.artemis.modeling.dto.ApollonDiagramUpdateDTO;
 import de.tum.cit.aet.artemis.modeling.repository.ApollonDiagramRepository;
 
 /**
@@ -60,27 +63,28 @@ public class ApollonDiagramResource {
     /**
      * POST /course/{courseId}/apollon-diagrams : Create a new apollonDiagram.
      *
-     * @param apollonDiagram the apollonDiagram to create
-     * @param courseId       the id of the current course
+     * @param dto      the apollonDiagram DTO to create
+     * @param courseId the id of the current course
      * @return the ResponseEntity with status 201 (Created) and with body the new apollonDiagram, or with status 400 (Bad Request) if the apollonDiagram has already an ID
      * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PostMapping("course/{courseId}/apollon-diagrams")
     @EnforceAtLeastTutor
-    public ResponseEntity<ApollonDiagram> createApollonDiagram(@RequestBody ApollonDiagram apollonDiagram, @PathVariable Long courseId) throws URISyntaxException {
-        log.debug("REST request to save ApollonDiagram : {}", apollonDiagram);
+    public ResponseEntity<ApollonDiagram> createApollonDiagram(@Valid @RequestBody ApollonDiagramUpdateDTO dto, @PathVariable Long courseId) throws URISyntaxException {
+        log.debug("REST request to save ApollonDiagram for course: {}", courseId);
 
-        if (apollonDiagram.getId() != null) {
+        if (dto.id() != null) {
             throw new BadRequestAlertException("A new apollonDiagram cannot already have an ID", ENTITY_NAME, "idExists");
         }
 
-        if (!Objects.equals(apollonDiagram.getCourseId(), courseId)) {
+        if (!Objects.equals(dto.courseId(), courseId)) {
             throw new ConflictException("Specified course id does not match request payload", "ApollonDiagram", "courseMismatch");
         }
 
         Course course = courseRepository.findByIdElseThrow(courseId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, null);
 
+        ApollonDiagram apollonDiagram = dto.toEntity();
         ApollonDiagram result = apollonDiagramRepository.save(apollonDiagram);
         return ResponseEntity.created(new URI("/api/modeling/apollon-diagrams/" + result.getId())).body(result);
     }
@@ -88,28 +92,34 @@ public class ApollonDiagramResource {
     /**
      * PUT /course/{courseId}/apollon-diagrams : Updates an existing apollonDiagram.
      *
-     * @param apollonDiagram the apollonDiagram to update
-     * @param courseId       the id of the current course
-     * @return the ResponseEntity with status 200 (OK) and with body the updated apollonDiagram, or with status 201 (CREATED) if the apollonDiagram has not been created before, or
-     *         with status 500 (Internal Server Error) if the apollonDiagram couldn't be updated
-     * @throws URISyntaxException if the Location URI syntax is incorrect
+     * @param diagramUpdateDTO the apollonDiagram update DTO containing the new values
+     * @param courseId         the id of the current course
+     * @return the ResponseEntity with status 200 (OK) and with body the updated apollonDiagram,
+     *         or with status 500 (Internal Server Error) if the apollonDiagram couldn't be updated
      */
     @PutMapping("course/{courseId}/apollon-diagrams")
     @EnforceAtLeastTutor
-    public ResponseEntity<ApollonDiagram> updateApollonDiagram(@RequestBody ApollonDiagram apollonDiagram, @PathVariable Long courseId) throws URISyntaxException {
-        log.debug("REST request to update ApollonDiagram : {}", apollonDiagram);
+    public ResponseEntity<ApollonDiagram> updateApollonDiagram(@RequestBody ApollonDiagramUpdateDTO diagramUpdateDTO, @PathVariable Long courseId) {
+        log.debug("REST request to update ApollonDiagram : {}", diagramUpdateDTO);
 
-        if (apollonDiagram.getId() == null) {
-            return createApollonDiagram(apollonDiagram, courseId);
+        if (diagramUpdateDTO.id() == null) {
+            throw new BadRequestAlertException("An apollonDiagram update must have an ID", ENTITY_NAME, "idMissing");
         }
 
-        if (!Objects.equals(apollonDiagram.getCourseId(), courseId)) {
+        if (!Objects.equals(diagramUpdateDTO.courseId(), courseId)) {
             throw new ConflictException("Specified course id does not match request payload", "ApollonDiagram", "courseMismatch");
         }
+
         Course course = courseRepository.findByIdElseThrow(courseId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, null);
 
-        ApollonDiagram result = apollonDiagramRepository.save(apollonDiagram);
+        // Fetch the existing diagram from the database (this is the managed entity)
+        ApollonDiagram existingDiagram = apollonDiagramRepository.findByIdElseThrow(diagramUpdateDTO.id());
+
+        // Apply DTO values to the managed entity
+        diagramUpdateDTO.applyTo(existingDiagram);
+
+        ApollonDiagram result = apollonDiagramRepository.save(existingDiagram);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/modeling/web/ModelingExerciseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/web/ModelingExerciseResource.java
@@ -195,7 +195,13 @@ public class ModelingExerciseResource {
         // Validate plagiarism detection config
         PlagiarismDetectionConfigHelper.validatePlagiarismDetectionConfigOrThrow(modelingExercise, ENTITY_NAME);
 
-        ModelingExercise result = exerciseService.saveWithCompetencyLinks(modelingExercise, modelingExerciseRepository::save);
+        var competencyLinks = exerciseService.extractCompetencyLinksForCreation(modelingExercise);
+        ModelingExercise savedExercise = modelingExerciseRepository.save(modelingExercise);
+        if (!competencyLinks.isEmpty()) {
+            exerciseService.addCompetencyLinksForCreation(savedExercise, competencyLinks);
+            savedExercise = modelingExerciseRepository.save(savedExercise);
+        }
+        final ModelingExercise result = savedExercise;
 
         channelService.createExerciseChannel(result, Optional.ofNullable(modelingExercise.getChannelName()));
         groupNotificationScheduleService.checkNotificationsForNewExerciseAsync(modelingExercise);
@@ -283,7 +289,7 @@ public class ModelingExerciseResource {
 
         channelService.updateExerciseChannel(originalExercise, updatedExercise);
 
-        ModelingExercise persistedExercise = exerciseService.saveWithCompetencyLinks(updatedExercise, modelingExerciseRepository::save);
+        ModelingExercise persistedExercise = modelingExerciseRepository.save(updatedExercise);
 
         exerciseService.logUpdate(updatedExercise, updatedExercise.getCourseViaExerciseGroupOrCourseMember(), user);
         exerciseService.updatePointsInRelatedParticipantScores(oldMaxPoints, oldBonusPoints, persistedExercise);

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/PlagiarismPostService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/PlagiarismPostService.java
@@ -182,6 +182,13 @@ public class PlagiarismPostService extends PostingService {
         Post post = postRepository.findPostByIdElseThrow(postId);
         authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, user);
 
+        // Clear the bidirectional PlagiarismCase reference to avoid TransientObjectException in Hibernate 6.6
+        PlagiarismCase plagiarismCase = post.getPlagiarismCase();
+        if (plagiarismCase != null) {
+            plagiarismCase.setPost(null);
+            plagiarismCaseRepository.save(plagiarismCase);
+        }
+
         // delete
         postRepository.deleteById(postId);
         preparePostForBroadcast(post);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/dto/AuxiliaryRepositoryDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/dto/AuxiliaryRepositoryDTO.java
@@ -1,0 +1,42 @@
+package de.tum.cit.aet.artemis.programming.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.programming.domain.AuxiliaryRepository;
+
+/**
+ * DTO for AuxiliaryRepository.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record AuxiliaryRepositoryDTO(Long id, String name, String repositoryUri, String checkoutDirectory, String description) {
+
+    /**
+     * Creates a DTO from an AuxiliaryRepository entity.
+     *
+     * @param auxRepo the AuxiliaryRepository entity to convert
+     * @return a new AuxiliaryRepositoryDTO with data from the entity
+     */
+    public static AuxiliaryRepositoryDTO of(AuxiliaryRepository auxRepo) {
+        if (auxRepo == null) {
+            return null;
+        }
+        return new AuxiliaryRepositoryDTO(auxRepo.getId(), auxRepo.getName(), auxRepo.getRepositoryUri(), auxRepo.getCheckoutDirectory(), auxRepo.getDescription());
+    }
+
+    /**
+     * Converts this DTO to an AuxiliaryRepository entity.
+     *
+     * @return a new AuxiliaryRepository entity with data from this DTO
+     */
+    public AuxiliaryRepository toEntity() {
+        AuxiliaryRepository auxRepo = new AuxiliaryRepository();
+        auxRepo.setId(id);
+        auxRepo.setName(name);
+        auxRepo.setRepositoryUri(repositoryUri);
+        auxRepo.setCheckoutDirectory(checkoutDirectory);
+        auxRepo.setDescription(description);
+        return auxRepo;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/programming/dto/ProgrammingExerciseTimelineUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/dto/ProgrammingExerciseTimelineUpdateDTO.java
@@ -1,0 +1,45 @@
+package de.tum.cit.aet.artemis.programming.dto;
+
+import java.time.ZonedDateTime;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
+
+/**
+ * DTO for updating the timeline of a programming exercise.
+ * Contains only the date-related fields that can be updated via the timeline endpoint.
+ *
+ * @param id                                         the ID of the programming exercise (required)
+ * @param releaseDate                                the release date of the exercise
+ * @param startDate                                  the start date of the exercise
+ * @param dueDate                                    the due date of the exercise
+ * @param assessmentType                             the assessment type
+ * @param assessmentDueDate                          the assessment due date
+ * @param exampleSolutionPublicationDate             the date when the example solution is published
+ * @param buildAndTestStudentSubmissionsAfterDueDate the date when student submissions are built and tested after due date
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ProgrammingExerciseTimelineUpdateDTO(@NotNull Long id, ZonedDateTime releaseDate, ZonedDateTime startDate, ZonedDateTime dueDate, AssessmentType assessmentType,
+        ZonedDateTime assessmentDueDate, ZonedDateTime exampleSolutionPublicationDate, ZonedDateTime buildAndTestStudentSubmissionsAfterDueDate) {
+
+    /**
+     * Applies the timeline values from this DTO to an existing ProgrammingExercise entity.
+     *
+     * @param exercise the programming exercise to update
+     */
+    public void applyTo(ProgrammingExercise exercise) {
+        exercise.setReleaseDate(releaseDate);
+        exercise.setStartDate(startDate);
+        exercise.setDueDate(dueDate);
+        exercise.setAssessmentType(assessmentType);
+        exercise.setAssessmentDueDate(assessmentDueDate);
+        exercise.setExampleSolutionPublicationDate(exampleSolutionPublicationDate);
+        exercise.setBuildAndTestStudentSubmissionsAfterDueDate(buildAndTestStudentSubmissionsAfterDueDate);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/programming/dto/UpdateProgrammingExerciseBuildConfigDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/dto/UpdateProgrammingExerciseBuildConfigDTO.java
@@ -1,0 +1,36 @@
+package de.tum.cit.aet.artemis.programming.dto;
+
+import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseBuildConfig;
+
+/**
+ * DTO for updating ProgrammingExerciseBuildConfig.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record UpdateProgrammingExerciseBuildConfigDTO(Long id, Boolean sequentialTestRuns, String branch, String buildPlanConfiguration, String buildScript,
+        boolean checkoutSolutionRepository, String testCheckoutPath, String assignmentCheckoutPath, String solutionCheckoutPath, int timeoutSeconds, String dockerFlags,
+        @Nullable String theiaImage, boolean allowBranching, @Nullable String branchRegex) {
+
+    /**
+     * Creates a DTO from a ProgrammingExerciseBuildConfig entity.
+     *
+     * @param buildConfig the ProgrammingExerciseBuildConfig entity to convert
+     * @return a new UpdateProgrammingExerciseBuildConfigDTO with data from the entity, or null if entity is null
+     */
+    @Nullable
+    public static UpdateProgrammingExerciseBuildConfigDTO of(@Nullable ProgrammingExerciseBuildConfig buildConfig) {
+        if (buildConfig == null || !Hibernate.isInitialized(buildConfig)) {
+            return null;
+        }
+        return new UpdateProgrammingExerciseBuildConfigDTO(buildConfig.getId(), buildConfig.hasSequentialTestRuns(), buildConfig.getBranch(),
+                buildConfig.getBuildPlanConfiguration(), buildConfig.getBuildScript(), buildConfig.getCheckoutSolutionRepository(), buildConfig.getTestCheckoutPath(),
+                buildConfig.getAssignmentCheckoutPath(), buildConfig.getSolutionCheckoutPath(), buildConfig.getTimeoutSeconds(), buildConfig.getDockerFlags(),
+                buildConfig.getTheiaImage(), buildConfig.isAllowBranching(), buildConfig.getBranchRegex());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/programming/dto/UpdateProgrammingExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/dto/UpdateProgrammingExerciseDTO.java
@@ -1,0 +1,107 @@
+package de.tum.cit.aet.artemis.programming.dto;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
+import de.tum.cit.aet.artemis.assessment.dto.GradingCriterionDTO;
+import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
+import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
+import de.tum.cit.aet.artemis.exercise.domain.DifficultyLevel;
+import de.tum.cit.aet.artemis.exercise.domain.IncludedInOverallScore;
+import de.tum.cit.aet.artemis.exercise.dto.CompetencyLinksHolderDTO;
+import de.tum.cit.aet.artemis.lecture.dto.CompetencyLinkDTO;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage;
+import de.tum.cit.aet.artemis.programming.domain.ProjectType;
+import de.tum.cit.aet.artemis.programming.domain.submissionpolicy.SubmissionPolicy;
+
+/**
+ * DTO for updating ProgrammingExercise.
+ * This DTO includes all fields that can be updated through the update endpoint.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record UpdateProgrammingExerciseDTO(
+        // Core identification
+        @Nullable Long id,
+
+        // Exercise base fields
+        String title, String channelName, String shortName, String problemStatement, Set<String> categories, DifficultyLevel difficulty, Double maxPoints, Double bonusPoints,
+        IncludedInOverallScore includedInOverallScore, Boolean allowComplaintsForAutomaticAssessments, Boolean allowFeedbackRequests, Boolean presentationScoreEnabled,
+        Boolean secondCorrectionEnabled, String feedbackSuggestionModule, String gradingInstructions,
+
+        // Timeline fields
+        ZonedDateTime releaseDate, ZonedDateTime startDate, ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, ZonedDateTime exampleSolutionPublicationDate,
+
+        // Course/ExerciseGroup
+        Long courseId, Long exerciseGroupId,
+
+        // Grading and competencies
+        Set<GradingCriterionDTO> gradingCriteria, Set<CompetencyLinkDTO> competencyLinks,
+
+        // Programming exercise specific fields
+        String testRepositoryUri, String solutionRepositoryUri, List<AuxiliaryRepositoryDTO> auxiliaryRepositories, Boolean allowOnlineEditor, Boolean allowOfflineIde,
+        boolean allowOnlineIde, Boolean staticCodeAnalysisEnabled, Integer maxStaticCodeAnalysisPenalty, ProgrammingLanguage programmingLanguage, String packageName,
+        boolean showTestNamesToStudents, @Nullable ZonedDateTime buildAndTestStudentSubmissionsAfterDueDate, Boolean testCasesChanged, String projectKey,
+        @Nullable SubmissionPolicy submissionPolicy, @Nullable ProjectType projectType, boolean releaseTestsWithExampleSolution,
+
+        // Build config
+        UpdateProgrammingExerciseBuildConfigDTO buildConfig) implements CompetencyLinksHolderDTO {
+
+    /**
+     * Creates a DTO from a ProgrammingExercise entity.
+     * Used when you need to send exercise data to the client for editing.
+     *
+     * @param exercise the ProgrammingExercise entity to convert
+     * @return a new UpdateProgrammingExerciseDTO with data from the entity
+     */
+    public static UpdateProgrammingExerciseDTO of(ProgrammingExercise exercise) {
+        if (exercise == null) {
+            throw new BadRequestAlertException("No programming exercise was provided.", "programmingExercise", "programmingExercise.isNull");
+        }
+
+        // For course exercises: set courseId, leave exerciseGroupId null
+        // For exam exercises: set exerciseGroupId, leave courseId null
+        Long courseId = exercise.isCourseExercise() && exercise.getCourseViaExerciseGroupOrCourseMember() != null ? exercise.getCourseViaExerciseGroupOrCourseMember().getId()
+                : null;
+        Long exerciseGroupId = exercise.getExerciseGroup() != null ? exercise.getExerciseGroup().getId() : null;
+
+        Set<GradingCriterionDTO> gradingCriterionDTOs = null;
+        Set<CompetencyLinkDTO> competencyLinkDTOs = null;
+        List<AuxiliaryRepositoryDTO> auxiliaryRepositoryDTOs = null;
+
+        Set<GradingCriterion> criteria = exercise.getGradingCriteria();
+        Set<CompetencyExerciseLink> competencyLinks = exercise.getCompetencyLinks();
+
+        if (criteria != null && Hibernate.isInitialized(criteria)) {
+            gradingCriterionDTOs = criteria.isEmpty() ? Set.of() : criteria.stream().map(GradingCriterionDTO::of).collect(Collectors.toSet());
+        }
+        if (competencyLinks != null && Hibernate.isInitialized(competencyLinks)) {
+            competencyLinkDTOs = competencyLinks.isEmpty() ? Set.of() : competencyLinks.stream().map(CompetencyLinkDTO::of).collect(Collectors.toSet());
+        }
+        if (exercise.getAuxiliaryRepositories() != null && Hibernate.isInitialized(exercise.getAuxiliaryRepositories())) {
+            auxiliaryRepositoryDTOs = exercise.getAuxiliaryRepositories().isEmpty() ? List.of()
+                    : exercise.getAuxiliaryRepositories().stream().map(AuxiliaryRepositoryDTO::of).toList();
+        }
+
+        return new UpdateProgrammingExerciseDTO(exercise.getId(), exercise.getTitle(), exercise.getChannelName(), exercise.getShortName(), exercise.getProblemStatement(),
+                exercise.getCategories(), exercise.getDifficulty(), exercise.getMaxPoints(), exercise.getBonusPoints(), exercise.getIncludedInOverallScore(),
+                exercise.getAllowComplaintsForAutomaticAssessments(), exercise.getAllowFeedbackRequests(), exercise.getPresentationScoreEnabled(),
+                exercise.getSecondCorrectionEnabled(), exercise.getFeedbackSuggestionModule(), exercise.getGradingInstructions(), exercise.getReleaseDate(),
+                exercise.getStartDate(), exercise.getDueDate(), exercise.getAssessmentDueDate(), exercise.getExampleSolutionPublicationDate(), courseId, exerciseGroupId,
+                gradingCriterionDTOs, competencyLinkDTOs, exercise.getTestRepositoryUri(), exercise.getSolutionRepositoryUri(), auxiliaryRepositoryDTOs,
+                exercise.isAllowOnlineEditor(), exercise.isAllowOfflineIde(), exercise.isAllowOnlineIde(), exercise.isStaticCodeAnalysisEnabled(),
+                exercise.getMaxStaticCodeAnalysisPenalty(), exercise.getProgrammingLanguage(), exercise.getPackageName(), exercise.getShowTestNamesToStudents(),
+                exercise.getBuildAndTestStudentSubmissionsAfterDueDate(), exercise.getTestCasesChanged(), exercise.getProjectKey(), exercise.getSubmissionPolicy(),
+                exercise.getProjectType(), exercise.isReleaseTestsWithExampleSolution(), UpdateProgrammingExerciseBuildConfigDTO.of(exercise.getBuildConfig()));
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
@@ -627,6 +627,19 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
     Optional<ProgrammingExercise> findByIdWithGradingCriteria(@Param("exerciseId") long exerciseId);
 
     @Query("""
+            SELECT DISTINCT e
+            FROM ProgrammingExercise e
+                LEFT JOIN FETCH e.gradingCriteria
+                LEFT JOIN FETCH e.exampleSubmissions
+            WHERE e.id = :exerciseId
+            """)
+    Optional<ProgrammingExercise> findByIdWithGradingCriteriaAndExampleSubmissions(@Param("exerciseId") long exerciseId);
+
+    default ProgrammingExercise findByIdWithGradingCriteriaAndExampleSubmissionsElseThrow(long exerciseId) {
+        return getValueElseThrow(findByIdWithGradingCriteriaAndExampleSubmissions(exerciseId), exerciseId);
+    }
+
+    @Query("""
             SELECT e
             FROM ProgrammingExercise e
                 LEFT JOIN FETCH e.competencyLinks

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
@@ -94,7 +94,7 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
     Optional<ProgrammingExercise> findWithAuxiliaryRepositoriesById(long exerciseId);
 
     @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation", "auxiliaryRepositories", "competencyLinks.competency", "buildConfig",
-            "categories" })
+            "categories", "plagiarismDetectionConfig" })
     Optional<ProgrammingExercise> findForUpdateById(long exerciseId);
 
     @EntityGraph(type = LOAD, attributePaths = "submissionPolicy")

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
@@ -93,7 +93,8 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
     @EntityGraph(type = LOAD, attributePaths = "auxiliaryRepositories")
     Optional<ProgrammingExercise> findWithAuxiliaryRepositoriesById(long exerciseId);
 
-    @EntityGraph(type = LOAD, attributePaths = { "auxiliaryRepositories", "competencyLinks.competency", "buildConfig", "categories" })
+    @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation", "auxiliaryRepositories", "competencyLinks.competency", "buildConfig",
+            "categories" })
     Optional<ProgrammingExercise> findForUpdateById(long exerciseId);
 
     @EntityGraph(type = LOAD, attributePaths = "submissionPolicy")

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseCreationUpdateService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseCreationUpdateService.java
@@ -43,6 +43,7 @@ import de.tum.cit.aet.artemis.programming.domain.Repository;
 import de.tum.cit.aet.artemis.programming.domain.RepositoryType;
 import de.tum.cit.aet.artemis.programming.domain.SolutionProgrammingExerciseParticipation;
 import de.tum.cit.aet.artemis.programming.domain.TemplateProgrammingExerciseParticipation;
+import de.tum.cit.aet.artemis.programming.dto.ProgrammingExerciseTimelineUpdateDTO;
 import de.tum.cit.aet.artemis.programming.repository.AuxiliaryRepositoryRepository;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseBuildConfigRepository;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseRepository;
@@ -181,11 +182,14 @@ public class ProgrammingExerciseCreationUpdateService {
         programmingExercise.setTemplateParticipation(null);
         programmingExercise.getBuildConfig().setId(null);
 
+        // Extract competency links before first save - they require the exercise ID which doesn't exist yet
+        var competencyLinks = exerciseService.extractCompetencyLinksForCreation(programmingExercise);
+
         // We save once in order to generate an id for the programming exercise
         var savedBuildConfig = programmingExerciseBuildConfigRepository.saveAndFlush(programmingExercise.getBuildConfig());
         programmingExercise.setBuildConfig(savedBuildConfig);
 
-        var savedProgrammingExercise = exerciseService.saveWithCompetencyLinks(programmingExercise, programmingExerciseRepository::saveForCreation);
+        var savedProgrammingExercise = programmingExerciseRepository.save(programmingExercise);
 
         savedProgrammingExercise.getBuildConfig().setProgrammingExercise(savedProgrammingExercise);
         programmingExerciseBuildConfigRepository.save(savedProgrammingExercise.getBuildConfig());
@@ -222,6 +226,9 @@ public class ProgrammingExerciseCreationUpdateService {
 
         programmingExerciseCreationScheduleService.performScheduleOperationsAndCheckNotifications(savedProgrammingExercise);
         programmingExerciseAtlasIrisService.updateCompetencyProgressOnCreation(savedProgrammingExercise);
+
+        // Restore competency links with proper exercise reference before final save
+        exerciseService.addCompetencyLinksForCreation(savedProgrammingExercise, competencyLinks);
 
         return programmingExerciseRepository.saveForCreation(savedProgrammingExercise);
     }
@@ -307,7 +314,7 @@ public class ProgrammingExerciseCreationUpdateService {
         programmingExerciseTaskService.replaceTestNamesWithIds(updatedProgrammingExercise);
         programmingExerciseBuildConfigRepository.save(updatedProgrammingExercise.getBuildConfig());
 
-        ProgrammingExercise savedProgrammingExercise = exerciseService.saveWithCompetencyLinks(updatedProgrammingExercise, programmingExerciseRepository::save);
+        ProgrammingExercise savedProgrammingExercise = programmingExerciseRepository.save(updatedProgrammingExercise);
 
         // The returned value should use test case names since it gets send back to the client
         savedProgrammingExercise.setProblemStatement(problemStatementWithTestNames);
@@ -352,14 +359,14 @@ public class ProgrammingExerciseCreationUpdateService {
     }
 
     /**
-     * Updates the timeline attributes of the given programming exercise
+     * Updates the timeline attributes of the given programming exercise with the values from the DTO.
      *
-     * @param updatedProgrammingExercise containing the changes that have to be saved
-     * @param notificationText           optional text for a notification to all students about the update
+     * @param timelineUpdateDTO containing the timeline changes that have to be saved
+     * @param notificationText  optional text for a notification to all students about the update
      * @return the updated ProgrammingExercise object.
      */
-    public ProgrammingExercise updateTimeline(ProgrammingExercise updatedProgrammingExercise, @Nullable String notificationText) {
-        ProgrammingExercise programmingExercise = programmingExerciseRepository.findByIdElseThrow(updatedProgrammingExercise.getId());
+    public ProgrammingExercise updateTimeline(ProgrammingExerciseTimelineUpdateDTO timelineUpdateDTO, @Nullable String notificationText) {
+        ProgrammingExercise programmingExercise = programmingExerciseRepository.findByIdElseThrow(timelineUpdateDTO.id());
 
         // create slim copy of programmingExercise before the update - needed for notifications (only release date needed)
         ProgrammingExercise programmingExerciseBeforeUpdate = new ProgrammingExercise();
@@ -367,13 +374,8 @@ public class ProgrammingExerciseCreationUpdateService {
         programmingExerciseBeforeUpdate.setStartDate(programmingExercise.getStartDate());
         programmingExerciseBeforeUpdate.setAssessmentDueDate(programmingExercise.getAssessmentDueDate());
 
-        programmingExercise.setReleaseDate(updatedProgrammingExercise.getReleaseDate());
-        programmingExercise.setStartDate(updatedProgrammingExercise.getStartDate());
-        programmingExercise.setDueDate(updatedProgrammingExercise.getDueDate());
-        programmingExercise.setBuildAndTestStudentSubmissionsAfterDueDate(updatedProgrammingExercise.getBuildAndTestStudentSubmissionsAfterDueDate());
-        programmingExercise.setAssessmentType(updatedProgrammingExercise.getAssessmentType());
-        programmingExercise.setAssessmentDueDate(updatedProgrammingExercise.getAssessmentDueDate());
-        programmingExercise.setExampleSolutionPublicationDate(updatedProgrammingExercise.getExampleSolutionPublicationDate());
+        // Apply the DTO values to the existing exercise
+        timelineUpdateDTO.applyTo(programmingExercise);
 
         programmingExercise.validateDates();
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportBasicService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportBasicService.java
@@ -187,7 +187,12 @@ public class ProgrammingExerciseImportBasicService {
             }
         }
 
-        final ProgrammingExercise importedExercise = exerciseService.saveWithCompetencyLinks(newProgrammingExercise, programmingExerciseRepository::save);
+        var competencyLinks = exerciseService.extractCompetencyLinksForCreation(newProgrammingExercise);
+        ProgrammingExercise importedExercise = programmingExerciseRepository.save(newProgrammingExercise);
+        if (!competencyLinks.isEmpty()) {
+            exerciseService.addCompetencyLinksForCreation(importedExercise, competencyLinks);
+            importedExercise = programmingExerciseRepository.save(importedExercise);
+        }
 
         final Map<Long, Long> newTestCaseIdByOldId = importTestCases(originalProgrammingExercise, importedExercise);
         importTasks(originalProgrammingExercise, importedExercise, newTestCaseIdByOldId);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseExportImportResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseExportImportResource.java
@@ -208,6 +208,9 @@ public class ProgrammingExerciseExportImportResource {
         newExercise.checkCourseAndExerciseGroupExclusivity(ENTITY_NAME);
 
         log.debug("REST request to import programming exercise {} into course {}", sourceExerciseId, newExercise.getCourseViaExerciseGroupOrCourseMember().getId());
+        // Clear competency links from the incoming exercise - they are not imported because competencies are course-specific
+        // This prevents detached entity errors when the exercise contains competency links with serialized competency entities
+        newExercise.setCompetencyLinks(new java.util.HashSet<>());
         newExercise.validateGeneralSettings();
         newExercise.validateProgrammingSettings();
         newExercise.validateSettingsForFeedbackRequest();

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExercisePartialUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExercisePartialUpdateResource.java
@@ -27,6 +27,7 @@ import de.tum.cit.aet.artemis.core.util.HeaderUtil;
 import de.tum.cit.aet.artemis.exercise.service.ExerciseService;
 import de.tum.cit.aet.artemis.exercise.service.ExerciseVersionService;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
+import de.tum.cit.aet.artemis.programming.dto.ProgrammingExerciseTimelineUpdateDTO;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseRepository;
 import de.tum.cit.aet.artemis.programming.service.ProgrammingExerciseCreationUpdateService;
 import de.tum.cit.aet.artemis.programming.service.ProgrammingExerciseTaskService;
@@ -76,21 +77,21 @@ public class ProgrammingExercisePartialUpdateResource {
     /**
      * PUT /programming-exercises/timeline : Updates the timeline attributes of a given exercise
      *
-     * @param updatedProgrammingExercise containing the changes that have to be saved
-     * @param notificationText           an optional text to notify the student group about the update on the programming exercise
+     * @param timelineUpdateDTO containing the timeline changes that have to be saved
+     * @param notificationText  an optional text to notify the student group about the update on the programming exercise
      * @return the ResponseEntity with status 200 (OK) with the updated ProgrammingExercise, or with status 403 (Forbidden)
      *         if the user is not allowed to update the exercise or with 404 (Not Found) if the updated ProgrammingExercise couldn't be found in the database
      */
     @PutMapping("programming-exercises/timeline")
     @EnforceAtLeastEditor
     @FeatureToggle(Feature.ProgrammingExercises)
-    public ResponseEntity<ProgrammingExercise> updateProgrammingExerciseTimeline(@RequestBody ProgrammingExercise updatedProgrammingExercise,
+    public ResponseEntity<ProgrammingExercise> updateProgrammingExerciseTimeline(@RequestBody ProgrammingExerciseTimelineUpdateDTO timelineUpdateDTO,
             @RequestParam(value = "notificationText", required = false) String notificationText) {
-        log.debug("REST request to update the timeline of ProgrammingExercise : {}", updatedProgrammingExercise);
-        var existingProgrammingExercise = programmingExerciseRepository.findByIdElseThrow(updatedProgrammingExercise.getId());
+        log.debug("REST request to update the timeline of ProgrammingExercise : {}", timelineUpdateDTO.id());
+        var existingProgrammingExercise = programmingExerciseRepository.findByIdElseThrow(timelineUpdateDTO.id());
         var user = userRepository.getUserWithGroupsAndAuthorities();
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, existingProgrammingExercise, user);
-        updatedProgrammingExercise = programmingExerciseCreationUpdateService.updateTimeline(updatedProgrammingExercise, notificationText);
+        var updatedProgrammingExercise = programmingExerciseCreationUpdateService.updateTimeline(timelineUpdateDTO, notificationText);
         exerciseService.logUpdate(updatedProgrammingExercise, updatedProgrammingExercise.getCourseViaExerciseGroupOrCourseMember(), user);
         exerciseVersionService.createExerciseVersion(updatedProgrammingExercise, user);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, updatedProgrammingExercise.getTitle()))

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseUpdateResource.java
@@ -409,8 +409,8 @@ public class ProgrammingExerciseUpdateResource {
             @RequestParam(value = "deleteFeedback", required = false) Boolean deleteFeedbackAfterGradingInstructionUpdate) throws JsonProcessingException {
         log.debug("REST request to re-evaluate ProgrammingExercise with id: {}", updateDTO.id());
 
-        // Check that the exercise exists for given id (with grading criteria for re-evaluation)
-        var programmingExercise = programmingExerciseRepository.findByIdWithGradingCriteriaElseThrow(exerciseId);
+        // Check that the exercise exists for given id (with grading criteria and example submissions for re-evaluation)
+        var programmingExercise = programmingExerciseRepository.findByIdWithGradingCriteriaAndExampleSubmissionsElseThrow(exerciseId);
 
         if (updateDTO.id() == null || exerciseId != updateDTO.id()) {
             throw new ConflictException("Exercise id in path does not match id in request body", ENTITY_NAME, "idMismatch");

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseUpdateResource.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.programming.web;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -20,6 +21,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
+import de.tum.cit.aet.artemis.assessment.dto.GradingCriterionDTO;
 import de.tum.cit.aet.artemis.athena.api.AthenaApi;
 import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
@@ -36,7 +39,12 @@ import de.tum.cit.aet.artemis.exercise.service.ExerciseService;
 import de.tum.cit.aet.artemis.exercise.service.ExerciseVersionService;
 import de.tum.cit.aet.artemis.lecture.api.SlideApi;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismDetectionConfigHelper;
+import de.tum.cit.aet.artemis.programming.domain.AuxiliaryRepository;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseBuildConfig;
+import de.tum.cit.aet.artemis.programming.dto.AuxiliaryRepositoryDTO;
+import de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseBuildConfigDTO;
+import de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseRepository;
 import de.tum.cit.aet.artemis.programming.service.AuxiliaryRepositoryService;
 import de.tum.cit.aet.artemis.programming.service.ProgrammingExerciseCreationUpdateService;
@@ -103,30 +111,59 @@ public class ProgrammingExerciseUpdateResource {
     }
 
     /**
-     * PUT /programming-exercises : Updates an existing updatedProgrammingExercise.
+     * PUT /programming-exercises : Updates an existing programming exercise.
      *
-     * @param updatedProgrammingExercise the programmingExercise that has been updated on the client
-     * @param notificationText           to notify the student group about the update on the programming exercise
+     * @param updateDTO        the DTO containing the updated programming exercise data
+     * @param notificationText to notify the student group about the update on the programming exercise
      * @return the ResponseEntity with status 200 (OK) and with body the updated ProgrammingExercise, or with status 400 (Bad Request) if the updated ProgrammingExercise
      *         is not valid, or with status 500 (Internal Server Error) if the updated ProgrammingExercise couldn't be saved to the database
      */
     @PutMapping("programming-exercises")
     @EnforceAtLeastEditor
     @FeatureToggle(Feature.ProgrammingExercises)
-    public ResponseEntity<ProgrammingExercise> updateProgrammingExercise(@RequestBody ProgrammingExercise updatedProgrammingExercise,
+    public ResponseEntity<ProgrammingExercise> updateProgrammingExercise(@RequestBody UpdateProgrammingExerciseDTO updateDTO,
             @RequestParam(value = "notificationText", required = false) String notificationText) throws JsonProcessingException {
-        log.debug("REST request to update ProgrammingExercise : {}", updatedProgrammingExercise);
-        if (updatedProgrammingExercise.getId() == null) {
+        log.debug("REST request to update ProgrammingExercise with id: {}", updateDTO.id());
+
+        if (updateDTO.id() == null || updateDTO.id() == 0) {
             throw new BadRequestAlertException("Programming exercise cannot have an empty id when updating", ENTITY_NAME, "noProgrammingExerciseId");
         }
 
-        updatedProgrammingExercise.validateGeneralSettings();
+        // Validate that either courseId or exerciseGroupId is set, but not both
+        if (updateDTO.courseId() == null && updateDTO.exerciseGroupId() == null) {
+            throw new BadRequestAlertException("Either courseId or exerciseGroupId must be set", ENTITY_NAME, "noCourseOrExerciseGroup");
+        }
+        if (updateDTO.courseId() != null && updateDTO.exerciseGroupId() != null) {
+            throw new BadRequestAlertException("A programming exercise can only be associated with either a course or an exercise group, not both", ENTITY_NAME,
+                    "bothCourseAndExerciseGroupSet");
+        }
 
-        // Valid exercises have set either a course or an exerciseGroup
+        // Load the existing exercise from the database with all necessary associations
+        var programmingExerciseBeforeUpdate = programmingExerciseRepository.findForUpdateByIdElseThrow(updateDTO.id());
+
+        // Validate that courseId or exerciseGroupId hasn't changed
+        // For course exercises: courseId must match
+        // For exam exercises: exerciseGroupId must match
+        Long existingCourseId = programmingExerciseBeforeUpdate.isCourseExercise() && programmingExerciseBeforeUpdate.getCourseViaExerciseGroupOrCourseMember() != null
+                ? programmingExerciseBeforeUpdate.getCourseViaExerciseGroupOrCourseMember().getId()
+                : null;
+        Long existingExerciseGroupId = programmingExerciseBeforeUpdate.getExerciseGroup() != null ? programmingExerciseBeforeUpdate.getExerciseGroup().getId() : null;
+        if (!Objects.equals(existingCourseId, updateDTO.courseId()) || !Objects.equals(existingExerciseGroupId, updateDTO.exerciseGroupId())) {
+            throw new ConflictException("The course or exercise group cannot be changed", ENTITY_NAME, "courseOrExerciseGroupCannotChange");
+        }
+
+        // Create a copy for "before update" state to track changes
+        var originalExercise = programmingExerciseRepository.findForUpdateByIdElseThrow(updateDTO.id());
+
+        // Update the existing exercise with DTO values
+        ProgrammingExercise updatedProgrammingExercise = update(updateDTO, programmingExerciseBeforeUpdate);
+
+        // Validate the updated exercise
+        updatedProgrammingExercise.validateGeneralSettings();
         updatedProgrammingExercise.checkCourseAndExerciseGroupExclusivity(ENTITY_NAME);
         programmingExerciseValidationService.validateStaticCodeAnalysisSettings(updatedProgrammingExercise);
 
-        // fetch course from database to make sure client didn't change groups
+        // Fetch course from database to make sure client didn't change groups
         var user = userRepository.getUserWithGroupsAndAuthorities();
         Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(updatedProgrammingExercise);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, user);
@@ -135,32 +172,31 @@ public class ProgrammingExerciseUpdateResource {
         // Validate plagiarism detection config
         PlagiarismDetectionConfigHelper.validatePlagiarismDetectionConfigOrThrow(updatedProgrammingExercise, ENTITY_NAME);
 
-        var programmingExerciseBeforeUpdate = programmingExerciseRepository.findForUpdateByIdElseThrow(updatedProgrammingExercise.getId());
-        if (!Objects.equals(programmingExerciseBeforeUpdate.getShortName(), updatedProgrammingExercise.getShortName())) {
+        // Validate immutable fields haven't changed
+        if (!Objects.equals(originalExercise.getShortName(), updateDTO.shortName())) {
             throw new BadRequestAlertException("The programming exercise short name cannot be changed", ENTITY_NAME, "shortNameCannotChange");
         }
-        if (!Objects.equals(programmingExerciseBeforeUpdate.isStaticCodeAnalysisEnabled(), updatedProgrammingExercise.isStaticCodeAnalysisEnabled())) {
+        if (!Objects.equals(originalExercise.isStaticCodeAnalysisEnabled(), updateDTO.staticCodeAnalysisEnabled())) {
             throw new BadRequestAlertException("Static code analysis enabled flag must not be changed", ENTITY_NAME, "staticCodeAnalysisCannotChange");
         }
         // Check if Theia is enabled
         if (moduleFeatureService.isTheiaEnabled()) {
             // Require 1 / 3 participation modes to be enabled
-            if (!Boolean.TRUE.equals(updatedProgrammingExercise.isAllowOnlineEditor()) && !Boolean.TRUE.equals(updatedProgrammingExercise.isAllowOfflineIde())
-                    && !updatedProgrammingExercise.isAllowOnlineIde()) {
+            if (!Boolean.TRUE.equals(updateDTO.allowOnlineEditor()) && !Boolean.TRUE.equals(updateDTO.allowOfflineIde()) && !updateDTO.allowOnlineIde()) {
                 throw new BadRequestAlertException("You need to allow at least one participation mode, the online editor, the offline IDE, or the online IDE", ENTITY_NAME,
                         "noParticipationModeAllowed");
             }
         }
         else {
             // Require 1 / 2 participation modes to be enabled
-            if (!Boolean.TRUE.equals(updatedProgrammingExercise.isAllowOnlineEditor()) && !Boolean.TRUE.equals(updatedProgrammingExercise.isAllowOfflineIde())) {
+            if (!Boolean.TRUE.equals(updateDTO.allowOnlineEditor()) && !Boolean.TRUE.equals(updateDTO.allowOfflineIde())) {
                 throw new BadRequestAlertException("You need to allow at least one participation mode, the online editor or the offline IDE", ENTITY_NAME,
                         "noParticipationModeAllowed");
             }
         }
 
-        // Verify that the checkout directories have not been changed. This is required since the buildScript and result paths are determined during the creation of the exercise.
-        programmingExerciseValidationService.validateCheckoutDirectoriesUnchanged(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
+        // Verify that the checkout directories have not been changed
+        programmingExerciseValidationService.validateCheckoutDirectoriesUnchanged(originalExercise, updatedProgrammingExercise);
 
         // Verify that the programming language supports the selected network access option
         programmingExerciseValidationService.validateDockerFlags(updatedProgrammingExercise);
@@ -169,56 +205,197 @@ public class ProgrammingExerciseUpdateResource {
         if (updatedProgrammingExercise.isAllowOnlineIde() && updatedProgrammingExercise.getBuildConfig().getTheiaImage() == null) {
             throw new BadRequestAlertException("You need to provide a Theia image when the online IDE is enabled", ENTITY_NAME, "noTheiaImageProvided");
         }
-        // Forbid changing the course the exercise belongs to.
-        if (!Objects.equals(programmingExerciseBeforeUpdate.getCourseViaExerciseGroupOrCourseMember().getId(),
-                updatedProgrammingExercise.getCourseViaExerciseGroupOrCourseMember().getId())) {
+
+        // Forbid changing the course the exercise belongs to
+        if (!Objects.equals(originalExercise.getCourseViaExerciseGroupOrCourseMember().getId(), updatedProgrammingExercise.getCourseViaExerciseGroupOrCourseMember().getId())) {
             throw new ConflictException("Exercise course id does not match the stored course id", ENTITY_NAME, "cannotChangeCourseId");
         }
+
         // Forbid conversion between normal course exercise and exam exercise
-        exerciseService.checkForConversionBetweenExamAndCourseExercise(updatedProgrammingExercise, programmingExerciseBeforeUpdate, ENTITY_NAME);
+        exerciseService.checkForConversionBetweenExamAndCourseExercise(updatedProgrammingExercise, originalExercise, ENTITY_NAME);
 
         // Check that only allowed Athena modules are used
         athenaApi.ifPresentOrElse(api -> api.checkHasAccessToAthenaModule(updatedProgrammingExercise, course, ENTITY_NAME),
                 () -> updatedProgrammingExercise.setFeedbackSuggestionModule(null));
         // Changing Athena module after the due date has passed is not allowed
-        athenaApi.ifPresent(api -> api.checkValidAthenaModuleChange(programmingExerciseBeforeUpdate, updatedProgrammingExercise, ENTITY_NAME));
+        athenaApi.ifPresent(api -> api.checkValidAthenaModuleChange(originalExercise, updatedProgrammingExercise, ENTITY_NAME));
 
-        // Ignore changes to the default branch
-        updatedProgrammingExercise.getBuildConfig().setBranch(programmingExerciseBeforeUpdate.getBuildConfig().getBranch());
+        // Ignore changes to the default branch - preserve the original
+        updatedProgrammingExercise.getBuildConfig().setBranch(originalExercise.getBuildConfig().getBranch());
 
         if (updatedProgrammingExercise.getAuxiliaryRepositories() == null) {
-            // make sure the default value is set properly
             updatedProgrammingExercise.setAuxiliaryRepositories(new ArrayList<>());
         }
 
         // Update the auxiliary repositories in the DB and ProgrammingExercise instance
-        auxiliaryRepositoryService.handleAuxiliaryRepositoriesWhenUpdatingExercises(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
+        auxiliaryRepositoryService.handleAuxiliaryRepositoriesWhenUpdatingExercises(originalExercise, updatedProgrammingExercise);
 
-        // Update the auxiliary repositories in the VCS. This needs to be decoupled to break circular dependencies.
-        programmingExerciseRepositoryService.handleAuxiliaryRepositoriesWhenUpdatingExercises(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
+        // Update the auxiliary repositories in the VCS
+        programmingExerciseRepositoryService.handleAuxiliaryRepositoriesWhenUpdatingExercises(originalExercise, updatedProgrammingExercise);
 
         if (updatedProgrammingExercise.getBonusPoints() == null) {
-            // make sure the default value is set properly
             updatedProgrammingExercise.setBonusPoints(0.0);
         }
 
         // Only save after checking for errors
-        ProgrammingExercise savedProgrammingExercise = programmingExerciseCreationUpdateService.updateProgrammingExercise(programmingExerciseBeforeUpdate,
-                updatedProgrammingExercise, notificationText);
+        ProgrammingExercise savedProgrammingExercise = programmingExerciseCreationUpdateService.updateProgrammingExercise(originalExercise, updatedProgrammingExercise,
+                notificationText);
 
         exerciseService.logUpdate(updatedProgrammingExercise, updatedProgrammingExercise.getCourseViaExerciseGroupOrCourseMember(), user);
-        exerciseService.updatePointsInRelatedParticipantScores(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
-        slideApi.ifPresent(api -> api.handleDueDateChange(programmingExerciseBeforeUpdate, updatedProgrammingExercise));
+        exerciseService.updatePointsInRelatedParticipantScores(originalExercise, updatedProgrammingExercise);
+        slideApi.ifPresent(api -> api.handleDueDateChange(originalExercise, updatedProgrammingExercise));
         exerciseVersionService.createExerciseVersion(savedProgrammingExercise, user);
-
         return ResponseEntity.ok(savedProgrammingExercise);
+    }
+
+    /**
+     * Updates the existing ProgrammingExercise entity with values from the DTO.
+     * This includes updating competency links using the proper mechanism.
+     *
+     * @param dto      the DTO containing updated values
+     * @param exercise the existing exercise entity to update
+     * @return the updated exercise entity
+     */
+    private ProgrammingExercise update(UpdateProgrammingExerciseDTO dto, ProgrammingExercise exercise) {
+        if (dto == null) {
+            throw new BadRequestAlertException("No programming exercise was provided.", ENTITY_NAME, "isNull");
+        }
+
+        // Update base exercise fields
+        exercise.setTitle(dto.title());
+        exercise.validateTitle();
+        exercise.setShortName(dto.shortName());
+
+        String newProblemStatement = dto.problemStatement() == null ? "" : dto.problemStatement();
+        exercise.setProblemStatement(newProblemStatement);
+
+        exercise.setChannelName(dto.channelName());
+        exercise.setCategories(dto.categories());
+        exercise.setDifficulty(dto.difficulty());
+
+        exercise.setMaxPoints(dto.maxPoints());
+        exercise.setBonusPoints(dto.bonusPoints());
+        exercise.setIncludedInOverallScore(dto.includedInOverallScore());
+
+        exercise.setReleaseDate(dto.releaseDate());
+        exercise.setStartDate(dto.startDate());
+        exercise.setDueDate(dto.dueDate());
+        exercise.setAssessmentDueDate(dto.assessmentDueDate());
+        exercise.setExampleSolutionPublicationDate(dto.exampleSolutionPublicationDate());
+
+        // Only set boolean values if they are explicitly provided (not null)
+        if (dto.allowComplaintsForAutomaticAssessments() != null) {
+            exercise.setAllowComplaintsForAutomaticAssessments(dto.allowComplaintsForAutomaticAssessments());
+        }
+        if (dto.allowFeedbackRequests() != null) {
+            exercise.setAllowFeedbackRequests(dto.allowFeedbackRequests());
+        }
+        if (dto.presentationScoreEnabled() != null) {
+            exercise.setPresentationScoreEnabled(dto.presentationScoreEnabled());
+        }
+        if (dto.secondCorrectionEnabled() != null) {
+            exercise.setSecondCorrectionEnabled(dto.secondCorrectionEnabled());
+        }
+
+        exercise.setFeedbackSuggestionModule(dto.feedbackSuggestionModule());
+        exercise.setGradingInstructions(dto.gradingInstructions());
+
+        // Update programming exercise specific fields
+        if (dto.allowOnlineEditor() != null) {
+            exercise.setAllowOnlineEditor(dto.allowOnlineEditor());
+        }
+        if (dto.allowOfflineIde() != null) {
+            exercise.setAllowOfflineIde(dto.allowOfflineIde());
+        }
+        exercise.setAllowOnlineIde(dto.allowOnlineIde());
+
+        if (dto.maxStaticCodeAnalysisPenalty() != null) {
+            exercise.setMaxStaticCodeAnalysisPenalty(dto.maxStaticCodeAnalysisPenalty());
+        }
+
+        exercise.setShowTestNamesToStudents(dto.showTestNamesToStudents());
+        exercise.setBuildAndTestStudentSubmissionsAfterDueDate(dto.buildAndTestStudentSubmissionsAfterDueDate());
+
+        if (dto.testCasesChanged() != null) {
+            exercise.setTestCasesChanged(dto.testCasesChanged());
+        }
+
+        exercise.setSubmissionPolicy(dto.submissionPolicy());
+        exercise.setProjectType(dto.projectType());
+        exercise.setReleaseTestsWithExampleSolution(dto.releaseTestsWithExampleSolution());
+
+        // Update auxiliary repositories
+        if (dto.auxiliaryRepositories() != null) {
+            List<AuxiliaryRepository> auxRepos = dto.auxiliaryRepositories().stream().map(AuxiliaryRepositoryDTO::toEntity).toList();
+            exercise.setAuxiliaryRepositories(new ArrayList<>(auxRepos));
+        }
+
+        // Update build config
+        updateBuildConfig(dto.buildConfig(), exercise.getBuildConfig());
+
+        // Update grading criteria
+        updateGradingCriteria(dto, exercise);
+
+        // Update competency links using the proper mechanism
+        exerciseService.updateCompetencyLinks(dto, exercise);
+
+        return exercise;
+    }
+
+    /**
+     * Updates the build config entity with values from the DTO.
+     *
+     * @param dto         the DTO containing updated build config values
+     * @param buildConfig the existing build config entity to update
+     */
+    private void updateBuildConfig(UpdateProgrammingExerciseBuildConfigDTO dto, ProgrammingExerciseBuildConfig buildConfig) {
+        if (dto == null || buildConfig == null) {
+            return;
+        }
+
+        if (dto.sequentialTestRuns() != null) {
+            buildConfig.setSequentialTestRuns(dto.sequentialTestRuns());
+        }
+        // Note: branch is preserved from original (immutable during update)
+        if (dto.buildPlanConfiguration() != null) {
+            buildConfig.setBuildPlanConfiguration(dto.buildPlanConfiguration());
+        }
+        if (dto.buildScript() != null) {
+            buildConfig.setBuildScript(dto.buildScript());
+        }
+        buildConfig.setCheckoutSolutionRepository(dto.checkoutSolutionRepository());
+        buildConfig.setTestCheckoutPath(dto.testCheckoutPath());
+        buildConfig.setAssignmentCheckoutPath(dto.assignmentCheckoutPath());
+        buildConfig.setSolutionCheckoutPath(dto.solutionCheckoutPath());
+        buildConfig.setTimeoutSeconds(dto.timeoutSeconds());
+        buildConfig.setDockerFlags(dto.dockerFlags());
+        buildConfig.setTheiaImage(dto.theiaImage());
+        buildConfig.setAllowBranching(dto.allowBranching());
+        buildConfig.setBranchRegex(dto.branchRegex());
+    }
+
+    /**
+     * Updates grading criteria from the DTO.
+     *
+     * @param dto      the DTO containing grading criteria
+     * @param exercise the exercise to update
+     */
+    private void updateGradingCriteria(UpdateProgrammingExerciseDTO dto, ProgrammingExercise exercise) {
+        if (dto.gradingCriteria() != null) {
+            exercise.getGradingCriteria().clear();
+            for (GradingCriterionDTO criterionDTO : dto.gradingCriteria()) {
+                GradingCriterion criterion = criterionDTO.toEntity();
+                criterion.setExercise(exercise);
+                exercise.getGradingCriteria().add(criterion);
+            }
+        }
     }
 
     /**
      * PUT /programming-exercises/{exerciseId}/re-evaluate : Re-evaluates and updates an existing ProgrammingExercise.
      *
      * @param exerciseId                                  of the exercise
-     * @param programmingExercise                         the ProgrammingExercise to re-evaluate and update
+     * @param updateDTO                                   the DTO containing the ProgrammingExercise data to re-evaluate and update
      * @param deleteFeedbackAfterGradingInstructionUpdate boolean flag that indicates whether the associated feedback should be deleted or not
      * @return the ResponseEntity with status 200 (OK) and with body the updated ProgrammingExercise, or with status 400 (Bad Request) if the ProgrammingExercise is not valid,
      *         or with status 409 (Conflict) if given exerciseId is not same as in the object of the request body, or with status 500 (Internal Server Error) if the
@@ -228,20 +405,23 @@ public class ProgrammingExerciseUpdateResource {
     @PutMapping("programming-exercises/{exerciseId}/re-evaluate")
     @EnforceAtLeastEditor
     @FeatureToggle(Feature.ProgrammingExercises)
-    public ResponseEntity<ProgrammingExercise> reEvaluateAndUpdateProgrammingExercise(@PathVariable long exerciseId, @RequestBody ProgrammingExercise programmingExercise,
+    public ResponseEntity<ProgrammingExercise> reEvaluateAndUpdateProgrammingExercise(@PathVariable long exerciseId, @RequestBody UpdateProgrammingExerciseDTO updateDTO,
             @RequestParam(value = "deleteFeedback", required = false) Boolean deleteFeedbackAfterGradingInstructionUpdate) throws JsonProcessingException {
-        log.debug("REST request to re-evaluate ProgrammingExercise : {}", programmingExercise);
-        // check that the exercise exists for given id
-        programmingExerciseRepository.findByIdElseThrow(exerciseId);
-        authCheckService.checkGivenExerciseIdSameForExerciseInRequestBodyElseThrow(exerciseId, programmingExercise);
+        log.debug("REST request to re-evaluate ProgrammingExercise with id: {}", updateDTO.id());
 
-        // fetch course from database to make sure client didn't change groups
+        // Check that the exercise exists for given id (with grading criteria for re-evaluation)
+        var programmingExercise = programmingExerciseRepository.findByIdWithGradingCriteriaElseThrow(exerciseId);
+
+        if (updateDTO.id() == null || exerciseId != updateDTO.id()) {
+            throw new ConflictException("Exercise id in path does not match id in request body", ENTITY_NAME, "idMismatch");
+        }
+
+        // Fetch course from database to make sure client didn't change groups
         var user = userRepository.getUserWithGroupsAndAuthorities();
         Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(programmingExercise);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, user);
 
         exerciseService.reEvaluateExercise(programmingExercise, deleteFeedbackAfterGradingInstructionUpdate);
-        return updateProgrammingExercise(programmingExercise, null);
+        return updateProgrammingExercise(updateDTO, null);
     }
-
 }

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/QuizBatchFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/QuizBatchFromEditorDTO.java
@@ -1,0 +1,55 @@
+package de.tum.cit.aet.artemis.quiz.dto;
+
+import java.time.ZonedDateTime;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.quiz.domain.QuizBatch;
+
+/**
+ * DTO for quiz batches in the editor context.
+ * Supports both creating new batches (id is null) and updating existing batches (id is non-null).
+ *
+ * @param id        the ID of the batch, null for new batches
+ * @param startTime the start time of the batch
+ * @param password  the password for the batch (for batched mode)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record QuizBatchFromEditorDTO(Long id, ZonedDateTime startTime, String password) {
+
+    /**
+     * Creates a QuizBatchFromEditorDTO from the given QuizBatch domain object.
+     *
+     * @param quizBatch the quiz batch to convert
+     * @return the corresponding DTO
+     */
+    public static QuizBatchFromEditorDTO of(QuizBatch quizBatch) {
+        return new QuizBatchFromEditorDTO(quizBatch.getId(), quizBatch.getStartTime(), quizBatch.getPassword());
+    }
+
+    /**
+     * Creates a new QuizBatch domain object from this DTO.
+     * Note: This should only be used for new batches (id is null).
+     * For existing batches, use applyTo() to update the existing entity.
+     *
+     * @return a new QuizBatch domain object
+     */
+    public QuizBatch toDomainObject() {
+        QuizBatch quizBatch = new QuizBatch();
+        quizBatch.setStartTime(this.startTime);
+        quizBatch.setPassword(this.password);
+        return quizBatch;
+    }
+
+    /**
+     * Applies the DTO values to an existing QuizBatch entity.
+     *
+     * @param quizBatch the existing quiz batch to update
+     */
+    public void applyTo(QuizBatch quizBatch) {
+        quizBatch.setStartTime(this.startTime);
+        quizBatch.setPassword(this.password);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/exercise/UpdateQuizExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/exercise/UpdateQuizExerciseDTO.java
@@ -30,7 +30,7 @@ import de.tum.cit.aet.artemis.quiz.dto.question.fromEditor.QuizQuestionFromEdito
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record UpdateQuizExerciseDTO(String title, String channelName, Set<String> categories, Set<CompetencyLinkDTO> competencyLinks, DifficultyLevel difficulty, Integer duration,
         Boolean randomizeQuestionOrder, QuizMode quizMode, Set<@Valid QuizBatchFromEditorDTO> quizBatches, ZonedDateTime releaseDate, ZonedDateTime startDate,
-        ZonedDateTime dueDate, IncludedInOverallScore includedInOverallScore, List<@Valid ? extends QuizQuestionFromEditorDTO> quizQuestions) implements CompetencyLinksHolderDTO {
+        ZonedDateTime dueDate, IncludedInOverallScore includedInOverallScore, List<@Valid QuizQuestionFromEditorDTO> quizQuestions) implements CompetencyLinksHolderDTO {
 
     /**
      * Creates a QuizExerciseFromEditorDTO from the given QuizExercise domain object.

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/exercise/UpdateQuizExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/exercise/UpdateQuizExerciseDTO.java
@@ -1,0 +1,54 @@
+package de.tum.cit.aet.artemis.quiz.dto.exercise;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.validation.Valid;
+
+import org.hibernate.Hibernate;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.exercise.domain.DifficultyLevel;
+import de.tum.cit.aet.artemis.exercise.domain.IncludedInOverallScore;
+import de.tum.cit.aet.artemis.exercise.dto.CompetencyLinksHolderDTO;
+import de.tum.cit.aet.artemis.lecture.dto.CompetencyLinkDTO;
+import de.tum.cit.aet.artemis.quiz.domain.QuizExercise;
+import de.tum.cit.aet.artemis.quiz.domain.QuizMode;
+import de.tum.cit.aet.artemis.quiz.dto.QuizBatchFromEditorDTO;
+import de.tum.cit.aet.artemis.quiz.dto.question.fromEditor.QuizQuestionFromEditorDTO;
+
+/**
+ * DTO for updating quiz exercises from the editor.
+ * Uses DTOs instead of entity classes to avoid Hibernate detached entity issues.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record UpdateQuizExerciseDTO(String title, String channelName, Set<String> categories, Set<CompetencyLinkDTO> competencyLinks, DifficultyLevel difficulty, Integer duration,
+        Boolean randomizeQuestionOrder, QuizMode quizMode, Set<@Valid QuizBatchFromEditorDTO> quizBatches, ZonedDateTime releaseDate, ZonedDateTime startDate,
+        ZonedDateTime dueDate, IncludedInOverallScore includedInOverallScore, List<@Valid ? extends QuizQuestionFromEditorDTO> quizQuestions) implements CompetencyLinksHolderDTO {
+
+    /**
+     * Creates a QuizExerciseFromEditorDTO from the given QuizExercise domain object.
+     *
+     * @param quizExercise the quiz exercise to convert
+     * @return the corresponding DTO
+     */
+    public static UpdateQuizExerciseDTO of(QuizExercise quizExercise) {
+        List<QuizQuestionFromEditorDTO> questionDTOs = quizExercise.getQuizQuestions().stream().map(QuizQuestionFromEditorDTO::of).toList();
+        Set<QuizBatchFromEditorDTO> batchDTOs = Optional.ofNullable(quizExercise.getQuizBatches()).orElse(Set.of()).stream().map(QuizBatchFromEditorDTO::of)
+                .collect(Collectors.toSet());
+        // Only convert competency links if they are initialized (to avoid LazyInitializationException)
+        Set<CompetencyLinkDTO> competencyLinkDTOs = null;
+        if (Hibernate.isInitialized(quizExercise.getCompetencyLinks()) && quizExercise.getCompetencyLinks() != null) {
+            competencyLinkDTOs = quizExercise.getCompetencyLinks().stream().map(CompetencyLinkDTO::of).collect(Collectors.toSet());
+        }
+        return new UpdateQuizExerciseDTO(quizExercise.getTitle(), quizExercise.getChannelName(), quizExercise.getCategories(), competencyLinkDTOs, quizExercise.getDifficulty(),
+                quizExercise.getDuration(), quizExercise.isRandomizeQuestionOrder(), quizExercise.getQuizMode(), batchDTOs, quizExercise.getReleaseDate(),
+                quizExercise.getStartDate(), quizExercise.getDueDate(), quizExercise.getIncludedInOverallScore(), questionDTOs);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/AnswerOptionFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/AnswerOptionFromEditorDTO.java
@@ -1,0 +1,60 @@
+package de.tum.cit.aet.artemis.quiz.dto.question.fromEditor;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.quiz.domain.AnswerOption;
+
+/**
+ * DTO for answer options in the editor context.
+ * Supports both creating new options (id is null) and updating existing options (id is non-null).
+ *
+ * @param id          the ID of the answer option, null for new options
+ * @param text        the text of the answer option
+ * @param hint        the hint for the answer option
+ * @param explanation the explanation for the answer option
+ * @param isCorrect   whether this option is correct
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record AnswerOptionFromEditorDTO(Long id, @NotEmpty String text, String hint, String explanation, @NotNull Boolean isCorrect) {
+
+    /**
+     * Creates an AnswerOptionFromEditorDTO from the given AnswerOption domain object.
+     *
+     * @param answerOption the answer option to convert
+     * @return the corresponding DTO
+     */
+    public static AnswerOptionFromEditorDTO of(AnswerOption answerOption) {
+        return new AnswerOptionFromEditorDTO(answerOption.getId(), answerOption.getText(), answerOption.getHint(), answerOption.getExplanation(), answerOption.isIsCorrect());
+    }
+
+    /**
+     * Creates a new AnswerOption domain object from this DTO.
+     *
+     * @return a new AnswerOption domain object
+     */
+    public AnswerOption toDomainObject() {
+        AnswerOption answerOption = new AnswerOption();
+        answerOption.setText(text);
+        answerOption.setHint(hint);
+        answerOption.setExplanation(explanation);
+        answerOption.setIsCorrect(isCorrect);
+        return answerOption;
+    }
+
+    /**
+     * Applies the DTO values to an existing AnswerOption entity.
+     *
+     * @param answerOption the existing answer option to update
+     */
+    public void applyTo(AnswerOption answerOption) {
+        answerOption.setText(text);
+        answerOption.setHint(hint);
+        answerOption.setExplanation(explanation);
+        answerOption.setIsCorrect(isCorrect);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/DragAndDropMappingFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/DragAndDropMappingFromEditorDTO.java
@@ -1,0 +1,53 @@
+package de.tum.cit.aet.artemis.quiz.dto.question.fromEditor;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.quiz.domain.DragAndDropMapping;
+import de.tum.cit.aet.artemis.quiz.domain.DragItem;
+import de.tum.cit.aet.artemis.quiz.domain.DropLocation;
+
+/**
+ * DTO for drag and drop mappings in the editor context.
+ * Uses temporary IDs to reference drag items and drop locations.
+ * For persisted entities, uses real IDs as fallback when tempID is null.
+ *
+ * @param id                 the ID of the mapping, null for new mappings
+ * @param dragItemTempId     the temporary ID of the associated drag item (can be null for persisted entities, will use real ID)
+ * @param dropLocationTempId the temporary ID of the associated drop location (can be null for persisted entities, will use real ID)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record DragAndDropMappingFromEditorDTO(Long id, Long dragItemTempId, Long dropLocationTempId) {
+
+    /**
+     * Creates a DragAndDropMappingFromEditorDTO from the given DragAndDropMapping domain object.
+     * For persisted entities, uses real IDs as tempIDs when tempID is null.
+     *
+     * @param mapping the mapping to convert
+     * @return the corresponding DTO
+     */
+    public static DragAndDropMappingFromEditorDTO of(DragAndDropMapping mapping) {
+        // Use real ID as fallback for tempID when dealing with persisted entities
+        Long dragItemEffectiveId = mapping.getDragItem().getTempID() != null ? mapping.getDragItem().getTempID() : mapping.getDragItem().getId();
+        Long dropLocationEffectiveId = mapping.getDropLocation().getTempID() != null ? mapping.getDropLocation().getTempID() : mapping.getDropLocation().getId();
+        return new DragAndDropMappingFromEditorDTO(mapping.getId(), dragItemEffectiveId, dropLocationEffectiveId);
+    }
+
+    /**
+     * Creates a new DragAndDropMapping domain object from this DTO.
+     * The mapping contains temporary DragItem and DropLocation objects that need to be resolved later.
+     *
+     * @return a new DragAndDropMapping domain object
+     */
+    public DragAndDropMapping toDomainObject() {
+        DragAndDropMapping mapping = new DragAndDropMapping();
+        DragItem dragItem = new DragItem();
+        DropLocation dropLocation = new DropLocation();
+        dragItem.setTempID(dragItemTempId);
+        dropLocation.setTempID(dropLocationTempId);
+        mapping.setDragItem(dragItem);
+        mapping.setDropLocation(dropLocation);
+        return mapping;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/DragAndDropQuestionFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/DragAndDropQuestionFromEditorDTO.java
@@ -1,0 +1,82 @@
+package de.tum.cit.aet.artemis.quiz.dto.question.fromEditor;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.quiz.domain.DragAndDropMapping;
+import de.tum.cit.aet.artemis.quiz.domain.DragAndDropQuestion;
+import de.tum.cit.aet.artemis.quiz.domain.DragItem;
+import de.tum.cit.aet.artemis.quiz.domain.DropLocation;
+import de.tum.cit.aet.artemis.quiz.domain.ScoringType;
+
+/**
+ * DTO for drag and drop questions in the editor context.
+ * Supports both creating new questions (id is null) and updating existing questions (id is non-null).
+ *
+ * @param id                 the ID of the question, null for new questions
+ * @param title              the title of the question
+ * @param text               the question text
+ * @param hint               the hint for the question
+ * @param explanation        the explanation for the question
+ * @param points             the points for the question
+ * @param scoringType        the scoring type
+ * @param randomizeOrder     whether to randomize drag item order
+ * @param backgroundFilePath the background image file path
+ * @param dropLocations      the list of drop locations
+ * @param dragItems          the list of drag items
+ * @param correctMappings    the list of correct mappings
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record DragAndDropQuestionFromEditorDTO(Long id, @NotEmpty String title, String text, String hint, String explanation, @NotNull @Positive Double points,
+        @NotNull ScoringType scoringType, Boolean randomizeOrder, String backgroundFilePath, @NotEmpty List<@Valid DropLocationFromEditorDTO> dropLocations,
+        @NotEmpty List<@Valid DragItemFromEditorDTO> dragItems, @NotEmpty List<@Valid DragAndDropMappingFromEditorDTO> correctMappings) implements QuizQuestionFromEditorDTO {
+
+    /**
+     * Creates a DragAndDropQuestionFromEditorDTO from the given DragAndDropQuestion domain object.
+     *
+     * @param question the question to convert
+     * @return the corresponding DTO
+     */
+    public static DragAndDropQuestionFromEditorDTO of(DragAndDropQuestion question) {
+        List<DropLocationFromEditorDTO> locationDTOs = question.getDropLocations().stream().map(DropLocationFromEditorDTO::of).toList();
+        List<DragItemFromEditorDTO> itemDTOs = question.getDragItems().stream().map(DragItemFromEditorDTO::of).toList();
+        List<DragAndDropMappingFromEditorDTO> mappingDTOs = question.getCorrectMappings().stream().map(DragAndDropMappingFromEditorDTO::of).toList();
+        return new DragAndDropQuestionFromEditorDTO(question.getId(), question.getTitle(), question.getText(), question.getHint(), question.getExplanation(), question.getPoints(),
+                question.getScoringType(), question.isRandomizeOrder(), question.getBackgroundFilePath(), locationDTOs, itemDTOs, mappingDTOs);
+    }
+
+    /**
+     * Creates a new DragAndDropQuestion domain object from this DTO.
+     *
+     * @return a new DragAndDropQuestion domain object
+     */
+    @Override
+    public DragAndDropQuestion toDomainObject() {
+        DragAndDropQuestion question = new DragAndDropQuestion();
+        question.setId(id);
+        question.setTitle(title);
+        question.setText(text);
+        question.setHint(hint);
+        question.setExplanation(explanation);
+        question.setPoints(points);
+        question.setScoringType(scoringType);
+        question.setRandomizeOrder(randomizeOrder != null ? randomizeOrder : Boolean.FALSE);
+        question.setBackgroundFilePath(backgroundFilePath);
+
+        List<DropLocation> locations = dropLocations.stream().map(DropLocationFromEditorDTO::toDomainObject).toList();
+        List<DragItem> items = dragItems.stream().map(DragItemFromEditorDTO::toDomainObject).toList();
+        List<DragAndDropMapping> mappings = correctMappings.stream().map(DragAndDropMappingFromEditorDTO::toDomainObject).toList();
+        question.setDropLocations(locations);
+        question.setDragItems(items);
+        question.setCorrectMappings(mappings);
+        return question;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/DragAndDropQuestionFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/DragAndDropQuestionFromEditorDTO.java
@@ -71,9 +71,9 @@ public record DragAndDropQuestionFromEditorDTO(Long id, @NotEmpty String title, 
         question.setRandomizeOrder(randomizeOrder != null ? randomizeOrder : Boolean.FALSE);
         question.setBackgroundFilePath(backgroundFilePath);
 
-        List<DropLocation> locations = dropLocations.stream().map(DropLocationFromEditorDTO::toDomainObject).toList();
-        List<DragItem> items = dragItems.stream().map(DragItemFromEditorDTO::toDomainObject).toList();
-        List<DragAndDropMapping> mappings = correctMappings.stream().map(DragAndDropMappingFromEditorDTO::toDomainObject).toList();
+        List<DropLocation> locations = new java.util.ArrayList<>(dropLocations.stream().map(DropLocationFromEditorDTO::toDomainObject).toList());
+        List<DragItem> items = new java.util.ArrayList<>(dragItems.stream().map(DragItemFromEditorDTO::toDomainObject).toList());
+        List<DragAndDropMapping> mappings = new java.util.ArrayList<>(correctMappings.stream().map(DragAndDropMappingFromEditorDTO::toDomainObject).toList());
         question.setDropLocations(locations);
         question.setDragItems(items);
         question.setCorrectMappings(mappings);

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/DragItemFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/DragItemFromEditorDTO.java
@@ -1,0 +1,67 @@
+package de.tum.cit.aet.artemis.quiz.dto.question.fromEditor;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.quiz.domain.DragItem;
+
+/**
+ * DTO for drag items in the editor context.
+ * Supports both creating new items (id is null) and updating existing items (id is non-null).
+ *
+ * @param id              the ID of the drag item, null for new items
+ * @param tempID          the temporary ID for matching during creation (can be null for persisted entities, will use id instead)
+ * @param text            the text of the drag item (for text-based items)
+ * @param pictureFilePath the picture file path (for image-based items)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record DragItemFromEditorDTO(Long id, Long tempID, String text, String pictureFilePath) {
+
+    /**
+     * Creates a DragItemFromEditorDTO from the given DragItem domain object.
+     * For persisted entities, uses the id as tempID if tempID is null.
+     *
+     * @param dragItem the drag item to convert
+     * @return the corresponding DTO
+     */
+    public static DragItemFromEditorDTO of(DragItem dragItem) {
+        // Use id as tempID fallback for persisted entities
+        Long effectiveTempID = dragItem.getTempID() != null ? dragItem.getTempID() : dragItem.getId();
+        return new DragItemFromEditorDTO(dragItem.getId(), effectiveTempID, dragItem.getText(), dragItem.getPictureFilePath());
+    }
+
+    /**
+     * Creates a new DragItem domain object from this DTO.
+     *
+     * @return a new DragItem domain object
+     */
+    public DragItem toDomainObject() {
+        DragItem dragItem = new DragItem();
+        // Use id as tempID fallback for mapping resolution
+        dragItem.setTempID(tempID != null ? tempID : id);
+        dragItem.setText(text);
+        dragItem.setPictureFilePath(pictureFilePath);
+        return dragItem;
+    }
+
+    /**
+     * Applies the DTO values to an existing DragItem entity.
+     *
+     * @param dragItem the existing drag item to update
+     */
+    public void applyTo(DragItem dragItem) {
+        dragItem.setTempID(tempID != null ? tempID : id);
+        dragItem.setText(text);
+        dragItem.setPictureFilePath(pictureFilePath);
+    }
+
+    /**
+     * Gets the effective ID used for mapping resolution (tempID if available, otherwise id).
+     *
+     * @return the effective ID for matching
+     */
+    public Long effectiveId() {
+        return tempID != null ? tempID : id;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/DropLocationFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/DropLocationFromEditorDTO.java
@@ -1,0 +1,76 @@
+package de.tum.cit.aet.artemis.quiz.dto.question.fromEditor;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.quiz.domain.DropLocation;
+
+/**
+ * DTO for drop locations in the editor context.
+ * Supports both creating new locations (id is null) and updating existing locations (id is non-null).
+ *
+ * @param id     the ID of the drop location, null for new locations
+ * @param tempID the temporary ID for matching during creation (can be null for persisted entities, will use id instead)
+ * @param posX   the X position
+ * @param posY   the Y position
+ * @param width  the width
+ * @param height the height
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record DropLocationFromEditorDTO(Long id, Long tempID, @NotNull Double posX, @NotNull Double posY, @NotNull Double width, @NotNull Double height) {
+
+    /**
+     * Creates a DropLocationFromEditorDTO from the given DropLocation domain object.
+     * For persisted entities, uses the id as tempID if tempID is null.
+     *
+     * @param dropLocation the drop location to convert
+     * @return the corresponding DTO
+     */
+    public static DropLocationFromEditorDTO of(DropLocation dropLocation) {
+        // Use id as tempID fallback for persisted entities
+        Long effectiveTempID = dropLocation.getTempID() != null ? dropLocation.getTempID() : dropLocation.getId();
+        return new DropLocationFromEditorDTO(dropLocation.getId(), effectiveTempID, dropLocation.getPosX(), dropLocation.getPosY(), dropLocation.getWidth(),
+                dropLocation.getHeight());
+    }
+
+    /**
+     * Creates a new DropLocation domain object from this DTO.
+     *
+     * @return a new DropLocation domain object
+     */
+    public DropLocation toDomainObject() {
+        DropLocation dropLocation = new DropLocation();
+        // Use id as tempID fallback for mapping resolution
+        dropLocation.setTempID(tempID != null ? tempID : id);
+        dropLocation.setPosX(posX);
+        dropLocation.setPosY(posY);
+        dropLocation.setWidth(width);
+        dropLocation.setHeight(height);
+        return dropLocation;
+    }
+
+    /**
+     * Applies the DTO values to an existing DropLocation entity.
+     *
+     * @param dropLocation the existing drop location to update
+     */
+    public void applyTo(DropLocation dropLocation) {
+        dropLocation.setTempID(tempID != null ? tempID : id);
+        dropLocation.setPosX(posX);
+        dropLocation.setPosY(posY);
+        dropLocation.setWidth(width);
+        dropLocation.setHeight(height);
+    }
+
+    /**
+     * Gets the effective ID used for mapping resolution (tempID if available, otherwise id).
+     *
+     * @return the effective ID for matching
+     */
+    public Long effectiveId() {
+        return tempID != null ? tempID : id;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/MultipleChoiceQuestionFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/MultipleChoiceQuestionFromEditorDTO.java
@@ -1,0 +1,72 @@
+package de.tum.cit.aet.artemis.quiz.dto.question.fromEditor;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.quiz.domain.AnswerOption;
+import de.tum.cit.aet.artemis.quiz.domain.MultipleChoiceQuestion;
+import de.tum.cit.aet.artemis.quiz.domain.ScoringType;
+
+/**
+ * DTO for multiple choice questions in the editor context.
+ * Supports both creating new questions (id is null) and updating existing questions (id is non-null).
+ *
+ * @param id             the ID of the question, null for new questions
+ * @param title          the title of the question
+ * @param text           the question text
+ * @param hint           the hint for the question
+ * @param explanation    the explanation for the question
+ * @param points         the points for the question
+ * @param scoringType    the scoring type
+ * @param randomizeOrder whether to randomize answer order
+ * @param answerOptions  the list of answer options
+ * @param singleChoice   whether only one answer can be selected
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record MultipleChoiceQuestionFromEditorDTO(Long id, @NotNull String title, String text, String hint, String explanation, @NotNull @Positive Double points,
+        @NotNull ScoringType scoringType, Boolean randomizeOrder, @NotEmpty List<@Valid AnswerOptionFromEditorDTO> answerOptions, @NotNull Boolean singleChoice)
+        implements QuizQuestionFromEditorDTO {
+
+    /**
+     * Creates a MultipleChoiceQuestionFromEditorDTO from the given MultipleChoiceQuestion domain object.
+     *
+     * @param question the question to convert
+     * @return the corresponding DTO
+     */
+    public static MultipleChoiceQuestionFromEditorDTO of(MultipleChoiceQuestion question) {
+        List<AnswerOptionFromEditorDTO> optionDTOs = question.getAnswerOptions().stream().map(AnswerOptionFromEditorDTO::of).toList();
+        return new MultipleChoiceQuestionFromEditorDTO(question.getId(), question.getTitle(), question.getText(), question.getHint(), question.getExplanation(),
+                question.getPoints(), question.getScoringType(), question.isRandomizeOrder(), optionDTOs, question.isSingleChoice());
+    }
+
+    /**
+     * Creates a new MultipleChoiceQuestion domain object from this DTO.
+     *
+     * @return a new MultipleChoiceQuestion domain object
+     */
+    @Override
+    public MultipleChoiceQuestion toDomainObject() {
+        MultipleChoiceQuestion question = new MultipleChoiceQuestion();
+        question.setId(id);
+        question.setTitle(title);
+        question.setText(text);
+        question.setHint(hint);
+        question.setExplanation(explanation);
+        question.setPoints(points);
+        question.setScoringType(scoringType);
+        question.setRandomizeOrder(randomizeOrder != null ? randomizeOrder : Boolean.FALSE);
+        question.setSingleChoice(singleChoice);
+
+        List<AnswerOption> options = answerOptions.stream().map(AnswerOptionFromEditorDTO::toDomainObject).toList();
+        question.setAnswerOptions(options);
+        return question;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/MultipleChoiceQuestionFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/MultipleChoiceQuestionFromEditorDTO.java
@@ -65,7 +65,7 @@ public record MultipleChoiceQuestionFromEditorDTO(Long id, @NotNull String title
         question.setRandomizeOrder(randomizeOrder != null ? randomizeOrder : Boolean.FALSE);
         question.setSingleChoice(singleChoice);
 
-        List<AnswerOption> options = answerOptions.stream().map(AnswerOptionFromEditorDTO::toDomainObject).toList();
+        List<AnswerOption> options = new java.util.ArrayList<>(answerOptions.stream().map(AnswerOptionFromEditorDTO::toDomainObject).toList());
         question.setAnswerOptions(options);
         return question;
     }

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/QuizQuestionFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/QuizQuestionFromEditorDTO.java
@@ -1,0 +1,54 @@
+package de.tum.cit.aet.artemis.quiz.dto.question.fromEditor;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
+import de.tum.cit.aet.artemis.quiz.domain.DragAndDropQuestion;
+import de.tum.cit.aet.artemis.quiz.domain.MultipleChoiceQuestion;
+import de.tum.cit.aet.artemis.quiz.domain.QuizQuestion;
+import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerQuestion;
+
+/**
+ * DTO interface for quiz questions in the editor context.
+ * Supports both creating new questions (id is null) and updating existing questions (id is non-null).
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({ @JsonSubTypes.Type(value = MultipleChoiceQuestionFromEditorDTO.class, name = "multiple-choice"),
+        @JsonSubTypes.Type(value = DragAndDropQuestionFromEditorDTO.class, name = "drag-and-drop"),
+        @JsonSubTypes.Type(value = ShortAnswerQuestionFromEditorDTO.class, name = "short-answer") })
+public sealed interface QuizQuestionFromEditorDTO permits DragAndDropQuestionFromEditorDTO, MultipleChoiceQuestionFromEditorDTO, ShortAnswerQuestionFromEditorDTO {
+
+    String ENTITY_NAME = "QuizExercise";
+
+    /**
+     * Gets the ID of the question (null for new questions).
+     *
+     * @return the question ID or null
+     */
+    Long id();
+
+    /**
+     * Converts this DTO to a QuizQuestion domain object.
+     * This should only be used for new questions (id is null).
+     * For existing questions, use applyTo() to update the existing entity.
+     *
+     * @return the QuizQuestion domain object
+     */
+    QuizQuestion toDomainObject();
+
+    /**
+     * Creates a QuizQuestionFromEditorDTO from the given QuizQuestion domain object.
+     *
+     * @param question the quiz question to convert
+     * @return the corresponding DTO
+     */
+    static QuizQuestionFromEditorDTO of(QuizQuestion question) {
+        return switch (question) {
+            case MultipleChoiceQuestion mc -> MultipleChoiceQuestionFromEditorDTO.of(mc);
+            case DragAndDropQuestion dnd -> DragAndDropQuestionFromEditorDTO.of(dnd);
+            case ShortAnswerQuestion sa -> ShortAnswerQuestionFromEditorDTO.of(sa);
+            default -> throw new BadRequestAlertException("The quiz question type is invalid", ENTITY_NAME, "invalidQuiz");
+        };
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/ShortAnswerMappingFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/ShortAnswerMappingFromEditorDTO.java
@@ -1,0 +1,53 @@
+package de.tum.cit.aet.artemis.quiz.dto.question.fromEditor;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerMapping;
+import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerSolution;
+import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerSpot;
+
+/**
+ * DTO for short answer mappings in the editor context.
+ * Uses temporary IDs to reference solutions and spots.
+ * For persisted entities, uses real IDs as fallback when tempID is null.
+ *
+ * @param id             the ID of the mapping, null for new mappings
+ * @param solutionTempId the temporary ID of the associated solution (can be null for persisted entities, will use real ID)
+ * @param spotTempId     the temporary ID of the associated spot (can be null for persisted entities, will use real ID)
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ShortAnswerMappingFromEditorDTO(Long id, Long solutionTempId, Long spotTempId) {
+
+    /**
+     * Creates a ShortAnswerMappingFromEditorDTO from the given ShortAnswerMapping domain object.
+     * For persisted entities, uses real IDs as tempIDs when tempID is null.
+     *
+     * @param mapping the mapping to convert
+     * @return the corresponding DTO
+     */
+    public static ShortAnswerMappingFromEditorDTO of(ShortAnswerMapping mapping) {
+        // Use real ID as fallback for tempID when dealing with persisted entities
+        Long solutionEffectiveId = mapping.getSolution().getTempID() != null ? mapping.getSolution().getTempID() : mapping.getSolution().getId();
+        Long spotEffectiveId = mapping.getSpot().getTempID() != null ? mapping.getSpot().getTempID() : mapping.getSpot().getId();
+        return new ShortAnswerMappingFromEditorDTO(mapping.getId(), solutionEffectiveId, spotEffectiveId);
+    }
+
+    /**
+     * Creates a new ShortAnswerMapping domain object from this DTO.
+     * The mapping contains temporary ShortAnswerSolution and ShortAnswerSpot objects that need to be resolved later.
+     *
+     * @return a new ShortAnswerMapping domain object
+     */
+    public ShortAnswerMapping toDomainObject() {
+        ShortAnswerMapping mapping = new ShortAnswerMapping();
+        ShortAnswerSolution solution = new ShortAnswerSolution();
+        ShortAnswerSpot spot = new ShortAnswerSpot();
+        solution.setTempID(solutionTempId);
+        spot.setTempID(spotTempId);
+        mapping.setSolution(solution);
+        mapping.setSpot(spot);
+        return mapping;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/ShortAnswerQuestionFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/ShortAnswerQuestionFromEditorDTO.java
@@ -1,0 +1,85 @@
+package de.tum.cit.aet.artemis.quiz.dto.question.fromEditor;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.quiz.domain.ScoringType;
+import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerMapping;
+import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerQuestion;
+import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerSolution;
+import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerSpot;
+
+/**
+ * DTO for short answer questions in the editor context.
+ * Supports both creating new questions (id is null) and updating existing questions (id is non-null).
+ *
+ * @param id              the ID of the question, null for new questions
+ * @param title           the title of the question
+ * @param text            the question text
+ * @param hint            the hint for the question
+ * @param explanation     the explanation for the question
+ * @param points          the points for the question
+ * @param scoringType     the scoring type
+ * @param randomizeOrder  whether to randomize order
+ * @param spots           the list of spots
+ * @param solutions       the list of solutions
+ * @param correctMappings the list of correct mappings
+ * @param similarityValue the similarity value for comparing answers
+ * @param matchLetterCase whether to match letter case
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ShortAnswerQuestionFromEditorDTO(Long id, @NotEmpty String title, String text, String hint, String explanation, @NotNull @Positive Double points,
+        @NotNull ScoringType scoringType, Boolean randomizeOrder, @NotEmpty List<@Valid ShortAnswerSpotFromEditorDTO> spots,
+        @NotEmpty List<@Valid ShortAnswerSolutionFromEditorDTO> solutions, @NotEmpty List<@Valid ShortAnswerMappingFromEditorDTO> correctMappings, @NotNull Integer similarityValue,
+        @NotNull Boolean matchLetterCase) implements QuizQuestionFromEditorDTO {
+
+    /**
+     * Creates a ShortAnswerQuestionFromEditorDTO from the given ShortAnswerQuestion domain object.
+     *
+     * @param question the question to convert
+     * @return the corresponding DTO
+     */
+    public static ShortAnswerQuestionFromEditorDTO of(ShortAnswerQuestion question) {
+        List<ShortAnswerSpotFromEditorDTO> spotDTOs = question.getSpots().stream().map(ShortAnswerSpotFromEditorDTO::of).toList();
+        List<ShortAnswerSolutionFromEditorDTO> solutionDTOs = question.getSolutions().stream().map(ShortAnswerSolutionFromEditorDTO::of).toList();
+        List<ShortAnswerMappingFromEditorDTO> mappingDTOs = question.getCorrectMappings().stream().map(ShortAnswerMappingFromEditorDTO::of).toList();
+        return new ShortAnswerQuestionFromEditorDTO(question.getId(), question.getTitle(), question.getText(), question.getHint(), question.getExplanation(), question.getPoints(),
+                question.getScoringType(), question.isRandomizeOrder(), spotDTOs, solutionDTOs, mappingDTOs, question.getSimilarityValue(), question.getMatchLetterCase());
+    }
+
+    /**
+     * Creates a new ShortAnswerQuestion domain object from this DTO.
+     *
+     * @return a new ShortAnswerQuestion domain object
+     */
+    @Override
+    public ShortAnswerQuestion toDomainObject() {
+        ShortAnswerQuestion question = new ShortAnswerQuestion();
+        question.setId(id);
+        question.setTitle(title);
+        question.setText(text);
+        question.setHint(hint);
+        question.setExplanation(explanation);
+        question.setPoints(points);
+        question.setScoringType(scoringType);
+        question.setRandomizeOrder(randomizeOrder != null ? randomizeOrder : Boolean.FALSE);
+        question.setSimilarityValue(similarityValue);
+        question.setMatchLetterCase(matchLetterCase);
+
+        List<ShortAnswerSpot> shortAnswerSpots = spots.stream().map(ShortAnswerSpotFromEditorDTO::toDomainObject).toList();
+        List<ShortAnswerSolution> shortAnswerSolutions = solutions.stream().map(ShortAnswerSolutionFromEditorDTO::toDomainObject).toList();
+        List<ShortAnswerMapping> shortAnswerMappings = correctMappings.stream().map(ShortAnswerMappingFromEditorDTO::toDomainObject).toList();
+        question.setSpots(shortAnswerSpots);
+        question.setSolutions(shortAnswerSolutions);
+        question.setCorrectMappings(shortAnswerMappings);
+        return question;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/ShortAnswerQuestionFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/ShortAnswerQuestionFromEditorDTO.java
@@ -74,9 +74,9 @@ public record ShortAnswerQuestionFromEditorDTO(Long id, @NotEmpty String title, 
         question.setSimilarityValue(similarityValue);
         question.setMatchLetterCase(matchLetterCase);
 
-        List<ShortAnswerSpot> shortAnswerSpots = spots.stream().map(ShortAnswerSpotFromEditorDTO::toDomainObject).toList();
-        List<ShortAnswerSolution> shortAnswerSolutions = solutions.stream().map(ShortAnswerSolutionFromEditorDTO::toDomainObject).toList();
-        List<ShortAnswerMapping> shortAnswerMappings = correctMappings.stream().map(ShortAnswerMappingFromEditorDTO::toDomainObject).toList();
+        List<ShortAnswerSpot> shortAnswerSpots = new java.util.ArrayList<>(spots.stream().map(ShortAnswerSpotFromEditorDTO::toDomainObject).toList());
+        List<ShortAnswerSolution> shortAnswerSolutions = new java.util.ArrayList<>(solutions.stream().map(ShortAnswerSolutionFromEditorDTO::toDomainObject).toList());
+        List<ShortAnswerMapping> shortAnswerMappings = new java.util.ArrayList<>(correctMappings.stream().map(ShortAnswerMappingFromEditorDTO::toDomainObject).toList());
         question.setSpots(shortAnswerSpots);
         question.setSolutions(shortAnswerSolutions);
         question.setCorrectMappings(shortAnswerMappings);

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/ShortAnswerSolutionFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/ShortAnswerSolutionFromEditorDTO.java
@@ -1,0 +1,66 @@
+package de.tum.cit.aet.artemis.quiz.dto.question.fromEditor;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerSolution;
+
+/**
+ * DTO for short answer solutions in the editor context.
+ * Supports both creating new solutions (id is null) and updating existing solutions (id is non-null).
+ *
+ * @param id     the ID of the solution, null for new solutions
+ * @param tempID the temporary ID for matching during creation (can be null for persisted entities, will use id instead)
+ * @param text   the solution text
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ShortAnswerSolutionFromEditorDTO(Long id, Long tempID, @NotEmpty String text) {
+
+    /**
+     * Creates a ShortAnswerSolutionFromEditorDTO from the given ShortAnswerSolution domain object.
+     * For persisted entities, uses the id as tempID if tempID is null.
+     *
+     * @param solution the solution to convert
+     * @return the corresponding DTO
+     */
+    public static ShortAnswerSolutionFromEditorDTO of(ShortAnswerSolution solution) {
+        // Use id as tempID fallback for persisted entities
+        Long effectiveTempID = solution.getTempID() != null ? solution.getTempID() : solution.getId();
+        return new ShortAnswerSolutionFromEditorDTO(solution.getId(), effectiveTempID, solution.getText());
+    }
+
+    /**
+     * Creates a new ShortAnswerSolution domain object from this DTO.
+     *
+     * @return a new ShortAnswerSolution domain object
+     */
+    public ShortAnswerSolution toDomainObject() {
+        ShortAnswerSolution solution = new ShortAnswerSolution();
+        // Use id as tempID fallback for mapping resolution
+        solution.setTempID(tempID != null ? tempID : id);
+        solution.setText(text);
+        return solution;
+    }
+
+    /**
+     * Applies the DTO values to an existing ShortAnswerSolution entity.
+     *
+     * @param solution the existing solution to update
+     */
+    public void applyTo(ShortAnswerSolution solution) {
+        solution.setTempID(tempID != null ? tempID : id);
+        solution.setText(text);
+    }
+
+    /**
+     * Gets the effective ID used for mapping resolution (tempID if available, otherwise id).
+     *
+     * @return the effective ID for matching
+     */
+    public Long effectiveId() {
+        return tempID != null ? tempID : id;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/ShortAnswerSpotFromEditorDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/dto/question/fromEditor/ShortAnswerSpotFromEditorDTO.java
@@ -1,0 +1,69 @@
+package de.tum.cit.aet.artemis.quiz.dto.question.fromEditor;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerSpot;
+
+/**
+ * DTO for short answer spots in the editor context.
+ * Supports both creating new spots (id is null) and updating existing spots (id is non-null).
+ *
+ * @param id     the ID of the spot, null for new spots
+ * @param tempID the temporary ID for matching during creation (can be null for persisted entities, will use id instead)
+ * @param width  the width of the input field
+ * @param spotNr the spot number in the text
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ShortAnswerSpotFromEditorDTO(Long id, Long tempID, Integer width, @NotNull Integer spotNr) {
+
+    /**
+     * Creates a ShortAnswerSpotFromEditorDTO from the given ShortAnswerSpot domain object.
+     * For persisted entities, uses the id as tempID if tempID is null.
+     *
+     * @param spot the spot to convert
+     * @return the corresponding DTO
+     */
+    public static ShortAnswerSpotFromEditorDTO of(ShortAnswerSpot spot) {
+        // Use id as tempID fallback for persisted entities
+        Long effectiveTempID = spot.getTempID() != null ? spot.getTempID() : spot.getId();
+        return new ShortAnswerSpotFromEditorDTO(spot.getId(), effectiveTempID, spot.getWidth(), spot.getSpotNr());
+    }
+
+    /**
+     * Creates a new ShortAnswerSpot domain object from this DTO.
+     *
+     * @return a new ShortAnswerSpot domain object
+     */
+    public ShortAnswerSpot toDomainObject() {
+        ShortAnswerSpot spot = new ShortAnswerSpot();
+        // Use id as tempID fallback for mapping resolution
+        spot.setTempID(tempID != null ? tempID : id);
+        spot.setWidth(width);
+        spot.setSpotNr(spotNr);
+        return spot;
+    }
+
+    /**
+     * Applies the DTO values to an existing ShortAnswerSpot entity.
+     *
+     * @param spot the existing spot to update
+     */
+    public void applyTo(ShortAnswerSpot spot) {
+        spot.setTempID(tempID != null ? tempID : id);
+        spot.setWidth(width);
+        spot.setSpotNr(spotNr);
+    }
+
+    /**
+     * Gets the effective ID used for mapping resolution (tempID if available, otherwise id).
+     *
+     * @return the effective ID for matching
+     */
+    public Long effectiveId() {
+        return tempID != null ? tempID : id;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizExerciseService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizExerciseService.java
@@ -39,8 +39,6 @@ import org.springframework.web.multipart.MultipartFile;
 import de.tum.cit.aet.artemis.assessment.domain.Result;
 import de.tum.cit.aet.artemis.assessment.repository.ResultRepository;
 import de.tum.cit.aet.artemis.atlas.api.CompetencyProgressApi;
-import de.tum.cit.aet.artemis.atlas.api.CourseCompetencyApi;
-import de.tum.cit.aet.artemis.atlas.domain.competency.Competency;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
 import de.tum.cit.aet.artemis.communication.domain.conversation.Channel;
 import de.tum.cit.aet.artemis.communication.service.conversation.ChannelService;
@@ -55,7 +53,6 @@ import de.tum.cit.aet.artemis.core.dto.calendar.CalendarEventDTO;
 import de.tum.cit.aet.artemis.core.dto.calendar.QuizExerciseCalendarEventDTO;
 import de.tum.cit.aet.artemis.core.dto.pageablesearch.SearchTermPageableSearchDTO;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
-import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
 import de.tum.cit.aet.artemis.core.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.service.messaging.InstanceMessageSendService;
 import de.tum.cit.aet.artemis.core.util.CalendarEventType;
@@ -83,12 +80,13 @@ import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerQuestion;
 import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerSolution;
 import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerSpot;
 import de.tum.cit.aet.artemis.quiz.domain.SubmittedAnswer;
-import de.tum.cit.aet.artemis.quiz.dto.CompetencyExerciseLinkFromEditorDTO;
-import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseFromEditorDTO;
+import de.tum.cit.aet.artemis.quiz.dto.QuizBatchFromEditorDTO;
 import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseReEvaluateDTO;
 import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseWithQuestionsDTO;
 import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseWithSolutionDTO;
 import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseWithoutQuestionsDTO;
+import de.tum.cit.aet.artemis.quiz.dto.exercise.UpdateQuizExerciseDTO;
+import de.tum.cit.aet.artemis.quiz.dto.question.fromEditor.QuizQuestionFromEditorDTO;
 import de.tum.cit.aet.artemis.quiz.dto.question.reevaluate.AnswerOptionReEvaluateDTO;
 import de.tum.cit.aet.artemis.quiz.dto.question.reevaluate.DragAndDropQuestionReEvaluateDTO;
 import de.tum.cit.aet.artemis.quiz.dto.question.reevaluate.DragItemReEvaluateDTO;
@@ -141,14 +139,12 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
 
     private final Optional<SlideApi> slideApi;
 
-    private final Optional<CourseCompetencyApi> courseCompetencyApi;
-
     public QuizExerciseService(QuizExerciseRepository quizExerciseRepository, ResultRepository resultRepository, QuizSubmissionRepository quizSubmissionRepository,
             InstanceMessageSendService instanceMessageSendService, QuizStatisticService quizStatisticService, QuizBatchService quizBatchService,
             ExerciseSpecificationService exerciseSpecificationService, DragAndDropMappingRepository dragAndDropMappingRepository,
             ShortAnswerMappingRepository shortAnswerMappingRepository, ExerciseService exerciseService, UserRepository userRepository, QuizBatchRepository quizBatchRepository,
             ChannelService channelService, GroupNotificationScheduleService groupNotificationScheduleService, Optional<CompetencyProgressApi> competencyProgressApi,
-            Optional<SlideApi> slideApi, Optional<CourseCompetencyApi> courseCompetencyApi) {
+            Optional<SlideApi> slideApi) {
         super(dragAndDropMappingRepository, shortAnswerMappingRepository);
         this.quizExerciseRepository = quizExerciseRepository;
         this.resultRepository = resultRepository;
@@ -164,7 +160,6 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
         this.groupNotificationScheduleService = groupNotificationScheduleService;
         this.competencyProgressApi = competencyProgressApi;
         this.slideApi = slideApi;
-        this.courseCompetencyApi = courseCompetencyApi;
     }
 
     /**
@@ -573,18 +568,11 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
         Map<FilePathType, Set<String>> oldPaths = getAllPathsFromDragAndDropQuestionsOfExercise(originalQuizExercise);
         boolean questionsChanged = applyBaseQuizQuestionData(quizExerciseDTO, originalQuizExercise);
         questionsChanged = applyQuizQuestionsFromDTOAndCheckIfChanged(quizExerciseDTO, originalQuizExercise) || questionsChanged;
-        validateQuizExerciseFiles(originalQuizExercise, files);
+        validateQuizExerciseFiles(originalQuizExercise, files, oldPaths);
         Map<FilePathType, Set<String>> filesToRemove = new HashMap<>(oldPaths);
-        Map<String, MultipartFile> fileMap = files.stream().collect(Collectors.toMap(MultipartFile::getOriginalFilename, Function.identity()));
-        for (var question : originalQuizExercise.getQuizQuestions()) {
-            if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
-                handleDndQuestionUpdate(dragAndDropQuestion, oldPaths, filesToRemove, fileMap, dragAndDropQuestion);
-            }
-        }
-        var allFilesToRemoveMerged = filesToRemove.entrySet().stream()
-                .flatMap(entry -> entry.getValue().stream().map(path -> FilePathConverter.fileSystemPathForExternalUri(URI.create(path), entry.getKey()))).filter(Objects::nonNull)
-                .toList();
-        FileUtil.deleteFiles(allFilesToRemoveMerged);
+
+        deleteOldFiles(originalQuizExercise, files, oldPaths, filesToRemove);
+
         originalQuizExercise.setMaxPoints(originalQuizExercise.getOverallQuizPoints());
         originalQuizExercise.reconnectJSONIgnoreAttributes();
         updateResultsOnQuizChanges(originalQuizExercise);
@@ -748,24 +736,24 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
      * @param originalExercise the original quiz exercise
      * @param files            the provided files
      */
-    public void handleDndQuizFileUpdates(QuizExercise updatedExercise, QuizExercise originalExercise, List<MultipartFile> files) throws IOException {
-        List<MultipartFile> nullsafeFiles = files == null ? new ArrayList<>() : files;
-        validateQuizExerciseFiles(updatedExercise, nullsafeFiles);
+    public void handleDndQuizFileUpdates(QuizExercise updatedExercise, QuizExercise originalExercise, @NonNull List<MultipartFile> files) throws IOException {
         Map<FilePathType, Set<String>> oldPaths = getAllPathsFromDragAndDropQuestionsOfExercise(originalExercise);
+        validateQuizExerciseFiles(updatedExercise, files, oldPaths);
         Map<FilePathType, Set<String>> filesToRemove = new HashMap<>(oldPaths);
 
-        Map<String, MultipartFile> fileMap = nullsafeFiles.stream().collect(Collectors.toMap(MultipartFile::getOriginalFilename, file -> file));
+        deleteOldFiles(updatedExercise, files, oldPaths, filesToRemove);
+    }
 
-        for (var question : updatedExercise.getQuizQuestions()) {
+    private void deleteOldFiles(QuizExercise quizExercise, @NonNull List<MultipartFile> files, Map<FilePathType, Set<String>> oldPaths,
+            Map<FilePathType, Set<String>> filesToRemove) throws IOException {
+        Map<String, MultipartFile> fileMap = files.stream().collect(Collectors.toMap(MultipartFile::getOriginalFilename, file -> file));
+        for (var question : quizExercise.getQuizQuestions()) {
             if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
                 handleDndQuestionUpdate(dragAndDropQuestion, oldPaths, filesToRemove, fileMap, dragAndDropQuestion);
             }
         }
-
         var allFilesToRemoveMerged = filesToRemove.entrySet().stream()
-                .flatMap(entry -> entry.getValue().stream().map(path -> FilePathConverter.fileSystemPathForExternalUri(URI.create(path), entry.getKey()))).filter(Objects::nonNull)
-                .toList();
-
+                .flatMap(entry -> entry.getValue().stream().map(path -> FilePathConverter.fileSystemPathForExternalUri(URI.create(path), entry.getKey()))).toList();
         FileUtil.deleteFiles(allFilesToRemoveMerged);
     }
 
@@ -824,6 +812,17 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
      * @param providedFiles the provided files to validate
      */
     public void validateQuizExerciseFiles(QuizExercise quizExercise, @NonNull List<MultipartFile> providedFiles) {
+        validateQuizExerciseFiles(quizExercise, providedFiles, null);
+    }
+
+    /**
+     * Verifies that the provided files match the provided filenames in the exercise entity.
+     *
+     * @param quizExercise  the quiz exercise to validate
+     * @param providedFiles the provided files to validate
+     * @param oldPaths      Optional map of paths that already existed in the original exercise (should not require new files)
+     */
+    public void validateQuizExerciseFiles(QuizExercise quizExercise, @NonNull List<MultipartFile> providedFiles, @Nullable Map<FilePathType, Set<String>> oldPaths) {
         long fileCount = providedFiles.size();
 
         Map<FilePathType, Set<String>> exerciseFilePathsMap = getAllPathsFromDragAndDropQuestionsOfExercise(quizExercise);
@@ -832,7 +831,6 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
         for (Map.Entry<FilePathType, Set<String>> entry : exerciseFilePathsMap.entrySet()) {
             FilePathType type = entry.getKey();
             Set<String> paths = entry.getValue();
-            Set<String> newPaths = new HashSet<>();
             for (String path : paths) {
                 FileUtil.sanitizeFilePathByCheckingForInvalidCharactersElseThrow(path);
                 URI uri = URI.create(path);
@@ -840,15 +838,17 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
 
                 if (Files.exists(fsPath)) {
                     URI intendedSubPath = type == FilePathType.DRAG_AND_DROP_BACKGROUND ? URI.create(FileUtil.BACKGROUND_FILE_SUBPATH) : URI.create(FileUtil.PICTURE_FILE_SUBPATH);
-                    FileUtil.sanitizeByCheckingIfPathStartsWithSubPathElseThrow(uri, intendedSubPath);
+                    FileUtil.sanitizeByCheckingIfPathStartsWithSubPathElseThrow(URI.create(path), intendedSubPath);
                 }
-                else {
-                    newPaths.add(path);
-                }
-            }
 
-            if (!newPaths.isEmpty()) {
-                newFilePathsMap.put(type, newPaths);
+                // A path is "new" if it doesn't exist on disk AND it wasn't in the original exercise
+                Set<String> oldPathsForType = oldPaths != null ? oldPaths.getOrDefault(type, Set.of()) : Set.of();
+                Set<String> newPaths = paths.stream().filter(filePath -> !Files.exists(FilePathConverter.fileSystemPathForExternalUri(URI.create(filePath), type)))
+                        .filter(filePath -> !oldPathsForType.contains(filePath)).collect(Collectors.toSet());
+
+                if (!newPaths.isEmpty()) {
+                    newFilePathsMap.put(type, newPaths);
+                }
             }
         }
 
@@ -940,7 +940,7 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
         // make sure the pointers in the statistics are correct
         quizExercise.recalculatePointCounters();
 
-        QuizExercise savedQuizExercise = exerciseService.saveWithCompetencyLinks(quizExercise, super::save);
+        QuizExercise savedQuizExercise = super.save(quizExercise);
 
         if (savedQuizExercise.isCourseExercise()) {
             // only schedule quizzes for course exercises, not for exam exercises
@@ -1015,7 +1015,7 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
      * @throws BadRequestAlertException if the updated quiz is invalid (e.g., fails validation checks,
      *                                      quiz has already started, or conversion between exam/course types).
      */
-    public QuizExercise performUpdate(QuizExercise originalQuiz, QuizExercise updatedQuiz, List<MultipartFile> files, String notificationText) throws IOException {
+    public QuizExercise performUpdate(QuizExercise originalQuiz, QuizExercise updatedQuiz, @NonNull List<MultipartFile> files, String notificationText) throws IOException {
 
         if (!updatedQuiz.isValid()) {
             throw new BadRequestAlertException("The quiz exercise is not valid", ENTITY_NAME, "invalidQuiz");
@@ -1057,88 +1057,61 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
     }
 
     /**
-     * Method to update competency exercise links for a quiz exercise.
-     *
-     * @param quizExercise The quiz exercise to update the competency links for
-     * @param competencies The competency links from the editor DTO
-     * @param course       The course the quiz exercise belongs to
-     * @return The updated set of competency exercise links
-     */
-    private Set<CompetencyExerciseLink> updateCompetencyExerciseLinks(QuizExercise quizExercise, Set<CompetencyExerciseLinkFromEditorDTO> competencies, Course course) {
-        if (courseCompetencyApi.isEmpty()) {
-            return Set.of();
-        }
-        CourseCompetencyApi courseCompetencyApi = this.courseCompetencyApi.get();
-        Set<CompetencyExerciseLink> updatedLinks = new HashSet<>();
-        Set<Long> competencyIds = competencies.stream().map(CompetencyExerciseLinkFromEditorDTO::competencyId).collect(Collectors.toSet());
-        Set<Competency> foundCompetencies = courseCompetencyApi.findCourseCompetenciesByIdsAndCourseId(competencyIds, course.getId());
-        for (CompetencyExerciseLinkFromEditorDTO dto : competencies) {
-            Optional<Competency> matchingCompetency = foundCompetencies.stream().filter(c -> c.getId().equals(dto.competencyId())).findFirst();
-            if (matchingCompetency.isPresent()) {
-                CompetencyExerciseLink link = new CompetencyExerciseLink();
-                link.setCompetency(matchingCompetency.get());
-                link.setWeight(dto.weight());
-                link.setExercise(quizExercise);
-                updatedLinks.add(link);
-            }
-            else {
-                throw new EntityNotFoundException("Competency with id " + dto.competencyId() + " not found in course " + course.getId());
-            }
-        }
-        return updatedLinks;
-    }
-
-    /**
      * Merges the properties of the QuizExerciseFromEditorDTO into the QuizExercise domain object.
+     * This method converts DTOs to new entity objects to avoid Hibernate detached entity issues.
      *
-     * @param quizExercise              The QuizExercise domain object to be updated
-     * @param quizExerciseFromEditorDTO The DTO containing the properties to be merged into the domain object.
-     * @param course                    The course the quiz exercise belongs to
+     * @param quizExercise          The QuizExercise domain object to be updated
+     * @param updateQuizExerciseDTO The DTO containing the properties to be merged into the domain object.
      */
-    public void mergeDTOIntoDomainObject(QuizExercise quizExercise, QuizExerciseFromEditorDTO quizExerciseFromEditorDTO, Course course) {
-        if (quizExerciseFromEditorDTO.title() != null) {
-            quizExercise.setTitle(quizExerciseFromEditorDTO.title());
+    public void mergeDTOIntoDomainObject(QuizExercise quizExercise, UpdateQuizExerciseDTO updateQuizExerciseDTO) {
+        if (updateQuizExerciseDTO.title() != null) {
+            quizExercise.setTitle(updateQuizExerciseDTO.title());
         }
-        if (quizExerciseFromEditorDTO.channelName() != null) {
-            quizExercise.setChannelName(quizExerciseFromEditorDTO.channelName());
+        if (updateQuizExerciseDTO.channelName() != null) {
+            quizExercise.setChannelName(updateQuizExerciseDTO.channelName());
         }
-        if (quizExerciseFromEditorDTO.categories() != null) {
-            quizExercise.setCategories(quizExerciseFromEditorDTO.categories());
+        // TODO: we must support empty competency links, so checking for null here might be a problem
+        if (updateQuizExerciseDTO.categories() != null) {
+            quizExercise.setCategories(updateQuizExerciseDTO.categories());
         }
-        if (quizExerciseFromEditorDTO.competencyLinks() != null) {
-            quizExercise.setCompetencyLinks(updateCompetencyExerciseLinks(quizExercise, quizExerciseFromEditorDTO.competencyLinks(), course));
+
+        if (updateQuizExerciseDTO.difficulty() != null) {
+            quizExercise.setDifficulty(updateQuizExerciseDTO.difficulty());
         }
-        if (quizExerciseFromEditorDTO.difficulty() != null) {
-            quizExercise.setDifficulty(quizExerciseFromEditorDTO.difficulty());
+        if (updateQuizExerciseDTO.duration() != null) {
+            quizExercise.setDuration(updateQuizExerciseDTO.duration());
         }
-        if (quizExerciseFromEditorDTO.duration() != null) {
-            quizExercise.setDuration(quizExerciseFromEditorDTO.duration());
+        if (updateQuizExerciseDTO.randomizeQuestionOrder() != null) {
+            quizExercise.setRandomizeQuestionOrder(updateQuizExerciseDTO.randomizeQuestionOrder());
         }
-        if (quizExerciseFromEditorDTO.randomizeQuestionOrder() != null) {
-            quizExercise.setRandomizeQuestionOrder(quizExerciseFromEditorDTO.randomizeQuestionOrder());
+        if (updateQuizExerciseDTO.quizMode() != null) {
+            quizExercise.setQuizMode(updateQuizExerciseDTO.quizMode());
         }
-        if (quizExerciseFromEditorDTO.quizMode() != null) {
-            quizExercise.setQuizMode(quizExerciseFromEditorDTO.quizMode());
-        }
-        if (quizExerciseFromEditorDTO.quizBatches() != null) {
+        // TODO: should it really be possible to update quiz batches in the quiz exercise update endpoint?
+        if (updateQuizExerciseDTO.quizBatches() != null) {
+            // Convert DTOs to new entities to avoid detached entity issues
+            Set<QuizBatch> newBatches = updateQuizExerciseDTO.quizBatches().stream().map(QuizBatchFromEditorDTO::toDomainObject).collect(Collectors.toSet());
             quizExercise.getQuizBatches().clear();
-            quizExercise.getQuizBatches().addAll(quizExerciseFromEditorDTO.quizBatches());
+            quizExercise.getQuizBatches().addAll(newBatches);
         }
-        if (quizExerciseFromEditorDTO.releaseDate() != null) {
-            quizExercise.setReleaseDate(quizExerciseFromEditorDTO.releaseDate());
+        if (updateQuizExerciseDTO.releaseDate() != null) {
+            quizExercise.setReleaseDate(updateQuizExerciseDTO.releaseDate());
         }
-        if (quizExerciseFromEditorDTO.startDate() != null) {
-            quizExercise.setStartDate(quizExerciseFromEditorDTO.startDate());
+        if (updateQuizExerciseDTO.startDate() != null) {
+            quizExercise.setStartDate(updateQuizExerciseDTO.startDate());
         }
-        if (quizExerciseFromEditorDTO.dueDate() != null) {
-            quizExercise.setDueDate(quizExerciseFromEditorDTO.dueDate());
+        if (updateQuizExerciseDTO.dueDate() != null) {
+            quizExercise.setDueDate(updateQuizExerciseDTO.dueDate());
         }
-        if (quizExerciseFromEditorDTO.includedInOverallScore() != null) {
-            quizExercise.setIncludedInOverallScore(quizExerciseFromEditorDTO.includedInOverallScore());
+        if (updateQuizExerciseDTO.includedInOverallScore() != null) {
+            quizExercise.setIncludedInOverallScore(updateQuizExerciseDTO.includedInOverallScore());
         }
-        if (quizExerciseFromEditorDTO.quizQuestions() != null) {
-            quizExercise.setQuizQuestions(quizExerciseFromEditorDTO.quizQuestions());
+        if (updateQuizExerciseDTO.quizQuestions() != null) {
+            // Convert DTOs to new entities to avoid detached entity issues
+            List<QuizQuestion> newQuestions = updateQuizExerciseDTO.quizQuestions().stream().map(QuizQuestionFromEditorDTO::toDomainObject).toList();
+            quizExercise.setQuizQuestions(newQuestions);
         }
+        exerciseService.updateCompetencyLinks(updateQuizExerciseDTO, quizExercise);
     }
 
     /**
@@ -1308,20 +1281,31 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
     /**
      * Creates a new quiz exercise, handling validation, file processing, saving, and related updates.
      *
-     * @param quizExercise the quiz exercise domain object to create
-     * @param files        the files for drag and drop questions (optional)
-     * @param isExam       true if creating for an exam, false for a course
+     * @param quizExercise    the quiz exercise domain object to create (without competency links)
+     * @param files           the files for drag and drop questions (optional)
+     * @param isExam          true if creating for an exam, false for a course
+     * @param competencyLinks the competency links to associate with the exercise (can be null or empty)
      * @return the created and saved quiz exercise
      * @throws IOException if there is an error handling the files
      */
-    public QuizExercise createQuizExercise(QuizExercise quizExercise, List<MultipartFile> files, boolean isExam) throws IOException {
+    public QuizExercise createQuizExercise(QuizExercise quizExercise, List<MultipartFile> files, boolean isExam, Set<CompetencyExerciseLink> competencyLinks) throws IOException {
         resolveQuizQuestionMappings(quizExercise);
         if (!quizExercise.isValid()) {
             throw new BadRequestAlertException("The quiz exercise is invalid", ENTITY_NAME, "invalidQuiz");
         }
         quizExercise.validateGeneralSettings();
         handleDndQuizFileCreation(quizExercise, files);
-        QuizExercise result = save(quizExercise);
+
+        // Save the exercise first to get an ID (competency links are passed separately and require the exercise ID)
+        QuizExercise savedExercise = save(quizExercise);
+
+        // Restore competency links with proper exercise reference and save again
+        if (competencyLinks != null && !competencyLinks.isEmpty()) {
+            exerciseService.addCompetencyLinksForCreation(savedExercise, competencyLinks);
+            savedExercise = save(savedExercise);
+        }
+
+        QuizExercise result = savedExercise;
         if (!isExam) {
             channelService.createExerciseChannel(result, Optional.ofNullable(quizExercise.getChannelName()));
         }

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizExerciseService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizExerciseService.java
@@ -86,7 +86,6 @@ import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseWithQuestionsDTO;
 import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseWithSolutionDTO;
 import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseWithoutQuestionsDTO;
 import de.tum.cit.aet.artemis.quiz.dto.exercise.UpdateQuizExerciseDTO;
-import de.tum.cit.aet.artemis.quiz.dto.question.fromEditor.QuizQuestionFromEditorDTO;
 import de.tum.cit.aet.artemis.quiz.dto.question.reevaluate.AnswerOptionReEvaluateDTO;
 import de.tum.cit.aet.artemis.quiz.dto.question.reevaluate.DragAndDropQuestionReEvaluateDTO;
 import de.tum.cit.aet.artemis.quiz.dto.question.reevaluate.DragItemReEvaluateDTO;
@@ -1107,8 +1106,20 @@ public class QuizExerciseService extends QuizService<QuizExercise> {
             quizExercise.setIncludedInOverallScore(updateQuizExerciseDTO.includedInOverallScore());
         }
         if (updateQuizExerciseDTO.quizQuestions() != null) {
+            // Build a map of existing questions by ID so we can preserve statistics
+            Map<Long, QuizQuestion> existingQuestionsById = quizExercise.getQuizQuestions().stream().filter(q -> q.getId() != null)
+                    .collect(Collectors.toMap(QuizQuestion::getId, Function.identity()));
+
             // Convert DTOs to new entities to avoid detached entity issues
-            List<QuizQuestion> newQuestions = updateQuizExerciseDTO.quizQuestions().stream().map(QuizQuestionFromEditorDTO::toDomainObject).toList();
+            List<QuizQuestion> newQuestions = new ArrayList<>(updateQuizExerciseDTO.quizQuestions().stream().map(dto -> {
+                QuizQuestion newQuestion = dto.toDomainObject();
+                // For existing questions, preserve statistics from the managed entity
+                if (newQuestion.getId() != null && existingQuestionsById.containsKey(newQuestion.getId())) {
+                    QuizQuestion existingQuestion = existingQuestionsById.get(newQuestion.getId());
+                    newQuestion.setQuizQuestionStatistic(existingQuestion.getQuizQuestionStatistic());
+                }
+                return newQuestion;
+            }).toList());
             quizExercise.setQuizQuestions(newQuestions);
         }
         exerciseService.updateCompetencyLinks(updateQuizExerciseDTO, quizExercise);

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizExerciseCreationUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizExerciseCreationUpdateResource.java
@@ -41,8 +41,8 @@ import de.tum.cit.aet.artemis.exam.domain.ExerciseGroup;
 import de.tum.cit.aet.artemis.exercise.service.ExerciseVersionService;
 import de.tum.cit.aet.artemis.quiz.domain.QuizExercise;
 import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseCreateDTO;
-import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseFromEditorDTO;
 import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseWithStatisticsDTO;
+import de.tum.cit.aet.artemis.quiz.dto.exercise.UpdateQuizExerciseDTO;
 import de.tum.cit.aet.artemis.quiz.repository.QuizExerciseRepository;
 import de.tum.cit.aet.artemis.quiz.service.QuizExerciseService;
 
@@ -120,7 +120,7 @@ public class QuizExerciseCreationUpdateResource {
         Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(quizExercise);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, null);
 
-        QuizExercise result = quizExerciseService.createQuizExercise(quizExercise, files, true);
+        QuizExercise result = quizExerciseService.createQuizExercise(quizExercise, files, true, quizExerciseDTO.competencyLinks());
         exerciseVersionService.createExerciseVersion(result);
         return ResponseEntity.created(new URI("/api/quiz/quiz-exercises/" + result.getId()))
                 .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getId().toString())).body(result);
@@ -150,7 +150,7 @@ public class QuizExerciseCreationUpdateResource {
         QuizExercise quizExercise = quizExerciseDTO.toDomainObject();
         quizExercise.setCourse(course);
 
-        QuizExercise result = quizExerciseService.createQuizExercise(quizExercise, files, false);
+        QuizExercise result = quizExerciseService.createQuizExercise(quizExercise, files, false, quizExerciseDTO.competencyLinks());
 
         // Notify AtlasML about the new quiz exercise
         notifyAtlasML(result, OperationTypeDTO.UPDATE, "quiz exercise creation");
@@ -165,14 +165,14 @@ public class QuizExerciseCreationUpdateResource {
      * PATCH /quiz-exercises/:exerciseId : Update an existing quizExercise with a
      * DTO.
      *
-     * @param exerciseId                the id of the quizExercise to save
-     * @param quizExerciseFromEditorDTO the quizExercise to update
-     * @param files                     the new files for drag and drop questions to
-     *                                      upload (optional). The original file name
-     *                                      must equal the file path of the image in
-     *                                      {@code quizExercise}
-     * @param notificationText          about the quiz exercise update that should
-     *                                      be displayed to the student group
+     * @param exerciseId            the id of the quizExercise to save
+     * @param updateQuizExerciseDTO the quizExercise to update
+     * @param files                 the new files for drag and drop questions to
+     *                                  upload (optional). The original file name
+     *                                  must equal the file path of the image in
+     *                                  {@code quizExercise}
+     * @param notificationText      about the quiz exercise update that should
+     *                                  be displayed to the student group
      * @return the ResponseEntity with status 200 (OK) and with body the updated
      *         quizExercise, or with status 400 (Bad Request) if the quizExercise is
      *         not valid, or with status 500
@@ -181,16 +181,15 @@ public class QuizExerciseCreationUpdateResource {
     @PatchMapping(value = "quiz-exercises/{exerciseId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @EnforceAtLeastEditorInExercise
     public ResponseEntity<QuizExerciseWithStatisticsDTO> updateQuizExercise(@PathVariable Long exerciseId,
-            @RequestPart("exercise") @Valid QuizExerciseFromEditorDTO quizExerciseFromEditorDTO, @RequestPart(value = "files", required = false) List<MultipartFile> files,
+            @RequestPart("exercise") @Valid UpdateQuizExerciseDTO updateQuizExerciseDTO, @RequestPart(value = "files", required = false) List<MultipartFile> files,
             @RequestParam(value = "notificationText", required = false) String notificationText) throws IOException {
         log.info("REST request to patch quiz exercise : {}", exerciseId);
         QuizExercise quizBase = quizExerciseRepository.findByIdWithQuestionsAndStatisticsAndCompetenciesAndBatchesAndGradingCriteriaElseThrow(exerciseId);
-        Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(quizBase);
 
         QuizExercise originalQuiz = quizExerciseService.copyFieldsForUpdate(quizBase);
 
-        quizExerciseService.mergeDTOIntoDomainObject(quizBase, quizExerciseFromEditorDTO, course);
-        QuizExercise result = quizExerciseService.performUpdate(originalQuiz, quizBase, files, notificationText);
+        quizExerciseService.mergeDTOIntoDomainObject(quizBase, updateQuizExerciseDTO);
+        QuizExercise result = quizExerciseService.performUpdate(originalQuiz, quizBase, files != null ? files : List.of(), notificationText);
 
         // Notify AtlasML about the quiz exercise update
         notifyAtlasML(result, OperationTypeDTO.UPDATE, "quiz exercise update");

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizExerciseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizExerciseResource.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import de.tum.cit.aet.artemis.communication.service.notifications.GroupNotificationService;
 import de.tum.cit.aet.artemis.core.config.Constants;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.repository.UserRepository;
@@ -72,8 +71,6 @@ public class QuizExerciseResource {
 
     private final AuthorizationCheckService authCheckService;
 
-    private final GroupNotificationService groupNotificationService;
-
     private final QuizBatchService quizBatchService;
 
     private final QuizExerciseRepository quizExerciseRepository;
@@ -85,16 +82,14 @@ public class QuizExerciseResource {
     private final ExerciseVersionService exerciseVersionService;
 
     public QuizExerciseResource(QuizExerciseService quizExerciseService, QuizMessagingService quizMessagingService, QuizExerciseRepository quizExerciseRepository,
-            UserRepository userRepository, InstanceMessageSendService instanceMessageSendService, AuthorizationCheckService authCheckService,
-            GroupNotificationService groupNotificationService, QuizBatchService quizBatchService, QuizBatchRepository quizBatchRepository,
-            QuizSubmissionService quizSubmissionService, ExerciseVersionService exerciseVersionService) {
+            UserRepository userRepository, InstanceMessageSendService instanceMessageSendService, AuthorizationCheckService authCheckService, QuizBatchService quizBatchService,
+            QuizBatchRepository quizBatchRepository, QuizSubmissionService quizSubmissionService, ExerciseVersionService exerciseVersionService) {
         this.quizExerciseService = quizExerciseService;
         this.quizMessagingService = quizMessagingService;
         this.quizExerciseRepository = quizExerciseRepository;
         this.userRepository = userRepository;
         this.instanceMessageSendService = instanceMessageSendService;
         this.authCheckService = authCheckService;
-        this.groupNotificationService = groupNotificationService;
         this.quizBatchService = quizBatchService;
         this.quizBatchRepository = quizBatchRepository;
         this.quizSubmissionService = quizSubmissionService;

--- a/src/main/java/de/tum/cit/aet/artemis/text/dto/TextAssessmentEventInputDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/dto/TextAssessmentEventInputDTO.java
@@ -1,0 +1,45 @@
+package de.tum.cit.aet.artemis.text.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.FeedbackType;
+import de.tum.cit.aet.artemis.text.domain.TextAssessmentEvent;
+import de.tum.cit.aet.artemis.text.domain.TextBlockType;
+
+/**
+ * DTO for creating TextAssessmentEvent entries.
+ * Uses DTOs instead of entity classes to avoid Hibernate detached entity issues.
+ * <p>
+ * This DTO intentionally excludes the {@code id} field to prevent clients from specifying
+ * their own IDs when creating events. Any {@code id} field sent by the client in the JSON
+ * request body will be silently ignored during deserialization (Jackson's default behavior
+ * for unknown properties). The server always generates new IDs for created events.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record TextAssessmentEventInputDTO(@NotNull Long userId, @NotNull TextAssessmentEventType eventType, @Nullable FeedbackType feedbackType,
+        @Nullable TextBlockType segmentType, @NotNull Long courseId, @NotNull Long textExerciseId, @NotNull Long participationId, @NotNull Long submissionId) {
+
+    /**
+     * Creates a new TextAssessmentEvent entity from this DTO.
+     *
+     * @return a new TextAssessmentEvent entity
+     */
+    public TextAssessmentEvent toEntity() {
+        TextAssessmentEvent event = new TextAssessmentEvent();
+        event.setUserId(userId);
+        event.setEventType(eventType);
+        event.setFeedbackType(feedbackType);
+        event.setSegmentType(segmentType);
+        event.setCourseId(courseId);
+        event.setTextExerciseId(textExerciseId);
+        event.setParticipationId(participationId);
+        event.setSubmissionId(submissionId);
+        return event;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/text/dto/UpdateTextExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/dto/UpdateTextExerciseDTO.java
@@ -4,136 +4,68 @@ import java.time.ZonedDateTime;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.validation.constraints.NotNull;
-
 import org.hibernate.Hibernate;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
+import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
+import de.tum.cit.aet.artemis.assessment.dto.GradingCriterionDTO;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
+import de.tum.cit.aet.artemis.atlas.dto.CompetencyExerciseLinkDTO;
+import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.exercise.domain.DifficultyLevel;
-import de.tum.cit.aet.artemis.exercise.domain.ExerciseMode;
 import de.tum.cit.aet.artemis.exercise.domain.IncludedInOverallScore;
-import de.tum.cit.aet.artemis.exercise.dto.CompetencyLinksHolderDTO;
-import de.tum.cit.aet.artemis.lecture.dto.CompetencyLinkDTO;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 
 /**
  * DTO for updating text exercises.
  * Uses DTOs instead of entity classes to avoid Hibernate detached entity issues.
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record UpdateTextExerciseDTO(
-        // Base exercise fields
-        Long id, String title, String shortName, @NotNull Double maxPoints, Double bonusPoints, AssessmentType assessmentType, ZonedDateTime releaseDate, ZonedDateTime startDate,
-        ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, ZonedDateTime exampleSolutionPublicationDate, DifficultyLevel difficulty, ExerciseMode mode,
-        // Exercise fields
-        IncludedInOverallScore includedInOverallScore, String problemStatement, String gradingInstructions, Set<String> categories, Boolean presentationScoreEnabled,
-        Boolean secondCorrectionEnabled, String feedbackSuggestionModule, Boolean allowComplaintsForAutomaticAssessments, Boolean allowFeedbackRequests, String channelName,
-        // Competency links as DTOs
-        Set<CompetencyLinkDTO> competencyLinks,
-        // Course/ExerciseGroup references (by ID)
-        Long courseId, Long exerciseGroupId,
-        // TextExercise specific fields
-        String exampleSolution) implements CompetencyLinksHolderDTO {
+public record UpdateTextExerciseDTO(Long id, String title, String channelName, String shortName, String problemStatement, Set<String> categories, DifficultyLevel difficulty,
+        Double maxPoints, Double bonusPoints, IncludedInOverallScore includedInOverallScore, Boolean allowComplaintsForAutomaticAssessments, Boolean allowFeedbackRequests,
+        Boolean presentationScoreEnabled, Boolean secondCorrectionEnabled, String feedbackSuggestionModule, String gradingInstructions, ZonedDateTime releaseDate,
+        ZonedDateTime startDate, ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, ZonedDateTime exampleSolutionPublicationDate, String exampleSolution, Long courseId,
+        Long exerciseGroupId, Set<GradingCriterionDTO> gradingCriteria, Set<CompetencyExerciseLinkDTO> competencyLinks) {
 
     /**
-     * Creates a TextExerciseFromEditorDTO from the given TextExercise domain object.
+     * Creates an UpdateTextExerciseDTO from the given TextExercise domain object.
      *
      * @param exercise the text exercise to convert
      * @return the corresponding DTO
      */
     public static UpdateTextExerciseDTO of(TextExercise exercise) {
-        // Only convert competency links if they are initialized (to avoid LazyInitializationException)
-        Set<CompetencyLinkDTO> competencyLinkDTOs = null;
-        Set<CompetencyExerciseLink> competencyLinks = exercise.getCompetencyLinks();
-        if (competencyLinks != null && Hibernate.isInitialized(competencyLinks)) {
-            competencyLinkDTOs = competencyLinks.isEmpty() ? Set.of() : competencyLinks.stream().map(CompetencyLinkDTO::of).collect(Collectors.toSet());
+        if (exercise == null) {
+            throw new BadRequestAlertException("No text exercise was provided.", "textExercise", "textExercise.isNull");
         }
 
-        // Determine courseId and exerciseGroupId based on the exercise type
-        Long courseId = exercise.isCourseExercise() ? exercise.getCourseViaExerciseGroupOrCourseMember().getId() : null;
+        Long courseId = exercise.getCourseViaExerciseGroupOrCourseMember() != null ? exercise.getCourseViaExerciseGroupOrCourseMember().getId() : null;
         Long exerciseGroupId = exercise.getExerciseGroup() != null ? exercise.getExerciseGroup().getId() : null;
 
-        return new UpdateTextExerciseDTO(exercise.getId(), exercise.getTitle(), exercise.getShortName(), exercise.getMaxPoints(), exercise.getBonusPoints(),
-                exercise.getAssessmentType(), exercise.getReleaseDate(), exercise.getStartDate(), exercise.getDueDate(), exercise.getAssessmentDueDate(),
-                exercise.getExampleSolutionPublicationDate(), exercise.getDifficulty(), exercise.getMode(), exercise.getIncludedInOverallScore(), exercise.getProblemStatement(),
-                exercise.getGradingInstructions(), exercise.getCategories(), exercise.getPresentationScoreEnabled(), exercise.getSecondCorrectionEnabled(),
-                exercise.getFeedbackSuggestionModule(), exercise.getAllowComplaintsForAutomaticAssessments(), exercise.getAllowFeedbackRequests(), exercise.getChannelName(),
-                competencyLinkDTOs, courseId, exerciseGroupId, exercise.getExampleSolution());
-    }
+        Set<GradingCriterionDTO> gradingCriterionDTOs;
+        Set<CompetencyExerciseLinkDTO> competencyLinkDTOs;
 
-    /**
-     * Applies the DTO values to an existing TextExercise entity.
-     * This updates the managed entity with values from the DTO.
-     *
-     * @param textExercise the existing text exercise to update
-     */
-    public void applyTo(TextExercise textExercise) {
-        // Base exercise fields
-        if (title != null) {
-            textExercise.setTitle(title);
+        Set<GradingCriterion> criteria = exercise.getGradingCriteria();
+        Set<CompetencyExerciseLink> competencyLinks = exercise.getCompetencyLinks();
+
+        if (criteria != null && Hibernate.isInitialized(criteria)) {
+            gradingCriterionDTOs = criteria.isEmpty() ? Set.of() : criteria.stream().map(GradingCriterionDTO::of).collect(Collectors.toSet());
         }
-        if (shortName != null) {
-            textExercise.setShortName(shortName);
+        else {
+            gradingCriterionDTOs = null;
         }
-        if (maxPoints != null) {
-            textExercise.setMaxPoints(maxPoints);
+        if (competencyLinks != null && Hibernate.isInitialized(competencyLinks)) {
+            competencyLinkDTOs = competencyLinks.isEmpty() ? Set.of() : competencyLinks.stream().map(CompetencyExerciseLinkDTO::of).collect(Collectors.toSet());
         }
-        if (bonusPoints != null) {
-            textExercise.setBonusPoints(bonusPoints);
-        }
-        if (assessmentType != null) {
-            textExercise.setAssessmentType(assessmentType);
-        }
-        textExercise.setReleaseDate(releaseDate);
-        textExercise.setStartDate(startDate);
-        textExercise.setDueDate(dueDate);
-        textExercise.setAssessmentDueDate(assessmentDueDate);
-        textExercise.setExampleSolutionPublicationDate(exampleSolutionPublicationDate);
-        if (difficulty != null) {
-            textExercise.setDifficulty(difficulty);
-        }
-        if (mode != null) {
-            textExercise.setMode(mode);
+        else {
+            competencyLinkDTOs = null;
         }
 
-        // Exercise fields
-        if (includedInOverallScore != null) {
-            textExercise.setIncludedInOverallScore(includedInOverallScore);
-        }
-        if (problemStatement != null) {
-            textExercise.setProblemStatement(problemStatement);
-        }
-        if (gradingInstructions != null) {
-            textExercise.setGradingInstructions(gradingInstructions);
-        }
-        if (categories != null) {
-            textExercise.setCategories(categories);
-        }
-        if (presentationScoreEnabled != null) {
-            textExercise.setPresentationScoreEnabled(presentationScoreEnabled);
-        }
-        if (secondCorrectionEnabled != null) {
-            textExercise.setSecondCorrectionEnabled(secondCorrectionEnabled);
-        }
-        // feedbackSuggestionModule can be null intentionally, so we always set it
-        textExercise.setFeedbackSuggestionModule(feedbackSuggestionModule);
-        if (allowComplaintsForAutomaticAssessments != null) {
-            textExercise.setAllowComplaintsForAutomaticAssessments(allowComplaintsForAutomaticAssessments);
-        }
-        if (allowFeedbackRequests != null) {
-            textExercise.setAllowFeedbackRequests(allowFeedbackRequests);
-        }
-        if (channelName != null) {
-            textExercise.setChannelName(channelName);
-        }
-
-        // TextExercise specific fields
-        // exampleSolution can be null intentionally
-        textExercise.setExampleSolution(exampleSolution);
+        return new UpdateTextExerciseDTO(exercise.getId(), exercise.getTitle(), exercise.getChannelName(), exercise.getShortName(), exercise.getProblemStatement(),
+                exercise.getCategories(), exercise.getDifficulty(), exercise.getMaxPoints(), exercise.getBonusPoints(), exercise.getIncludedInOverallScore(),
+                exercise.getAllowComplaintsForAutomaticAssessments(), exercise.getAllowFeedbackRequests(), exercise.getPresentationScoreEnabled(),
+                exercise.getSecondCorrectionEnabled(), exercise.getFeedbackSuggestionModule(), exercise.getGradingInstructions(), exercise.getReleaseDate(),
+                exercise.getStartDate(), exercise.getDueDate(), exercise.getAssessmentDueDate(), exercise.getExampleSolutionPublicationDate(), exercise.getExampleSolution(),
+                courseId, exerciseGroupId, gradingCriterionDTOs, competencyLinkDTOs);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/text/dto/UpdateTextExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/dto/UpdateTextExerciseDTO.java
@@ -1,0 +1,139 @@
+package de.tum.cit.aet.artemis.text.dto;
+
+import java.time.ZonedDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.validation.constraints.NotNull;
+
+import org.hibernate.Hibernate;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
+import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
+import de.tum.cit.aet.artemis.exercise.domain.DifficultyLevel;
+import de.tum.cit.aet.artemis.exercise.domain.ExerciseMode;
+import de.tum.cit.aet.artemis.exercise.domain.IncludedInOverallScore;
+import de.tum.cit.aet.artemis.exercise.dto.CompetencyLinksHolderDTO;
+import de.tum.cit.aet.artemis.lecture.dto.CompetencyLinkDTO;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
+
+/**
+ * DTO for updating text exercises.
+ * Uses DTOs instead of entity classes to avoid Hibernate detached entity issues.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record UpdateTextExerciseDTO(
+        // Base exercise fields
+        Long id, String title, String shortName, @NotNull Double maxPoints, Double bonusPoints, AssessmentType assessmentType, ZonedDateTime releaseDate, ZonedDateTime startDate,
+        ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, ZonedDateTime exampleSolutionPublicationDate, DifficultyLevel difficulty, ExerciseMode mode,
+        // Exercise fields
+        IncludedInOverallScore includedInOverallScore, String problemStatement, String gradingInstructions, Set<String> categories, Boolean presentationScoreEnabled,
+        Boolean secondCorrectionEnabled, String feedbackSuggestionModule, Boolean allowComplaintsForAutomaticAssessments, Boolean allowFeedbackRequests, String channelName,
+        // Competency links as DTOs
+        Set<CompetencyLinkDTO> competencyLinks,
+        // Course/ExerciseGroup references (by ID)
+        Long courseId, Long exerciseGroupId,
+        // TextExercise specific fields
+        String exampleSolution) implements CompetencyLinksHolderDTO {
+
+    /**
+     * Creates a TextExerciseFromEditorDTO from the given TextExercise domain object.
+     *
+     * @param exercise the text exercise to convert
+     * @return the corresponding DTO
+     */
+    public static UpdateTextExerciseDTO of(TextExercise exercise) {
+        // Only convert competency links if they are initialized (to avoid LazyInitializationException)
+        Set<CompetencyLinkDTO> competencyLinkDTOs = null;
+        Set<CompetencyExerciseLink> competencyLinks = exercise.getCompetencyLinks();
+        if (competencyLinks != null && Hibernate.isInitialized(competencyLinks)) {
+            competencyLinkDTOs = competencyLinks.isEmpty() ? Set.of() : competencyLinks.stream().map(CompetencyLinkDTO::of).collect(Collectors.toSet());
+        }
+
+        // Determine courseId and exerciseGroupId based on the exercise type
+        Long courseId = exercise.isCourseExercise() ? exercise.getCourseViaExerciseGroupOrCourseMember().getId() : null;
+        Long exerciseGroupId = exercise.getExerciseGroup() != null ? exercise.getExerciseGroup().getId() : null;
+
+        return new UpdateTextExerciseDTO(exercise.getId(), exercise.getTitle(), exercise.getShortName(), exercise.getMaxPoints(), exercise.getBonusPoints(),
+                exercise.getAssessmentType(), exercise.getReleaseDate(), exercise.getStartDate(), exercise.getDueDate(), exercise.getAssessmentDueDate(),
+                exercise.getExampleSolutionPublicationDate(), exercise.getDifficulty(), exercise.getMode(), exercise.getIncludedInOverallScore(), exercise.getProblemStatement(),
+                exercise.getGradingInstructions(), exercise.getCategories(), exercise.getPresentationScoreEnabled(), exercise.getSecondCorrectionEnabled(),
+                exercise.getFeedbackSuggestionModule(), exercise.getAllowComplaintsForAutomaticAssessments(), exercise.getAllowFeedbackRequests(), exercise.getChannelName(),
+                competencyLinkDTOs, courseId, exerciseGroupId, exercise.getExampleSolution());
+    }
+
+    /**
+     * Applies the DTO values to an existing TextExercise entity.
+     * This updates the managed entity with values from the DTO.
+     *
+     * @param textExercise the existing text exercise to update
+     */
+    public void applyTo(TextExercise textExercise) {
+        // Base exercise fields
+        if (title != null) {
+            textExercise.setTitle(title);
+        }
+        if (shortName != null) {
+            textExercise.setShortName(shortName);
+        }
+        if (maxPoints != null) {
+            textExercise.setMaxPoints(maxPoints);
+        }
+        if (bonusPoints != null) {
+            textExercise.setBonusPoints(bonusPoints);
+        }
+        if (assessmentType != null) {
+            textExercise.setAssessmentType(assessmentType);
+        }
+        textExercise.setReleaseDate(releaseDate);
+        textExercise.setStartDate(startDate);
+        textExercise.setDueDate(dueDate);
+        textExercise.setAssessmentDueDate(assessmentDueDate);
+        textExercise.setExampleSolutionPublicationDate(exampleSolutionPublicationDate);
+        if (difficulty != null) {
+            textExercise.setDifficulty(difficulty);
+        }
+        if (mode != null) {
+            textExercise.setMode(mode);
+        }
+
+        // Exercise fields
+        if (includedInOverallScore != null) {
+            textExercise.setIncludedInOverallScore(includedInOverallScore);
+        }
+        if (problemStatement != null) {
+            textExercise.setProblemStatement(problemStatement);
+        }
+        if (gradingInstructions != null) {
+            textExercise.setGradingInstructions(gradingInstructions);
+        }
+        if (categories != null) {
+            textExercise.setCategories(categories);
+        }
+        if (presentationScoreEnabled != null) {
+            textExercise.setPresentationScoreEnabled(presentationScoreEnabled);
+        }
+        if (secondCorrectionEnabled != null) {
+            textExercise.setSecondCorrectionEnabled(secondCorrectionEnabled);
+        }
+        // feedbackSuggestionModule can be null intentionally, so we always set it
+        textExercise.setFeedbackSuggestionModule(feedbackSuggestionModule);
+        if (allowComplaintsForAutomaticAssessments != null) {
+            textExercise.setAllowComplaintsForAutomaticAssessments(allowComplaintsForAutomaticAssessments);
+        }
+        if (allowFeedbackRequests != null) {
+            textExercise.setAllowFeedbackRequests(allowFeedbackRequests);
+        }
+        if (channelName != null) {
+            textExercise.setChannelName(channelName);
+        }
+
+        // TextExercise specific fields
+        // exampleSolution can be null intentionally
+        textExercise.setExampleSolution(exampleSolution);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/text/repository/TextExerciseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/repository/TextExerciseRepository.java
@@ -39,6 +39,14 @@ public interface TextExerciseRepository extends ArtemisJpaRepository<TextExercis
     @EntityGraph(type = LOAD, attributePaths = { "competencyLinks.competency", "categories" })
     Optional<TextExercise> findWithEagerCompetenciesAndCategoriesById(long exerciseId);
 
+    @EntityGraph(type = LOAD, attributePaths = { "competencyLinks.competency", "categories", "gradingCriteria", "plagiarismDetectionConfig", "exampleSubmissions" })
+    Optional<TextExercise> findWithCompetenciesCategoriesAndGradingCriteriaById(long exerciseId);
+
+    @NonNull
+    default TextExercise findWithCompetenciesCategoriesAndGradingCriteriaByIdElseThrow(long exerciseId) {
+        return getValueElseThrow(findWithCompetenciesCategoriesAndGradingCriteriaById(exerciseId), exerciseId);
+    }
+
     @EntityGraph(type = LOAD, attributePaths = { "teamAssignmentConfig", "categories", "competencyLinks.competency" })
     Optional<TextExercise> findWithEagerTeamAssignmentConfigAndCategoriesAndCompetenciesById(long exerciseId);
 

--- a/src/main/java/de/tum/cit/aet/artemis/text/service/TextExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/service/TextExerciseImportService.java
@@ -95,7 +95,13 @@ public class TextExerciseImportService extends ExerciseImportService {
             newExercise.setFeedbackSuggestionModule(null);
         }
 
-        TextExercise newTextExercise = exerciseService.saveWithCompetencyLinks(newExercise, textExerciseRepository::save);
+        var competencyLinks = exerciseService.extractCompetencyLinksForCreation(newExercise);
+        TextExercise savedExercise = textExerciseRepository.save(newExercise);
+        if (!competencyLinks.isEmpty()) {
+            exerciseService.addCompetencyLinksForCreation(savedExercise, competencyLinks);
+            savedExercise = textExerciseRepository.save(savedExercise);
+        }
+        final TextExercise newTextExercise = savedExercise;
 
         channelService.createExerciseChannel(newTextExercise, Optional.ofNullable(importedExercise.getChannelName()));
         newExercise.setExampleSubmissions(copyExampleSubmission(templateExercise, newExercise, gradingInstructionCopyTracker));

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextAssessmentEventResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextAssessmentEventResource.java
@@ -30,6 +30,7 @@ import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.text.config.TextEnabled;
 import de.tum.cit.aet.artemis.text.domain.TextAssessmentEvent;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
+import de.tum.cit.aet.artemis.text.dto.TextAssessmentEventInputDTO;
 import de.tum.cit.aet.artemis.text.repository.TextSubmissionRepository;
 
 /**
@@ -78,14 +79,15 @@ public class TextAssessmentEventResource {
     /**
      * POST event-insights/text-assessment/events : Adds an assessment event into the text_assessment_event table.
      *
-     * @param event to be added
+     * @param dto the DTO containing the event data to be added
      * @return the status of the finished request
      */
     @PostMapping("event-insights/text-assessment/events")
     @EnforceAtLeastTutor
-    public ResponseEntity<Void> addAssessmentEvent(@RequestBody TextAssessmentEvent event) throws URISyntaxException {
-        log.debug("REST request to save assessmentEvent : {}", event);
+    public ResponseEntity<Void> addAssessmentEvent(@RequestBody TextAssessmentEventInputDTO dto) throws URISyntaxException {
+        log.debug("REST request to save assessmentEvent : {}", dto);
 
+        TextAssessmentEvent event = dto.toEntity();
         // Check if the text assessment analytics feature is enabled
         // Save the event if it is valid. All other requests are considered bad requests.
         if (isTextAssessmentAnalyticsEnabled() && validateEvent(event)) {
@@ -128,9 +130,10 @@ public class TextAssessmentEventResource {
         // avoid access from tutor if they are not part of the course
         User user = userRepository.getUserWithGroupsAndAuthorities();
 
-        // make sure that the received event doesn't already have an ID
-        // reject if the logged-in user id and received event user id do not match
-        // make sure that the event submission id is not null
+        // The ID check is defense-in-depth: the DTO doesn't have an ID field, so client-specified IDs
+        // are silently ignored during JSON deserialization. This check guards against future changes.
+        // Also reject if the logged-in user id and received event user id do not match,
+        // or if the event submission id is null.
         if (event.getId() != null || !user.getId().equals(event.getUserId()) || event.getSubmissionId() == null) {
             return false;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseCreationUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseCreationUpdateResource.java
@@ -154,7 +154,13 @@ public class TextExerciseCreationUpdateResource {
         // Check that only allowed athena modules are used
         athenaApi.ifPresentOrElse(api -> api.checkHasAccessToAthenaModule(textExercise, course, ENTITY_NAME), () -> textExercise.setFeedbackSuggestionModule(null));
 
-        TextExercise result = exerciseService.saveWithCompetencyLinks(textExercise, textExerciseRepository::save);
+        var competencyLinks = exerciseService.extractCompetencyLinksForCreation(textExercise);
+        TextExercise savedExercise = textExerciseRepository.save(textExercise);
+        if (!competencyLinks.isEmpty()) {
+            exerciseService.addCompetencyLinksForCreation(savedExercise, competencyLinks);
+            savedExercise = textExerciseRepository.save(savedExercise);
+        }
+        final TextExercise result = savedExercise;
 
         channelService.createExerciseChannel(result, Optional.ofNullable(textExercise.getChannelName()));
         instanceMessageSendService.sendTextExerciseSchedule(result.getId());
@@ -242,7 +248,7 @@ public class TextExerciseCreationUpdateResource {
 
         channelService.updateExerciseChannel(originalExercise, updatedExercise);
 
-        TextExercise persistedExercise = exerciseService.saveWithCompetencyLinks(updatedExercise, textExerciseRepository::save);
+        TextExercise persistedExercise = textExerciseRepository.save(updatedExercise);
 
         exerciseService.logUpdate(persistedExercise, persistedExercise.getCourseViaExerciseGroupOrCourseMember(), user);
         exerciseService.updatePointsInRelatedParticipantScores(oldMaxPoints, oldBonusPoints, persistedExercise);

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseCreationUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseCreationUpdateResource.java
@@ -2,9 +2,15 @@ package de.tum.cit.aet.artemis.text.web;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Conditional;
@@ -18,14 +24,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
 import de.tum.cit.aet.artemis.athena.api.AthenaApi;
 import de.tum.cit.aet.artemis.atlas.api.AtlasMLApi;
+import de.tum.cit.aet.artemis.atlas.api.CompetencyApi;
 import de.tum.cit.aet.artemis.atlas.api.CompetencyProgressApi;
+import de.tum.cit.aet.artemis.atlas.domain.competency.Competency;
+import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
 import de.tum.cit.aet.artemis.atlas.dto.atlasml.SaveCompetencyRequestDTO.OperationTypeDTO;
 import de.tum.cit.aet.artemis.communication.service.conversation.ChannelService;
 import de.tum.cit.aet.artemis.communication.service.notifications.GroupNotificationScheduleService;
 import de.tum.cit.aet.artemis.core.domain.Course;
-import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.exception.ConflictException;
 import de.tum.cit.aet.artemis.core.repository.UserRepository;
@@ -41,6 +50,7 @@ import de.tum.cit.aet.artemis.lecture.api.SlideApi;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismDetectionConfigHelper;
 import de.tum.cit.aet.artemis.text.config.TextEnabled;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
+import de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO;
 import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
 
 /**
@@ -72,6 +82,8 @@ public class TextExerciseCreationUpdateResource {
 
     private final Optional<CompetencyProgressApi> competencyProgressApi;
 
+    private final Optional<CompetencyApi> competencyApi;
+
     private final Optional<SlideApi> slideApi;
 
     private final Optional<AtlasMLApi> atlasMLApi;
@@ -87,8 +99,8 @@ public class TextExerciseCreationUpdateResource {
     public TextExerciseCreationUpdateResource(TextExerciseRepository textExerciseRepository, UserRepository userRepository, AuthorizationCheckService authCheckService,
             CourseService courseService, ParticipationRepository participationRepository, ExerciseService exerciseService,
             GroupNotificationScheduleService groupNotificationScheduleService, InstanceMessageSendService instanceMessageSendService, ChannelService channelService,
-            ExerciseVersionService exerciseVersionService, Optional<AthenaApi> athenaApi, Optional<CompetencyProgressApi> competencyProgressApi, Optional<SlideApi> slideApi,
-            Optional<AtlasMLApi> atlasMLApi) {
+            ExerciseVersionService exerciseVersionService, Optional<AthenaApi> athenaApi, Optional<CompetencyProgressApi> competencyProgressApi,
+            Optional<CompetencyApi> competencyApi, Optional<SlideApi> slideApi, Optional<AtlasMLApi> atlasMLApi) {
         this.textExerciseRepository = textExerciseRepository;
         this.userRepository = userRepository;
         this.courseService = courseService;
@@ -101,6 +113,7 @@ public class TextExerciseCreationUpdateResource {
         this.exerciseVersionService = exerciseVersionService;
         this.athenaApi = athenaApi;
         this.competencyProgressApi = competencyProgressApi;
+        this.competencyApi = competencyApi;
         this.slideApi = slideApi;
         this.atlasMLApi = atlasMLApi;
     }
@@ -159,70 +172,94 @@ public class TextExerciseCreationUpdateResource {
     /**
      * PUT /text-exercises : Updates an existing textExercise.
      *
-     * @param textExercise     the textExercise to update
-     * @param notificationText about the text exercise update that should be
-     *                             displayed for the
-     *                             student group
+     * @param updateTextExerciseDTO the textExercise DTO to update
+     * @param notificationText      about the text exercise update that should be
+     *                                  displayed for the student group
      * @return the ResponseEntity with status 200 (OK) and with body the updated
-     *         textExercise, or
-     *         with status 400 (Bad Request) if the textExercise is not valid, or
-     *         with status 500 (Internal
-     *         Server Error) if the textExercise couldn't be updated
-     * @throws URISyntaxException if the Location URI syntax is incorrect
+     *         textExercise, or with status 400 (Bad Request) if the textExercise is not valid, or
+     *         with status 500 (Internal Server Error) if the textExercise couldn't be updated
      */
     @PutMapping("text-exercises")
     @EnforceAtLeastEditor
-    public ResponseEntity<TextExercise> updateTextExercise(@RequestBody TextExercise textExercise,
-            @RequestParam(value = "notificationText", required = false) String notificationText) throws URISyntaxException {
-        log.debug("REST request to update TextExercise : {}", textExercise);
-        if (textExercise.getId() == null) {
-            return createTextExercise(textExercise);
+    public ResponseEntity<TextExercise> updateTextExercise(@RequestBody UpdateTextExerciseDTO updateTextExerciseDTO,
+            @RequestParam(value = "notificationText", required = false) String notificationText) {
+        log.debug("REST request to update TextExercise : {}", updateTextExerciseDTO);
+
+        // If no id is provided, delegate to create
+        if (updateTextExerciseDTO.id() == null) {
+            TextExercise textExercise = new TextExercise();
+            applyDtoToNewExercise(updateTextExerciseDTO, textExercise);
+            try {
+                return createTextExercise(textExercise);
+            }
+            catch (URISyntaxException e) {
+                throw new BadRequestAlertException("Invalid URI syntax", ENTITY_NAME, "uriSyntaxError");
+            }
         }
-        // validates general settings: points, dates
-        textExercise.validateGeneralSettings();
-        // Valid exercises have set either a course or an exerciseGroup
-        textExercise.checkCourseAndExerciseGroupExclusivity(ENTITY_NAME);
+
+        final TextExercise originalExercise = textExerciseRepository.findWithCompetenciesCategoriesAndGradingCriteriaByIdElseThrow(updateTextExerciseDTO.id());
 
         // Check that the user is authorized to update the exercise
         var user = userRepository.getUserWithGroupsAndAuthorities();
         // Important: use the original exercise for permission check
-        final TextExercise textExerciseBeforeUpdate = textExerciseRepository.findWithEagerCompetenciesAndCategoriesByIdElseThrow(textExercise.getId());
-        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, textExerciseBeforeUpdate, user);
-
-        // Validate plagiarism detection config
-        PlagiarismDetectionConfigHelper.validatePlagiarismDetectionConfigOrThrow(textExercise, ENTITY_NAME);
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, originalExercise, user);
 
         // Forbid changing the course the exercise belongs to.
-        if (!Objects.equals(textExerciseBeforeUpdate.getCourseViaExerciseGroupOrCourseMember().getId(), textExercise.getCourseViaExerciseGroupOrCourseMember().getId())) {
+        if (updateTextExerciseDTO.courseId() == null && updateTextExerciseDTO.exerciseGroupId() == null) {
+            throw new BadRequestAlertException("Either courseId or exerciseGroupId must be provided.", ENTITY_NAME, "courseOrExerciseGroupMissing");
+        }
+        if (!Objects.equals(originalExercise.getCourseViaExerciseGroupOrCourseMember().getId(), updateTextExerciseDTO.courseId())) {
             throw new ConflictException("Exercise course id does not match the stored course id", ENTITY_NAME, "cannotChangeCourseId");
         }
 
+        ZonedDateTime oldDueDate = originalExercise.getDueDate();
+        ZonedDateTime oldAssessmentDueDate = originalExercise.getAssessmentDueDate();
+        ZonedDateTime oldReleaseDate = originalExercise.getReleaseDate();
+        Double oldMaxPoints = originalExercise.getMaxPoints();
+        Double oldBonusPoints = originalExercise.getBonusPoints();
+        String oldProblemStatement = originalExercise.getProblemStatement();
+        String oldFeedbackSuggestionModule = originalExercise.getFeedbackSuggestionModule();
+
+        // Apply the DTO to the original exercise
+        TextExercise updatedExercise = update(updateTextExerciseDTO, originalExercise);
+        // Valid exercises have set either a course or an exerciseGroup
+        updatedExercise.checkCourseAndExerciseGroupExclusivity(ENTITY_NAME);
         // Forbid conversion between normal course exercise and exam exercise
-        exerciseService.checkForConversionBetweenExamAndCourseExercise(textExercise, textExerciseBeforeUpdate, ENTITY_NAME);
+        exerciseService.checkForConversionBetweenExamAndCourseExercise(updatedExercise, originalExercise, ENTITY_NAME);
+
+        // Validate plagiarism detection config
+        PlagiarismDetectionConfigHelper.validatePlagiarismDetectionConfigOrThrow(updatedExercise, ENTITY_NAME);
 
         // Check that only allowed athena modules are used
-        Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(textExerciseBeforeUpdate);
-        athenaApi.ifPresentOrElse(api -> api.checkHasAccessToAthenaModule(textExercise, course, ENTITY_NAME), () -> textExercise.setFeedbackSuggestionModule(null));
+        Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(originalExercise);
+        athenaApi.ifPresentOrElse(api -> api.checkHasAccessToAthenaModule(updatedExercise, course, ENTITY_NAME), () -> updatedExercise.setFeedbackSuggestionModule(null));
         // Changing Athena module after the due date has passed is not allowed
-        athenaApi.ifPresent(api -> api.checkValidAthenaModuleChange(textExerciseBeforeUpdate, textExercise, ENTITY_NAME));
+        // Use a proxy exercise with the old module for comparison since update() mutates the original
+        TextExercise exerciseWithOldModule = new TextExercise();
+        exerciseWithOldModule.setFeedbackSuggestionModule(oldFeedbackSuggestionModule);
+        exerciseWithOldModule.setDueDate(oldDueDate);
+        athenaApi.ifPresent(api -> api.checkValidAthenaModuleChange(exerciseWithOldModule, updatedExercise, ENTITY_NAME));
 
-        channelService.updateExerciseChannel(textExerciseBeforeUpdate, textExercise);
+        channelService.updateExerciseChannel(originalExercise, updatedExercise);
 
-        TextExercise updatedTextExercise = exerciseService.saveWithCompetencyLinks(textExercise, textExerciseRepository::save);
+        TextExercise persistedExercise = exerciseService.saveWithCompetencyLinks(updatedExercise, textExerciseRepository::save);
 
-        exerciseService.logUpdate(updatedTextExercise, updatedTextExercise.getCourseViaExerciseGroupOrCourseMember(), user);
-        exerciseService.updatePointsInRelatedParticipantScores(textExerciseBeforeUpdate, updatedTextExercise);
-        participationRepository.removeIndividualDueDatesIfBeforeDueDate(updatedTextExercise, textExerciseBeforeUpdate.getDueDate());
-        instanceMessageSendService.sendTextExerciseSchedule(updatedTextExercise.getId());
-        exerciseService.checkExampleSubmissions(updatedTextExercise);
-        exerciseService.notifyAboutExerciseChanges(textExerciseBeforeUpdate, updatedTextExercise, notificationText);
-        slideApi.ifPresent(api -> api.handleDueDateChange(textExerciseBeforeUpdate, updatedTextExercise));
+        exerciseService.logUpdate(persistedExercise, persistedExercise.getCourseViaExerciseGroupOrCourseMember(), user);
+        exerciseService.updatePointsInRelatedParticipantScores(oldMaxPoints, oldBonusPoints, persistedExercise);
+        participationRepository.removeIndividualDueDatesIfBeforeDueDate(persistedExercise, oldDueDate);
+        instanceMessageSendService.sendTextExerciseSchedule(persistedExercise.getId());
+        exerciseService.checkExampleSubmissions(persistedExercise);
+        exerciseService.notifyAboutExerciseChanges(oldReleaseDate, oldAssessmentDueDate, oldProblemStatement, persistedExercise, notificationText);
+        slideApi.ifPresent(api -> api.handleDueDateChange(oldDueDate, persistedExercise));
 
-        competencyProgressApi.ifPresent(api -> api.updateProgressForUpdatedLearningObjectAsync(textExerciseBeforeUpdate, Optional.of(textExercise)));
+        competencyProgressApi.ifPresent(api -> api.updateProgressForUpdatedLearningObjectAsync(originalExercise, Optional.of(persistedExercise)));
 
-        exerciseVersionService.createExerciseVersion(updatedTextExercise);
+        // Notify AtlasML about the text exercise update
+        notifyAtlasML(persistedExercise, OperationTypeDTO.UPDATE, "text exercise update");
 
-        return ResponseEntity.ok(updatedTextExercise);
+        exerciseVersionService.createExerciseVersion(persistedExercise);
+
+        return ResponseEntity.ok(persistedExercise);
     }
 
     /**
@@ -230,50 +267,231 @@ public class TextExerciseCreationUpdateResource {
      * existing textExercise.
      *
      * @param exerciseId                                  of the exercise
-     * @param textExercise                                the textExercise to
-     *                                                        re-evaluate and update
+     * @param updateTextExerciseDTO                       the textExercise DTO to re-evaluate and update
      * @param deleteFeedbackAfterGradingInstructionUpdate boolean flag that
      *                                                        indicates whether the
      *                                                        associated feedback should
      *                                                        be deleted or not
      * @return the ResponseEntity with status 200 (OK) and with body the updated
-     *         textExercise, or
-     *         with status 400 (Bad Request) if the textExercise is not valid, or
-     *         with status 409 (Conflict)
-     *         if given exerciseId is not same as in the object of the request body,
-     *         or with status 500
-     *         (Internal Server Error) if the textExercise couldn't be updated
-     * @throws URISyntaxException if the Location URI syntax is incorrect
+     *         textExercise, or with status 400 (Bad Request) if the textExercise is not valid, or
+     *         with status 409 (Conflict) if given exerciseId is not same as in the object of the request body, or
+     *         with status 500 (Internal Server Error) if the textExercise couldn't be updated
      */
     @PutMapping("text-exercises/{exerciseId}/re-evaluate")
     @EnforceAtLeastEditor
-    public ResponseEntity<TextExercise> reEvaluateAndUpdateTextExercise(@PathVariable long exerciseId, @RequestBody TextExercise textExercise,
-            @RequestParam(value = "deleteFeedback", required = false) Boolean deleteFeedbackAfterGradingInstructionUpdate) throws URISyntaxException {
-        log.debug("REST request to re-evaluate TextExercise : {}", textExercise);
+    public ResponseEntity<TextExercise> reEvaluateAndUpdateTextExercise(@PathVariable long exerciseId, @RequestBody UpdateTextExerciseDTO updateTextExerciseDTO,
+            @RequestParam(value = "deleteFeedback", required = false) Boolean deleteFeedbackAfterGradingInstructionUpdate) {
+        log.debug("REST request to re-evaluate TextExercise : {}", updateTextExerciseDTO);
 
-        // check that the exercise exists for given id
-        textExerciseRepository.findByIdWithStudentParticipationsAndSubmissionsElseThrow(exerciseId);
+        final TextExercise existingExercise = textExerciseRepository.findByIdWithExampleSubmissionsAndResultsAndGradingCriteriaElseThrow(exerciseId);
+        authCheckService.checkGivenExerciseIdSameForExerciseRequestBodyIdElseThrow(exerciseId, updateTextExerciseDTO.id());
 
-        authCheckService.checkGivenExerciseIdSameForExerciseInRequestBodyElseThrow(exerciseId, textExercise);
-
-        Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(textExercise);
-
-        // Check that the user is authorized to update the exercise
-        User user = userRepository.getUserWithGroupsAndAuthorities();
+        var user = userRepository.getUserWithGroupsAndAuthorities();
+        // Apply DTO to existing exercise
+        TextExercise exerciseForReevaluation = update(updateTextExerciseDTO, existingExercise);
+        Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(exerciseForReevaluation);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, user);
 
-        exerciseService.reEvaluateExercise(textExercise, deleteFeedbackAfterGradingInstructionUpdate);
-        return updateTextExercise(textExercise, null);
+        exerciseService.reEvaluateExercise(exerciseForReevaluation, deleteFeedbackAfterGradingInstructionUpdate);
+
+        return updateTextExercise(updateTextExerciseDTO, null);
+    }
+
+    /**
+     * Applies the DTO's data to the given exercise, mutating it in place.
+     *
+     * @param dto      the DTO containing the updated state
+     * @param exercise the exercise to update (will be mutated)
+     * @return the same exercise instance after applying the updates
+     */
+    private TextExercise update(UpdateTextExerciseDTO dto, TextExercise exercise) {
+        if (dto == null) {
+            throw new BadRequestAlertException("No text exercise was provided.", ENTITY_NAME, "isNull");
+        }
+        exercise.setTitle(dto.title());
+        exercise.validateTitle();
+        exercise.setShortName(dto.shortName());
+        // problemStatement: null -> empty string
+        String newProblemStatement = dto.problemStatement() == null ? "" : dto.problemStatement();
+        exercise.setProblemStatement(newProblemStatement);
+
+        exercise.setChannelName(dto.channelName());
+        exercise.setCategories(dto.categories());
+        exercise.setDifficulty(dto.difficulty());
+
+        exercise.setMaxPoints(dto.maxPoints());
+        exercise.setBonusPoints(dto.bonusPoints());
+        exercise.setIncludedInOverallScore(dto.includedInOverallScore());
+
+        exercise.setReleaseDate(dto.releaseDate());
+        exercise.setStartDate(dto.startDate());
+        exercise.setDueDate(dto.dueDate());
+        exercise.setAssessmentDueDate(dto.assessmentDueDate());
+        exercise.setExampleSolutionPublicationDate(dto.exampleSolutionPublicationDate());
+
+        // validates general settings: points, dates, etc.
+        exercise.validateGeneralSettings();
+
+        // Only set boolean values if they are explicitly provided (not null)
+        if (dto.allowComplaintsForAutomaticAssessments() != null) {
+            exercise.setAllowComplaintsForAutomaticAssessments(dto.allowComplaintsForAutomaticAssessments());
+        }
+        if (dto.allowFeedbackRequests() != null) {
+            exercise.setAllowFeedbackRequests(dto.allowFeedbackRequests());
+        }
+        if (dto.presentationScoreEnabled() != null) {
+            exercise.setPresentationScoreEnabled(dto.presentationScoreEnabled());
+        }
+        if (dto.secondCorrectionEnabled() != null) {
+            exercise.setSecondCorrectionEnabled(dto.secondCorrectionEnabled());
+        }
+        exercise.setFeedbackSuggestionModule(dto.feedbackSuggestionModule());
+        exercise.setGradingInstructions(dto.gradingInstructions());
+
+        // TextExercise specific fields
+        exercise.setExampleSolution(dto.exampleSolution());
+
+        updateGradingCriteria(dto, exercise);
+        updateCompetencyLinks(dto, exercise);
+
+        return exercise;
+    }
+
+    /**
+     * Replaces the grading criteria of the given exercise according to PUT semantics.
+     */
+    private void updateGradingCriteria(UpdateTextExerciseDTO dto, TextExercise exercise) {
+        if (dto.gradingCriteria() == null || dto.gradingCriteria().isEmpty()) {
+            clearInitializedCollection(exercise.getGradingCriteria());
+            return;
+        }
+
+        Set<GradingCriterion> managedCriteria = exercise.ensureGradingCriteriaSet();
+
+        Map<Long, GradingCriterion> existingById = managedCriteria.stream().filter(gc -> gc.getId() != null)
+                .collect(Collectors.toMap(GradingCriterion::getId, gc -> gc, (a, b) -> a));
+
+        Set<GradingCriterion> updated = dto.gradingCriteria().stream().map(gcDto -> {
+            GradingCriterion criterion = (gcDto.id() != null) ? existingById.get(gcDto.id()) : null;
+            if (criterion == null) {
+                criterion = gcDto.toEntity();
+                criterion.setExercise(exercise);
+            }
+            else {
+                gcDto.applyTo(criterion);
+            }
+            return criterion;
+        }).collect(Collectors.toSet());
+
+        managedCriteria.clear();
+        managedCriteria.addAll(updated);
+    }
+
+    /**
+     * Replaces the competency links of the given exercise according to PUT semantics.
+     */
+    private void updateCompetencyLinks(UpdateTextExerciseDTO dto, TextExercise exercise) {
+        if (dto.competencyLinks() == null || dto.competencyLinks().isEmpty()) {
+            clearInitializedCollection(exercise.getCompetencyLinks());
+            return;
+        }
+        CompetencyApi api = competencyApi.orElseThrow(() -> new BadRequestAlertException("Competency links require Atlas to be enabled.", "CourseCompetency", "atlasDisabled"));
+
+        Set<CompetencyExerciseLink> managedLinks = exercise.ensureCompetencyLinksSet();
+
+        Map<Long, CompetencyExerciseLink> existingByCompetencyId = managedLinks.stream().filter(link -> link.getCompetency() != null && link.getCompetency().getId() != null)
+                .collect(Collectors.toMap(link -> link.getCompetency().getId(), link -> link, (a, b) -> a));
+
+        Long exerciseCourseId = exercise.getCourseViaExerciseGroupOrCourseMember() != null ? exercise.getCourseViaExerciseGroupOrCourseMember().getId() : null;
+
+        Set<CompetencyExerciseLink> updated = new HashSet<>();
+        for (var linkDto : dto.competencyLinks()) {
+
+            if (exerciseCourseId != null && linkDto.courseId() != null && !Objects.equals(exerciseCourseId, linkDto.courseId())) {
+                throw new BadRequestAlertException("The competency does not belong to the exercise's course.", "CourseCompetency", "wrongCourse");
+            }
+
+            var competencyDto = linkDto.courseCompetencyDTO();
+            Long competencyId = competencyDto.id();
+
+            CompetencyExerciseLink link = existingByCompetencyId.get(competencyId);
+            if (link == null) {
+                Competency competencyRef = api.loadCompetency(competencyId);
+                competencyRef.validateCompetencyBelongsToExerciseCourse(exerciseCourseId);
+                link = new CompetencyExerciseLink(competencyRef, exercise, linkDto.weight());
+            }
+            else {
+                link.setWeight(linkDto.weight());
+            }
+
+            updated.add(link);
+        }
+
+        managedLinks.clear();
+        managedLinks.addAll(updated);
+    }
+
+    /**
+     * Clears the given collection if it is initialized.
+     */
+    private static <T> void clearInitializedCollection(Set<T> set) {
+        if (set != null && Hibernate.isInitialized(set)) {
+            set.clear();
+        }
+    }
+
+    /**
+     * Applies DTO values to a new TextExercise entity for creation via PUT.
+     * Sets courseId/exerciseGroupId as proxy objects so that
+     * {@link CourseService#retrieveCourseOverExerciseGroupOrCourseId} can resolve them.
+     */
+    private void applyDtoToNewExercise(UpdateTextExerciseDTO dto, TextExercise exercise) {
+        exercise.setTitle(dto.title());
+        exercise.setShortName(dto.shortName());
+        exercise.setProblemStatement(dto.problemStatement());
+        exercise.setChannelName(dto.channelName());
+        exercise.setCategories(dto.categories());
+        exercise.setDifficulty(dto.difficulty());
+        exercise.setMaxPoints(dto.maxPoints());
+        exercise.setBonusPoints(dto.bonusPoints());
+        exercise.setIncludedInOverallScore(dto.includedInOverallScore());
+        exercise.setReleaseDate(dto.releaseDate());
+        exercise.setStartDate(dto.startDate());
+        exercise.setDueDate(dto.dueDate());
+        exercise.setAssessmentDueDate(dto.assessmentDueDate());
+        exercise.setExampleSolutionPublicationDate(dto.exampleSolutionPublicationDate());
+        exercise.setFeedbackSuggestionModule(dto.feedbackSuggestionModule());
+        exercise.setGradingInstructions(dto.gradingInstructions());
+        exercise.setExampleSolution(dto.exampleSolution());
+        if (dto.allowComplaintsForAutomaticAssessments() != null) {
+            exercise.setAllowComplaintsForAutomaticAssessments(dto.allowComplaintsForAutomaticAssessments());
+        }
+        if (dto.allowFeedbackRequests() != null) {
+            exercise.setAllowFeedbackRequests(dto.allowFeedbackRequests());
+        }
+        if (dto.presentationScoreEnabled() != null) {
+            exercise.setPresentationScoreEnabled(dto.presentationScoreEnabled());
+        }
+        if (dto.secondCorrectionEnabled() != null) {
+            exercise.setSecondCorrectionEnabled(dto.secondCorrectionEnabled());
+        }
+
+        // Set course or exercise group reference
+        if (dto.courseId() != null) {
+            Course courseRef = new Course();
+            courseRef.setId(dto.courseId());
+            exercise.setCourse(courseRef);
+        }
+        if (dto.exerciseGroupId() != null) {
+            var exerciseGroup = new de.tum.cit.aet.artemis.exam.domain.ExerciseGroup();
+            exerciseGroup.setId(dto.exerciseGroupId());
+            exercise.setExerciseGroup(exerciseGroup);
+        }
     }
 
     /**
      * Helper method to notify AtlasML about text exercise changes with consistent
      * error handling.
-     *
-     * @param exercise             the exercise to save
-     * @param operationType        the operation type (UPDATE or DELETE)
-     * @param operationDescription the description of the operation for logging
-     *                                 purposes
      */
     private void notifyAtlasML(TextExercise exercise, OperationTypeDTO operationType, String operationDescription) {
         atlasMLApi.ifPresent(api -> {

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseExportImportResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseExportImportResource.java
@@ -113,8 +113,7 @@ public class TextExerciseExportImportResource {
         }
 
         final var newTextExercise = textExerciseImportService.importTextExercise(originalTextExercise, importedExercise);
-        var savedExercise = textExerciseRepository.save(newTextExercise);
-        exerciseVersionService.createExerciseVersion(savedExercise, user);
+        exerciseVersionService.createExerciseVersion(newTextExercise, user);
         return ResponseEntity.created(new URI("/api/text/text-exercises/" + newTextExercise.getId())).body(newTextExercise);
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/tutorialgroup/dto/TutorialGroupsConfigurationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/tutorialgroup/dto/TutorialGroupsConfigurationDTO.java
@@ -1,0 +1,54 @@
+package de.tum.cit.aet.artemis.tutorialgroup.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.tutorialgroup.domain.TutorialGroupsConfiguration;
+
+/**
+ * DTO for creating and updating tutorial groups configuration.
+ * For creation, id should be null. For updates, id is required.
+ *
+ * @param id                             the id of the configuration (null for creation, required for update)
+ * @param tutorialPeriodStartInclusive   the start date of the tutorial period in ISO 8601 format
+ * @param tutorialPeriodEndInclusive     the end date of the tutorial period in ISO 8601 format
+ * @param useTutorialGroupChannels       whether to create tutorial group channels
+ * @param usePublicTutorialGroupChannels whether the tutorial group channels should be public
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record TutorialGroupsConfigurationDTO(@Nullable Long id, @NotNull String tutorialPeriodStartInclusive, @NotNull String tutorialPeriodEndInclusive,
+        @NotNull Boolean useTutorialGroupChannels, @NotNull Boolean usePublicTutorialGroupChannels) {
+
+    /**
+     * Creates a new TutorialGroupsConfiguration entity from this DTO.
+     * Used for creation of new configurations.
+     *
+     * @return a new TutorialGroupsConfiguration with the DTO values applied
+     */
+    public TutorialGroupsConfiguration toEntity() {
+        TutorialGroupsConfiguration config = new TutorialGroupsConfiguration();
+        config.setTutorialPeriodStartInclusive(tutorialPeriodStartInclusive);
+        config.setTutorialPeriodEndInclusive(tutorialPeriodEndInclusive);
+        config.setUseTutorialGroupChannels(useTutorialGroupChannels);
+        config.setUsePublicTutorialGroupChannels(usePublicTutorialGroupChannels);
+        return config;
+    }
+
+    /**
+     * Applies the DTO values to an existing TutorialGroupsConfiguration entity.
+     * Used for updating existing configurations.
+     *
+     * @param config the configuration to update
+     */
+    public void applyTo(TutorialGroupsConfiguration config) {
+        config.setTutorialPeriodStartInclusive(tutorialPeriodStartInclusive);
+        config.setTutorialPeriodEndInclusive(tutorialPeriodEndInclusive);
+        config.setUseTutorialGroupChannels(useTutorialGroupChannels);
+        config.setUsePublicTutorialGroupChannels(usePublicTutorialGroupChannels);
+    }
+}

--- a/src/main/webapp/app/assessment/manage/grading/grading-service.ts
+++ b/src/main/webapp/app/assessment/manage/grading/grading-service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { GradingScale } from 'app/assessment/shared/entities/grading-scale.model';
+import { GradeType, GradingScale } from 'app/assessment/shared/entities/grading-scale.model';
 import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { GradeDTO, GradeStep, GradeStepsDTO } from 'app/assessment/shared/entities/grade-step.model';
@@ -10,6 +10,34 @@ import { Course } from 'app/core/course/shared/entities/course.model';
 
 export type EntityResponseType = HttpResponse<GradingScale>;
 export type EntityArrayResponseType = HttpResponse<GradingScale[]>;
+
+/**
+ * DTO for updating a grading scale.
+ */
+export interface GradingScaleUpdateDTO {
+    gradeType: GradeType;
+    bonusStrategy?: string;
+    plagiarismGrade?: string;
+    noParticipationGrade?: string;
+    presentationsNumber?: number;
+    presentationsWeight?: number;
+    gradeSteps: GradeStepDTO[];
+    courseMaxPoints?: number;
+    coursePresentationScore?: number;
+    examMaxPoints?: number;
+}
+
+/**
+ * DTO for a grade step within a grading scale.
+ */
+export interface GradeStepDTO {
+    lowerBoundPercentage: number;
+    lowerBoundInclusive: boolean;
+    upperBoundPercentage: number;
+    upperBoundInclusive: boolean;
+    gradeName: string;
+    isPassingGrade: boolean;
+}
 
 @Injectable({ providedIn: 'root' })
 export class GradingService {
@@ -24,7 +52,8 @@ export class GradingService {
      * @param gradingScale the grading scale to be created
      */
     createGradingScaleForCourse(courseId: number, gradingScale: GradingScale): Observable<EntityResponseType> {
-        return this.http.post<GradingScale>(`${this.resourceUrl}/${courseId}/grading-scale`, gradingScale, { observe: 'response' });
+        const dto = this.toUpdateDTO(gradingScale);
+        return this.http.post<GradingScale>(`${this.resourceUrl}/${courseId}/grading-scale`, dto, { observe: 'response' });
     }
 
     /**
@@ -34,7 +63,8 @@ export class GradingService {
      * @param gradingScale the grading scale to be updated
      */
     updateGradingScaleForCourse(courseId: number, gradingScale: GradingScale): Observable<EntityResponseType> {
-        return this.http.put<GradingScale>(`${this.resourceUrl}/${courseId}/grading-scale`, gradingScale, { observe: 'response' });
+        const dto = this.toUpdateDTO(gradingScale);
+        return this.http.put<GradingScale>(`${this.resourceUrl}/${courseId}/grading-scale`, dto, { observe: 'response' });
     }
 
     /**
@@ -63,7 +93,8 @@ export class GradingService {
      * @param gradingScale the grading scale to be created
      */
     createGradingScaleForExam(courseId: number, examId: number, gradingScale: GradingScale): Observable<EntityResponseType> {
-        return this.http.post<GradingScale>(`${this.resourceUrl}/${courseId}/exams/${examId}/grading-scale`, gradingScale, { observe: 'response' });
+        const dto = this.toUpdateDTO(gradingScale);
+        return this.http.post<GradingScale>(`${this.resourceUrl}/${courseId}/exams/${examId}/grading-scale`, dto, { observe: 'response' });
     }
 
     /**
@@ -74,7 +105,8 @@ export class GradingService {
      * @param gradingScale the grading scale to be updated
      */
     updateGradingScaleForExam(courseId: number, examId: number, gradingScale: GradingScale): Observable<EntityResponseType> {
-        return this.http.put<GradingScale>(`${this.resourceUrl}/${courseId}/exams/${examId}/grading-scale`, gradingScale, { observe: 'response' });
+        const dto = this.toUpdateDTO(gradingScale);
+        return this.http.put<GradingScale>(`${this.resourceUrl}/${courseId}/exams/${examId}/grading-scale`, dto, { observe: 'response' });
     }
 
     /**
@@ -345,5 +377,30 @@ export class GradingService {
             return undefined;
         }
         return numericValue;
+    }
+
+    /**
+     * Converts a GradingScale to an update DTO for sending to the server.
+     */
+    private toUpdateDTO(gradingScale: GradingScale): GradingScaleUpdateDTO {
+        return {
+            gradeType: gradingScale.gradeType,
+            bonusStrategy: (gradingScale as any).bonusStrategy,
+            plagiarismGrade: gradingScale.plagiarismGrade,
+            noParticipationGrade: gradingScale.noParticipationGrade,
+            presentationsNumber: gradingScale.presentationsNumber,
+            presentationsWeight: gradingScale.presentationsWeight,
+            gradeSteps: gradingScale.gradeSteps.map((step) => ({
+                lowerBoundPercentage: step.lowerBoundPercentage,
+                lowerBoundInclusive: step.lowerBoundInclusive,
+                upperBoundPercentage: step.upperBoundPercentage,
+                upperBoundInclusive: step.upperBoundInclusive,
+                gradeName: step.gradeName,
+                isPassingGrade: step.isPassingGrade,
+            })),
+            courseMaxPoints: gradingScale.course?.maxPoints,
+            coursePresentationScore: gradingScale.course?.presentationScore,
+            examMaxPoints: gradingScale.exam?.examMaxPoints,
+        };
     }
 }

--- a/src/main/webapp/app/core/admin/lti-configuration/lti-configuration.service.ts
+++ b/src/main/webapp/app/core/admin/lti-configuration/lti-configuration.service.ts
@@ -4,6 +4,20 @@ import { Observable } from 'rxjs';
 import { LtiPlatformConfiguration } from 'app/lti/shared/entities/lti-configuration.model';
 import { createRequestOption } from 'app/shared/util/request.util';
 
+/**
+ * DTO for creating and updating LTI platform configurations.
+ */
+export interface LtiPlatformConfigurationUpdateDTO {
+    id?: number;
+    registrationId?: string;
+    clientId: string;
+    originalUrl?: string;
+    customName?: string;
+    authorizationUri: string;
+    jwkSetUri: string;
+    tokenUri: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class LtiConfigurationService {
     private http = inject(HttpClient);
@@ -25,7 +39,8 @@ export class LtiConfigurationService {
      * @return Observable of the HTTP response.
      */
     addLtiPlatformConfiguration(ltiPlatformConfiguration: LtiPlatformConfiguration): Observable<HttpResponse<LtiPlatformConfiguration>> {
-        return this.http.post<LtiPlatformConfiguration>(`api/lti/admin/lti-platform`, ltiPlatformConfiguration, { observe: 'response' });
+        const dto = this.toDTO(ltiPlatformConfiguration);
+        return this.http.post<LtiPlatformConfiguration>(`api/lti/admin/lti-platform`, dto, { observe: 'response' });
     }
 
     /**
@@ -34,7 +49,21 @@ export class LtiConfigurationService {
      * @return Observable of the HTTP response.
      */
     updateLtiPlatformConfiguration(ltiPlatformConfiguration: LtiPlatformConfiguration): Observable<HttpResponse<LtiPlatformConfiguration>> {
-        return this.http.put<LtiPlatformConfiguration>(`api/lti/admin/lti-platform`, ltiPlatformConfiguration, { observe: 'response' });
+        const dto = this.toDTO(ltiPlatformConfiguration);
+        return this.http.put<LtiPlatformConfiguration>(`api/lti/admin/lti-platform`, dto, { observe: 'response' });
+    }
+
+    private toDTO(config: LtiPlatformConfiguration): LtiPlatformConfigurationUpdateDTO {
+        return {
+            id: config.id,
+            registrationId: config.registrationId,
+            clientId: config.clientId,
+            originalUrl: config.originalUrl,
+            customName: config.customName,
+            authorizationUri: config.authorizationUri,
+            jwkSetUri: config.jwkSetUri,
+            tokenUri: config.tokenUri,
+        };
     }
 
     /**

--- a/src/main/webapp/app/core/course/manage/services/course-admin.service.ts
+++ b/src/main/webapp/app/core/course/manage/services/course-admin.service.ts
@@ -8,6 +8,7 @@ import { CourseManagementService } from 'app/core/course/manage/services/course-
 import { CourseSummaryDTO } from 'app/core/course/shared/entities/course-summary.model';
 import { CourseOperationProgressDTO } from 'app/core/course/shared/entities/course-operation-progress.model';
 import { convertDateFromServer } from 'app/shared/util/date.utils';
+import { toCourseCreateDTO } from 'app/core/course/shared/entities/course-update-dto.model';
 
 export type EntityResponseType = HttpResponse<Course>;
 export type EntityArrayResponseType = HttpResponse<Course[]>;
@@ -32,9 +33,9 @@ export class CourseAdminService {
      * @param courseImage - the course icon file
      */
     create(course: Course, courseImage?: Blob): Observable<EntityResponseType> {
-        const copy = CourseManagementService.convertCourseDatesFromClient(course);
+        const dto = toCourseCreateDTO(course);
         const formData = new FormData();
-        formData.append('course', objectToJsonBlob(copy));
+        formData.append('course', objectToJsonBlob(dto));
         if (courseImage) {
             // The image was cropped by us and is a blob, so we need to set a placeholder name for the server check
             formData.append('file', courseImage, 'placeholderName.png');

--- a/src/main/webapp/app/core/course/manage/services/course-management.service.ts
+++ b/src/main/webapp/app/core/course/manage/services/course-management.service.ts
@@ -30,6 +30,7 @@ import { TutorialGroupsService } from 'app/tutorialgroup/shared/service/tutorial
 import { CourseNotificationService } from 'app/communication/course-notification/course-notification.service';
 import { EntityTitleService, EntityType } from 'app/core/navbar/entity-title.service';
 import { LocalStorageService } from 'app/shared/service/local-storage.service';
+import { toCourseUpdateDTO } from 'app/core/course/shared/entities/course-update-dto.model';
 
 export type EntityResponseType = HttpResponse<Course>;
 export type EntityArrayResponseType = HttpResponse<Course[]>;
@@ -85,9 +86,9 @@ export class CourseManagementService {
      * @param courseImage - the course icon file
      */
     update(courseId: number, courseUpdate: Course, courseImage?: Blob): Observable<EntityResponseType> {
-        const copy = CourseManagementService.convertCourseDatesFromClient(courseUpdate);
+        const dto = toCourseUpdateDTO(courseUpdate);
         const formData = new FormData();
-        formData.append('course', objectToJsonBlob(copy));
+        formData.append('course', objectToJsonBlob(dto));
         if (courseImage) {
             // The image was cropped by us and is a blob, so we need to set a placeholder name for the server check
             formData.append('file', courseImage, 'placeholderName.png');

--- a/src/main/webapp/app/core/course/shared/entities/course-update-dto.model.ts
+++ b/src/main/webapp/app/core/course/shared/entities/course-update-dto.model.ts
@@ -1,0 +1,246 @@
+import { convertDateFromClient } from 'app/shared/util/date.utils';
+import { Course, CourseInformationSharingConfiguration, Language } from './course.model';
+import { ProgrammingLanguage } from 'app/programming/shared/entities/programming-exercise.model';
+
+/**
+ * DTO for creating a new course.
+ * Mirrors the server-side CourseCreateDTO to send only the necessary fields.
+ * Note: No 'id' field since this is for creation.
+ */
+export interface CourseCreateDTO {
+    // Basic info
+    title: string;
+    shortName: string;
+    description?: string;
+    semester?: string;
+
+    // Group names
+    studentGroupName?: string;
+    teachingAssistantGroupName?: string;
+    editorGroupName?: string;
+    instructorGroupName?: string;
+
+    // Dates (as ISO strings for server)
+    startDate?: string;
+    endDate?: string;
+    enrollmentStartDate?: string;
+    enrollmentEndDate?: string;
+    unenrollmentEndDate?: string;
+
+    // Configuration flags
+    testCourse: boolean;
+    onlineCourse?: boolean;
+    language?: Language;
+    defaultProgrammingLanguage?: ProgrammingLanguage;
+
+    // Complaint settings
+    maxComplaints?: number;
+    maxTeamComplaints?: number;
+    maxComplaintTimeDays: number;
+    maxRequestMoreFeedbackTimeDays: number;
+    maxComplaintTextLimit: number;
+    maxComplaintResponseTextLimit: number;
+
+    // UI settings
+    color?: string;
+    enrollmentEnabled?: boolean;
+    enrollmentConfirmationMessage?: string;
+    unenrollmentEnabled: boolean;
+
+    // Course features
+    faqEnabled: boolean;
+    learningPathsEnabled: boolean;
+    studentCourseAnalyticsDashboardEnabled: boolean;
+    presentationScore?: number;
+    maxPoints?: number;
+    accuracyOfScores?: number;
+    restrictedAthenaModulesAccess: boolean;
+    timeZone?: string;
+    courseInformationSharingConfiguration?: CourseInformationSharingConfiguration;
+}
+
+/**
+ * Converts a Course entity to a CourseCreateDTO for sending to the server.
+ *
+ * @param course the course entity to convert
+ * @returns a CourseCreateDTO with only the fields needed for creation
+ */
+export function toCourseCreateDTO(course: Course): CourseCreateDTO {
+    return {
+        // Basic info
+        title: course.title!,
+        shortName: course.shortName!,
+        description: course.description,
+        semester: course.semester,
+
+        // Group names
+        studentGroupName: course.studentGroupName,
+        teachingAssistantGroupName: course.teachingAssistantGroupName,
+        editorGroupName: course.editorGroupName,
+        instructorGroupName: course.instructorGroupName,
+
+        // Dates (converted to ISO strings)
+        startDate: convertDateFromClient(course.startDate),
+        endDate: convertDateFromClient(course.endDate),
+        enrollmentStartDate: convertDateFromClient(course.enrollmentStartDate),
+        enrollmentEndDate: convertDateFromClient(course.enrollmentEndDate),
+        unenrollmentEndDate: convertDateFromClient(course.unenrollmentEndDate),
+
+        // Configuration flags
+        testCourse: course.testCourse ?? false,
+        onlineCourse: course.onlineCourse,
+        language: course.language,
+        defaultProgrammingLanguage: course.defaultProgrammingLanguage,
+
+        // Complaint settings
+        maxComplaints: course.maxComplaints,
+        maxTeamComplaints: course.maxTeamComplaints,
+        maxComplaintTimeDays: course.maxComplaintTimeDays ?? 7,
+        maxRequestMoreFeedbackTimeDays: course.maxRequestMoreFeedbackTimeDays ?? 7,
+        maxComplaintTextLimit: course.maxComplaintTextLimit ?? 2000,
+        maxComplaintResponseTextLimit: course.maxComplaintResponseTextLimit ?? 2000,
+
+        // UI settings
+        color: course.color,
+        enrollmentEnabled: course.enrollmentEnabled,
+        enrollmentConfirmationMessage: course.enrollmentConfirmationMessage,
+        unenrollmentEnabled: course.unenrollmentEnabled ?? false,
+
+        // Course features
+        faqEnabled: course.faqEnabled ?? false,
+        learningPathsEnabled: course.learningPathsEnabled ?? false,
+        studentCourseAnalyticsDashboardEnabled: course.studentCourseAnalyticsDashboardEnabled ?? false,
+        presentationScore: course.presentationScore,
+        maxPoints: course.maxPoints,
+        accuracyOfScores: course.accuracyOfScores,
+        restrictedAthenaModulesAccess: course.restrictedAthenaModulesAccess ?? false,
+        timeZone: course.timeZone,
+        courseInformationSharingConfiguration: course.courseInformationSharingConfiguration,
+    };
+}
+
+/**
+ * DTO for updating an existing course.
+ * Mirrors the server-side CourseUpdateDTO to send only the necessary fields.
+ */
+export interface CourseUpdateDTO {
+    // ID is required for update
+    id: number;
+
+    // Basic info
+    title: string;
+    shortName: string;
+    description?: string;
+    semester?: string;
+
+    // Group names
+    studentGroupName?: string;
+    teachingAssistantGroupName?: string;
+    editorGroupName?: string;
+    instructorGroupName?: string;
+
+    // Dates (as ISO strings for server)
+    startDate?: string;
+    endDate?: string;
+    enrollmentStartDate?: string;
+    enrollmentEndDate?: string;
+    unenrollmentEndDate?: string;
+
+    // Configuration flags
+    testCourse: boolean;
+    onlineCourse?: boolean;
+    language?: Language;
+    defaultProgrammingLanguage?: ProgrammingLanguage;
+
+    // Complaint settings
+    maxComplaints?: number;
+    maxTeamComplaints?: number;
+    maxComplaintTimeDays: number;
+    maxRequestMoreFeedbackTimeDays: number;
+    maxComplaintTextLimit: number;
+    maxComplaintResponseTextLimit: number;
+
+    // UI settings
+    color?: string;
+    courseIcon?: string;
+    enrollmentEnabled?: boolean;
+    enrollmentConfirmationMessage?: string;
+    unenrollmentEnabled: boolean;
+    courseInformationSharingMessagingCodeOfConduct?: string;
+
+    // Course features
+    faqEnabled: boolean;
+    learningPathsEnabled: boolean;
+    studentCourseAnalyticsDashboardEnabled: boolean;
+    presentationScore?: number;
+    maxPoints?: number;
+    accuracyOfScores?: number;
+    restrictedAthenaModulesAccess: boolean;
+    timeZone?: string;
+    courseInformationSharingConfiguration?: CourseInformationSharingConfiguration;
+}
+
+/**
+ * Converts a Course entity to a CourseUpdateDTO for sending to the server.
+ *
+ * @param course the course entity to convert
+ * @returns a CourseUpdateDTO with only the fields needed for update
+ */
+export function toCourseUpdateDTO(course: Course): CourseUpdateDTO {
+    return {
+        // ID is required for update
+        id: course.id!,
+
+        // Basic info
+        title: course.title!,
+        shortName: course.shortName!,
+        description: course.description,
+        semester: course.semester,
+
+        // Group names
+        studentGroupName: course.studentGroupName,
+        teachingAssistantGroupName: course.teachingAssistantGroupName,
+        editorGroupName: course.editorGroupName,
+        instructorGroupName: course.instructorGroupName,
+
+        // Dates (converted to ISO strings)
+        startDate: convertDateFromClient(course.startDate),
+        endDate: convertDateFromClient(course.endDate),
+        enrollmentStartDate: convertDateFromClient(course.enrollmentStartDate),
+        enrollmentEndDate: convertDateFromClient(course.enrollmentEndDate),
+        unenrollmentEndDate: convertDateFromClient(course.unenrollmentEndDate),
+
+        // Configuration flags
+        testCourse: course.testCourse ?? false,
+        onlineCourse: course.onlineCourse,
+        language: course.language,
+        defaultProgrammingLanguage: course.defaultProgrammingLanguage,
+
+        // Complaint settings
+        maxComplaints: course.maxComplaints,
+        maxTeamComplaints: course.maxTeamComplaints,
+        maxComplaintTimeDays: course.maxComplaintTimeDays ?? 7,
+        maxRequestMoreFeedbackTimeDays: course.maxRequestMoreFeedbackTimeDays ?? 7,
+        maxComplaintTextLimit: course.maxComplaintTextLimit ?? 2000,
+        maxComplaintResponseTextLimit: course.maxComplaintResponseTextLimit ?? 2000,
+
+        // UI settings
+        color: course.color,
+        courseIcon: course.courseIcon,
+        enrollmentEnabled: course.enrollmentEnabled,
+        enrollmentConfirmationMessage: course.enrollmentConfirmationMessage,
+        unenrollmentEnabled: course.unenrollmentEnabled ?? false,
+        courseInformationSharingMessagingCodeOfConduct: course.courseInformationSharingMessagingCodeOfConduct,
+
+        // Course features
+        faqEnabled: course.faqEnabled ?? false,
+        learningPathsEnabled: course.learningPathsEnabled ?? false,
+        studentCourseAnalyticsDashboardEnabled: course.studentCourseAnalyticsDashboardEnabled ?? false,
+        presentationScore: course.presentationScore,
+        maxPoints: course.maxPoints,
+        accuracyOfScores: course.accuracyOfScores,
+        restrictedAthenaModulesAccess: course.restrictedAthenaModulesAccess ?? false,
+        timeZone: course.timeZone,
+        courseInformationSharingConfiguration: course.courseInformationSharingConfiguration,
+    };
+}

--- a/src/main/webapp/app/exam/manage/services/exam-management.service.ts
+++ b/src/main/webapp/app/exam/manage/services/exam-management.service.ts
@@ -22,6 +22,7 @@ import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { ExamWideAnnouncementEvent } from 'app/exam/overview/services/exam-participation-live-events.service';
 import { EntityTitleService, EntityType } from 'app/core/navbar/entity-title.service';
 import { ExamDeletionSummaryDTO } from 'app/exam/shared/entities/exam-deletion-summary.model';
+import { toExamUpdateDTO } from 'app/exam/manage/services/exam-update-dto.model';
 import { ExportExamUserDTO } from 'app/exam/manage/students/export-users/students-export.model';
 
 type EntityResponseType = HttpResponse<Exam>;
@@ -42,9 +43,9 @@ export class ExamManagementService {
      * @param exam The exam to create.
      */
     create(courseId: number, exam: Exam): Observable<EntityResponseType> {
-        const copy = ExamManagementService.convertExamDatesFromClient(exam);
+        const dto = toExamUpdateDTO(exam);
         return this.http
-            .post<Exam>(`${this.resourceUrl}/${courseId}/exams`, copy, { observe: 'response' })
+            .post<Exam>(`${this.resourceUrl}/${courseId}/exams`, dto, { observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.processExamResponseFromServer(res)));
     }
 
@@ -54,9 +55,9 @@ export class ExamManagementService {
      * @param exam The exam to update.
      */
     update(courseId: number, exam: Exam): Observable<EntityResponseType> {
-        const copy = ExamManagementService.convertExamDatesFromClient(exam);
+        const dto = toExamUpdateDTO(exam);
         return this.http
-            .put<Exam>(`${this.resourceUrl}/${courseId}/exams`, copy, { observe: 'response' })
+            .put<Exam>(`${this.resourceUrl}/${courseId}/exams`, dto, { observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.processExamResponseFromServer(res)));
     }
 
@@ -83,14 +84,14 @@ export class ExamManagementService {
     }
 
     /**
-     * Imports an exam on the server using a PUT request.
+     * Imports an exam on the server using a POST request.
      * @param courseId The course id into which the exam should be imported
      * @param exam The exam with exercises to import.
      */
     import(courseId: number, exam: Exam): Observable<EntityResponseType> {
-        const copy = ExamManagementService.convertExamDatesFromClient(exam);
+        const dto = ExamManagementService.convertExamToImportDTO(exam, courseId);
         return this.http
-            .post<Exam>(`${this.resourceUrl}/${courseId}/exam-import`, copy, { observe: 'response' })
+            .post<Exam>(`${this.resourceUrl}/${courseId}/exam-import`, dto, { observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.processExamResponseFromServer(res)));
     }
 
@@ -435,15 +436,51 @@ export class ExamManagementService {
             .pipe(map((res: EntityResponseType) => this.processExamResponseFromServer(res)));
     }
 
-    public static convertExamDatesFromClient(exam: Exam): Exam {
-        return Object.assign({}, exam, {
+    /**
+     * Converts an Exam to an ExamImportDTO for the server.
+     * @param exam The exam to convert
+     * @param courseId The target course id
+     */
+    public static convertExamToImportDTO(exam: Exam, courseId: number): object {
+        return {
+            title: exam.title,
+            testExam: exam.testExam ?? false,
+            examWithAttendanceCheck: exam.examWithAttendanceCheck ?? false,
+            visibleDate: convertDateFromClient(exam.visibleDate),
             startDate: convertDateFromClient(exam.startDate),
             endDate: convertDateFromClient(exam.endDate),
-            visibleDate: convertDateFromClient(exam.visibleDate),
             publishResultsDate: convertDateFromClient(exam.publishResultsDate),
             examStudentReviewStart: convertDateFromClient(exam.examStudentReviewStart),
             examStudentReviewEnd: convertDateFromClient(exam.examStudentReviewEnd),
-        });
+            gracePeriod: exam.gracePeriod,
+            workingTime: exam.workingTime ?? 0,
+            startText: exam.startText,
+            endText: exam.endText,
+            confirmationStartText: exam.confirmationStartText,
+            confirmationEndText: exam.confirmationEndText,
+            examMaxPoints: exam.examMaxPoints,
+            randomizeExerciseOrder: exam.randomizeExerciseOrder,
+            numberOfExercisesInExam: exam.numberOfExercisesInExam,
+            numberOfCorrectionRoundsInExam: exam.numberOfCorrectionRoundsInExam,
+            examiner: exam.examiner,
+            moduleNumber: exam.moduleNumber,
+            courseName: exam.courseName,
+            exampleSolutionPublicationDate: convertDateFromClient(exam.exampleSolutionPublicationDate),
+            channelName: exam.channelName,
+            courseId: courseId,
+            exerciseGroups: exam.exerciseGroups?.map((group) => ({
+                title: group.title,
+                isMandatory: group.isMandatory ?? true,
+                exercises: group.exercises?.map((exercise) => ({
+                    id: exercise.id,
+                    exerciseType: exercise.type?.toUpperCase().replace('-', '_'),
+                    title: exercise.title,
+                    shortName: exercise.shortName,
+                    maxPoints: exercise.maxPoints,
+                    bonusPoints: exercise.bonusPoints,
+                })),
+            })),
+        };
     }
 
     private processExamResponseFromServer(res: EntityResponseType): EntityResponseType {

--- a/src/main/webapp/app/exam/manage/services/exam-update-dto.model.ts
+++ b/src/main/webapp/app/exam/manage/services/exam-update-dto.model.ts
@@ -1,0 +1,73 @@
+import { Exam } from 'app/exam/shared/entities/exam.model';
+import { convertDateFromClient } from 'app/shared/util/date.utils';
+
+/**
+ * DTO for updating exams.
+ * Matches the server-side ExamUpdateDTO record structure.
+ * Only includes the fields that the server expects, avoiding unnecessary data transfer.
+ */
+export interface ExamUpdateDTO {
+    id?: number;
+    title: string;
+    testExam: boolean;
+    examWithAttendanceCheck: boolean;
+    visibleDate?: string;
+    startDate?: string;
+    endDate?: string;
+    publishResultsDate?: string;
+    examStudentReviewStart?: string;
+    examStudentReviewEnd?: string;
+    gracePeriod?: number;
+    workingTime: number;
+    startText?: string;
+    endText?: string;
+    confirmationStartText?: string;
+    confirmationEndText?: string;
+    examMaxPoints?: number;
+    randomizeExerciseOrder?: boolean;
+    numberOfExercisesInExam?: number;
+    numberOfCorrectionRoundsInExam?: number;
+    examiner?: string;
+    moduleNumber?: string;
+    courseName?: string;
+    exampleSolutionPublicationDate?: string;
+    channelName?: string;
+}
+
+/**
+ * Converts an Exam entity to an ExamUpdateDTO.
+ * This ensures only the required data is sent to the server,
+ * reducing network payload and avoiding issues with circular references.
+ *
+ * @param exam the exam to convert
+ * @returns the corresponding DTO
+ */
+export function toExamUpdateDTO(exam: Exam): ExamUpdateDTO {
+    return {
+        id: exam.id,
+        title: exam.title!,
+        testExam: exam.testExam ?? false,
+        examWithAttendanceCheck: exam.examWithAttendanceCheck ?? false,
+        visibleDate: convertDateFromClient(exam.visibleDate),
+        startDate: convertDateFromClient(exam.startDate),
+        endDate: convertDateFromClient(exam.endDate),
+        publishResultsDate: convertDateFromClient(exam.publishResultsDate),
+        examStudentReviewStart: convertDateFromClient(exam.examStudentReviewStart),
+        examStudentReviewEnd: convertDateFromClient(exam.examStudentReviewEnd),
+        gracePeriod: exam.gracePeriod,
+        workingTime: exam.workingTime ?? 0,
+        startText: exam.startText,
+        endText: exam.endText,
+        confirmationStartText: exam.confirmationStartText,
+        confirmationEndText: exam.confirmationEndText,
+        examMaxPoints: exam.examMaxPoints,
+        randomizeExerciseOrder: exam.randomizeExerciseOrder,
+        numberOfExercisesInExam: exam.numberOfExercisesInExam,
+        numberOfCorrectionRoundsInExam: exam.numberOfCorrectionRoundsInExam,
+        examiner: exam.examiner,
+        moduleNumber: exam.moduleNumber,
+        courseName: exam.courseName,
+        exampleSolutionPublicationDate: convertDateFromClient(exam.exampleSolutionPublicationDate),
+        channelName: exam.channelName,
+    };
+}

--- a/src/main/webapp/app/exercise/participation/participation.service.ts
+++ b/src/main/webapp/app/exercise/participation/participation.service.ts
@@ -16,6 +16,24 @@ import dayjs from 'dayjs/esm';
 export type EntityResponseType = HttpResponse<StudentParticipation>;
 export type EntityArrayResponseType = HttpResponse<StudentParticipation[]>;
 
+/**
+ * DTO for updating a participation's presentation score.
+ */
+export interface ParticipationUpdateDTO {
+    id: number;
+    exerciseId: number;
+    presentationScore?: number;
+}
+
+/**
+ * DTO for updating a participation's individual due date.
+ */
+export interface ParticipationDueDateUpdateDTO {
+    id: number;
+    exerciseId: number;
+    individualDueDate?: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class ParticipationService {
     private http = inject(HttpClient);
@@ -25,23 +43,30 @@ export class ParticipationService {
     public resourceUrl = 'api/exercise/participations';
 
     update(exercise: Exercise, participation: StudentParticipation): Observable<EntityResponseType> {
-        const copy = this.convertParticipationForServer(participation, exercise);
+        // Create DTO with only the fields needed for updating presentation score
+        const dto: ParticipationUpdateDTO = {
+            id: participation.id!,
+            exerciseId: exercise.id!,
+            presentationScore: participation.presentationScore,
+        };
         return this.http
-            .put<StudentParticipation>(`api/exercise/exercises/${exercise.id}/participations`, copy, { observe: 'response' })
+            .put<StudentParticipation>(`api/exercise/exercises/${exercise.id}/participations`, dto, { observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.processParticipationEntityResponseType(res)));
     }
 
     updateIndividualDueDates(exercise: Exercise, participations: StudentParticipation[]): Observable<EntityArrayResponseType> {
-        const copies = participations.map((participation) => this.convertParticipationForServer(participation, exercise));
+        const dtos = participations.map((participation) => this.toDueDateUpdateDTO(participation, exercise.id!));
         return this.http
-            .put<StudentParticipation[]>(`api/exercise/exercises/${exercise.id}/participations/update-individual-due-date`, copies, { observe: 'response' })
+            .put<StudentParticipation[]>(`api/exercise/exercises/${exercise.id}/participations/update-individual-due-date`, dtos, { observe: 'response' })
             .pipe(map((res: EntityArrayResponseType) => this.processParticipationEntityArrayResponseType(res)));
     }
 
-    private convertParticipationForServer(participation: StudentParticipation, exercise: Exercise): StudentParticipation {
-        // make sure participation and exercise are connected, because this is expected by the server
-        participation.exercise = ExerciseService.convertExerciseFromClient(exercise);
-        return this.convertParticipationDatesFromClient(participation);
+    private toDueDateUpdateDTO(participation: StudentParticipation, exerciseId: number): ParticipationDueDateUpdateDTO {
+        return {
+            id: participation.id!,
+            exerciseId: exerciseId,
+            individualDueDate: convertDateFromClient(participation.individualDueDate),
+        };
     }
 
     find(participationId: number): Observable<EntityResponseType> {

--- a/src/main/webapp/app/exercise/services/exercise.service.ts
+++ b/src/main/webapp/app/exercise/services/exercise.service.ts
@@ -64,27 +64,6 @@ export class ExerciseService {
     public courseResourceUrl = 'api/core/courses';
 
     /**
-     * Persist a new exercise
-     * @param { Exercise } exercise - Exercise that will be persisted
-     * return
-     */
-    create(exercise: Exercise): Observable<EntityResponseType> {
-        const copy = ExerciseService.convertExerciseDatesFromClient(exercise);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
-        return this.http.post<Exercise>(this.resourceUrl, copy, { observe: 'response' }).pipe(map((res: EntityResponseType) => this.processExerciseEntityResponse(res)));
-    }
-
-    /**
-     * Update existing exercise
-     * @param { Exercise } exercise - Exercise that will be updated
-     */
-    update(exercise: Exercise): Observable<EntityResponseType> {
-        const copy = ExerciseService.convertExerciseDatesFromClient(exercise);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
-        return this.http.put<Exercise>(this.resourceUrl, copy, { observe: 'response' }).pipe(map((res: EntityResponseType) => this.processExerciseEntityResponse(res)));
-    }
-
-    /**
      * Validates if the dates are correct
      */
     validateDate(exercise: Exercise) {

--- a/src/main/webapp/app/exercise/team/team.service.ts
+++ b/src/main/webapp/app/exercise/team/team.service.ts
@@ -12,7 +12,39 @@ import { createRequestOption } from 'app/shared/util/request.util';
 import { Observable, Subscription } from 'rxjs';
 import { filter, map, shareReplay } from 'rxjs/operators';
 import { EntityResponseType } from 'app/exercise/services/exercise.service';
-import { convertDateFromClient, convertDateFromServer } from 'app/shared/util/date.utils';
+import { convertDateFromServer } from 'app/shared/util/date.utils';
+
+/**
+ * DTO for creating and updating teams.
+ * Uses user IDs for students and owner references.
+ */
+export interface TeamInputDTO {
+    id?: number;
+    name: string;
+    shortName: string;
+    image?: string;
+    students: number[];
+    ownerId?: number;
+}
+
+/**
+ * DTO for importing teams from a list.
+ * Students are identified by login or registration number.
+ */
+export interface TeamImportDTO {
+    name: string;
+    shortName: string;
+    image?: string;
+    students: StudentIdentifierDTO[];
+}
+
+/**
+ * DTO for identifying a student by login or registration number.
+ */
+export interface StudentIdentifierDTO {
+    login?: string;
+    visibleRegistrationNumber?: string;
+}
 
 export type TeamResponse = HttpResponse<Team>;
 export type TeamArrayResponse = HttpResponse<Team[]>;
@@ -126,9 +158,9 @@ export class TeamService implements ITeamService, OnDestroy {
      * @param {Team} team - Team to create
      */
     create(exercise: Exercise, team: Team): Observable<TeamResponse> {
-        const copy = TeamService.convertTeamDatesFromClient(team);
+        const dto = TeamService.toInputDTO(team);
         return this.http
-            .post<Team>(TeamService.resourceUrl(exercise.id!), copy, { observe: 'response' })
+            .post<Team>(TeamService.resourceUrl(exercise.id!), dto, { observe: 'response' })
             .pipe(map((res: TeamResponse) => TeamService.convertTeamResponseDatesFromServer(res)));
     }
 
@@ -138,9 +170,9 @@ export class TeamService implements ITeamService, OnDestroy {
      * @param {Team} team - Team to update
      */
     update(exercise: Exercise, team: Team): Observable<TeamResponse> {
-        const copy = TeamService.convertTeamDatesFromClient(team);
+        const dto = TeamService.toInputDTO(team);
         return this.http
-            .put<Team>(`${TeamService.resourceUrl(exercise.id!)}/${team.id}`, copy, { observe: 'response' })
+            .put<Team>(`${TeamService.resourceUrl(exercise.id!)}/${team.id}`, dto, { observe: 'response' })
             .pipe(map((res: TeamResponse) => TeamService.convertTeamResponseDatesFromServer(res)));
     }
 
@@ -205,8 +237,8 @@ export class TeamService implements ITeamService, OnDestroy {
      * @param {Team[]} teams - Teams that should be imported into the exercise
      */
     importTeams(exercise: Exercise, teams: Team[], importStrategyType: TeamImportStrategyType) {
-        const copy = teams.map((team) => TeamService.convertTeamDatesFromClient(team));
-        return this.http.put<Team[]>(`${TeamService.resourceUrl(exercise.id!)}/import-from-list?importStrategyType=${importStrategyType}`, copy, {
+        const dtos: TeamImportDTO[] = teams.map((team) => TeamService.toImportDTO(team));
+        return this.http.put<Team[]>(`${TeamService.resourceUrl(exercise.id!)}/import-from-list?importStrategyType=${importStrategyType}`, dtos, {
             observe: 'response',
         });
     }
@@ -332,17 +364,45 @@ export class TeamService implements ITeamService, OnDestroy {
         return team;
     }
 
-    private static convertTeamDatesFromClient(team: Team): Team {
-        return Object.assign({}, team, {
-            createdDate: convertDateFromClient(team.createdDate),
-            lastModifiedDate: convertDateFromClient(team.lastModifiedDate),
-        });
-    }
-
     private setAccessRightsCourseEntityResponseType(res: EntityResponseType): EntityResponseType {
         if (res.body) {
             this.accountService.setAccessRightsForCourse(res.body);
         }
         return res;
+    }
+
+    /**
+     * Converts a Team to a TeamInputDTO for create/update operations.
+     * @param team the team to convert
+     * @returns the TeamInputDTO
+     */
+    private static toInputDTO(team: Team): TeamInputDTO {
+        return {
+            id: team.id,
+            name: team.name ?? '',
+            shortName: team.shortName ?? '',
+            image: team.image,
+            students: team.students?.map((student) => student.id!).filter((id) => id !== undefined) ?? [],
+            ownerId: team.owner?.id,
+        };
+    }
+
+    /**
+     * Converts a Team to a TeamImportDTO for import operations.
+     * Students are identified by login or registration number.
+     * @param team the team to convert
+     * @returns the TeamImportDTO
+     */
+    private static toImportDTO(team: Team): TeamImportDTO {
+        return {
+            name: team.name ?? '',
+            shortName: team.shortName ?? '',
+            image: team.image,
+            students:
+                team.students?.map((student) => ({
+                    login: student.login,
+                    visibleRegistrationNumber: student.visibleRegistrationNumber,
+                })) ?? [],
+        };
     }
 }

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.html
@@ -55,7 +55,7 @@
         } @else {
             <div class="video-player-container">
                 <div class="ratio ratio-16x9">
-                    <iframe id="videoFrame" class="rounded" [src]="videoUrlWithTimestamp() | safeResourceUrl" allow="fullscreen"></iframe>
+                    <iframe id="videoFrame" class="rounded" [src]="videoUrl() | safeResourceUrl" allow="fullscreen"></iframe>
                 </div>
             </div>
         }

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.html
@@ -7,6 +7,7 @@
     [viewIsolatedButtonLabel]="'artemisApp.attachmentVideoUnit.download'"
     [viewIsolatedButtonIcon]="faDownload"
     [isPresentationMode]="isPresentationMode()"
+    [initiallyExpanded]="initiallyExpanded()"
     (onCompletion)="toggleCompletion($event)"
     (onCollapse)="toggleCollapse($event)"
     (onShowIsolated)="handleDownload()"
@@ -50,11 +51,11 @@
                 </div>
             </div>
         } @else if (playlistUrl() && hasTranscript()) {
-            <jhi-video-player [videoUrl]="playlistUrl()!" [transcriptSegments]="transcriptSegments()" />
+            <jhi-video-player [videoUrl]="playlistUrl()!" [transcriptSegments]="transcriptSegments()" [initialTimestamp]="targetTimestamp()" />
         } @else {
             <div class="video-player-container">
                 <div class="ratio ratio-16x9">
-                    <iframe id="videoFrame" class="rounded" [src]="videoUrl() | safeResourceUrl" allow="fullscreen"></iframe>
+                    <iframe id="videoFrame" class="rounded" [src]="videoUrlWithTimestamp() | safeResourceUrl" allow="fullscreen"></iframe>
                 </div>
             </div>
         }

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.spec.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.spec.ts
@@ -220,7 +220,6 @@ describe('AttachmentVideoUnitComponent', () => {
         expect(component.videoUrl()).toBeUndefined();
         parseSpy.mockRestore();
     });
-
     it('toggleCollapse(false): resets state, resolves playlist, fetches transcript (happy path)', async () => {
         // Arrange BEFORE first detectChanges so the computed() caches the right value
         const src = 'https://live.rbg.tum.de/w/abcd/1234?video_only=1';

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.spec.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.spec.ts
@@ -221,17 +221,6 @@ describe('AttachmentVideoUnitComponent', () => {
         parseSpy.mockRestore();
     });
 
-    it('videoUrlWithTimestamp: appends timestamp to allow-listed URL', () => {
-        const src = 'https://live.rbg.tum.de/w/abcd/1234?video_only=1';
-        component.lectureUnit().videoSource = src;
-        fixture.componentRef.setInput('targetTimestamp', 42.9);
-        fixture.detectChanges();
-
-        const withTimestamp = component.videoUrlWithTimestamp();
-        expect(withTimestamp).toBeDefined();
-        const parsed = new URL(withTimestamp!);
-        expect(parsed.searchParams.get('t')).toBe('42');
-    });
     it('toggleCollapse(false): resets state, resolves playlist, fetches transcript (happy path)', async () => {
         // Arrange BEFORE first detectChanges so the computed() caches the right value
         const src = 'https://live.rbg.tum.de/w/abcd/1234?video_only=1';

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.spec.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.spec.ts
@@ -220,6 +220,18 @@ describe('AttachmentVideoUnitComponent', () => {
         expect(component.videoUrl()).toBeUndefined();
         parseSpy.mockRestore();
     });
+
+    it('videoUrlWithTimestamp: appends timestamp to allow-listed URL', () => {
+        const src = 'https://live.rbg.tum.de/w/abcd/1234?video_only=1';
+        component.lectureUnit().videoSource = src;
+        fixture.componentRef.setInput('targetTimestamp', 42.9);
+        fixture.detectChanges();
+
+        const withTimestamp = component.videoUrlWithTimestamp();
+        expect(withTimestamp).toBeDefined();
+        const parsed = new URL(withTimestamp!);
+        expect(parsed.searchParams.get('t')).toBe('42');
+    });
     it('toggleCollapse(false): resets state, resolves playlist, fetches transcript (happy path)', async () => {
         // Arrange BEFORE first detectChanges so the computed() caches the right value
         const src = 'https://live.rbg.tum.de/w/abcd/1234?video_only=1';

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.ts
@@ -63,7 +63,6 @@ export class AttachmentVideoUnitComponent extends LectureUnitDirective<Attachmen
      * Return the URL of the video source
      */
     readonly videoUrl = computed(() => this.computeVideoUrl());
-    readonly videoUrlWithTimestamp = computed(() => this.appendTimestamp(this.videoUrl(), this.targetTimestamp()));
 
     /**
      * Computes the video URL based on the video source.
@@ -86,40 +85,6 @@ export class AttachmentVideoUnitComponent extends LectureUnitDirective<Attachmen
             }
         }
         return undefined;
-    }
-
-    private appendTimestamp(url: string | undefined, timestamp: number | undefined): string | undefined {
-        if (!url) {
-            return undefined;
-        }
-
-        const normalizedTimestamp = this.normalizeTimestamp(timestamp);
-        if (normalizedTimestamp === undefined) {
-            return url;
-        }
-
-        try {
-            const urlObj = new URL(url, window.location.origin);
-            const parsed = urlParser.parse(url);
-            if (parsed?.provider === 'youtube') {
-                urlObj.searchParams.set('start', String(normalizedTimestamp));
-            } else if (parsed?.provider === 'vimeo') {
-                urlObj.hash = `t=${normalizedTimestamp}s`;
-            } else {
-                urlObj.searchParams.set('t', String(normalizedTimestamp));
-            }
-            return urlObj.toString();
-        } catch {
-            const separator = url.includes('?') ? '&' : '?';
-            return `${url}${separator}t=${normalizedTimestamp}`;
-        }
-    }
-
-    private normalizeTimestamp(timestamp: number | undefined): number | undefined {
-        if (timestamp === undefined || !Number.isFinite(timestamp) || timestamp < 0) {
-            return undefined;
-        }
-        return Math.floor(timestamp);
     }
 
     override toggleCollapse(isCollapsed: boolean): void {

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
+import { Component, DestroyRef, computed, inject, input, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { LectureUnitDirective } from 'app/lecture/overview/course-lectures/lecture-unit/lecture-unit.directive';
 import { AttachmentVideoUnit } from 'app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model';
@@ -48,6 +48,8 @@ export class AttachmentVideoUnitComponent extends LectureUnitDirective<Attachmen
     private readonly attachmentVideoUnitService = inject(AttachmentVideoUnitService);
     private readonly lectureTranscriptionService = inject(LectureTranscriptionService);
 
+    targetTimestamp = input<number | undefined>(undefined);
+
     readonly transcriptSegments = signal<TranscriptSegment[]>([]);
     readonly playlistUrl = signal<string | undefined>(undefined);
     readonly isLoading = signal<boolean>(false);
@@ -61,6 +63,7 @@ export class AttachmentVideoUnitComponent extends LectureUnitDirective<Attachmen
      * Return the URL of the video source
      */
     readonly videoUrl = computed(() => this.computeVideoUrl());
+    readonly videoUrlWithTimestamp = computed(() => this.appendTimestamp(this.videoUrl(), this.targetTimestamp()));
 
     /**
      * Computes the video URL based on the video source.
@@ -83,6 +86,40 @@ export class AttachmentVideoUnitComponent extends LectureUnitDirective<Attachmen
             }
         }
         return undefined;
+    }
+
+    private appendTimestamp(url: string | undefined, timestamp: number | undefined): string | undefined {
+        if (!url) {
+            return undefined;
+        }
+
+        const normalizedTimestamp = this.normalizeTimestamp(timestamp);
+        if (normalizedTimestamp === undefined) {
+            return url;
+        }
+
+        try {
+            const urlObj = new URL(url, window.location.origin);
+            const parsed = urlParser.parse(url);
+            if (parsed?.provider === 'youtube') {
+                urlObj.searchParams.set('start', String(normalizedTimestamp));
+            } else if (parsed?.provider === 'vimeo') {
+                urlObj.hash = `t=${normalizedTimestamp}s`;
+            } else {
+                urlObj.searchParams.set('t', String(normalizedTimestamp));
+            }
+            return urlObj.toString();
+        } catch {
+            const separator = url.includes('?') ? '&' : '?';
+            return `${url}${separator}t=${normalizedTimestamp}`;
+        }
+    }
+
+    private normalizeTimestamp(timestamp: number | undefined): number | undefined {
+        if (timestamp === undefined || !Number.isFinite(timestamp) || timestamp < 0) {
+            return undefined;
+        }
+        return Math.floor(timestamp);
     }
 
     override toggleCollapse(isCollapsed: boolean): void {

--- a/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.html
@@ -71,13 +71,29 @@
                                         <jhi-exercise-unit [exerciseUnit]="lectureUnit" [course]="lecture!.course!" />
                                     }
                                     @case (LectureUnitType.ATTACHMENT_VIDEO) {
-                                        <jhi-attachment-video-unit [courseId]="courseId!" [lectureUnit]="lectureUnit" (onCompletion)="completeLectureUnit($event)" />
+                                        <jhi-attachment-video-unit
+                                            [courseId]="courseId!"
+                                            [lectureUnit]="lectureUnit"
+                                            [initiallyExpanded]="lectureUnit.id === targetUnitId()"
+                                            [targetTimestamp]="lectureUnit.id === targetUnitId() ? targetVideoTimestamp() : undefined"
+                                            (onCompletion)="completeLectureUnit($event)"
+                                        />
                                     }
                                     @case (LectureUnitType.TEXT) {
-                                        <jhi-text-unit [courseId]="courseId!" [lectureUnit]="lectureUnit" (onCompletion)="completeLectureUnit($event)" />
+                                        <jhi-text-unit
+                                            [courseId]="courseId!"
+                                            [lectureUnit]="lectureUnit"
+                                            [initiallyExpanded]="lectureUnit.id === targetUnitId()"
+                                            (onCompletion)="completeLectureUnit($event)"
+                                        />
                                     }
                                     @case (LectureUnitType.ONLINE) {
-                                        <jhi-online-unit [courseId]="courseId!" [lectureUnit]="lectureUnit" (onCompletion)="completeLectureUnit($event)" />
+                                        <jhi-online-unit
+                                            [courseId]="courseId!"
+                                            [lectureUnit]="lectureUnit"
+                                            [initiallyExpanded]="lectureUnit.id === targetUnitId()"
+                                            (onCompletion)="completeLectureUnit($event)"
+                                        />
                                     }
                                 }
                             </div>

--- a/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { Component, DestroyRef, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MODULE_FEATURE_IRIS, addPublicFilePrefix } from 'app/app.constants';
@@ -72,6 +73,7 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
     private readonly profileService = inject(ProfileService);
     private readonly irisSettingsService = inject(IrisSettingsService);
     private readonly scienceService = inject(ScienceService);
+    private readonly destroyRef = inject(DestroyRef);
 
     protected readonly LectureUnitType = LectureUnitType;
     protected readonly isCommunicationEnabled = isCommunicationEnabled;
@@ -94,6 +96,9 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
     irisEnabled = false;
     informationBoxData: InformationBox[] = [];
 
+    readonly targetUnitId = signal<number | undefined>(undefined);
+    readonly targetVideoTimestamp = signal<number | undefined>(undefined);
+
     ngOnInit(): void {
         this.irisEnabled = this.profileService.isModuleFeatureActive(MODULE_FEATURE_IRIS);
 
@@ -111,6 +116,22 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
             if (this.lectureId) {
                 this.scienceService.logEvent(ScienceEventType.LECTURE__OPEN, this.lectureId);
                 this.loadData();
+            }
+        });
+
+        this.activatedRoute.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
+            const unitId = Number(params['unit']);
+            if (Number.isInteger(unitId) && unitId > 0) {
+                this.targetUnitId.set(unitId);
+                const timestamp = Number(params['timestamp']);
+                this.targetVideoTimestamp.set(Number.isFinite(timestamp) && timestamp >= 0 ? timestamp : undefined);
+            } else {
+                this.targetUnitId.set(undefined);
+                this.targetVideoTimestamp.set(undefined);
+            }
+
+            if (this.lectureUnits.length > 0) {
+                this.ensureValidDeepLinkTargets();
             }
         });
     }
@@ -135,6 +156,7 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
                         });
 
                         this.lectureUnits = this.lecture?.lectureUnits ?? [];
+                        this.ensureValidDeepLinkTargets();
                         if (this.lectureUnits?.length) {
                             // Check if PDF attachments exist in lecture units
                             this.hasPdfLectureUnit =
@@ -216,6 +238,24 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
             content: boxContentStartDate,
             isContentComponent: true,
         };
+    }
+
+    private ensureValidDeepLinkTargets(): void {
+        const targetUnitId = this.targetUnitId();
+        if (!targetUnitId) {
+            return;
+        }
+
+        const targetUnit = this.lectureUnits.find((unit) => unit.id === targetUnitId);
+        if (!targetUnit) {
+            this.targetUnitId.set(undefined);
+            this.targetVideoTimestamp.set(undefined);
+            return;
+        }
+
+        if (targetUnit.type !== LectureUnitType.ATTACHMENT_VIDEO) {
+            this.targetVideoTimestamp.set(undefined);
+        }
     }
 
     ngOnDestroy() {

--- a/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.component.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Injector, afterNextRender, computed, inject, input, output, signal } from '@angular/core';
+import { Component, ElementRef, Injector, OnDestroy, afterNextRender, computed, effect, inject, input, output, signal, untracked } from '@angular/core';
 import { IconDefinition, faCheckCircle, faCircle, faDownload, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
@@ -17,10 +17,14 @@ import { CompetencyContributionComponent } from 'app/atlas/shared/competency-con
     templateUrl: './lecture-unit.component.html',
     styleUrl: './lecture-unit.component.scss',
 })
-export class LectureUnitComponent {
+export class LectureUnitComponent implements OnDestroy {
+    private static readonly SCROLL_INTO_VIEW_DELAY_MS = 500;
+
     private router = inject(Router);
     private elementRef = inject(ElementRef);
     private injector = inject(Injector);
+    private scrollTimeoutId: ReturnType<typeof setTimeout> | undefined;
+    private autoExpanded = false;
 
     protected faDownload = faDownload;
     protected faCheckCircle = faCheckCircle;
@@ -35,6 +39,7 @@ export class LectureUnitComponent {
     viewIsolatedButtonLabel = input<string>('artemisApp.textUnit.isolated');
     viewIsolatedButtonIcon = input<IconDefinition>(faExternalLinkAlt);
     isPresentationMode = input.required<boolean>();
+    initiallyExpanded = input<boolean>(false);
 
     readonly showOriginalVersionButton = input<boolean>(false);
     readonly onShowOriginalVersion = output<void>();
@@ -48,6 +53,35 @@ export class LectureUnitComponent {
     readonly isVisibleToStudents = computed(() => this.lectureUnit().visibleToStudents);
     readonly isStudentPath = computed(() => this.router.url.startsWith('/courses'));
 
+    constructor() {
+        effect(
+            (onCleanup) => {
+                const shouldAutoExpand = this.initiallyExpanded();
+                if (shouldAutoExpand && !this.autoExpanded) {
+                    this.autoExpanded = true;
+                    if (untracked(() => this.isCollapsed())) {
+                        this.isCollapsed.set(false);
+                        this.onCollapse.emit(false);
+                    }
+
+                    this.scheduleScroll('start', LectureUnitComponent.SCROLL_INTO_VIEW_DELAY_MS);
+                }
+                if (!shouldAutoExpand) {
+                    this.autoExpanded = false;
+                }
+
+                onCleanup(() => {
+                    this.clearScrollTimeout();
+                });
+            },
+            { injector: this.injector },
+        );
+    }
+
+    ngOnDestroy(): void {
+        this.clearScrollTimeout();
+    }
+
     toggleCompletion(event: Event) {
         event.stopPropagation();
         this.onCompletion.emit(!this.lectureUnit().completed!);
@@ -58,12 +92,7 @@ export class LectureUnitComponent {
         this.onCollapse.emit(this.isCollapsed());
 
         if (!this.isCollapsed()) {
-            afterNextRender(
-                () => {
-                    this.elementRef.nativeElement.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' });
-                },
-                { injector: this.injector },
-            );
+            this.scheduleScroll('nearest');
         }
     }
 
@@ -75,5 +104,26 @@ export class LectureUnitComponent {
     handleOriginalVersionView(event: Event) {
         event.stopPropagation();
         this.onShowOriginalVersion.emit();
+    }
+
+    private scheduleScroll(block: ScrollLogicalPosition, delayMs = 0): void {
+        afterNextRender(
+            () => {
+                const doScroll = () => this.elementRef.nativeElement.scrollIntoView?.({ behavior: 'smooth', block });
+                if (delayMs > 0) {
+                    this.scrollTimeoutId = setTimeout(doScroll, delayMs);
+                } else {
+                    doScroll();
+                }
+            },
+            { injector: this.injector },
+        );
+    }
+
+    private clearScrollTimeout(): void {
+        if (this.scrollTimeoutId !== undefined) {
+            clearTimeout(this.scrollTimeoutId);
+            this.scrollTimeoutId = undefined;
+        }
     }
 }

--- a/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.directive.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.directive.ts
@@ -7,6 +7,7 @@ import { LectureUnitCompletionEvent } from 'app/lecture/overview/course-lectures
 export class LectureUnitDirective<T extends LectureUnit> {
     courseId = input.required<number>();
     lectureUnit = input.required<T>();
+    initiallyExpanded = input<boolean>(false);
 
     readonly onCompletion = output<LectureUnitCompletionEvent>();
     readonly onCollapse = output<boolean>();

--- a/src/main/webapp/app/lecture/overview/course-lectures/online-unit/online-unit.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/online-unit/online-unit.component.html
@@ -5,6 +5,7 @@
     [showViewIsolatedButton]="true"
     [viewIsolatedButtonLabel]="'artemisApp.onlineUnit.doOpen'"
     [isPresentationMode]="isPresentationMode()"
+    [initiallyExpanded]="initiallyExpanded()"
     (onCompletion)="toggleCompletion($event)"
     (onCollapse)="toggleCollapse($event)"
     (onShowIsolated)="handleIsolatedView()"

--- a/src/main/webapp/app/lecture/overview/course-lectures/text-unit/text-unit.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/text-unit/text-unit.component.html
@@ -4,6 +4,7 @@
     [icon]="faScroll"
     [showViewIsolatedButton]="true"
     [isPresentationMode]="isPresentationMode()"
+    [initiallyExpanded]="initiallyExpanded()"
     (onCompletion)="toggleCompletion($event)"
     (onCollapse)="toggleCollapse($event)"
     (onShowIsolated)="handleIsolatedView()"

--- a/src/main/webapp/app/lecture/shared/video-player/video-player.component.spec.ts
+++ b/src/main/webapp/app/lecture/shared/video-player/video-player.component.spec.ts
@@ -149,9 +149,10 @@ describe('VideoPlayerComponent', () => {
         vi.restoreAllMocks();
     });
 
-    function setInputs(url?: string, segments: TranscriptSegment[] = []): void {
+    function setInputs(url?: string, segments: TranscriptSegment[] = [], initialTimestamp?: number): void {
         fixture.componentRef.setInput('videoUrl', url);
         fixture.componentRef.setInput('transcriptSegments', segments);
+        fixture.componentRef.setInput('initialTimestamp', initialTimestamp);
     }
 
     async function render(): Promise<void> {
@@ -241,6 +242,16 @@ describe('VideoPlayerComponent', () => {
 
         expect(videoElement.currentTime).toBe(42);
         expect(playSpy).toHaveBeenCalled();
+    });
+
+    it('applies initial timestamp after metadata is available', async () => {
+        setInputs('https://cdn.example.com/m.m3u8', [], 12.5);
+        await render();
+
+        videoElement.dispatchEvent(new Event('loadedmetadata'));
+
+        expect(videoElement.currentTime).toBe(12.5);
+        expect(component.currentSegmentIndex()).toBe(-1);
     });
 
     it('ngOnDestroy destroys hls instance', async () => {

--- a/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
+++ b/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, OnDestroy, input, signal, viewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, OnDestroy, effect, input, signal, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranscriptViewerComponent } from '../transcript-viewer/transcript-viewer.component';
 import Hls from 'hls.js';
@@ -34,6 +34,9 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
     /** Transcript segments to highlight and sync */
     transcriptSegments = input<TranscriptSegment[]>([]);
 
+    /** Optional timestamp to seek to once the player is ready */
+    initialTimestamp = input<number | undefined>(undefined);
+
     /** The HLS.js instance */
     private hls: Hls | undefined = undefined;
 
@@ -61,10 +64,42 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
     /** Minimum height for the transcript column */
     private readonly MIN_TRANSCRIPT_HEIGHT = 500;
 
+    private viewReady = signal<boolean>(false);
+    private lastInitialTimestamp: number | undefined;
+    private pendingInitialSeek: number | undefined;
+
+    constructor() {
+        effect(() => {
+            if (!this.viewReady()) {
+                return;
+            }
+
+            const timestamp = this.initialTimestamp();
+            if (timestamp === undefined || !Number.isFinite(timestamp) || timestamp < 0) {
+                this.lastInitialTimestamp = undefined;
+                return;
+            }
+
+            if (this.lastInitialTimestamp === timestamp) {
+                return;
+            }
+
+            const videoElement = this.videoRef()?.nativeElement;
+            if (!videoElement) {
+                return;
+            }
+
+            this.lastInitialTimestamp = timestamp;
+            this.queueInitialSeek(videoElement, timestamp);
+        });
+    }
+
     ngAfterViewInit(): void {
         const elRef = this.videoRef();
         const videoElement = elRef ? elRef.nativeElement : undefined;
         const src = this.videoUrl();
+
+        this.viewReady.set(true);
 
         if (!videoElement || !src) {
             return;
@@ -191,6 +226,34 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
 
         videoElement.currentTime = seconds;
         videoElement.play();
+    }
+
+    private queueInitialSeek(videoElement: HTMLVideoElement, seconds: number): void {
+        const target = Math.max(0, seconds);
+        if (videoElement.readyState >= 1) {
+            this.applyInitialSeek(videoElement, target);
+            return;
+        }
+
+        this.pendingInitialSeek = target;
+        videoElement.addEventListener(
+            'loadedmetadata',
+            () => {
+                const pending = this.pendingInitialSeek;
+                this.pendingInitialSeek = undefined;
+                if (pending !== undefined) {
+                    this.applyInitialSeek(videoElement, pending);
+                }
+            },
+            { once: true },
+        );
+    }
+
+    private applyInitialSeek(videoElement: HTMLVideoElement, seconds: number): void {
+        const duration = videoElement.duration;
+        const clamped = Number.isFinite(duration) ? Math.min(seconds, Math.max(0, duration)) : seconds;
+        videoElement.currentTime = clamped;
+        this.updateCurrentSegment(clamped);
     }
 
     /**

--- a/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
+++ b/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
@@ -251,7 +251,10 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
 
     private applyInitialSeek(videoElement: HTMLVideoElement, seconds: number): void {
         const duration = videoElement.duration;
-        const clamped = Number.isFinite(duration) ? Math.min(seconds, Math.max(0, duration)) : seconds;
+        if (Number.isFinite(duration) && seconds > duration) {
+            return;
+        }
+        const clamped = Number.isFinite(duration) ? Math.max(0, seconds) : seconds;
         videoElement.currentTime = clamped;
         this.updateCurrentSegment(clamped);
     }

--- a/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
+++ b/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
@@ -77,6 +77,7 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
             const timestamp = this.initialTimestamp();
             if (timestamp === undefined || !Number.isFinite(timestamp) || timestamp < 0) {
                 this.lastInitialTimestamp = undefined;
+                this.pendingInitialSeek = undefined;
                 return;
             }
 

--- a/src/main/webapp/app/programming/manage/services/programming-exercise-timeline-update-dto.model.ts
+++ b/src/main/webapp/app/programming/manage/services/programming-exercise-timeline-update-dto.model.ts
@@ -1,0 +1,38 @@
+import { convertDateFromClient } from 'app/shared/util/date.utils';
+import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
+import { AssessmentType } from 'app/assessment/shared/entities/assessment-type.model';
+
+/**
+ * DTO for updating the timeline of a programming exercise.
+ * Contains only the date-related fields that can be updated via the timeline endpoint.
+ */
+export interface ProgrammingExerciseTimelineUpdateDTO {
+    id: number;
+    releaseDate?: string;
+    startDate?: string;
+    dueDate?: string;
+    assessmentType?: AssessmentType;
+    assessmentDueDate?: string;
+    exampleSolutionPublicationDate?: string;
+    buildAndTestStudentSubmissionsAfterDueDate?: string;
+}
+
+/**
+ * Converts a ProgrammingExercise entity to a ProgrammingExerciseTimelineUpdateDTO
+ * for sending only timeline-related fields to the server.
+ *
+ * @param exercise the programming exercise to convert
+ * @returns a ProgrammingExerciseTimelineUpdateDTO with only timeline fields
+ */
+export function toProgrammingExerciseTimelineUpdateDTO(exercise: ProgrammingExercise): ProgrammingExerciseTimelineUpdateDTO {
+    return {
+        id: exercise.id!,
+        releaseDate: convertDateFromClient(exercise.releaseDate),
+        startDate: convertDateFromClient(exercise.startDate),
+        dueDate: convertDateFromClient(exercise.dueDate),
+        assessmentType: exercise.assessmentType,
+        assessmentDueDate: convertDateFromClient(exercise.assessmentDueDate),
+        exampleSolutionPublicationDate: convertDateFromClient(exercise.exampleSolutionPublicationDate),
+        buildAndTestStudentSubmissionsAfterDueDate: convertDateFromClient(exercise.buildAndTestStudentSubmissionsAfterDueDate),
+    };
+}

--- a/src/main/webapp/app/programming/manage/services/programming-exercise.service.ts
+++ b/src/main/webapp/app/programming/manage/services/programming-exercise.service.ts
@@ -8,6 +8,8 @@ import { omit as _omit } from 'lodash-es';
 import { createRequestOption } from 'app/shared/util/request.util';
 import { ExerciseService } from 'app/exercise/services/exercise.service';
 import { ProgrammingExercise, ProgrammingLanguage } from 'app/programming/shared/entities/programming-exercise.model';
+import { toUpdateProgrammingExerciseDTO } from 'app/programming/manage/services/update-programming-exercise-dto.model';
+import { toProgrammingExerciseTimelineUpdateDTO } from 'app/programming/manage/services/programming-exercise-timeline-update-dto.model';
 import { TemplateProgrammingExerciseParticipation } from 'app/exercise/shared/entities/participation/template-programming-exercise-participation.model';
 import { SolutionProgrammingExerciseParticipation } from 'app/exercise/shared/entities/participation/solution-programming-exercise-participation.model';
 import { PlagiarismOptions } from 'app/plagiarism/shared/entities/PlagiarismOptions';
@@ -161,11 +163,9 @@ export class ProgrammingExerciseService {
      */
     update(programmingExercise: ProgrammingExercise, req?: any): Observable<EntityResponseType> {
         const options = createRequestOption(req);
-        let copy = this.convertDataFromClient(programmingExercise);
-        copy = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        const dto = toUpdateProgrammingExerciseDTO(programmingExercise);
         return this.http
-            .put<ProgrammingExercise>(this.resourceUrl, copy, { params: options, observe: 'response' })
+            .put<ProgrammingExercise>(this.resourceUrl, dto, { params: options, observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.processProgrammingExerciseEntityResponse(res)));
     }
 
@@ -176,9 +176,9 @@ export class ProgrammingExerciseService {
      */
     updateTimeline(programmingExercise: ProgrammingExercise, req?: any): Observable<EntityResponseType> {
         const options = createRequestOption(req);
-        const copy = this.convertDataFromClient(programmingExercise);
+        const dto = toProgrammingExerciseTimelineUpdateDTO(programmingExercise);
         return this.http
-            .put<ProgrammingExercise>(`${this.resourceUrl}/timeline`, copy, { params: options, observe: 'response' })
+            .put<ProgrammingExercise>(`${this.resourceUrl}/timeline`, dto, { params: options, observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.processProgrammingExerciseEntityResponse(res)));
     }
 
@@ -474,11 +474,9 @@ export class ProgrammingExerciseService {
      */
     reevaluateAndUpdate(programmingExercise: ProgrammingExercise, req?: any): Observable<EntityResponseType> {
         const options = createRequestOption(req);
-        let copy = this.convertDataFromClient(programmingExercise);
-        copy = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        const dto = toUpdateProgrammingExerciseDTO(programmingExercise);
         return this.http
-            .put<ProgrammingExercise>(`${this.resourceUrl}/${programmingExercise.id}/re-evaluate`, copy, {
+            .put<ProgrammingExercise>(`${this.resourceUrl}/${programmingExercise.id}/re-evaluate`, dto, {
                 params: options,
                 observe: 'response',
             })

--- a/src/main/webapp/app/programming/manage/services/update-programming-exercise-dto.model.ts
+++ b/src/main/webapp/app/programming/manage/services/update-programming-exercise-dto.model.ts
@@ -1,0 +1,246 @@
+import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
+import { ExerciseService } from 'app/exercise/services/exercise.service';
+import { convertDateFromClient } from 'app/shared/util/date.utils';
+import { DifficultyLevel, IncludedInOverallScore } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { ProgrammingLanguage, ProjectType } from 'app/programming/shared/entities/programming-exercise.model';
+import { SubmissionPolicy } from 'app/exercise/shared/entities/submission/submission-policy.model';
+
+/**
+ * DTO for competency reference (just the ID)
+ */
+export interface CompetencyDTO {
+    id: number;
+}
+
+/**
+ * DTO for competency links with weight
+ */
+export interface CompetencyLinkDTO {
+    competency: CompetencyDTO;
+    weight: number;
+}
+
+/**
+ * DTO for grading criterion
+ */
+export interface GradingCriterionDTO {
+    id?: number;
+    title?: string;
+    structuredGradingInstructions?: GradingInstructionDTO[];
+}
+
+/**
+ * DTO for grading instruction
+ */
+export interface GradingInstructionDTO {
+    id?: number;
+    credits?: number;
+    gradingScale?: string;
+    instructionDescription?: string;
+    feedback?: string;
+    usageCount?: number;
+}
+
+/**
+ * DTO for auxiliary repository
+ */
+export interface AuxiliaryRepositoryDTO {
+    id?: number;
+    name?: string;
+    checkoutDirectory?: string;
+    repositoryUri?: string;
+    description?: string;
+}
+
+/**
+ * DTO for build config
+ */
+export interface UpdateProgrammingExerciseBuildConfigDTO {
+    sequentialTestRuns?: boolean;
+    buildPlanConfiguration?: string;
+    buildScript?: string;
+    checkoutSolutionRepository: boolean;
+    testCheckoutPath?: string;
+    assignmentCheckoutPath?: string;
+    solutionCheckoutPath?: string;
+    timeoutSeconds: number;
+    dockerFlags?: string;
+    theiaImage?: string;
+    allowBranching: boolean;
+    branchRegex?: string;
+}
+
+/**
+ * DTO for updating programming exercises.
+ * Matches the server-side UpdateProgrammingExerciseDTO record structure.
+ */
+export interface UpdateProgrammingExerciseDTO {
+    // Core identification
+    id: number;
+
+    // Exercise base fields
+    title?: string;
+    channelName?: string;
+    shortName?: string;
+    problemStatement?: string;
+    categories?: string[];
+    difficulty?: DifficultyLevel;
+    maxPoints?: number;
+    bonusPoints?: number;
+    includedInOverallScore?: IncludedInOverallScore;
+    allowComplaintsForAutomaticAssessments?: boolean;
+    allowFeedbackRequests?: boolean;
+    presentationScoreEnabled?: boolean;
+    secondCorrectionEnabled?: boolean;
+    feedbackSuggestionModule?: string;
+    gradingInstructions?: string;
+
+    // Timeline fields
+    releaseDate?: string;
+    startDate?: string;
+    dueDate?: string;
+    assessmentDueDate?: string;
+    exampleSolutionPublicationDate?: string;
+
+    // Course/ExerciseGroup references (by ID)
+    courseId?: number;
+    exerciseGroupId?: number;
+
+    // Grading and competencies
+    gradingCriteria?: GradingCriterionDTO[];
+    competencyLinks?: CompetencyLinkDTO[];
+
+    // Programming exercise specific fields
+    testRepositoryUri?: string;
+    auxiliaryRepositories?: AuxiliaryRepositoryDTO[];
+    allowOnlineEditor?: boolean;
+    allowOfflineIde?: boolean;
+    allowOnlineIde: boolean;
+    staticCodeAnalysisEnabled?: boolean;
+    maxStaticCodeAnalysisPenalty?: number;
+    programmingLanguage?: ProgrammingLanguage;
+    packageName?: string;
+    showTestNamesToStudents: boolean;
+    buildAndTestStudentSubmissionsAfterDueDate?: string;
+    testCasesChanged?: boolean;
+    projectKey?: string;
+    submissionPolicy?: SubmissionPolicy;
+    projectType?: ProjectType;
+    releaseTestsWithExampleSolution: boolean;
+
+    // Build config
+    buildConfig?: UpdateProgrammingExerciseBuildConfigDTO;
+}
+
+/**
+ * Converts a ProgrammingExercise entity to an UpdateProgrammingExerciseDTO.
+ * This ensures the correct data structure is sent to the server.
+ *
+ * @param exercise the programming exercise to convert
+ * @returns the corresponding DTO
+ */
+export function toUpdateProgrammingExerciseDTO(exercise: ProgrammingExercise): UpdateProgrammingExerciseDTO {
+    // Apply bonus points constraint
+    ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(exercise);
+
+    // Convert competency links to DTOs
+    const competencyLinkDTOs: CompetencyLinkDTO[] | undefined = exercise.competencyLinks?.map((link) => ({
+        competency: { id: link.competency!.id! },
+        weight: link.weight,
+    }));
+
+    // Convert grading criteria to DTOs
+    const gradingCriteriaDTOs: GradingCriterionDTO[] | undefined = exercise.gradingCriteria?.map((criterion) => ({
+        id: criterion.id,
+        title: criterion.title,
+        structuredGradingInstructions: criterion.structuredGradingInstructions?.map((instruction) => ({
+            id: instruction.id,
+            credits: instruction.credits,
+            gradingScale: instruction.gradingScale,
+            instructionDescription: instruction.instructionDescription,
+            feedback: instruction.feedback,
+            usageCount: instruction.usageCount,
+        })),
+    }));
+
+    // Convert auxiliary repositories to DTOs
+    const auxiliaryRepositoryDTOs: AuxiliaryRepositoryDTO[] | undefined = exercise.auxiliaryRepositories?.map((repo) => ({
+        id: repo.id,
+        name: repo.name,
+        checkoutDirectory: repo.checkoutDirectory,
+        repositoryUri: repo.repositoryUri,
+        description: repo.description,
+    }));
+
+    // Convert build config to DTO
+    const buildConfigDTO: UpdateProgrammingExerciseBuildConfigDTO | undefined = exercise.buildConfig
+        ? {
+              sequentialTestRuns: exercise.buildConfig.sequentialTestRuns,
+              buildPlanConfiguration: exercise.buildConfig.buildPlanConfiguration,
+              buildScript: exercise.buildConfig.buildScript,
+              checkoutSolutionRepository: exercise.buildConfig.checkoutSolutionRepository ?? false,
+              testCheckoutPath: exercise.buildConfig.testCheckoutPath,
+              assignmentCheckoutPath: exercise.buildConfig.assignmentCheckoutPath,
+              solutionCheckoutPath: exercise.buildConfig.solutionCheckoutPath,
+              timeoutSeconds: exercise.buildConfig.timeoutSeconds ?? 120,
+              dockerFlags: exercise.buildConfig.dockerFlags,
+              theiaImage: exercise.buildConfig.theiaImage,
+              allowBranching: exercise.buildConfig.allowBranching ?? false,
+              branchRegex: exercise.buildConfig.branchRegex,
+          }
+        : undefined;
+
+    // Determine courseId and exerciseGroupId - only one should be set (mutually exclusive)
+    // For course exercises: set courseId, leave exerciseGroupId undefined
+    // For exam exercises: set exerciseGroupId, leave courseId undefined
+    const exerciseGroupId = exercise.exerciseGroup?.id;
+    const courseId = exerciseGroupId ? undefined : exercise.course?.id;
+
+    // Convert categories to JSON strings
+    const categories = ExerciseService.stringifyExerciseDTOCategories(exercise);
+
+    return {
+        id: exercise.id!,
+        title: exercise.title,
+        channelName: exercise.channelName,
+        shortName: exercise.shortName,
+        problemStatement: exercise.problemStatement,
+        categories,
+        difficulty: exercise.difficulty,
+        maxPoints: exercise.maxPoints,
+        bonusPoints: exercise.bonusPoints,
+        includedInOverallScore: exercise.includedInOverallScore,
+        allowComplaintsForAutomaticAssessments: exercise.allowComplaintsForAutomaticAssessments,
+        allowFeedbackRequests: exercise.allowFeedbackRequests,
+        presentationScoreEnabled: exercise.presentationScoreEnabled,
+        secondCorrectionEnabled: exercise.secondCorrectionEnabled,
+        feedbackSuggestionModule: exercise.feedbackSuggestionModule,
+        gradingInstructions: exercise.gradingInstructions,
+        releaseDate: convertDateFromClient(exercise.releaseDate),
+        startDate: convertDateFromClient(exercise.startDate),
+        dueDate: convertDateFromClient(exercise.dueDate),
+        assessmentDueDate: convertDateFromClient(exercise.assessmentDueDate),
+        exampleSolutionPublicationDate: convertDateFromClient(exercise.exampleSolutionPublicationDate),
+        courseId,
+        exerciseGroupId,
+        gradingCriteria: gradingCriteriaDTOs,
+        competencyLinks: competencyLinkDTOs,
+        testRepositoryUri: exercise.testRepositoryUri,
+        auxiliaryRepositories: auxiliaryRepositoryDTOs,
+        allowOnlineEditor: exercise.allowOnlineEditor,
+        allowOfflineIde: exercise.allowOfflineIde,
+        allowOnlineIde: exercise.allowOnlineIde ?? false,
+        staticCodeAnalysisEnabled: exercise.staticCodeAnalysisEnabled,
+        maxStaticCodeAnalysisPenalty: exercise.maxStaticCodeAnalysisPenalty,
+        programmingLanguage: exercise.programmingLanguage,
+        packageName: exercise.packageName,
+        showTestNamesToStudents: exercise.showTestNamesToStudents ?? false,
+        buildAndTestStudentSubmissionsAfterDueDate: convertDateFromClient(exercise.buildAndTestStudentSubmissionsAfterDueDate),
+        testCasesChanged: exercise.testCasesChanged,
+        projectKey: exercise.projectKey,
+        submissionPolicy: exercise.submissionPolicy,
+        projectType: exercise.projectType,
+        releaseTestsWithExampleSolution: exercise.releaseTestsWithExampleSolution ?? false,
+        buildConfig: buildConfigDTO,
+    };
+}

--- a/src/main/webapp/app/quiz/manage/apollon-diagrams/services/apollon-diagram.service.ts
+++ b/src/main/webapp/app/quiz/manage/apollon-diagrams/services/apollon-diagram.service.ts
@@ -3,10 +3,22 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
 
 import { ApollonDiagram } from 'app/modeling/shared/entities/apollon-diagram.model';
+import { UMLDiagramType } from '@ls1intum/apollon';
 import { createRequestOption } from 'app/shared/util/request.util';
 import { EntityTitleService, EntityType } from 'app/core/navbar/entity-title.service';
 
 export type EntityResponseType = HttpResponse<ApollonDiagram>;
+
+/**
+ * DTO for creating and updating ApollonDiagrams.
+ */
+export interface ApollonDiagramUpdateDTO {
+    id?: number;
+    title?: string;
+    jsonRepresentation?: string;
+    diagramType?: UMLDiagramType;
+    courseId: number;
+}
 
 @Injectable({ providedIn: 'root' })
 export class ApollonDiagramService {
@@ -21,8 +33,8 @@ export class ApollonDiagramService {
      * @param courseId - id of the course.
      */
     create(apollonDiagram: ApollonDiagram, courseId: number): Observable<EntityResponseType> {
-        const copy = this.convert(apollonDiagram);
-        return this.http.post<ApollonDiagram>(`${this.resourceUrl}/course/${courseId}/apollon-diagrams`, copy, { observe: 'response' });
+        const dto = this.toDTO(apollonDiagram, courseId);
+        return this.http.post<ApollonDiagram>(`${this.resourceUrl}/course/${courseId}/apollon-diagrams`, dto, { observe: 'response' });
     }
 
     /**
@@ -31,8 +43,8 @@ export class ApollonDiagramService {
      * @param courseId - id of the course.
      */
     update(apollonDiagram: ApollonDiagram, courseId: number): Observable<EntityResponseType> {
-        const copy = this.convert(apollonDiagram);
-        return this.http.put<ApollonDiagram>(`${this.resourceUrl}/course/${courseId}/apollon-diagrams`, copy, { observe: 'response' });
+        const dto = this.toDTO(apollonDiagram, courseId);
+        return this.http.put<ApollonDiagram>(`${this.resourceUrl}/course/${courseId}/apollon-diagrams`, dto, { observe: 'response' });
     }
 
     /**
@@ -65,8 +77,14 @@ export class ApollonDiagramService {
             .pipe(tap((res) => res?.body?.forEach(this.sendTitlesToEntityTitleService.bind(this))));
     }
 
-    private convert(apollonDiagram: ApollonDiagram): ApollonDiagram {
-        return Object.assign({}, apollonDiagram);
+    private toDTO(apollonDiagram: ApollonDiagram, courseId: number): ApollonDiagramUpdateDTO {
+        return {
+            id: apollonDiagram.id,
+            title: apollonDiagram.title,
+            jsonRepresentation: apollonDiagram.jsonRepresentation,
+            diagramType: apollonDiagram.diagramType,
+            courseId: courseId,
+        };
     }
 
     private sendTitlesToEntityTitleService(diagram: ApollonDiagram | undefined | null) {

--- a/src/main/webapp/app/text/manage/text-exercise/service/text-exercise.service.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/service/text-exercise.service.ts
@@ -6,6 +6,7 @@ import { map } from 'rxjs/operators';
 import { TextExercise } from 'app/text/shared/entities/text-exercise.model';
 import { createRequestOption } from 'app/shared/util/request.util';
 import { ExerciseServicable, ExerciseService } from 'app/exercise/services/exercise.service';
+import { toUpdateTextExerciseDTO } from 'app/text/manage/text-exercise/service/update-text-exercise-dto.model';
 import { PlagiarismOptions } from 'app/plagiarism/shared/entities/PlagiarismOptions';
 import { TutorEffort } from 'app/assessment/shared/entities/tutor-effort.model';
 import { PlagiarismResultDTO } from 'app/plagiarism/shared/entities/PlagiarismResultDTO';
@@ -56,11 +57,9 @@ export class TextExerciseService implements ExerciseServicable<TextExercise> {
      */
     update(textExercise: TextExercise, req?: any): Observable<EntityResponseType> {
         const options = createRequestOption(req);
-        let copy = ExerciseService.convertExerciseDatesFromClient(textExercise);
-        copy = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        const dto = toUpdateTextExerciseDTO(textExercise);
         return this.http
-            .put<TextExercise>(this.resourceUrl, copy, { params: options, observe: 'response' })
+            .put<TextExercise>(this.resourceUrl, dto, { params: options, observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.exerciseService.processExerciseEntityResponse(res)));
     }
 

--- a/src/main/webapp/app/text/manage/text-exercise/service/update-text-exercise-dto.model.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/service/update-text-exercise-dto.model.ts
@@ -1,0 +1,123 @@
+import dayjs from 'dayjs/esm';
+import { AssessmentType } from 'app/assessment/shared/entities/assessment-type.model';
+import { DifficultyLevel, ExerciseMode, IncludedInOverallScore } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { TextExercise } from 'app/text/shared/entities/text-exercise.model';
+import { ExerciseService } from 'app/exercise/services/exercise.service';
+import { convertDateFromClient } from 'app/shared/util/date.utils';
+
+/**
+ * DTO for competency reference (just the ID)
+ */
+export interface CompetencyDTO {
+    id: number;
+}
+
+/**
+ * DTO for competency links with weight
+ */
+export interface CompetencyLinkDTO {
+    competency: CompetencyDTO;
+    weight: number;
+}
+
+/**
+ * DTO for updating text exercises.
+ * Matches the server-side UpdateTextExerciseDTO record structure.
+ * Uses IDs instead of entity objects to avoid Hibernate detached entity issues.
+ */
+export interface UpdateTextExerciseDTO {
+    // Base exercise fields
+    id?: number;
+    title?: string;
+    shortName?: string;
+    maxPoints: number;
+    bonusPoints?: number;
+    assessmentType?: AssessmentType;
+    releaseDate?: dayjs.Dayjs | string | null;
+    startDate?: dayjs.Dayjs | string | null;
+    dueDate?: dayjs.Dayjs | string | null;
+    assessmentDueDate?: dayjs.Dayjs | string | null;
+    exampleSolutionPublicationDate?: dayjs.Dayjs | string | null;
+    difficulty?: DifficultyLevel;
+    mode?: ExerciseMode;
+
+    // Exercise fields
+    includedInOverallScore?: IncludedInOverallScore;
+    problemStatement?: string;
+    gradingInstructions?: string;
+    categories?: string[];
+    presentationScoreEnabled?: boolean;
+    secondCorrectionEnabled?: boolean;
+    feedbackSuggestionModule?: string;
+    allowComplaintsForAutomaticAssessments?: boolean;
+    allowFeedbackRequests?: boolean;
+    channelName?: string;
+
+    // Competency links as DTOs
+    competencyLinks?: CompetencyLinkDTO[];
+
+    // Course/ExerciseGroup references (by ID)
+    courseId?: number;
+    exerciseGroupId?: number;
+
+    // TextExercise specific fields
+    exampleSolution?: string;
+}
+
+/**
+ * Converts a TextExercise entity to an UpdateTextExerciseDTO.
+ * This ensures the correct data structure is sent to the server,
+ * with courseId and exerciseGroupId as IDs instead of full objects.
+ *
+ * @param textExercise the text exercise to convert
+ * @returns the corresponding DTO
+ */
+export function toUpdateTextExerciseDTO(textExercise: TextExercise): UpdateTextExerciseDTO {
+    // Apply bonus points constraint (modifies in place and returns the same object)
+    ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(textExercise);
+
+    // Convert competency links to DTOs (just competency ID and weight)
+    const competencyLinkDTOs: CompetencyLinkDTO[] | undefined = textExercise.competencyLinks?.map((link) => ({
+        competency: { id: link.competency!.id! },
+        weight: link.weight,
+    }));
+
+    // Determine courseId and exerciseGroupId - only one should be set (mutually exclusive)
+    // For course exercises: set courseId, leave exerciseGroupId undefined
+    // For exam exercises: set exerciseGroupId, leave courseId undefined
+    const exerciseGroupId = textExercise.exerciseGroup?.id;
+    const courseId = exerciseGroupId ? undefined : textExercise.course?.id;
+
+    // Convert categories to JSON strings
+    const categories = ExerciseService.stringifyExerciseDTOCategories(textExercise);
+
+    return {
+        id: textExercise.id,
+        title: textExercise.title,
+        shortName: textExercise.shortName,
+        maxPoints: textExercise.maxPoints!,
+        bonusPoints: textExercise.bonusPoints,
+        assessmentType: textExercise.assessmentType,
+        releaseDate: convertDateFromClient(textExercise.releaseDate),
+        startDate: convertDateFromClient(textExercise.startDate),
+        dueDate: convertDateFromClient(textExercise.dueDate),
+        assessmentDueDate: convertDateFromClient(textExercise.assessmentDueDate),
+        exampleSolutionPublicationDate: convertDateFromClient(textExercise.exampleSolutionPublicationDate),
+        difficulty: textExercise.difficulty,
+        mode: textExercise.mode,
+        includedInOverallScore: textExercise.includedInOverallScore,
+        problemStatement: textExercise.problemStatement,
+        gradingInstructions: textExercise.gradingInstructions,
+        categories,
+        presentationScoreEnabled: textExercise.presentationScoreEnabled,
+        secondCorrectionEnabled: textExercise.secondCorrectionEnabled,
+        feedbackSuggestionModule: textExercise.feedbackSuggestionModule,
+        allowComplaintsForAutomaticAssessments: textExercise.allowComplaintsForAutomaticAssessments,
+        allowFeedbackRequests: textExercise.allowFeedbackRequests,
+        channelName: textExercise.channelName,
+        competencyLinks: competencyLinkDTOs,
+        courseId,
+        exerciseGroupId,
+        exampleSolution: textExercise.exampleSolution,
+    };
+}

--- a/src/main/webapp/app/tutorialgroup/shared/service/tutorial-groups-configuration.service.ts
+++ b/src/main/webapp/app/tutorialgroup/shared/service/tutorial-groups-configuration.service.ts
@@ -7,6 +7,17 @@ import { TutorialGroupConfigurationDTO } from 'app/tutorialgroup/shared/entities
 
 type DtoResponseType = HttpResponse<TutorialGroupConfigurationDTO>;
 
+/**
+ * DTO for creating and updating tutorial groups configuration.
+ */
+export interface TutorialGroupsConfigurationDTO {
+    id?: number;
+    tutorialPeriodStartInclusive: string;
+    tutorialPeriodEndInclusive: string;
+    useTutorialGroupChannels: boolean;
+    usePublicTutorialGroupChannels: boolean;
+}
+
 @Injectable({ providedIn: 'root' })
 export class TutorialGroupsConfigurationService {
     private httpClient = inject(HttpClient);

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/GradingScaleIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/GradingScaleIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.cit.aet.artemis.assessment.domain.GradeStep;
 import de.tum.cit.aet.artemis.assessment.domain.GradeType;
 import de.tum.cit.aet.artemis.assessment.domain.GradingScale;
+import de.tum.cit.aet.artemis.assessment.dto.GradingScaleUpdateDTO;
 import de.tum.cit.aet.artemis.assessment.repository.GradingScaleRepository;
 import de.tum.cit.aet.artemis.assessment.util.GradingScaleUtilService;
 import de.tum.cit.aet.artemis.core.domain.Course;
@@ -76,6 +78,13 @@ class GradingScaleIntegrationTest extends AbstractSpringIntegrationIndependentTe
         gradeSteps = new HashSet<>();
         courseGradingScale.setGradeSteps(gradeSteps);
         examGradingScale.setGradeSteps(gradeSteps);
+    }
+
+    private GradingScaleUpdateDTO toDTO(GradingScale gradingScale, Integer coursePresentationScore) {
+        Set<GradingScaleUpdateDTO.GradeStepDTO> gradeStepDTOs = gradingScale.getGradeSteps().stream().map(gs -> new GradingScaleUpdateDTO.GradeStepDTO(gs.getLowerBoundPercentage(),
+                gs.isLowerBoundInclusive(), gs.getUpperBoundPercentage(), gs.isUpperBoundInclusive(), gs.getGradeName(), gs.getIsPassingGrade())).collect(Collectors.toSet());
+        return new GradingScaleUpdateDTO(gradingScale.getGradeType(), gradingScale.getBonusStrategy(), gradingScale.getPlagiarismGrade(), gradingScale.getNoParticipationGrade(),
+                gradingScale.getPresentationsNumber(), gradingScale.getPresentationsWeight(), gradeStepDTOs, null, coursePresentationScore, null);
     }
 
     /**
@@ -190,16 +199,16 @@ class GradingScaleIntegrationTest extends AbstractSpringIntegrationIndependentTe
         courseGradingScale.setGradeSteps(gradeSteps);
 
         // The presentationsNumber and presentationsWeight must be null.
-        course.setPresentationScore(2);
         courseGradingScale.setPresentationsNumber(1);
         courseGradingScale.setPresentationsWeight(20.0);
-        request.post("/api/assessment/courses/" + course.getId() + "/grading-scale", courseGradingScale, HttpStatus.BAD_REQUEST);
+        GradingScaleUpdateDTO dto1 = toDTO(courseGradingScale, 2);
+        request.post("/api/assessment/courses/" + course.getId() + "/grading-scale", dto1, HttpStatus.BAD_REQUEST);
         courseGradingScale.setPresentationsNumber(null);
         courseGradingScale.setPresentationsWeight(null);
 
         // The presentationScore must be above 0.
-        course.setPresentationScore(-1);
-        request.post("/api/assessment/courses/" + course.getId() + "/grading-scale", courseGradingScale, HttpStatus.BAD_REQUEST);
+        GradingScaleUpdateDTO dto2 = toDTO(courseGradingScale, -1);
+        request.post("/api/assessment/courses/" + course.getId() + "/grading-scale", dto2, HttpStatus.BAD_REQUEST);
     }
 
     /**
@@ -232,15 +241,14 @@ class GradingScaleIntegrationTest extends AbstractSpringIntegrationIndependentTe
     void testSaveGradingScaleForCourseWithChangedPresentationScore() throws Exception {
         gradeSteps = gradingScaleUtilService.generateGradeStepSet(courseGradingScale, true);
         courseGradingScale.setGradeSteps(gradeSteps);
-        course.setPresentationScore(5);
 
-        GradingScale savedGradingScale = request.postWithResponseBody("/api/assessment/courses/" + course.getId() + "/grading-scale", courseGradingScale, GradingScale.class,
-                HttpStatus.CREATED);
+        GradingScaleUpdateDTO dto = toDTO(courseGradingScale, 5);
+
+        GradingScale savedGradingScale = request.postWithResponseBody("/api/assessment/courses/" + course.getId() + "/grading-scale", dto, GradingScale.class, HttpStatus.CREATED);
 
         assertThat(savedGradingScale.getGradeSteps()).hasSameSizeAs(courseGradingScale.getGradeSteps());
         assertThat(savedGradingScale.getGradeSteps()).allMatch(gradeStep -> isGradeStepInSet(courseGradingScale.getGradeSteps(), gradeStep));
         assertThat(savedGradingScale.getCourse().getPresentationScore()).isEqualTo(5);
-        assertThat(savedGradingScale).usingRecursiveComparison().ignoringFields("id", "exam", "course", "gradeSteps").ignoringCollectionOrder().isEqualTo(courseGradingScale);
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/ResultListenerIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/ResultListenerIntegrationTest.java
@@ -115,7 +115,7 @@ class ResultListenerIntegrationTest extends AbstractSpringIntegrationLocalCILoca
         exercise.setMaxPoints(100.0);
         exercise.setBonusPoints(100.0);
         userUtilService.changeUser(TEST_PREFIX + "instructor1");
-        request.put("/api/text/text-exercises", exercise, HttpStatus.OK);
+        request.put("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of((TextExercise) exercise), HttpStatus.OK);
 
         participantScoreScheduleService.executeScheduledTasks();
         await().atMost(60, TimeUnit.SECONDS).until(() -> participantScoreScheduleService.isIdle());

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/architecture/AssessmentEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/architecture/AssessmentEntityUsageArchitectureTest.java
@@ -24,7 +24,7 @@ class AssessmentEntityUsageArchitectureTest extends AbstractModuleEntityUsageArc
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getMaxEntityInputViolations() {
-        return 10;
+        return 6;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs

--- a/src/test/java/de/tum/cit/aet/artemis/athena/AthenaExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/athena/AthenaExerciseIntegrationTest.java
@@ -109,7 +109,8 @@ class AthenaExerciseIntegrationTest extends AbstractAthenaTest {
 
         textExercise.setFeedbackSuggestionModule(ATHENA_RESTRICTED_MODULE_TEXT_TEST);
 
-        TextExercise updatedExercise = request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.OK);
+        TextExercise updatedExercise = request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise),
+                TextExercise.class, HttpStatus.OK);
 
         // Wait for async Weaviate upsert operation to complete to prevent race conditions
         assertExerciseExistsInWeaviate(weaviateService, updatedExercise);
@@ -120,7 +121,7 @@ class AthenaExerciseIntegrationTest extends AbstractAthenaTest {
     void testUpdateTextExercise_useRestrictedAthenaModule_badRequest() throws Exception {
         textExercise.setFeedbackSuggestionModule(ATHENA_RESTRICTED_MODULE_TEXT_TEST);
 
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -131,7 +132,7 @@ class AthenaExerciseIntegrationTest extends AbstractAthenaTest {
 
         textExercise.setFeedbackSuggestionModule(ATHENA_MODULE_TEXT_TEST);
 
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/communication/architecture/CommunicationEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/architecture/CommunicationEntityUsageArchitectureTest.java
@@ -21,10 +21,10 @@ class CommunicationEntityUsageArchitectureTest extends AbstractModuleEntityUsage
         return 14;
     }
 
-    // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
+    // This module is already compliant for input violations
     @Override
     protected int getMaxEntityInputViolations() {
-        return 2;
+        return 0;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs

--- a/src/test/java/de/tum/cit/aet/artemis/core/architecture/CoreEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/architecture/CoreEntityUsageArchitectureTest.java
@@ -24,7 +24,7 @@ class CoreEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitect
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getMaxEntityInputViolations() {
-        return 3;
+        return 2;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs

--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExamIntegrationTest.java
@@ -65,10 +65,12 @@ import de.tum.cit.aet.artemis.exam.domain.ExerciseGroup;
 import de.tum.cit.aet.artemis.exam.domain.StudentExam;
 import de.tum.cit.aet.artemis.exam.domain.SuspiciousSessionReason;
 import de.tum.cit.aet.artemis.exam.dto.ExamChecklistDTO;
+import de.tum.cit.aet.artemis.exam.dto.ExamImportDTO;
 import de.tum.cit.aet.artemis.exam.dto.ExamInformationDTO;
 import de.tum.cit.aet.artemis.exam.dto.ExamScoresDTO;
 import de.tum.cit.aet.artemis.exam.dto.ExamSessionDTO;
 import de.tum.cit.aet.artemis.exam.dto.ExamSidebarDataDTO;
+import de.tum.cit.aet.artemis.exam.dto.ExamUpdateDTO;
 import de.tum.cit.aet.artemis.exam.dto.ExamWithIdAndCourseDTO;
 import de.tum.cit.aet.artemis.exam.dto.SuspiciousExamSessionsDTO;
 import de.tum.cit.aet.artemis.exam.repository.ExamUserRepository;
@@ -387,8 +389,8 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
 
     private void testAllPreAuthorize(Course course, Exam exam) throws Exception {
         Exam newExam = ExamFactory.generateExam(course1);
-        request.post("/api/exam/courses/" + course.getId() + "/exams", newExam, HttpStatus.FORBIDDEN);
-        request.put("/api/exam/courses/" + course.getId() + "/exams", newExam, HttpStatus.FORBIDDEN);
+        request.post("/api/exam/courses/" + course.getId() + "/exams", ExamUpdateDTO.of(newExam), HttpStatus.FORBIDDEN);
+        request.put("/api/exam/courses/" + course.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.FORBIDDEN);
         request.get("/api/exam/courses/" + course.getId() + "/exams/" + exam.getId(), HttpStatus.FORBIDDEN, Exam.class);
         request.delete("/api/exam/courses/" + course.getId() + "/exams/" + exam.getId(), HttpStatus.FORBIDDEN);
         request.delete("/api/exam/courses/" + course.getId() + "/exams/" + exam.getId() + "/reset", HttpStatus.FORBIDDEN);
@@ -424,7 +426,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     void testCreateExam_checkCourseAccess_instructorNotInCourse_failsWithForbidden() throws Exception {
         Exam exam = ExamFactory.generateExam(course1);
 
-        request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.FORBIDDEN);
+        request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -433,7 +435,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         Exam exam = ExamFactory.generateExam(course1, "examE");
         exam.setTitle("          Exam 123              ");
 
-        URI savedExamUri = request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.CREATED);
+        URI savedExamUri = request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.CREATED);
         Exam savedExam = request.get(String.valueOf(savedExamUri), HttpStatus.OK, Exam.class);
 
         assertThat(savedExam.getTitle()).isEqualTo("Exam 123");
@@ -444,13 +446,11 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testCreateExam_asInstructor_returnsBody() throws Exception {
         final Exam exam = validExamWithCustomFieldValues();
-        exam.setQuizExamMaxPoints(40);  // this is only returned by the POST endpoint (createExam),
-        // not the GET endpoint (getExam), because it's an unfinished feature
 
-        final Exam savedExam = request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exams", exam, Exam.class, HttpStatus.CREATED);
+        final Exam savedExam = request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), Exam.class, HttpStatus.CREATED);
 
         checkCustomFieldValuesExamsAreEffectivelyEqual(savedExam, exam);
-        assertThat(savedExam.getQuizExamMaxPoints()).isEqualTo(exam.getQuizExamMaxPoints());
+        // quizExamMaxPoints is a computed field not included in the DTO, so we don't assert it here
     }
 
     @Test
@@ -459,7 +459,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         Course course = courseUtilService.createCourseWithMessagingEnabled();
         Exam exam = ExamFactory.generateExam(course, "examG");
 
-        Exam savedExam = request.postWithResponseBody("/api/exam/courses/" + course.getId() + "/exams", exam, Exam.class, HttpStatus.CREATED);
+        Exam savedExam = request.postWithResponseBody("/api/exam/courses/" + course.getId() + "/exams", ExamUpdateDTO.of(exam), Exam.class, HttpStatus.CREATED);
 
         Channel channelFromDB = channelRepository.findChannelByExamId(savedExam.getId());
         assertThat(channelFromDB).isNotNull();
@@ -473,16 +473,19 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
 
         examA.setId(55L);
 
-        request.post("/api/exam/courses/" + course1.getId() + "/exams", examA, HttpStatus.BAD_REQUEST);
+        request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(examA), HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testCreateExam_failsWithCourseIdMismatch() throws Exception {
-        // Test for bad request when course id deviates from course specified in route.
+    void testCreateExam_usesCourseFromPath() throws Exception {
+        // With the DTO approach, the course is always taken from the path, not from the exam.
+        // So creating an exam with a different course in the DTO should work,
+        // and the exam should be associated with the course from the path.
         Exam examC = ExamFactory.generateExam(course1, "examC");
 
-        request.post("/api/exam/courses/" + course2.getId() + "/exams", examC, HttpStatus.BAD_REQUEST);
+        Exam savedExam = request.postWithResponseBody("/api/exam/courses/" + course2.getId() + "/exams", ExamUpdateDTO.of(examC), Exam.class, HttpStatus.CREATED);
+        assertThat(savedExam.getCourse().getId()).isEqualTo(course2.getId());
     }
 
     private List<Exam> provideExamsWithInvalidDates() {
@@ -514,18 +517,21 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     @MethodSource("provideExamsWithInvalidDates")
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testCreateExam_failsWithInvalidDates(Exam exam) throws Exception {
-        request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.BAD_REQUEST);
+        request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testCreateExam_failsWithExerciseGroups() throws Exception {
-        // Test for conflict when user tries to create an exam with exercise groups.
+        // Note: With DTO approach, exercise groups are not passed, so this test now expects CREATED
+        // since the conflict check happens after the exam is created from DTO
         Exam examD = ExamFactory.generateExam(course1, "examD");
 
         examD.addExerciseGroup(ExamFactory.generateExerciseGroup(true, exam1));
 
-        request.post("/api/exam/courses/" + course1.getId() + "/exams", examD, HttpStatus.CONFLICT);
+        // Exercise groups are not included in ExamUpdateDTO, so this won't cause a conflict
+        // The exam will be created without exercise groups
+        request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(examD), HttpStatus.CREATED);
     }
 
     @Test
@@ -535,8 +541,9 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
 
         examB.setCourse(null);
 
-        // Test for bad request when course is null.
-        request.post("/api/exam/courses/" + course1.getId() + "/exams", examB, HttpStatus.BAD_REQUEST);
+        // Test for bad request when course is null - now the course comes from the path variable, not the DTO
+        // so this test should now succeed since the course is taken from the path
+        request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(examB), HttpStatus.CREATED);
     }
 
     @Test
@@ -545,7 +552,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         Exam exam = ExamFactory.generateExam(course1, "examMaxPointsTest");
         exam.setExamMaxPoints(10000); // Max allowed is 9999
 
-        request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.BAD_REQUEST);
+        request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -554,7 +561,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         Exam exam = ExamFactory.generateExam(course1, "examGracePeriodTest");
         exam.setGracePeriod(3601); // Max allowed is 3600 seconds
 
-        request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.BAD_REQUEST);
+        request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -563,7 +570,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         Exam exam = ExamFactory.generateExam(course1, "examNumberOfExercisesTest");
         exam.setNumberOfExercisesInExam(101); // Max allowed is 100
 
-        request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.BAD_REQUEST);
+        request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -575,7 +582,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         exam.setNumberOfCorrectionRoundsInExam(0);
         exam.setWorkingTime(2592001); // Max allowed is 2592000 seconds (30 days)
 
-        request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.BAD_REQUEST);
+        request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -583,7 +590,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     void testUpdateExam_failsWithExamMaxPointsTooHigh() throws Exception {
         exam1.setExamMaxPoints(10000); // Max allowed is 9999
 
-        request.put("/api/exam/courses/" + course1.getId() + "/exams", exam1, HttpStatus.BAD_REQUEST);
+        request.put("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam1), HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -591,7 +598,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     void testUpdateExam_failsWithGracePeriodTooHigh() throws Exception {
         exam1.setGracePeriod(3601); // Max allowed is 3600 seconds
 
-        request.put("/api/exam/courses/" + course1.getId() + "/exams", exam1, HttpStatus.BAD_REQUEST);
+        request.put("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam1), HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -599,54 +606,44 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     void testUpdateExam_failsWithNumberOfExercisesTooHigh() throws Exception {
         exam1.setNumberOfExercisesInExam(101); // Max allowed is 100
 
-        request.put("/api/exam/courses/" + course1.getId() + "/exams", exam1, HttpStatus.BAD_REQUEST);
+        request.put("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam1), HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testUpdateExam_failsWithWorkingTimeTooHigh() throws Exception {
-        // Test with a test exam where workingTime is directly validated
-        exam1.setTestExam(true);
-        exam1.setNumberOfCorrectionRoundsInExam(0);
-        exam1.setWorkingTime(2592001); // Max allowed is 2592000 seconds (30 days)
+        // Create a test exam since testExam mode cannot be changed after creation
+        Exam testExam = ExamFactory.generateTestExam(course1);
+        testExam = examRepository.save(testExam);
+        testExam.setWorkingTime(2592001); // Max allowed is 2592000 seconds (30 days)
 
-        request.put("/api/exam/courses/" + course1.getId() + "/exams", exam1, HttpStatus.BAD_REQUEST);
+        request.put("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(testExam), HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testUpdateExam_createsExamWithoutId() throws Exception {
-        // Create instead of update if no id was set
+    void testUpdateExam_failsWithoutId() throws Exception {
+        // Update requires an ID - use entity without ID to simulate missing ID case
         Exam exam = ExamFactory.generateExam(course1, "exam1");
         exam.setTitle("Over 9000!");
-        long examCountBefore = examRepository.count();
-        Exam createdExam = request.putWithResponseBody("/api/exam/courses/" + course1.getId() + "/exams", exam, Exam.class, HttpStatus.CREATED);
-
-        assertThat(exam.getEndDate()).isEqualTo(createdExam.getEndDate());
-        assertThat(exam.getStartDate()).isEqualTo(createdExam.getStartDate());
-        assertThat(exam.getVisibleDate()).isEqualTo(createdExam.getVisibleDate());
-        // Note: ZonedDateTime has problems with comparison due to time zone differences for values saved in the database and values not saved in the database
-        assertThat(exam).usingRecursiveComparison().ignoringFields("id", "course", "endDate", "startDate", "visibleDate").isEqualTo(createdExam);
-        assertThat(examCountBefore + 1).isEqualTo(examRepository.count());
+        // Exam without ID should fail
+        request.put("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testUpdateExam_failsWithoutCourse() throws Exception {
-        // No course is set -> bad request
+    void testUpdateExam_failsWithExamNotFound() throws Exception {
+        // Exam with non-existent ID -> not found
         Exam exam = ExamFactory.generateExam(course1);
-        exam.setId(1L);
-        exam.setCourse(null);
-        request.put("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.BAD_REQUEST);
+        exam.setId(999999L);
+        request.put("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.NOT_FOUND);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testUpdateExam_failsWithExamIdMismatch() throws Exception {
-        // Course id in the updated exam and in the REST resource url do not match -> bad request
-        Exam exam = ExamFactory.generateExam(course1);
-        exam.setId(1L);
-        request.put("/api/exam/courses/" + course2.getId() + "/exams", exam, HttpStatus.BAD_REQUEST);
+    void testUpdateExam_failsWithExamCourseMismatch() throws Exception {
+        // Exam belongs to course1 but URL has course2 -> conflict (course id mismatch)
+        request.put("/api/exam/courses/" + course2.getId() + "/exams", ExamUpdateDTO.of(exam1), HttpStatus.CONFLICT);
     }
 
     @ParameterizedTest
@@ -654,8 +651,9 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testUpdateExam_failsForInvalidDates(Exam exam) throws Exception {
         // Dates in the updated exam are not valid -> bad request
-        exam.setId(1L);
-        request.put("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.BAD_REQUEST);
+        // Use exam1's ID since validation happens after fetching
+        exam.setId(exam1.getId());
+        request.put("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -663,8 +661,8 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     void testUpdateExam_updatesExamTitle() throws Exception {
         // Update the exam -> ok
         exam1.setTitle("Best exam ever");
-        var returnedExam = request.putWithResponseBody("/api/exam/courses/" + course1.getId() + "/exams", exam1, Exam.class, HttpStatus.OK);
-        assertThat(returnedExam).isEqualTo(exam1);
+        var returnedExam = request.putWithResponseBody("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam1), Exam.class, HttpStatus.OK);
+        assertThat(returnedExam.getTitle()).isEqualTo(exam1.getTitle());
     }
 
     @Test
@@ -673,7 +671,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         StudentExam studentExam = examUtilService.addStudentExam(exam1);
         exam1.setTitle("Best exam ever");
 
-        request.put("/api/exam/courses/" + course1.getId() + "/exams", exam1, HttpStatus.OK);
+        request.put("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam1), HttpStatus.OK);
 
         assertThat(examLiveEventRepository.findAllByStudentExamId(studentExam.getId())).isEmpty();
     }
@@ -684,7 +682,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         StudentExam studentExam = examUtilService.addStudentExam(exam1);
         exam1.setEndDate(exam1.getEndDate().plusNanos(1));
 
-        request.put("/api/exam/courses/" + course1.getId() + "/exams", exam1, HttpStatus.OK);
+        request.put("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam1), HttpStatus.OK);
 
         assertThat(examLiveEventRepository.findAllByStudentExamId(studentExam.getId())).isEmpty();
     }
@@ -695,7 +693,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         StudentExam studentExam = examUtilService.addStudentExam(exam1);
         exam1.setEndDate(exam1.getEndDate().plusHours(1));
 
-        request.put("/api/exam/courses/" + course1.getId() + "/exams", exam1, HttpStatus.OK);
+        request.put("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam1), HttpStatus.OK);
 
         assertThat(examLiveEventRepository.findAllByStudentExamId(studentExam.getId())).isNotEmpty();
     }
@@ -711,7 +709,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         examWithModelingEx.setPublishResultsDate(now().minusHours(2));
         examWithModelingEx.setExampleSolutionPublicationDate(now().minusHours(1));
 
-        request.put("/api/exam/courses/" + examWithModelingEx.getCourse().getId() + "/exams", examWithModelingEx, HttpStatus.OK);
+        request.put("/api/exam/courses/" + examWithModelingEx.getCourse().getId() + "/exams", ExamUpdateDTO.of(examWithModelingEx), HttpStatus.OK);
 
         Exam fetchedExam = examRepository.findWithExerciseGroupsAndExercisesByIdOrElseThrow(examWithModelingEx.getId());
         Exercise exercise = fetchedExam.getExerciseGroups().getFirst().getExercises().stream().findFirst().orElseThrow();
@@ -740,7 +738,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         ZonedDateTime newEndDate = now().minusHours(6);
         examUtilService.setVisibleStartAndEndDateOfExam(exam, newVisibleDate, newStartDate, newEndDate);
 
-        request.put("/api/exam/courses/" + exam.getCourse().getId() + "/exams", exam, HttpStatus.OK);
+        request.put("/api/exam/courses/" + exam.getCourse().getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.OK);
 
         Exam fetchedExam = examRepository.findWithExerciseGroupsAndExercisesByIdOrElseThrow(exam.getId());
         WeaviateTestUtil.assertExerciseExamDatesInWeaviate(weaviateService, modelingExercise.getId(), fetchedExam);
@@ -1172,7 +1170,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     void testCourseAndExamAccessForInstructors_notInstructorInCourse_forbidden() throws Exception {
         // Instructor10 is not instructor for the course
         // Update exam
-        request.put("/api/exam/courses/" + course1.getId() + "/exams", exam1, HttpStatus.FORBIDDEN);
+        request.put("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam1), HttpStatus.FORBIDDEN);
         // Get exam
         request.get("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId(), HttpStatus.FORBIDDEN, Exam.class);
         // Add student to exam
@@ -1504,7 +1502,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     void testCreateAndGetExam_asInstructor_returnsBody() throws Exception {
         Exam exam = validExamWithCustomFieldValues();
 
-        final URI createdExamURI = request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.CREATED);
+        final URI createdExamURI = request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.CREATED);
 
         /// GETS the "/api/exam/courses/{course-id}/exams/{exam-id}" endpoint
         final Exam receivedExam = request.get(String.valueOf(createdExamURI), HttpStatus.OK, Exam.class);
@@ -1518,7 +1516,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         final var examinerName = "Prof. Dr. Stephan Krusche";
         Exam exam = ExamFactory.generateExam(course1);
         exam.setExaminer(examinerName);
-        final URI receivedExamURI = request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.CREATED);
+        final URI receivedExamURI = request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.CREATED);
 
         /// GETS the "/api/exam/courses/{course-id}/exams/{exam-id}" endpoint
         final Exam requestedExam = request.get(String.valueOf(receivedExamURI), HttpStatus.OK, Exam.class);
@@ -1566,7 +1564,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         final Exam exam = isTestExam ? ExamFactory.generateTestExam(course1) : ExamFactory.generateExam(course1);
         exam.setNumberOfCorrectionRoundsInExam(plannedCorrectionRounds);
         assertThat(exam.getNumberOfCorrectionRoundsInExam()).isEqualTo(actualCorrectionRounds);
-        final URI receivedExamURI = request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, expectedStatus);
+        final URI receivedExamURI = request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), expectedStatus);
 
         if (expectedStatus == HttpStatus.CREATED) {
             /// GETS the "/api/exam/courses/{course-id}/exams/{exam-id}" endpoint
@@ -1580,7 +1578,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     void testGetCourseNameNullName() throws Exception {
         final Exam exam = ExamFactory.generateExam(course1);
         exam.setCourseName(null);
-        final URI receivedExamURI = request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.CREATED);
+        final URI receivedExamURI = request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.CREATED);
 
         /// GETS the "/api/exam/courses/{course-id}/exams/{exam-id}" endpoint
         Exam receivedExam = request.get(String.valueOf(receivedExamURI), HttpStatus.OK, Exam.class);
@@ -1594,7 +1592,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         final Exam exam = ExamFactory.generateExam(course1);
         exam.setVisibleDate(ZonedDateTime.now().minusSeconds(beforeSeconds));
 
-        final URI receivedExamURI = request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.CREATED);
+        final URI receivedExamURI = request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.CREATED);
 
         /// GETS the "/api/exam/courses/{course-id}/exams/{exam-id}" endpoint
         final Exam receivedExam = request.get(String.valueOf(receivedExamURI), HttpStatus.OK, Exam.class);
@@ -1615,7 +1613,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         exam.setEndDate(visibleDate.plusMinutes(5).plusSeconds(workingTimeSeconds));
         exam.setWorkingTime(workingTimeSeconds);
 
-        final URI receivedExamURI = request.post("/api/exam/courses/" + course1.getId() + "/exams", exam, HttpStatus.CREATED);
+        final URI receivedExamURI = request.post("/api/exam/courses/" + course1.getId() + "/exams", ExamUpdateDTO.of(exam), HttpStatus.CREATED);
 
         /// GETS the "/api/exam/courses/{course-id}/exams/{exam-id}" endpoint
         final Exam receivedExam = request.get(String.valueOf(receivedExamURI), HttpStatus.OK, Exam.class);
@@ -1894,37 +1892,13 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testImportExamWithExercises_asStudent_failsWithForbidden() throws Exception {
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", exam1, HttpStatus.FORBIDDEN, null);
+        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", ExamImportDTO.of(exam1, course1.getId()), HttpStatus.FORBIDDEN, null);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TUTOR")
     void testImportExamWithExercises_asTutor_failsWithForbidden() throws Exception {
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", exam1, HttpStatus.FORBIDDEN, null);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testImportExamWithExercises_failsWithIdExists() throws Exception {
-        final Exam exam = ExamFactory.generateExam(course1);
-
-        exam.setId(2L);
-
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", exam, HttpStatus.BAD_REQUEST, null);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testImportExamWithExercises_failsWithCourseMismatch() throws Exception {
-        // No Course
-        final Exam examA = ExamFactory.generateExam(course1);
-        examA.setCourse(null);
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", examA, HttpStatus.BAD_REQUEST, null);
-
-        // Exam Course and REST-Course mismatch
-        final Exam examB = ExamFactory.generateExam(course1);
-        examB.setCourse(course2);
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", examB, HttpStatus.BAD_REQUEST, null);
+        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", ExamImportDTO.of(exam1, course1.getId()), HttpStatus.FORBIDDEN, null);
     }
 
     @Test
@@ -1933,22 +1907,12 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         // Visible Date after Started Date
         final Exam examA = ExamFactory.generateExam(course1);
         examA.setVisibleDate(ZonedDateTime.now().plusHours(2));
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", examA, HttpStatus.BAD_REQUEST, null);
-
-        // Visible Date missing
-        final Exam examB = ExamFactory.generateExam(course1);
-        examB.setVisibleDate(null);
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", examB, HttpStatus.BAD_REQUEST, null);
+        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", ExamImportDTO.of(examA, course1.getId()), HttpStatus.BAD_REQUEST, null);
 
         // Started Date after End Date
         final Exam examC = ExamFactory.generateExam(course1);
         examC.setStartDate(ZonedDateTime.now().plusHours(2));
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", examC, HttpStatus.BAD_REQUEST, null);
-
-        // Started Date missing
-        final Exam examD = ExamFactory.generateExam(course1);
-        examD.setStartDate(null);
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", examD, HttpStatus.BAD_REQUEST, null);
+        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", ExamImportDTO.of(examC, course1.getId()), HttpStatus.BAD_REQUEST, null);
     }
 
     @Test
@@ -1957,12 +1921,12 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         // Working Time larger than Working window
         final Exam examA = ExamFactory.generateTestExam(course1);
         examA.setWorkingTime(3 * 60 * 60);
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", examA, HttpStatus.BAD_REQUEST, null);
+        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", ExamImportDTO.of(examA, course1.getId()), HttpStatus.BAD_REQUEST, null);
 
         // Working Time larger than Working window
         final Exam examB = ExamFactory.generateTestExam(course1);
         examB.setWorkingTime(0);
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", examB, HttpStatus.BAD_REQUEST, null);
+        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", ExamImportDTO.of(examB, course1.getId()), HttpStatus.BAD_REQUEST, null);
     }
 
     @Test
@@ -1970,7 +1934,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     void testImportExamWithExercises_failsWithPointConflict() throws Exception {
         final Exam examA = ExamFactory.generateExam(course1);
         examA.setExamMaxPoints(-5);
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", examA, HttpStatus.BAD_REQUEST, null);
+        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", ExamImportDTO.of(examA, course1.getId()), HttpStatus.BAD_REQUEST, null);
     }
 
     @Test
@@ -1979,27 +1943,27 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         // Correction round <= 0
         final Exam examA = ExamFactory.generateExam(course1);
         examA.setNumberOfCorrectionRoundsInExam(0);
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", examA, HttpStatus.BAD_REQUEST, null);
+        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", ExamImportDTO.of(examA, course1.getId()), HttpStatus.BAD_REQUEST, null);
 
         // Correction round >= 2
         final Exam examB = ExamFactory.generateExam(course1);
         examB.setNumberOfCorrectionRoundsInExam(3);
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", examB, HttpStatus.BAD_REQUEST, null);
+        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", ExamImportDTO.of(examB, course1.getId()), HttpStatus.BAD_REQUEST, null);
 
         // Correction round != 0 for test exam
         final Exam examC = ExamFactory.generateTestExam(course1);
         examC.setNumberOfCorrectionRoundsInExam(1);
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", examC, HttpStatus.BAD_REQUEST, null);
+        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exam-import", ExamImportDTO.of(examC, course1.getId()), HttpStatus.BAD_REQUEST, null);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testImportExamWithExercises_successfulWithoutExercises() throws Exception {
         Exam exam = examUtilService.addExam(course1);
-        exam.setId(null);
 
         exam.setChannelName("channelname-imported");
-        final Exam received = request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exam-import", exam, Exam.class, HttpStatus.CREATED);
+        ExamImportDTO importDTO = ExamImportDTO.of(exam, course1.getId());
+        final Exam received = request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exam-import", importDTO, Exam.class, HttpStatus.CREATED);
         assertThat(received.getId()).isNotNull();
         assertThat(received.getTitle()).isEqualTo(exam.getTitle());
         assertThat(received.isTestExam()).isFalse();
@@ -2029,9 +1993,9 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testImportExamWithExercises_successfulWithExercises() throws Exception {
         Exam exam = examUtilService.addExamWithModellingAndTextAndFileUploadAndQuizAndEmptyGroup(course1);
-        exam.setId(null);
         exam.setChannelName("testchannelname-imported");
-        final Exam received = request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exam-import", exam, Exam.class, CREATED);
+        ExamImportDTO importDTO2 = ExamImportDTO.of(exam, course1.getId());
+        final Exam received = request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exam-import", importDTO2, Exam.class, CREATED);
         assertThat(received.getId()).isNotNull();
         assertThat(received.getTitle()).isEqualTo(exam.getTitle());
         assertThat(received.getCourse()).isEqualTo(course1);
@@ -2059,8 +2023,8 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         quizGroup.addExercise(quiz);
         exerciseRepository.save(quiz);
 
-        exam.setId(null);
-        final Exam received = request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exam-import", exam, Exam.class, CREATED);
+        ExamImportDTO quizImportDTO = ExamImportDTO.of(exam, course1.getId());
+        final Exam received = request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exam-import", quizImportDTO, Exam.class, CREATED);
         assertThat(received.getExerciseGroups()).hasSize(1);
 
         ExerciseGroup receivedGroup = received.getExerciseGroups().getFirst();
@@ -2081,17 +2045,10 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
     void testImportExamWithExercises_successfulWithImportToOtherCourse() throws Exception {
         setupMocks();
         Exam exam = examUtilService.addExamWithModellingAndTextAndFileUploadAndQuizAndProgramming(course2);
-        exam.setCourse(course1);
-        exam.setId(null);
         exam.setChannelName("testchannelname");
 
-        // Null all exercise group and exercise IDs to force new entities
-        exam.getExerciseGroups().forEach(group -> {
-            group.setId(null);
-            group.getExercises().forEach(ex -> ex.setId(null));
-        });
-
-        final Exam received = request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exam-import", exam, Exam.class, CREATED);
+        ExamImportDTO otherCourseImportDTO = ExamImportDTO.of(exam, course1.getId());
+        final Exam received = request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exam-import", otherCourseImportDTO, Exam.class, CREATED);
         assertThat(received.getExerciseGroups()).hasSize(5);
 
         for (int i = 0; i <= 4; i++) {

--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExerciseGroupIntegrationJenkinsLocalVCTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExerciseGroupIntegrationJenkinsLocalVCTest.java
@@ -27,6 +27,7 @@ import de.tum.cit.aet.artemis.core.user.util.UserUtilService;
 import de.tum.cit.aet.artemis.core.util.CourseUtilService;
 import de.tum.cit.aet.artemis.exam.domain.Exam;
 import de.tum.cit.aet.artemis.exam.domain.ExerciseGroup;
+import de.tum.cit.aet.artemis.exam.dto.ExerciseGroupUpdateDTO;
 import de.tum.cit.aet.artemis.exam.test_repository.ExamTestRepository;
 import de.tum.cit.aet.artemis.exam.util.ExamFactory;
 import de.tum.cit.aet.artemis.exam.util.ExamUtilService;
@@ -111,7 +112,7 @@ class ExerciseGroupIntegrationJenkinsLocalVCTest extends AbstractSpringIntegrati
     private void testAllPreAuthorize() throws Exception {
         ExerciseGroup exerciseGroup = ExamFactory.generateExerciseGroup(true, exam1);
         request.post("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exercise-groups", exerciseGroup, HttpStatus.FORBIDDEN);
-        request.put("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exercise-groups", exerciseGroup, HttpStatus.FORBIDDEN);
+        request.put("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exercise-groups", ExerciseGroupUpdateDTO.of(exerciseGroup1), HttpStatus.FORBIDDEN);
         request.get("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exercise-groups/" + exerciseGroup1.getId(), HttpStatus.FORBIDDEN, ExerciseGroup.class);
         request.getList("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exercise-groups", HttpStatus.FORBIDDEN, ExerciseGroup.class);
         request.delete("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exercise-groups/" + exerciseGroup1.getId(), HttpStatus.FORBIDDEN);
@@ -140,10 +141,13 @@ class ExerciseGroupIntegrationJenkinsLocalVCTest extends AbstractSpringIntegrati
     @Test
     @WithMockUser(username = TEST_PREFIX + "editor1", roles = "EDITOR")
     void testUpdateExerciseGroup_asEditor() throws Exception {
+        // Exercise group with non-existent ID -> not found
         ExerciseGroup exerciseGroup = ExamFactory.generateExerciseGroup(true, exam1);
-        exerciseGroup.setExam(null);
-        request.put("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exercise-groups", exerciseGroup, HttpStatus.CONFLICT);
-        request.put("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exercise-groups", exerciseGroup1, HttpStatus.OK);
+        exerciseGroup.setId(999999L);
+        request.put("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exercise-groups", ExerciseGroupUpdateDTO.of(exerciseGroup), HttpStatus.NOT_FOUND);
+
+        // Valid update
+        request.put("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exercise-groups", ExerciseGroupUpdateDTO.of(exerciseGroup1), HttpStatus.OK);
         verify(examAccessService).checkCourseAndExamAndExerciseGroupAccessElseThrow(Role.EDITOR, course1.getId(), exam1.getId(), exerciseGroup1);
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/exam/architecture/ExamEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/architecture/ExamEntityUsageArchitectureTest.java
@@ -18,13 +18,13 @@ class ExamEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitect
     // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getMaxEntityReturnViolations() {
-        return 36;
+        return 35;
     }
 
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getMaxEntityInputViolations() {
-        return 9;
+        return 5;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/architecture/ExerciseEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/architecture/ExerciseEntityUsageArchitectureTest.java
@@ -18,13 +18,13 @@ class ExerciseEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchi
     // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getMaxEntityReturnViolations() {
-        return 29;
+        return 28;
     }
 
-    // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
+    // This module is already compliant for input violations
     @Override
     protected int getMaxEntityInputViolations() {
-        return 5;
+        return 0;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.verify;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -65,6 +64,8 @@ import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.ParticipationDueDateUpdateDTO;
+import de.tum.cit.aet.artemis.exercise.dto.ParticipationUpdateDTO;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
 import de.tum.cit.aet.artemis.exercise.repository.TeamRepository;
@@ -1127,8 +1128,8 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         participation.setPresentationScore(1.);
         participation = participationRepo.save(participation);
-        participation.setPresentationScore(null);
-        var actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", participation, StudentParticipation.class,
+        var dto = new ParticipationUpdateDTO(participation.getId(), textExercise.getId(), null);
+        var actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto, StudentParticipation.class,
                 HttpStatus.OK);
         assertThat(actualParticipation).as("The participation was updated").isNotNull();
         assertThat(actualParticipation.getPresentationScore()).as("Presentation score was set to null").isNull();
@@ -1137,9 +1138,13 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void updateParticipation_notStored() throws Exception {
-        var participation = ParticipationFactory.generateStudentParticipation(InitializationState.INITIALIZED, textExercise,
-                userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
-        request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", participation, StudentParticipation.class, HttpStatus.BAD_REQUEST);
+        var dto = new ParticipationUpdateDTO(-1L, textExercise.getId(), null);
+        request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto, StudentParticipation.class, HttpStatus.NOT_FOUND);
+    }
+
+    // Helper method to create a ParticipationUpdateDTO from a StudentParticipation
+    private ParticipationUpdateDTO toUpdateDTO(StudentParticipation participation) {
+        return new ParticipationUpdateDTO(participation.getId(), participation.getExercise().getId(), participation.getPresentationScore());
     }
 
     @Test
@@ -1148,8 +1153,8 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         var participation = ParticipationFactory.generateStudentParticipation(InitializationState.INITIALIZED, textExercise,
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         participation = participationRepo.save(participation);
-        participation.setPresentationScore(2.);
-        var actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", participation, StudentParticipation.class,
+        var dto = new ParticipationUpdateDTO(participation.getId(), textExercise.getId(), 2.);
+        var actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto, StudentParticipation.class,
                 HttpStatus.OK);
         assertThat(actualParticipation).as("The participation was updated").isNotNull();
         assertThat(actualParticipation.getPresentationScore()).as("Presentation score was set to 1").isEqualTo(1.);
@@ -1161,6 +1166,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void updateParticipation_gradedPresentation(double input, boolean isBadRequest) throws Exception {
         Course course = textExercise.getCourseViaExerciseGroupOrCourseMember();
         course.setPresentationScore(0);
+        courseRepository.save(course);
 
         GradingScale gradingScale = gradingScaleUtilService.generateGradingScale(2, new double[] { 0, 50, 100 }, true, 1, Optional.empty(), course, 2, 20.);
         gradingScaleService.saveGradingScale(gradingScale);
@@ -1169,15 +1175,15 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         participation = participationRepo.save(participation);
 
-        participation.setPresentationScore(input);
+        var dto = new ParticipationUpdateDTO(participation.getId(), textExercise.getId(), input);
 
         if (isBadRequest) {
-            StudentParticipation actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", participation,
+            StudentParticipation actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto,
                     StudentParticipation.class, HttpStatus.BAD_REQUEST);
             assertThat(actualParticipation).as("The participation was not updated").isNull();
         }
         else {
-            StudentParticipation actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", participation,
+            StudentParticipation actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto,
                     StudentParticipation.class, HttpStatus.OK);
             assertThat(actualParticipation).as("The participation was updated").isNotNull();
             assertThat(actualParticipation.getPresentationScore()).as("Presentation score was set to " + input).isEqualTo(input);
@@ -1189,6 +1195,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void updateParticipation_exceedingPresentationNumber() throws Exception {
         Course course = textExercise.getCourseViaExerciseGroupOrCourseMember();
         course.setPresentationScore(0);
+        courseRepository.save(course);
 
         GradingScale gradingScale = gradingScaleUtilService.generateGradingScale(2, new double[] { 0, 50, 100 }, true, 1, Optional.empty(), course, 1, 20.);
         gradingScaleService.saveGradingScale(gradingScale);
@@ -1199,17 +1206,17 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         participationUtilService.createSubmissionAndResult(participation1, 50, true);
 
         // SHOULD ADD FIRST PRESENTATION GRADE
-        participation1.setPresentationScore(100.0);
+        var dto1 = new ParticipationUpdateDTO(participation1.getId(), textExercise.getId(), 100.0);
 
-        var actualParticipation1 = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", participation1, StudentParticipation.class,
+        var actualParticipation1 = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto1, StudentParticipation.class,
                 HttpStatus.OK);
         assertThat(actualParticipation1).as("The participation was updated").isNotNull();
         assertThat(actualParticipation1.getPresentationScore()).as("Presentation score was set to 100").isEqualTo(100.0);
 
         // SHOULD UPDATE FIRST PRESENTATION GRADE
-        participation1.setPresentationScore(80.0);
+        var dto1Update = new ParticipationUpdateDTO(participation1.getId(), textExercise.getId(), 80.0);
 
-        actualParticipation1 = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", participation1, StudentParticipation.class,
+        actualParticipation1 = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto1Update, StudentParticipation.class,
                 HttpStatus.OK);
         assertThat(actualParticipation1).as("The participation was updated").isNotNull();
         assertThat(actualParticipation1.getPresentationScore()).as("Presentation score was set to 80").isEqualTo(80.0);
@@ -1219,9 +1226,9 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         participation2 = participationRepo.save(participation2);
 
-        participation2.setPresentationScore(100.0);
+        var dto2 = new ParticipationUpdateDTO(participation2.getId(), modelingExercise.getId(), 100.0);
 
-        request.putWithResponseBody("/api/exercise/exercises/" + modelingExercise.getId() + "/participations", participation2, StudentParticipation.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody("/api/exercise/exercises/" + modelingExercise.getId() + "/participations", dto2, StudentParticipation.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -1230,7 +1237,8 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         var participation = ParticipationFactory.generateStudentParticipation(InitializationState.INITIALIZED, textExercise,
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         participation = participationRepo.save(participation);
-        request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", participation, StudentParticipation.class, HttpStatus.FORBIDDEN);
+        var dto = new ParticipationUpdateDTO(participation.getId(), textExercise.getId(), null);
+        request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto, StudentParticipation.class, HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -1242,7 +1250,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         participation = participationRepo.save(participation);
         participation.setIndividualDueDate(ZonedDateTime.now().plusDays(3));
 
-        final var participationsToUpdate = new StudentParticipationList(participation);
+        final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         request.putAndExpectError(String.format("/api/exercise/exercises/%d/participations/update-individual-due-date", exercise.getId()), participationsToUpdate,
                 HttpStatus.BAD_REQUEST, "examexercise");
     }
@@ -1257,7 +1265,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         participation = participationRepo.save(participation);
         participation.setIndividualDueDate(ZonedDateTime.now().plusDays(3));
 
-        final var participationsToUpdate = new StudentParticipationList(participation);
+        final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         request.putAndExpectError(String.format("/api/exercise/exercises/%d/participations/update-individual-due-date", exercise.getId()), participationsToUpdate,
                 HttpStatus.BAD_REQUEST, "quizexercise");
     }
@@ -1273,7 +1281,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         var submission = fileUploadExerciseUtilService.addFileUploadSubmission(exercise, ParticipationFactory.generateFileUploadSubmission(true), TEST_PREFIX + "student1");
         submission.getParticipation().setIndividualDueDate(ZonedDateTime.now().plusDays(1));
 
-        final var participationsToUpdate = new StudentParticipationList((StudentParticipation) submission.getParticipation());
+        final var participationsToUpdate = new DueDateUpdateDTOList((StudentParticipation) submission.getParticipation());
         final var response = request.putWithResponseBodyList(String.format("/api/exercise/exercises/%d/participations/update-individual-due-date", exercise.getId()),
                 participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
 
@@ -1298,7 +1306,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         final var participation2 = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student2");
         participation2.setIndividualDueDate(ZonedDateTime.now().plusHours(1));
 
-        final var participationsToUpdate = new StudentParticipationList(participation, participation2);
+        final var participationsToUpdate = new DueDateUpdateDTOList(participation, participation2);
         final var response = request.putWithResponseBodyList(String.format("/api/exercise/exercises/%d/participations/update-individual-due-date", exercise.getId()),
                 participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
 
@@ -1317,7 +1325,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         exercise = exerciseRepository.save(exercise);
 
         final var participation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
-        final var participationsToUpdate = new StudentParticipationList(participation);
+        final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         final var response = request.putWithResponseBodyList(String.format("/api/exercise/exercises/%d/participations/update-individual-due-date", exercise.getId()),
                 participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
 
@@ -1336,7 +1344,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         var participation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
         participation.setIndividualDueDate(ZonedDateTime.now().plusHours(4));
 
-        final var participationsToUpdate = new StudentParticipationList(participation);
+        final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         final var response = request.putWithResponseBodyList(String.format("/api/exercise/exercises/%d/participations/update-individual-due-date", exercise.getId()),
                 participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
 
@@ -1358,7 +1366,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         participation.setIndividualDueDate(ZonedDateTime.now().plusHours(2));
 
-        final var participationsToUpdate = new StudentParticipationList(participation);
+        final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         final var response = request.putWithResponseBodyList(String.format("/api/exercise/exercises/%d/participations/update-individual-due-date", exercise.getId()),
                 participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
 
@@ -1381,7 +1389,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         participation.setIndividualDueDate(ZonedDateTime.now().minusHours(2));
 
-        final var participationsToUpdate = new StudentParticipationList(participation);
+        final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         final var response = request.putWithResponseBodyList(String.format("/api/exercise/exercises/%d/participations/update-individual-due-date", exercise.getId()),
                 participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
 
@@ -1390,16 +1398,14 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     }
 
     /**
-     * When using {@code List<StudentParticipation>} directly as body in the unit tests, the deserialization fails as
-     * there no longer is a {@code type} attribute due to type erasure. Therefore, Jackson does not know which subtype
-     * of {@link Participation} is stored in the list.
-     * <p>
-     * Using this wrapper-class avoids this issue.
+     * Wrapper for a list of ParticipationDueDateUpdateDTO to avoid type erasure issues in tests.
      */
-    private static class StudentParticipationList extends ArrayList<StudentParticipation> {
+    private static class DueDateUpdateDTOList extends ArrayList<ParticipationDueDateUpdateDTO> {
 
-        public StudentParticipationList(StudentParticipation... participations) {
-            this.addAll(Arrays.asList(participations));
+        public DueDateUpdateDTOList(StudentParticipation... participations) {
+            for (StudentParticipation participation : participations) {
+                this.add(ParticipationDueDateUpdateDTO.of(participation));
+            }
         }
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/TeamWebsocketServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/TeamWebsocketServiceTest.java
@@ -24,6 +24,7 @@ import de.tum.cit.aet.artemis.exercise.domain.ExerciseMode;
 import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.dto.TeamAssignmentPayload;
 import de.tum.cit.aet.artemis.exercise.dto.TeamImportStrategyType;
+import de.tum.cit.aet.artemis.exercise.dto.TeamInputDTO;
 import de.tum.cit.aet.artemis.exercise.repository.TeamRepository;
 import de.tum.cit.aet.artemis.exercise.team.TeamUtilService;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
@@ -89,7 +90,7 @@ class TeamWebsocketServiceTest extends AbstractSpringIntegrationIndependentTest 
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void testSendTeamAssignmentUpdateOnTeamCreate() throws Exception {
         Team team = new Team().name("Team").shortName("team").exercise(modelingExercise).students(students);
-        team = request.postWithResponseBody(teamResourceUrl(), team, Team.class, HttpStatus.CREATED);
+        team = request.postWithResponseBody(teamResourceUrl(), TeamInputDTO.of(team), Team.class, HttpStatus.CREATED);
 
         TeamAssignmentPayload expectedPayload = new TeamAssignmentPayload(modelingExercise, team, List.of());
         team.getStudents().forEach(user -> verify(websocketMessagingService, timeout(2000)).sendMessageToUser(user.getLogin(), assignmentTopic, expectedPayload));
@@ -104,7 +105,7 @@ class TeamWebsocketServiceTest extends AbstractSpringIntegrationIndependentTest 
 
         User studentToRemoveFromTeam = students.iterator().next();
         Team updatedTeam = new Team(team).id(team.getId()).removeStudents(studentToRemoveFromTeam);
-        request.putWithResponseBody(teamResourceUrl() + "/" + updatedTeam.getId(), updatedTeam, Team.class, HttpStatus.OK);
+        request.putWithResponseBody(teamResourceUrl() + "/" + updatedTeam.getId(), TeamInputDTO.of(updatedTeam), Team.class, HttpStatus.OK);
 
         TeamAssignmentPayload expectedPayload = new TeamAssignmentPayload(modelingExercise, null, List.of());
         verify(websocketMessagingService, timeout(2000)).sendMessageToUser(studentToRemoveFromTeam.getLogin(), assignmentTopic, expectedPayload);
@@ -118,7 +119,7 @@ class TeamWebsocketServiceTest extends AbstractSpringIntegrationIndependentTest 
         teamRepository.save(team);
 
         Team updatedTeam = new Team(team).id(team.getId()).students(students);
-        updatedTeam = request.putWithResponseBody(teamResourceUrl() + "/" + updatedTeam.getId(), updatedTeam, Team.class, HttpStatus.OK);
+        updatedTeam = request.putWithResponseBody(teamResourceUrl() + "/" + updatedTeam.getId(), TeamInputDTO.of(updatedTeam), Team.class, HttpStatus.OK);
 
         TeamAssignmentPayload expectedPayload = new TeamAssignmentPayload(modelingExercise, updatedTeam, List.of());
         team.getStudents().forEach(user -> verify(websocketMessagingService, timeout(2000)).sendMessageToUser(user.getLogin(), assignmentTopic, expectedPayload));

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/team/TeamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/team/TeamIntegrationTest.java
@@ -27,6 +27,7 @@ import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.domain.TeamAssignmentConfig;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
 import de.tum.cit.aet.artemis.exercise.dto.ExerciseDetailsDTO;
+import de.tum.cit.aet.artemis.exercise.dto.TeamInputDTO;
 import de.tum.cit.aet.artemis.exercise.dto.TeamSearchUserDTO;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
@@ -133,7 +134,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         team.setExercise(exercise);
         team.setStudents(students);
 
-        Team serverTeam = request.postWithResponseBody(resourceUrl(), team, Team.class, HttpStatus.CREATED);
+        Team serverTeam = request.postWithResponseBody(resourceUrl(), TeamInputDTO.of(team), Team.class, HttpStatus.CREATED);
 
         assertThat(serverTeam.getName()).as("Team has correct name").isEqualTo(TEAM_NAME);
         assertThat(serverTeam.getShortName()).as("Team has correct short name").isEqualTo(TEAM_SHORT_NAME);
@@ -156,7 +157,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
         // Try to create team with a student that is already assigned to another team
         Team team2 = new Team().name(TEST_PREFIX + "Team 2").shortName(TEST_PREFIX + "team2").exercise(exercise).students(students);
-        request.postWithResponseBody(resourceUrl(), team2, Team.class, HttpStatus.BAD_REQUEST);
+        request.postWithResponseBody(resourceUrl(), TeamInputDTO.of(team2), Team.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -165,7 +166,9 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         // Try creating a team that already has an id set
         Team team1 = new Team();
         team1.setId(1L);
-        request.postWithResponseBody(resourceUrl(), team1, Team.class, HttpStatus.BAD_REQUEST);
+        team1.setName("team");
+        team1.setShortName("team");
+        request.postWithResponseBody(resourceUrl(), TeamInputDTO.of(team1), Team.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -180,7 +183,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         team.setShortName("team");
         team.setExercise(exercise);
         team.setStudents(students);
-        request.postWithResponseBody(resourceUrl(), team, Team.class, HttpStatus.FORBIDDEN);
+        request.postWithResponseBody(resourceUrl(), TeamInputDTO.of(team), Team.class, HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -188,10 +191,10 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     void testCreateTeam_InvalidShortName_BadRequest() throws Exception {
         Team team = new Team();
         team.setName("1 Invalid Name");
-        team.setShortName("1InvalidName");
+        team.setShortName("1invalid");
         team.setExercise(exercise);
         team.setStudents(students);
-        request.postWithResponseBody(resourceUrl(), team, Team.class, HttpStatus.BAD_REQUEST);
+        request.postWithResponseBody(resourceUrl(), TeamInputDTO.of(team), Team.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -203,7 +206,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         team.setName(TEAM_NAME_UPDATED);
         team.setStudents(students);
 
-        Team serverTeam = request.putWithResponseBody(resourceUrl() + "/" + team.getId(), team, Team.class, HttpStatus.OK);
+        Team serverTeam = request.putWithResponseBody(resourceUrl() + "/" + team.getId(), TeamInputDTO.of(team), Team.class, HttpStatus.OK);
         assertThat(serverTeam.getName()).as("Team name was updated correctly").isEqualTo(TEAM_NAME_UPDATED);
         assertThat(serverTeam.getStudents()).as("Team students were updated correctly").isEqualTo(students);
     }
@@ -212,15 +215,15 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void testUpdateTeam_BadRequest() throws Exception {
         // Try updating a team that has no id specified
-        Team team1 = new Team();
-        request.putWithResponseBody(resourceUrl() + "/1", team1, Team.class, HttpStatus.BAD_REQUEST);
+        var dto1 = new TeamInputDTO(null, "name", "shortname", null, null, null);
+        request.putWithResponseBody(resourceUrl() + "/1", dto1, Team.class, HttpStatus.BAD_REQUEST);
 
         // Try updating a team with an id specified that does not match the team id param in the route
         Team team2 = teamUtilService.addTeamForExercise(exercise, tutor);
-        request.putWithResponseBody(resourceUrl() + "/" + (team2.getId() + 1), team2, Team.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody(resourceUrl() + "/" + (team2.getId() + 1), TeamInputDTO.of(team2), Team.class, HttpStatus.BAD_REQUEST);
 
         // Try updating a team with an exercise specified that does not match the exercise id param in the route
-        request.putWithResponseBody(resourceUrlWithWrongExerciseId() + "/" + team2.getId(), team2, Team.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody(resourceUrlWithWrongExerciseId() + "/" + team2.getId(), TeamInputDTO.of(team2), Team.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -238,17 +241,15 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
         // Try to update team with a student that is already assigned to another team
         team1.setStudents(students);
-        request.putWithResponseBody(resourceUrl() + "/" + team1.getId(), team1, Team.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody(resourceUrl() + "/" + team1.getId(), TeamInputDTO.of(team1), Team.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void testUpdateTeam_NotFound() throws Exception {
         // Try updating a non-existing team
-        Team team4 = new Team();
-        team4.setId(NON_EXISTING_ID);
-        team4.setExercise(exercise);
-        request.putWithResponseBody(resourceUrl() + "/" + team4.getId(), team4, Team.class, HttpStatus.NOT_FOUND);
+        var dto = new TeamInputDTO(NON_EXISTING_ID, "name", "shortname", null, null, null);
+        request.putWithResponseBody(resourceUrl() + "/" + NON_EXISTING_ID, dto, Team.class, HttpStatus.NOT_FOUND);
     }
 
     @Test
@@ -260,7 +261,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
         Team team = teamUtilService.addTeamForExercise(exercise, tutor);
         team.setName("Updated Team Name");
-        request.putWithResponseBody(resourceUrl() + "/" + team.getId(), team, Team.class, HttpStatus.FORBIDDEN);
+        request.putWithResponseBody(resourceUrl() + "/" + team.getId(), TeamInputDTO.of(team), Team.class, HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -268,8 +269,8 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     void testUpdateTeam_Forbidden_ShortNameChanged() throws Exception {
         // It should not be allowed to change a team's short name (unique identifier) after creation
         Team team = teamUtilService.addTeamForExercise(exercise, tutor);
-        team.setShortName(TEST_PREFIX + team.getShortName() + " Updated");
-        request.putWithResponseBody(resourceUrl() + "/" + team.getId(), team, Team.class, HttpStatus.BAD_REQUEST);
+        team.setShortName("changed");
+        request.putWithResponseBody(resourceUrl() + "/" + team.getId(), TeamInputDTO.of(team), Team.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -278,7 +279,7 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         // It should not be allowed to change a team's owner as a tutor
         Team team = teamUtilService.addTeamForExercise(exercise, tutor);
         team.setOwner(userTestRepository.findOneByLogin(TEST_PREFIX + "tutor2").orElseThrow());
-        request.putWithResponseBody(resourceUrl() + "/" + team.getId(), team, Team.class, HttpStatus.FORBIDDEN);
+        request.putWithResponseBody(resourceUrl() + "/" + team.getId(), TeamInputDTO.of(team), Team.class, HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -437,12 +438,12 @@ class TeamIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testTeamOperationsAsStudent() throws Exception {
         Team existingTeam = teamUtilService.addTeamForExercise(exercise, tutor);
-        Team unsavedTeam = teamUtilService.generateTeamForExercise(exercise, TEST_PREFIX + "Team Unsaved", TEST_PREFIX + "teamUnsaved", 2, tutor);
+        Team unsavedTeam = teamUtilService.generateTeamForExercise(exercise, "Team Unsaved", "unsaved", 2, tutor);
 
         // Create team
-        request.postWithResponseBody(resourceUrl(), unsavedTeam, Team.class, HttpStatus.FORBIDDEN);
+        request.postWithResponseBody(resourceUrl(), TeamInputDTO.of(unsavedTeam), Team.class, HttpStatus.FORBIDDEN);
         // Update team
-        request.putWithResponseBody(resourceUrl() + "/" + existingTeam.getId(), existingTeam, Team.class, HttpStatus.FORBIDDEN);
+        request.putWithResponseBody(resourceUrl() + "/" + existingTeam.getId(), TeamInputDTO.of(existingTeam), Team.class, HttpStatus.FORBIDDEN);
         // Get other team
         request.get(resourceUrl() + "/" + existingTeam.getId(), HttpStatus.FORBIDDEN, Team.class);
         // Get all teams for exercise

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/architecture/LectureEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/architecture/LectureEntityUsageArchitectureTest.java
@@ -24,7 +24,7 @@ class LectureEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchit
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getMaxEntityInputViolations() {
-        return 8;
+        return 7;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs

--- a/src/test/java/de/tum/cit/aet/artemis/lti/architecture/LtiEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/architecture/LtiEntityUsageArchitectureTest.java
@@ -24,7 +24,7 @@ class LtiEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitectu
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getMaxEntityInputViolations() {
-        return 3;
+        return 1;
     }
 
     // This module is already compliant for DTO entity field violations

--- a/src/test/java/de/tum/cit/aet/artemis/modeling/apollon/ApollonDiagramResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/modeling/apollon/ApollonDiagramResourceIntegrationTest.java
@@ -95,7 +95,7 @@ class ApollonDiagramResourceIntegrationTest extends AbstractSpringIntegrationInd
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void testUpdateApollonDiagram_CREATED() throws Exception {
         apollonDiagram.setCourseId(course1.getId());
-        request.put("/api/modeling/course/" + course1.getId() + "/apollon-diagrams", apollonDiagram, HttpStatus.CREATED);
+        request.post("/api/modeling/course/" + course1.getId() + "/apollon-diagrams", apollonDiagram, HttpStatus.CREATED);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/modeling/architecture/ModelingEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/modeling/architecture/ModelingEntityUsageArchitectureTest.java
@@ -24,7 +24,7 @@ class ModelingEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchi
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getMaxEntityInputViolations() {
-        return 7;
+        return 5;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/architecture/PlagiarismEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/architecture/PlagiarismEntityUsageArchitectureTest.java
@@ -18,13 +18,13 @@ class PlagiarismEntityUsageArchitectureTest extends AbstractModuleEntityUsageArc
     // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getMaxEntityReturnViolations() {
-        return 13;
+        return 12;
     }
 
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getMaxEntityInputViolations() {
-        return 4;
+        return 3;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
@@ -99,6 +99,7 @@ import de.tum.cit.aet.artemis.programming.domain.RepositoryType;
 import de.tum.cit.aet.artemis.programming.dto.ProgrammingExerciseResetOptionsDTO;
 import de.tum.cit.aet.artemis.programming.dto.ProgrammingExerciseTestCaseDTO;
 import de.tum.cit.aet.artemis.programming.dto.ProgrammingExerciseTestCaseStateDTO;
+import de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO;
 import de.tum.cit.aet.artemis.programming.icl.LocalVCLocalCITestService;
 import de.tum.cit.aet.artemis.programming.repository.AuxiliaryRepositoryRepository;
 import de.tum.cit.aet.artemis.programming.repository.SolutionProgrammingExerciseParticipationRepository;
@@ -839,22 +840,23 @@ public class ProgrammingExerciseIntegrationTestService {
     void updateProgrammingExercise_invalidTemplateBuildPlan_badRequest() throws Exception {
         programmingExerciseParticipationUtilService.addTemplateParticipationForProgrammingExercise(programmingExercise);
         mockDelegate.mockCheckIfBuildPlanExists(programmingExercise.getProjectKey(), programmingExercise.getTemplateBuildPlanId(), false, false);
-        request.putAndExpectError("/api/programming/programming-exercises", programmingExercise, HttpStatus.BAD_REQUEST, INVALID_TEMPLATE_BUILD_PLAN_ID);
+        request.putAndExpectError("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.BAD_REQUEST,
+                INVALID_TEMPLATE_BUILD_PLAN_ID);
     }
 
     void updateProgrammingExercise_idIsNull_badRequest() throws Exception {
         programmingExerciseParticipationUtilService.addTemplateParticipationForProgrammingExercise(programmingExercise);
         programmingExercise.setId(null);
-        request.put("/api/programming/programming-exercises", programmingExercise, HttpStatus.BAD_REQUEST);
+        request.put("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.BAD_REQUEST);
     }
 
     void updateProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest() throws Exception {
         // both values are not set --> bad request
         programmingExercise.setCourse(null);
-        request.put("/api/programming/programming-exercises", programmingExercise, HttpStatus.BAD_REQUEST);
+        request.put("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.BAD_REQUEST);
         // both values are set --> bad request
         programmingExerciseInExam.setCourse(course);
-        request.put("/api/programming/programming-exercises", programmingExerciseInExam, HttpStatus.BAD_REQUEST);
+        request.put("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExerciseInExam), HttpStatus.BAD_REQUEST);
     }
 
     void updateProgrammingExercise_correctlySavesTestIds() throws Exception {
@@ -867,7 +869,8 @@ public class ProgrammingExerciseIntegrationTestService {
 
         mockBuildPlanAndRepositoryCheck(programmingExercise);
 
-        var response = request.putWithResponseBody("/api/programming/programming-exercises", programmingExercise, ProgrammingExercise.class, HttpStatus.OK);
+        var response = request.putWithResponseBody("/api/programming/programming-exercises",
+                de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(programmingExercise), ProgrammingExercise.class, HttpStatus.OK);
         assertThat(response.getProblemStatement()).as("the REST endpoint should return a problem statement with test names").isEqualTo(problemStatement);
 
         programmingExercise = programmingExerciseRepository.findByIdElseThrow(programmingExercise.getId());
@@ -882,7 +885,7 @@ public class ProgrammingExerciseIntegrationTestService {
     void updateProgrammingExercise_staticCodeAnalysisMustNotChange_falseToTrue_badRequest() throws Exception {
         mockBuildPlanAndRepositoryCheck(programmingExercise);
         programmingExercise.setStaticCodeAnalysisEnabled(true);
-        request.put("/api/programming/programming-exercises", programmingExercise, HttpStatus.BAD_REQUEST);
+        request.put("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.BAD_REQUEST);
     }
 
     void updateProgrammingExercise_staticCodeAnalysisMustNotChange_trueToFalse_badRequest() throws Exception {
@@ -890,18 +893,19 @@ public class ProgrammingExerciseIntegrationTestService {
         programmingExercise.setStaticCodeAnalysisEnabled(true);
         programmingExerciseRepository.save(programmingExercise);
         programmingExercise.setStaticCodeAnalysisEnabled(false);
-        request.put("/api/programming/programming-exercises", programmingExercise, HttpStatus.BAD_REQUEST);
+        request.put("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.BAD_REQUEST);
     }
 
     void updateProgrammingExercise_instructorNotInCourse_forbidden() throws Exception {
         userUtilService.addInstructor("other-instructors", userPrefix + "instructoralt1");
-        request.put("/api/programming/programming-exercises", programmingExercise, HttpStatus.FORBIDDEN);
+        request.put("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.FORBIDDEN);
     }
 
     void updateProgrammingExercise_invalidTemplateVcs_badRequest() throws Exception {
         programmingExerciseParticipationUtilService.addTemplateParticipationForProgrammingExercise(programmingExercise);
         mockDelegate.mockCheckIfBuildPlanExists(programmingExercise.getProjectKey(), programmingExercise.getTemplateBuildPlanId(), true, false);
-        request.putAndExpectError("/api/programming/programming-exercises", programmingExercise, HttpStatus.BAD_REQUEST, INVALID_TEMPLATE_REPOSITORY_URL);
+        request.putAndExpectError("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.BAD_REQUEST,
+                INVALID_TEMPLATE_REPOSITORY_URL);
     }
 
     void updateProgrammingExercise_invalidSolutionBuildPlan_badRequest() throws Exception {
@@ -910,7 +914,8 @@ public class ProgrammingExerciseIntegrationTestService {
         mockDelegate.mockCheckIfBuildPlanExists(programmingExercise.getProjectKey(), programmingExercise.getTemplateBuildPlanId(), true, false);
         mockDelegate.mockCheckIfBuildPlanExists(programmingExercise.getProjectKey(), programmingExercise.getSolutionBuildPlanId(), false, false);
 
-        request.putAndExpectError("/api/programming/programming-exercises", programmingExercise, HttpStatus.BAD_REQUEST, INVALID_SOLUTION_BUILD_PLAN_ID);
+        request.putAndExpectError("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.BAD_REQUEST,
+                INVALID_SOLUTION_BUILD_PLAN_ID);
     }
 
     void updateProgrammingExercise_invalidSolutionRepository_badRequest() throws Exception {
@@ -918,13 +923,15 @@ public class ProgrammingExerciseIntegrationTestService {
         programmingExerciseParticipationUtilService.addSolutionParticipationForProgrammingExercise(programmingExercise);
         mockDelegate.mockCheckIfBuildPlanExists(programmingExercise.getProjectKey(), programmingExercise.getTemplateBuildPlanId(), true, false);
         mockDelegate.mockCheckIfBuildPlanExists(programmingExercise.getProjectKey(), programmingExercise.getSolutionBuildPlanId(), true, false);
-        request.putAndExpectError("/api/programming/programming-exercises", programmingExercise, HttpStatus.BAD_REQUEST, INVALID_SOLUTION_REPOSITORY_URL);
+        request.putAndExpectError("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.BAD_REQUEST,
+                INVALID_SOLUTION_REPOSITORY_URL);
     }
 
     void updateProgrammingExercise_checkIfBuildPlanExistsFails_badRequest() throws Exception {
         programmingExerciseParticipationUtilService.addTemplateParticipationForProgrammingExercise(programmingExercise);
         mockDelegate.mockCheckIfBuildPlanExists(programmingExercise.getProjectKey(), programmingExercise.getTemplateBuildPlanId(), true, true);
-        request.putAndExpectError("/api/programming/programming-exercises", programmingExercise, HttpStatus.BAD_REQUEST, INVALID_TEMPLATE_BUILD_PLAN_ID);
+        request.putAndExpectError("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.BAD_REQUEST,
+                INVALID_TEMPLATE_BUILD_PLAN_ID);
     }
 
     /**
@@ -943,7 +950,7 @@ public class ProgrammingExerciseIntegrationTestService {
         newProgrammingExercise.setCourse(newCourse);
 
         // Programming exercise update with the new course should fail.
-        request.put("/api/programming/programming-exercises", newProgrammingExercise, HttpStatus.CONFLICT);
+        request.put("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(newProgrammingExercise), HttpStatus.CONFLICT);
     }
 
     /**
@@ -955,7 +962,7 @@ public class ProgrammingExerciseIntegrationTestService {
         ProgrammingExercise updatedExercise = programmingExercise;
         updatedExercise.setStaticCodeAnalysisEnabled(true);
 
-        request.put("/api/programming/programming-exercises", updatedExercise, HttpStatus.BAD_REQUEST);
+        request.put("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(updatedExercise), HttpStatus.BAD_REQUEST);
     }
 
     void updateExerciseDueDateWithIndividualDueDateUpdate() throws Exception {
@@ -973,7 +980,7 @@ public class ProgrammingExerciseIntegrationTestService {
         programmingExercise.setDueDate(ZonedDateTime.now().plusHours(12));
         assertThat(programmingExercise.getDueDate()).isNotNull();
         programmingExercise.setReleaseDate(programmingExercise.getDueDate().minusDays(1));
-        request.put("/api/programming/programming-exercises", programmingExercise, HttpStatus.OK);
+        request.put("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.OK);
 
         {
             final var participations = programmingExerciseStudentParticipationRepository.findByExerciseId(programmingExercise.getId());
@@ -999,7 +1006,7 @@ public class ProgrammingExerciseIntegrationTestService {
 
         programmingExercise.setDueDate(null);
         programmingExercise.setAssessmentDueDate(null);
-        request.put("/api/programming/programming-exercises", programmingExercise, HttpStatus.OK);
+        request.put("/api/programming/programming-exercises", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.OK);
 
         {
             final var participations = programmingExerciseStudentParticipationRepository.findByExerciseId(programmingExercise.getId());
@@ -2102,7 +2109,8 @@ public class ProgrammingExerciseIntegrationTestService {
 
     private void testAuxRepo(List<AuxiliaryRepository> body, HttpStatus expectedStatus) throws Exception {
         programmingExercise.setAuxiliaryRepositories(body);
-        request.putWithResponseBody(defaultAuxiliaryRepositoryEndpoint(), programmingExercise, ProgrammingExercise.class, expectedStatus);
+        var updateDTO = UpdateProgrammingExerciseDTO.of(programmingExercise);
+        request.putWithResponseBody(defaultAuxiliaryRepositoryEndpoint(), updateDTO, ProgrammingExercise.class, expectedStatus);
     }
 
     private static class AuxiliaryRepositoryBuilder {
@@ -2180,11 +2188,12 @@ public class ProgrammingExerciseIntegrationTestService {
         userUtilService.addInstructor("other-instructors", testPrefix + "instructoralt1");
         programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
         ProgrammingExercise programmingExercise = programmingExerciseTestRepository.findAllWithEagerTemplateAndSolutionParticipations().getFirst();
-        request.put("/api/programming/programming-exercises/" + programmingExercise.getId() + "/re-evaluate", programmingExercise, HttpStatus.FORBIDDEN);
+        request.put("/api/programming/programming-exercises/" + programmingExercise.getId() + "/re-evaluate", UpdateProgrammingExerciseDTO.of(programmingExercise),
+                HttpStatus.FORBIDDEN);
     }
 
     void testReEvaluateAndUpdateProgrammingExercise_notFound() throws Exception {
-        request.put("/api/programming/programming-exercises/" + 123456789 + "/re-evaluate", programmingExercise, HttpStatus.NOT_FOUND);
+        request.put("/api/programming/programming-exercises/" + 123456789 + "/re-evaluate", UpdateProgrammingExerciseDTO.of(programmingExercise), HttpStatus.NOT_FOUND);
     }
 
     void testReEvaluateAndUpdateProgrammingExercise_isNotSameGivenExerciseIdInRequestBody_conflict() throws Exception {
@@ -2193,7 +2202,8 @@ public class ProgrammingExerciseIntegrationTestService {
         ProgrammingExercise programmingExercise = programmingExerciseTestRepository.findAllWithEagerTemplateAndSolutionParticipations().getFirst();
         ProgrammingExercise programmingExerciseToBeConflicted = programmingExerciseTestRepository.findAllWithEagerTemplateAndSolutionParticipations().get(1);
 
-        request.put("/api/programming/programming-exercises/" + programmingExercise.getId() + "/re-evaluate", programmingExerciseToBeConflicted, HttpStatus.CONFLICT);
+        request.put("/api/programming/programming-exercises/" + programmingExercise.getId() + "/re-evaluate", UpdateProgrammingExerciseDTO.of(programmingExerciseToBeConflicted),
+                HttpStatus.CONFLICT);
     }
 
     void test_redirectGetTemplateRepositoryFilesWithContentOmitBinaries() throws Exception {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseTest.java
@@ -55,8 +55,8 @@ class ProgrammingExerciseTest extends AbstractProgrammingIntegrationJenkinsLocal
 
         var programmingExerciseCountBefore = programmingExerciseRepository.count();
 
-        ProgrammingExercise updatedProgrammingExercise = request.putWithResponseBody("/api/programming/programming-exercises", programmingExercise, ProgrammingExercise.class,
-                HttpStatus.OK);
+        ProgrammingExercise updatedProgrammingExercise = request.putWithResponseBody("/api/programming/programming-exercises",
+                de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(programmingExercise), ProgrammingExercise.class, HttpStatus.OK);
 
         // The result from the put response should be updated with the new data.
         assertThat(updatedProgrammingExercise.getProblemStatement()).isEqualTo(newProblem);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseVersionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseVersionIntegrationTest.java
@@ -256,7 +256,8 @@ class ProgrammingExerciseVersionIntegrationTest extends AbstractProgrammingInteg
 
         ExerciseVersionUtilService.updateExercise(programmingExercise);
 
-        request.putWithResponseBody("/api/programming/programming-exercises", programmingExercise, ProgrammingExercise.class, HttpStatus.OK);
+        request.putWithResponseBody("/api/programming/programming-exercises", de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(programmingExercise),
+                ProgrammingExercise.class, HttpStatus.OK);
 
         ExerciseVersion newVersion = exerciseVersionUtilService.verifyExerciseVersionCreated(programmingExercise.getId(), TEST_PREFIX + "instructor1", ExerciseType.PROGRAMMING);
         assertThat(newVersion.getId()).isNotEqualTo(originalVersion.getId());
@@ -273,7 +274,8 @@ class ProgrammingExerciseVersionIntegrationTest extends AbstractProgrammingInteg
 
         ExerciseVersionUtilService.updateExercise(programmingExercise);
         final var endpoint = "/api/programming/programming-exercises/" + programmingExercise.getId() + "/re-evaluate?deleteFeedback=false";
-        request.putWithResponseBody(endpoint, programmingExercise, ProgrammingExercise.class, HttpStatus.OK);
+        request.putWithResponseBody(endpoint, de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(programmingExercise), ProgrammingExercise.class,
+                HttpStatus.OK);
 
         ExerciseVersion newVersion = exerciseVersionUtilService.verifyExerciseVersionCreated(programmingExercise.getId(), TEST_PREFIX + "instructor1", ExerciseType.PROGRAMMING);
         assertThat(newVersion.getId()).isNotEqualTo(originalVersion.getId());
@@ -425,7 +427,8 @@ class ProgrammingExerciseVersionIntegrationTest extends AbstractProgrammingInteg
         ExerciseVersion version1 = exerciseVersionUtilService.verifyExerciseVersionCreated(programmingExercise.getId(), TEST_PREFIX + "instructor1", ExerciseType.PROGRAMMING);
 
         ExerciseVersionUtilService.updateExercise(programmingExercise);
-        request.putWithResponseBody("/api/programming/programming-exercises", programmingExercise, ProgrammingExercise.class, HttpStatus.OK);
+        request.putWithResponseBody("/api/programming/programming-exercises", de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(programmingExercise),
+                ProgrammingExercise.class, HttpStatus.OK);
 
         ExerciseVersion version2 = exerciseVersionUtilService.verifyExerciseVersionCreated(programmingExercise.getId(), TEST_PREFIX + "instructor1", ExerciseType.PROGRAMMING);
         assertThat(version2.getId()).isNotEqualTo(version1.getId());
@@ -476,7 +479,8 @@ class ProgrammingExerciseVersionIntegrationTest extends AbstractProgrammingInteg
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testGetExerciseVersions_includesPaginationHeaders() throws Exception {
         ExerciseVersionUtilService.updateExercise(programmingExercise);
-        request.putWithResponseBody("/api/programming/programming-exercises", programmingExercise, ProgrammingExercise.class, HttpStatus.OK);
+        request.putWithResponseBody("/api/programming/programming-exercises", de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(programmingExercise),
+                ProgrammingExercise.class, HttpStatus.OK);
         exerciseVersionUtilService.verifyExerciseVersionCreated(programmingExercise.getId(), TEST_PREFIX + "instructor1", ExerciseType.PROGRAMMING);
 
         MvcResult mvcResult = request

--- a/src/test/java/de/tum/cit/aet/artemis/programming/architecture/ProgrammingEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/architecture/ProgrammingEntityUsageArchitectureTest.java
@@ -18,18 +18,18 @@ class ProgrammingEntityUsageArchitectureTest extends AbstractModuleEntityUsageAr
     // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getMaxEntityReturnViolations() {
-        return 44;
+        return 45;
     }
 
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getMaxEntityInputViolations() {
-        return 11;
+        return 8;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs
     @Override
     protected int getMaxDtoEntityFieldViolations() {
-        return 2;
+        return 3;
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/programming/icl/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/icl/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
@@ -251,7 +251,8 @@ class ProgrammingExerciseLocalVCLocalCIIntegrationTest extends AbstractProgrammi
         programmingExercise.setCompetencyLinks(Set.of(new CompetencyExerciseLink(competency, programmingExercise, 1)));
         programmingExercise.getCompetencyLinks().forEach(link -> link.getCompetency().setCourse(null));
 
-        ProgrammingExercise updatedExercise = request.putWithResponseBody("/api/programming/programming-exercises", programmingExercise, ProgrammingExercise.class, HttpStatus.OK);
+        ProgrammingExercise updatedExercise = request.putWithResponseBody("/api/programming/programming-exercises",
+                de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(programmingExercise), ProgrammingExercise.class, HttpStatus.OK);
 
         // Compare as instants because PostgreSQL stores timestamps as UTC and the
         // original timezone offset is not preserved through the database round-trip.
@@ -276,16 +277,9 @@ class ProgrammingExerciseLocalVCLocalCIIntegrationTest extends AbstractProgrammi
         }
     }
 
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testUpdateProgrammingExercise_templateRepositoryUriIsInvalid() throws Exception {
-        programmingExercise.setTemplateRepositoryUri("http://localhost:9999/some/invalid/url.git");
-        request.put("/api/programming/programming-exercises", programmingExercise, HttpStatus.BAD_REQUEST);
-
-        programmingExercise.setTemplateRepositoryUri(
-                "http://localhost:49152/invalidUrlMapping/" + programmingExercise.getProjectKey() + "/" + programmingExercise.getProjectKey().toLowerCase() + "-exercise.git");
-        request.put("/api/programming/programming-exercises", programmingExercise, HttpStatus.BAD_REQUEST);
-    }
+    // Note: testUpdateProgrammingExercise_templateRepositoryUriIsInvalid was removed because
+    // UpdateProgrammingExerciseDTO intentionally doesn't include templateRepositoryUri.
+    // Repository URIs are immutable after exercise creation and cannot be modified through the update endpoint.
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseTestService.java
@@ -2723,12 +2723,14 @@ public class ProgrammingExerciseTestService {
         config.setContinuousPlagiarismControlPlagiarismCaseStudentResponsePeriod(7);
         exercise.setPlagiarismDetectionConfig(config);
 
-        request.putWithResponseBody("/api/programming/programming-exercises", exercise, ProgrammingExercise.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody("/api/programming/programming-exercises", de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(exercise),
+                ProgrammingExercise.class, HttpStatus.BAD_REQUEST);
 
         // Test invalid response period lower bound
         config.setSimilarityThreshold(50);
         config.setContinuousPlagiarismControlPlagiarismCaseStudentResponsePeriod(6); // invalid: below 7
-        request.putWithResponseBody("/api/programming/programming-exercises", exercise, ProgrammingExercise.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody("/api/programming/programming-exercises", de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(exercise),
+                ProgrammingExercise.class, HttpStatus.BAD_REQUEST);
     }
 
     // TEST

--- a/src/test/java/de/tum/cit/aet/artemis/quiz/AbstractQuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/quiz/AbstractQuizExerciseIntegrationTest.java
@@ -6,9 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -29,10 +27,9 @@ import de.tum.cit.aet.artemis.quiz.domain.QuizExercise;
 import de.tum.cit.aet.artemis.quiz.domain.QuizMode;
 import de.tum.cit.aet.artemis.quiz.domain.QuizQuestion;
 import de.tum.cit.aet.artemis.quiz.domain.ShortAnswerQuestion;
-import de.tum.cit.aet.artemis.quiz.dto.CompetencyExerciseLinkFromEditorDTO;
 import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseCreateDTO;
-import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseFromEditorDTO;
 import de.tum.cit.aet.artemis.quiz.dto.exercise.QuizExerciseReEvaluateDTO;
+import de.tum.cit.aet.artemis.quiz.dto.exercise.UpdateQuizExerciseDTO;
 import de.tum.cit.aet.artemis.quiz.service.QuizExerciseService;
 import de.tum.cit.aet.artemis.quiz.test_repository.QuizExerciseTestRepository;
 import de.tum.cit.aet.artemis.quiz.util.QuizExerciseFactory;
@@ -232,13 +229,7 @@ public class AbstractQuizExerciseIntegrationTest extends AbstractSpringIntegrati
      */
     protected QuizExercise updateQuizExerciseWithFiles(QuizExercise quizExercise, List<String> fileNames, HttpStatus expectedStatus, MultiValueMap<String, String> params)
             throws Exception {
-        Set<CompetencyExerciseLinkFromEditorDTO> competencyLinks = null;
-        if (Hibernate.isInitialized(quizExercise.getCompetencyLinks()) && quizExercise.getCompetencyLinks() != null) {
-            competencyLinks = quizExercise.getCompetencyLinks().stream().map(CompetencyExerciseLinkFromEditorDTO::of).collect(Collectors.toSet());
-        }
-        QuizExerciseFromEditorDTO dto = new QuizExerciseFromEditorDTO(quizExercise.getTitle(), quizExercise.getChannelName(), quizExercise.getCategories(), competencyLinks,
-                quizExercise.getDifficulty(), quizExercise.getDuration(), quizExercise.isRandomizeQuestionOrder(), quizExercise.getQuizMode(), quizExercise.getQuizBatches(),
-                quizExercise.getReleaseDate(), quizExercise.getStartDate(), quizExercise.getDueDate(), quizExercise.getIncludedInOverallScore(), quizExercise.getQuizQuestions());
+        UpdateQuizExerciseDTO dto = UpdateQuizExerciseDTO.of(quizExercise);
 
         var builder = MockMvcRequestBuilders.multipart(HttpMethod.PATCH, "/api/quiz/quiz-exercises/" + quizExercise.getId());
         if (params != null) {
@@ -253,7 +244,8 @@ public class AbstractQuizExerciseIntegrationTest extends AbstractSpringIntegrati
         MvcResult result = request.performMvcRequest(builder).andExpect(status().is(expectedStatus.value())).andReturn();
         request.restoreSecurityContext();
         if (HttpStatus.valueOf(result.getResponse().getStatus()).is2xxSuccessful()) {
-            return objectMapper.readValue(result.getResponse().getContentAsString(), QuizExercise.class);
+            // Reload from database to get full entity with all associations
+            return quizExerciseTestRepository.findOneWithQuestionsAndStatistics(quizExercise.getId());
         }
         return null;
     }

--- a/src/test/java/de/tum/cit/aet/artemis/quiz/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/quiz/QuizExerciseIntegrationTest.java
@@ -780,13 +780,7 @@ class QuizExerciseIntegrationTest extends AbstractQuizExerciseIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testReevaluateStatistics() throws Exception {
-        QuizExercise quizExercise = createQuizOnServer(ZonedDateTime.now().plusSeconds(5), null, QuizMode.SYNCHRONIZED);
-
-        // we expect a bad request because the quiz has not ended yet
-        reevalQuizExerciseWithFiles(quizExercise, quizExercise.getId(), List.of(), HttpStatus.BAD_REQUEST);
-        quizExercise.setReleaseDate(ZonedDateTime.now().minusHours(5));
-        quizExerciseService.endQuiz(quizExercise);
-        quizExercise = updateQuizExerciseWithFiles(quizExercise, List.of(), OK);
+        QuizExercise quizExercise = createQuizOnServer(ZonedDateTime.now().minusHours(5), ZonedDateTime.now().minusHours(2), QuizMode.SYNCHRONIZED);
 
         // generate rated submissions for each student
         int numberOfParticipants = 10;
@@ -885,18 +879,13 @@ class QuizExerciseIntegrationTest extends AbstractQuizExerciseIntegrationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testReevaluateStatistics_Practice() throws Exception {
-        QuizExercise quizExercise = createQuizOnServer(ZonedDateTime.now().plusSeconds(5), null, QuizMode.SYNCHRONIZED);
-        // use the exact other scoring types to cover all combinations in the tests
+        QuizExercise quizExercise = createQuizOnServer(ZonedDateTime.now().minusHours(5), ZonedDateTime.now().minusHours(2), QuizMode.SYNCHRONIZED);
+        // Modify scoring types directly in the database (quiz has already started, so we can't use the update endpoint)
         quizExercise.getQuizQuestions().getFirst().setScoringType(ScoringType.PROPORTIONAL_WITH_PENALTY);   // MC
         quizExercise.getQuizQuestions().get(1).setScoringType(ScoringType.ALL_OR_NOTHING);              // DnD
         quizExercise.getQuizQuestions().get(2).setScoringType(ScoringType.PROPORTIONAL_WITH_PENALTY);   // SA
-
-        // we expect a bad request because the quiz has not ended yet
-        reevalQuizExerciseWithFiles(quizExercise, quizExercise.getId(), List.of(), HttpStatus.BAD_REQUEST);
-        quizExercise.setReleaseDate(ZonedDateTime.now().minusHours(2));
         quizExercise.setDuration(3600);
-        quizExerciseService.endQuiz(quizExercise);
-        quizExercise = updateQuizExerciseWithFiles(quizExercise, List.of(), OK);
+        quizExerciseTestRepository.saveAndFlush(quizExercise);
 
         // generate unrated submissions for each student
         int numberOfParticipants = 10;
@@ -925,7 +914,8 @@ class QuizExerciseIntegrationTest extends AbstractQuizExerciseIntegrationTest {
         assertThat(resultRepository.findAllBySubmissionParticipationExerciseId(quizExercise.getId())).hasSize(10);
 
         // calculate statistics
-        quizExercise = request.get("/api/quiz/quiz-exercises/" + quizExercise.getId() + "/recalculate-statistics", OK, QuizExercise.class);
+        request.get("/api/quiz/quiz-exercises/" + quizExercise.getId() + "/recalculate-statistics", OK, Object.class);
+        quizExercise = quizExerciseTestRepository.findByIdWithQuestionsAndStatisticsElseThrow(quizExercise.getId());
 
         log.debug("QuizPointStatistic before re-evaluate: {}", quizExercise.getQuizPointStatistic());
 

--- a/src/test/java/de/tum/cit/aet/artemis/quiz/QuizSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/quiz/QuizSubmissionIntegrationTest.java
@@ -714,6 +714,10 @@ class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
         quizExercise.setDuration((int) Duration.between(quizExercise.getReleaseDate(), ZonedDateTime.now()).getSeconds() - Constants.QUIZ_GRACE_PERIOD_IN_SECONDS);
         quizExercise = exerciseRepository.saveAndFlush(quizExercise);
 
+        // Wait for participant score updates to complete before deleting to avoid FK constraint violations
+        participantScoreScheduleService.executeScheduledTasks();
+        await().until(() -> participantScoreScheduleService.isIdle());
+
         // ...delete the quiz
         request.delete("/api/quiz/quiz-exercises/" + quizExercise.getId(), HttpStatus.OK);
 
@@ -742,7 +746,7 @@ class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
         participationUtilService.addResultToSubmission(quizSubmission, AssessmentType.AUTOMATIC, null, quizExercise.getScoreForSubmission(quizSubmission), true);
 
         QuizExerciseReEvaluateDTO dto = QuizExerciseReEvaluateDTO.of(quizExercise);
-        quizExerciseService.reEvaluate(dto, quizExercise, generateMultipartFilesFromQuizExercise(quizExercise));
+        quizExerciseService.reEvaluate(dto, quizExercise, List.of());
         assertThat(quizSubmissionTestRepository.findByQuizExerciseId(quizExercise.getId())).isPresent();
 
         List<Result> results = resultRepository.findByExerciseIdOrderByCompletionDateAsc(quizExercise.getId());
@@ -785,7 +789,7 @@ class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
         participationUtilService.addResultToSubmission(quizSubmission, AssessmentType.AUTOMATIC, null, quizExercise.getScoreForSubmission(quizSubmission), true);
 
         QuizExerciseReEvaluateDTO dto = QuizExerciseReEvaluateDTO.of(quizExercise);
-        quizExerciseService.reEvaluate(dto, quizExercise, generateMultipartFilesFromQuizExercise(quizExercise));
+        quizExerciseService.reEvaluate(dto, quizExercise, List.of());
         assertThat(submissionRepository.countByExerciseIdSubmitted(quizExercise.getId())).isEqualTo(1);
 
         List<Result> results = resultRepository.findByExerciseIdOrderByCompletionDateAsc(quizExercise.getId());

--- a/src/test/java/de/tum/cit/aet/artemis/text/AssessmentEventIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/AssessmentEventIntegrationTest.java
@@ -108,19 +108,6 @@ class AssessmentEventIntegrationTest extends AbstractSpringIntegrationIndependen
         request.post("/api/text/event-insights/text-assessment/events", event, expected);
     }
 
-    /**
-     * Tests addition of a single event with event id not null. The event is auto generated in the server side,
-     * that is why we treat incoming events with an already generated id as badly formed requests
-     */
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
-    void testAddSingleCompleteAssessmentEvent_withNotNullEventId() throws Exception {
-        TextAssessmentEvent event = textExerciseUtilService.createSingleTextAssessmentEvent(course.getId(), tutor.getId(), exercise.getId(), studentParticipation.getId(),
-                textSubmission.getId());
-        event.setId(1L);
-        request.post("/api/text/event-insights/text-assessment/events", event, HttpStatus.BAD_REQUEST);
-    }
-
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void testAddSingleCompleteAssessmentEvent_withExampleSubmission() throws Exception {

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
@@ -353,7 +353,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         // Update
         textExercise = textExerciseRepository.findByCourseIdWithCategories(course.getId()).getFirst();
         textExercise.setTitle("AtlasML Update");
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.OK);
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.OK);
 
         // Delete
         request.delete("/api/text/text-exercises/" + textExercise.getId(), HttpStatus.OK);
@@ -394,7 +394,9 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void updateTextExercise_invalidPlagiarismDetectionConfig_badRequest() throws Exception {
+    void updateTextExercise_invalidPlagiarismDetectionConfig_doesNotAffectUpdate() throws Exception {
+        // With the DTO approach, PlagiarismDetectionConfig is not included in the UpdateTextExerciseDTO.
+        // Invalid config set on the local object is never sent to the server, so the update succeeds.
         Course course = textExerciseUtilService.addCourseWithOneReleasedTextExercise();
         TextExercise textExercise = textExerciseRepository.findByCourseIdWithCategories(course.getId()).getFirst();
 
@@ -405,12 +407,8 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         config.setContinuousPlagiarismControlPlagiarismCaseStudentResponsePeriod(7);
         textExercise.setPlagiarismDetectionConfig(config);
 
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.BAD_REQUEST);
-
-        // Test invalid response period lower bound
-        config.setSimilarityThreshold(50);
-        config.setContinuousPlagiarismControlPlagiarismCaseStudentResponsePeriod(6); // invalid: below 7
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.BAD_REQUEST);
+        // The DTO does not include plagiarism config, so the server validates the stored (valid) config
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.OK);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
@@ -443,7 +441,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void updateTextExercise_InvalidMaxScore() throws Exception {
         textExercise.setMaxPoints(0.0);
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -452,7 +450,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         textExercise.setMaxPoints(10.0);
         textExercise.setBonusPoints(1.0);
         textExercise.setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_AS_BONUS);
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -461,7 +459,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         textExercise.setMaxPoints(10.0);
         textExercise.setBonusPoints(1.0);
         textExercise.setIncludedInOverallScore(IncludedInOverallScore.NOT_INCLUDED);
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -479,7 +477,8 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
         criterion.addStructuredGradingInstruction(gradingInstruction);
         textExercise.setGradingCriteria(Set.of(criterion));
-        TextExercise actualExercise = request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.OK);
+        TextExercise actualExercise = request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise),
+                TextExercise.class, HttpStatus.OK);
 
         assertThat(actualExercise.getGradingCriteria()).hasSize(1);
         GradingCriterion testCriterion = GradingCriterionUtil.findGradingCriterionByTitle(actualExercise, "Test");
@@ -512,9 +511,9 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         exampleSubmissionRepo.save(exampleSubmission);
         textExercise.addExampleSubmission(exampleSubmission);
         textExercise.setCompetencyLinks(Set.of(new CompetencyExerciseLink(competency, textExercise, 1)));
-        textExercise.getCompetencyLinks().forEach(link -> link.getCompetency().setCourse(null));
 
-        TextExercise updatedTextExercise = request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.OK);
+        TextExercise updatedTextExercise = request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise),
+                TextExercise.class, HttpStatus.OK);
 
         assertThat(updatedTextExercise.getTitle()).as("text exercise title was correctly updated").isEqualTo(title);
         assertThat(updatedTextExercise.getDifficulty()).as("text exercise difficulty was correctly updated").isEqualTo(difficulty);
@@ -546,7 +545,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         }
 
         textExercise.setDueDate(ZonedDateTime.now().plusHours(12));
-        request.put("/api/text/text-exercises", textExercise, HttpStatus.OK);
+        request.put("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), HttpStatus.OK);
 
         {
             final var participations = studentParticipationRepository.findByExerciseId(textExercise.getId());
@@ -564,7 +563,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
     void updateTextExercise_setExerciseIdNull_created() throws Exception {
         textExercise.setId(null);
         textExercise.setChannelName("test" + UUID.randomUUID().toString().substring(0, 8));
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.CREATED);
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.CREATED);
     }
 
     @Test
@@ -580,7 +579,8 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         existingTextExercise.setCourse(newCourse);
 
         // Text exercise update with the new course should fail.
-        TextExercise returnedTextExercise = request.putWithResponseBody("/api/text/text-exercises", existingTextExercise, TextExercise.class, HttpStatus.CONFLICT);
+        TextExercise returnedTextExercise = request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(existingTextExercise),
+                TextExercise.class, HttpStatus.CONFLICT);
         assertThat(returnedTextExercise).isNull();
     }
 
@@ -590,7 +590,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         course.setInstructorGroupName("test");
         courseRepository.save(course);
 
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.FORBIDDEN);
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -609,7 +609,8 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         // update problem statement
         textExercise.setProblemStatement("New problem statement");
 
-        TextExercise updatedTextExercise = request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.OK);
+        TextExercise updatedTextExercise = request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise),
+                TextExercise.class, HttpStatus.OK);
 
         assertThat(updatedTextExercise.getTitle()).as("text exercise title was correctly updated").isEqualTo(updateTitle);
         assertThat(updatedTextExercise.getDifficulty()).as("text exercise difficulty was correctly updated").isEqualTo(updateDifficulty);
@@ -628,16 +629,19 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         TextExercise textExercise = TextExerciseFactory.generateTextExerciseForExam(exerciseGroup);
         textExerciseRepository.save(textExercise);
 
-        request.putWithResponseBody("/api/text/text-exercises", invalidDates.applyTo(textExercise), TextExercise.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(invalidDates.applyTo(textExercise)), TextExercise.class,
+                HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void updateTextExercise_setCourseAndExerciseGroup_badRequest() throws Exception {
+    void updateTextExercise_setCourseAndExerciseGroup_conflict() throws Exception {
         ExerciseGroup exerciseGroup = examUtilService.addExerciseGroupWithExamAndCourse(true);
         textExercise.setExerciseGroup(exerciseGroup);
 
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.BAD_REQUEST);
+        // With DTO approach, setting an exercise group from a different course results in CONFLICT
+        // because the courseId from the DTO doesn't match the stored exercise's courseId
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.CONFLICT);
     }
 
     @Test
@@ -645,17 +649,18 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
     void updateTextExercise_setNeitherCourseAndExerciseGroup_badRequest() throws Exception {
         textExercise.setCourse(null);
 
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void updateTextExercise_convertFromCourseToExamExercise_badRequest() throws Exception {
+    void updateTextExercise_convertFromCourseToExamExercise_conflict() throws Exception {
         ExerciseGroup exerciseGroup = examUtilService.addExerciseGroupWithExamAndCourse(true);
 
         textExercise.setExerciseGroup(exerciseGroup);
 
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.BAD_REQUEST);
+        // With DTO approach, converting from course to exam exercise through a different course results in CONFLICT
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.CONFLICT);
     }
 
     @Test
@@ -667,7 +672,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
         textExercise.setExerciseGroup(null);
 
-        request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.BAD_REQUEST);
+        request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -1271,8 +1276,8 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         gradingCriteria.removeIf(criterion -> criterion != toUpdate);
         textExercise.setGradingCriteria(gradingCriteria);
 
-        TextExercise updatedTextExercise = request.putWithResponseBody("/api/text/text-exercises/" + textExercise.getId() + "/re-evaluate" + "?deleteFeedback=false", textExercise,
-                TextExercise.class, HttpStatus.OK);
+        TextExercise updatedTextExercise = request.putWithResponseBody("/api/text/text-exercises/" + textExercise.getId() + "/re-evaluate" + "?deleteFeedback=false",
+                de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.OK);
         List<Result> updatedResults = participationUtilService.getResultsForExercise(updatedTextExercise);
         assertThat(GradingCriterionUtil.findAnyInstructionWhere(updatedTextExercise.getGradingCriteria(), instruction -> instruction.getCredits() == 3)).isPresent();
         assertThat(updatedResults.getFirst().getScore()).isEqualTo(60);
@@ -1300,7 +1305,8 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         exampleSubmissionSet.add(exampleSubmission);
         textExercise.setExampleSubmissions(exampleSubmissionSet);
 
-        request.putWithResponseBody("/api/text/text-exercises/" + textExercise.getId() + "/re-evaluate" + "?deleteFeedback=false", textExercise, TextExercise.class, HttpStatus.OK);
+        request.putWithResponseBody("/api/text/text-exercises/" + textExercise.getId() + "/re-evaluate" + "?deleteFeedback=false",
+                de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.OK);
     }
 
     @Test
@@ -1315,8 +1321,8 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         gradingCriteria.removeIf(criterion -> criterion.getTitle() == null);
         textExercise.setGradingCriteria(gradingCriteria);
 
-        TextExercise updatedTextExercise = request.putWithResponseBody("/api/text/text-exercises/" + textExercise.getId() + "/re-evaluate" + "?deleteFeedback=true", textExercise,
-                TextExercise.class, HttpStatus.OK);
+        TextExercise updatedTextExercise = request.putWithResponseBody("/api/text/text-exercises/" + textExercise.getId() + "/re-evaluate" + "?deleteFeedback=true",
+                de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.OK);
         List<Result> updatedResults = participationUtilService.getResultsForExercise(updatedTextExercise);
         assertThat(updatedTextExercise.getGradingCriteria()).hasSize(2);
         assertThat(updatedResults.getFirst().getScore()).isZero();
@@ -1329,7 +1335,8 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         course.setInstructorGroupName("test");
         courseRepository.save(course);
 
-        request.putWithResponseBody("/api/text/text-exercises/" + textExercise.getId() + "/re-evaluate", textExercise, TextExercise.class, HttpStatus.FORBIDDEN);
+        request.putWithResponseBody("/api/text/text-exercises/" + textExercise.getId() + "/re-evaluate", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise),
+                TextExercise.class, HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -1338,13 +1345,15 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         TextExercise textExerciseToBeConflicted = textExerciseRepository.findByCourseIdWithCategories(course.getId()).getFirst();
         textExerciseToBeConflicted.setId(123456789L);
 
-        request.putWithResponseBody("/api/text/text-exercises/" + textExercise.getId() + "/re-evaluate", textExerciseToBeConflicted, TextExercise.class, HttpStatus.CONFLICT);
+        request.putWithResponseBody("/api/text/text-exercises/" + textExercise.getId() + "/re-evaluate",
+                de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExerciseToBeConflicted), TextExercise.class, HttpStatus.CONFLICT);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testReEvaluateAndUpdateTextExercise_notFound() throws Exception {
-        request.putWithResponseBody("/api/text/text-exercises/" + 123456789 + "/re-evaluate", textExercise, TextExercise.class, HttpStatus.NOT_FOUND);
+        request.putWithResponseBody("/api/text/text-exercises/" + 123456789 + "/re-evaluate", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise),
+                TextExercise.class, HttpStatus.NOT_FOUND);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseVersionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseVersionIntegrationTest.java
@@ -88,11 +88,12 @@ class TextExerciseVersionIntegrationTest extends AbstractSpringIntegrationIndepe
         // Act: Update the exercise
         TextExercise updatedExercise;
         if (reEvaluate) {
-            updatedExercise = request.putWithResponseBody("/api/text/text-exercises/" + exerciseId + "/re-evaluate?deleteFeedback=false", textExercise, TextExercise.class,
-                    HttpStatus.OK);
+            updatedExercise = request.putWithResponseBody("/api/text/text-exercises/" + exerciseId + "/re-evaluate?deleteFeedback=false",
+                    de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class, HttpStatus.OK);
         }
         else {
-            updatedExercise = request.putWithResponseBody("/api/text/text-exercises", textExercise, TextExercise.class, HttpStatus.OK);
+            updatedExercise = request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class,
+                    HttpStatus.OK);
         }
 
         // Assert: Verify operation succeeded

--- a/src/test/java/de/tum/cit/aet/artemis/text/architecture/TextEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/architecture/TextEntityUsageArchitectureTest.java
@@ -18,7 +18,7 @@ class TextEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitect
     // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getMaxEntityReturnViolations() {
-        return 22;
+        return 23;
     }
 
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart

--- a/src/test/java/de/tum/cit/aet/artemis/text/architecture/TextEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/architecture/TextEntityUsageArchitectureTest.java
@@ -24,7 +24,7 @@ class TextEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitect
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getMaxEntityInputViolations() {
-        return 7;
+        return 6;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs

--- a/src/test/java/de/tum/cit/aet/artemis/tutorialgroup/architecture/TutorialGroupEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/tutorialgroup/architecture/TutorialGroupEntityUsageArchitectureTest.java
@@ -18,13 +18,13 @@ class TutorialGroupEntityUsageArchitectureTest extends AbstractModuleEntityUsage
     // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getMaxEntityReturnViolations() {
-        return 20;
+        return 17;
     }
 
-    // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
+    // This module is already compliant for input violations
     @Override
     protected int getMaxEntityInputViolations() {
-        return 2;
+        return 0;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 
This PR enables deep linking within the HLS video player. It is planned to be used to link the citations Iris gives to the according timestamp in a video.


### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Server
no changes on server side


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [ x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
no changes affection programming exercises


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR will later help the deep linking from Iris citations to the corresponding timestamp in videos. 


### Description
<!-- Describe your changes in detail -->
The HLS video player can be deep linked now. When adding the query parameters unit and timestamp, the video of the lecture unit is opened at the corresponding timestamp.
This is only for the HLS video player and not for videos displayed in an iframe player. Supporting videos in the iframe player is not necessary for this use case because Iris is only able to cite from transcribed videos. Also only videos which are available in the M3U8 format are transcribed in Artemis. So Iris can only cite from video in the M3U8 format having a transcript. As soon as a video fulfills these two points it is presented in an HLS player. (only TUMLive videos)


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- Lecture with an Attachment Video Unit
- Video in an HLS player. Either add a transcript to your database and change the code so that it accepts m3u8 files, or upload a TUMLive video to a test server or use my course "Test Video Player" with lecture unit "videotumlive" on TS1.

1. Open a deep link like .../courses/<COURSE_ID>/lectures/<LECTURE_ID>?unit=<UNIT_ID>&timestamp=<SECONDS> (where ... is your Artemis base URL) for a valid in‑range timestamp.
2. Verify the unit auto‑expands and the HLS player seeks to the given timestamp.


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| attachment-video-unit.component.ts | 96.38% | 209 | 51 | 24.4 |
| course-lecture-details.component.ts | 84.69% | 237 | 28 | 11.8 |
| lecture-unit.component.ts | 85.71% | 107 | 10 | 9.3 |
| lecture-unit.directive.ts | 88.88% | 19 | ? | ? |
| video-player.component.ts | 86.02% | 212 | 38 | 17.9 |

_Last updated: 2026-03-16 22:44:52 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep-linking to specific lecture units and video timestamps — links auto-expand the target unit and resume the video at the linked time.
  * Units (video, text, online) can now open initially expanded when targeted.
  * Auto-scroll behavior improved to bring the expanded unit into view.

* **Tests**
  * Added test validating initial video timestamp behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->