### PR TITLE
`Development`: Use self-hosted runners for deployment

### DIFF
--- a/.github/workflows/prod-like-deployment.yml
+++ b/.github/workflows/prod-like-deployment.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   check-build-status:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, deploy-artemis]
     outputs:
       build_workflow_run_id: ${{ steps.set_build_workflow_id.outputs.workflow_id }}
     steps:

--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -47,7 +47,7 @@ jobs:
   # Log the inputs for debugging
   log-inputs:
     name: Log Inputs
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, deploy-artemis]
     steps:
       - name: Print Inputs
         run: |
@@ -58,7 +58,7 @@ jobs:
 
   determine-build-context:
     name: Determine Build Context
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, deploy-artemis]
     needs: log-inputs
     outputs:
       pr_number: ${{ steps.get_pr.outputs.pr_number }}
@@ -131,7 +131,7 @@ jobs:
     name: Check Existing Build of Pull Request
     if: ${{ needs.determine-build-context.outputs.pr_number != '' }}
     needs: determine-build-context
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, deploy-artemis]
     steps:
       - name: Get latest successful build for branch
         id: check_build
@@ -151,7 +151,7 @@ jobs:
     name: Check Existing Build of main or develop branch
     if: ${{ needs.determine-build-context.outputs.is_main_or_develop == 'true' }}
     needs: determine-build-context
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, deploy-artemis]
     steps:
       - name: Get latest successful build for main or develop branch
         id: check_main_build
@@ -169,8 +169,7 @@ jobs:
 
   check-database-migration-approval:
     name: Check Database Migration Approval
-    runs-on: ubuntu-latest
-    needs: [determine-build-context]
+    runs-on: [self-hosted, deploy-artemis]
     if: ${{ needs.determine-build-context.outputs.pr_number != '' }}
     steps:
       - name: Checkout Repository
@@ -203,7 +202,7 @@ jobs:
     # Use always() since one of the jobs will always skip
     if: always() && (needs.conditional-build.result == 'success' || needs.check-existing-build-for-pull-request.result == 'success' || needs.check-existing-build-for-branch.result == 'success') && (needs.check-database-migration-approval.result == 'success' || needs.check-database-migration-approval.result == 'skipped')
     name: Deploy to Test-Server
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, deploy-artemis]
     environment:
       name: ${{ github.event.inputs.environment_name }}
       url: ${{ vars.DEPLOYMENT_URL }}

--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -170,6 +170,7 @@ jobs:
   check-database-migration-approval:
     name: Check Database Migration Approval
     runs-on: [self-hosted, deploy-artemis]
+    needs: [determine-build-context]
     if: ${{ needs.determine-build-context.outputs.pr_number != '' }}
     steps:
       - name: Checkout Repository


### PR DESCRIPTION

### Summary 

Switch deployment workflows from `ubuntu-latest` to dedicated self-hosted runners (`[self-hosted, deploy-artemis]`) to significantly improve deployment speed and avoid delays caused by waiting for hosted runners to become available.

### Checklist
- [x] This is a small issue.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


### Motivation and Context

Deployments using `ubuntu-latest` runners can be delayed due to limited availability and queue times on GitHub-hosted infrastructure. This leads to slower feedback cycles and longer waiting times.
By switching to self-hosted runners, deployments can start immediately without queueing, resulting in faster and more reliable deployment execution.


### Description

This change updates all relevant GitHub Actions deployment workflows to use self-hosted runners labeled `deploy-artemis` instead of `ubuntu-latest`.


### Steps for Testing

1. Deploy PR on a test server
2. Check that the deployment works


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
