### PR TITLE
`Development`: Fix E2E JUnit report showing only 1 test

### DIFF
--- a/src/test/playwright/run-tests.sh
+++ b/src/test/playwright/run-tests.sh
@@ -79,7 +79,13 @@ fi
 
 # Merge reports
 echo "--- Merging test reports ---"
-npm run merge-junit-reports || true
+if [ -f ./test-reports/results-parallel.xml ] && [ -f ./test-reports/results-sequential.xml ]; then
+    npm run merge-junit-reports || true
+elif [ -f ./test-reports/results-parallel.xml ]; then
+    cp ./test-reports/results-parallel.xml ./test-reports/results.xml
+elif [ -f ./test-reports/results-sequential.xml ]; then
+    cp ./test-reports/results-sequential.xml ./test-reports/results.xml
+fi
 npm run merge-coverage-reports || true
 
 # Write marker file if reporter failed but tests passed (picked up by execute.sh for CI reporting).

--- a/src/test/playwright/run-tests.sh
+++ b/src/test/playwright/run-tests.sh
@@ -85,6 +85,8 @@ elif [ -f ./test-reports/results-parallel.xml ]; then
     cp ./test-reports/results-parallel.xml ./test-reports/results.xml
 elif [ -f ./test-reports/results-sequential.xml ]; then
     cp ./test-reports/results-sequential.xml ./test-reports/results.xml
+else
+    echo 'Warning: No JUnit report files found to merge'
 fi
 npm run merge-coverage-reports || true
 


### PR DESCRIPTION
### Summary

Fixes the E2E JUnit report incorrectly showing only 1 test instead of the actual test count. PR #12240 removed sequential tests but did not update the `merge-junit-reports` step, which requires both `results-parallel.xml` and `results-sequential.xml`. When `results-sequential.xml` is missing, `junit-merge` fails silently (`|| true`), leaving `results.xml` with only the setup test (1 test), while the real results in `results-parallel.xml` get deleted by the Docker cleanup step.

### Checklist

#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

Since #12240 was merged (2026-03-14), all E2E runs report only 1 test in the JUnit summary. The root cause:

1. `run-tests.sh` calls `npm run merge-junit-reports` which runs `junit-merge ./test-reports/results-parallel.xml ./test-reports/results-sequential.xml -o ./test-reports/results.xml`
2. `results-sequential.xml` no longer exists (sequential tests removed in #12240)
3. `junit-merge` fails → swallowed by `|| true`
4. `results.xml` retains the content from `playwright:setup` (the `playwright test init` step), which only has 1 test
5. The Docker cleanup step then deletes `results-parallel.xml` (the file with actual results)
6. Only the stale `results.xml` (1 setup test) gets uploaded as the artifact

### Description

Updated the merge step in `run-tests.sh` to handle missing intermediate XML files:
- **Both files exist** → merge as before via `junit-merge`
- **Only `results-parallel.xml` exists** → copy it directly to `results.xml`
- **Only `results-sequential.xml` exists** → copy it directly to `results.xml`

### Steps for Testing

N/A

### Testserver States

N/A

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test report processing now conditionally handles parallel and sequential results: when both exist they are merged; when only one exists it is promoted as the main report; a warning is emitted if no reports are found. Coverage report merging is unchanged.
  * The reporter-failed marker is now created only under the correct pass/fail condition instead of being written unconditionally.
* **Documentation**
  * Clarified inline comment about reporter-failure handling (no functional change beyond the gating condition).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->