### PR TITLE
`Development`: Fix CI pipeline failures after DTO conversion merge

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           # TODO these values should become zero in the future
           max_large_classes=16
-          max_complex_beans=14
+          max_complex_beans=15
 
           python supporting_scripts/analyze_java_files.py \
             --max-large-classes $max_large_classes \

--- a/.github/workflows/query-quality.yml
+++ b/.github/workflows/query-quality.yml
@@ -36,7 +36,7 @@ jobs:
           total_violations=$((entitygraph_violations + query_violations))
 
           # TODO these values should become zero in the future
-          max_entitygraph_violations=10
+          max_entitygraph_violations=11
           max_query_violations=24
           max_total_violations=$((max_entitygraph_violations + max_query_violations))
 

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/api/CompetencyRelationApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/api/CompetencyRelationApi.java
@@ -39,6 +39,12 @@ public class CompetencyRelationApi extends AbstractAtlasApi {
         competencyExerciseLinkRepository.deleteAll(competencyExerciseLinks);
     }
 
+    /**
+     * Saves all given competency exercise links, ensuring referenced competencies are managed entities.
+     *
+     * @param competencyExerciseLinks the links to save
+     * @return the saved links
+     */
     public List<CompetencyExerciseLink> saveAllExerciseLinks(Iterable<CompetencyExerciseLink> competencyExerciseLinks) {
         return competencyExerciseLinkRepository.saveAll(competencyExerciseLinks);
     }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/api/CompetencyRelationApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/api/CompetencyRelationApi.java
@@ -40,7 +40,7 @@ public class CompetencyRelationApi extends AbstractAtlasApi {
     }
 
     /**
-     * Saves all given competency exercise links, ensuring referenced competencies are managed entities.
+     * Saves all given competency exercise links by directly delegating to {@link CompetencyExerciseLinkRepository#saveAll(Iterable)}.
      *
      * @param competencyExerciseLinks the links to save
      * @return the saved links

--- a/src/main/webapp/app/exam/manage/services/exam-management.service.spec.ts
+++ b/src/main/webapp/app/exam/manage/services/exam-management.service.spec.ts
@@ -20,7 +20,6 @@ import { provideHttpClient } from '@angular/common/http';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
 import { MockAccountService } from 'test/helpers/mocks/service/mock-account.service';
-import { toExamUpdateDTO } from 'app/exam/manage/services/exam-update-dto.model';
 
 describe('Exam Management Service Tests', () => {
     let service: ExamManagementService;
@@ -59,7 +58,7 @@ describe('Exam Management Service Tests', () => {
     it('should create an exam', fakeAsync(() => {
         // GIVEN
         const mockExam: Exam = { id: 1 };
-        const expectedBody = toExamUpdateDTO({ id: 1 } as Exam);
+        const expectedBody = ExamManagementService.convertExamDatesFromClient({ id: 1 } as Exam);
 
         // WHEN
         service.create(course.id!, mockExam).subscribe((res) => expect(res.body).toEqual(mockExam));
@@ -76,7 +75,7 @@ describe('Exam Management Service Tests', () => {
     it('should update an exam', fakeAsync(() => {
         // GIVEN
         const mockExam: Exam = { id: 1 };
-        const expectedBody = toExamUpdateDTO({ id: 1 } as Exam);
+        const expectedBody = ExamManagementService.convertExamDatesFromClient({ id: 1 } as Exam);
 
         // WHEN
         service.update(course.id!, mockExam).subscribe((res) => expect(res.body).toEqual(mockExam));
@@ -93,7 +92,7 @@ describe('Exam Management Service Tests', () => {
     it('should import an exam', fakeAsync(() => {
         // GIVEN
         const mockExam: Exam = { id: 1 };
-        const expectedBody = ExamManagementService.convertExamToImportDTO({ id: 1 } as Exam, course.id!);
+        const expectedBody = ExamManagementService.convertExamDatesFromClient({ id: 1 } as Exam);
 
         // WHEN
         service.import(course.id!, mockExam).subscribe((res) => expect(res.body).toEqual(mockExam));

--- a/src/main/webapp/app/exam/manage/services/exam-management.service.spec.ts
+++ b/src/main/webapp/app/exam/manage/services/exam-management.service.spec.ts
@@ -20,6 +20,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
 import { MockAccountService } from 'test/helpers/mocks/service/mock-account.service';
+import { toExamUpdateDTO } from 'app/exam/manage/services/exam-update-dto.model';
 
 describe('Exam Management Service Tests', () => {
     let service: ExamManagementService;
@@ -58,14 +59,14 @@ describe('Exam Management Service Tests', () => {
     it('should create an exam', fakeAsync(() => {
         // GIVEN
         const mockExam: Exam = { id: 1 };
-        const mockCopyExam = ExamManagementService.convertExamDatesFromClient({ id: 1 });
+        const expectedBody = toExamUpdateDTO({ id: 1 } as Exam);
 
         // WHEN
         service.create(course.id!, mockExam).subscribe((res) => expect(res.body).toEqual(mockExam));
 
         // THEN
         const req = httpMock.expectOne({ method: 'POST', url: `${service.resourceUrl}/${course.id!}/exams` });
-        expect(req.request.body).toEqual(mockCopyExam);
+        expect(req.request.body).toEqual(expectedBody);
 
         // CLEANUP
         req.flush(mockExam);
@@ -75,14 +76,14 @@ describe('Exam Management Service Tests', () => {
     it('should update an exam', fakeAsync(() => {
         // GIVEN
         const mockExam: Exam = { id: 1 };
-        const mockCopyExam = ExamManagementService.convertExamDatesFromClient({ id: 1 });
+        const expectedBody = toExamUpdateDTO({ id: 1 } as Exam);
 
         // WHEN
         service.update(course.id!, mockExam).subscribe((res) => expect(res.body).toEqual(mockExam));
 
         // THEN
         const req = httpMock.expectOne({ method: 'PUT', url: `${service.resourceUrl}/${course.id!}/exams` });
-        expect(req.request.body).toEqual(mockCopyExam);
+        expect(req.request.body).toEqual(expectedBody);
 
         // CLEANUP
         req.flush(mockExam);
@@ -92,14 +93,14 @@ describe('Exam Management Service Tests', () => {
     it('should import an exam', fakeAsync(() => {
         // GIVEN
         const mockExam: Exam = { id: 1 };
-        const mockCopyExam = ExamManagementService.convertExamDatesFromClient({ id: 1 });
+        const expectedBody = ExamManagementService.convertExamToImportDTO({ id: 1 } as Exam, course.id!);
 
         // WHEN
         service.import(course.id!, mockExam).subscribe((res) => expect(res.body).toEqual(mockExam));
 
         // THEN
         const req = httpMock.expectOne({ method: 'POST', url: `${service.resourceUrl}/${course.id!}/exam-import` });
-        expect(req.request.body).toEqual(mockCopyExam);
+        expect(req.request.body).toEqual(expectedBody);
 
         // CLEANUP
         req.flush(mockExam);
@@ -127,9 +128,8 @@ describe('Exam Management Service Tests', () => {
         // GIVEN
         const mockExam: Exam = { id: 1, exerciseGroups: [{ id: 2 } as ExerciseGroup] };
         const expected: Exam = { id: 1, exerciseGroups: [{ id: 2 } as ExerciseGroup] };
-        const mockCopyExam = ExamManagementService.convertExamDatesFromClient(expected);
         // WHEN
-        service.findWithExercisesAndWithoutCourseId(mockExam.id!).subscribe((res) => expect(res.body).toEqual(mockCopyExam));
+        service.findWithExercisesAndWithoutCourseId(mockExam.id!).subscribe((res) => expect(res.body).toEqual(expected));
 
         // THEN
         const req = httpMock.expectOne({
@@ -147,9 +147,8 @@ describe('Exam Management Service Tests', () => {
         // GIVEN
         const mockExam: Exam = { id: 1 };
         const expected: Exam = { id: 1 };
-        const mockCopyExam = ExamManagementService.convertExamDatesFromClient(expected);
         // WHEN
-        service.find(course.id!, mockExam.id!).subscribe((res) => expect(res.body).toEqual(mockCopyExam));
+        service.find(course.id!, mockExam.id!).subscribe((res) => expect(res.body).toEqual(expected));
 
         // THEN
         const req = httpMock.expectOne({

--- a/src/main/webapp/app/exam/manage/services/exam-management.service.spec.ts
+++ b/src/main/webapp/app/exam/manage/services/exam-management.service.spec.ts
@@ -127,8 +127,10 @@ describe('Exam Management Service Tests', () => {
         // GIVEN
         const mockExam: Exam = { id: 1, exerciseGroups: [{ id: 2 } as ExerciseGroup] };
         const expected: Exam = { id: 1, exerciseGroups: [{ id: 2 } as ExerciseGroup] };
+        const mockCopyExam = ExamManagementService.convertExamDatesFromClient(expected);
+
         // WHEN
-        service.findWithExercisesAndWithoutCourseId(mockExam.id!).subscribe((res) => expect(res.body).toEqual(expected));
+        service.findWithExercisesAndWithoutCourseId(mockExam.id!).subscribe((res) => expect(res.body).toEqual(mockCopyExam));
 
         // THEN
         const req = httpMock.expectOne({
@@ -146,8 +148,10 @@ describe('Exam Management Service Tests', () => {
         // GIVEN
         const mockExam: Exam = { id: 1 };
         const expected: Exam = { id: 1 };
+        const mockCopyExam = ExamManagementService.convertExamDatesFromClient(expected);
+
         // WHEN
-        service.find(course.id!, mockExam.id!).subscribe((res) => expect(res.body).toEqual(expected));
+        service.find(course.id!, mockExam.id!).subscribe((res) => expect(res.body).toEqual(mockCopyExam));
 
         // THEN
         const req = httpMock.expectOne({

--- a/src/main/webapp/app/exercise/services/exercise.service.spec.ts
+++ b/src/main/webapp/app/exercise/services/exercise.service.spec.ts
@@ -19,7 +19,6 @@ import { ArtemisMarkdownService } from 'app/shared/service/markdown.service';
 import { MockProvider } from 'ng-mocks';
 import { SafeHtml } from '@angular/platform-browser';
 import { ExerciseCategory } from 'app/exercise/shared/entities/exercise/exercise-category.model';
-import { Observable } from 'rxjs';
 import { AccountService } from 'app/core/auth/account.service';
 import { provideHttpClient } from '@angular/common/http';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
@@ -392,58 +391,6 @@ describe('Exercise Service', () => {
         expect(entityTitleServiceSpy).toHaveBeenCalledWith(exerciseFromServer);
 
         expect(profileServiceSpy).not.toHaveBeenCalled();
-    });
-
-    it.each(['create', 'update'])('should send %s request for the exercise', (action: string) => {
-        const serviceSpy = jest.spyOn(service, 'processExerciseEntityResponse');
-
-        const category = {
-            color: '#6ae8ac',
-            category: 'category1',
-        } as ExerciseCategory;
-
-        const releaseDate = dayjs();
-
-        exercise = Object.assign({}, textExercise, {
-            categories: [category],
-            releaseDate,
-        });
-        const expectedReturnedExercise = { id: exercise.id } as Exercise;
-
-        const expectedUrl = `api/exercise/exercises`;
-        let result$: Observable<EntityResponseType>;
-        let method: string;
-        if (action === 'create') {
-            result$ = service.create(exercise);
-            method = 'POST';
-        } else if (action === 'update') {
-            result$ = service.update(exercise);
-            method = 'PUT';
-        } else {
-            throw new Error(`Unexpected action: ${action}`);
-        }
-
-        let actualReturnedExercise = undefined;
-        result$.subscribe((exerciseResponse) => (actualReturnedExercise = exerciseResponse.body!));
-
-        const testRequest = httpMock.expectOne({
-            url: expectedUrl,
-            method,
-        });
-
-        testRequest.flush(expectedReturnedExercise);
-
-        const sentBody = testRequest.request.body;
-
-        expect(sentBody.categories).toHaveLength(1);
-        expect(sentBody.categories[0]).toBe(JSON.stringify(category));
-
-        expect(sentBody.releaseDate).toBe(releaseDate.toJSON());
-        expect(sentBody.startDate).toBeUndefined();
-
-        expect(serviceSpy).toHaveBeenCalledOnce();
-        expect(serviceSpy).toHaveBeenCalledWith(expect.objectContaining({ body: expectedReturnedExercise }));
-        expect(actualReturnedExercise).toEqual(expectedReturnedExercise);
     });
 
     it('should get exercise details', () => {


### PR DESCRIPTION
### Summary

Fix CI pipeline failures on develop caused by the DTO conversion merge and its follow-up commits: broken client tests, a missing Javadoc comment, and threshold violations in quality checks.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).

### Motivation and Context

After merging the DTO conversion and its follow-up fixes into develop, several CI jobs are failing:

1. **Client test compilation fails** — introduced by `b85c155892` (*Development: Convert REST controllers to use DTOs instead of raw entities*):
   - `ExamManagementService.convertExamDatesFromClient()` was removed, but `exam-management.service.spec.ts` still references it.
   - `ExerciseService.create()` and `ExerciseService.update()` were removed, but `exercise.service.spec.ts` still tests them.

2. **Checkstyle violation** — introduced by `2302102198` (*fix issues*, a follow-up fix to the DTO conversion):
   - `CompetencyRelationApi.saveAllExerciseLinks()` was added without a Javadoc comment.

3. **Quality check: complex beans threshold exceeded** — introduced by `b85c155892`:
   - The new `ProgrammingExerciseUpdateResource` class has 13 constructor parameters, pushing the count from 14 to 15 (threshold was 14).

4. **Query quality check: EntityGraph threshold exceeded** — introduced by `f1f38785b7` (*fix remaining issues*, a follow-up fix to the DTO conversion):
   - `ProgrammingExerciseRepository.findForUpdateById()` was expanded from 4 to 7 attribute paths (`templateParticipation`, `solutionParticipation`, `plagiarismDetectionConfig` added), pushing the EntityGraph violation count from 10 to 11 (threshold was 10). These fetches are necessary because the update endpoint now needs these associations for validation and persistence.

### Known Failing Server Tests (not addressed by this PR)

The following server tests also fail on develop but are **not caused by this PR** and are **not fixed here**:

- **`QuizExerciseIntegrationTest > testCreateAndUpdateQuizWithCompetency()`**: Expects 404 when updating a quiz exercise with a non-existent competency (ID 999), but gets 200. This is a pre-existing issue introduced by the DTO conversion (`a7cbd489ac` *Development: Fix server tests for DTO conversion and fix Hibernate compatibility issues*). The `UpdateQuizExerciseDTO.of()` conversion likely drops the competency links due to the `Hibernate.isInitialized()` check, causing the update to silently clear competency links instead of rejecting the non-existent competency.

- **`LocalCIDockerImageIntegrationTest > setupCExerciseWithGcc_usesConfiguredDockerImage()`**: Expects score 100.0 but gets 85.7. This is a pre-existing flaky test unrelated to the DTO conversion (last changed in `6de5378e90` *Programming exercises: Update fact docker image*).

### Description

- Update `exam-management.service.spec.ts` to use `toExamUpdateDTO()` for `create`/`update` test assertions and `ExamManagementService.convertExamToImportDTO()` for the `import` test, matching the new service implementation. Remove no-op `convertExamDatesFromClient` calls in `find` tests.
- Remove the `create`/`update` test from `exercise.service.spec.ts` since those methods no longer exist on `ExerciseService`. The same behavior is already tested in the exercise-type-specific service tests (`TextExerciseService`, `ModelingExerciseService`, `FileUploadExerciseService`). Clean up the unused `Observable` import.
- Add Javadoc to `CompetencyRelationApi.saveAllExerciseLinks()` to fix the checkstyle violation.
- Adjust `max_complex_beans` from 14 to 15 in `quality.yml` (caused by the new `ProgrammingExerciseUpdateResource` with 13 constructor parameters).
- Adjust `max_entitygraph_violations` from 10 to 11 in `query-quality.yml` (caused by `findForUpdateById` expanding from 4 to 7 attribute paths for the DTO-based update flow).

### Steps for Testing
Prerequisites:
- 1 Developer

1. Verify that the CI pipeline passes on this branch
2. Run `npm run compile:tests` locally — should succeed with no errors
3. Run `./gradlew checkstyleMain -x webapp` locally — should succeed with no violations

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| CompetencyRelationApi.java | 84.62% | 40 |

_Last updated: 2026-03-17 18:32:15 UTC_

