### PR TITLE
`Lectures`: Create deep linking for HLS video player

### DIFF
--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.html
@@ -55,7 +55,7 @@
         } @else {
             <div class="video-player-container">
                 <div class="ratio ratio-16x9">
-                    <iframe id="videoFrame" class="rounded" [src]="videoUrlWithTimestamp() | safeResourceUrl" allow="fullscreen"></iframe>
+                    <iframe id="videoFrame" class="rounded" [src]="videoUrl() | safeResourceUrl" allow="fullscreen"></iframe>
                 </div>
             </div>
         }

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.html
@@ -7,6 +7,7 @@
     [viewIsolatedButtonLabel]="'artemisApp.attachmentVideoUnit.download'"
     [viewIsolatedButtonIcon]="faDownload"
     [isPresentationMode]="isPresentationMode()"
+    [initiallyExpanded]="initiallyExpanded()"
     (onCompletion)="toggleCompletion($event)"
     (onCollapse)="toggleCollapse($event)"
     (onShowIsolated)="handleDownload()"
@@ -50,11 +51,11 @@
                 </div>
             </div>
         } @else if (playlistUrl() && hasTranscript()) {
-            <jhi-video-player [videoUrl]="playlistUrl()!" [transcriptSegments]="transcriptSegments()" />
+            <jhi-video-player [videoUrl]="playlistUrl()!" [transcriptSegments]="transcriptSegments()" [initialTimestamp]="targetTimestamp()" />
         } @else {
             <div class="video-player-container">
                 <div class="ratio ratio-16x9">
-                    <iframe id="videoFrame" class="rounded" [src]="videoUrl() | safeResourceUrl" allow="fullscreen"></iframe>
+                    <iframe id="videoFrame" class="rounded" [src]="videoUrlWithTimestamp() | safeResourceUrl" allow="fullscreen"></iframe>
                 </div>
             </div>
         }

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.spec.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.spec.ts
@@ -220,7 +220,6 @@ describe('AttachmentVideoUnitComponent', () => {
         expect(component.videoUrl()).toBeUndefined();
         parseSpy.mockRestore();
     });
-
     it('toggleCollapse(false): resets state, resolves playlist, fetches transcript (happy path)', async () => {
         // Arrange BEFORE first detectChanges so the computed() caches the right value
         const src = 'https://live.rbg.tum.de/w/abcd/1234?video_only=1';

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.spec.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.spec.ts
@@ -221,17 +221,6 @@ describe('AttachmentVideoUnitComponent', () => {
         parseSpy.mockRestore();
     });
 
-    it('videoUrlWithTimestamp: appends timestamp to allow-listed URL', () => {
-        const src = 'https://live.rbg.tum.de/w/abcd/1234?video_only=1';
-        component.lectureUnit().videoSource = src;
-        fixture.componentRef.setInput('targetTimestamp', 42.9);
-        fixture.detectChanges();
-
-        const withTimestamp = component.videoUrlWithTimestamp();
-        expect(withTimestamp).toBeDefined();
-        const parsed = new URL(withTimestamp!);
-        expect(parsed.searchParams.get('t')).toBe('42');
-    });
     it('toggleCollapse(false): resets state, resolves playlist, fetches transcript (happy path)', async () => {
         // Arrange BEFORE first detectChanges so the computed() caches the right value
         const src = 'https://live.rbg.tum.de/w/abcd/1234?video_only=1';

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.spec.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.spec.ts
@@ -220,6 +220,18 @@ describe('AttachmentVideoUnitComponent', () => {
         expect(component.videoUrl()).toBeUndefined();
         parseSpy.mockRestore();
     });
+
+    it('videoUrlWithTimestamp: appends timestamp to allow-listed URL', () => {
+        const src = 'https://live.rbg.tum.de/w/abcd/1234?video_only=1';
+        component.lectureUnit().videoSource = src;
+        fixture.componentRef.setInput('targetTimestamp', 42.9);
+        fixture.detectChanges();
+
+        const withTimestamp = component.videoUrlWithTimestamp();
+        expect(withTimestamp).toBeDefined();
+        const parsed = new URL(withTimestamp!);
+        expect(parsed.searchParams.get('t')).toBe('42');
+    });
     it('toggleCollapse(false): resets state, resolves playlist, fetches transcript (happy path)', async () => {
         // Arrange BEFORE first detectChanges so the computed() caches the right value
         const src = 'https://live.rbg.tum.de/w/abcd/1234?video_only=1';

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.ts
@@ -63,7 +63,6 @@ export class AttachmentVideoUnitComponent extends LectureUnitDirective<Attachmen
      * Return the URL of the video source
      */
     readonly videoUrl = computed(() => this.computeVideoUrl());
-    readonly videoUrlWithTimestamp = computed(() => this.appendTimestamp(this.videoUrl(), this.targetTimestamp()));
 
     /**
      * Computes the video URL based on the video source.
@@ -86,40 +85,6 @@ export class AttachmentVideoUnitComponent extends LectureUnitDirective<Attachmen
             }
         }
         return undefined;
-    }
-
-    private appendTimestamp(url: string | undefined, timestamp: number | undefined): string | undefined {
-        if (!url) {
-            return undefined;
-        }
-
-        const normalizedTimestamp = this.normalizeTimestamp(timestamp);
-        if (normalizedTimestamp === undefined) {
-            return url;
-        }
-
-        try {
-            const urlObj = new URL(url, window.location.origin);
-            const parsed = urlParser.parse(url);
-            if (parsed?.provider === 'youtube') {
-                urlObj.searchParams.set('start', String(normalizedTimestamp));
-            } else if (parsed?.provider === 'vimeo') {
-                urlObj.hash = `t=${normalizedTimestamp}s`;
-            } else {
-                urlObj.searchParams.set('t', String(normalizedTimestamp));
-            }
-            return urlObj.toString();
-        } catch {
-            const separator = url.includes('?') ? '&' : '?';
-            return `${url}${separator}t=${normalizedTimestamp}`;
-        }
-    }
-
-    private normalizeTimestamp(timestamp: number | undefined): number | undefined {
-        if (timestamp === undefined || !Number.isFinite(timestamp) || timestamp < 0) {
-            return undefined;
-        }
-        return Math.floor(timestamp);
     }
 
     override toggleCollapse(isCollapsed: boolean): void {

--- a/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/attachment-video-unit/attachment-video-unit.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
+import { Component, DestroyRef, computed, inject, input, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { LectureUnitDirective } from 'app/lecture/overview/course-lectures/lecture-unit/lecture-unit.directive';
 import { AttachmentVideoUnit } from 'app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model';
@@ -48,6 +48,8 @@ export class AttachmentVideoUnitComponent extends LectureUnitDirective<Attachmen
     private readonly attachmentVideoUnitService = inject(AttachmentVideoUnitService);
     private readonly lectureTranscriptionService = inject(LectureTranscriptionService);
 
+    targetTimestamp = input<number | undefined>(undefined);
+
     readonly transcriptSegments = signal<TranscriptSegment[]>([]);
     readonly playlistUrl = signal<string | undefined>(undefined);
     readonly isLoading = signal<boolean>(false);
@@ -61,6 +63,7 @@ export class AttachmentVideoUnitComponent extends LectureUnitDirective<Attachmen
      * Return the URL of the video source
      */
     readonly videoUrl = computed(() => this.computeVideoUrl());
+    readonly videoUrlWithTimestamp = computed(() => this.appendTimestamp(this.videoUrl(), this.targetTimestamp()));
 
     /**
      * Computes the video URL based on the video source.
@@ -83,6 +86,40 @@ export class AttachmentVideoUnitComponent extends LectureUnitDirective<Attachmen
             }
         }
         return undefined;
+    }
+
+    private appendTimestamp(url: string | undefined, timestamp: number | undefined): string | undefined {
+        if (!url) {
+            return undefined;
+        }
+
+        const normalizedTimestamp = this.normalizeTimestamp(timestamp);
+        if (normalizedTimestamp === undefined) {
+            return url;
+        }
+
+        try {
+            const urlObj = new URL(url, window.location.origin);
+            const parsed = urlParser.parse(url);
+            if (parsed?.provider === 'youtube') {
+                urlObj.searchParams.set('start', String(normalizedTimestamp));
+            } else if (parsed?.provider === 'vimeo') {
+                urlObj.hash = `t=${normalizedTimestamp}s`;
+            } else {
+                urlObj.searchParams.set('t', String(normalizedTimestamp));
+            }
+            return urlObj.toString();
+        } catch {
+            const separator = url.includes('?') ? '&' : '?';
+            return `${url}${separator}t=${normalizedTimestamp}`;
+        }
+    }
+
+    private normalizeTimestamp(timestamp: number | undefined): number | undefined {
+        if (timestamp === undefined || !Number.isFinite(timestamp) || timestamp < 0) {
+            return undefined;
+        }
+        return Math.floor(timestamp);
     }
 
     override toggleCollapse(isCollapsed: boolean): void {

--- a/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.html
@@ -71,13 +71,29 @@
                                         <jhi-exercise-unit [exerciseUnit]="lectureUnit" [course]="lecture!.course!" />
                                     }
                                     @case (LectureUnitType.ATTACHMENT_VIDEO) {
-                                        <jhi-attachment-video-unit [courseId]="courseId!" [lectureUnit]="lectureUnit" (onCompletion)="completeLectureUnit($event)" />
+                                        <jhi-attachment-video-unit
+                                            [courseId]="courseId!"
+                                            [lectureUnit]="lectureUnit"
+                                            [initiallyExpanded]="lectureUnit.id === targetUnitId()"
+                                            [targetTimestamp]="lectureUnit.id === targetUnitId() ? targetVideoTimestamp() : undefined"
+                                            (onCompletion)="completeLectureUnit($event)"
+                                        />
                                     }
                                     @case (LectureUnitType.TEXT) {
-                                        <jhi-text-unit [courseId]="courseId!" [lectureUnit]="lectureUnit" (onCompletion)="completeLectureUnit($event)" />
+                                        <jhi-text-unit
+                                            [courseId]="courseId!"
+                                            [lectureUnit]="lectureUnit"
+                                            [initiallyExpanded]="lectureUnit.id === targetUnitId()"
+                                            (onCompletion)="completeLectureUnit($event)"
+                                        />
                                     }
                                     @case (LectureUnitType.ONLINE) {
-                                        <jhi-online-unit [courseId]="courseId!" [lectureUnit]="lectureUnit" (onCompletion)="completeLectureUnit($event)" />
+                                        <jhi-online-unit
+                                            [courseId]="courseId!"
+                                            [lectureUnit]="lectureUnit"
+                                            [initiallyExpanded]="lectureUnit.id === targetUnitId()"
+                                            (onCompletion)="completeLectureUnit($event)"
+                                        />
                                     }
                                 }
                             </div>

--- a/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { Component, DestroyRef, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MODULE_FEATURE_IRIS, addPublicFilePrefix } from 'app/app.constants';
@@ -72,6 +73,7 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
     private readonly profileService = inject(ProfileService);
     private readonly irisSettingsService = inject(IrisSettingsService);
     private readonly scienceService = inject(ScienceService);
+    private readonly destroyRef = inject(DestroyRef);
 
     protected readonly LectureUnitType = LectureUnitType;
     protected readonly isCommunicationEnabled = isCommunicationEnabled;
@@ -94,6 +96,9 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
     irisEnabled = false;
     informationBoxData: InformationBox[] = [];
 
+    readonly targetUnitId = signal<number | undefined>(undefined);
+    readonly targetVideoTimestamp = signal<number | undefined>(undefined);
+
     ngOnInit(): void {
         this.irisEnabled = this.profileService.isModuleFeatureActive(MODULE_FEATURE_IRIS);
 
@@ -111,6 +116,22 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
             if (this.lectureId) {
                 this.scienceService.logEvent(ScienceEventType.LECTURE__OPEN, this.lectureId);
                 this.loadData();
+            }
+        });
+
+        this.activatedRoute.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
+            const unitId = Number(params['unit']);
+            if (Number.isInteger(unitId) && unitId > 0) {
+                this.targetUnitId.set(unitId);
+                const timestamp = Number(params['timestamp']);
+                this.targetVideoTimestamp.set(Number.isFinite(timestamp) && timestamp >= 0 ? timestamp : undefined);
+            } else {
+                this.targetUnitId.set(undefined);
+                this.targetVideoTimestamp.set(undefined);
+            }
+
+            if (this.lectureUnits.length > 0) {
+                this.ensureValidDeepLinkTargets();
             }
         });
     }
@@ -135,6 +156,7 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
                         });
 
                         this.lectureUnits = this.lecture?.lectureUnits ?? [];
+                        this.ensureValidDeepLinkTargets();
                         if (this.lectureUnits?.length) {
                             // Check if PDF attachments exist in lecture units
                             this.hasPdfLectureUnit =
@@ -216,6 +238,24 @@ export class CourseLectureDetailsComponent implements OnInit, OnDestroy {
             content: boxContentStartDate,
             isContentComponent: true,
         };
+    }
+
+    private ensureValidDeepLinkTargets(): void {
+        const targetUnitId = this.targetUnitId();
+        if (!targetUnitId) {
+            return;
+        }
+
+        const targetUnit = this.lectureUnits.find((unit) => unit.id === targetUnitId);
+        if (!targetUnit) {
+            this.targetUnitId.set(undefined);
+            this.targetVideoTimestamp.set(undefined);
+            return;
+        }
+
+        if (targetUnit.type !== LectureUnitType.ATTACHMENT_VIDEO) {
+            this.targetVideoTimestamp.set(undefined);
+        }
     }
 
     ngOnDestroy() {

--- a/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.component.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Injector, afterNextRender, computed, inject, input, output, signal } from '@angular/core';
+import { Component, ElementRef, Injector, OnDestroy, afterNextRender, computed, effect, inject, input, output, signal, untracked } from '@angular/core';
 import { IconDefinition, faCheckCircle, faCircle, faDownload, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
@@ -17,10 +17,14 @@ import { CompetencyContributionComponent } from 'app/atlas/shared/competency-con
     templateUrl: './lecture-unit.component.html',
     styleUrl: './lecture-unit.component.scss',
 })
-export class LectureUnitComponent {
+export class LectureUnitComponent implements OnDestroy {
+    private static readonly SCROLL_INTO_VIEW_DELAY_MS = 500;
+
     private router = inject(Router);
     private elementRef = inject(ElementRef);
     private injector = inject(Injector);
+    private scrollTimeoutId: ReturnType<typeof setTimeout> | undefined;
+    private autoExpanded = false;
 
     protected faDownload = faDownload;
     protected faCheckCircle = faCheckCircle;
@@ -35,6 +39,7 @@ export class LectureUnitComponent {
     viewIsolatedButtonLabel = input<string>('artemisApp.textUnit.isolated');
     viewIsolatedButtonIcon = input<IconDefinition>(faExternalLinkAlt);
     isPresentationMode = input.required<boolean>();
+    initiallyExpanded = input<boolean>(false);
 
     readonly showOriginalVersionButton = input<boolean>(false);
     readonly onShowOriginalVersion = output<void>();
@@ -48,6 +53,35 @@ export class LectureUnitComponent {
     readonly isVisibleToStudents = computed(() => this.lectureUnit().visibleToStudents);
     readonly isStudentPath = computed(() => this.router.url.startsWith('/courses'));
 
+    constructor() {
+        effect(
+            (onCleanup) => {
+                const shouldAutoExpand = this.initiallyExpanded();
+                if (shouldAutoExpand && !this.autoExpanded) {
+                    this.autoExpanded = true;
+                    if (untracked(() => this.isCollapsed())) {
+                        this.isCollapsed.set(false);
+                        this.onCollapse.emit(false);
+                    }
+
+                    this.scheduleScroll('start', LectureUnitComponent.SCROLL_INTO_VIEW_DELAY_MS);
+                }
+                if (!shouldAutoExpand) {
+                    this.autoExpanded = false;
+                }
+
+                onCleanup(() => {
+                    this.clearScrollTimeout();
+                });
+            },
+            { injector: this.injector },
+        );
+    }
+
+    ngOnDestroy(): void {
+        this.clearScrollTimeout();
+    }
+
     toggleCompletion(event: Event) {
         event.stopPropagation();
         this.onCompletion.emit(!this.lectureUnit().completed!);
@@ -58,12 +92,7 @@ export class LectureUnitComponent {
         this.onCollapse.emit(this.isCollapsed());
 
         if (!this.isCollapsed()) {
-            afterNextRender(
-                () => {
-                    this.elementRef.nativeElement.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' });
-                },
-                { injector: this.injector },
-            );
+            this.scheduleScroll('nearest');
         }
     }
 
@@ -75,5 +104,26 @@ export class LectureUnitComponent {
     handleOriginalVersionView(event: Event) {
         event.stopPropagation();
         this.onShowOriginalVersion.emit();
+    }
+
+    private scheduleScroll(block: ScrollLogicalPosition, delayMs = 0): void {
+        afterNextRender(
+            () => {
+                const doScroll = () => this.elementRef.nativeElement.scrollIntoView?.({ behavior: 'smooth', block });
+                if (delayMs > 0) {
+                    this.scrollTimeoutId = setTimeout(doScroll, delayMs);
+                } else {
+                    doScroll();
+                }
+            },
+            { injector: this.injector },
+        );
+    }
+
+    private clearScrollTimeout(): void {
+        if (this.scrollTimeoutId !== undefined) {
+            clearTimeout(this.scrollTimeoutId);
+            this.scrollTimeoutId = undefined;
+        }
     }
 }

--- a/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.directive.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.directive.ts
@@ -7,6 +7,7 @@ import { LectureUnitCompletionEvent } from 'app/lecture/overview/course-lectures
 export class LectureUnitDirective<T extends LectureUnit> {
     courseId = input.required<number>();
     lectureUnit = input.required<T>();
+    initiallyExpanded = input<boolean>(false);
 
     readonly onCompletion = output<LectureUnitCompletionEvent>();
     readonly onCollapse = output<boolean>();

--- a/src/main/webapp/app/lecture/overview/course-lectures/online-unit/online-unit.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/online-unit/online-unit.component.html
@@ -5,6 +5,7 @@
     [showViewIsolatedButton]="true"
     [viewIsolatedButtonLabel]="'artemisApp.onlineUnit.doOpen'"
     [isPresentationMode]="isPresentationMode()"
+    [initiallyExpanded]="initiallyExpanded()"
     (onCompletion)="toggleCompletion($event)"
     (onCollapse)="toggleCollapse($event)"
     (onShowIsolated)="handleIsolatedView()"

--- a/src/main/webapp/app/lecture/overview/course-lectures/text-unit/text-unit.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/text-unit/text-unit.component.html
@@ -4,6 +4,7 @@
     [icon]="faScroll"
     [showViewIsolatedButton]="true"
     [isPresentationMode]="isPresentationMode()"
+    [initiallyExpanded]="initiallyExpanded()"
     (onCompletion)="toggleCompletion($event)"
     (onCollapse)="toggleCollapse($event)"
     (onShowIsolated)="handleIsolatedView()"

--- a/src/main/webapp/app/lecture/shared/video-player/video-player.component.spec.ts
+++ b/src/main/webapp/app/lecture/shared/video-player/video-player.component.spec.ts
@@ -149,9 +149,10 @@ describe('VideoPlayerComponent', () => {
         vi.restoreAllMocks();
     });
 
-    function setInputs(url?: string, segments: TranscriptSegment[] = []): void {
+    function setInputs(url?: string, segments: TranscriptSegment[] = [], initialTimestamp?: number): void {
         fixture.componentRef.setInput('videoUrl', url);
         fixture.componentRef.setInput('transcriptSegments', segments);
+        fixture.componentRef.setInput('initialTimestamp', initialTimestamp);
     }
 
     async function render(): Promise<void> {
@@ -241,6 +242,16 @@ describe('VideoPlayerComponent', () => {
 
         expect(videoElement.currentTime).toBe(42);
         expect(playSpy).toHaveBeenCalled();
+    });
+
+    it('applies initial timestamp after metadata is available', async () => {
+        setInputs('https://cdn.example.com/m.m3u8', [], 12.5);
+        await render();
+
+        videoElement.dispatchEvent(new Event('loadedmetadata'));
+
+        expect(videoElement.currentTime).toBe(12.5);
+        expect(component.currentSegmentIndex()).toBe(-1);
     });
 
     it('ngOnDestroy destroys hls instance', async () => {

--- a/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
+++ b/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, OnDestroy, input, signal, viewChild } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, OnDestroy, effect, input, signal, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranscriptViewerComponent } from '../transcript-viewer/transcript-viewer.component';
 import Hls from 'hls.js';
@@ -34,6 +34,9 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
     /** Transcript segments to highlight and sync */
     transcriptSegments = input<TranscriptSegment[]>([]);
 
+    /** Optional timestamp to seek to once the player is ready */
+    initialTimestamp = input<number | undefined>(undefined);
+
     /** The HLS.js instance */
     private hls: Hls | undefined = undefined;
 
@@ -61,10 +64,42 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
     /** Minimum height for the transcript column */
     private readonly MIN_TRANSCRIPT_HEIGHT = 500;
 
+    private viewReady = signal<boolean>(false);
+    private lastInitialTimestamp: number | undefined;
+    private pendingInitialSeek: number | undefined;
+
+    constructor() {
+        effect(() => {
+            if (!this.viewReady()) {
+                return;
+            }
+
+            const timestamp = this.initialTimestamp();
+            if (timestamp === undefined || !Number.isFinite(timestamp) || timestamp < 0) {
+                this.lastInitialTimestamp = undefined;
+                return;
+            }
+
+            if (this.lastInitialTimestamp === timestamp) {
+                return;
+            }
+
+            const videoElement = this.videoRef()?.nativeElement;
+            if (!videoElement) {
+                return;
+            }
+
+            this.lastInitialTimestamp = timestamp;
+            this.queueInitialSeek(videoElement, timestamp);
+        });
+    }
+
     ngAfterViewInit(): void {
         const elRef = this.videoRef();
         const videoElement = elRef ? elRef.nativeElement : undefined;
         const src = this.videoUrl();
+
+        this.viewReady.set(true);
 
         if (!videoElement || !src) {
             return;
@@ -191,6 +226,34 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
 
         videoElement.currentTime = seconds;
         videoElement.play();
+    }
+
+    private queueInitialSeek(videoElement: HTMLVideoElement, seconds: number): void {
+        const target = Math.max(0, seconds);
+        if (videoElement.readyState >= 1) {
+            this.applyInitialSeek(videoElement, target);
+            return;
+        }
+
+        this.pendingInitialSeek = target;
+        videoElement.addEventListener(
+            'loadedmetadata',
+            () => {
+                const pending = this.pendingInitialSeek;
+                this.pendingInitialSeek = undefined;
+                if (pending !== undefined) {
+                    this.applyInitialSeek(videoElement, pending);
+                }
+            },
+            { once: true },
+        );
+    }
+
+    private applyInitialSeek(videoElement: HTMLVideoElement, seconds: number): void {
+        const duration = videoElement.duration;
+        const clamped = Number.isFinite(duration) ? Math.min(seconds, Math.max(0, duration)) : seconds;
+        videoElement.currentTime = clamped;
+        this.updateCurrentSegment(clamped);
     }
 
     /**

--- a/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
+++ b/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
@@ -251,7 +251,10 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
 
     private applyInitialSeek(videoElement: HTMLVideoElement, seconds: number): void {
         const duration = videoElement.duration;
-        const clamped = Number.isFinite(duration) ? Math.min(seconds, Math.max(0, duration)) : seconds;
+        if (Number.isFinite(duration) && seconds > duration) {
+            return;
+        }
+        const clamped = Number.isFinite(duration) ? Math.max(0, seconds) : seconds;
         videoElement.currentTime = clamped;
         this.updateCurrentSegment(clamped);
     }

--- a/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
+++ b/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
@@ -77,6 +77,7 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
             const timestamp = this.initialTimestamp();
             if (timestamp === undefined || !Number.isFinite(timestamp) || timestamp < 0) {
                 this.lastInitialTimestamp = undefined;
+                this.pendingInitialSeek = undefined;
                 return;
             }
 

--- a/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
+++ b/src/main/webapp/app/lecture/shared/video-player/video-player.component.ts
@@ -58,6 +58,9 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
     /** Store reference to window resize handler for cleanup */
     private resizeHandler: (() => void) | undefined = undefined;
 
+    /** Store reference to loadedmetadata handler for cleanup */
+    private loadedmetadataHandler: (() => void) | undefined = undefined;
+
     /** ResizeObserver for syncing transcript height with video column */
     private resizeObserver: ResizeObserver | undefined = undefined;
 
@@ -237,17 +240,23 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
         }
 
         this.pendingInitialSeek = target;
-        videoElement.addEventListener(
-            'loadedmetadata',
-            () => {
-                const pending = this.pendingInitialSeek;
-                this.pendingInitialSeek = undefined;
-                if (pending !== undefined) {
-                    this.applyInitialSeek(videoElement, pending);
-                }
-            },
-            { once: true },
-        );
+
+        // Remove any existing listener before adding a new one
+        if (this.loadedmetadataHandler) {
+            videoElement.removeEventListener('loadedmetadata', this.loadedmetadataHandler);
+        }
+
+        // Create a named listener function that can be removed later
+        this.loadedmetadataHandler = () => {
+            const pending = this.pendingInitialSeek;
+            this.pendingInitialSeek = undefined;
+            this.loadedmetadataHandler = undefined; // Clear reference after firing
+            if (pending !== undefined) {
+                this.applyInitialSeek(videoElement, pending);
+            }
+        };
+
+        videoElement.addEventListener('loadedmetadata', this.loadedmetadataHandler, { once: true });
     }
 
     private applyInitialSeek(videoElement: HTMLVideoElement, seconds: number): void {
@@ -288,6 +297,13 @@ export class VideoPlayerComponent implements AfterViewInit, OnDestroy {
         if (videoElement && this.timeupdateHandler) {
             videoElement.removeEventListener('timeupdate', this.timeupdateHandler);
             this.timeupdateHandler = undefined;
+        }
+
+        // Remove loadedmetadata listener to prevent memory leaks
+        if (videoElement && this.loadedmetadataHandler) {
+            videoElement.removeEventListener('loadedmetadata', this.loadedmetadataHandler);
+            this.loadedmetadataHandler = undefined;
+            this.pendingInitialSeek = undefined; // Clear pending seek as well
         }
 
         // Destroy HLS instance


### PR DESCRIPTION
FIXES IRIS-34

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 
This PR enables deep linking within the HLS video player. It is planned to be used to link the citations Iris gives to the according timestamp in a video.


### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Server
no changes on server side


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [ x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


#### Changes affecting Programming Exercises
no changes affection programming exercises


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR will later help the deep linking from Iris citations to the corresponding timestamp in videos. 


### Description
<!-- Describe your changes in detail -->
The HLS video player can be deep linked now. When adding the query parameters unit and timestamp, the video of the lecture unit is opened at the corresponding timestamp.
This is only for the HLS video player and not for videos displayed in an iframe player. Supporting videos in the iframe player is not necessary for this use case because Iris is only able to cite from transcribed videos. Also only videos which are available in the M3U8 format are transcribed in Artemis. So Iris can only cite from video in the M3U8 format having a transcript. As soon as a video fulfills these two points it is presented in an HLS player. (only TUMLive videos)


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- Lecture with an Attachment Video Unit
- Video in an HLS player. Either add a transcript to your database and change the code so that it accepts m3u8 files, or upload a TUMLive video to a test server or use my course "Test Video Player" with lecture unit "videotumlive" on TS1.

1. Open a deep link like .../courses/<COURSE_ID>/lectures/<LECTURE_ID>?unit=<UNIT_ID>&timestamp=<SECONDS> (where ... is your Artemis base URL) for a valid in‑range timestamp.
2. Verify the unit auto‑expands and the HLS player seeks to the given timestamp.


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| attachment-video-unit.component.ts | 96.38% | 209 | 51 | 24.4 |
| course-lecture-details.component.ts | 84.69% | 237 | 28 | 11.8 |
| lecture-unit.component.ts | 85.71% | 107 | 10 | 9.3 |
| lecture-unit.directive.ts | 88.88% | 19 | ? | ? |
| video-player.component.ts | 84.24% | 220 | 38 | 17.3 |

_Last updated: 2026-03-17 18:05:37 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep-linking to specific lecture units with automatic expansion and delayed smooth scroll into view.
  * Start video attachments at a specified initial timestamp when opening a video.
  * New initiallyExpanded input across lecture unit types to control their initial expanded state.

* **Tests**
  * Added test ensuring the initial video timestamp is applied after video metadata loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->