### PR TITLE
`Development`: Display links to unresolved comments if ready to merge check fails

### DIFF
--- a/.github/act-events/pullrequest-ready-to-merge-validator.json
+++ b/.github/act-events/pullrequest-ready-to-merge-validator.json
@@ -1,0 +1,12 @@
+{
+  "action": "labeled",
+  "label": {
+    "name": "ready to merge"
+  },
+  "pull_request": {
+    "number": 0,
+    "user": {
+      "login": "REPLACE_WITH_PR_AUTHOR"
+    }
+  }
+}

--- a/.github/workflows/pullrequest-ready-to-merge-validator.yml
+++ b/.github/workflows/pullrequest-ready-to-merge-validator.yml
@@ -3,16 +3,10 @@ name: Ready to Merge Label Validator
 on:
   pull_request_target:
     types: [labeled]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number to validate (for testing)'
-        required: true
-        type: number
 
 jobs:
   validate-ready-to-merge:
-    if: github.event.label.name == 'ready to merge' || github.event_name == 'workflow_dispatch'
+    if: github.event.label.name == 'ready to merge'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -25,24 +19,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = context.payload.inputs?.pr_number
-              ? parseInt(context.payload.inputs.pr_number)
-              : context.payload.pull_request.number;
+            const prNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-
-            // For workflow_dispatch, fetch the PR to get the author
-            let author;
-            if (context.payload.pull_request) {
-              author = context.payload.pull_request.user.login;
-            } else {
-              const { data: prData } = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number: prNumber
-              });
-              author = prData.user.login;
-            }
+            const author = context.payload.pull_request.user.login;
 
             console.log(`Validating PR #${prNumber} for "ready to merge" label`);
 
@@ -88,6 +68,9 @@ jobs:
                           nodes {
                             body
                             url
+                            author {
+                              login
+                            }
                           }
                         }
                       }
@@ -113,9 +96,10 @@ jobs:
                 items: unresolvedThreads.slice(0, 5).map(thread => {
                   const firstComment = thread.comments.nodes[0]?.body || '';
                   const url = thread.comments.nodes[0]?.url || '';
+                  const commentAuthor = thread.comments.nodes[0]?.author?.login || '';
                   // Truncate long comments
                   const preview = firstComment.length > 80 ? firstComment.substring(0, 77) + '...' : firstComment;
-                  return { preview, url };
+                  return { preview, url, commentAuthor };
                 })
               });
             }
@@ -157,10 +141,11 @@ jobs:
               if (threadIssue) {
                 commentBody += `### Unresolved Review Threads (${threadIssue.count})\n\n`;
                 threadIssue.items.forEach((item, index) => {
+                  const authorTag = item.commentAuthor ? `@${item.commentAuthor}: ` : '';
                   if (item.url) {
-                    commentBody += `${index + 1}. [${item.preview}](${item.url})\n`;
+                    commentBody += `${index + 1}. ${authorTag}[${item.preview}](${item.url})\n`;
                   } else {
-                    commentBody += `${index + 1}. "${item.preview}"\n`;
+                    commentBody += `${index + 1}. ${authorTag}"${item.preview}"\n`;
                   }
                 });
                 if (threadIssue.count > 5) {

--- a/.github/workflows/pullrequest-ready-to-merge-validator.yml
+++ b/.github/workflows/pullrequest-ready-to-merge-validator.yml
@@ -67,6 +67,7 @@ jobs:
                         comments(first: 1) {
                           nodes {
                             body
+                            url
                           }
                         }
                       }
@@ -91,8 +92,10 @@ jobs:
                 count: unresolvedThreads.length,
                 items: unresolvedThreads.slice(0, 5).map(thread => {
                   const firstComment = thread.comments.nodes[0]?.body || '';
+                  const url = thread.comments.nodes[0]?.url || '';
                   // Truncate long comments
-                  return firstComment.length > 80 ? firstComment.substring(0, 77) + '...' : firstComment;
+                  const preview = firstComment.length > 80 ? firstComment.substring(0, 77) + '...' : firstComment;
+                  return { preview, url };
                 })
               });
             }
@@ -133,8 +136,12 @@ jobs:
               const threadIssue = issues.find(i => i.type === 'threads');
               if (threadIssue) {
                 commentBody += `### Unresolved Review Threads (${threadIssue.count})\n\n`;
-                threadIssue.items.forEach((preview, index) => {
-                  commentBody += `${index + 1}. "${preview}"\n`;
+                threadIssue.items.forEach((item, index) => {
+                  if (item.url) {
+                    commentBody += `${index + 1}. [${item.preview}](${item.url})\n`;
+                  } else {
+                    commentBody += `${index + 1}. "${item.preview}"\n`;
+                  }
                 });
                 if (threadIssue.count > 5) {
                   commentBody += `\n... and ${threadIssue.count - 5} more unresolved threads\n`;

--- a/.github/workflows/pullrequest-ready-to-merge-validator.yml
+++ b/.github/workflows/pullrequest-ready-to-merge-validator.yml
@@ -3,10 +3,16 @@ name: Ready to Merge Label Validator
 on:
   pull_request_target:
     types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to validate (for testing)'
+        required: true
+        type: number
 
 jobs:
   validate-ready-to-merge:
-    if: github.event.label.name == 'ready to merge'
+    if: github.event.label.name == 'ready to merge' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -19,10 +25,24 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = context.payload.pull_request.number;
+            const prNumber = context.payload.inputs?.pr_number
+              ? parseInt(context.payload.inputs.pr_number)
+              : context.payload.pull_request.number;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const author = context.payload.pull_request.user.login;
+
+            // For workflow_dispatch, fetch the PR to get the author
+            let author;
+            if (context.payload.pull_request) {
+              author = context.payload.pull_request.user.login;
+            } else {
+              const { data: prData } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: prNumber
+              });
+              author = prData.user.login;
+            }
 
             console.log(`Validating PR #${prNumber} for "ready to merge" label`);
 

--- a/.github/workflows/pullrequest-ready-to-merge-validator.yml
+++ b/.github/workflows/pullrequest-ready-to-merge-validator.yml
@@ -97,8 +97,9 @@ jobs:
                   const firstComment = thread.comments.nodes[0]?.body || '';
                   const url = thread.comments.nodes[0]?.url || '';
                   const commentAuthor = thread.comments.nodes[0]?.author?.login || '';
-                  // Truncate long comments
-                  const preview = firstComment.length > 80 ? firstComment.substring(0, 77) + '...' : firstComment;
+                  // Sanitize for Markdown link syntax: strip newlines and remove [] characters
+                  const sanitized = firstComment.replace(/[\r\n]+/g, ' ').replace(/[\[\]]/g, '');
+                  const preview = sanitized.length > 80 ? sanitized.substring(0, 77) + '...' : sanitized;
                   return { preview, url, commentAuthor };
                 })
               });

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 ######################
 # Project Specific
 ######################
+.github/act-events/
 /build/www/**
 /src/test/javascript/coverage/
 /src/test/javascript/PhantomJS*/


### PR DESCRIPTION
### Summary

Add clickable links to unresolved review comments in the ready-to-merge validator GitHub comment.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


### Motivation and Context

When the "ready to merge" label is added to a PR that still has unresolved review threads, the validator removes the label and posts a comment listing the unresolved threads. However, the comment only showed truncated text previews of the unresolved comments, requiring the PR author to manually search through the PR to find them. Adding direct links makes it easy to jump straight to each unresolved comment and address the feedback.

### Description

- Added the `url` and `author.login` fields to the GraphQL query that fetches review thread comments.
- Changed the data structure for unresolved thread items from a plain string to an object containing `preview`, `url`, and `commentAuthor`.
- Updated the GitHub comment rendering to display each unresolved thread as a clickable Markdown link pointing directly to the comment, with the comment author linked. Falls back to the previous quoted text format if no URL is available.

**Expected comment format:**
```
### Unresolved Review Threads (2)

1. @reviewer-name: [Fix the naming convention here](https://github.com/.../pull/123#discussion_r456)
2. @other-reviewer: [This method should handle edge cases for...](https://github.com/.../pull/123#discussion_r789)
```

### Steps for Testing
Prerequisites:
- 1 PR with unresolved review threads
- [nektos/act](https://github.com/nektos/act) installed locally (`brew install act`)

1. Update the event payload in `.github/act-events/pullrequest-ready-to-merge-validator.json` with the PR number and author login.
2. Run the workflow locally using `act` (on the branch with the changes):
   ```bash
   act pull_request_target -j validate-ready-to-merge \
     -e .github/act-events/pullrequest-ready-to-merge-validator.json \
     -s GITHUB_TOKEN="$(gh auth token)" \
     --container-architecture linux/amd64
   ```
   > **Note:** This runs the workflow from the local branch (unlike GitHub's `pull_request_target` which uses the base branch), making it possible to test changes before merging.
   >
   > **Warning:** This executes real API calls — it will post a comment and attempt to remove the label on the actual PR.
3. Check the posted comment on the PR: each unresolved review thread should be displayed as `@author: [comment preview](link)` with a clickable link navigating directly to the comment.

### Review Progress
#### Code Review
- [ ] Code Review 1
#### Manual Tests
- [ ] Test 1
