### PR TITLE
`Development`: Improve e2e test documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,13 @@ npm run test-diff                    # Test changed files vs origin/develop
 npm run test:ci                      # Full CI with module coverage check
 # Single test:
 npm run test:one -- --test-path-pattern='src/main/webapp/app/path/to/spec\.ts$'
+
+# E2E Tests (Playwright) — preferred way to run locally
+# The script auto-kills processes on ports 8080/9000/7921, starts Postgres, server, and client.
+./run-e2e-tests-local-fast.sh                              # Run all E2E tests
+./run-e2e-tests-local-fast.sh --filter "Quiz"              # Run tests matching "Quiz"
+./run-e2e-tests-local-fast.sh --filter "ExamAssessment|SystemHealth"  # Multiple patterns
+./run-e2e-tests-local-fast.sh --stop                       # Stop all services
 ```
 
 ## Project Structure
@@ -165,6 +172,10 @@ Organized by feature module:
   - Run Vitest: `npm run vitest` (watch), `npm run vitest:run` (single run), `npm run vitest:coverage`
 - Name server tests `*Test.java`; reuse module base classes when present
 - When comparing `ZonedDateTime` values in tests, use `toInstant()` for comparisons since PostgreSQL stores timestamps as UTC (timezone offset is not preserved through database round-trips)
+- **E2E tests: Use `./run-e2e-tests-local-fast.sh`** — this is the intended way to run Playwright E2E tests locally (for both developers and AI agents)
+  - The script automatically kills processes on ports 8080, 9000, and 7921 before starting
+  - Use `--filter "TestName"` to run specific tests; supports regex patterns (e.g., `--filter "Quiz|Exam"`)
+  - After the first run, reuse running services with `--skip-server --skip-client --skip-db`
 - Add screenshots for UI changes in PRs
 - Verify linting before submitting: `npm run lint`, `./gradlew checkstyleMain -x webapp`
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build & Deploy](https://github.com/ls1intum/Artemis/actions/workflows/build.yml/badge.svg?event=push)](https://github.com/ls1intum/Artemis/actions/workflows/build.yml)
 [![Test](https://github.com/ls1intum/Artemis/actions/workflows/test.yml/badge.svg?event=push)](https://github.com/ls1intum/Artemis/actions/workflows/test.yml)
-[![Documentation](https://github.com/ls1intum/Artemis/actions/workflows/docs.yml/badge.svg?event=push)](https://docs.artemis.tum.de)
+[![Documentation](https://github.com/ls1intum/Artemis/actions/workflows/deploy-documentation.yml/badge.svg?event=push)](https://docs.artemis.tum.de)
 [![Code Quality Status](https://app.codacy.com/project/badge/Grade/89860aea5fa74d998ec884f1a875ed0c)](https://www.codacy.com/gh/ls1intum/Artemis?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ls1intum/Artemis&amp;utm_campaign=Badge_Grade)
 [![Coverage Status](https://app.codacy.com/project/badge/Coverage/89860aea5fa74d998ec884f1a875ed0c)](https://www.codacy.com/gh/ls1intum/Artemis?utm_source=github.com&utm_medium=referral&utm_content=ls1intum/Artemis&utm_campaign=Badge_Coverage)
 [![Latest version)](https://img.shields.io/github/v/tag/ls1intum/Artemis?label=%20Latest%20version&sort=semver)](https://github.com/ls1intum/Artemis/releases/latest)
@@ -91,19 +91,14 @@ Additional services are available in the EduTelligence suite for advanced deploy
 
 The Artemis development team prioritizes the following areas in the future. We welcome feature requests from students, tutors, instructors, and administrators. We are happy to discuss any suggestions for improvements.
 
-* **Short term**: Further improve the communication features with mobile apps for iOS and Android
-* **Short term**: Add the possibility to use Iris for questions on all exercise types and lectures (partly done)
-* **Short term**: Provide GenAI based automatic feedback to modeling, text and programming exercise with Athena
-* **Short term**: Improve the LTI integration with Moodle
+* **Medium term**: Provide GenAI based automatic feedback to modeling, text and programming exercise with Athena
 * **Medium term**: Improve the REST API of the server application
-* **Medium term**: Integrate an online IDE (e.g. Eclipse Theia) into Artemis for enhanced user experience
 * **Medium term**: Add more learning analytics features while preserving data privacy
 * **Medium term**: Improve the user experience, usability and navigation
 * **Medium term**: Add automatic generation of hints for programming exercises
 * **Medium term**: Add GenAI support for reviewing exercises for instructors
 * **Medium term**: Add GenAI support for learning analytics (partly done)
 * **Long term**: Allow students to take notes on lecture slides and support the automatic updates of lecture slides
-* **Long term**: Develop an exchange platform for exercises
 
 ## Contributing
 

--- a/documentation/docs/developer/e2e-testing-playwright.mdx
+++ b/documentation/docs/developer/e2e-testing-playwright.mdx
@@ -28,14 +28,14 @@ the prelive system, which is already properly setup in the university data cente
 To run the tests locally, developers need to set up Playwright on their machines.
 End-to-end tests test entire workflows; therefore, they require the whole Artemis setup - database, client, and server to be running.
 Playwright tests rely on the Playwright Node.js library, browser binaries, and some helper packages.
-To run playwright tests locally, you need to start the Artemis server and client, have the correct users set up and install and run playwright.
-This setup should be used for debugging, and creating new tests for your code, but needs intellij to work, and relies on fully setting up your local Artemis instance
-following [the server setup guide](./setup.mdx).
 
-For a quick test setup with only three steps, you can use the scripts provided in `supporting_scripts/playwright`.
-The README explains what you need to do.
-It sets up Artemis inside a dockerized environment, creates users and directly starts playwright. The main drawback with this setup is, that you cannot
-easily change the version of Artemis itself.
+**The recommended way to run E2E tests locally is the [fast local runner](#fast-local-runner-recommended-for-development)** — a single script
+(`./run-e2e-tests-local-fast.sh`) that handles database, server, client, and Playwright setup automatically.
+It auto-kills conflicting processes on ports 8080/9000, keeps services running between re-runs, and supports filtering individual tests.
+
+Alternatively, you can use the Docker-based scripts in `supporting_scripts/playwright` (see the README there),
+or set up everything manually as described below. The manual setup relies on fully configuring your local Artemis instance
+following [the server setup guide](./setup.mdx) and is useful when you need IntelliJ integration for debugging.
 
 ### Supporting scripts overview
 
@@ -57,8 +57,12 @@ The three steps for setting up Playwright with these supporting scripts are:
 ### Fast local runner (recommended for development)
 
 For the fastest local development experience, use the `run-e2e-tests-local-fast.sh` script in the repository root.
+This is the **recommended way to run E2E tests locally** for both developers and AI agents.
 Unlike the Docker-based approach above, this script runs only PostgreSQL in Docker while running the server and client directly on the host.
 Services stay running between test runs, so re-runs only take seconds.
+
+The script automatically kills any processes occupying ports 8080 (server), 9000 (client), and 7921 (local VC SSH),
+so you don't need to manually stop conflicting processes before running it.
 
 **Prerequisites:** Docker, Java 25+, Node.js 24+, npm.
 
@@ -77,7 +81,21 @@ Services stay running between test runs, so re-runs only take seconds.
 
 This starts PostgreSQL, boots the server (~30-90s), starts the client (~10-20s), then runs all Playwright tests.
 
+**Run specific tests:**
+
+Use `--filter` with a pattern (supports regex) to run only matching tests:
+
+```bash
+# Run tests with "Quiz" in the name
+./run-e2e-tests-local-fast.sh --filter "Quiz"
+
+# Run tests matching multiple patterns
+./run-e2e-tests-local-fast.sh --filter "ExamAssessment|SystemHealth"
+```
+
 **Re-run tests (services already running):**
+
+After the first run, services stay running. Skip startup for faster re-runs:
 
 ```bash
 # Run all tests (skips starting services that are already running)
@@ -101,12 +119,15 @@ This starts PostgreSQL, boots the server (~30-90s), starts the client (~10-20s),
 | Flag | Description |
 |------|-------------|
 | `--stop` | Kill server, client, and database; exit |
-| `--filter <pattern>` | Run only tests matching the pattern (e.g., `"Quiz"`) |
+| `--filter <pattern>` | Run only tests matching the pattern (supports regex, e.g., `"Quiz"` or `"Quiz\|Exam"`) |
 | `--skip-server` | Reuse already-running server |
 | `--skip-client` | Reuse already-running client |
 | `--skip-db` | Reuse already-running PostgreSQL |
 | `--headed` | Run Playwright in headed mode (visible browser) |
 | `--ui` | Open Playwright UI mode for interactive debugging |
+| `--video` | Enable video recording (off by default to save CPU) |
+| `--coverage` | Enable coverage collection (off by default, requires extra memory) |
+| `--debug` | Show server and client output inline (normally only in log files) |
 
 Logs and PID files are stored in the `.e2e-local/` directory (gitignored).
 

--- a/run-e2e-tests-local-fast.sh
+++ b/run-e2e-tests-local-fast.sh
@@ -89,10 +89,23 @@ check_port_available() {
 
     listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
     if [ -n "$listeners" ]; then
-        echo -e "${RED}ERROR: Port ${port} is already in use by another process, so the ${service_name} cannot start.${NC}"
-        echo "$listeners"
-        echo "Stop the conflicting process or rerun with the corresponding --skip-* flag if you intentionally want to reuse that service."
-        exit 1
+        echo -e "${YELLOW}Port ${port} (${service_name}) is in use — killing existing process...${NC}"
+        # Extract PIDs from lsof output (skip header line) and kill them
+        local pids
+        pids=$(echo "$listeners" | awk 'NR>1 {print $2}' | sort -u)
+        for pid in $pids; do
+            echo "  Killing PID $pid..."
+            kill_tree "$pid"
+        done
+        sleep 2
+        # Verify port is now free
+        listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
+        if [ -n "$listeners" ]; then
+            echo -e "${RED}ERROR: Port ${port} is still in use after killing processes. Cannot start ${service_name}.${NC}"
+            echo "$listeners"
+            exit 1
+        fi
+        echo -e "${GREEN}Port ${port} is now free.${NC}"
     fi
 }
 

--- a/supporting_scripts/playwright/README.md
+++ b/supporting_scripts/playwright/README.md
@@ -1,5 +1,12 @@
 # Easy Artemis set up and running playwright locally
 
+> **Recommended:** For the fastest local E2E setup, use `./run-e2e-tests-local-fast.sh` from the repository root instead.
+> It handles everything (database, server, client, test users, Playwright) in a single command and automatically
+> kills conflicting processes on ports 8080/9000. See the [E2E testing docs](../../documentation/docs/developer/e2e-testing-playwright.mdx)
+> for details.
+
+The scripts below provide an alternative Docker-based approach where Artemis runs entirely in containers.
+
 Running playwright locally involves three steps:
 1. Run an Artemis application instance, with client and server.
 2. If no users have been set up, set up users.


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary
The local E2E test runner script (`run-e2e-tests-local-fast.sh`) now automatically kills processes occupying ports 8080, 9000, and 7921 instead of failing with an error. This removes a common friction point when re-running E2E tests locally. The developer documentation is updated to recommend this script as the primary way to run E2E tests locally (for both developers and AI agents) and documents how to run individual tests via `--filter`.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


### Motivation and Context
When running `./run-e2e-tests-local-fast.sh`, the script would error out if ports 8080 or 9000 were already in use (e.g. from a previous interrupted run). Users had to manually find and kill the conflicting processes. This was especially problematic for AI agents that cannot easily handle such interactive troubleshooting.

### Description
**Script changes (`run-e2e-tests-local-fast.sh`):**
- `check_port_available()` now auto-kills processes on the target port instead of exiting with an error
- Uses `kill_tree()` to terminate the process and all its children, waits 2s, then verifies the port is free
- Falls back to an error only if the port is still occupied after killing

**Documentation changes:**
- `CLAUDE.md`: Added E2E test commands to the Testing section and testing guidelines
- `e2e-testing-playwright.mdx`: Rewrote intro to recommend the fast local runner as default, documented auto-kill behavior, added "Run specific tests" section with `--filter` examples, documented missing `--video`/`--coverage`/`--debug` flags
- `supporting_scripts/playwright/README.md`: Added callout recommending the fast local runner over the Docker-based scripts
- `README.md`: Fixed documentation badge URL, updated roadmap

### Steps for Testing
Prerequisites:
- A local development environment with Docker, Java, and Node.js

1. Start any process on port 9000 (e.g. `npx http-server -p 9000`) or leave a previous server running on 8080
2. Run `./run-e2e-tests-local-fast.sh`
3. Verify the script automatically kills the conflicting process and proceeds with startup (instead of erroring out)
4. Verify the documentation renders correctly at `documentation/docs/developer/e2e-testing-playwright.mdx`

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
#### Manual Tests
- [x] Test 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined E2E testing workflow with single-command local execution and automatic port conflict resolution
  * Enhanced developer testing guidance featuring regex filtering, video recording, and debugging capabilities
  * Updated roadmap to prioritize AI-powered automatic feedback features

* **Chores**
  * Updated CI/CD references and configuration links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->