### PR TITLE
`Development`: Fix weaviate search integration tests

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/globalsearch/ExerciseWeaviateResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/globalsearch/ExerciseWeaviateResourceIntegrationTest.java
@@ -86,13 +86,13 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
         // Create course with a released programming exercise
         course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
         releasedExercise = ExerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
-        releasedExercise.setTitle("WeaviateSearchableReleasedExercise");
+        releasedExercise.setTitle("WeaviateSearchable Released Exercise");
         releasedExercise.setReleaseDate(ZonedDateTime.now().minusDays(1));
         exerciseRepository.save(releasedExercise);
 
         // Create an unreleased exercise in the same course (release date in the future)
         unreleasedExercise = programmingExerciseUtilService.addProgrammingExerciseToCourse(course, false);
-        unreleasedExercise.setTitle("WeaviateSearchableUnreleasedExercise");
+        unreleasedExercise.setTitle("WeaviateSearchable Unreleased Exercise");
         unreleasedExercise.setReleaseDate(ZonedDateTime.now().plusDays(7));
         exerciseRepository.save(unreleasedExercise);
 
@@ -102,7 +102,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
         var notStartedExerciseGroup = ExamFactory.generateExerciseGroup(true, notStartedExam);
         notStartedExerciseGroup = exerciseGroupRepository.save(notStartedExerciseGroup);
         notStartedExamExercise = TextExerciseFactory.generateTextExerciseForExam(notStartedExerciseGroup);
-        notStartedExamExercise.setTitle("WeaviateSearchableNotStartedExamExercise");
+        notStartedExamExercise.setTitle("WeaviateSearchable NotStarted Exam Exercise");
         notStartedExamExercise = exerciseRepository.save(notStartedExamExercise);
 
         // Create an exam exercise where the exam is ongoing (started but not ended)
@@ -111,7 +111,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
         var ongoingExerciseGroup = ExamFactory.generateExerciseGroup(true, ongoingExam);
         ongoingExerciseGroup = exerciseGroupRepository.save(ongoingExerciseGroup);
         ongoingExamExercise = TextExerciseFactory.generateTextExerciseForExam(ongoingExerciseGroup);
-        ongoingExamExercise.setTitle("WeaviateSearchableOngoingExamExercise");
+        ongoingExamExercise.setTitle("WeaviateSearchable Ongoing Exam Exercise");
         ongoingExamExercise = exerciseRepository.save(ongoingExamExercise);
 
         // Create an exam exercise where the exam has already ended
@@ -120,7 +120,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
         var endedExerciseGroup = ExamFactory.generateExerciseGroup(true, endedExam);
         endedExerciseGroup = exerciseGroupRepository.save(endedExerciseGroup);
         endedExamExercise = TextExerciseFactory.generateTextExerciseForExam(endedExerciseGroup);
-        endedExamExercise.setTitle("WeaviateSearchableEndedExamExercise");
+        endedExamExercise.setTitle("WeaviateSearchable Ended Exam Exercise");
         endedExamExercise = exerciseRepository.save(endedExamExercise);
 
         // Index all exercises in Weaviate
@@ -153,7 +153,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).doesNotContain("WeaviateSearchableNotStartedExamExercise");
+            assertThat(titles).doesNotContain("WeaviateSearchable NotStarted Exam Exercise");
         }
 
         @Test
@@ -162,7 +162,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableOngoingExamExercise", "WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Ongoing Exam Exercise", "WeaviateSearchable Ended Exam Exercise");
         }
 
         @Test
@@ -171,8 +171,8 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise");
-            assertThat(titles).doesNotContain("WeaviateSearchableUnreleasedExercise");
+            assertThat(titles).contains("WeaviateSearchable Released Exercise");
+            assertThat(titles).doesNotContain("WeaviateSearchable Unreleased Exercise");
         }
 
         @Test
@@ -181,7 +181,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).doesNotContain("WeaviateSearchableNotStartedExamExercise", "WeaviateSearchableOngoingExamExercise");
+            assertThat(titles).doesNotContain("WeaviateSearchable NotStarted Exam Exercise", "WeaviateSearchable Ongoing Exam Exercise");
         }
 
         @Test
@@ -190,7 +190,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Ended Exam Exercise");
         }
 
         @Test
@@ -199,7 +199,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableUnreleasedExercise");
+            assertThat(titles).contains("WeaviateSearchable Unreleased Exercise");
         }
 
         @Test
@@ -208,8 +208,8 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise", "WeaviateSearchableUnreleasedExercise", "WeaviateSearchableNotStartedExamExercise",
-                    "WeaviateSearchableOngoingExamExercise", "WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Released Exercise", "WeaviateSearchable Unreleased Exercise", "WeaviateSearchable NotStarted Exam Exercise",
+                    "WeaviateSearchable Ongoing Exam Exercise", "WeaviateSearchable Ended Exam Exercise");
         }
 
         @Test
@@ -218,8 +218,8 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise", "WeaviateSearchableUnreleasedExercise", "WeaviateSearchableNotStartedExamExercise",
-                    "WeaviateSearchableOngoingExamExercise", "WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Released Exercise", "WeaviateSearchable Unreleased Exercise", "WeaviateSearchable NotStarted Exam Exercise",
+                    "WeaviateSearchable Ongoing Exam Exercise", "WeaviateSearchable Ended Exam Exercise");
         }
     }
 
@@ -233,8 +233,8 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&limit=100", HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise");
-            assertThat(titles).doesNotContain("WeaviateSearchableUnreleasedExercise", "WeaviateSearchableNotStartedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Released Exercise");
+            assertThat(titles).doesNotContain("WeaviateSearchable Unreleased Exercise", "WeaviateSearchable NotStarted Exam Exercise");
         }
 
         @Test
@@ -244,8 +244,8 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&limit=100", HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise", "WeaviateSearchableUnreleasedExercise", "WeaviateSearchableNotStartedExamExercise",
-                    "WeaviateSearchableOngoingExamExercise", "WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Released Exercise", "WeaviateSearchable Unreleased Exercise", "WeaviateSearchable NotStarted Exam Exercise",
+                    "WeaviateSearchable Ongoing Exam Exercise", "WeaviateSearchable Ended Exam Exercise");
         }
     }
 
@@ -258,7 +258,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/exercises/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).doesNotContain("WeaviateSearchableNotStartedExamExercise", "WeaviateSearchableUnreleasedExercise");
+            assertThat(titles).doesNotContain("WeaviateSearchable NotStarted Exam Exercise", "WeaviateSearchable Unreleased Exercise");
         }
 
         @Test
@@ -267,7 +267,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/exercises/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableOngoingExamExercise", "WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Ongoing Exam Exercise", "WeaviateSearchable Ended Exam Exercise");
         }
 
         @Test
@@ -276,8 +276,8 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/exercises/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise", "WeaviateSearchableUnreleasedExercise", "WeaviateSearchableNotStartedExamExercise",
-                    "WeaviateSearchableOngoingExamExercise", "WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Released Exercise", "WeaviateSearchable Unreleased Exercise", "WeaviateSearchable NotStarted Exam Exercise",
+                    "WeaviateSearchable Ongoing Exam Exercise", "WeaviateSearchable Ended Exam Exercise");
         }
 
         @Test
@@ -287,26 +287,4 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
         }
     }
 
-    @Nested
-    class ProgrammingExerciseWeaviateEndpointTests {
-
-        @Test
-        @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-        void testStudentOnlySeesReleasedProgrammingExercises() throws Exception {
-            var results = request.getList("/api/courses/" + course.getId() + "/programming-exercises/weaviate", HttpStatus.OK, GlobalSearchResultDTO.class);
-            var titles = getResultTitles(results);
-
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise");
-            assertThat(titles).doesNotContain("WeaviateSearchableUnreleasedExercise");
-        }
-
-        @Test
-        @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-        void testInstructorSeesAllProgrammingExercises() throws Exception {
-            var results = request.getList("/api/courses/" + course.getId() + "/programming-exercises/weaviate", HttpStatus.OK, GlobalSearchResultDTO.class);
-            var titles = getResultTitles(results);
-
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise", "WeaviateSearchableUnreleasedExercise");
-        }
-    }
 }


### PR DESCRIPTION
### Summary
Fix 12 failing Weaviate integration tests by restoring space-separated exercise titles for proper BM25 keyword tokenization, and removing tests for a non-existent endpoint.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
After #12284, all 12 tests in `ExerciseWeaviateResourceIntegrationTest` that assert the *presence* of exercises in search results were failing with empty result lists. Tests that only assert *absence* passed trivially because empty results never contain anything.

**Root cause 1 — BM25 tokenization mismatch:** Exercise titles were changed from space-separated words (e.g. `"WeaviateSearchable Released Exercise"`) to CamelCase (e.g. `"WeaviateSearchableReleasedExercise"`). Weaviate's BM25 uses word-level tokenization (splitting on whitespace), so the query `"WeaviateSearchable"` no longer matched any token in CamelCase titles — it became a single token `weaviatesearchablereleasedexercise` instead of `weaviatesearchable released exercise`.

**Root cause 2 — Missing endpoint:** `ProgrammingExerciseWeaviateEndpointTests` tested `GET /api/courses/{id}/programming-exercises/weaviate`, an endpoint that was never created.

### Description
- Restored space-separated exercise titles so BM25 search can tokenize and match the query `"WeaviateSearchable"` as a standalone word
- Removed `ProgrammingExerciseWeaviateEndpointTests` nested class (2 tests for a non-existent endpoint with no client usage)
- All 56 globalsearch module tests pass locally (0 failures, 0 skipped)

### Steps for Testing
Prerequisites:
- None (test-only changes)

1. Run `./gradlew test --tests "de.tum.cit.aet.artemis.globalsearch.*" -x webapp`
2. Verify all tests pass

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1 — All 56 globalsearch tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixture titles and corresponding assertions in integration tests for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->