### PR TITLE
`Development`: Fix weaviate integration tests

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/globalsearch/ExerciseWeaviateResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/globalsearch/ExerciseWeaviateResourceIntegrationTest.java
@@ -86,13 +86,13 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
         // Create course with a released programming exercise
         course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
         releasedExercise = ExerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
-        releasedExercise.setTitle("WeaviateSearchableReleasedExercise");
+        releasedExercise.setTitle("WeaviateSearchable Released Exercise");
         releasedExercise.setReleaseDate(ZonedDateTime.now().minusDays(1));
         exerciseRepository.save(releasedExercise);
 
         // Create an unreleased exercise in the same course (release date in the future)
         unreleasedExercise = programmingExerciseUtilService.addProgrammingExerciseToCourse(course, false);
-        unreleasedExercise.setTitle("WeaviateSearchableUnreleasedExercise");
+        unreleasedExercise.setTitle("WeaviateSearchable Unreleased Exercise");
         unreleasedExercise.setReleaseDate(ZonedDateTime.now().plusDays(7));
         exerciseRepository.save(unreleasedExercise);
 
@@ -102,7 +102,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
         var notStartedExerciseGroup = ExamFactory.generateExerciseGroup(true, notStartedExam);
         notStartedExerciseGroup = exerciseGroupRepository.save(notStartedExerciseGroup);
         notStartedExamExercise = TextExerciseFactory.generateTextExerciseForExam(notStartedExerciseGroup);
-        notStartedExamExercise.setTitle("WeaviateSearchableNotStartedExamExercise");
+        notStartedExamExercise.setTitle("WeaviateSearchable NotStarted Exam Exercise");
         notStartedExamExercise = exerciseRepository.save(notStartedExamExercise);
 
         // Create an exam exercise where the exam is ongoing (started but not ended)
@@ -111,7 +111,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
         var ongoingExerciseGroup = ExamFactory.generateExerciseGroup(true, ongoingExam);
         ongoingExerciseGroup = exerciseGroupRepository.save(ongoingExerciseGroup);
         ongoingExamExercise = TextExerciseFactory.generateTextExerciseForExam(ongoingExerciseGroup);
-        ongoingExamExercise.setTitle("WeaviateSearchableOngoingExamExercise");
+        ongoingExamExercise.setTitle("WeaviateSearchable Ongoing Exam Exercise");
         ongoingExamExercise = exerciseRepository.save(ongoingExamExercise);
 
         // Create an exam exercise where the exam has already ended
@@ -120,7 +120,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
         var endedExerciseGroup = ExamFactory.generateExerciseGroup(true, endedExam);
         endedExerciseGroup = exerciseGroupRepository.save(endedExerciseGroup);
         endedExamExercise = TextExerciseFactory.generateTextExerciseForExam(endedExerciseGroup);
-        endedExamExercise.setTitle("WeaviateSearchableEndedExamExercise");
+        endedExamExercise.setTitle("WeaviateSearchable Ended Exam Exercise");
         endedExamExercise = exerciseRepository.save(endedExamExercise);
 
         // Index all exercises in Weaviate
@@ -153,7 +153,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).doesNotContain("WeaviateSearchableNotStartedExamExercise");
+            assertThat(titles).doesNotContain("WeaviateSearchable NotStarted Exam Exercise");
         }
 
         @Test
@@ -162,7 +162,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableOngoingExamExercise", "WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Ongoing Exam Exercise", "WeaviateSearchable Ended Exam Exercise");
         }
 
         @Test
@@ -171,8 +171,8 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise");
-            assertThat(titles).doesNotContain("WeaviateSearchableUnreleasedExercise");
+            assertThat(titles).contains("WeaviateSearchable Released Exercise");
+            assertThat(titles).doesNotContain("WeaviateSearchable Unreleased Exercise");
         }
 
         @Test
@@ -181,7 +181,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).doesNotContain("WeaviateSearchableNotStartedExamExercise", "WeaviateSearchableOngoingExamExercise");
+            assertThat(titles).doesNotContain("WeaviateSearchable NotStarted Exam Exercise", "WeaviateSearchable Ongoing Exam Exercise");
         }
 
         @Test
@@ -190,7 +190,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Ended Exam Exercise");
         }
 
         @Test
@@ -199,7 +199,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableUnreleasedExercise");
+            assertThat(titles).contains("WeaviateSearchable Unreleased Exercise");
         }
 
         @Test
@@ -208,8 +208,8 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise", "WeaviateSearchableUnreleasedExercise", "WeaviateSearchableNotStartedExamExercise",
-                    "WeaviateSearchableOngoingExamExercise", "WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Released Exercise", "WeaviateSearchable Unreleased Exercise", "WeaviateSearchable NotStarted Exam Exercise",
+                    "WeaviateSearchable Ongoing Exam Exercise", "WeaviateSearchable Ended Exam Exercise");
         }
 
         @Test
@@ -218,8 +218,8 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise", "WeaviateSearchableUnreleasedExercise", "WeaviateSearchableNotStartedExamExercise",
-                    "WeaviateSearchableOngoingExamExercise", "WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Released Exercise", "WeaviateSearchable Unreleased Exercise", "WeaviateSearchable NotStarted Exam Exercise",
+                    "WeaviateSearchable Ongoing Exam Exercise", "WeaviateSearchable Ended Exam Exercise");
         }
     }
 
@@ -233,8 +233,8 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&limit=100", HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise");
-            assertThat(titles).doesNotContain("WeaviateSearchableUnreleasedExercise", "WeaviateSearchableNotStartedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Released Exercise");
+            assertThat(titles).doesNotContain("WeaviateSearchable Unreleased Exercise", "WeaviateSearchable NotStarted Exam Exercise");
         }
 
         @Test
@@ -244,8 +244,8 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/search?q=WeaviateSearchable&limit=100", HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise", "WeaviateSearchableUnreleasedExercise", "WeaviateSearchableNotStartedExamExercise",
-                    "WeaviateSearchableOngoingExamExercise", "WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Released Exercise", "WeaviateSearchable Unreleased Exercise", "WeaviateSearchable NotStarted Exam Exercise",
+                    "WeaviateSearchable Ongoing Exam Exercise", "WeaviateSearchable Ended Exam Exercise");
         }
     }
 
@@ -258,7 +258,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/exercises/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).doesNotContain("WeaviateSearchableNotStartedExamExercise", "WeaviateSearchableUnreleasedExercise");
+            assertThat(titles).doesNotContain("WeaviateSearchable NotStarted Exam Exercise", "WeaviateSearchable Unreleased Exercise");
         }
 
         @Test
@@ -267,7 +267,7 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/exercises/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableOngoingExamExercise", "WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Ongoing Exam Exercise", "WeaviateSearchable Ended Exam Exercise");
         }
 
         @Test
@@ -276,8 +276,8 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
             var results = request.getList("/api/exercises/search?q=WeaviateSearchable&courseId=" + course.getId(), HttpStatus.OK, GlobalSearchResultDTO.class);
             var titles = getResultTitles(results);
 
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise", "WeaviateSearchableUnreleasedExercise", "WeaviateSearchableNotStartedExamExercise",
-                    "WeaviateSearchableOngoingExamExercise", "WeaviateSearchableEndedExamExercise");
+            assertThat(titles).contains("WeaviateSearchable Released Exercise", "WeaviateSearchable Unreleased Exercise", "WeaviateSearchable NotStarted Exam Exercise",
+                    "WeaviateSearchable Ongoing Exam Exercise", "WeaviateSearchable Ended Exam Exercise");
         }
 
         @Test
@@ -287,26 +287,4 @@ class ExerciseWeaviateResourceIntegrationTest extends AbstractProgrammingIntegra
         }
     }
 
-    @Nested
-    class ProgrammingExerciseWeaviateEndpointTests {
-
-        @Test
-        @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-        void testStudentOnlySeesReleasedProgrammingExercises() throws Exception {
-            var results = request.getList("/api/courses/" + course.getId() + "/programming-exercises/weaviate", HttpStatus.OK, GlobalSearchResultDTO.class);
-            var titles = getResultTitles(results);
-
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise");
-            assertThat(titles).doesNotContain("WeaviateSearchableUnreleasedExercise");
-        }
-
-        @Test
-        @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-        void testInstructorSeesAllProgrammingExercises() throws Exception {
-            var results = request.getList("/api/courses/" + course.getId() + "/programming-exercises/weaviate", HttpStatus.OK, GlobalSearchResultDTO.class);
-            var titles = getResultTitles(results);
-
-            assertThat(titles).contains("WeaviateSearchableReleasedExercise", "WeaviateSearchableUnreleasedExercise");
-        }
-    }
 }


### PR DESCRIPTION
### Summary

Fixes broken `ExerciseWeaviateResourceIntegrationTest` tests introduced by #12284.
The changes in that file were unintentional and can simply be reverted.

### Checklist
#### General
- [x] I tested **all** changes and their related features locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

#12284 broke the tests in `ExerciseWeaviateResourceIntegrationTest` in two ways:

1. **BM25 tokenization mismatch:** Exercise titles were changed from space-separated words (e.g. `"WeaviateSearchable Released Exercise"`) to camelCase (e.g. `"WeaviateSearchableReleasedExercise"`). In the test environment, the Weaviate vectorizer is `"none"`, so `searchExercisesWithFilter` uses BM25 (keyword) search. BM25 tokenizes on whitespace — with the original titles, `"WeaviateSearchable"` matched as a standalone token. With camelCase titles, the entire string is a single token, so the search query no longer matches and all tests return empty results.


2. **Non-existent endpoint:** A `ProgrammingExerciseWeaviateEndpointTests` nested class was added that calls `GET /api/courses/{courseId}/programming-exercises/weaviate`, but this endpoint was never implemented. The existing `/api/search` endpoint already covers the same scenarios (course filtering, role-based access control, empty-query support).

### Description

- Reverted exercise titles back to space-separated words so BM25 tokenization can match the search query `"WeaviateSearchable"`
- Removed `ProgrammingExerciseWeaviateEndpointTests` that tested a non-existent endpoint

### Steps for Testing

1. Run `ExerciseWeaviateResourceIntegrationTest` — all tests should pass
2. Verify no regressions in other Weaviate integration tests

### Review Progress
#### Code Review
- [ ] Code Review 1

### Test Coverage


