### PR TITLE
`Development`: Update server dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -595,7 +595,8 @@ def getMajorVersion = { String version ->
 }
 
 tasks.named("dependencyUpdates").configure {
-    def skipMajor = System.getProperty("skipMajorUpdates") != null
+    def rawSkipMajor = System.getProperty("skipMajorUpdates")
+    def skipMajor = rawSkipMajor != null && (rawSkipMajor.isBlank() || rawSkipMajor.toBoolean())
     rejectVersionIf {
         isNonStable(it.candidate.version) || (skipMajor && getMajorVersion(it.candidate.version) != getMajorVersion(it.currentVersion))
     }

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ java {
 }
 
 wrapper {
-    gradleVersion = "9.3.1"
+    gradleVersion = "9.4.1"
 }
 
 node {
@@ -221,7 +221,7 @@ dependencies {
     implementation "de.jplag:typescript:${jplag_version}"
 
     // Align all Spring AI modules to the same version
-    implementation platform("org.springframework.ai:spring-ai-bom:1.1.2")
+    implementation platform("org.springframework.ai:spring-ai-bom:1.1.3")
     // Azure OpenAI (prod, or when you want Azure)
     implementation "org.springframework.ai:spring-ai-starter-model-azure-openai" // can also use non-azure models
     implementation "org.springframework.ai:spring-ai-starter-model-chat-memory-repository-jdbc"
@@ -303,7 +303,7 @@ dependencies {
     implementation "io.opentelemetry:opentelemetry-exporter-otlp"
 
     // Prometheus requires the protobuf-java dependency, but we explicitly use the latest version to avoid security vulnerabilities
-    implementation "com.google.protobuf:protobuf-java:4.34.0"
+    implementation "com.google.protobuf:protobuf-java:4.34.1"
 
     implementation "tech.jhipster:jhipster-framework:${jhipster_dependencies_version}"
 
@@ -368,8 +368,8 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
     implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
 
-    implementation "org.springframework.data:spring-data-jpa:3.5.9"
-    implementation "org.springframework.data:spring-data-ldap:3.5.9"
+    implementation "org.springframework.data:spring-data-jpa:3.5.10"
+    implementation "org.springframework.data:spring-data-ldap:3.5.10"
     implementation "org.springframework.ldap:spring-ldap-core:3.3.6"
 
     implementation "org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:${spring_cloud_version}"
@@ -429,9 +429,9 @@ dependencies {
     implementation "org.zalando:problem-spring-web:0.29.1"
     implementation "org.zalando:jackson-datatype-problem:0.27.1"
     // Required by JPlag
-    implementation "com.ibm.icu:icu4j-charset:78.2"
+    implementation "com.ibm.icu:icu4j-charset:78.3"
     // Required by exam session service
-    implementation "com.github.seancfoley:ipaddress:5.6.1"
+    implementation "com.github.seancfoley:ipaddress:5.6.2"
 
     // used for testing and Java Template Upgrade Service
     implementation "org.apache.maven:maven-model:3.9.14"
@@ -455,7 +455,7 @@ dependencies {
 
     implementation "com.google.errorprone:error_prone_annotations:2.48.0"
     // needed for OpenAPI generation
-    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15"
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16"
 
 
     // NOTE: we want to keep the same unique version for all configurations, implementation and annotationProcessor
@@ -470,7 +470,7 @@ dependencies {
     annotationProcessor "org.glassfish.jaxb:jaxb-runtime:${jaxb_runtime_version}"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
-    implementation "org.mnode.ical4j:ical4j:4.2.3"
+    implementation "org.mnode.ical4j:ical4j:4.2.4"
 
 
     // ---- CHECKSTYLE DEPENDENCIES ----
@@ -498,7 +498,7 @@ dependencies {
     testImplementation "io.github.classgraph:classgraph:4.8.184"
     testImplementation "org.awaitility:awaitility:4.3.0"
     testImplementation "org.apache.maven.shared:maven-invoker:3.3.0"
-    testImplementation "org.gradle:gradle-tooling-api:9.3.1"
+    testImplementation "org.gradle:gradle-tooling-api:9.4.1"
     testImplementation "org.apache.maven.surefire:surefire-report-parser:3.5.5"
     testImplementation "io.zonky.test:embedded-database-spring-test:2.8.0"
     testImplementation "com.redis:testcontainers-redis:2.2.4"
@@ -590,13 +590,14 @@ def isNonStable = { String version ->
     return !stableKeyword && !(version ==~ regex)
 }
 
-tasks.named("dependencyUpdates").configure {
-    rejectVersionIf {
-        isNonStable(it.candidate.version)
-    }
+def getMajorVersion = { String version ->
+    version.tokenize('.')[0]
+}
 
+tasks.named("dependencyUpdates").configure {
+    def skipMajor = System.getProperty("skipMajorUpdates") != null
     rejectVersionIf {
-        isNonStable(it.candidate.version) && !isNonStable(it.currentVersion)
+        isNonStable(it.candidate.version) || (skipMajor && getMajorVersion(it.candidate.version) != getMajorVersion(it.currentVersion))
     }
 }
 
@@ -612,7 +613,8 @@ tasks.named("dependencyUpdates").configure {
 // 3) Verify code coverage (after tests):           ./gradlew jacocoTestCoverageVerification -x webapp
 // 4) Check Java code format:                       ./gradlew spotlessCheck -x webapp
 // 5) Apply Java code formatter:                    ./gradlew spotlessApply -x webapp
-// 6) Find dependency updates:                      ./gradlew dependencyUpdates -Drevision=release
+// 6) Find dependency updates:                      ./gradlew dependencyUpdates -Drevision=release -x webapp
+// 6a) Find only minor/patch dependency updates:     ./gradlew dependencyUpdates -Drevision=release -DskipMajorUpdates -x webapp
 // 7) Check JavaDoc:                                ./gradlew checkstyleMain -x webapp
 // 8) Detects uses of legacy code:                  ./gradlew modernizer -x webapp
 // 9) Check for vulnerabilities in dependencies     ./gradlew dependencyCheckAnalyze -x webapp

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ npm_version=11.5.1
 
 # Dependency versions
 jhipster_dependencies_version=8.12.0
-spring_boot_version=3.5.11
+spring_boot_version=3.5.12
 spring_cloud_version=4.3.1
 # TODO: upgrading to 6.6.x currently leads to issues due to internal changes in Hibernate and potentially wrong use in Artemis server code. See https://hibernate.atlassian.net/browse/HHH-19249
 hibernate_version=6.5.3.Final
@@ -15,7 +15,7 @@ opensaml_version=5.2.1
 jwt_version=0.13.0
 jaxb_runtime_version=4.0.7
 hazelcast_version=5.6.0
-fasterxml_version=2.21.1
+fasterxml_version=2.21.2
 jgit_version=7.6.0.202603022253-r
 sshd_version=2.17.1
 checkstyle_version=13.3.0
@@ -24,9 +24,9 @@ jplag_version=6.3.0
 # NOTE: we cannot need to use the latest version 9.x or 10.x here as long as Stanford CoreNLP does not reference it
 lucene_version=8.11.4
 slf4j_version=2.0.17
-sentry_version=8.35.0
+sentry_version=8.36.0
 liquibase_version=5.0.2
-docker_java_version=3.7.0
+docker_java_version=3.7.1
 logback_version=1.5.21
 java_parser_version=3.26.2
 byte_buddy_version=1.18.7
@@ -49,7 +49,7 @@ redisson_version=4.3.0
 # make sure both versions are compatible
 junit_version=6.0.3
 mockito_version=5.23.0
-testcontainers_version=2.0.3
+testcontainers_version=2.0.4
 ryuk_version=0.14.0
 
 
@@ -57,8 +57,8 @@ ryuk_version=0.14.0
 gradle_node_plugin_version=7.1.0
 apt_plugin_version=0.21
 liquibase_plugin_version=3.1.0
-modernizer_plugin_version=1.12.0
-spotless_plugin_version=8.3.0
+modernizer_plugin_version=1.13.0
+spotless_plugin_version=8.4.0
 
 org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en \
   --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=2ab2958f2a1e51120c326cad6f385153bb11ee93b3c216c5fccebfdfbb7ec6cb
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
### Summary
Update all server dependencies to their latest minor/patch versions and upgrade the Gradle wrapper from 9.3.1 to 9.4.1. Also improve the `dependencyUpdates` task to support filtering out major version bumps with `-DskipMajorUpdates`.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
Keeping dependencies up to date reduces security vulnerabilities and ensures compatibility with the latest bug fixes. This PR updates all non-major server dependencies.

### Description

**Updated dependencies in `gradle.properties`:**

| Dependency | Old | New |
|---|---|---|
| Jackson (fasterxml) | 2.21.1 | 2.21.2 |
| Docker Java | 3.7.0 | 3.7.1 |
| Sentry | 8.35.0 | 8.36.0 |
| Testcontainers | 2.0.3 | 2.0.4 |
| Spotless plugin | 8.3.0 | 8.4.0 |
| Modernizer plugin | 1.12.0 | 1.13.0 |

**Updated dependencies in `build.gradle`:**

| Dependency | Old | New |
|---|---|---|
| protobuf-java | 4.34.0 | 4.34.1 |
| icu4j-charset | 78.2 | 78.3 |
| ipaddress | 5.6.1 | 5.6.2 |
| ical4j | 4.2.3 | 4.2.4 |
| Spring AI BOM | 1.1.2 | 1.1.3 |
| springdoc-openapi | 2.8.15 | 2.8.16 |
| spring-data-jpa | 3.5.9 | 3.5.10 |
| spring-data-ldap | 3.5.9 | 3.5.10 |
| gradle-tooling-api (test) | 9.3.1 | 9.4.1 |

**Gradle wrapper:** 9.3.1 → 9.4.1

**Build improvements:**
- Added `skipMajorUpdates` option to `dependencyUpdates` task: use `-DskipMajorUpdates` to only see minor/patch updates
- Documented the new option in the command reference at the bottom of `build.gradle`

### Steps for Testing
1. Run `./gradlew dependencies -x webapp` and verify all dependencies resolve
2. Run `./gradlew dependencyUpdates -Drevision=release -x webapp` to see all available updates (including major)
3. Run `./gradlew dependencyUpdates -Drevision=release -DskipMajorUpdates -x webapp` to verify major updates are filtered out
4. Run `./gradlew spotlessCheck -x webapp` and `./gradlew checkstyleMain -x webapp` to verify code quality checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Gradle to the latest stable release and added an integrity checksum for the wrapper to improve build reliability.
  * Updated a range of dependencies and plugin versions (framework, libraries, and tooling) for security and compatibility.
  * Enhanced dependency update checks with an optional gate to skip major-version upgrades and updated command guidance for running the check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->