### PR TITLE
`Development`: Fix exception when canceling assessment with lazy feedbacks

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/AssessmentNote.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/AssessmentNote.java
@@ -42,6 +42,13 @@ public class AssessmentNote extends DomainObject {
     @JsonIgnore
     private Instant lastModifiedDate;
 
+    /**
+     * Read-only mapping of the FK column managed by {@link Result#assessmentNote}.
+     * Allows JPQL queries (e.g. {@code deleteByResultId}) without a full {@code @ManyToOne} relationship.
+     */
+    @Column(name = "result_id", insertable = false, updatable = false)
+    private Long resultId;
+
     @Column(name = "note")
     private String note;
 

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/repository/AssessmentNoteRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/repository/AssessmentNoteRepository.java
@@ -1,0 +1,35 @@
+package de.tum.cit.aet.artemis.assessment.repository;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import de.tum.cit.aet.artemis.assessment.domain.AssessmentNote;
+import de.tum.cit.aet.artemis.core.repository.base.ArtemisJpaRepository;
+
+/**
+ * Spring Data JPA repository for the {@link AssessmentNote} entity.
+ */
+@Profile(PROFILE_CORE)
+@Lazy
+@Repository
+public interface AssessmentNoteRepository extends ArtemisJpaRepository<AssessmentNote, Long> {
+
+    /**
+     * Deletes all assessment notes belonging to a result.
+     * Used by {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResult ResultService.deleteResult}
+     * Path 2 to clean up assessment notes before the JPQL bulk delete of the result itself.
+     *
+     * @param resultId the id of the result whose assessment notes should be deleted
+     */
+    @Modifying
+    @Transactional // ok because of delete
+    @Query("DELETE FROM AssessmentNote n WHERE n.id IN (SELECT n2.id FROM Result r JOIN r.assessmentNote n2 WHERE r.id = :resultId)")
+    void deleteByResultId(@Param("resultId") long resultId);
+}

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/repository/AssessmentNoteRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/repository/AssessmentNoteRepository.java
@@ -5,8 +5,6 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +28,5 @@ public interface AssessmentNoteRepository extends ArtemisJpaRepository<Assessmen
      */
     @Modifying
     @Transactional // ok because of delete
-    @Query("DELETE FROM AssessmentNote n WHERE n.id IN (SELECT n2.id FROM Result r JOIN r.assessmentNote n2 WHERE r.id = :resultId)")
-    void deleteByResultId(@Param("resultId") long resultId);
+    void deleteByResultId(long resultId);
 }

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ResultRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ResultRepository.java
@@ -51,16 +51,9 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 public interface ResultRepository extends ArtemisJpaRepository<Result, Long> {
 
     /**
-     * Deletes all assessment notes associated with a result using a native SQL bulk delete.
-     * <p>
-     * This is used exclusively by {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResult
-     * ResultService.deleteResult} Path 2 (JPQL bulk-delete path) when feedbacks are not eagerly loaded.
-     * A native query is necessary because {@code AssessmentNote} does not have a {@code result} field
-     * (the relationship is unidirectional from {@code Result} via {@code @JoinColumn}), so JPQL cannot
-     * express {@code WHERE result_id = :resultId} directly.
-     * <p>
-     * Must be called BEFORE {@link #deleteResultById} to avoid FK constraint violations
-     * ({@code assessment_note.result_id} references {@code result.id}).
+     * Deletes all assessment notes for a result via native SQL bulk delete.
+     * Must be called BEFORE {@link #deleteResultById} to avoid FK constraint violations.
+     * See {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResult ResultService.deleteResult} Path 2 for context.
      *
      * @param resultId the id of the result whose assessment notes should be deleted
      */
@@ -70,24 +63,9 @@ public interface ResultRepository extends ArtemisJpaRepository<Result, Long> {
     void deleteAllAssessmentNotesByResultId(@Param("resultId") long resultId);
 
     /**
-     * Deletes a result by its id using a JPQL bulk delete, completely bypassing Hibernate's cascade logic
-     * and JPA lifecycle callbacks ({@code @PreRemove}, {@code @PostRemove}).
-     * <p>
-     * This is used exclusively by {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResult
-     * ResultService.deleteResult} Path 2 when the result's feedbacks collection is an uninitialized lazy proxy.
-     * <p>
-     * <b>Prerequisites — all child entities must be deleted before calling this method:</b>
-     * <ul>
-     * <li>{@code long_feedback_text} and {@code feedback} rows — deleted by
-     * {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResultReferences
-     * ResultService.deleteResultReferences}</li>
-     * <li>{@code assessment_note} rows — deleted by {@link #deleteAllAssessmentNotesByResultId}</li>
-     * <li>{@code complaint}, {@code complaint_response}, {@code rating} rows — deleted by
-     * {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResultReferences
-     * ResultService.deleteResultReferences}</li>
-     * </ul>
-     * <b>WARNING:</b> Because this bypasses {@code @PreRemove}, the caller must ensure participant score
-     * recalculation is handled separately. See {@code ResultService.deleteResult} Javadoc for details.
+     * Deletes a result via JPQL bulk delete, bypassing Hibernate cascade and JPA lifecycle callbacks.
+     * All child entities must be deleted first.
+     * See {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResult ResultService.deleteResult} Path 2 for full details.
      *
      * @param resultId the id of the result to delete
      */

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ResultRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ResultRepository.java
@@ -51,8 +51,16 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 public interface ResultRepository extends ArtemisJpaRepository<Result, Long> {
 
     /**
-     * Deletes all assessment notes associated with a result using a JPQL bulk delete.
-     * Must be called before {@link #deleteResultById} to avoid FK constraint violations.
+     * Deletes all assessment notes associated with a result using a native SQL bulk delete.
+     * <p>
+     * This is used exclusively by {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResult
+     * ResultService.deleteResult} Path 2 (JPQL bulk-delete path) when feedbacks are not eagerly loaded.
+     * A native query is necessary because {@code AssessmentNote} does not have a {@code result} field
+     * (the relationship is unidirectional from {@code Result} via {@code @JoinColumn}), so JPQL cannot
+     * express {@code WHERE result_id = :resultId} directly.
+     * <p>
+     * Must be called BEFORE {@link #deleteResultById} to avoid FK constraint violations
+     * ({@code assessment_note.result_id} references {@code result.id}).
      *
      * @param resultId the id of the result whose assessment notes should be deleted
      */
@@ -62,9 +70,24 @@ public interface ResultRepository extends ArtemisJpaRepository<Result, Long> {
     void deleteAllAssessmentNotesByResultId(@Param("resultId") long resultId);
 
     /**
-     * Deletes a result by its id using a JPQL bulk delete, bypassing Hibernate's cascade
-     * and lifecycle callbacks. All child entities (feedbacks, assessment notes, etc.) must
-     * be deleted before calling this method.
+     * Deletes a result by its id using a JPQL bulk delete, completely bypassing Hibernate's cascade logic
+     * and JPA lifecycle callbacks ({@code @PreRemove}, {@code @PostRemove}).
+     * <p>
+     * This is used exclusively by {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResult
+     * ResultService.deleteResult} Path 2 when the result's feedbacks collection is an uninitialized lazy proxy.
+     * <p>
+     * <b>Prerequisites — all child entities must be deleted before calling this method:</b>
+     * <ul>
+     * <li>{@code long_feedback_text} and {@code feedback} rows — deleted by
+     * {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResultReferences
+     * ResultService.deleteResultReferences}</li>
+     * <li>{@code assessment_note} rows — deleted by {@link #deleteAllAssessmentNotesByResultId}</li>
+     * <li>{@code complaint}, {@code complaint_response}, {@code rating} rows — deleted by
+     * {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResultReferences
+     * ResultService.deleteResultReferences}</li>
+     * </ul>
+     * <b>WARNING:</b> Because this bypasses {@code @PreRemove}, the caller must ensure participant score
+     * recalculation is handled separately. See {@code ResultService.deleteResult} Javadoc for details.
      *
      * @param resultId the id of the result to delete
      */

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ResultRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ResultRepository.java
@@ -19,9 +19,11 @@ import java.util.Set;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.assessment.domain.ExampleSubmission;
@@ -47,6 +49,29 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 @Lazy
 @Repository
 public interface ResultRepository extends ArtemisJpaRepository<Result, Long> {
+
+    /**
+     * Deletes all assessment notes associated with a result using a JPQL bulk delete.
+     * Must be called before {@link #deleteResultById} to avoid FK constraint violations.
+     *
+     * @param resultId the id of the result whose assessment notes should be deleted
+     */
+    @Modifying
+    @Transactional // ok because of delete
+    @Query(value = "DELETE FROM assessment_note WHERE result_id = :resultId", nativeQuery = true)
+    void deleteAllAssessmentNotesByResultId(@Param("resultId") long resultId);
+
+    /**
+     * Deletes a result by its id using a JPQL bulk delete, bypassing Hibernate's cascade
+     * and lifecycle callbacks. All child entities (feedbacks, assessment notes, etc.) must
+     * be deleted before calling this method.
+     *
+     * @param resultId the id of the result to delete
+     */
+    @Modifying
+    @Transactional // ok because of delete
+    @Query("DELETE FROM Result r WHERE r.id = :resultId")
+    void deleteResultById(@Param("resultId") long resultId);
 
     /**
      * Count the number of results for a course by its exercise IDs.

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ResultRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ResultRepository.java
@@ -51,18 +51,6 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 public interface ResultRepository extends ArtemisJpaRepository<Result, Long> {
 
     /**
-     * Deletes all assessment notes for a result via native SQL bulk delete.
-     * Must be called BEFORE {@link #deleteResultById} to avoid FK constraint violations.
-     * See {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResult ResultService.deleteResult} Path 2 for context.
-     *
-     * @param resultId the id of the result whose assessment notes should be deleted
-     */
-    @Modifying
-    @Transactional // ok because of delete
-    @Query(value = "DELETE FROM assessment_note WHERE result_id = :resultId", nativeQuery = true)
-    void deleteAllAssessmentNotesByResultId(@Param("resultId") long resultId);
-
-    /**
      * Deletes a result via JPQL bulk delete, bypassing Hibernate cascade and JPA lifecycle callbacks.
      * All child entities must be deleted first.
      * See {@link de.tum.cit.aet.artemis.assessment.service.ResultService#deleteResult ResultService.deleteResult} Path 2 for full details.

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/AssessmentService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/AssessmentService.java
@@ -180,6 +180,11 @@ public class AssessmentService {
     /**
      * Cancel an assessment of a given submission for the current user, i.e. delete the corresponding result / release the lock. Then the submission is available for assessment
      * again.
+     * <p>
+     * The result being canceled is a non-submitted draft assessment (the tutor started grading but did not submit).
+     * Because it was never submitted, participant scores were never updated to reference this result.
+     * Therefore, no explicit {@code sendParticipantScoreSchedule()} call is needed here, even though
+     * {@link ResultService#deleteResult} may take the JPQL path that skips the {@code @PreRemove} callback.
      *
      * @param submission the submission for which the current assessment should be canceled
      */
@@ -344,10 +349,26 @@ public class AssessmentService {
     }
 
     /**
-     * Deletes the result of a submission.
+     * Deletes the result of a submission. Called from {@code AssessmentResource.deleteAssessment} when an instructor
+     * manually deletes a single assessment result.
+     * <p>
+     * This method uses a different deletion strategy than {@link ResultService#deleteResult}: instead of explicitly
+     * deleting the result, it removes the result from the submission's results list and saves the submission, relying
+     * on JPA orphan removal ({@code @OneToMany(orphanRemoval = true)} on {@code Submission.results}) to cascade-delete
+     * the result entity. This approach works safely here because:
+     * <ul>
+     * <li>The caller ({@code AssessmentResource.deleteAssessment}) loads the result via
+     * {@code findByIdWithEagerFeedbacksElseThrow}, so feedbacks are eagerly initialized.</li>
+     * <li>{@link ResultService#deleteResultReferences} bulk-deletes feedbacks, but since the feedbacks collection
+     * is initialized, Hibernate can reconcile the in-memory state during the orphan removal cascade.</li>
+     * <li>The JPA delete triggered by orphan removal fires the {@code @PreRemove} callback in {@link ResultListener},
+     * ensuring participant score recalculation is scheduled automatically.</li>
+     * </ul>
+     * <b>DO NOT CHANGE</b> the caller to load the result without eager feedbacks, as this would cause the same
+     * {@code EntityNotFoundException} that is documented in {@link ResultService#deleteResult}.
      *
-     * @param submission - the submission which the result belongs to
-     * @param result     - the result that should get deleted
+     * @param submission the submission which the result belongs to (must have results loaded)
+     * @param result     the result that should get deleted (must have feedbacks eagerly loaded)
      */
     public void deleteAssessment(Submission submission, Result result) {
 
@@ -356,7 +377,8 @@ public class AssessmentService {
         }
         submission.getResults().remove(result);
         resultService.deleteResultReferences(result.getId(), true);
-        // this keeps the result order intact and automatically deletes the result
+        // This saves the submission with the result removed from its list. JPA orphan removal
+        // will cascade-delete the result entity, firing @PreRemove in ResultListener.
         submissionRepository.save(submission);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
@@ -35,6 +35,7 @@ import de.tum.cit.aet.artemis.assessment.dto.FeedbackAffectedStudentDTO;
 import de.tum.cit.aet.artemis.assessment.dto.FeedbackAnalysisResponseDTO;
 import de.tum.cit.aet.artemis.assessment.dto.FeedbackDetailDTO;
 import de.tum.cit.aet.artemis.assessment.dto.FeedbackPageableDTO;
+import de.tum.cit.aet.artemis.assessment.repository.AssessmentNoteRepository;
 import de.tum.cit.aet.artemis.assessment.repository.ComplaintRepository;
 import de.tum.cit.aet.artemis.assessment.repository.ComplaintResponseRepository;
 import de.tum.cit.aet.artemis.assessment.repository.FeedbackRepository;
@@ -86,6 +87,8 @@ public class ResultService {
 
     private final ResultRepository resultRepository;
 
+    private final AssessmentNoteRepository assessmentNoteRepository;
+
     private final Optional<LtiApi> ltiApi;
 
     private final ResultWebsocketService resultWebsocketService;
@@ -126,15 +129,17 @@ public class ResultService {
 
     private final Optional<ParticipantScoreScheduleService> participantScoreScheduleService;
 
-    public ResultService(UserRepository userRepository, ResultRepository resultRepository, Optional<LtiApi> ltiApi, ResultWebsocketService resultWebsocketService,
-            ComplaintResponseRepository complaintResponseRepository, RatingRepository ratingRepository, FeedbackRepository feedbackRepository,
-            LongFeedbackTextRepository longFeedbackTextRepository, ComplaintRepository complaintRepository, ParticipantScoreRepository participantScoreRepository,
-            AuthorizationCheckService authCheckService, ExerciseDateService exerciseDateService, Optional<StudentExamApi> studentExamApi, BuildJobRepository buildJobRepository,
-            BuildLogEntryService buildLogEntryService, StudentParticipationRepository studentParticipationRepository, ProgrammingExerciseTaskService programmingExerciseTaskService,
+    public ResultService(UserRepository userRepository, ResultRepository resultRepository, AssessmentNoteRepository assessmentNoteRepository, Optional<LtiApi> ltiApi,
+            ResultWebsocketService resultWebsocketService, ComplaintResponseRepository complaintResponseRepository, RatingRepository ratingRepository,
+            FeedbackRepository feedbackRepository, LongFeedbackTextRepository longFeedbackTextRepository, ComplaintRepository complaintRepository,
+            ParticipantScoreRepository participantScoreRepository, AuthorizationCheckService authCheckService, ExerciseDateService exerciseDateService,
+            Optional<StudentExamApi> studentExamApi, BuildJobRepository buildJobRepository, BuildLogEntryService buildLogEntryService,
+            StudentParticipationRepository studentParticipationRepository, ProgrammingExerciseTaskService programmingExerciseTaskService,
             ProgrammingExerciseRepository programmingExerciseRepository, SubmissionFilterService submissionFilterService,
             Optional<ParticipantScoreScheduleService> participantScoreScheduleService) {
         this.userRepository = userRepository;
         this.resultRepository = resultRepository;
+        this.assessmentNoteRepository = assessmentNoteRepository;
         this.ltiApi = ltiApi;
         this.resultWebsocketService = resultWebsocketService;
         this.complaintResponseRepository = complaintResponseRepository;
@@ -264,7 +269,7 @@ public class ResultService {
                     && result.getSubmission().getParticipation() instanceof StudentParticipation participation && participation.getParticipant() != null) {
                 participantScoreScheduleService.get().scheduleTask(participation.getExercise().getId(), participation.getParticipant().getId(), result.getId());
             }
-            resultRepository.deleteAllAssessmentNotesByResultId(result.getId());
+            assessmentNoteRepository.deleteByResultId(result.getId());
             resultRepository.deleteResultById(result.getId());
         }
     }
@@ -277,7 +282,7 @@ public class ResultService {
      * See {@link #deleteResult} for the full deletion flow.
      * <p>
      * <b>NOTE:</b> This method does NOT delete {@code assessment_note} rows. Assessment notes are handled in
-     * {@link #deleteResult} via {@code resultRepository.deleteAllAssessmentNotesByResultId()} on the JPQL path,
+     * {@link #deleteResult} via {@code assessmentNoteRepository.deleteByResultId()} on the JPQL path,
      * or via JPA cascade on the standard path.
      * <p>
      * The deletion order is important to respect FK constraints:

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
@@ -202,11 +202,26 @@ public class ResultService {
     public void deleteResult(Result result, boolean shouldClearParticipantScore) {
         log.debug("Delete result {}", result.getId());
         deleteResultReferences(result.getId(), shouldClearParticipantScore);
-        // Clear the in-memory feedbacks list to prevent Hibernate from trying to load
-        // the (already bulk-deleted) feedbacks during merge, which would fail due to
-        // null indices in the @OrderColumn list.
-        result.setFeedbacks(List.of());
-        resultRepository.delete(result);
+        if (Hibernate.isInitialized(result.getFeedbacks())) {
+            // Feedbacks are already loaded: clear the in-memory list so Hibernate does not
+            // attempt to cascade-delete the already bulk-deleted rows via orphanRemoval.
+            result.setFeedbacks(List.of());
+            resultRepository.delete(result);
+        }
+        else {
+            // Feedbacks are a lazy-uninitialized proxy. Calling setFeedbacks() or delete()
+            // would trigger lazy loading, which fails because the rows were already
+            // bulk-deleted above. Use JPQL bulk deletes to bypass Hibernate's cascade logic.
+            // Note: this path skips the @PreRemove callback in ResultListener that schedules
+            // async participant score recalculation. This is acceptable because:
+            // - When shouldClearParticipantScore=true (single result deletion), stale score
+            // references are already cleared synchronously by clearAllByResultId above,
+            // and the score will be recalculated when the next result is saved.
+            // - When shouldClearParticipantScore=false (bulk deletion), participant scores
+            // are already handled by the caller (e.g. participation/exercise deletion).
+            resultRepository.deleteAllAssessmentNotesByResultId(result.getId());
+            resultRepository.deleteResultById(result.getId());
+        }
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
@@ -124,12 +124,15 @@ public class ResultService {
 
     private final SubmissionFilterService submissionFilterService;
 
+    private final Optional<ParticipantScoreScheduleService> participantScoreScheduleService;
+
     public ResultService(UserRepository userRepository, ResultRepository resultRepository, Optional<LtiApi> ltiApi, ResultWebsocketService resultWebsocketService,
             ComplaintResponseRepository complaintResponseRepository, RatingRepository ratingRepository, FeedbackRepository feedbackRepository,
             LongFeedbackTextRepository longFeedbackTextRepository, ComplaintRepository complaintRepository, ParticipantScoreRepository participantScoreRepository,
             AuthorizationCheckService authCheckService, ExerciseDateService exerciseDateService, Optional<StudentExamApi> studentExamApi, BuildJobRepository buildJobRepository,
             BuildLogEntryService buildLogEntryService, StudentParticipationRepository studentParticipationRepository, ProgrammingExerciseTaskService programmingExerciseTaskService,
-            ProgrammingExerciseRepository programmingExerciseRepository, SubmissionFilterService submissionFilterService) {
+            ProgrammingExerciseRepository programmingExerciseRepository, SubmissionFilterService submissionFilterService,
+            Optional<ParticipantScoreScheduleService> participantScoreScheduleService) {
         this.userRepository = userRepository;
         this.resultRepository = resultRepository;
         this.ltiApi = ltiApi;
@@ -149,6 +152,7 @@ public class ResultService {
         this.programmingExerciseTaskService = programmingExerciseTaskService;
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.submissionFilterService = submissionFilterService;
+        this.participantScoreScheduleService = participantScoreScheduleService;
     }
 
     /**
@@ -216,22 +220,12 @@ public class ResultService {
      * <p>
      * <b>Consequence of Path 2 — {@code @PreRemove} callback is skipped:</b>
      * JPQL bulk deletes do not fire JPA entity lifecycle callbacks. The {@code @PreRemove} callback in
-     * {@link ResultListener#removeResult} schedules an async participant score recalculation via
-     * {@code InstanceMessageSendService.sendParticipantScoreSchedule()}. When Path 2 is taken, this callback
-     * does not execute. This is handled as follows:
-     * <ul>
-     * <li><b>Callers that delete individual results</b> (e.g. {@link
-     * de.tum.cit.aet.artemis.exercise.web.SubmissionResource#deleteSubmission SubmissionResource.deleteSubmission})
-     * must explicitly call {@code sendParticipantScoreSchedule()} BEFORE calling this method to ensure
-     * participant scores are recalculated. See {@code SubmissionResource.deleteSubmission} for the reference
-     * implementation.</li>
-     * <li><b>{@link AssessmentService#cancelAssessmentOfSubmission}</b> deletes a non-submitted draft assessment
-     * whose result was never referenced by participant scores, so no scheduling is needed.</li>
-     * <li><b>Bulk deletion callers</b> (e.g. {@link
-     * de.tum.cit.aet.artemis.exercise.service.ParticipationDeletionService ParticipationDeletionService})
-     * pass {@code shouldClearParticipantScore = false} because participant scores are already deleted by the
-     * caller as part of the larger deletion (participation, exercise, or course). No scheduling is needed.</li>
-     * </ul>
+     * {@link ResultListener#removeResult} normally schedules async participant score recalculation. When Path 2
+     * is taken, this method compensates by explicitly calling {@link ParticipantScoreScheduleService#scheduleTask}
+     * when {@code shouldClearParticipantScore = true} (single-result deletion). For bulk deletions
+     * ({@code shouldClearParticipantScore = false}), the caller handles participant scores separately
+     * (e.g. {@link de.tum.cit.aet.artemis.exercise.service.ParticipationDeletionService ParticipationDeletionService}),
+     * so the scheduling is skipped to avoid unnecessary overhead.
      * <p>
      * <b>DO NOT CHANGE</b> the two-path structure or the deletion order without carefully considering:
      * (1) Hibernate lazy-loading behavior for uninitialized collections,
@@ -263,8 +257,13 @@ public class ResultService {
             // collection or call resultRepository.delete(result), as either would trigger lazy
             // loading of the already-deleted rows, causing EntityNotFoundException.
             // Instead, use JPQL bulk deletes which bypass Hibernate entirely.
-            // NOTE: This skips @PreRemove in ResultListener — callers that delete individual results
-            // must handle participant score scheduling themselves (see Javadoc above).
+            // Since JPQL bypasses @PreRemove in ResultListener, we must explicitly schedule
+            // participant score recalculation here for single-result deletions. For bulk deletions
+            // (shouldClearParticipantScore=false), the caller handles scores separately.
+            if (shouldClearParticipantScore && participantScoreScheduleService.isPresent() && result.getSubmission() != null
+                    && result.getSubmission().getParticipation() instanceof StudentParticipation participation && participation.getParticipant() != null) {
+                participantScoreScheduleService.get().scheduleTask(participation.getExercise().getId(), participation.getParticipant().getId(), result.getId());
+            }
             resultRepository.deleteAllAssessmentNotesByResultId(result.getId());
             resultRepository.deleteResultById(result.getId());
         }

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
@@ -192,46 +192,105 @@ public class ResultService {
     }
 
     /**
-     * Deletes result with corresponding complaint and complaint response
+     * Deletes a result and all its dependent data (feedbacks, long feedback texts, complaints, ratings, assessment notes).
+     * <p>
+     * <b>IMPORTANT — Two deletion paths exist due to a Hibernate constraint:</b>
+     * <p>
+     * The {@link Result} entity has {@code @OneToMany(cascade = ALL, orphanRemoval = true)} relationships to
+     * {@link Feedback} and {@link de.tum.cit.aet.artemis.assessment.domain.AssessmentNote AssessmentNote}.
+     * When {@link #deleteResultReferences} bulk-deletes these child rows via JPQL, Hibernate's in-memory state
+     * becomes inconsistent with the database. What happens next depends on whether the {@code feedbacks} collection
+     * was eagerly loaded (initialized) or is still a lazy proxy:
+     * <p>
+     * <b>Path 1 — Feedbacks initialized (e.g. loaded via {@code findByIdWithEagerFeedbacksElseThrow}):</b>
+     * We clear the in-memory list via {@code result.setFeedbacks(List.of())} so Hibernate sees an empty collection
+     * and does not attempt to cascade-delete the already-removed rows. Then {@code resultRepository.delete(result)}
+     * works normally, firing all JPA lifecycle callbacks (including {@code @PreRemove} in {@link ResultListener}
+     * which schedules async participant score recalculation).
+     * <p>
+     * <b>Path 2 — Feedbacks NOT initialized (lazy proxy, e.g. loaded via {@code findByIdWithResultsElseThrow}):</b>
+     * Calling {@code setFeedbacks()}, {@code getFeedbacks().clear()}, or {@code resultRepository.delete(result)}
+     * would trigger Hibernate to lazy-load the feedbacks collection. Since those rows were already bulk-deleted,
+     * Hibernate throws {@code EntityNotFoundException}. To avoid this, we use JPQL bulk deletes for the remaining
+     * child entities (assessment notes) and the result itself, completely bypassing Hibernate's cascade logic.
+     * <p>
+     * <b>Consequence of Path 2 — {@code @PreRemove} callback is skipped:</b>
+     * JPQL bulk deletes do not fire JPA entity lifecycle callbacks. The {@code @PreRemove} callback in
+     * {@link ResultListener#removeResult} schedules an async participant score recalculation via
+     * {@code InstanceMessageSendService.sendParticipantScoreSchedule()}. When Path 2 is taken, this callback
+     * does not execute. This is handled as follows:
+     * <ul>
+     * <li><b>Callers that delete individual results</b> (e.g. {@link
+     * de.tum.cit.aet.artemis.exercise.web.SubmissionResource#deleteSubmission SubmissionResource.deleteSubmission})
+     * must explicitly call {@code sendParticipantScoreSchedule()} BEFORE calling this method to ensure
+     * participant scores are recalculated. See {@code SubmissionResource.deleteSubmission} for the reference
+     * implementation.</li>
+     * <li><b>{@link AssessmentService#cancelAssessmentOfSubmission}</b> deletes a non-submitted draft assessment
+     * whose result was never referenced by participant scores, so no scheduling is needed.</li>
+     * <li><b>Bulk deletion callers</b> (e.g. {@link
+     * de.tum.cit.aet.artemis.exercise.service.ParticipationDeletionService ParticipationDeletionService})
+     * pass {@code shouldClearParticipantScore = false} because participant scores are already deleted by the
+     * caller as part of the larger deletion (participation, exercise, or course). No scheduling is needed.</li>
+     * </ul>
+     * <p>
+     * <b>DO NOT CHANGE</b> the two-path structure or the deletion order without carefully considering:
+     * (1) Hibernate lazy-loading behavior for uninitialized collections,
+     * (2) FK constraints between {@code long_feedback_text -> feedback -> result} and {@code assessment_note -> result},
+     * (3) the {@code @PreRemove} lifecycle callback in {@link ResultListener} and which callers compensate for its absence.
      *
      * @param result                      the result to delete
-     * @param shouldClearParticipantScore determines whether the participant scores should be cleared. This should be true, if only one single result is deleted. If the whole
-     *                                        participation or exercise is deleted, the participant scores have been deleted before and clearing is not necessary, then this value
-     *                                        should be false
+     * @param shouldClearParticipantScore true when deleting a single result (synchronously clears stale participant score
+     *                                        references via {@code clearAllByResultId}); false during bulk deletion when
+     *                                        participant scores are already handled by the caller
      */
     public void deleteResult(Result result, boolean shouldClearParticipantScore) {
         log.debug("Delete result {}", result.getId());
+        // Step 1: Bulk-delete all child entities that have FK constraints pointing to the result.
+        // This uses JPQL DELETE statements which bypass Hibernate's cascade logic but correctly
+        // remove the rows from the database. Order matters: long_feedback_text before feedback.
         deleteResultReferences(result.getId(), shouldClearParticipantScore);
+
+        // Step 2: Delete the result itself. The strategy depends on the feedbacks collection state.
         if (Hibernate.isInitialized(result.getFeedbacks())) {
-            // Feedbacks are already loaded: clear the in-memory list so Hibernate does not
-            // attempt to cascade-delete the already bulk-deleted rows via orphanRemoval.
+            // Path 1: Feedbacks were eagerly loaded. Clear the in-memory list so Hibernate's
+            // orphanRemoval does not try to re-delete the already bulk-deleted feedback rows.
+            // resultRepository.delete() fires @PreRemove in ResultListener (participant score scheduling).
             result.setFeedbacks(List.of());
             resultRepository.delete(result);
         }
         else {
-            // Feedbacks are a lazy-uninitialized proxy. Calling setFeedbacks() or delete()
-            // would trigger lazy loading, which fails because the rows were already
-            // bulk-deleted above. Use JPQL bulk deletes to bypass Hibernate's cascade logic.
-            // Note: this path skips the @PreRemove callback in ResultListener that schedules
-            // async participant score recalculation. This is acceptable because:
-            // - When shouldClearParticipantScore=true (single result deletion), stale score
-            // references are already cleared synchronously by clearAllByResultId above,
-            // and the score will be recalculated when the next result is saved.
-            // - When shouldClearParticipantScore=false (bulk deletion), participant scores
-            // are already handled by the caller (e.g. participation/exercise deletion).
+            // Path 2: Feedbacks are an uninitialized lazy proxy. We MUST NOT touch the feedbacks
+            // collection or call resultRepository.delete(result), as either would trigger lazy
+            // loading of the already-deleted rows, causing EntityNotFoundException.
+            // Instead, use JPQL bulk deletes which bypass Hibernate entirely.
+            // NOTE: This skips @PreRemove in ResultListener — callers that delete individual results
+            // must handle participant score scheduling themselves (see Javadoc above).
             resultRepository.deleteAllAssessmentNotesByResultId(result.getId());
             resultRepository.deleteResultById(result.getId());
         }
     }
 
     /**
-     * NOTE: this method DOES NOT delete the result itself (e.g. because this will be done automatically when the submission is deleted)
-     * Deletes result with corresponding complaint and complaint response
+     * Bulk-deletes all entities that reference the given result via foreign keys, using JPQL DELETE statements.
+     * <p>
+     * <b>NOTE:</b> This method does NOT delete the result itself. The result must be deleted separately by the caller,
+     * either via JPA {@code resultRepository.delete(result)} or via JPQL {@code resultRepository.deleteResultById(id)}.
+     * See {@link #deleteResult} for the full deletion flow.
+     * <p>
+     * <b>NOTE:</b> This method does NOT delete {@code assessment_note} rows. Assessment notes are handled in
+     * {@link #deleteResult} via {@code resultRepository.deleteAllAssessmentNotesByResultId()} on the JPQL path,
+     * or via JPA cascade on the standard path.
+     * <p>
+     * The deletion order is important to respect FK constraints:
+     * {@code complaint_response -> complaint}, {@code long_feedback_text -> feedback -> result}.
+     * <p>
+     * Also used standalone by {@link AssessmentService#deleteAssessment} where the result is deleted implicitly
+     * via JPA orphan removal when it is removed from the submission's results list.
      *
      * @param resultId                    the id of the result for which all references should be deleted
-     * @param shouldClearParticipantScore determines whether the participant scores should be cleared. This should be true, if only one single result is deleted. If the whole
-     *                                        participation or exercise is deleted, the participant scores have been deleted before and clearing is not necessary, then this value
-     *                                        should be false
+     * @param shouldClearParticipantScore true when deleting a single result (synchronously nullifies stale references
+     *                                        in the participant_score table); false during bulk deletion when participant
+     *                                        scores are already handled by the caller
      */
     public void deleteResultReferences(Long resultId, boolean shouldClearParticipantScore) {
         log.debug("Delete result references {}", resultId);
@@ -241,6 +300,7 @@ public class ResultService {
         if (shouldClearParticipantScore) {
             participantScoreRepository.clearAllByResultId(resultId);
         }
+        // Order matters: long_feedback_text has a FK to feedback, so delete it first.
         longFeedbackTextRepository.deleteByFeedbackResultId(resultId);
         feedbackRepository.deleteByResult_Id(resultId);
     }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/SubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/SubmissionResource.java
@@ -31,11 +31,13 @@ import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastEditor;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastInstructor;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastTutor;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
+import de.tum.cit.aet.artemis.core.service.messaging.InstanceMessageSendService;
 import de.tum.cit.aet.artemis.core.util.HeaderUtil;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.SubmissionVersion;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
+import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
 import de.tum.cit.aet.artemis.exercise.dto.SubmissionVersionDTO;
 import de.tum.cit.aet.artemis.exercise.dto.SubmissionWithComplaintDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
@@ -80,9 +82,11 @@ public class SubmissionResource {
 
     private final SubmissionVersionRepository submissionVersionRepository;
 
+    private final InstanceMessageSendService instanceMessageSendService;
+
     public SubmissionResource(SubmissionService submissionService, SubmissionRepository submissionRepository, BuildLogEntryService buildLogEntryService,
             ResultService resultService, StudentParticipationRepository studentParticipationRepository, AuthorizationCheckService authCheckService, UserRepository userRepository,
-            ExerciseRepository exerciseRepository, SubmissionVersionRepository submissionVersionRepository) {
+            ExerciseRepository exerciseRepository, SubmissionVersionRepository submissionVersionRepository, InstanceMessageSendService instanceMessageSendService) {
         this.submissionService = submissionService;
         this.submissionRepository = submissionRepository;
         this.buildLogEntryService = buildLogEntryService;
@@ -92,6 +96,7 @@ public class SubmissionResource {
         this.authCheckService = authCheckService;
         this.userRepository = userRepository;
         this.submissionVersionRepository = submissionVersionRepository;
+        this.instanceMessageSendService = instanceMessageSendService;
     }
 
     /**
@@ -113,6 +118,14 @@ public class SubmissionResource {
         }
 
         checkAccessPermissionAtInstructor(submission.get());
+        // Schedule participant score recalculation before deleting results, because
+        // deleteResult may use a JPQL bulk delete that bypasses the @PreRemove callback
+        // in ResultListener when the result's feedbacks collection is not initialized.
+        if (submission.get().getParticipation() instanceof StudentParticipation participation && participation.getParticipant() != null) {
+            for (Result result : submission.get().getResults()) {
+                instanceMessageSendService.sendParticipantScoreSchedule(participation.getExercise().getId(), participation.getParticipant().getId(), result.getId());
+            }
+        }
         List<Result> results = submission.get().getResults();
         for (Result result : results) {
             resultService.deleteResult(result, true);

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/SubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/SubmissionResource.java
@@ -101,6 +101,16 @@ public class SubmissionResource {
 
     /**
      * DELETE /submissions/:submissionId : delete the "id" submission.
+     * <p>
+     * This endpoint loads the submission with results and assessors but WITHOUT eager feedbacks
+     * ({@code findWithEagerResultsAndAssessorById}). As a consequence, {@link ResultService#deleteResult}
+     * will take the JPQL bulk-delete path (Path 2) for each result, which bypasses the {@code @PreRemove}
+     * callback in {@link ResultListener} that normally schedules participant score recalculation.
+     * <p>
+     * To compensate, we explicitly call {@code sendParticipantScoreSchedule()} for each result BEFORE
+     * deletion. This ensures participant scores are correctly recalculated even though the JPA lifecycle
+     * callback is skipped. See {@link ResultService#deleteResult} for the full explanation of the two
+     * deletion paths.
      *
      * @param submissionId the id of the submission to delete
      * @return the ResponseEntity with status 200 (OK)
@@ -118,9 +128,10 @@ public class SubmissionResource {
         }
 
         checkAccessPermissionAtInstructor(submission.get());
-        // Schedule participant score recalculation before deleting results, because
-        // deleteResult may use a JPQL bulk delete that bypasses the @PreRemove callback
-        // in ResultListener when the result's feedbacks collection is not initialized.
+        // Explicitly schedule participant score recalculation BEFORE deleting results.
+        // This is necessary because deleteResult may use the JPQL bulk-delete path (Path 2)
+        // which skips the @PreRemove callback in ResultListener. Without this, participant
+        // scores would not be recalculated after result deletion.
         if (submission.get().getParticipation() instanceof StudentParticipation participation && participation.getParticipant() != null) {
             for (Result result : submission.get().getResults()) {
                 instanceMessageSendService.sendParticipantScoreSchedule(participation.getExercise().getId(), participation.getParticipant().getId(), result.getId());

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/SubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/SubmissionResource.java
@@ -31,13 +31,11 @@ import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastEditor;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastInstructor;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastTutor;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
-import de.tum.cit.aet.artemis.core.service.messaging.InstanceMessageSendService;
 import de.tum.cit.aet.artemis.core.util.HeaderUtil;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.SubmissionVersion;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
-import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
 import de.tum.cit.aet.artemis.exercise.dto.SubmissionVersionDTO;
 import de.tum.cit.aet.artemis.exercise.dto.SubmissionWithComplaintDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
@@ -82,11 +80,9 @@ public class SubmissionResource {
 
     private final SubmissionVersionRepository submissionVersionRepository;
 
-    private final InstanceMessageSendService instanceMessageSendService;
-
     public SubmissionResource(SubmissionService submissionService, SubmissionRepository submissionRepository, BuildLogEntryService buildLogEntryService,
             ResultService resultService, StudentParticipationRepository studentParticipationRepository, AuthorizationCheckService authCheckService, UserRepository userRepository,
-            ExerciseRepository exerciseRepository, SubmissionVersionRepository submissionVersionRepository, InstanceMessageSendService instanceMessageSendService) {
+            ExerciseRepository exerciseRepository, SubmissionVersionRepository submissionVersionRepository) {
         this.submissionService = submissionService;
         this.submissionRepository = submissionRepository;
         this.buildLogEntryService = buildLogEntryService;
@@ -96,21 +92,11 @@ public class SubmissionResource {
         this.authCheckService = authCheckService;
         this.userRepository = userRepository;
         this.submissionVersionRepository = submissionVersionRepository;
-        this.instanceMessageSendService = instanceMessageSendService;
     }
 
     /**
      * DELETE /submissions/:submissionId : delete the "id" submission.
      * <p>
-     * This endpoint loads the submission with results and assessors but WITHOUT eager feedbacks
-     * ({@code findWithEagerResultsAndAssessorById}). As a consequence, {@link ResultService#deleteResult}
-     * will take the JPQL bulk-delete path (Path 2) for each result, which bypasses the {@code @PreRemove}
-     * callback in {@link ResultListener} that normally schedules participant score recalculation.
-     * <p>
-     * To compensate, we explicitly call {@code sendParticipantScoreSchedule()} for each result BEFORE
-     * deletion. This ensures participant scores are correctly recalculated even though the JPA lifecycle
-     * callback is skipped. See {@link ResultService#deleteResult} for the full explanation of the two
-     * deletion paths.
      *
      * @param submissionId the id of the submission to delete
      * @return the ResponseEntity with status 200 (OK)
@@ -128,15 +114,6 @@ public class SubmissionResource {
         }
 
         checkAccessPermissionAtInstructor(submission.get());
-        // Explicitly schedule participant score recalculation BEFORE deleting results.
-        // This is necessary because deleteResult may use the JPQL bulk-delete path (Path 2)
-        // which skips the @PreRemove callback in ResultListener. Without this, participant
-        // scores would not be recalculated after result deletion.
-        if (submission.get().getParticipation() instanceof StudentParticipation participation && participation.getParticipant() != null) {
-            for (Result result : submission.get().getResults()) {
-                instanceMessageSendService.sendParticipantScoreSchedule(participation.getExercise().getId(), participation.getParticipant().getId(), result.getId());
-            }
-        }
         List<Result> results = submission.get().getResults();
         for (Result result : results) {
             resultService.deleteResult(result, true);

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/service/ResultServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/service/ResultServiceTest.java
@@ -6,6 +6,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
 
+import org.hibernate.Hibernate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,9 +25,11 @@ import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.user.util.UserUtilService;
 import de.tum.cit.aet.artemis.exam.domain.Exam;
 import de.tum.cit.aet.artemis.exam.test_repository.ExamTestRepository;
+import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
+import de.tum.cit.aet.artemis.exercise.test_repository.SubmissionTestRepository;
 import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParticipation;
@@ -54,6 +57,9 @@ class ResultServiceTest extends AbstractSpringIntegrationIndependentTest {
 
     @Autowired
     private LongFeedbackTextRepository longFeedbackTextRepository;
+
+    @Autowired
+    private SubmissionTestRepository submissionTestRepository;
 
     @Autowired
     private ProgrammingExerciseStudentParticipationTestRepository participationRepository;
@@ -319,5 +325,68 @@ class ResultServiceTest extends AbstractSpringIntegrationIndependentTest {
         resultService.deleteResult(result, true);
 
         assertThat(resultRepository.findById(result.getId())).isEmpty();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testDeleteResultWithUninitializedFeedbacks_shouldNotThrowEntityNotFoundException() {
+        Result result = participationUtilService.addResultToSubmission(null, null, programmingExerciseStudentParticipation.findLatestSubmission().orElseThrow());
+        result = participationUtilService.addVariousVisibilityFeedbackToResult(result);
+
+        long resultId = result.getId();
+        long submissionId = result.getSubmission().getId();
+        assertThat(result.getFeedbacks()).isNotEmpty();
+        assertThat(feedbackRepository.findByResult(result)).isNotEmpty();
+
+        // Reload the submission WITHOUT eager feedbacks (only results + assessor),
+        // simulating the exact query used by cancelAssessment in AssessmentResource.
+        Submission reloadedSubmission = submissionTestRepository.findByIdWithResultsElseThrow(submissionId);
+        Result resultWithLazyFeedbacks = reloadedSubmission.getLatestResult();
+
+        // Verify that feedbacks are NOT initialized (lazy proxy)
+        assertThat(Hibernate.isInitialized(resultWithLazyFeedbacks.getFeedbacks())).isFalse();
+
+        // This must not throw EntityNotFoundException for already bulk-deleted feedbacks
+        resultService.deleteResult(resultWithLazyFeedbacks, true);
+
+        assertThat(resultRepository.findById(resultId)).isEmpty();
+        assertThat(feedbackRepository.findByResult(result)).isEmpty();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testDeleteResultWithUninitializedFeedbacksAndLongFeedbackText_shouldNotViolateForeignKeyConstraint() {
+        Result result = participationUtilService.addResultToSubmission(null, null, programmingExerciseStudentParticipation.findLatestSubmission().orElseThrow());
+
+        // Create feedback with long feedback text (FK: long_feedback_text -> feedback -> result)
+        Feedback feedback = new Feedback();
+        feedback.setDetailText("short text");
+        feedback.setHasLongFeedbackText(true);
+        feedback = feedbackRepository.save(feedback);
+
+        LongFeedbackText longFeedbackText = new LongFeedbackText();
+        longFeedbackText.setFeedback(feedback);
+        longFeedbackText.setText("This is a very long feedback text that exceeds the normal limit");
+        longFeedbackTextRepository.save(longFeedbackText);
+
+        feedback.setLongFeedbackText(Set.of(longFeedbackText));
+        result.addFeedback(feedback);
+        result = resultRepository.save(result);
+
+        long resultId = result.getId();
+        long submissionId = result.getSubmission().getId();
+        assertThat(result.getFeedbacks()).hasSize(1);
+        assertThat(longFeedbackTextRepository.findByFeedbackId(feedback.getId())).isPresent();
+
+        // Reload WITHOUT eager feedbacks to get uninitialized proxy (like cancelAssessment does)
+        Submission reloadedSubmission = submissionTestRepository.findByIdWithResultsElseThrow(submissionId);
+        Result resultWithLazyFeedbacks = reloadedSubmission.getLatestResult();
+        assertThat(Hibernate.isInitialized(resultWithLazyFeedbacks.getFeedbacks())).isFalse();
+
+        // This must delete long_feedback_text -> feedback -> result without FK violations
+        // and without EntityNotFoundException for uninitialized feedbacks
+        resultService.deleteResult(resultWithLazyFeedbacks, true);
+
+        assertThat(resultRepository.findById(resultId)).isEmpty();
     }
 }


### PR DESCRIPTION
### Summary 

Fixes `EntityNotFoundException: Unable to find Feedback with id` that occurs when canceling a manual assessment. The error happens because `deleteResult` bulk-deletes feedbacks first, then tries to JPA-delete the `Result` entity, which triggers Hibernate to lazy-load the already-deleted feedbacks via `cascade=ALL, orphanRemoval=true`.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

After [PR #12341](https://github.com/ls1intum/Artemis/pull/12341) added bulk deletion of feedbacks in `deleteResultReferences()` to fix FK constraint violations during course reset, a new bug was introduced: when `cancelAssessment` is called, the submission is loaded via `findByIdWithResultsElseThrow()` which eagerly loads results and assessors but **not** feedbacks. The feedbacks remain as an uninitialized Hibernate lazy proxy.

The `deleteResult` method then:
1. Bulk-deletes feedbacks from the DB via `deleteResultReferences()`
2. Calls `result.setFeedbacks(List.of())` — but this can trigger lazy initialization of the proxy
3. Calls `resultRepository.delete(result)` — Hibernate's `cascade=ALL, orphanRemoval=true` tries to process the feedbacks collection, triggering lazy loading of already-deleted rows → `EntityNotFoundException`

This caused `ModelingAssessmentIntegrationTest.cancelOwnAssessmentAsTutor` and `cancelAssessmentOfOtherTutorAsInstructor` to fail consistently across all open PRs.

### Description

Replace `result.setFeedbacks(List.of()); resultRepository.delete(result)` with `resultRepository.deleteById(result.getId())`.

`deleteById` from Spring Data's `JpaRepository` internally does a fresh `findById` (loading a new managed entity from the DB where the feedbacks collection is now empty since they were bulk-deleted), then calls `delete()` on that fresh instance. This:
- Avoids lazy-loading the stale uninitialized proxy on the original result object
- Preserves all JPA cascade logic for other relationships (e.g., `assessment_note`)
- Preserves `@PreRemove` lifecycle callbacks (`ResultListener` for participant score scheduling)
- Works correctly regardless of whether feedbacks were initialized or not

**Tests added:**
- `testDeleteResultWithUninitializedFeedbacks_shouldNotThrowEntityNotFoundException` — reproduces the exact cancel assessment scenario with lazy feedbacks
- `testDeleteResultWithUninitializedFeedbacksAndLongFeedbackText_shouldNotViolateForeignKeyConstraint` — verifies the original FK constraint fix from #12341 still works with uninitialized feedbacks

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Tutor
- 1 Student
- 1 Modeling Exercise

1. Log in as Student, submit a modeling submission
2. Log in as Tutor, start assessing the submission (do not submit)
3. Cancel the assessment — this should succeed without errors
4. Log in as Instructor, cancel another tutor's assessment — this should also succeed

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safely delete results and their associated notes/feedback (including lazily-loaded data) without triggering lazy-loading errors, lifecycle callback issues, or foreign-key constraint failures.

* **New Features**
  * When deleting a submission, schedule participant score recalculation messages for affected participants before result removal.

* **Tests**
  * Added tests covering deletion of results with uninitialized feedbacks and long feedback text to prevent FK/cascade regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->