### PR TITLE
`Development`: Cleanup SSH agent after test server deployment

### DIFF
--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -228,6 +228,7 @@ jobs:
           DEPLOYMENT_SSH_KEY: "${{ secrets.DEPLOYMENT_SSH_KEY }}"
         run: |
           mkdir -p ~/.ssh
+          rm -f $SSH_AUTH_SOCK
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
           ssh-add - <<< $GATEWAY_SSH_KEY
           ssh-add - <<< $DEPLOYMENT_SSH_KEY
@@ -243,3 +244,8 @@ jobs:
           DEPLOYMENT_FOLDER: ${{ vars.DEPLOYMENT_FOLDER }}
         run: |
           ./artemis-server-cli docker-deploy "$DEPLOYMENT_USER@$DEPLOYMENT_HOSTS" -g "$GATEWAY_USER@$GATEWAY_HOST" -t $TAG -b $BRANCH_NAME -d $DEPLOYMENT_FOLDER -y
+
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -f /tmp/ssh_agent.sock


### PR DESCRIPTION
### Summary 

Cleanup the SSH agent after deployment.

### Checklist
#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

Deployments are failing because of this error: `unix_listener: cannot bind to path /tmp/ssh_agent.sock: Address already in use`.


### Description

Cleanup the SSH agent after deployment.

### Steps for Testing

_Not possible_

### Testserver States


### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

