### PR TITLE
`Development`: Restore stopping stale processes when running e2e tests locally

### DIFF
--- a/run-e2e-tests-local-fast.sh
+++ b/run-e2e-tests-local-fast.sh
@@ -82,6 +82,13 @@ kill_tree() {
     kill "$pid" 2>/dev/null || true
 }
 
+# Ensures a required port is available before starting a service.
+# If a leftover process (e.g. from a previous crashed run) occupies the port,
+# it is automatically killed so the script can proceed without manual intervention.
+# This is intentional: developers and CI agents should not have to manually hunt
+# down stale processes every time they re-run E2E tests. Do NOT replace this with
+# a simple "error and exit" — that was tried and reverted because it broke the
+# hands-free workflow that this script is designed to provide.
 check_port_available() {
     local port=$1
     local service_name=$2
@@ -89,10 +96,23 @@ check_port_available() {
 
     listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
     if [ -n "$listeners" ]; then
-        echo -e "${RED}ERROR: Port ${port} is already in use by another process, so the ${service_name} cannot start.${NC}"
-        echo "$listeners"
-        echo "Stop the conflicting process or rerun with the corresponding --skip-* flag if you intentionally want to reuse that service."
-        exit 1
+        echo -e "${YELLOW}Port ${port} (${service_name}) is in use — killing existing process...${NC}"
+        # Extract PIDs from lsof output (skip header line) and kill them
+        local pids
+        pids=$(echo "$listeners" | awk 'NR>1 {print $2}' | sort -u)
+        for pid in $pids; do
+            echo "  Killing PID $pid..."
+            kill_tree "$pid"
+        done
+        sleep 2
+        # Verify port is now free after killing
+        listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
+        if [ -n "$listeners" ]; then
+            echo -e "${RED}ERROR: Port ${port} is still in use after killing processes. Cannot start ${service_name}.${NC}"
+            echo "$listeners"
+            exit 1
+        fi
+        echo -e "${GREEN}Port ${port} is now free.${NC}"
     fi
 }
 


### PR DESCRIPTION
### Summary

Restores the automatic cleanup of stale processes on E2E ports (8080, 9000, 7921) in `run-e2e-tests-local-fast.sh`, which was accidentally removed in #12340. Adds inline documentation to prevent future removal.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

PR #12340 replaced the auto-kill logic in `check_port_available()` with a simple "error and exit" message. This broke the hands-free workflow that the E2E test runner script is designed to provide — developers and CI agents now had to manually find and kill leftover processes before re-running tests.

### Description

- Reverted the `check_port_available()` function to its original behavior: when a required port is occupied by a stale process, the script automatically kills it and verifies the port is free before proceeding.
- Added a detailed comment block above the function explaining **why** the auto-kill behavior exists and explicitly warning against replacing it with error-and-exit.

### Steps for Testing

Prerequisites:
- A machine that can run the E2E test script

1. Start any process on port 8080 (e.g. `python3 -m http.server 8080`)
2. Run `./run-e2e-tests-local-fast.sh`
3. Verify that the script automatically kills the process on port 8080 and proceeds (instead of exiting with an error)

### Testserver States
Not applicable — this only changes the local E2E test runner script.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced local test runner to handle port conflicts more gracefully. When a required port is already in use, the script now attempts to terminate conflicting processes and retries, only failing if the port remains occupied after cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->