### PR TITLE
`Development`: Improve path validation order in drag-and-drop file import

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizExerciseImportService.java
@@ -187,7 +187,10 @@ public class QuizExerciseImportService extends ExerciseImportService {
             // Validate the path before any filesystem access to prevent path traversal
             FileUtil.sanitizeFilePathByCheckingForInvalidCharactersElseThrow(original.getBackgroundFilePath());
             FileUtil.sanitizeByCheckingIfPathStartsWithSubPathElseThrow(backgroundFilePublicPath, backgroundFileIntendedPath);
-            Path oldPath = FilePathConverter.fileSystemPathForExternalUri(backgroundFilePublicPath, FilePathType.DRAG_AND_DROP_BACKGROUND);
+            Path oldPath = FilePathConverter.fileSystemPathForExternalUri(backgroundFilePublicPath, FilePathType.DRAG_AND_DROP_BACKGROUND).normalize();
+            if (!oldPath.startsWith(FilePathConverter.getDragAndDropBackgroundFilePath().normalize())) {
+                throw new IllegalArgumentException("Invalid background file path: resolved path is outside the expected directory");
+            }
             if (Files.exists(oldPath)) {
                 Path newPath = FileUtil.copyExistingFileToTarget(oldPath, FilePathConverter.getDragAndDropBackgroundFilePath(), FilePathType.DRAG_AND_DROP_BACKGROUND);
                 copy.setBackgroundFilePath(FilePathConverter.externalUriForFileSystemPath(newPath, FilePathType.DRAG_AND_DROP_BACKGROUND, null).toString());
@@ -242,7 +245,10 @@ public class QuizExerciseImportService extends ExerciseImportService {
         // Validate the path before any filesystem access to prevent path traversal
         FileUtil.sanitizeFilePathByCheckingForInvalidCharactersElseThrow(source.getPictureFilePath());
         FileUtil.sanitizeByCheckingIfPathStartsWithSubPathElseThrow(pictureFilePublicPath, pictureFileIntendedPath);
-        Path oldPath = FilePathConverter.fileSystemPathForExternalUri(pictureFilePublicPath, FilePathType.DRAG_ITEM);
+        Path oldPath = FilePathConverter.fileSystemPathForExternalUri(pictureFilePublicPath, FilePathType.DRAG_ITEM).normalize();
+        if (!oldPath.startsWith(FilePathConverter.getDragItemFilePath().normalize())) {
+            throw new IllegalArgumentException("Invalid drag item file path: resolved path is outside the expected directory");
+        }
         if (Files.exists(oldPath)) {
             Path newPath = FileUtil.copyExistingFileToTarget(oldPath, FilePathConverter.getDragItemFilePath(), FilePathType.DRAG_ITEM);
             target.setPictureFilePath(FilePathConverter.externalUriForFileSystemPath(newPath, FilePathType.DRAG_ITEM, null).toString());

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizExerciseImportService.java
@@ -184,10 +184,11 @@ public class QuizExerciseImportService extends ExerciseImportService {
         if (original.getBackgroundFilePath() != null) {
             URI backgroundFilePublicPath = URI.create(original.getBackgroundFilePath());
             URI backgroundFileIntendedPath = URI.create(FileUtil.BACKGROUND_FILE_SUBPATH);
+            // Validate the path before any filesystem access to prevent path traversal
             FileUtil.sanitizeFilePathByCheckingForInvalidCharactersElseThrow(original.getBackgroundFilePath());
-            if (Files.exists(FilePathConverter.fileSystemPathForExternalUri(backgroundFilePublicPath, FilePathType.DRAG_AND_DROP_BACKGROUND))) {
-                FileUtil.sanitizeByCheckingIfPathStartsWithSubPathElseThrow(backgroundFilePublicPath, backgroundFileIntendedPath);
-                Path oldPath = FilePathConverter.fileSystemPathForExternalUri(backgroundFilePublicPath, FilePathType.DRAG_AND_DROP_BACKGROUND);
+            FileUtil.sanitizeByCheckingIfPathStartsWithSubPathElseThrow(backgroundFilePublicPath, backgroundFileIntendedPath);
+            Path oldPath = FilePathConverter.fileSystemPathForExternalUri(backgroundFilePublicPath, FilePathType.DRAG_AND_DROP_BACKGROUND);
+            if (Files.exists(oldPath)) {
                 Path newPath = FileUtil.copyExistingFileToTarget(oldPath, FilePathConverter.getDragAndDropBackgroundFilePath(), FilePathType.DRAG_AND_DROP_BACKGROUND);
                 copy.setBackgroundFilePath(FilePathConverter.externalUriForFileSystemPath(newPath, FilePathType.DRAG_AND_DROP_BACKGROUND, null).toString());
             }
@@ -238,10 +239,11 @@ public class QuizExerciseImportService extends ExerciseImportService {
         }
         URI pictureFilePublicPath = URI.create(source.getPictureFilePath());
         URI pictureFileIntendedPath = URI.create(FileUtil.PICTURE_FILE_SUBPATH);
+        // Validate the path before any filesystem access to prevent path traversal
         FileUtil.sanitizeFilePathByCheckingForInvalidCharactersElseThrow(source.getPictureFilePath());
-        if (Files.exists(FilePathConverter.fileSystemPathForExternalUri(pictureFilePublicPath, FilePathType.DRAG_ITEM))) {
-            FileUtil.sanitizeByCheckingIfPathStartsWithSubPathElseThrow(pictureFilePublicPath, pictureFileIntendedPath);
-            Path oldPath = FilePathConverter.fileSystemPathForExternalUri(pictureFilePublicPath, FilePathType.DRAG_ITEM);
+        FileUtil.sanitizeByCheckingIfPathStartsWithSubPathElseThrow(pictureFilePublicPath, pictureFileIntendedPath);
+        Path oldPath = FilePathConverter.fileSystemPathForExternalUri(pictureFilePublicPath, FilePathType.DRAG_ITEM);
+        if (Files.exists(oldPath)) {
             Path newPath = FileUtil.copyExistingFileToTarget(oldPath, FilePathConverter.getDragItemFilePath(), FilePathType.DRAG_ITEM);
             target.setPictureFilePath(FilePathConverter.externalUriForFileSystemPath(newPath, FilePathType.DRAG_ITEM, null).toString());
         }


### PR DESCRIPTION
### Summary

Reorder path sanitization checks in `QuizExerciseImportService` so that all validation (both invalid-character checks and path-prefix checks) runs **before** any filesystem access (`Files.exists()`). This is a defense-in-depth improvement that addresses CodeQL alert [#819](https://github.com/ls1intum/Artemis/security/code-scanning/819) (CWE-22 path traversal).

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).

### Motivation and Context

CodeQL alert [#819](https://github.com/ls1intum/Artemis/security/code-scanning/819) flagged a potential CWE-22 path traversal in `QuizExerciseImportService.copyDragItemFile()`. While the alert is effectively a false positive (the data comes from the database, `fileSystemPathForExternalUri` extracts only the filename component, and the invalid-character check runs before `Files.exists()`), the `sanitizeByCheckingIfPathStartsWithSubPathElseThrow` validation was previously placed **inside** the `if (Files.exists(...))` block, meaning it only gated the file copy operation but not the existence check itself.

### Description

In `QuizExerciseImportService`, two methods copy drag-and-drop quiz files during import:
- `copyDragAndDropQuestion` (background images)
- `copyDragItemFile` (drag item images)

Both methods previously had this ordering:
1. Check for invalid characters (before `Files.exists`) ✅
2. `Files.exists()` — filesystem access
3. Check path starts with expected subpath (inside `if` block) — too late

This PR reorders so **both** sanitization checks run before any filesystem access, and also eliminates a redundant call to `FilePathConverter.fileSystemPathForExternalUri()` by extracting the `oldPath` variable before the `if` block.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Course with a Quiz Exercise containing drag-and-drop questions with images

1. Log in as instructor
2. Import the quiz exercise to the same or different course
3. Verify drag-and-drop images are correctly copied to the new exercise
4. Verify background images are correctly displayed

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
#### Manual Tests
- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| QuizExerciseImportService.java | 3.05% | 291 |

_Last updated: 2026-04-01 12:05:08 UTC_



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved file handling during quiz exercise imports with enhanced path validation for drag-and-drop questions, ensuring files are correctly located and copied to their proper destinations. This provides more robust imports with better handling of file references and reduces errors from missing or misplaced files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->