### PR TITLE
`Communication`: Fix naming for delete message buttons

### DIFF
--- a/src/main/webapp/app/communication/answer-post/answer-post.component.html
+++ b/src/main/webapp/app/communication/answer-post/answer-post.component.html
@@ -99,7 +99,7 @@
         @if (mayDelete) {
             <button class="dropdown-item d-flex" (click)="deletePost()">
                 <fa-icon [icon]="faTrash" class="item-icon" />
-                <span jhiTranslate="artemisApp.metis.post.deleteAnswer"></span>
+                <span jhiTranslate="artemisApp.metis.answerPost.deleteAnswer"></span>
             </button>
         }
         <button class="dropdown-item d-flex" (click)="toggleSavePost()">

--- a/src/main/webapp/app/communication/answer-post/answer-post.component.html
+++ b/src/main/webapp/app/communication/answer-post/answer-post.component.html
@@ -99,7 +99,7 @@
         @if (mayDelete) {
             <button class="dropdown-item d-flex" (click)="deletePost()">
                 <fa-icon [icon]="faTrash" class="item-icon" />
-                <span jhiTranslate="artemisApp.metis.post.deleteMessage"></span>
+                <span jhiTranslate="artemisApp.metis.post.deleteAnswer"></span>
             </button>
         }
         <button class="dropdown-item d-flex" (click)="toggleSavePost()">

--- a/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.html
+++ b/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.html
@@ -113,8 +113,8 @@
                 <jhi-confirm-icon
                     iconSize="sm"
                     (confirmEvent)="deletePosting()"
-                    [initialTooltip]="'artemisApp.metis.deleteAnswer' | artemisTranslate"
-                    [confirmTooltip]="'artemisApp.metis.confirmDeleteAnswer' | artemisTranslate"
+                    [initialTooltip]="('artemisApp.metis.delete' + (getPostingType() === 'answerPost' ? 'Answer' : 'Post')) | artemisTranslate"
+                    [confirmTooltip]="('artemisApp.metis.confirmDelete' + (getPostingType() === 'answerPost' ? 'Answer' : 'Post')) | artemisTranslate"
                 />
             </button>
         }

--- a/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.html
+++ b/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.html
@@ -113,8 +113,8 @@
                 <jhi-confirm-icon
                     iconSize="sm"
                     (confirmEvent)="deletePosting()"
-                    [initialTooltip]="('artemisApp.metis.delete' + (getPostingType() === 'answerPost' ? 'Answer' : 'Post')) | artemisTranslate"
-                    [confirmTooltip]="('artemisApp.metis.confirmDelete' + (getPostingType() === 'answerPost' ? 'Answer' : 'Post')) | artemisTranslate"
+                    [initialTooltip]="'artemisApp.metis.delete' + (getPostingType() === 'answerPost' ? 'Answer' : 'Post') | artemisTranslate"
+                    [confirmTooltip]="'artemisApp.metis.confirmDelete' + (getPostingType() === 'answerPost' ? 'Answer' : 'Post') | artemisTranslate"
                 />
             </button>
         }

--- a/src/main/webapp/i18n/de/metis.json
+++ b/src/main/webapp/i18n/de/metis.json
@@ -165,7 +165,8 @@
             },
             "answerPost": {
                 "created": "Antwort erfolgreich erstellt",
-                "deleted": "Antwort erfolgreich gelöscht"
+                "deleted": "Antwort erfolgreich gelöscht",
+                "deleteAnswer": "Antwort löschen"
             },
             "userRoles": {
                 "instructor": "Instruktor",

--- a/src/main/webapp/i18n/en/metis.json
+++ b/src/main/webapp/i18n/en/metis.json
@@ -165,7 +165,8 @@
             },
             "answerPost": {
                 "created": "New reply successfully created",
-                "deleted": "Reply successfully deleted"
+                "deleted": "Reply successfully deleted",
+                "deleteAnswer": "Delete answer"
             },
             "userRoles": {
                 "instructor": "Instructor",


### PR DESCRIPTION
### Summary 
The delete button for deleting messages always talks about deleting a "reply" in its tooltip, despite it deleting messages. This PR updates the button's tooltips (and title in the context menu) to ensure it is clear what is being deleted.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
Resolves:
- Delete message button tooltip not respecting the kind of message it is deleting
- Context menu for answers mentioning "Delete message" instead of "Delete Answer"


### Description
In the hover menu, the tooltip picks its title based on the type of post being used (answer vs post). The context menu for answer posts is updated to use the corresponding string.


### Steps for Testing
Prerequisites:
- 1 User
- 1 Course with communication enabled and a few messages/replies you can delete 

1. Hover over a post, ensure the delete button says it is deleting a *message*.
2. Open a thread
3. Hover over a reply, ensure delete buttons says *answer*.
4. Right click on messages and replies, confirm that the delete button mentions the correct type of post being deleted.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-04-01 16:24:58 UTC_


### Screenshots
<img width="250" src="https://github.com/user-attachments/assets/b5ef594a-dffb-4422-b346-4916796d7fac" />

<img width="250" src="https://github.com/user-attachments/assets/c11ad8da-91c4-4f75-b3f8-8e24aed72f34" />
<img width="250" src="https://github.com/user-attachments/assets/f465b6fb-f354-44a3-902f-28c32e4a281a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated delete button and confirmation tooltip text to be context-specific for answers versus posts
  * Added translations for answer-specific deletion messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->