### PR TITLE
`Athena`: programming feedback credit grouping and repository URLs

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaDTOConverterService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaDTOConverterService.java
@@ -2,12 +2,14 @@ package de.tum.cit.aet.artemis.athena.service;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_ATHENA;
 
+import java.net.URI;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import de.tum.cit.aet.artemis.assessment.domain.Feedback;
 import de.tum.cit.aet.artemis.assessment.repository.GradingCriterionRepository;
@@ -46,6 +48,9 @@ public class AthenaDTOConverterService {
     @Value("${server.url}")
     private String artemisServerUrl;
 
+    @Value("${server.port}")
+    private int artemisServerPort;
+
     private final Optional<TextRepositoryApi> textRepositoryApi;
 
     private final ProgrammingExerciseRepository programmingExerciseRepository;
@@ -66,6 +71,7 @@ public class AthenaDTOConverterService {
      * @return *ExerciseDTO for Athena
      */
     public ExerciseBaseDTO ofExercise(Exercise exercise) {
+        var athenaRepositoryBaseUrl = getAthenaRepositoryBaseUrl();
         switch (exercise.getExerciseType()) {
             case TEXT -> {
                 // Fetch text exercise with grade criteria
@@ -75,7 +81,7 @@ public class AthenaDTOConverterService {
             case PROGRAMMING -> {
                 // Fetch programming exercise with grading criteria
                 var programmingExercise = programmingExerciseRepository.findByIdWithGradingCriteriaElseThrow(exercise.getId());
-                return ProgrammingExerciseDTO.of(programmingExercise, artemisServerUrl);
+                return ProgrammingExerciseDTO.of(programmingExercise, athenaRepositoryBaseUrl);
             }
             case MODELING -> {
                 // Fetch grading criteria for modeling exercise
@@ -98,11 +104,12 @@ public class AthenaDTOConverterService {
         if (submission == null) {
             return null;
         }
+        var athenaRepositoryBaseUrl = getAthenaRepositoryBaseUrl();
         if (submission instanceof TextSubmission textSubmission) {
             return TextSubmissionDTO.of(exerciseId, textSubmission);
         }
         else if (submission instanceof ProgrammingSubmission programmingSubmission) {
-            return ProgrammingSubmissionDTO.of(exerciseId, programmingSubmission, artemisServerUrl);
+            return ProgrammingSubmissionDTO.of(exerciseId, programmingSubmission, athenaRepositoryBaseUrl);
         }
         else if (submission instanceof ModelingSubmission modelingSubmission) {
             return ModelingSubmissionDTO.of(exerciseId, modelingSubmission);
@@ -135,5 +142,18 @@ public class AthenaDTOConverterService {
             }
         }
         throw new IllegalArgumentException("Feedback type not supported: " + exercise.getId());
+    }
+
+    private String getAthenaRepositoryBaseUrl() {
+        URI serverUri = URI.create(artemisServerUrl);
+        if (serverUri.getPort() != -1 || !isLoopbackHost(serverUri.getHost())) {
+            return artemisServerUrl;
+        }
+
+        return UriComponentsBuilder.fromUri(serverUri).port(artemisServerPort).build(false).toUriString();
+    }
+
+    private static boolean isLoopbackHost(String host) {
+        return host != null && ("localhost".equalsIgnoreCase(host) || "127.0.0.1".equals(host) || "::1".equals(host));
     }
 }

--- a/src/main/webapp/app/exercise/feedback/group/programming-feedback-groups.ts
+++ b/src/main/webapp/app/exercise/feedback/group/programming-feedback-groups.ts
@@ -2,6 +2,7 @@ import { FeedbackGroup } from 'app/exercise/feedback/group/feedback-group';
 import { FeedbackItem } from 'app/exercise/feedback/item/feedback-item';
 import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
+import { Feedback } from 'app/assessment/shared/entities/feedback.model';
 
 /**
  * Returns all FeedbackItemGroups for Programming exercises in the order, in which they will be displayed
@@ -23,9 +24,11 @@ class ProgrammingFeedbackGroupWrong extends FeedbackGroup {
 
     shouldContain(feedbackItem: FeedbackItem): boolean {
         const isReviewerFeedback = feedbackItem.type === 'Reviewer' && feedbackItem.credits !== undefined && feedbackItem.credits < 0;
+        const isAthenaNonGradedWrongFeedback =
+            feedbackItem.type === 'Reviewer' && Feedback.isNonGradedFeedbackSuggestion(feedbackItem.feedbackReference) && feedbackItem.credits === 0;
         const isTestFeedback = feedbackItem.type === 'Test';
         const isFailedTest = feedbackItem.positive === false || (feedbackItem.positive === undefined && feedbackItem.credits === 0);
-        return isReviewerFeedback || (isTestFeedback && isFailedTest);
+        return isReviewerFeedback || isAthenaNonGradedWrongFeedback || (isTestFeedback && isFailedTest);
     }
 }
 
@@ -62,9 +65,10 @@ class ProgrammingFeedbackGroupInfo extends FeedbackGroup {
     }
 
     shouldContain(feedbackItem: FeedbackItem): boolean {
+        const isAthenaNonGradedFeedback = Feedback.isNonGradedFeedbackSuggestion(feedbackItem.feedbackReference);
         const isReviewerFeedback = feedbackItem.type === 'Reviewer' && feedbackItem.credits === 0;
         const isSubsequentFeedback = feedbackItem.type === 'Subsequent';
-        return isReviewerFeedback || isSubsequentFeedback;
+        return (isReviewerFeedback && !isAthenaNonGradedFeedback) || isSubsequentFeedback;
     }
 }
 
@@ -82,8 +86,10 @@ class ProgrammingFeedbackGroupCorrect extends FeedbackGroup {
 
     shouldContain(feedbackItem: FeedbackItem): boolean {
         const isReviewerFeedback = feedbackItem.type === 'Reviewer' && feedbackItem.credits !== undefined && feedbackItem.credits > 0;
+        const isAthenaNonGradedCorrectFeedback =
+            feedbackItem.type === 'Reviewer' && Feedback.isNonGradedFeedbackSuggestion(feedbackItem.feedbackReference) && (feedbackItem.credits ?? 0) > 0;
         const isTestFeedback = feedbackItem.type === 'Test';
         const isSuccessfulTest = feedbackItem.positive === true || (feedbackItem.positive === undefined && !!feedbackItem.credits);
-        return isReviewerFeedback || (isTestFeedback && isSuccessfulTest);
+        return isReviewerFeedback || isAthenaNonGradedCorrectFeedback || (isTestFeedback && isSuccessfulTest);
     }
 }

--- a/src/main/webapp/app/exercise/feedback/node/feedback-node.component.html
+++ b/src/main/webapp/app/exercise/feedback/node/feedback-node.component.html
@@ -2,8 +2,8 @@
     <div class="alert feedback-item" [ngClass]="'alert-' + feedbackItem.color">
         <div class="feedback-item__header">
             <h4 class="feedback-item__category">{{ feedbackItem.name }} {{ feedbackItem.title && '· ' + feedbackItem.title }}</h4>
-            @if (feedbackItem.credits) {
-                <span class="fw-bold feedback-item__credits">
+            @if (feedbackItem.credits !== undefined) {
+                <span class="fw-bold feedback-item__credits" [ngClass]="getCreditsBadgeClasses(feedbackItem)">
                     {{ roundValueSpecifiedByCourseSettings(feedbackItem.credits, course) }}P
                     @if (feedbackItem.type === 'Subsequent') {
                         <fa-icon [icon]="faExclamationTriangle" [ngbTooltip]="'artemisApp.assessment.subsequentFeedback' | artemisTranslate" />
@@ -25,7 +25,7 @@
                 <fa-icon class="me-2" [icon]="feedbackItemGroup.open ? faAngleUp : faAngleDown" />
                 <h4 class="feedback-item__category">{{ 'artemisApp.feedback.group.' + feedbackItemGroup.name | artemisTranslate }} ({{ feedbackItemGroup.members.length }})</h4>
             </div>
-            @if (feedbackItemGroup.credits !== 0) {
+            @if (feedbackItemGroup.credits !== undefined) {
                 <span class="fw-bold">{{ roundValueSpecifiedByCourseSettings(feedbackItemGroup.credits, course) }}P </span>
             }
         </div>

--- a/src/main/webapp/app/exercise/feedback/node/feedback-node.component.ts
+++ b/src/main/webapp/app/exercise/feedback/node/feedback-node.component.ts
@@ -2,6 +2,7 @@ import { roundValueSpecifiedByCourseSettings } from 'app/shared/util/utils';
 import { Component, Input, OnInit } from '@angular/core';
 import { Course } from 'app/core/course/shared/entities/course.model';
 import { faAngleDown, faAngleUp, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { Feedback } from 'app/assessment/shared/entities/feedback.model';
 import { FeedbackGroup, isFeedbackGroup } from 'app/exercise/feedback/group/feedback-group';
 import { FeedbackItem } from 'app/exercise/feedback/item/feedback-item';
 import { FeedbackNode } from 'app/exercise/feedback/node/feedback-node';
@@ -32,6 +33,18 @@ export class FeedbackNodeComponent implements OnInit {
     faExclamationTriangle = faExclamationTriangle;
     faAngleUp = faAngleUp;
     faAngleDown = faAngleDown;
+
+    getCreditsBadgeClasses(feedbackItem: FeedbackItem) {
+        const credits = feedbackItem.credits ?? 0;
+        const isAthenaNonGradedSuggestion = Feedback.isNonGradedFeedbackSuggestion(feedbackItem.feedbackReference);
+
+        return {
+            badge: true,
+            'bg-success': credits > 0,
+            'bg-danger': credits < 0 || (isAthenaNonGradedSuggestion && credits === 0),
+            'bg-warning': credits === 0 && !isAthenaNonGradedSuggestion,
+        };
+    }
 
     ngOnInit(): void {
         if (isFeedbackGroup(this.feedbackItemNode)) {

--- a/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-inline-feedback/code-editor-tutor-assessment-inline-feedback.component.html
+++ b/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-inline-feedback/code-editor-tutor-assessment-inline-feedback.component.html
@@ -2,10 +2,10 @@
     id="code-editor-inline-feedback-{{ codeLine }}"
     class="alert p-0 mb-0 border rounded"
     [style.max-width.%]="95"
-    [class.alert-success]="feedback.credits! > 0 && feedback.isSubsequent === undefined"
-    [class.alert-danger]="feedback.credits! < 0 && feedback.isSubsequent === undefined"
+    [class.alert-success]="(feedback.credits! > 0 && feedback.isSubsequent === undefined && !isAthenaNonGradedFeedback(feedback)) || isPositiveAthenaNonGradedFeedback(feedback)"
+    [class.alert-danger]="(feedback.credits! < 0 && feedback.isSubsequent === undefined) || isNegativeAthenaNonGradedFeedback(feedback)"
     [class.alert-warning]="!feedback.credits && feedback.isSubsequent === undefined && !Feedback.isNonGradedFeedbackSuggestion(feedback)"
-    [class.alert-info]="Feedback.isNonGradedFeedbackSuggestion(feedback)"
+    [class.alert-info]="Feedback.isNonGradedFeedbackSuggestion(feedback) && !isPositiveAthenaNonGradedFeedback(feedback) && !isNegativeAthenaNonGradedFeedback(feedback)"
     [class.alert-secondary]="readOnly && feedback.isSubsequent"
 >
     @if (Feedback.isFeedbackSuggestion(feedback) && !readOnly) {
@@ -95,12 +95,15 @@
             <div class="row flex-nowrap align-items-top m-1">
                 <div class="col flex-grow-0 ps-0">
                     <h5 class="d-inline">
-                        @if (!Feedback.isNonGradedFeedbackSuggestion(feedback)) {
+                        @if (feedback.credits !== undefined) {
                             <span
                                 class="badge"
-                                [class.bg-success]="feedback.credits! > 0 && feedback.isSubsequent === undefined"
-                                [class.bg-danger]="feedback.credits! < 0 && feedback.isSubsequent === undefined"
-                                [class.bg-warning]="feedback.credits === 0 && feedback.isSubsequent === undefined"
+                                [class.bg-success]="
+                                    (feedback.credits! > 0 && feedback.isSubsequent === undefined && !isAthenaNonGradedFeedback(feedback)) ||
+                                    isPositiveAthenaNonGradedFeedback(feedback)
+                                "
+                                [class.bg-danger]="(feedback.credits! < 0 && feedback.isSubsequent === undefined) || isNegativeAthenaNonGradedFeedback(feedback)"
+                                [class.bg-warning]="feedback.credits === 0 && feedback.isSubsequent === undefined && !isAthenaNonGradedFeedback(feedback)"
                                 [class.bg-secondary]="readOnly && feedback.isSubsequent"
                                 >{{ roundScoreSpecifiedByCourseSettings(feedback.credits, course) + 'P' }}</span
                             >

--- a/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-inline-feedback/code-editor-tutor-assessment-inline-feedback.component.ts
+++ b/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-inline-feedback/code-editor-tutor-assessment-inline-feedback.component.ts
@@ -83,6 +83,18 @@ export class CodeEditorTutorAssessmentInlineFeedbackComponent {
     private dialogErrorSource = new Subject<string>();
     dialogError$ = this.dialogErrorSource.asObservable();
 
+    protected isAthenaNonGradedFeedback(feedback: Feedback): boolean {
+        return Feedback.isNonGradedFeedbackSuggestion(feedback);
+    }
+
+    protected isPositiveAthenaNonGradedFeedback(feedback: Feedback): boolean {
+        return this.isAthenaNonGradedFeedback(feedback) && (feedback.credits ?? 0) > 0;
+    }
+
+    protected isNegativeAthenaNonGradedFeedback(feedback: Feedback): boolean {
+        return this.isAthenaNonGradedFeedback(feedback) && (feedback.credits ?? 0) === 0;
+    }
+
     /**
      * Updates the current feedback and sets props and emits the feedback to parent component
      */

--- a/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSuggestionsServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSuggestionsServiceTest.java
@@ -57,6 +57,9 @@ class AthenaFeedbackSuggestionsServiceTest extends AbstractAthenaTest {
     @Value("${server.url}")
     private String serverUrl;
 
+    @Value("${server.port}")
+    private int serverPort;
+
     private TextExercise textExercise;
 
     private TextSubmission textSubmission;
@@ -143,7 +146,7 @@ class AthenaFeedbackSuggestionsServiceTest extends AbstractAthenaTest {
         athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("programming", jsonPath("$.exercise.id").value(programmingExercise.getId()),
                 jsonPath("$.exercise.title").value(programmingExercise.getTitle()), jsonPath("$.submission.id").value(programmingSubmission.getId()),
                 jsonPath("$.submission.repositoryUri")
-                        .value(serverUrl + "/api/athena/internal/programming-exercises/" + programmingExercise.getId() + "/submissions/3/repository"));
+                        .value(serverUrl + ":" + serverPort + "/api/athena/internal/programming-exercises/" + programmingExercise.getId() + "/submissions/3/repository"));
         List<ProgrammingFeedbackDTO> suggestions = athenaFeedbackSuggestionsService.getProgrammingFeedbackSuggestions(programmingExercise, programmingSubmission, true);
         assertThat(suggestions.getFirst().title()).isEqualTo("Not so good");
         assertThat(suggestions.getFirst().lineStart()).isEqualTo(3);

--- a/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaSubmissionSendingServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaSubmissionSendingServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.cit.aet.artemis.athena.AbstractAthenaTest;
@@ -57,6 +58,12 @@ class AthenaSubmissionSendingServiceTest extends AbstractAthenaTest {
 
     @Autowired
     private UserUtilService userUtilService;
+
+    @Value("${server.url}")
+    private String serverUrl;
+
+    @Value("${server.port}")
+    private int serverPort;
 
     private AthenaSubmissionSendingService athenaSubmissionSendingService;
 
@@ -119,27 +126,36 @@ class AthenaSubmissionSendingServiceTest extends AbstractAthenaTest {
         athenaRequestMockProvider.verify();
     }
 
-    private void createProgrammingSubmissionForSubmissionSending() {
+    private long createProgrammingSubmissionForSubmissionSending() {
         var studentParticipation = ParticipationFactory.generateStudentParticipation(InitializationState.FINISHED, programmingExercise,
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         studentParticipation.setExercise(programmingExercise);
         studentParticipationRepository.save(studentParticipation);
         var submission = ParticipationFactory.generateProgrammingSubmission(true);
         submission.setParticipation(studentParticipation);
-        submissionRepository.save(submission);
+        submission = submissionRepository.save(submission);
         athenaRequestMockProvider.verify();
+        return submission.getId();
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void testSendSubmissionsSuccessProgramming() {
-        createProgrammingSubmissionForSubmissionSending();
+        long submissionId = createProgrammingSubmissionForSubmissionSending();
         athenaRequestMockProvider.mockSendSubmissionsAndExpect("programming", jsonPath("$.exercise.id").value(programmingExercise.getId()),
                 jsonPath("$.exercise.title").value(programmingExercise.getTitle()), jsonPath("$.exercise.maxPoints").value(programmingExercise.getMaxPoints()),
                 jsonPath("$.exercise.bonusPoints").value(programmingExercise.getBonusPoints()),
                 jsonPath("$.exercise.gradingInstructions").value(programmingExercise.getGradingInstructions()),
                 jsonPath("$.exercise.problemStatement").value(programmingExercise.getProblemStatement()),
-                jsonPath("$.submissions[0].exerciseId").value(programmingExercise.getId()), jsonPath("$.submissions[0].repositoryUri").isString());
+                jsonPath("$.submissions[0].exerciseId").value(programmingExercise.getId()),
+                jsonPath("$.exercise.solutionRepositoryUri")
+                        .value(serverUrl + ":" + serverPort + "/api/athena/internal/programming-exercises/" + programmingExercise.getId() + "/repository/solution"),
+                jsonPath("$.exercise.templateRepositoryUri")
+                        .value(serverUrl + ":" + serverPort + "/api/athena/internal/programming-exercises/" + programmingExercise.getId() + "/repository/template"),
+                jsonPath("$.exercise.testsRepositoryUri")
+                        .value(serverUrl + ":" + serverPort + "/api/athena/internal/programming-exercises/" + programmingExercise.getId() + "/repository/tests"),
+                jsonPath("$.submissions[0].repositoryUri").value(serverUrl + ":" + serverPort + "/api/athena/internal/programming-exercises/" + programmingExercise.getId()
+                        + "/submissions/" + submissionId + "/repository"));
 
         athenaSubmissionSendingService.sendSubmissions(programmingExercise);
         athenaRequestMockProvider.verify();


### PR DESCRIPTION
**Summary**
- include the configured server port in Athena programming repository URLs when `server.url` uses a loopback host without an explicit port
- render zero-credit programming feedback consistently and classify Athena non-graded suggestions into correct or wrong groups based on their meaning
- update Athena connector tests to assert the full programming repository URLs sent in requests

**Testing**
- Not run (not requested)