### PR TITLE
`Integrated code lifecycle`: Prioritize token authentication as default repository auth method

### DIFF
--- a/documentation/docs/admin/production-setup/integrated-code-lifecycle-setup.mdx
+++ b/documentation/docs/admin/production-setup/integrated-code-lifecycle-setup.mdx
@@ -32,7 +32,7 @@ artemis:
     version-control:
         url: http://localhost:8080
         # order and supported authentication mechanisms:
-        repository-authentication-mechanisms: password,token,ssh
+        repository-authentication-mechanisms: token,ssh,password
     continuous-integration:
         # Only necessary on ARM-based systems, the default is amd64 for Intel/AMD systems
         # ARM-based systems include Apple M-series, Raspberry Pi, etc.

--- a/documentation/docs/student/tools-reference/integrated-code-lifecycle.mdx
+++ b/documentation/docs/student/tools-reference/integrated-code-lifecycle.mdx
@@ -139,8 +139,8 @@ Here is a short overview on the advantages and disadvantages of the provided mec
 
 The participation token is the recommended authentication method for students due to its simplicity, security, and lack of setup requirements.
 While SSH provides strong security, its complexity and setup challenges may make it less convenient.
-Password authentication remains the default but should be used with caution — admins are encouraged to disable it when possible or enforce strong password policies to enhance security.
-Therefore, the generally suggested order of authentication mechanisms would ideally be: token, SSH, and lastly password.
+Password authentication should be used with caution — admins are encouraged to disable it when possible or enforce strong password policies to enhance security.
+The default order of authentication mechanisms is: token, SSH, and lastly password.
 
 ---
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/localvc/LocalVCInfoContributor.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/localvc/LocalVCInfoContributor.java
@@ -26,7 +26,7 @@ public class LocalVCInfoContributor implements InfoContributor {
     @Value("${server.url}")
     private URI artemisServerUri;
 
-    @Value("${artemis.version-control.repository-authentication-mechanisms:password,token,ssh}")
+    @Value("${artemis.version-control.repository-authentication-mechanisms:token,ssh,password}")
     private List<String> orderedRepositoryAuthenticationMechanisms;
 
     @Value("${artemis.version-control.ssh-port:7921}")

--- a/src/main/resources/config/application-artemis.yml
+++ b/src/main/resources/config/application-artemis.yml
@@ -51,7 +51,7 @@ artemis:
     #        ssh-private-key-folder-path: <ssh-private-key-folder-path>       # the path to the folder in which the private ssh key file (e.g. id_rsa) is stored that can be used to clone git repos on the version control server
     #        ssh-private-key-password: <ssh-private-key-password>        # the password for the private ssh key
     default-branch: main            # The branch that should be used as default branch for all newly created repositories. This does NOT have to be equal to the default branch of the VCS
-    repository-authentication-mechanisms: password,token,ssh # the order of authentication mechanisms in the code button pop up. Removing parts removes them from the drop-down
+    repository-authentication-mechanisms: token,ssh,password # the order of authentication mechanisms in the code button pop up. Removing parts removes them from the drop-down
   continuous-integration:
     user: <username>                # e.g. ga12abc
     password: <password>

--- a/src/main/webapp/app/shared/components/buttons/code-button/code-button.component.spec.ts
+++ b/src/main/webapp/app/shared/components/buttons/code-button/code-button.component.spec.ts
@@ -62,7 +62,7 @@ describe('CodeButtonComponent', () => {
                 MockProvider(AlertService),
                 { provide: ActivatedRoute, useValue: route },
                 { provide: Router, useValue: router },
-                LocalStorageService,
+                MockProvider(LocalStorageService),
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: AccountService, useClass: MockAccountService },
                 { provide: ProfileService, useClass: MockProfileService },
@@ -197,6 +197,7 @@ describe('CodeButtonComponent', () => {
         participation.team = {};
         fixture.componentRef.setInput('participations', [participation]);
         localStorageState = RepositoryAuthenticationMethod.Password;
+        component.onClick();
         fixture.changeDetectorRef.detectChanges();
 
         let url = component.getHttpOrSshRepositoryUri();
@@ -269,6 +270,7 @@ describe('CodeButtonComponent', () => {
             testRun: true,
         };
         fixture.componentRef.setInput('participations', [participation1, participation2]);
+        component.selectedAuthenticationMechanism.set(RepositoryAuthenticationMethod.Password);
         fixture.detectChanges();
         await fixture.whenStable();
 
@@ -287,6 +289,7 @@ describe('CodeButtonComponent', () => {
     it('should handle no participation', () => {
         fixture.componentRef.setInput('repositoryUri', 'https://artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.solution.git');
         fixture.componentRef.setInput('participations', []);
+        component.selectedAuthenticationMechanism.set(RepositoryAuthenticationMethod.Password);
         fixture.changeDetectorRef.detectChanges();
 
         expect(component.isTeamParticipation()).toBe(false);

--- a/src/main/webapp/app/shared/components/buttons/code-button/code-button.component.spec.ts
+++ b/src/main/webapp/app/shared/components/buttons/code-button/code-button.component.spec.ts
@@ -316,7 +316,7 @@ describe('CodeButtonComponent', () => {
 
         component.sshEnabled = true;
         component.sshTemplateUrl = 'ssh://git@artemis.tum.de:7999/';
-        component.authenticationMechanisms.set([RepositoryAuthenticationMethod.Password, RepositoryAuthenticationMethod.Token, RepositoryAuthenticationMethod.SSH]);
+        component.authenticationMechanisms.set([RepositoryAuthenticationMethod.Token, RepositoryAuthenticationMethod.SSH, RepositoryAuthenticationMethod.Password]);
 
         fixture.changeDetectorRef.detectChanges();
 

--- a/src/main/webapp/app/shared/components/buttons/code-button/code-button.component.ts
+++ b/src/main/webapp/app/shared/components/buttons/code-button/code-button.component.ts
@@ -116,9 +116,9 @@ export class CodeButtonComponent implements OnInit {
     ideName = signal('');
     // this is the fallback with a default order in case the server does not specify this as part of the profile info endpoint
     authenticationMechanisms = signal<RepositoryAuthenticationMethod[]>([
-        RepositoryAuthenticationMethod.Password,
         RepositoryAuthenticationMethod.Token,
         RepositoryAuthenticationMethod.SSH,
+        RepositoryAuthenticationMethod.Password,
     ]);
 
     // Computed/Derived States
@@ -140,7 +140,7 @@ export class CodeButtonComponent implements OnInit {
         return this.participationService.getSpecificStudentParticipation(participations, this.isPractice()) ?? participations[0];
     });
     selectedAuthenticationMechanism = signal<RepositoryAuthenticationMethod>(
-        this.localStorageService.retrieve<RepositoryAuthenticationMethod>('code-button-state') ?? RepositoryAuthenticationMethod.Password,
+        this.localStorageService.retrieve<RepositoryAuthenticationMethod>('code-button-state') ?? this.authenticationMechanisms()[0],
     );
     useToken = computed(() => this.selectedAuthenticationMechanism() === RepositoryAuthenticationMethod.Token);
     useSsh = computed(() => this.selectedAuthenticationMechanism() === RepositoryAuthenticationMethod.SSH);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalVCInfoContributorTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/icl/LocalVCInfoContributorTest.java
@@ -15,7 +15,7 @@ class LocalVCInfoContributorTest {
     @Test
     void testContribute() {
         Info.Builder builder = new Info.Builder();
-        var repositoryAuthenticationMechanisms = List.of("password", "token", "ssh");
+        var repositoryAuthenticationMechanisms = List.of("token", "ssh", "password");
         LocalVCInfoContributor localVCInfoContributor = new LocalVCInfoContributor();
         ReflectionTestUtils.setField(localVCInfoContributor, "orderedRepositoryAuthenticationMechanisms", repositoryAuthenticationMechanisms);
 

--- a/src/test/javascript/spec/helpers/sample/profile-info-sample-data.ts
+++ b/src/test/javascript/spec/helpers/sample/profile-info-sample-data.ts
@@ -105,7 +105,7 @@ export const expectedProfileInfo: ProfileInfo = {
     operatorName: 'TUM',
     programmingLanguageFeatures: programmingLanguageFeatures,
     registrationEnabled: true,
-    repositoryAuthenticationMechanisms: ['ssh', 'token', 'password'],
+    repositoryAuthenticationMechanisms: ['token', 'ssh', 'password'],
     sentry: { dsn: 'https://e52d0b9b6b61769f50b088634b4bc781@sentry.aet.cit.tum.de/2' },
     sshCloneURLTemplate: 'ssh://git@artemistest2.aet.cit.tum.de:2222/',
     studentExamStoreSessionData: false,


### PR DESCRIPTION
### Summary
Changes the default repository authentication mechanism order from `password,token,ssh` to `token,ssh,password` to enhance security by prioritizing token authentication. This affects the order shown in the code button dropdown for git clone operations.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
The previous default authentication order (`password,token,ssh`) prioritized password authentication, which is less secure and can be slow with external authentication providers. This PR establishes token authentication as the primary method, improving security and user experience.

### Description
Updated all locations where repository authentication mechanism ordering is defined or documented:

**Server:**
- `LocalVCInfoContributor.java`: Changed `@Value` default from `password,token,ssh` to `token,ssh,password`
- `application-artemis.yml`: Updated default configuration
- `LocalVCInfoContributorTest.java`: Updated test expectations

**Client:**
- `code-button.component.ts`:
  - Changed fallback `authenticationMechanisms` array from `[Password, Token, SSH]` to `[Token, SSH, Password]`
  - Fixed `selectedAuthenticationMechanism` default to use `authenticationMechanisms()[0]` instead of hardcoded `Password`
- `code-button.component.spec.ts`: Fixed pre-existing Vitest test failures (real `LocalStorageService` was being used during component construction, causing `localStorage.getItem is not a function` in jsdom); replaced with `MockProvider(LocalStorageService)` and added explicit auth mechanism setup in 3 tests that relied on Password as the initial fallback
- `profile-info-sample-data.ts`: Updated test fixture

**Documentation:**
- `integrated-code-lifecycle-setup.mdx`: Updated admin setup example
- `integrated-code-lifecycle.mdx`: Removed "Password remains default" claim, updated to reflect new default order

### Steps for Testing
Prerequisites:
- Any programming exercise with LocalVC enabled

**Testing Default Order:**
1. Log in as a student
2. Navigate to any programming exercise
3. Click the "Code" button dropdown
4. Verify the first option shown is "Clone with Personal Token" (or "Clone with Participation Token")
5. Verify SSH is second, password is last

**Testing Stored Preference:**
1. Select SSH from the dropdown
2. Refresh the page
3. Verify SSH remains selected (localStorage persistence)

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Server tests failed. Coverage could not be fully measured. Please check the [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/24090379099).

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| code-button.component.ts | not found (modified) | 350 | 65 | 18.6 |

_Last updated: 2026-04-07 16:54:32 UTC_


### Review Progress
#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2