### PR TITLE
Lecture processing: Add row-level locking for retry dispatch

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureUnitProcessingStateRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureUnitProcessingStateRepository.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.cit.aet.artemis.core.repository.base.ArtemisJpaRepository;
 import de.tum.cit.aet.artemis.lecture.config.LectureEnabled;
@@ -59,18 +60,25 @@ public interface LectureUnitProcessingStateRepository extends ArtemisJpaReposito
      * - retryEligibleAt has passed (backoff period complete)
      * <p>
      * This query is mutually exclusive with findStuckStates (which requires retryEligibleAt IS NULL).
+     * <p>
+     * Uses {@code FOR UPDATE SKIP LOCKED} to prevent multiple Artemis nodes from claiming
+     * the same retry-eligible job simultaneously. Each row is locked by the first node that
+     * reads it; concurrent nodes silently skip already-locked rows.
      *
-     * @param phase the processing phase to check
+     * @param phase the processing phase to check (enum name as string, e.g. "TRANSCRIBING")
      * @param now   the current time to compare against retryEligibleAt
-     * @return list of states ready for retry
+     * @return list of states ready for retry, locked for the duration of the calling transaction
      */
-    @Query("""
-            SELECT ps FROM LectureUnitProcessingState ps
+    @Transactional
+    @Query(value = """
+            SELECT *
+            FROM lecture_unit_processing_state ps
             WHERE ps.phase = :phase
-            AND ps.retryEligibleAt IS NOT NULL
-            AND ps.retryEligibleAt <= :now
-            """)
-    List<LectureUnitProcessingState> findStatesReadyForRetry(@Param("phase") ProcessingPhase phase, @Param("now") ZonedDateTime now);
+            AND ps.retry_eligible_at IS NOT NULL
+            AND ps.retry_eligible_at <= :now
+            FOR UPDATE SKIP LOCKED
+            """, nativeQuery = true)
+    List<LectureUnitProcessingState> findStatesReadyForRetry(@Param("phase") String phase, @Param("now") ZonedDateTime now);
 
     /**
      * Find all processing states for a course.

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingScheduler.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingScheduler.java
@@ -114,13 +114,12 @@ public class LectureContentProcessingScheduler {
 
     /**
      * Find and retry all states in a specific phase that are ready for retry.
-     * The query handles the backoff check via retryEligibleAt timestamp.
+     * Uses an atomic claim step to prevent multiple nodes from retrying the same job.
      *
      * @param phase the processing phase to check
      */
     private void retryFailedStates(ProcessingPhase phase) {
-        ZonedDateTime now = ZonedDateTime.now();
-        List<LectureUnitProcessingState> states = processingStateRepository.findStatesReadyForRetry(phase, now);
+        List<LectureUnitProcessingState> states = processingService.claimRetryEligibleStates(phase);
 
         for (LectureUnitProcessingState state : states) {
             retryState(state, phase);
@@ -166,6 +165,10 @@ public class LectureContentProcessingScheduler {
         }
         catch (Exception e) {
             log.error("Failed to retry {} for unit {}: {}", phase, freshState.getLectureUnit().getId(), e.getMessage());
+            // Re-schedule so the claimed job is not lost (retryEligibleAt was cleared during claim)
+            long backoffMinutes = ProcessingStateCallbackService.calculateBackoffMinutes(freshState.getRetryCount());
+            freshState.scheduleRetry(backoffMinutes);
+            processingStateRepository.save(freshState);
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingService.java
@@ -17,6 +17,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.cit.aet.artemis.core.security.SecurityUtils;
 import de.tum.cit.aet.artemis.core.service.feature.Feature;
@@ -90,6 +91,29 @@ public class LectureContentProcessingService {
         boolean canTranscribe = transcriptionApi.isPresent() && tumLiveApi.isPresent();
         boolean canIngest = irisLectureApi.isPresent();
         return canTranscribe || canIngest;
+    }
+
+    /**
+     * Atomically claim retry-eligible processing states for a given phase.
+     * <p>
+     * Uses {@code SELECT ... FOR UPDATE SKIP LOCKED} to prevent multiple nodes from
+     * claiming the same jobs. Within the same transaction, clears {@code retryEligibleAt}
+     * so that no other node can re-select these rows after the transaction commits.
+     * <p>
+     * The caller should process the returned states <b>outside</b> this transaction
+     * to avoid holding row locks during external HTTP calls.
+     *
+     * @param phase the processing phase to claim retry-eligible states for
+     * @return the list of claimed states with {@code retryEligibleAt} already cleared
+     */
+    @Transactional
+    public List<LectureUnitProcessingState> claimRetryEligibleStates(ProcessingPhase phase) {
+        List<LectureUnitProcessingState> states = processingStateRepository.findStatesReadyForRetry(phase.name(), ZonedDateTime.now());
+        for (LectureUnitProcessingState state : states) {
+            state.clearRetryEligibility();
+        }
+        processingStateRepository.saveAll(states);
+        return states;
     }
 
     // -------------------- Public API --------------------

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingSchedulerTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingSchedulerTest.java
@@ -86,7 +86,7 @@ class LectureContentProcessingSchedulerTest {
             // Only return state for TRANSCRIBING phase query
             when(processingStateRepository.findStuckStates(eq(List.of(ProcessingPhase.TRANSCRIBING)), any(ZonedDateTime.class))).thenReturn(List.of(testState));
             when(processingStateRepository.findStuckStates(eq(List.of(ProcessingPhase.INGESTING)), any(ZonedDateTime.class))).thenReturn(List.of());
-            when(processingStateRepository.findStatesReadyForRetry(any(), any())).thenReturn(List.of());
+            when(processingService.claimRetryEligibleStates(any())).thenReturn(List.of());
             when(processingStateRepository.findById(testState.getId())).thenReturn(Optional.of(testState));
             when(processingStateRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
@@ -112,7 +112,7 @@ class LectureContentProcessingSchedulerTest {
 
             when(processingStateRepository.findStuckStates(eq(List.of(ProcessingPhase.TRANSCRIBING)), any(ZonedDateTime.class))).thenReturn(List.of(testState));
             when(processingStateRepository.findStuckStates(eq(List.of(ProcessingPhase.INGESTING)), any(ZonedDateTime.class))).thenReturn(List.of());
-            when(processingStateRepository.findStatesReadyForRetry(any(), any())).thenReturn(List.of());
+            when(processingService.claimRetryEligibleStates(any())).thenReturn(List.of());
             when(processingStateRepository.findById(testState.getId())).thenReturn(Optional.of(testState));
             when(processingStateRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
@@ -136,7 +136,7 @@ class LectureContentProcessingSchedulerTest {
 
             // The query should not return this state (startedAt is not past cutoff)
             when(processingStateRepository.findStuckStates(anyList(), any(ZonedDateTime.class))).thenReturn(List.of());
-            when(processingStateRepository.findStatesReadyForRetry(any(), any())).thenReturn(List.of());
+            when(processingService.claimRetryEligibleStates(any())).thenReturn(List.of());
 
             // When
             scheduler.processScheduledRetries();
@@ -159,8 +159,8 @@ class LectureContentProcessingSchedulerTest {
 
             // Query returns the state because retryEligibleAt <= now
             when(processingStateRepository.findStuckStates(anyList(), any(ZonedDateTime.class))).thenReturn(List.of());
-            when(processingStateRepository.findStatesReadyForRetry(eq(ProcessingPhase.TRANSCRIBING), any(ZonedDateTime.class))).thenReturn(List.of(testState));
-            when(processingStateRepository.findStatesReadyForRetry(eq(ProcessingPhase.INGESTING), any(ZonedDateTime.class))).thenReturn(List.of());
+            when(processingService.claimRetryEligibleStates(ProcessingPhase.TRANSCRIBING)).thenReturn(List.of(testState));
+            when(processingService.claimRetryEligibleStates(ProcessingPhase.INGESTING)).thenReturn(List.of());
             when(processingStateRepository.findById(testState.getId())).thenReturn(Optional.of(testState));
 
             // When
@@ -179,7 +179,7 @@ class LectureContentProcessingSchedulerTest {
 
             // Query should NOT return this state (retryEligibleAt > now)
             when(processingStateRepository.findStuckStates(anyList(), any(ZonedDateTime.class))).thenReturn(List.of());
-            when(processingStateRepository.findStatesReadyForRetry(any(), any())).thenReturn(List.of());
+            when(processingService.claimRetryEligibleStates(any())).thenReturn(List.of());
 
             // When
             scheduler.processScheduledRetries();
@@ -198,7 +198,7 @@ class LectureContentProcessingSchedulerTest {
 
             // Query should NOT return this state (retryEligibleAt IS NULL)
             when(processingStateRepository.findStuckStates(anyList(), any(ZonedDateTime.class))).thenReturn(List.of());
-            when(processingStateRepository.findStatesReadyForRetry(any(), any())).thenReturn(List.of());
+            when(processingService.claimRetryEligibleStates(any())).thenReturn(List.of());
 
             // When
             scheduler.processScheduledRetries();
@@ -220,8 +220,8 @@ class LectureContentProcessingSchedulerTest {
 
             // Batch query returns the state
             when(processingStateRepository.findStuckStates(anyList(), any(ZonedDateTime.class))).thenReturn(List.of());
-            when(processingStateRepository.findStatesReadyForRetry(eq(ProcessingPhase.TRANSCRIBING), any())).thenReturn(List.of(testState));
-            when(processingStateRepository.findStatesReadyForRetry(eq(ProcessingPhase.INGESTING), any())).thenReturn(List.of());
+            when(processingService.claimRetryEligibleStates(ProcessingPhase.TRANSCRIBING)).thenReturn(List.of(testState));
+            when(processingService.claimRetryEligibleStates(ProcessingPhase.INGESTING)).thenReturn(List.of());
 
             // But when we re-fetch, the state is now IDLE (user changed it)
             LectureUnitProcessingState freshState = new LectureUnitProcessingState(testUnit);
@@ -236,6 +236,31 @@ class LectureContentProcessingSchedulerTest {
         }
 
         @Test
+        void shouldRescheduleRetryWhenRetryThrowsException() {
+            // Given: A claimed state whose retryTranscription throws an unexpected exception
+            testState.setPhase(ProcessingPhase.TRANSCRIBING);
+            testState.setRetryCount(2);
+            testState.setRetryEligibleAt(null); // Already cleared by claim step
+
+            when(processingStateRepository.findStuckStates(anyList(), any(ZonedDateTime.class))).thenReturn(List.of());
+            when(processingService.claimRetryEligibleStates(ProcessingPhase.TRANSCRIBING)).thenReturn(List.of(testState));
+            when(processingService.claimRetryEligibleStates(ProcessingPhase.INGESTING)).thenReturn(List.of());
+            when(processingStateRepository.findById(testState.getId())).thenReturn(Optional.of(testState));
+            when(processingStateRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+            // retryTranscription throws
+            doThrow(new RuntimeException("Connection refused")).when(processingService).retryTranscription(testState);
+
+            // When
+            scheduler.processScheduledRetries();
+
+            // Then: Should re-schedule retry so the job is not lost
+            assertThat(testState.getRetryEligibleAt()).isNotNull();
+            assertThat(testState.getRetryEligibleAt()).isAfter(ZonedDateTime.now());
+            verify(processingStateRepository).save(testState);
+        }
+
+        @Test
         void shouldSkipRecoveryWhenStateChangedSinceBatchRead() {
             // Given: State was TRANSCRIBING when batch was read, but user reset it to IDLE
             testState.setPhase(ProcessingPhase.TRANSCRIBING);
@@ -246,7 +271,7 @@ class LectureContentProcessingSchedulerTest {
             // Batch query returns the state
             when(processingStateRepository.findStuckStates(eq(List.of(ProcessingPhase.TRANSCRIBING)), any(ZonedDateTime.class))).thenReturn(List.of(testState));
             when(processingStateRepository.findStuckStates(eq(List.of(ProcessingPhase.INGESTING)), any(ZonedDateTime.class))).thenReturn(List.of());
-            when(processingStateRepository.findStatesReadyForRetry(any(), any())).thenReturn(List.of());
+            when(processingService.claimRetryEligibleStates(any())).thenReturn(List.of());
 
             // But when we re-fetch, the state is now IDLE (user changed it)
             LectureUnitProcessingState freshState = new LectureUnitProcessingState(testUnit);
@@ -277,7 +302,7 @@ class LectureContentProcessingSchedulerTest {
 
             when(processingStateRepository.findStuckStates(eq(List.of(ProcessingPhase.TRANSCRIBING)), any(ZonedDateTime.class))).thenReturn(List.of(testState));
             when(processingStateRepository.findStuckStates(eq(List.of(ProcessingPhase.INGESTING)), any(ZonedDateTime.class))).thenReturn(List.of());
-            when(processingStateRepository.findStatesReadyForRetry(any(), any())).thenReturn(List.of());
+            when(processingService.claimRetryEligibleStates(any())).thenReturn(List.of());
             when(processingStateRepository.findById(testState.getId())).thenReturn(Optional.of(testState));
             when(processingStateRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 


### PR DESCRIPTION
## Summary

- Convert `findStatesReadyForRetry` from JPQL to native SQL with `FOR UPDATE SKIP LOCKED` to prevent multiple Artemis nodes from claiming the same retry-eligible job simultaneously
- Introduce `claimRetryEligibleStates` in `LectureContentProcessingService` as a `@Transactional` claim step that atomically selects and clears `retryEligibleAt`, so no other node can re-select the same rows after commit
- Add re-scheduling in `retryState`'s outer catch block so claimed jobs are never lost if the retry fails to start

## Test plan

- [x] All 18 unit tests pass (including new `shouldRescheduleRetryWhenRetryThrowsException` test)
- [x] Checkstyle passes
- [ ] Verify native query works on PostgreSQL (CI Testcontainers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of lecture content processing retry mechanism; failed retry attempts now properly reschedule states instead of leaving them unscheduled.
  * Improved concurrent access handling for retry-eligible states.

* **Tests**
  * Updated and expanded test coverage for retry scheduling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->