### PR TITLE
`Development`: Fix lazy initialization exception on account endpoint

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/JacksonConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/JacksonConfiguration.java
@@ -41,6 +41,8 @@ public class JacksonConfiguration {
      * </ul>
      * This is required because {@code spring.jpa.open-in-view} is {@code false}, meaning
      * the Hibernate session is closed before Jackson serializes the response.
+     *
+     * @return the configured Hibernate7Module
      */
     @Bean
     public Hibernate7Module hibernateModule() {

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/JacksonConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/JacksonConfiguration.java
@@ -28,12 +28,26 @@ public class JacksonConfiguration {
         return new JavaTimeModule();
     }
 
-    /*
+    /**
      * Support for Hibernate types in Jackson.
+     * <p>
+     * Configures the module to safely handle lazy-loaded proxies:
+     * <ul>
+     * <li>{@code REPLACE_PERSISTENT_COLLECTIONS} converts Hibernate collections to standard
+     * Java collections before serialization, so uninitialized proxies become empty
+     * collections instead of triggering {@code LazyInitializationException}.</li>
+     * <li>{@code WRITE_MISSING_ENTITIES_AS_NULL} serializes unloaded entity proxies
+     * ({@code @ManyToOne}, {@code @OneToOne}) as {@code null}.</li>
+     * </ul>
+     * This is required because {@code spring.jpa.open-in-view} is {@code false}, meaning
+     * the Hibernate session is closed before Jackson serializes the response.
      */
     @Bean
     public Hibernate7Module hibernateModule() {
-        return new Hibernate7Module();
+        Hibernate7Module module = new Hibernate7Module();
+        module.enable(Hibernate7Module.Feature.REPLACE_PERSISTENT_COLLECTIONS);
+        module.enable(Hibernate7Module.Feature.WRITE_MISSING_ENTITIES_AS_NULL);
+        return module;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/UserDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/UserDTO.java
@@ -129,7 +129,9 @@ public class UserDTO extends AuditingEntityDTO {
         if (authorities != null && Hibernate.isInitialized(authorities)) {
             this.authorities = authorities.stream().map(Authority::getName).collect(Collectors.toSet());
         }
-        this.groups = groups;
+        if (groups != null && Hibernate.isInitialized(groups)) {
+            this.groups = groups;
+        }
         if (organizations != null && Hibernate.isInitialized(organizations)) {
             this.organizations = organizations;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/UserDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/UserDTO.java
@@ -130,7 +130,9 @@ public class UserDTO extends AuditingEntityDTO {
             this.authorities = authorities.stream().map(Authority::getName).collect(Collectors.toSet());
         }
         this.groups = groups;
-        this.organizations = organizations;
+        if (organizations != null && Hibernate.isInitialized(organizations)) {
+            this.organizations = organizations;
+        }
         this.selectedLLMUsage = selectedLLMUsage;
         this.selectedLLMUsageTimestamp = selectedLLMUsageTimestamp;
         this.memirisEnabled = memirisEnabled;

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -231,6 +231,13 @@ management:
                     name: http.server.requests
 
 spring: #disabled by default, you must enable it
+    http:
+        converters:
+            # Jackson 3 is on the classpath (transitive from spring-ai) but the application uses Jackson 2
+            # for serialization (Hibernate7Module, JavaTimeModule, etc.). Without this setting, Spring Boot 4
+            # defaults to Jackson 3, which bypasses the registered Jackson 2 modules and causes
+            # LazyInitializationException during JSON serialization of Hibernate proxies.
+            preferred-json-mapper: jackson2
     ai:
         model:
             chat: none # possible values: openai, azure-openai, none

--- a/src/test/java/de/tum/cit/aet/artemis/core/user/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/user/AccountResourceIntegrationTest.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.core.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -18,12 +19,14 @@ import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.cit.aet.artemis.core.config.Constants;
 import de.tum.cit.aet.artemis.core.domain.AiSelectionDecision;
+import de.tum.cit.aet.artemis.core.domain.Organization;
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.dto.PasswordChangeDTO;
 import de.tum.cit.aet.artemis.core.dto.SelectedLLMUsageDTO;
 import de.tum.cit.aet.artemis.core.dto.UserDTO;
 import de.tum.cit.aet.artemis.core.dto.vm.KeyAndPasswordVM;
 import de.tum.cit.aet.artemis.core.dto.vm.ManagedUserVM;
+import de.tum.cit.aet.artemis.core.organization.util.OrganizationUtilService;
 import de.tum.cit.aet.artemis.core.service.AccountService;
 import de.tum.cit.aet.artemis.core.service.user.PasswordService;
 import de.tum.cit.aet.artemis.core.user.util.UserFactory;
@@ -52,6 +55,9 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
 
     @Autowired
     private PasskeyCredentialUtilService passkeyCredentialUtilService;
+
+    @Autowired
+    private OrganizationUtilService organizationUtilService;
 
     private void testWithRegistrationDisabled(Executable test) throws Throwable {
         ConfigUtil.testWithChangedConfig(accountService, "registrationEnabled", Optional.of(Boolean.FALSE), test);
@@ -236,6 +242,60 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
         assertThat(account.getAskToSetupPasskey()).isTrue();
         assertThat(account.isLoggedInWithPasskey()).isFalse();
         assertThat(account.isPasskeySuperAdminApproved()).isFalse();
+    }
+
+    /**
+     * Verifies that constructing and serializing a UserDTO does not throw a
+     * {@code LazyInitializationException} when the user has organizations assigned but
+     * the organizations collection was not eagerly loaded.
+     * <p>
+     * The account endpoint loads the user with {@code @EntityGraph({"groups", "authorities"})}
+     * — organizations remain an uninitialized Hibernate proxy. The UserDTO constructor must
+     * guard against this (via {@code Hibernate.isInitialized}) so that serialization succeeds
+     * even when the Jackson Hibernate module is not active (e.g. when Jackson 3 is the
+     * preferred JSON mapper in Spring Boot 4).
+     * <p>
+     * This test serializes the DTO with a plain ObjectMapper (no Hibernate module) to
+     * simulate the Jackson 3 path. Without the guard, serialization triggers lazy loading
+     * on the closed session and fails.
+     */
+    @Test
+    @WithMockUser(AUTHENTICATEDUSER)
+    void getAccountWithOrganizationDoesNotTriggerLazyLoading() throws Exception {
+        User user = userUtilService.createAndSaveUser(AUTHENTICATEDUSER);
+        Organization organization = organizationUtilService.createOrganization();
+        userTestRepository.addOrganizationToUser(user.getId(), organization);
+
+        // Load user exactly as the account endpoint does — organizations are NOT in the entity graph
+        User lazyUser = userTestRepository.findOneWithGroupsAndAuthoritiesByLogin(AUTHENTICATEDUSER).orElseThrow();
+
+        // Build DTO outside the transaction (session is closed because open-in-view=false)
+        UserDTO dto = new UserDTO(lazyUser);
+
+        // Serialize with a plain ObjectMapper (no Hibernate module) to simulate Jackson 3,
+        // which does not have the Hibernate7Module registered. If the DTO still holds an
+        // uninitialized PersistentSet, this will throw LazyInitializationException.
+        var plainMapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        plainMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        assertThatCode(() -> plainMapper.writeValueAsString(dto)).doesNotThrowAnyException();
+    }
+
+    /**
+     * Verifies that the full account endpoint returns 200 (not 500) when the user has
+     * organizations. This tests the complete HTTP serialization stack including the
+     * configured Jackson message converter and Hibernate module.
+     */
+    @Test
+    @WithMockUser(AUTHENTICATEDUSER)
+    void getAccountWithOrganization() throws Exception {
+        User user = userUtilService.createAndSaveUser(AUTHENTICATEDUSER);
+        Organization organization = organizationUtilService.createOrganization();
+        userTestRepository.addOrganizationToUser(user.getId(), organization);
+
+        UserDTO account = request.get("/api/core/public/account", HttpStatus.OK, UserDTO.class);
+
+        assertThat(account).isNotNull();
+        assertThat(account.getLogin()).isEqualTo(AUTHENTICATEDUSER);
     }
 
     @Test


### PR DESCRIPTION
### Summary

Fix a 500 "Failed to write request" error on `GET /api/core/public/account` caused by `LazyInitializationException` when serializing the `UserDTO`. The `organizations` collection is lazy-loaded but not included in the entity graph, and after the Spring Boot 4 upgrade, Jackson 3 became the default HTTP serializer — bypassing the `Hibernate7Module` registered on the Jackson 2 `ObjectMapper`.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

After upgrading to Spring Boot 4, developers reported being unable to log in on local setups. The `GET /api/core/public/account` endpoint returned:

```json
{
  "detail": "Failed to write request",
  "status": 500,
  "title": "Internal Server Error"
}
```

**Root cause:** Spring Boot 4.0.5 introduces dual Jackson support (Jackson 2 + Jackson 3). The default `spring.http.converters.preferred-json-mapper` is `"jackson"` (= Jackson 3). Jackson 3 is on the classpath as a transitive dependency from `spring-ai-bom`. The `Hibernate7Module` is a Jackson 2 module, invisible to the Jackson 3 `JsonMapper`. When Jackson 3 serializes a `UserDTO` containing an uninitialized `PersistentSet` (the lazy `organizations` collection), it calls `PersistentSet.isEmpty()` to evaluate `@JsonInclude(NON_EMPTY)`, which triggers `LazyInitializationException` because the Hibernate session is already closed (`open-in-view: false`).

### Description

**Three layers of defense:**

1. **`application.yml`**: Set `spring.http.converters.preferred-json-mapper: jackson2` to route HTTP serialization through the Jackson 2 converter where the `Hibernate7Module` is registered. This is the root cause fix.

2. **`UserDTO`**: Add `Hibernate.isInitialized()` guard for the `organizations` collection before storing it in the DTO, consistent with the existing guard for `authorities`. This prevents the uninitialized proxy from ever reaching Jackson, regardless of which converter is used.

3. **`JacksonConfiguration`**: Enable `REPLACE_PERSISTENT_COLLECTIONS` and `WRITE_MISSING_ENTITIES_AS_NULL` on the `Hibernate7Module` for additional safety — converts Hibernate collections to standard Java collections and writes unloaded entity proxies as null.

**Two regression tests:**

- `getAccountWithOrganizationDoesNotTriggerLazyLoading`: Serializes the DTO with a plain `ObjectMapper` (no Hibernate module, simulating Jackson 3) to verify the DTO guard prevents `LazyInitializationException`.
- `getAccountWithOrganization`: Tests the full HTTP endpoint stack to verify the account endpoint returns 200 when the user has organizations.

### Steps for Testing
Prerequisites:
- 1 Admin user (e.g. `artemis_admin`)
- 1 Organization assigned to the admin user

1. Log in to Artemis as `artemis_admin`
2. Verify the login succeeds and the account page loads without errors
3. Check that `GET /api/core/public/account` returns 200 with user data

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| JacksonConfiguration.java | 100.00% | 28 |
| UserDTO.java | 98.20% | 237 |

_Last updated: 2026-04-07 20:46:38 UTC_

