### PR TITLE
`Quiz exercises`: Add feature flag to temporarily disable Apollon drag-and-drop quiz

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/service/feature/Feature.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/feature/Feature.java
@@ -3,5 +3,5 @@ package de.tum.cit.aet.artemis.core.service.feature;
 // Must be the same as FeatureToggle in feature-toggle.service.ts on the client side
 public enum Feature {
     ProgrammingExercises, PlagiarismChecks, Exports, LearningPaths, Science, StandardizedCompetencies, StudentCourseAnalyticsDashboard, TutorSuggestions, AtlasML, AtlasAgent,
-    Memiris, LectureContentProcessing, RateLimit, GlobalSearch
+    Memiris, LectureContentProcessing, RateLimit, GlobalSearch, ApollonQuizDragAndDrop
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/feature/FeatureToggleService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/feature/FeatureToggleService.java
@@ -94,7 +94,7 @@ public class FeatureToggleService {
         // This ensures that all features (except Science, TutorSuggestions, AtlasML, AtlasAgent, Memiris, RateLimit, and GlobalSearch) are enabled once the system starts up
         for (Feature feature : Feature.values()) {
             if (!features.containsKey(feature) && feature != Feature.Science && feature != Feature.TutorSuggestions && feature != Feature.AtlasML && feature != Feature.AtlasAgent
-                    && feature != Feature.Memiris && feature != Feature.RateLimit && feature != Feature.GlobalSearch) {
+                    && feature != Feature.Memiris && feature != Feature.RateLimit && feature != Feature.GlobalSearch && feature != Feature.ApollonQuizDragAndDrop) {
                 features.put(feature, true);
             }
         }
@@ -121,6 +121,10 @@ public class FeatureToggleService {
 
         if (!features.containsKey(Feature.GlobalSearch)) {
             features.put(Feature.GlobalSearch, globalSearchEnabledOnStart);
+        }
+
+        if (!features.containsKey(Feature.ApollonQuizDragAndDrop)) {
+            features.put(Feature.ApollonQuizDragAndDrop, false);
         }
 
         // Disable LectureContentProcessing in dev profile to avoid issues with local file system access

--- a/src/main/webapp/app/core/admin/features/admin-feature-toggle.component.spec.ts
+++ b/src/main/webapp/app/core/admin/features/admin-feature-toggle.component.spec.ts
@@ -51,7 +51,7 @@ describe('AdminFeatureToggleComponentTest', () => {
         it('ngOnInit should load all feature toggles', () => {
             expect(comp.featureToggles()).toHaveLength(0);
             comp.ngOnInit();
-            expect(comp.featureToggles()).toHaveLength(14);
+            expect(comp.featureToggles()).toHaveLength(15);
         });
 
         it('ngOnInit should set isActive based on active toggles', () => {

--- a/src/main/webapp/app/quiz/manage/list-edit/quiz-question-list-edit.component.html
+++ b/src/main/webapp/app/quiz/manage/list-edit/quiz-question-list-edit.component.html
@@ -60,7 +60,7 @@
                     <span jhiTranslate="artemisApp.quizExercise.addDragAndDropQuestion"></span>
                 </button>
             </div>
-            <div class="col-12 col-sm-6 col-xl mb-1">
+            <div class="col-12 col-sm-6 col-xl mb-1" [jhiFeatureToggleHide]="ApollonQuizDragAndDrop">
                 <button id="quiz-import-apollon-dnd-question" class="btn btn-block btn-success" (click)="importApollonDragAndDropQuestion()">
                     <fa-icon [icon]="faPlus" />
                     <span jhiTranslate="artemisApp.quizExercise.addApollonDragAndDropQuestion"></span>

--- a/src/main/webapp/app/quiz/manage/list-edit/quiz-question-list-edit.component.ts
+++ b/src/main/webapp/app/quiz/manage/list-edit/quiz-question-list-edit.component.ts
@@ -12,6 +12,8 @@ import { DragAndDropQuestionEditComponent } from 'app/quiz/manage/drag-and-drop-
 import { ShortAnswerQuestionEditComponent } from 'app/quiz/manage/short-answer-question/short-answer-question-edit.component';
 import { ApollonDiagramImportDialogComponent } from 'app/quiz/manage/apollon-diagrams/import-dialog/apollon-diagram-import-dialog.component';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
+import { FeatureToggleHideDirective } from 'app/shared/feature-toggle/feature-toggle-hide.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { NgClass } from '@angular/common';
 import { QuizQuestionListEditExistingComponent } from '../list-edit-existing/quiz-question-list-edit-existing.component';
@@ -30,6 +32,7 @@ import { QuizQuestionListEditExistingComponent } from '../list-edit-existing/qui
         FaIconComponent,
         NgClass,
         QuizQuestionListEditExistingComponent,
+        FeatureToggleHideDirective,
     ],
 })
 export class QuizQuestionListEditComponent {
@@ -52,6 +55,7 @@ export class QuizQuestionListEditComponent {
     readonly DRAG_AND_DROP = QuizQuestionType.DRAG_AND_DROP;
     readonly MULTIPLE_CHOICE = QuizQuestionType.MULTIPLE_CHOICE;
     readonly SHORT_ANSWER = QuizQuestionType.SHORT_ANSWER;
+    readonly ApollonQuizDragAndDrop = FeatureToggle.ApollonQuizDragAndDrop;
 
     faPlus = faPlus;
 

--- a/src/main/webapp/app/shared/feature-toggle/feature-toggle.service.ts
+++ b/src/main/webapp/app/shared/feature-toggle/feature-toggle.service.ts
@@ -25,6 +25,7 @@ export enum FeatureToggle {
     LectureContentProcessing = 'LectureContentProcessing',
     RateLimit = 'RateLimit',
     GlobalSearch = 'GlobalSearch',
+    ApollonQuizDragAndDrop = 'ApollonQuizDragAndDrop',
 }
 export type ActiveFeatureToggles = Array<FeatureToggle>;
 

--- a/src/main/webapp/i18n/de/featureToggles.json
+++ b/src/main/webapp/i18n/de/featureToggles.json
@@ -192,6 +192,11 @@
                     "name": "Globale Suche",
                     "description": "Aktiviert eine einheitliche Suchoberfläche, die über Cmd+K/Strg+K erreichbar ist und es Nutzer:innen ermöglicht, schnell über Kurse, Aufgaben, Vorlesungen und andere Inhalte zu suchen.",
                     "disableWarning": "Nutzer:innen haben keinen Zugriff auf die globale Suchfunktion und müssen manuell durch die Oberfläche navigieren."
+                },
+                "ApollonQuizDragAndDrop": {
+                    "name": "Apollon-Quiz-Drag-and-Drop-Import",
+                    "description": "Ermöglicht Lehrenden, im Quiz-Editor Apollon-basierte Drag-and-Drop-Fragen hinzuzufügen.",
+                    "disableWarning": "Lehrende können im Quiz-Editor keine neuen Apollon-basierten Drag-and-Drop-Fragen erstellen."
                 }
             }
         }

--- a/src/main/webapp/i18n/en/featureToggles.json
+++ b/src/main/webapp/i18n/en/featureToggles.json
@@ -192,6 +192,11 @@
                     "name": "Global Search",
                     "description": "Enables a unified search interface accessible via Cmd+K/Ctrl+K that allows users to quickly search across courses, exercises, lectures, and other content.",
                     "disableWarning": "Users will not have access to the global search functionality and must navigate manually through the interface."
+                },
+                "ApollonQuizDragAndDrop": {
+                    "name": "Apollon Quiz Drag-and-Drop Import",
+                    "description": "Allows instructors to add Apollon-based drag-and-drop quiz questions from the quiz editor.",
+                    "disableWarning": "Instructors will not be able to create new Apollon-based drag-and-drop quiz questions from the quiz editor."
                 }
             }
         }

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/FeatureToggleServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/FeatureToggleServiceTest.java
@@ -15,8 +15,8 @@ import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTe
 
 class FeatureToggleServiceTest extends AbstractSpringIntegrationIndependentTest {
 
-    // science, TutorSuggestions, AtlasAgent, AtlasML, Memiris, RateLimit, GlobalSearch disabled by default
-    private static final int FEATURES_DISABLED_DEFAULT = 7;
+    // science, TutorSuggestions, AtlasAgent, AtlasML, Memiris, RateLimit, GlobalSearch, ApollonQuizDragAndDrop disabled by default
+    private static final int FEATURES_DISABLED_DEFAULT = 8;
 
     @Autowired
     private FeatureToggleService featureToggleService;
@@ -39,6 +39,7 @@ class FeatureToggleServiceTest extends AbstractSpringIntegrationIndependentTest 
         assertThat(featureToggleService.isFeatureEnabled(Feature.Memiris)).isFalse();
         assertThat(featureToggleService.isFeatureEnabled(Feature.RateLimit)).isFalse();
         assertThat(featureToggleService.isFeatureEnabled(Feature.GlobalSearch)).isFalse();
+        assertThat(featureToggleService.isFeatureEnabled(Feature.ApollonQuizDragAndDrop)).isFalse();
 
     }
 
@@ -58,6 +59,7 @@ class FeatureToggleServiceTest extends AbstractSpringIntegrationIndependentTest 
         featureToggleService.disableFeature(Feature.RateLimit);
         featureToggleService.disableFeature(Feature.GlobalSearch);
         featureToggleService.disableFeature(Feature.Memiris);
+        featureToggleService.disableFeature(Feature.ApollonQuizDragAndDrop);
     }
 
     @Test


### PR DESCRIPTION

### Summary 
Temporary workaround for #12418: hide the Apollon drag-and-drop quiz question entry point behind a dedicated feature toggle that is disabled by default.

### Checklist
#### General
- [x] I tested the changes on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).


### Motivation and Context
Issue #12418 ("Quiz: Questions with Apollon Diagrams don't render properly") reports that Apollon-based quiz questions render incorrectly after creation, in preview, and during participation.

This PR is intentionally a temporary mitigation for the quiz exercise creation path from that issue. Instead of continuing to expose a broken entry point, Artemis now keeps the Apollon drag-and-drop quiz import disabled by default until the underlying rendering problem is fixed properly.



### Description

- add a new runtime feature toggle `ApollonQuizDragAndDrop` on the server and client
- initialize `ApollonQuizDragAndDrop` as disabled by default in `FeatureToggleService`
- hide the `Add Apollon Drag-And-Drop Question` button in the quiz question list editor while the toggle is disabled
- extend `FeatureToggleServiceTest` to cover the new default-disabled toggle

This keeps the workaround narrowly scoped to preventing new affected quiz questions from being created. It does not yet fix the underlying rendering defect, and it does not claim to resolve the separate modeling/exam symptoms also mentioned in #12418.

### Steps for Testing
Prerequisites:
- 1 Admin
- 1 Instructor
- 1 Course with a quiz exercise

1. Log in as the instructor.
2. Open an existing quiz exercise or create a new one and navigate to the question editor.
3. Verify that the regular question actions are still visible.
4. Verify that the `Add Apollon Drag-And-Drop Question` button is not visible by default.
5. Log in as an admin in a second browser/session and navigate to Administration > Features (`/admin/features`).
6. Enable the `ApollonQuizDragAndDrop` runtime feature toggle.
7. Reload the quiz question editor and verify that the `Add Apollon Drag-And-Drop Question` button becomes visible.
8. Disable the toggle again and verify that the button disappears after reloading.


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Apollon drag-and-drop quiz import feature toggle; the import UI option is hidden when disabled. The toggle is disabled by default.

* **Documentation**
  * Added English and German UI text for the new toggle (name, description, disable warning).

* **Tests**
  * Updated unit tests and admin feature list expectations to include the new toggle and its default disabled state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->