### PR TITLE
`General`: Improve header styling in exercise management table

### DIFF
--- a/src/main/webapp/app/core/course/manage/course-exercise-card/course-exercise-card.component.html
+++ b/src/main/webapp/app/core/course/manage/course-exercise-card/course-exercise-card.component.html
@@ -1,7 +1,9 @@
 <div class="question card rounded-4">
     <div class="question-options card-header">
         <h5 class="mb-0">
-            <fa-icon [icon]="leadingIcon()" [fixedWidth]="true" />
+            @if (leadingIcon(); as icon) {
+                <fa-icon [icon]="icon" [fixedWidth]="true" />
+            }
             <span [jhiTranslate]="headingJhiTranslate()"></span>
             <span> ({{ exerciseCount() }}) </span>
         </h5>

--- a/src/main/webapp/app/core/course/manage/course-exercise-card/course-exercise-card.component.html
+++ b/src/main/webapp/app/core/course/manage/course-exercise-card/course-exercise-card.component.html
@@ -1,8 +1,9 @@
-<div class="question card">
+<div class="question card rounded-4">
     <div class="question-options card-header">
         <h5 class="mb-0">
-            <span> {{ exerciseCount() }} </span>
+            <fa-icon [icon]="leadingIcon()" [fixedWidth]="true" />
             <span [jhiTranslate]="headingJhiTranslate()"></span>
+            <span> ({{ exerciseCount() }}) </span>
         </h5>
         @if (course()?.isAtLeastEditor) {
             <div class="ms-auto">
@@ -10,7 +11,7 @@
             </div>
         }
         <button class="btn question-collapse" (click)="isCollapsed.set(!isCollapsed())" [attr.aria-expanded]="!isCollapsed()" [attr.aria-controls]="'collapseQuestion'">
-            <fa-icon size="2x" [icon]="isCollapsed() ? faAngleRight : faAngleDown" />
+            <fa-icon size="lg" [icon]="isCollapsed() ? faAngleRight : faAngleDown" />
         </button>
     </div>
     <div class="card-body question-card-body" [ngbCollapse]="isCollapsed()">

--- a/src/main/webapp/app/core/course/manage/course-exercise-card/course-exercise-card.component.scss
+++ b/src/main/webapp/app/core/course/manage/course-exercise-card/course-exercise-card.component.scss
@@ -16,4 +16,9 @@
             width: 100%;
         }
     }
+
+    .card-header {
+        background-color: transparent;
+        border-bottom: 1px solid var(--course-exercise-card-border-color);
+    }
 }

--- a/src/main/webapp/app/core/course/manage/course-exercise-card/course-exercise-card.component.ts
+++ b/src/main/webapp/app/core/course/manage/course-exercise-card/course-exercise-card.component.ts
@@ -4,6 +4,7 @@ import { Course } from 'app/core/course/shared/entities/course.model';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 @Component({
     selector: 'jhi-course-exercise-card',
@@ -13,6 +14,7 @@ import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
 })
 export class CourseExerciseCardComponent {
     readonly headingJhiTranslate = input.required<string>();
+    readonly leadingIcon = input<IconProp | undefined>(undefined);
     readonly exerciseCount = input.required<number>();
     readonly course = input.required<Course>();
     readonly isCollapsed = signal(false);

--- a/src/main/webapp/app/core/course/manage/exercises/course-management-exercises.component.html
+++ b/src/main/webapp/app/core/course/manage/exercises/course-management-exercises.component.html
@@ -24,6 +24,7 @@
     }
     <jhi-course-exercise-card
         [headingJhiTranslate]="'artemisApp.course.programmingExercises'"
+        [leadingIcon]="iconMap[ExerciseType.PROGRAMMING]"
         [exerciseCount]="programmingExercisesCount()"
         [hidden]="shouldHideExerciseCard('programming')"
         [course]="course()!"
@@ -40,6 +41,7 @@
     </jhi-course-exercise-card>
     <jhi-course-exercise-card
         [headingJhiTranslate]="'artemisApp.course.quizExercises'"
+        [leadingIcon]="iconMap[ExerciseType.QUIZ]"
         [exerciseCount]="quizExercisesCount()"
         [hidden]="shouldHideExerciseCard('quiz')"
         [course]="course()!"
@@ -57,6 +59,7 @@
     @if (modelingExerciseEnabled()) {
         <jhi-course-exercise-card
             [headingJhiTranslate]="'artemisApp.course.modelingExercises'"
+            [leadingIcon]="iconMap[ExerciseType.MODELING]"
             [exerciseCount]="modelingExercisesCount()"
             [hidden]="shouldHideExerciseCard('modeling')"
             [course]="course()!"
@@ -75,6 +78,7 @@
     @if (textExerciseEnabled()) {
         <jhi-course-exercise-card
             [headingJhiTranslate]="'artemisApp.course.textExercises'"
+            [leadingIcon]="iconMap[ExerciseType.TEXT]"
             [exerciseCount]="textExercisesCount()"
             [hidden]="shouldHideExerciseCard('text')"
             [course]="course()!"
@@ -93,6 +97,7 @@
     @if (fileUploadExerciseEnabled()) {
         <jhi-course-exercise-card
             [headingJhiTranslate]="'artemisApp.course.fileUploadExercises'"
+            [leadingIcon]="iconMap[ExerciseType.FILE_UPLOAD]"
             [exerciseCount]="fileUploadExercisesCount()"
             [hidden]="shouldHideExerciseCard('file-upload')"
             [course]="course()!"

--- a/src/main/webapp/app/core/course/manage/exercises/course-management-exercises.component.ts
+++ b/src/main/webapp/app/core/course/manage/exercises/course-management-exercises.component.ts
@@ -3,7 +3,7 @@ import { Course } from 'app/core/course/shared/entities/course.model';
 import { ActivatedRoute } from '@angular/router';
 import { ExerciseFilter } from 'app/exercise/shared/entities/exercise/exercise-filter.model';
 import { DocumentationButtonComponent, DocumentationType } from 'app/shared/components/buttons/documentation-button/documentation-button.component';
-import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { ExerciseType, getIcon } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { CourseManagementExercisesSearchComponent } from '../exercises-search/course-management-exercises-search.component';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { CourseExerciseCardComponent } from '../course-exercise-card/course-exercise-card.component';
@@ -82,6 +82,14 @@ export class CourseManagementExercisesComponent implements OnInit {
             this.filteredTextExercisesCount() +
             this.filteredFileUploadExercisesCount(),
     );
+
+    readonly iconMap = {
+        [ExerciseType.MODELING]: getIcon(ExerciseType.MODELING),
+        [ExerciseType.PROGRAMMING]: getIcon(ExerciseType.PROGRAMMING),
+        [ExerciseType.QUIZ]: getIcon(ExerciseType.QUIZ),
+        [ExerciseType.TEXT]: getIcon(ExerciseType.TEXT),
+        [ExerciseType.FILE_UPLOAD]: getIcon(ExerciseType.FILE_UPLOAD),
+    };
 
     /**
      * initializes course

--- a/src/main/webapp/app/exercise/exercise-create-buttons/exercise-create-button/exercise-create-button.component.html
+++ b/src/main/webapp/app/exercise/exercise-create-buttons/exercise-create-button/exercise-create-button.component.html
@@ -1,5 +1,4 @@
 <p-button [id]="'create-' + exerciseType() + '-exercise'" size="small" (click)="linkToExerciseCreation()" [jhiFeatureToggleLink]="featureToggle() ? featureToggle()! : undefined">
     <fa-icon [icon]="faPlus" />
     <span jhiTranslate="artemisApp.exercise.createAction"></span>
-    <fa-icon [icon]="icon" />
 </p-button>

--- a/src/main/webapp/app/exercise/exercise-create-buttons/exercise-create-button/exercise-create-button.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-create-buttons/exercise-create-button/exercise-create-button.component.spec.ts
@@ -8,7 +8,6 @@ import { MockNgbModalService } from 'test/helpers/mocks/service/mock-ngb-modal.s
 import { ExerciseCreateButtonComponent } from 'app/exercise/exercise-create-buttons/exercise-create-button/exercise-create-button.component';
 import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { faFileUpload, faFont, faKeyboard, faProjectDiagram } from '@fortawesome/free-solid-svg-icons';
 import { provideHttpClient } from '@angular/common/http';
 import { DialogService } from 'primeng/dynamicdialog';
 import { MockDialogService } from 'test/helpers/mocks/service/mock-dialog.service';
@@ -51,15 +50,5 @@ describe('ExerciseCreateButtonComponent', () => {
         expect(beforeNavigateSpy).toHaveBeenCalledOnce();
         expect(modalService.dismissAll).toHaveBeenCalledOnce();
         expect(router.navigate).toHaveBeenCalledWith(['/course-management', 123, `${exerciseType}-exercises`, 'new']);
-    });
-    it.each([
-        { exerciseType: ExerciseType.MODELING, expectedIcon: faProjectDiagram },
-        { exerciseType: ExerciseType.FILE_UPLOAD, expectedIcon: faFileUpload },
-        { exerciseType: ExerciseType.TEXT, expectedIcon: faFont },
-        { exerciseType: ExerciseType.PROGRAMMING, expectedIcon: faKeyboard },
-    ])('should determine correct icon for exercise type', ({ exerciseType, expectedIcon }) => {
-        fixture.componentRef.setInput('exerciseType', exerciseType);
-        component.ngOnInit();
-        expect(component.icon).toEqual(expectedIcon);
     });
 });

--- a/src/main/webapp/app/exercise/exercise-create-buttons/exercise-import-button/exercise-import-button.component.html
+++ b/src/main/webapp/app/exercise/exercise-create-buttons/exercise-import-button/exercise-import-button.component.html
@@ -7,5 +7,4 @@
 >
     <fa-icon [icon]="faFileImport" />
     <span jhiTranslate="artemisApp.exercise.importAction"></span>
-    <fa-icon [icon]="icon" />
 </p-button>

--- a/src/main/webapp/app/exercise/exercise-create-buttons/exercise-import-button/exercise-import-button.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-create-buttons/exercise-import-button/exercise-import-button.component.spec.ts
@@ -9,7 +9,6 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateService } from '@ngx-translate/core';
 import { Router } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
-import { IconDefinition, faFileUpload, faFont, faKeyboard, faProjectDiagram } from '@fortawesome/free-solid-svg-icons';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { MockDialogService } from 'test/helpers/mocks/service/mock-dialog.service';
 import { Subject } from 'rxjs';
@@ -82,16 +81,5 @@ describe('ExerciseImportButtonComponent', () => {
         } else {
             expect(routerSpy).toHaveBeenCalledExactlyOnceWith(['/course-management', 123, `${exerciseType}-exercises`, 2, 'import']);
         }
-    });
-
-    it.each([
-        { exerciseType: ExerciseType.MODELING, expectedIcon: faProjectDiagram },
-        { exerciseType: ExerciseType.FILE_UPLOAD, expectedIcon: faFileUpload },
-        { exerciseType: ExerciseType.TEXT, expectedIcon: faFont },
-        { exerciseType: ExerciseType.PROGRAMMING, expectedIcon: faKeyboard },
-    ])('should determine correct icon for exercise type', ({ exerciseType, expectedIcon }: { exerciseType: ExerciseType; expectedIcon: IconDefinition }) => {
-        fixture.componentRef.setInput('exerciseType', exerciseType);
-        component.ngOnInit();
-        expect(component.icon).toEqual(expectedIcon);
     });
 });

--- a/src/main/webapp/app/exercise/exercise-create-buttons/exercise-manage-button/exercise-manage-button.component.ts
+++ b/src/main/webapp/app/exercise/exercise-create-buttons/exercise-manage-button/exercise-manage-button.component.ts
@@ -1,16 +1,15 @@
-import { Component, OnInit, inject, input, output } from '@angular/core';
-import { ExerciseType, getIcon } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { Component, inject, input, output } from '@angular/core';
+import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { Course } from 'app/core/course/shared/entities/course.model';
 import { Router } from '@angular/router';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { DialogService } from 'primeng/dynamicdialog';
-import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
 
 @Component({
     template: '',
 })
-export abstract class ExerciseManageButtonComponent implements OnInit {
+export abstract class ExerciseManageButtonComponent {
     protected router = inject(Router);
     // NgbModal is kept for dismissAll functionality used by ExerciseCreateButtonComponent
     protected modalService = inject(NgbModal);
@@ -22,9 +21,4 @@ export abstract class ExerciseManageButtonComponent implements OnInit {
     course = input.required<Course>();
     exerciseType = input.required<ExerciseType>();
     featureToggle = input<FeatureToggle | undefined>();
-    icon: IconProp;
-
-    ngOnInit(): void {
-        this.icon = getIcon(this.exerciseType());
-    }
 }

--- a/src/main/webapp/app/quiz/manage/create-buttons/quiz-exercise-create-buttons.component.html
+++ b/src/main/webapp/app/quiz/manage/create-buttons/quiz-exercise-create-buttons.component.html
@@ -4,7 +4,6 @@
         <p-button size="small" severity="secondary" [routerLink]="['/course-management', course()?.id, 'quiz-exercises', 'export']">
             <fa-icon [icon]="faFileExport" />
             <span jhiTranslate="artemisApp.exercise.exportAction"></span>
-            <fa-icon [icon]="faCheckDouble" />
         </p-button>
     }
     <jhi-exercise-create-button [course]="course()" [exerciseType]="ExerciseType.QUIZ" />

--- a/src/main/webapp/app/quiz/manage/create-buttons/quiz-exercise-create-buttons.component.ts
+++ b/src/main/webapp/app/quiz/manage/create-buttons/quiz-exercise-create-buttons.component.ts
@@ -2,7 +2,7 @@ import { Component, input } from '@angular/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { Course } from 'app/core/course/shared/entities/course.model';
-import { faCheckDouble, faFileExport } from '@fortawesome/free-solid-svg-icons';
+import { faFileExport } from '@fortawesome/free-solid-svg-icons';
 import { ExerciseCreateButtonComponent } from 'app/exercise/exercise-create-buttons/exercise-create-button/exercise-create-button.component';
 import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { ExerciseImportButtonComponent } from 'app/exercise/exercise-create-buttons/exercise-import-button/exercise-import-button.component';
@@ -19,6 +19,5 @@ export class QuizExerciseCreateButtonsComponent {
     quizExercisesCount = input<number>(0);
 
     protected readonly faFileExport = faFileExport;
-    protected readonly faCheckDouble = faCheckDouble;
     protected readonly ExerciseType = ExerciseType;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 
Improve the styling and clarity of the course exercise management table/cards by adding exercise-type icons to card headers, refining header/card visuals, and removing redundant icons from create/import/export actions.


### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR builds on https://github.com/ls1intum/Artemis/pull/12400 and further refines the exercise management view. It continues the improvements by enhancing visual emphasis and reducing repeated icons in action buttons to improve readability and overall clarity.

### Description
<!-- Describe your changes in detail -->
The exercise management cards were visually streamlined by adding exercise-type icons to the headers, showing counts in a clearer (<count>) format, and refining header/card styling. At the same time, redundant trailing icons in create/import/export buttons were removed, and the related button base component was simplified by deleting unused icon initialization logic.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Course with exercises across multiple types (Programming, Quiz, Modeling, Text, File Upload)

1. Log in to Artemis as instructor.
2. Navigate to `Course Manageemnt` -> your course -> `Exercises`.
3. Verify each exercise section card shows a leading icon and count format `(<count>)`.
4. Verify create/import/export buttons no longer show redundant trailing type icons.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| course-exercise-card.component.ts | 100.00% | 22 | 1 | 4.5 |
| course-management-exercises.component.ts | 94.59% | 104 | 3 | 2.9 |
| exercise-manage-button.component.ts | 100.00% | 19 | ? | ? |
| quiz-exercise-create-buttons.component.ts | 100.00% | 21 | ? | ? |

_Last updated: 2026-04-09 10:33:57 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
<img width="1060" height="197" alt="Screenshot 2026-04-08 at 21 53 06" src="https://github.com/user-attachments/assets/c3618da0-77c0-42db-8798-d87b143e544c" />

After: 
<img width="1047" height="204" alt="Screenshot 2026-04-08 at 21 43 00" src="https://github.com/user-attachments/assets/76ccfda5-df1a-44ff-a82a-13dff2aa8f3a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable leading icons to exercise cards for clearer exercise-type identification.
* **Style**
  * Improved card visuals with rounded corners and refined header border and icon sizing.
  * Harmonized create/import button visuals.
* **Tests**
  * Removed obsolete icon-focused unit tests where icon state is no longer component-managed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->