### PR TITLE
`Development`: Disable E2E test for quiz exercise with apollon drag and drop question

### DIFF
--- a/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseDropLocation.spec.ts
+++ b/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseDropLocation.spec.ts
@@ -15,7 +15,8 @@ test.describe('Quiz Exercise Drop Location Spec', { tag: '@slow' }, () => {
             await quizExerciseDragAndDropQuiz.createDnDQuiz('DnD Quiz Test');
         });
 
-        test('Checks drop locations', async ({ page, quizExerciseDragAndDropQuiz }) => {
+        // TODO: Enable test again after fixing https://github.com/ls1intum/Artemis/issues/12418
+        test.skip('Checks drop locations', async ({ page, quizExerciseDragAndDropQuiz }) => {
             await quizExerciseDragAndDropQuiz.dragUsingCoordinates(0, 100);
             await quizExerciseDragAndDropQuiz.dragUsingCoordinates(410, 240);
             await quizExerciseDragAndDropQuiz.dragUsingCoordinates(420, 90);


### PR DESCRIPTION
### Summary
Disable the `Checks drop locations` E2E test for Apollon drag-and-drop quiz questions, since the feature is currently broken and has been disabled via a feature flag in #12484.

### Checklist
#### General
- [x] This is a small issue that I tested locally.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
Apollon-based drag-and-drop quiz questions are broken (#12418) and the feature has been temporarily disabled via a feature flag in #12484. Since the feature is disabled, the corresponding E2E test consistently fails and should be skipped until the underlying issue is resolved.

### Description
Changed `test(` to `test.skip(` for the `Checks drop locations` test in `QuizExerciseDropLocation.spec.ts` and added a TODO comment referencing #12418 so the test can be re-enabled once the feature is fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily disabled a test case for drop location verification in quiz exercises while preserving its implementation for future use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->