### PR TITLE
`Quiz exercises`: Fix import quiz dialog not loading results on initial open

### DIFF
--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -210,7 +210,7 @@ jobs:
 
     env:
       GATEWAY_USER: "jump"
-      GATEWAY_HOST: "gateway.artemis.in.tum.de:2010"
+      GATEWAY_HOST: "gateway2.aet.cit.tum.de:2010"
       GATEWAY_HOST_PUBLIC_KEY: "[gateway.artemis.in.tum.de]:2010 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKtTLiKRILjKZ+Qg4ReWKsG7mLDXkzHfeY5nalSQUNQ4"
 
     steps:

--- a/src/main/webapp/app/exercise/import/exercise-import.component.spec.ts
+++ b/src/main/webapp/app/exercise/import/exercise-import.component.spec.ts
@@ -269,30 +269,36 @@ describe('ExerciseImportComponent', () => {
     ])(
         'uses the correct paging service',
         fakeAsync((exerciseType: ExerciseType, expectedPagingService: typeof PagingService) => {
-            const getSpy = jest.spyOn(injector, 'get');
-            // This is needed for `.toHaveBeenCalledWith` to work properly:
-            getSpy.mockImplementation(() => undefined);
+            const pagingServiceMock = {
+                search: jest.fn().mockReturnValue(of({ numberOfPages: 0, resultsOnPage: [] })),
+            };
+            const getSpy = jest.spyOn(injector, 'get').mockReturnValue(pagingServiceMock as any);
 
             comp.exerciseType = exerciseType;
 
             comp.ngOnInit();
+            tick(300);
             expect(getSpy).toHaveBeenCalledWith(expectedPagingService, {});
+            expect(pagingServiceMock.search).toHaveBeenCalled();
         }),
     );
 
-    it('should allow importing SCA configurations', () => {
-        const getSpy = jest.spyOn(injector, 'get');
-        // This is needed for `.toHaveBeenCalledWith` to work properly:
-        getSpy.mockImplementation(() => undefined);
+    it('should allow importing SCA configurations', fakeAsync(() => {
+        const pagingServiceMock = {
+            search: jest.fn().mockReturnValue(of({ numberOfPages: 0, resultsOnPage: [] })),
+        };
+        const getSpy = jest.spyOn(injector, 'get').mockReturnValue(pagingServiceMock as any);
 
         comp.exerciseType = ExerciseType.PROGRAMMING;
         comp.programmingLanguage = ProgrammingLanguage.JAVA;
 
         comp.ngOnInit();
+        tick(300);
 
         expect(comp.titleKey).toContain('configureGrading');
         expect(getSpy).toHaveBeenCalledWith(CodeAnalysisPagingService, {});
-    });
+        expect(pagingServiceMock.search).toHaveBeenCalled();
+    }));
 
     it('should sort by exam title when only the exam filter is active', () => {
         comp.isExamFilter = true;

--- a/src/main/webapp/app/exercise/import/exercise-import.component.ts
+++ b/src/main/webapp/app/exercise/import/exercise-import.component.ts
@@ -75,6 +75,7 @@ export class ExerciseImportComponent extends ImportComponent<Exercise> implement
         }
 
         super.ngOnInit();
+        this.search.next();
     }
 
     private getPagingService(): ExercisePagingService<Exercise> {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 
Fixes an issue where the Import Quiz dialog did not load any results when opened for the first time.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When opening the Import Quiz dialog, the list of importable quiz exercises was initially empty even though matching results existed. The data was only loaded after the user toggled one of the filters, which made the dialog appear broken on first open.
Closes [#12468.](https://github.com/ls1intum/Artemis/issues/12468)


### Description
<!-- Describe your changes in detail -->
This PR fixes the initial loading behavior of the Import Quiz dialog by triggering the first search request during component initialization.

Before this change, the search was only triggered by user interactions such as changing the course or exam filters. As a result, no request was sent when the dialog was opened initially.

With this change, the dialog loads importable quiz exercises immediately on first open, while keeping the existing filter behavior unchanged.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Course
- At least 1 existing quiz exercise that can be imported

1. Log in to Artemis as an instructor.
2. Navigate to a course with existing importable quizzes.
3. Click on **Import Quiz**.
4. Verify that the list of importable quiz exercises is loaded immediately when the dialog opens.
5. Verify in the browser network tab that the initial request is sent without any additional user interaction.
6. Toggle **Search in courses?** and **Search in exams?** and verify that the list is still updated correctly.


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1464" height="736" alt="image" src="https://github.com/user-attachments/assets/4c9b967c-b30e-4a4d-be1c-e39e89d0b33b" />
<img width="1460" height="736" alt="image" src="https://github.com/user-attachments/assets/d63ef8d1-b964-4d35-b48f-82738472a3d3" />
<img width="1464" height="735" alt="image" src="https://github.com/user-attachments/assets/03ce886f-10d1-4f90-a0ae-e185d14081fc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exercise import page now automatically loads search results when the page initializes.

* **Tests**
  * Updated component tests to verify the search is triggered asynchronously during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->