### PR TITLE
`Development`: Update gateway host name for test server deployments

### DIFF
--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -210,7 +210,7 @@ jobs:
 
     env:
       GATEWAY_USER: "jump"
-      GATEWAY_HOST: "gateway.artemis.in.tum.de:2010"
+      GATEWAY_HOST: "gateway2.aet.cit.tum.de:2010"
       GATEWAY_HOST_PUBLIC_KEY: "[gateway.artemis.in.tum.de]:2010 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKtTLiKRILjKZ+Qg4ReWKsG7mLDXkzHfeY5nalSQUNQ4"
 
     steps:


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary

Update the SSH gateway host name in the test server deployment workflow from `gateway.artemis.in.tum.de` to `gateway2.aet.cit.tum.de`.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

The SSH gateway for test server deployments has moved to a new host (`gateway2.aet.cit.tum.de`). The old hostname `gateway.artemis.in.tum.de` is no longer valid.

### Description

Updates the `GATEWAY_HOST` environment variable in `.github/workflows/testserver-deployment.yml` from `gateway.artemis.in.tum.de:2010` to `gateway2.aet.cit.tum.de:2010`.

### Steps for Testing

1. Trigger a test server deployment via [Helios](https://helios.aet.cit.tum.de/repo/69562331/ci-cd)
2. Verify the deployment connects through the new gateway successfully

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2