### PR TITLE
fix: restrict maxPoints to 2 decimal places using Math.round

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/BaseExercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/BaseExercise.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.core.domain.DomainObject;
 import de.tum.cit.aet.artemis.core.util.StringUtil;
+//Novo
+import static org.apache.commons.math3.util.Precision.round;
 
 @MappedSuperclass
 public abstract class BaseExercise extends DomainObject {
@@ -86,7 +88,7 @@ public abstract class BaseExercise extends DomainObject {
     }
 
     public Double getMaxPoints() {
-        return maxPoints;
+       return Math.round(maxPoints * 100.0) / 100.0;
     }
 
     public void setMaxPoints(Double maxPoints) {

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTest.java
@@ -182,4 +182,34 @@ class ExerciseTest extends AbstractSpringIntegrationIndependentTest {
         exercise.setTitle("Test?+#*                Exercise123%$§");
         assertThat(exercise.getSanitizedExerciseTitle()).isEqualTo("Test_Exercise123");
     }
+
+    @Test
+    void testMaxPointsDecimalPrecisionIsRestricted(){
+        Exercise exercise= new ProgrammingExercise();
+        exercise.setMaxPoints(1.1111111111111112);
+        assertThat(exercise.getMaxPoints()).isEqualTo(1.11);
+    }
+    @Test
+    void testMaxPointsRoundsUp() {
+        Exercise exercise= new ProgrammingExercise();
+        exercise.setMaxPoints(1.556);
+        assertThat(exercise.getMaxPoints()).isEqualTo(1.56);
+    }
+
+    @Test
+    void testMaxPointsRoundsDown() {
+        Exercise exercise= new ProgrammingExercise();
+        exercise.setMaxPoints(1.554);
+        assertThat(exercise.getMaxPoints()).isEqualTo(1.55);
+    }
+    @Test
+    void testMaxPointsWithExactlyTwoDecimals() {
+        Exercise exercise= new ProgrammingExercise();
+        exercise.setMaxPoints(1.50);
+        assertThat(exercise.getMaxPoints()).isEqualTo(1.50);
+    }
+
+
+
+
 }


### PR DESCRIPTION
## Description
Restrict maxPoints to 2 decimal places to avoid excessive floating-point precision.

## Changes
- Updated getMaxPoints to round values to 2 decimal places using Math.round
- Added unit tests to verify rounding behavior and precision handling

## Test Cases
- Excessive precision values 
- Rounding up 
- Rounding down 
- Exact 2-decimal values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Exercise maximum points are now consistently rounded to two decimal places for accurate display and calculations.

* **Tests**
  * Added unit tests to validate proper decimal rounding and precision handling for exercise point values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->