### PR TITLE
`Development`: Return DTOs from LTI configuration APIs

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/lti/dto/LtiPlatformConfigurationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/dto/LtiPlatformConfigurationDTO.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.lti.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import org.jspecify.annotations.Nullable;
 
@@ -14,7 +15,7 @@ import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record LtiPlatformConfigurationDTO(Long id, @NotBlank String registrationId, @NotBlank String clientId, @Nullable String originalUrl, @Nullable String customName,
+public record LtiPlatformConfigurationDTO(@NotNull Long id, @NotBlank String registrationId, @NotBlank String clientId, @Nullable String originalUrl, @Nullable String customName,
         @NotBlank String authorizationUri, @NotBlank String jwkSetUri, @NotBlank String tokenUri) {
 
     public static LtiPlatformConfigurationDTO of(LtiPlatformConfiguration config) {

--- a/src/main/java/de/tum/cit/aet/artemis/lti/dto/LtiPlatformConfigurationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/dto/LtiPlatformConfigurationDTO.java
@@ -1,0 +1,24 @@
+package de.tum.cit.aet.artemis.lti.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
+
+/**
+ * DTO for exposing LTI platform configurations via the REST API.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record LtiPlatformConfigurationDTO(Long id, @NotBlank String registrationId, @NotBlank String clientId, @Nullable String originalUrl, @Nullable String customName,
+        @NotBlank String authorizationUri, @NotBlank String jwkSetUri, @NotBlank String tokenUri) {
+
+    public static LtiPlatformConfigurationDTO of(LtiPlatformConfiguration config) {
+        return new LtiPlatformConfigurationDTO(config.getId(), config.getRegistrationId(), config.getClientId(), config.getOriginalUrl(), config.getCustomName(),
+                config.getAuthorizationUri(), config.getJwkSetUri(), config.getTokenUri());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/lti/dto/LtiPlatformConfigurationUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/dto/LtiPlatformConfigurationUpdateDTO.java
@@ -1,6 +1,6 @@
 package de.tum.cit.aet.artemis.lti.dto;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 
 import org.jspecify.annotations.Nullable;
 
@@ -15,8 +15,8 @@ import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record LtiPlatformConfigurationUpdateDTO(@Nullable Long id, @Nullable String registrationId, @NotNull String clientId, @Nullable String originalUrl,
-        @Nullable String customName, @NotNull String authorizationUri, @NotNull String jwkSetUri, @NotNull String tokenUri) {
+public record LtiPlatformConfigurationUpdateDTO(@Nullable Long id, @Nullable String registrationId, @NotBlank String clientId, @Nullable String originalUrl,
+        @Nullable String customName, @NotBlank String authorizationUri, @NotBlank String jwkSetUri, @NotBlank String tokenUri) {
 
     /**
      * Creates a LtiPlatformConfigurationUpdateDTO from the given LtiPlatformConfiguration domain object.

--- a/src/main/java/de/tum/cit/aet/artemis/lti/dto/OnlineCourseConfigurationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/dto/OnlineCourseConfigurationDTO.java
@@ -11,7 +11,6 @@ import org.jspecify.annotations.Nullable;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
 import de.tum.cit.aet.artemis.lti.domain.OnlineCourseConfiguration;
 
 /**
@@ -30,6 +29,10 @@ public record OnlineCourseConfigurationDTO(Long id, @NotBlank String userPrefix,
     /**
      * Creates an online course configuration entity from the given DTO.
      *
+     * The linked platform is intentionally not reconstructed from request data. Controllers must
+     * attach the managed platform entity explicitly to avoid detached-entity issues and to keep
+     * platform updates restricted to the admin endpoints.
+     *
      * @param dto the DTO to convert
      * @return the corresponding entity
      */
@@ -38,19 +41,6 @@ public record OnlineCourseConfigurationDTO(Long id, @NotBlank String userPrefix,
         config.setId(dto.id());
         config.setUserPrefix(Objects.requireNonNull(dto.userPrefix()));
         config.setRequireExistingUser(Objects.requireNonNull(dto.requireExistingUser()));
-        if (dto.ltiPlatformConfiguration() != null) {
-            LtiPlatformConfigurationDTO platformDTO = dto.ltiPlatformConfiguration();
-            LtiPlatformConfiguration platform = new LtiPlatformConfiguration();
-            platform.setId(platformDTO.id());
-            platform.setRegistrationId(platformDTO.registrationId());
-            platform.setClientId(platformDTO.clientId());
-            platform.setOriginalUrl(platformDTO.originalUrl());
-            platform.setCustomName(platformDTO.customName());
-            platform.setAuthorizationUri(platformDTO.authorizationUri());
-            platform.setJwkSetUri(platformDTO.jwkSetUri());
-            platform.setTokenUri(platformDTO.tokenUri());
-            config.setLtiPlatformConfiguration(platform);
-        }
         return config;
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lti/dto/OnlineCourseConfigurationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/dto/OnlineCourseConfigurationDTO.java
@@ -27,6 +27,12 @@ public record OnlineCourseConfigurationDTO(Long id, @NotBlank String userPrefix,
                 config.getLtiPlatformConfiguration() == null ? null : LtiPlatformConfigurationDTO.of(config.getLtiPlatformConfiguration()));
     }
 
+    /**
+     * Creates an online course configuration entity from the given DTO.
+     *
+     * @param dto the DTO to convert
+     * @return the corresponding entity
+     */
     public static OnlineCourseConfiguration from(OnlineCourseConfigurationDTO dto) {
         OnlineCourseConfiguration config = new OnlineCourseConfiguration();
         config.setId(dto.id());

--- a/src/main/java/de/tum/cit/aet/artemis/lti/dto/OnlineCourseConfigurationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/dto/OnlineCourseConfigurationDTO.java
@@ -1,0 +1,50 @@
+package de.tum.cit.aet.artemis.lti.dto;
+
+import java.util.Objects;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
+import de.tum.cit.aet.artemis.lti.domain.OnlineCourseConfiguration;
+
+/**
+ * DTO for exposing and updating online course LTI configuration.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record OnlineCourseConfigurationDTO(Long id, @NotBlank String userPrefix, @NotNull Boolean requireExistingUser,
+        @Valid @Nullable LtiPlatformConfigurationDTO ltiPlatformConfiguration) {
+
+    public static OnlineCourseConfigurationDTO of(OnlineCourseConfiguration config) {
+        return new OnlineCourseConfigurationDTO(config.getId(), config.getUserPrefix(), config.isRequireExistingUser(),
+                config.getLtiPlatformConfiguration() == null ? null : LtiPlatformConfigurationDTO.of(config.getLtiPlatformConfiguration()));
+    }
+
+    public static OnlineCourseConfiguration from(OnlineCourseConfigurationDTO dto) {
+        OnlineCourseConfiguration config = new OnlineCourseConfiguration();
+        config.setId(dto.id());
+        config.setUserPrefix(Objects.requireNonNull(dto.userPrefix()));
+        config.setRequireExistingUser(Objects.requireNonNull(dto.requireExistingUser()));
+        if (dto.ltiPlatformConfiguration() != null) {
+            LtiPlatformConfigurationDTO platformDTO = dto.ltiPlatformConfiguration();
+            LtiPlatformConfiguration platform = new LtiPlatformConfiguration();
+            platform.setId(platformDTO.id());
+            platform.setRegistrationId(platformDTO.registrationId());
+            platform.setClientId(platformDTO.clientId());
+            platform.setOriginalUrl(platformDTO.originalUrl());
+            platform.setCustomName(platformDTO.customName());
+            platform.setAuthorizationUri(platformDTO.authorizationUri());
+            platform.setJwkSetUri(platformDTO.jwkSetUri());
+            platform.setTokenUri(platformDTO.tokenUri());
+            config.setLtiPlatformConfiguration(platform);
+        }
+        return config;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/lti/dto/OnlineCourseConfigurationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/dto/OnlineCourseConfigurationDTO.java
@@ -2,7 +2,6 @@ package de.tum.cit.aet.artemis.lti.dto;
 
 import java.util.Objects;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -19,7 +18,7 @@ import de.tum.cit.aet.artemis.lti.domain.OnlineCourseConfiguration;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record OnlineCourseConfigurationDTO(Long id, @NotBlank String userPrefix, @NotNull Boolean requireExistingUser,
-        @Valid @Nullable LtiPlatformConfigurationDTO ltiPlatformConfiguration) {
+        @Nullable LtiPlatformConfigurationDTO ltiPlatformConfiguration) {
 
     public static OnlineCourseConfigurationDTO of(OnlineCourseConfiguration config) {
         return new OnlineCourseConfigurationDTO(config.getId(), config.getUserPrefix(), config.isRequireExistingUser(),

--- a/src/main/java/de/tum/cit/aet/artemis/lti/dto/OnlineCourseConfigurationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/dto/OnlineCourseConfigurationDTO.java
@@ -17,7 +17,7 @@ import de.tum.cit.aet.artemis.lti.domain.OnlineCourseConfiguration;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record OnlineCourseConfigurationDTO(Long id, @NotBlank String userPrefix, @NotNull Boolean requireExistingUser,
+public record OnlineCourseConfigurationDTO(@Nullable Long id, @NotBlank String userPrefix, @NotNull Boolean requireExistingUser,
         @Nullable LtiPlatformConfigurationDTO ltiPlatformConfiguration) {
 
     public static OnlineCourseConfigurationDTO of(OnlineCourseConfiguration config) {

--- a/src/main/java/de/tum/cit/aet/artemis/lti/service/OnlineCourseConfigurationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/service/OnlineCourseConfigurationService.java
@@ -79,10 +79,8 @@ public class OnlineCourseConfigurationService implements ClientRegistrationRepos
         }
 
         if (ocConfiguration.getLtiPlatformConfiguration() != null) {
-            Optional<LtiPlatformConfiguration> existingLtiPlatformConfiguration = ltiPlatformConfigurationRepository
-                    .findByRegistrationId(ocConfiguration.getLtiPlatformConfiguration().getRegistrationId());
-            if (existingLtiPlatformConfiguration.isEmpty()
-                    || !Objects.equals(existingLtiPlatformConfiguration.get().getId(), ocConfiguration.getLtiPlatformConfiguration().getId())) {
+            Long platformId = ocConfiguration.getLtiPlatformConfiguration().getId();
+            if (platformId == null || ltiPlatformConfigurationRepository.findById(platformId).isEmpty()) {
                 throw new BadRequestAlertException("No platform registration found", ENTITY_NAME, "invalidRegistrationId");
             }
         }

--- a/src/main/java/de/tum/cit/aet/artemis/lti/web/LtiResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/web/LtiResource.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import jakarta.validation.Valid;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Conditional;
@@ -45,6 +47,8 @@ import de.tum.cit.aet.artemis.core.web.util.PaginationUtil;
 import de.tum.cit.aet.artemis.lti.config.LtiEnabled;
 import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
 import de.tum.cit.aet.artemis.lti.domain.OnlineCourseConfiguration;
+import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationDTO;
+import de.tum.cit.aet.artemis.lti.dto.OnlineCourseConfigurationDTO;
 import de.tum.cit.aet.artemis.lti.repository.LtiPlatformConfigurationRepository;
 import de.tum.cit.aet.artemis.lti.service.DeepLinkingType;
 import de.tum.cit.aet.artemis.lti.service.LtiDeepLinkingService;
@@ -101,18 +105,20 @@ public class LtiResource {
     /**
      * PUT courses/:courseId/online-course-configuration : Updates the onlineCourseConfiguration for the given course.
      *
-     * @param courseId                  the id of the course to update
-     * @param onlineCourseConfiguration the online course configuration to update
+     * @param courseId                     the id of the course to update
+     * @param onlineCourseConfigurationDTO the online course configuration to update
      * @return the ResponseEntity with status 200 (OK) and with body the updated online course configuration
      */
     @PutMapping("courses/{courseId}/online-course-configuration")
     @EnforceAtLeastInstructor
-    public ResponseEntity<OnlineCourseConfiguration> updateOnlineCourseConfiguration(@PathVariable Long courseId,
-            @RequestBody OnlineCourseConfiguration onlineCourseConfiguration) {
+    public ResponseEntity<OnlineCourseConfigurationDTO> updateOnlineCourseConfiguration(@PathVariable Long courseId,
+            @Valid @RequestBody OnlineCourseConfigurationDTO onlineCourseConfigurationDTO) {
         log.debug("REST request to update the online course configuration for Course : {}", courseId);
 
         Course course = courseRepository.findByIdWithEagerOnlineCourseConfigurationElseThrow(courseId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
+
+        OnlineCourseConfiguration onlineCourseConfiguration = OnlineCourseConfigurationDTO.from(onlineCourseConfigurationDTO);
 
         if (!course.isOnlineCourse()) {
             throw new BadRequestAlertException("Course must be online course", Course.ENTITY_NAME, "courseMustBeOnline");
@@ -135,7 +141,7 @@ public class LtiResource {
 
         courseRepository.save(course);
 
-        return ResponseEntity.ok(onlineCourseConfiguration);
+        return ResponseEntity.ok(OnlineCourseConfigurationDTO.of(onlineCourseConfiguration));
     }
 
     /**
@@ -196,11 +202,11 @@ public class LtiResource {
      */
     @GetMapping("lti-platforms")
     @EnforceAtLeastInstructor
-    public ResponseEntity<List<LtiPlatformConfiguration>> getAllConfiguredLtiPlatforms(Pageable pageable) {
+    public ResponseEntity<List<LtiPlatformConfigurationDTO>> getAllConfiguredLtiPlatforms(Pageable pageable) {
         log.info("REST request to get all configured LTI platforms");
         Page<LtiPlatformConfiguration> platformsPage = ltiPlatformConfigurationRepository.findAll(pageable);
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), platformsPage);
-        return new ResponseEntity<>(platformsPage.getContent(), headers, HttpStatus.OK);
+        return new ResponseEntity<>(platformsPage.getContent().stream().map(LtiPlatformConfigurationDTO::of).toList(), headers, HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/lti/web/LtiResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/web/LtiResource.java
@@ -119,6 +119,10 @@ public class LtiResource {
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
 
         OnlineCourseConfiguration onlineCourseConfiguration = OnlineCourseConfigurationDTO.from(onlineCourseConfigurationDTO);
+        if (onlineCourseConfigurationDTO.ltiPlatformConfiguration() != null) {
+            Long platformId = onlineCourseConfigurationDTO.ltiPlatformConfiguration().id();
+            onlineCourseConfiguration.setLtiPlatformConfiguration(ltiPlatformConfigurationRepository.findByIdElseThrow(platformId));
+        }
 
         if (!course.isOnlineCourse()) {
             throw new BadRequestAlertException("Course must be online course", Course.ENTITY_NAME, "courseMustBeOnline");

--- a/src/main/java/de/tum/cit/aet/artemis/lti/web/LtiResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/web/LtiResource.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import jakarta.validation.Valid;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Conditional;
@@ -45,6 +47,8 @@ import de.tum.cit.aet.artemis.course.service.CourseService;
 import de.tum.cit.aet.artemis.lti.config.LtiEnabled;
 import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
 import de.tum.cit.aet.artemis.lti.domain.OnlineCourseConfiguration;
+import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationDTO;
+import de.tum.cit.aet.artemis.lti.dto.OnlineCourseConfigurationDTO;
 import de.tum.cit.aet.artemis.lti.repository.LtiPlatformConfigurationRepository;
 import de.tum.cit.aet.artemis.lti.service.DeepLinkingType;
 import de.tum.cit.aet.artemis.lti.service.LtiDeepLinkingService;
@@ -101,18 +105,20 @@ public class LtiResource {
     /**
      * PUT courses/:courseId/online-course-configuration : Updates the onlineCourseConfiguration for the given course.
      *
-     * @param courseId                  the id of the course to update
-     * @param onlineCourseConfiguration the online course configuration to update
+     * @param courseId                     the id of the course to update
+     * @param onlineCourseConfigurationDTO the online course configuration to update
      * @return the ResponseEntity with status 200 (OK) and with body the updated online course configuration
      */
     @PutMapping("courses/{courseId}/online-course-configuration")
     @EnforceAtLeastInstructor
-    public ResponseEntity<OnlineCourseConfiguration> updateOnlineCourseConfiguration(@PathVariable Long courseId,
-            @RequestBody OnlineCourseConfiguration onlineCourseConfiguration) {
+    public ResponseEntity<OnlineCourseConfigurationDTO> updateOnlineCourseConfiguration(@PathVariable Long courseId,
+            @Valid @RequestBody OnlineCourseConfigurationDTO onlineCourseConfigurationDTO) {
         log.debug("REST request to update the online course configuration for Course : {}", courseId);
 
         Course course = courseRepository.findByIdWithEagerOnlineCourseConfigurationElseThrow(courseId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
+
+        OnlineCourseConfiguration onlineCourseConfiguration = OnlineCourseConfigurationDTO.from(onlineCourseConfigurationDTO);
 
         if (!course.isOnlineCourse()) {
             throw new BadRequestAlertException("Course must be online course", Course.ENTITY_NAME, "courseMustBeOnline");
@@ -135,7 +141,7 @@ public class LtiResource {
 
         courseRepository.save(course);
 
-        return ResponseEntity.ok(onlineCourseConfiguration);
+        return ResponseEntity.ok(OnlineCourseConfigurationDTO.of(onlineCourseConfiguration));
     }
 
     /**
@@ -196,11 +202,11 @@ public class LtiResource {
      */
     @GetMapping("lti-platforms")
     @EnforceAtLeastInstructor
-    public ResponseEntity<List<LtiPlatformConfiguration>> getAllConfiguredLtiPlatforms(Pageable pageable) {
+    public ResponseEntity<List<LtiPlatformConfigurationDTO>> getAllConfiguredLtiPlatforms(Pageable pageable) {
         log.info("REST request to get all configured LTI platforms");
         Page<LtiPlatformConfiguration> platformsPage = ltiPlatformConfigurationRepository.findAll(pageable);
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), platformsPage);
-        return new ResponseEntity<>(platformsPage.getContent(), headers, HttpStatus.OK);
+        return new ResponseEntity<>(platformsPage.getContent().stream().map(LtiPlatformConfigurationDTO::of).toList(), headers, HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/lti/web/LtiResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/web/LtiResource.java
@@ -121,6 +121,9 @@ public class LtiResource {
         OnlineCourseConfiguration onlineCourseConfiguration = OnlineCourseConfigurationDTO.from(onlineCourseConfigurationDTO);
         if (onlineCourseConfigurationDTO.ltiPlatformConfiguration() != null) {
             Long platformId = onlineCourseConfigurationDTO.ltiPlatformConfiguration().id();
+            if (platformId == null) {
+                throw new BadRequestAlertException("LTI platform id must not be null", OnlineCourseConfiguration.ENTITY_NAME, "invalidRegistrationId");
+            }
             onlineCourseConfiguration.setLtiPlatformConfiguration(ltiPlatformConfigurationRepository.findByIdElseThrow(platformId));
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/lti/web/admin/AdminLtiConfigurationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/web/admin/AdminLtiConfigurationResource.java
@@ -2,6 +2,8 @@ package de.tum.cit.aet.artemis.lti.web.admin;
 
 import java.util.UUID;
 
+import jakarta.validation.Valid;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,6 +26,7 @@ import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
 import de.tum.cit.aet.artemis.core.util.HeaderUtil;
 import de.tum.cit.aet.artemis.lti.config.LtiEnabled;
 import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
+import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationDTO;
 import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationUpdateDTO;
 import de.tum.cit.aet.artemis.lti.repository.LtiPlatformConfigurationRepository;
 import de.tum.cit.aet.artemis.lti.service.LtiDynamicRegistrationService;
@@ -75,13 +78,13 @@ public class AdminLtiConfigurationResource {
      * Returns {@code ResponseEntity} with status OK if found, or NOT_FOUND if no configuration exists.
      *
      * @param platformId The ID of the LTI platform to retrieve configuration for.
-     * @return a {@code ResponseEntity} with an {@code Optional<LtiPlatformConfiguration>} and HTTP status.
+     * @return a {@code ResponseEntity} with the platform configuration DTO and HTTP status.
      */
     @GetMapping("lti-platform/{platformId}")
-    public ResponseEntity<LtiPlatformConfiguration> getLtiPlatformConfiguration(@PathVariable("platformId") String platformId) {
+    public ResponseEntity<LtiPlatformConfigurationDTO> getLtiPlatformConfiguration(@PathVariable("platformId") String platformId) {
         log.debug("REST request to configured lti platform");
         LtiPlatformConfiguration platform = ltiPlatformConfigurationRepository.findByIdElseThrow(Long.parseLong(platformId));
-        return new ResponseEntity<>(platform, HttpStatus.OK);
+        return new ResponseEntity<>(LtiPlatformConfigurationDTO.of(platform), HttpStatus.OK);
     }
 
     /**
@@ -109,7 +112,7 @@ public class AdminLtiConfigurationResource {
      *         or with status 400 (Bad Request) if the provided platform configuration is invalid (e.g., missing ID)
      */
     @PutMapping("lti-platform")
-    public ResponseEntity<Void> updateLtiPlatformConfiguration(@RequestBody LtiPlatformConfigurationUpdateDTO updateDTO) {
+    public ResponseEntity<LtiPlatformConfigurationDTO> updateLtiPlatformConfiguration(@Valid @RequestBody LtiPlatformConfigurationUpdateDTO updateDTO) {
         log.debug("REST request to update configured LTI platform");
 
         if (updateDTO.id() == null) {
@@ -127,7 +130,7 @@ public class AdminLtiConfigurationResource {
 
         ltiPlatformConfigurationRepository.save(existingPlatform);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(LtiPlatformConfigurationDTO.of(existingPlatform));
     }
 
     /**
@@ -137,7 +140,7 @@ public class AdminLtiConfigurationResource {
      * @return a {@link ResponseEntity} with status 200 (OK) if the creation was successful
      */
     @PostMapping("lti-platform")
-    public ResponseEntity<Void> addLtiPlatformConfiguration(@RequestBody LtiPlatformConfigurationUpdateDTO dto) {
+    public ResponseEntity<LtiPlatformConfigurationDTO> addLtiPlatformConfiguration(@Valid @RequestBody LtiPlatformConfigurationUpdateDTO dto) {
         log.debug("REST request to add new LTI platform");
 
         LtiPlatformConfiguration platform = dto.toEntity();
@@ -147,7 +150,7 @@ public class AdminLtiConfigurationResource {
         ltiPlatformConfigurationRepository.save(platform);
         oAuth2JWKSService.updateKey(clientRegistrationId);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(LtiPlatformConfigurationDTO.of(platform));
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/lti/web/admin/AdminLtiConfigurationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/web/admin/AdminLtiConfigurationResource.java
@@ -81,9 +81,9 @@ public class AdminLtiConfigurationResource {
      * @return a {@code ResponseEntity} with the platform configuration DTO and HTTP status.
      */
     @GetMapping({ "lti-platforms/{platformId}", "lti-platform/{platformId}" })
-    public ResponseEntity<LtiPlatformConfigurationDTO> getLtiPlatformConfiguration(@PathVariable("platformId") String platformId) {
+    public ResponseEntity<LtiPlatformConfigurationDTO> getLtiPlatformConfiguration(@PathVariable("platformId") Long platformId) {
         log.debug("REST request to configured lti platform");
-        LtiPlatformConfiguration platform = ltiPlatformConfigurationRepository.findByIdElseThrow(Long.parseLong(platformId));
+        LtiPlatformConfiguration platform = ltiPlatformConfigurationRepository.findByIdElseThrow(platformId);
         return new ResponseEntity<>(LtiPlatformConfigurationDTO.of(platform), HttpStatus.OK);
     }
 
@@ -94,14 +94,14 @@ public class AdminLtiConfigurationResource {
      * @return a {@code ResponseEntity<Void>} with status {@code 200 (OK)} and a header indicating the deletion.
      */
     @DeleteMapping({ "lti-platforms/{platformId}", "lti-platform/{platformId}" })
-    public ResponseEntity<Void> deleteLtiPlatformConfiguration(@PathVariable("platformId") String platformId) {
+    public ResponseEntity<Void> deleteLtiPlatformConfiguration(@PathVariable("platformId") Long platformId) {
         log.debug("REST request to delete configured LTI platform");
-        LtiPlatformConfiguration platform = ltiPlatformConfigurationRepository.findByIdElseThrow(Long.parseLong(platformId));
+        LtiPlatformConfiguration platform = ltiPlatformConfigurationRepository.findByIdElseThrow(platformId);
 
         ltiPlatformConfigurationRepository.delete(platform);
         oAuth2JWKSService.updateKey(platform.getRegistrationId());
 
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, platformId)).build();
+        return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, platformId.toString())).build();
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/lti/web/admin/AdminLtiConfigurationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/web/admin/AdminLtiConfigurationResource.java
@@ -2,6 +2,8 @@ package de.tum.cit.aet.artemis.lti.web.admin;
 
 import java.util.UUID;
 
+import jakarta.validation.Valid;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,6 +26,7 @@ import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
 import de.tum.cit.aet.artemis.core.util.HeaderUtil;
 import de.tum.cit.aet.artemis.lti.config.LtiEnabled;
 import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
+import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationDTO;
 import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationUpdateDTO;
 import de.tum.cit.aet.artemis.lti.repository.LtiPlatformConfigurationRepository;
 import de.tum.cit.aet.artemis.lti.service.LtiDynamicRegistrationService;
@@ -75,13 +78,13 @@ public class AdminLtiConfigurationResource {
      * Returns {@code ResponseEntity} with status OK if found, or NOT_FOUND if no configuration exists.
      *
      * @param platformId The ID of the LTI platform to retrieve configuration for.
-     * @return a {@code ResponseEntity} with an {@code Optional<LtiPlatformConfiguration>} and HTTP status.
+     * @return a {@code ResponseEntity} with the platform configuration DTO and HTTP status.
      */
     @GetMapping({ "lti-platforms/{platformId}", "lti-platform/{platformId}" })
-    public ResponseEntity<LtiPlatformConfiguration> getLtiPlatformConfiguration(@PathVariable("platformId") String platformId) {
+    public ResponseEntity<LtiPlatformConfigurationDTO> getLtiPlatformConfiguration(@PathVariable("platformId") String platformId) {
         log.debug("REST request to configured lti platform");
         LtiPlatformConfiguration platform = ltiPlatformConfigurationRepository.findByIdElseThrow(Long.parseLong(platformId));
-        return new ResponseEntity<>(platform, HttpStatus.OK);
+        return new ResponseEntity<>(LtiPlatformConfigurationDTO.of(platform), HttpStatus.OK);
     }
 
     /**
@@ -109,7 +112,7 @@ public class AdminLtiConfigurationResource {
      *         or with status 400 (Bad Request) if the provided platform configuration is invalid (e.g., missing ID)
      */
     @PutMapping({ "lti-platforms", "lti-platform" })
-    public ResponseEntity<Void> updateLtiPlatformConfiguration(@RequestBody LtiPlatformConfigurationUpdateDTO updateDTO) {
+    public ResponseEntity<LtiPlatformConfigurationDTO> updateLtiPlatformConfiguration(@Valid @RequestBody LtiPlatformConfigurationUpdateDTO updateDTO) {
         log.debug("REST request to update configured LTI platform");
 
         if (updateDTO.id() == null) {
@@ -127,7 +130,7 @@ public class AdminLtiConfigurationResource {
 
         ltiPlatformConfigurationRepository.save(existingPlatform);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(LtiPlatformConfigurationDTO.of(existingPlatform));
     }
 
     /**
@@ -137,7 +140,7 @@ public class AdminLtiConfigurationResource {
      * @return a {@link ResponseEntity} with status 200 (OK) if the creation was successful
      */
     @PostMapping({ "lti-platforms", "lti-platform" })
-    public ResponseEntity<Void> addLtiPlatformConfiguration(@RequestBody LtiPlatformConfigurationUpdateDTO dto) {
+    public ResponseEntity<LtiPlatformConfigurationDTO> addLtiPlatformConfiguration(@Valid @RequestBody LtiPlatformConfigurationUpdateDTO dto) {
         log.debug("REST request to add new LTI platform");
 
         LtiPlatformConfiguration platform = dto.toEntity();
@@ -147,7 +150,7 @@ public class AdminLtiConfigurationResource {
         ltiPlatformConfigurationRepository.save(platform);
         oAuth2JWKSService.updateKey(clientRegistrationId);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(LtiPlatformConfigurationDTO.of(platform));
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
@@ -31,6 +31,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
 import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
+import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationDTO;
+import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationUpdateDTO;
 
 class LtiIntegrationTest extends AbstractLtiIntegrationTest {
 
@@ -60,7 +62,7 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         ltiPlatformConfigurationRepository.save(platform1);
 
         LtiPlatformConfiguration platform2 = new LtiPlatformConfiguration();
-        platform1.setId(2L);
+        platform2.setId(2L);
         fillLtiPlatformConfig(platform2);
         ltiPlatformConfigurationRepository.save(platform2);
 
@@ -69,11 +71,11 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         MvcResult mvcResult = request.performMvcRequest(get("/api/lti/lti-platforms")).andExpect(status().isOk()).andReturn();
 
         String jsonContent = mvcResult.getResponse().getContentAsString();
-        List<LtiPlatformConfiguration> actualPlatforms = objectMapper.readValue(jsonContent, new TypeReference<>() {
+        List<LtiPlatformConfigurationDTO> actualPlatforms = objectMapper.readValue(jsonContent, new TypeReference<>() {
             // Empty block intended for type inference by Jackson's ObjectMapper
         });
 
-        assertThat(actualPlatforms).hasSize(expectedPlatforms.getSize());
+        assertThat(actualPlatforms).containsExactlyInAnyOrderElementsOf(expectedPlatforms.getContent().stream().map(LtiPlatformConfigurationDTO::of).toList());
     }
 
     @Test
@@ -95,9 +97,9 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         MvcResult mvcResult = request.performMvcRequest(get("/api/lti/admin/lti-platform/{platformId}", platformId)).andExpect(status().isOk()).andReturn();
 
         String jsonContent = mvcResult.getResponse().getContentAsString();
-        LtiPlatformConfiguration actualPlatform = objectMapper.readValue(jsonContent, LtiPlatformConfiguration.class);
+        LtiPlatformConfigurationDTO actualPlatform = objectMapper.readValue(jsonContent, LtiPlatformConfigurationDTO.class);
 
-        assertThat(actualPlatform).usingRecursiveComparison().isEqualTo(expectedPlatform);
+        assertThat(actualPlatform).isEqualTo(LtiPlatformConfigurationDTO.of(expectedPlatform));
     }
 
     @Test
@@ -129,8 +131,8 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
 
         doReturn(platformToUpdate).when(ltiPlatformConfigurationRepository).findByIdElseThrow(platformId);
 
-        request.performMvcRequest(put("/api/lti/admin/lti-platform").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(platformToUpdate)))
-                .andExpect(status().isOk());
+        request.performMvcRequest(put("/api/lti/admin/lti-platform").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(LtiPlatformConfigurationUpdateDTO.of(platformToUpdate)))).andExpect(status().isOk());
 
         verify(ltiPlatformConfigurationRepository).save(platformToUpdate);
     }
@@ -141,7 +143,7 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         LtiPlatformConfiguration platformToUpdate = new LtiPlatformConfiguration();
         fillLtiPlatformConfig(platformToUpdate);
 
-        request.put("/api/lti/admin/lti-platform", platformToUpdate, HttpStatus.BAD_REQUEST);
+        request.put("/api/lti/admin/lti-platform", LtiPlatformConfigurationUpdateDTO.of(platformToUpdate), HttpStatus.BAD_REQUEST);
 
         verify(ltiPlatformConfigurationRepository, never()).save(platformToUpdate);
     }
@@ -161,7 +163,7 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         LtiPlatformConfiguration platformWithNewRegistrationId = cloneLtiPlatformConfig(initialPlatform);
         platformWithNewRegistrationId.setRegistrationId("newRegistrationId-" + UUID.randomUUID());
 
-        request.put("/api/lti/admin/lti-platform", platformWithNewRegistrationId, HttpStatus.BAD_REQUEST);
+        request.put("/api/lti/admin/lti-platform", LtiPlatformConfigurationUpdateDTO.of(platformWithNewRegistrationId), HttpStatus.BAD_REQUEST);
 
         verify(ltiPlatformConfigurationRepository, never()).save(platformWithNewRegistrationId);
     }
@@ -174,8 +176,8 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         fillLtiPlatformConfig(platformToCreate);
         platformToCreate.setRegistrationId(null);
 
-        request.performMvcRequest(post("/api/lti/admin/lti-platform").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(platformToCreate)))
-                .andExpect(status().isOk());
+        request.performMvcRequest(post("/api/lti/admin/lti-platform").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(LtiPlatformConfigurationUpdateDTO.of(platformToCreate)))).andExpect(status().isOk());
 
         verify(ltiPlatformConfigurationRepository).save(any());
 

--- a/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
@@ -35,9 +35,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
 import de.tum.cit.aet.artemis.core.util.CourseFactory;
+import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
 import de.tum.cit.aet.artemis.lti.domain.OnlineCourseConfiguration;
 import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationDTO;

--- a/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
@@ -31,6 +31,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
 import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
+import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationDTO;
+import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationUpdateDTO;
 
 class LtiIntegrationTest extends AbstractLtiIntegrationTest {
 
@@ -60,7 +62,7 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         ltiPlatformConfigurationRepository.save(platform1);
 
         LtiPlatformConfiguration platform2 = new LtiPlatformConfiguration();
-        platform1.setId(2L);
+        platform2.setId(2L);
         fillLtiPlatformConfig(platform2);
         ltiPlatformConfigurationRepository.save(platform2);
 
@@ -69,11 +71,11 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         MvcResult mvcResult = request.performMvcRequest(get("/api/lti/lti-platforms")).andExpect(status().isOk()).andReturn();
 
         String jsonContent = mvcResult.getResponse().getContentAsString();
-        List<LtiPlatformConfiguration> actualPlatforms = objectMapper.readValue(jsonContent, new TypeReference<>() {
+        List<LtiPlatformConfigurationDTO> actualPlatforms = objectMapper.readValue(jsonContent, new TypeReference<>() {
             // Empty block intended for type inference by Jackson's ObjectMapper
         });
 
-        assertThat(actualPlatforms).hasSize(expectedPlatforms.getSize());
+        assertThat(actualPlatforms).containsExactlyInAnyOrderElementsOf(expectedPlatforms.getContent().stream().map(LtiPlatformConfigurationDTO::of).toList());
     }
 
     @Test
@@ -95,9 +97,9 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         MvcResult mvcResult = request.performMvcRequest(get("/api/lti/admin/lti-platforms/{platformId}", platformId)).andExpect(status().isOk()).andReturn();
 
         String jsonContent = mvcResult.getResponse().getContentAsString();
-        LtiPlatformConfiguration actualPlatform = objectMapper.readValue(jsonContent, LtiPlatformConfiguration.class);
+        LtiPlatformConfigurationDTO actualPlatform = objectMapper.readValue(jsonContent, LtiPlatformConfigurationDTO.class);
 
-        assertThat(actualPlatform).usingRecursiveComparison().isEqualTo(expectedPlatform);
+        assertThat(actualPlatform).isEqualTo(LtiPlatformConfigurationDTO.of(expectedPlatform));
     }
 
     @Test
@@ -129,8 +131,8 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
 
         doReturn(platformToUpdate).when(ltiPlatformConfigurationRepository).findByIdElseThrow(platformId);
 
-        request.performMvcRequest(put("/api/lti/admin/lti-platforms").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(platformToUpdate)))
-                .andExpect(status().isOk());
+        request.performMvcRequest(put("/api/lti/admin/lti-platforms").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(LtiPlatformConfigurationUpdateDTO.of(platformToUpdate)))).andExpect(status().isOk());
 
         verify(ltiPlatformConfigurationRepository).save(platformToUpdate);
     }
@@ -141,7 +143,7 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         LtiPlatformConfiguration platformToUpdate = new LtiPlatformConfiguration();
         fillLtiPlatformConfig(platformToUpdate);
 
-        request.put("/api/lti/admin/lti-platforms", platformToUpdate, HttpStatus.BAD_REQUEST);
+        request.put("/api/lti/admin/lti-platforms", LtiPlatformConfigurationUpdateDTO.of(platformToUpdate), HttpStatus.BAD_REQUEST);
 
         verify(ltiPlatformConfigurationRepository, never()).save(platformToUpdate);
     }
@@ -161,7 +163,7 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         LtiPlatformConfiguration platformWithNewRegistrationId = cloneLtiPlatformConfig(initialPlatform);
         platformWithNewRegistrationId.setRegistrationId("newRegistrationId-" + UUID.randomUUID());
 
-        request.put("/api/lti/admin/lti-platforms", platformWithNewRegistrationId, HttpStatus.BAD_REQUEST);
+        request.put("/api/lti/admin/lti-platforms", LtiPlatformConfigurationUpdateDTO.of(platformWithNewRegistrationId), HttpStatus.BAD_REQUEST);
 
         verify(ltiPlatformConfigurationRepository, never()).save(platformWithNewRegistrationId);
     }
@@ -174,8 +176,8 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         fillLtiPlatformConfig(platformToCreate);
         platformToCreate.setRegistrationId(null);
 
-        request.performMvcRequest(post("/api/lti/admin/lti-platforms").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(platformToCreate)))
-                .andExpect(status().isOk());
+        request.performMvcRequest(post("/api/lti/admin/lti-platforms").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(LtiPlatformConfigurationUpdateDTO.of(platformToCreate)))).andExpect(status().isOk());
 
         verify(ltiPlatformConfigurationRepository).save(any());
 

--- a/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.lti;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
@@ -13,6 +14,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.ZonedDateTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -28,9 +31,14 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.util.LinkedMultiValueMap;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
+import de.tum.cit.aet.artemis.core.util.CourseFactory;
 import de.tum.cit.aet.artemis.lti.domain.LtiPlatformConfiguration;
+import de.tum.cit.aet.artemis.lti.domain.OnlineCourseConfiguration;
 import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationDTO;
 import de.tum.cit.aet.artemis.lti.dto.LtiPlatformConfigurationUpdateDTO;
 
@@ -187,6 +195,45 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         assertThat(addedLtiPlatform.get().getAuthorizationUri()).isEqualTo(platformToCreate.getAuthorizationUri());
         assertThat(addedLtiPlatform.get().getJwkSetUri()).isEqualTo(platformToCreate.getJwkSetUri());
         assertThat(addedLtiPlatform.get().getTokenUri()).isEqualTo(platformToCreate.getTokenUri());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateOnlineCourseConfigurationAcceptsPlatformReferenceOnly() throws Exception {
+        userUtilService.addUsers(TEST_PREFIX, 0, 0, 0, 1);
+
+        LtiPlatformConfiguration platform = new LtiPlatformConfiguration();
+        fillLtiPlatformConfig(platform);
+        LtiPlatformConfiguration savedPlatform = ltiPlatformConfigurationRepository.save(platform);
+        doReturn(Optional.of(savedPlatform)).when(ltiPlatformConfigurationRepository).findByRegistrationId(savedPlatform.getRegistrationId());
+        doReturn(savedPlatform).when(ltiPlatformConfigurationRepository).findByIdElseThrow(savedPlatform.getId());
+        doReturn(savedPlatform).when(ltiPlatformConfigurationRepository).findLtiPlatformConfigurationWithEagerLoadedCoursesByIdElseThrow(anyLong());
+
+        Course course = CourseFactory.generateCourse(null, ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(1), new HashSet<>(), "student", "tutor", "editor",
+                TEST_PREFIX + "instructor");
+        course.setOnlineCourse(true);
+
+        OnlineCourseConfiguration onlineCourseConfiguration = new OnlineCourseConfiguration();
+        onlineCourseConfiguration.setUserPrefix("prefix");
+        onlineCourseConfiguration.setRequireExistingUser(false);
+        onlineCourseConfiguration.setCourse(course);
+        course.setOnlineCourseConfiguration(onlineCourseConfiguration);
+        Course savedCourse = courseRepository.saveAndFlush(course);
+
+        ObjectNode platformPayload = objectMapper.createObjectNode();
+        platformPayload.put("id", savedPlatform.getId());
+        platformPayload.put("registrationId", savedPlatform.getRegistrationId());
+        ObjectNode payload = objectMapper.createObjectNode();
+        payload.put("id", savedCourse.getOnlineCourseConfiguration().getId());
+        payload.put("userPrefix", "prefix");
+        payload.put("requireExistingUser", false);
+        payload.set("ltiPlatformConfiguration", platformPayload);
+
+        MvcResult mvcResult = request.performMvcRequest(put("/api/lti/courses/{courseId}/online-course-configuration", savedCourse.getId()).contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))).andExpect(status().isOk()).andReturn();
+
+        JsonNode response = objectMapper.readTree(mvcResult.getResponse().getContentAsString());
+        assertThat(response.get("ltiPlatformConfiguration").get("id").asLong()).isEqualTo(savedPlatform.getId());
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
@@ -205,7 +206,7 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         LtiPlatformConfiguration platform = new LtiPlatformConfiguration();
         fillLtiPlatformConfig(platform);
         LtiPlatformConfiguration savedPlatform = ltiPlatformConfigurationRepository.save(platform);
-        doReturn(Optional.of(savedPlatform)).when(ltiPlatformConfigurationRepository).findByRegistrationId(savedPlatform.getRegistrationId());
+        doReturn(Optional.empty()).when(ltiPlatformConfigurationRepository).findByRegistrationId(anyString());
         doReturn(savedPlatform).when(ltiPlatformConfigurationRepository).findByIdElseThrow(savedPlatform.getId());
         doReturn(savedPlatform).when(ltiPlatformConfigurationRepository).findLtiPlatformConfigurationWithEagerLoadedCoursesByIdElseThrow(anyLong());
 
@@ -222,7 +223,7 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
 
         ObjectNode platformPayload = objectMapper.createObjectNode();
         platformPayload.put("id", savedPlatform.getId());
-        platformPayload.put("registrationId", savedPlatform.getRegistrationId());
+        platformPayload.put("registrationId", "forged-" + UUID.randomUUID());
         ObjectNode payload = objectMapper.createObjectNode();
         payload.put("id", savedCourse.getOnlineCourseConfiguration().getId());
         payload.put("userPrefix", "prefix");
@@ -234,6 +235,8 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
 
         JsonNode response = objectMapper.readTree(mvcResult.getResponse().getContentAsString());
         assertThat(response.get("ltiPlatformConfiguration").get("id").asLong()).isEqualTo(savedPlatform.getId());
+        verify(ltiPlatformConfigurationRepository).findByIdElseThrow(savedPlatform.getId());
+        verify(ltiPlatformConfigurationRepository, never()).findByRegistrationId(anyString());
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
@@ -210,25 +210,12 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         doReturn(savedPlatform).when(ltiPlatformConfigurationRepository).findByIdElseThrow(savedPlatform.getId());
         doReturn(savedPlatform).when(ltiPlatformConfigurationRepository).findLtiPlatformConfigurationWithEagerLoadedCoursesByIdElseThrow(anyLong());
 
-        Course course = CourseFactory.generateCourse(null, ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(1), new HashSet<>(), "student", "tutor", "editor",
-                TEST_PREFIX + "instructor");
-        course.setOnlineCourse(true);
-
-        OnlineCourseConfiguration onlineCourseConfiguration = new OnlineCourseConfiguration();
-        onlineCourseConfiguration.setUserPrefix("prefix");
-        onlineCourseConfiguration.setRequireExistingUser(false);
-        onlineCourseConfiguration.setCourse(course);
-        course.setOnlineCourseConfiguration(onlineCourseConfiguration);
-        Course savedCourse = courseRepository.saveAndFlush(course);
+        Course savedCourse = createOnlineCourseWithConfiguration();
 
         ObjectNode platformPayload = objectMapper.createObjectNode();
         platformPayload.put("id", savedPlatform.getId());
         platformPayload.put("registrationId", "forged-" + UUID.randomUUID());
-        ObjectNode payload = objectMapper.createObjectNode();
-        payload.put("id", savedCourse.getOnlineCourseConfiguration().getId());
-        payload.put("userPrefix", "prefix");
-        payload.put("requireExistingUser", false);
-        payload.set("ltiPlatformConfiguration", platformPayload);
+        ObjectNode payload = onlineCourseConfigurationPayload(savedCourse, platformPayload);
 
         MvcResult mvcResult = request.performMvcRequest(put("/api/lti/courses/{courseId}/online-course-configuration", savedCourse.getId()).contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(payload))).andExpect(status().isOk()).andReturn();
@@ -237,6 +224,22 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
         assertThat(response.get("ltiPlatformConfiguration").get("id").asLong()).isEqualTo(savedPlatform.getId());
         verify(ltiPlatformConfigurationRepository).findByIdElseThrow(savedPlatform.getId());
         verify(ltiPlatformConfigurationRepository, never()).findByRegistrationId(anyString());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateOnlineCourseConfigurationRejectsPlatformReferenceWithoutId() throws Exception {
+        userUtilService.addUsers(TEST_PREFIX, 0, 0, 0, 1);
+        Course savedCourse = createOnlineCourseWithConfiguration();
+
+        ObjectNode platformPayload = objectMapper.createObjectNode();
+        platformPayload.put("registrationId", "forged-" + UUID.randomUUID());
+        ObjectNode payload = onlineCourseConfigurationPayload(savedCourse, platformPayload);
+
+        request.performMvcRequest(put("/api/lti/courses/{courseId}/online-course-configuration", savedCourse.getId()).contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(payload))).andExpect(status().isBadRequest());
+
+        verify(ltiPlatformConfigurationRepository, never()).findByIdElseThrow(any());
     }
 
     @Test
@@ -275,6 +278,28 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
 
         assertThat(fetchedPlatformConfiguration).isEqualTo(savedPlatformConfiguration);
         assertThat(Hibernate.isInitialized(fetchedPlatformConfiguration.getOnlineCourseConfigurations())).isTrue();
+    }
+
+    private Course createOnlineCourseWithConfiguration() {
+        Course course = CourseFactory.generateCourse(null, ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(1), new HashSet<>(), "student", "tutor", "editor",
+                TEST_PREFIX + "instructor");
+        course.setOnlineCourse(true);
+
+        OnlineCourseConfiguration onlineCourseConfiguration = new OnlineCourseConfiguration();
+        onlineCourseConfiguration.setUserPrefix("prefix");
+        onlineCourseConfiguration.setRequireExistingUser(false);
+        onlineCourseConfiguration.setCourse(course);
+        course.setOnlineCourseConfiguration(onlineCourseConfiguration);
+        return courseRepository.saveAndFlush(course);
+    }
+
+    private ObjectNode onlineCourseConfigurationPayload(Course savedCourse, ObjectNode platformPayload) {
+        ObjectNode payload = objectMapper.createObjectNode();
+        payload.put("id", savedCourse.getOnlineCourseConfiguration().getId());
+        payload.put("userPrefix", "prefix");
+        payload.put("requireExistingUser", false);
+        payload.set("ltiPlatformConfiguration", platformPayload);
+        return payload;
     }
 
     private void fillLtiPlatformConfig(LtiPlatformConfiguration ltiPlatformConfiguration) {

--- a/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/LtiIntegrationTest.java
@@ -47,6 +47,10 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
 
     private static final String TEST_PREFIX = "ltiintegrationtest";
 
+    private static final ZonedDateTime COURSE_START_DATE = ZonedDateTime.parse("2024-01-01T00:00:00Z");
+
+    private static final ZonedDateTime COURSE_END_DATE = ZonedDateTime.parse("2024-01-02T00:00:00Z");
+
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void dynamicRegistrationFailsAsStudent() throws Exception {
@@ -281,8 +285,7 @@ class LtiIntegrationTest extends AbstractLtiIntegrationTest {
     }
 
     private Course createOnlineCourseWithConfiguration() {
-        Course course = CourseFactory.generateCourse(null, ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(1), new HashSet<>(), "student", "tutor", "editor",
-                TEST_PREFIX + "instructor");
+        Course course = CourseFactory.generateCourse(null, COURSE_START_DATE, COURSE_END_DATE, new HashSet<>(), "student", "tutor", "editor", TEST_PREFIX + "instructor");
         course.setOnlineCourse(true);
 
         OnlineCourseConfiguration onlineCourseConfiguration = new OnlineCourseConfiguration();

--- a/src/test/java/de/tum/cit/aet/artemis/lti/architecture/LtiEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/architecture/LtiEntityUsageArchitectureTest.java
@@ -5,8 +5,6 @@ import de.tum.cit.aet.artemis.shared.architecture.module.AbstractModuleEntityUsa
 /**
  * Architecture test to verify that REST controllers in the LTI module
  * do not use @Entity types directly. Controllers should use DTOs instead.
- * <p>
- * TODO: Reduce violation counts to 0 by introducing DTOs for all endpoints.
  */
 class LtiEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitectureTest {
 
@@ -15,16 +13,14 @@ class LtiEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitectu
         return ARTEMIS_PACKAGE + ".lti";
     }
 
-    // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getMaxEntityReturnViolations() {
-        return 3;
+        return 0;
     }
 
-    // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getMaxEntityInputViolations() {
-        return 1;
+        return 0;
     }
 
     // This module is already compliant for DTO entity field violations

--- a/src/test/java/de/tum/cit/aet/artemis/lti/architecture/LtiEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/architecture/LtiEntityUsageArchitectureTest.java
@@ -5,8 +5,6 @@ import de.tum.cit.aet.artemis.shared.architecture.module.AbstractModuleEntityUsa
 /**
  * Architecture test to verify that REST controllers in the LTI module
  * do not use @Entity types directly. Controllers should use DTOs instead.
- * <p>
- * TODO: Reduce violation counts to 0 by introducing DTOs for all endpoints.
  */
 class LtiEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitectureTest {
 
@@ -15,16 +13,14 @@ class LtiEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitectu
         return ARTEMIS_PACKAGE + ".lti";
     }
 
-    // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getExpectedEntityReturnViolations() {
-        return 3;
+        return 0;
     }
 
-    // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getExpectedEntityInputViolations() {
-        return 1;
+        return 0;
     }
 
     // This module is already compliant for DTO entity field violations

--- a/src/test/java/de/tum/cit/aet/artemis/lti/service/OnlineCourseConfigurationServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/service/OnlineCourseConfigurationServiceTest.java
@@ -100,19 +100,16 @@ class OnlineCourseConfigurationServiceTest {
     void noLtiConfigurationValidateOnlineCourseConfiguration() {
         LtiPlatformConfiguration ltiPlatformConfiguration = getMockLtiPlatformConfiguration();
         OnlineCourseConfiguration onlineCourseConfiguration = getMockOnlineCourseConfiguration(ltiPlatformConfiguration);
-        when(ltiPlatformConfigurationRepository.findByRegistrationId(onlineCourseConfiguration.getLtiPlatformConfiguration().getRegistrationId())).thenReturn(Optional.empty());
+        when(ltiPlatformConfigurationRepository.findById(onlineCourseConfiguration.getLtiPlatformConfiguration().getId())).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> onlineCourseConfigurationService.validateOnlineCourseConfiguration(onlineCourseConfiguration)).isInstanceOf(BadRequestAlertException.class);
     }
 
     @Test
-    void invalidRegistrationIdValidateOnlineCourseConfiguration() {
+    void nullPlatformIdValidateOnlineCourseConfiguration() {
         LtiPlatformConfiguration ltiPlatformConfiguration = getMockLtiPlatformConfiguration();
-        ltiPlatformConfiguration.setId(2L);
-        OnlineCourseConfiguration onlineCourseConfiguration = getMockOnlineCourseConfiguration(getMockLtiPlatformConfiguration());
-
-        when(ltiPlatformConfigurationRepository.findByRegistrationId(onlineCourseConfiguration.getLtiPlatformConfiguration().getRegistrationId()))
-                .thenReturn(Optional.of(ltiPlatformConfiguration));
+        ltiPlatformConfiguration.setId(null);
+        OnlineCourseConfiguration onlineCourseConfiguration = getMockOnlineCourseConfiguration(ltiPlatformConfiguration);
 
         assertThatThrownBy(() -> onlineCourseConfigurationService.validateOnlineCourseConfiguration(onlineCourseConfiguration)).isInstanceOf(BadRequestAlertException.class);
     }


### PR DESCRIPTION
## Summary
- return DTOs from the LTI course and admin configuration endpoints instead of exposing entities directly
- add dedicated LTI DTOs for platform and online course configuration payloads
- update integration and architecture tests to enforce zero direct entity usage in LTI REST controllers

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.

### Steps for Testing

Prereqs: admin account **(use student id/pass on TEST 3 (!))**, instructor account, at least one online course, and an LTI platform configuration created via the admin UI.

#### `GET /api/lti/admin/lti-platform/{platformId}` (admin)
- [x] Open **Server Administration → LTI Platforms** and click an existing platform.
- [x] All fields render as before (registrationId, clientId, originalUrl, customName, authorizationUri, jwkSetUri, tokenUri).
- [x] In DevTools → Network, the response JSON contains only the DTO fields above plus `id` (no entity-only fields, no Hibernate proxies, no internal collections).

#### `GET /api/lti/lti-platforms` (instructor)
- [x] As an instructor, open *Edit course LTI configuration* on an online course (this triggers the paginated platform list).
- [x] The platform list renders with custom name + URL as before.
- [x] Response is a JSON array of platform DTOs and the pagination headers (`X-Total-Count`, `Link`) are still present.

#### `POST /api/lti/admin/lti-platform` (admin)
- [x] In **Server Administration → LTI Platforms → Add Platform**, fill in all required fields with valid values and save → 200, new platform appears in the list with a generated `registrationId` (`artemis-<uuid>`).
- [x] Response body now contains the created platform DTO (previously empty); UI navigates/refreshes correctly.
- [x] Submit with a missing required field (blank `clientId`, `authorizationUri`, `jwkSetUri`, or `tokenUri`) → 400 from the new `@Valid` enforcement.

#### `PUT /api/lti/admin/lti-platform` (admin)
- [x] Edit an existing platform (change `customName` and `clientId`), save → 200, response body contains the updated DTO.
- [x] Reload the platform detail page; changes persisted.
- [x] Submit with `id` missing (crafted request) → 400.
- [x] Submit with a `registrationId` that does not match the stored platform → 400 (registrationId remains immutable).
- [x] Submit with a blank required field → 400 from `@Valid`.

#### `PUT /api/lti/courses/{courseId}/online-course-configuration` (instructor)
- [x] On an online course, open *Edit course LTI configuration*, select an existing platform, change `userPrefix` and `requireExistingUser`, save → 200, response DTO reflects the saved values including the linked `ltiPlatformConfiguration` DTO.
- [x] Reload the course config; platform link and prefix persisted.
- [x] Switch the linked platform to a different one and save; the link updates correctly.
- [x] Clear the platform selection (null) and save; configuration is saved without a platform attached and no NPE occurs.
- [x] **Security check (manual API call):** issue a PUT with a forged `ltiPlatformConfiguration` payload whose `id` matches an existing platform but whose `clientId`/`authorizationUri`/etc. fields are altered. After save, fetch the platform via the admin endpoint and confirm those fields were **not** modified — the controller resolves the platform by id and ignores other nested fields.
- [x] PUT against a non-online course → 400 ("Course must be online course").
- [x] PUT where the DTO `id` does not match the course's existing config id → 400 (idMismatch).
- [x] Submit with a blank `userPrefix` or null `requireExistingUser` → 400 from `@Valid`.

#### Regression sanity (end-to-end LTI launch)
- [x] Follow the full flow documented at https://docs.artemis.tum.de/instructor/integrations/lti-configuration: register a platform, attach it to an online course, perform an LTI 1.3 launch from the platform side. Launch succeeds and the user lands in the course as before.


### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Coverage table could not be generated. The `Test` workflow concluded with status `failure`; coverage artifacts may be missing or incomplete. See [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/27537597186).

_Last updated: 2026-06-15 10:09:25 UTC_

