### PR TITLE
`General`: Restore one-click result feedback link alongside result history dropdown

### DIFF
--- a/src/main/webapp/app/exercise/exercise-headers/exercise-headers-information/exercise-headers-information.component.html
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-headers-information/exercise-headers-information.component.html
@@ -14,17 +14,19 @@
                 >
                     <jhi-information-box [informationBoxData]="informationBoxItem">
                         <span contentComponent class="d-flex align-items-center gap-1">
-                            <jhi-submission-result-status
-                                class="text-truncate result pe-none"
-                                [exercise]="informationBoxItem.content.value"
-                                [studentParticipation]="studentParticipation"
-                                [triggerLastGraded]="!isPractice"
-                                [showUngradedResults]="isPractice"
-                                [showCompletion]="false"
-                                [showBadge]="false"
-                                [showProgressBar]="true"
-                                [isInSidebarCard]="true"
-                            />
+                            <span (click)="$event.stopPropagation()" (keydown.enter)="$event.stopPropagation()" (keydown.space)="$event.stopPropagation()">
+                                <jhi-submission-result-status
+                                    class="text-truncate result"
+                                    [exercise]="informationBoxItem.content.value"
+                                    [studentParticipation]="studentParticipation"
+                                    [triggerLastGraded]="!isPractice"
+                                    [showUngradedResults]="isPractice"
+                                    [showCompletion]="false"
+                                    [showBadge]="false"
+                                    [showProgressBar]="true"
+                                    [isInSidebarCard]="false"
+                                />
+                            </span>
                             <jhi-result-history-dropdown
                                 #resultHistoryDropdown
                                 [exercise]="exercise"


### PR DESCRIPTION
### Summary

After #12335, students had to click twice to view their most recent result feedback: once to open the result history dropdown, then again to click the result. This PR restores the direct link on the result status so students can open feedback in a single click, while the dropdown for browsing result history remains fully functional.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).

### Motivation and Context

Introduced as a regression in #12335: the result status component was wrapped in a click handler for the result history dropdown and its own click was disabled via `isInSidebarCard=true` and `pe-none`. Students could no longer open result feedback directly.

### Description

In `exercise-headers-information.component.html`:
- Removed `pe-none` from `jhi-submission-result-status` and set `[isInSidebarCard]="false"` to re-enable the result click → `showDetails()` handler in `result.component`.
- Wrapped `jhi-submission-result-status` in a `<span>` that stops click propagation, preventing the outer dropdown trigger from also firing when the result is clicked directly.

### Steps for Testing

Prerequisites:
- 1 Student
- 1 Course with at least one exercise that has a graded result (e.g. a programming exercise)

1. Log in as the student and navigate to the exercise details page.
2. **One-click feedback**: Click directly on the result score/text in the status box → the feedback detail view should open immediately.
3. **Dropdown still works**: Click anywhere else on the status box (e.g. the chevron arrow) → the result history dropdown should open as before.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.

#### Code Review
- [x] Code Review 1

#### Manual Tests
- [x] Test 1


### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-04-13 12:54:57 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Reintroduced clickable link in the status:
<img width="416" height="121" alt="Bildschirmfoto 2026-04-12 um 20 30 04" src="https://github.com/user-attachments/assets/440cdc45-4960-4bf5-b84b-dbe17ba81591" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed submission status component responsiveness in the exercise information panel to properly handle user clicks and keyboard interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->