### PR TITLE
`Programming exercises`: Fix NPE during import when SCA flag is null

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportBasicService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportBasicService.java
@@ -209,7 +209,7 @@ public class ProgrammingExerciseImportBasicService {
         programmingExerciseTaskService.updateTestIds(importedExercise, newTestCaseIdByOldId);
 
         // Copy or create SCA categories
-        if (Boolean.TRUE.equals(importedExercise.isStaticCodeAnalysisEnabled() && Boolean.TRUE.equals(originalProgrammingExercise.isStaticCodeAnalysisEnabled()))) {
+        if (Boolean.TRUE.equals(importedExercise.isStaticCodeAnalysisEnabled()) && Boolean.TRUE.equals(originalProgrammingExercise.isStaticCodeAnalysisEnabled())) {
             importStaticCodeAnalysisCategories(originalProgrammingExercise, importedExercise);
         }
         else if (Boolean.TRUE.equals(importedExercise.isStaticCodeAnalysisEnabled()) && !Boolean.TRUE.equals(originalProgrammingExercise.isStaticCodeAnalysisEnabled())) {


### PR DESCRIPTION
### Summary
Fix a misplaced parenthesis in `ProgrammingExerciseImportBasicService` that caused a `NullPointerException` when importing programming exercises where `staticCodeAnalysisEnabled` is null.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).

#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context
Production error on a core node:
```
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise.isStaticCodeAnalysisEnabled()" is null
    at ...ProgrammingExerciseImportBasicService.importProgrammingExerciseBasis(ProgrammingExerciseImportBasicService.java:212)
```

### Description
Line 212 had a misplaced closing parenthesis:
```java
// Before (broken) — the && operator forces unboxing of the nullable Boolean, causing NPE
if (Boolean.TRUE.equals(importedExercise.isStaticCodeAnalysisEnabled() && Boolean.TRUE.equals(...))) {

// After (fixed) — each nullable Boolean is safely wrapped in Boolean.TRUE.equals()
if (Boolean.TRUE.equals(importedExercise.isStaticCodeAnalysisEnabled()) && Boolean.TRUE.equals(...)) {
```

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Programming Exercise with SCA disabled (or null SCA flag)
- 1 Programming Exercise with SCA enabled

1. Log in as instructor
2. Import the programming exercise where SCA is disabled/null into a course
3. Verify the import succeeds without error
4. Import the programming exercise where SCA is enabled
5. Verify SCA categories are correctly imported

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->