### PR TITLE
`Communication`: Update Hermes push notification relay URLs

### DIFF
--- a/documentation/docs/student/communication-support/notifications.mdx
+++ b/documentation/docs/student/communication-support/notifications.mdx
@@ -66,7 +66,7 @@ Here you can:
 
 Artemis can send push notifications to the native Artemis iOS and Android apps.
 
-These notifications are encrypted and delivered through Hermes service (https://hermes.artemis.cit.tum.de).
+These notifications are encrypted and delivered through Hermes service (https://hermes-prod.artemis.cit.tum.de).
 Users must explicitly opt in through their mobile application to receive push notifications and can deactivate them at any time.
 
 <Image src={notificationPushImg} alt={"notification-push"} size={ImageSize.small} />

--- a/src/main/java/de/tum/cit/aet/artemis/communication/config/HermesHealthIndicator.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/config/HermesHealthIndicator.java
@@ -28,7 +28,7 @@ public class HermesHealthIndicator implements HealthIndicator {
 
     private final RestTemplate shortTimeoutRestTemplate;
 
-    @Value("${artemis.push-notification-relay:https://hermes-sandbox.artemis.cit.tum.de}")
+    @Value("${artemis.push-notification-relay:https://hermes-staging.artemis.cit.tum.de}")
     private String hermesUrl;
 
     public HermesHealthIndicator(@Qualifier("shortTimeoutHermesRestTemplate") RestTemplate shortTimeoutRestTemplate) {

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/push_notifications/ApplePushNotificationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/push_notifications/ApplePushNotificationService.java
@@ -29,7 +29,7 @@ public class ApplePushNotificationService extends PushNotificationService {
 
     private final PushNotificationDeviceConfigurationRepository repository;
 
-    @Value("${artemis.push-notification-relay:https://hermes-sandbox.artemis.cit.tum.de}")
+    @Value("${artemis.push-notification-relay:https://hermes-staging.artemis.cit.tum.de}")
     private String relayServerBaseUrl;
 
     public ApplePushNotificationService(PushNotificationDeviceConfigurationRepository repository, RestTemplate restTemplate) {

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/push_notifications/FirebasePushNotificationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/notifications/push_notifications/FirebasePushNotificationService.java
@@ -33,7 +33,7 @@ public class FirebasePushNotificationService extends PushNotificationService {
 
     private final PushNotificationDeviceConfigurationRepository repository;
 
-    @Value("${artemis.push-notification-relay:https://hermes-sandbox.artemis.cit.tum.de}")
+    @Value("${artemis.push-notification-relay:https://hermes-staging.artemis.cit.tum.de}")
     private String relayServerBaseUrl;
 
     public FirebasePushNotificationService(PushNotificationDeviceConfigurationRepository pushNotificationDeviceConfigurationRepository, RestTemplate restTemplate) {

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -129,7 +129,7 @@ theia:
             C: "c-latest"
 
 artemis:
-    push-notification-relay: https://hermes-sandbox.artemis.cit.tum.de
+    push-notification-relay: https://hermes-staging.artemis.cit.tum.de
     # Telemetry service: disabled for development
     telemetry:
         enabled: false # Disable sending any telemetry information to the telemetry service by setting this to false

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -14,7 +14,7 @@
 # ===================================================================
 
 artemis:
-    push-notification-relay: https://hermes.artemis.cit.tum.de
+    push-notification-relay: https://hermes-prod.artemis.cit.tum.de
     # Artemis sends the artemis version, the university name, the universities main admin contact, (email + name), the server url,
     # and used profiles (localVC, ...) to a telemetry collection service.
     telemetry:

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -50,7 +50,7 @@ artemis:
 
     # activate the following line if you want to support push notifications for the mobile clients.
     # More information about the TUM hosted hermes service can be found here: https://github.com/ls1intum/Hermes
-    # push-notification-relay: https://hermes.artemis.cit.tum.de
+    # push-notification-relay: https://hermes-prod.artemis.cit.tum.de
 
     continuous-integration:
         # Defines the used docker images for certain programming languages.

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -29,7 +29,7 @@ artemis:
         release: "D2:E1:A6:6F:8C:00:55:97:9F:30:2F:3D:79:A9:5D:78:85:1F:C5:21:5A:7F:81:B3:BF:60:22:71:EF:6F:60:24"
         debug: "7F:CB:99:74:19:30:15:4B:86:4B:8A:73:B0:09:94:52:19:F6:BD:90:6A:7C:16:B1:76:37:AF:74:B1:48:3B:6C"
 
-    push-notification-relay: https://hermes-sandbox.artemis.cit.tum.de
+    push-notification-relay: https://hermes-staging.artemis.cit.tum.de
     sharing:
         enabled: true
         # the shared common secret (overwritten in tests)


### PR DESCRIPTION
### Summary
Update Hermes push notification relay URLs across all environments to reflect the new VM hostnames after migrating to Ubuntu 24.04.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).

### Motivation and Context
The Hermes push notification relay VMs were migrated to Ubuntu 24.04, resulting in new hostnames:
- `hermes-sandbox.artemis.cit.tum.de` → `hermes-staging.artemis.cit.tum.de`
- `hermes.artemis.cit.tum.de` → `hermes-prod.artemis.cit.tum.de`

See https://github.com/ls1intum/artemis-ansible/pull/67

### Description
Updates the Hermes relay URLs in:
- Default values in `@Value` annotations (`HermesHealthIndicator`, `ApplePushNotificationService`, `FirebasePushNotificationService`)
- Application config files (`application.yml`, `application-dev.yml`, `application-prod.yml`)
- Test config (`src/test/resources/config/application.yml`)
- Documentation (`notifications.mdx`)

### Steps for Testing
Prerequisites:
- 1 User with a mobile device (iOS or Android) with push notifications enabled

1. Deploy to a test server
2. Verify the health endpoint reports Hermes as UP
3. Trigger a notification (e.g., post in a channel) and verify push notification is received on the mobile device

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated push notification relay server endpoint reference.

* **Chores**
  * Updated default push notification relay server configuration endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->