### PR TITLE
`Iris`: Default course page skips Iris when user opted out of AI

### DIFF
--- a/src/main/webapp/app/core/course/overview/course-overview/course-overview-guard.spec.ts
+++ b/src/main/webapp/app/core/course/overview/course-overview/course-overview-guard.spec.ts
@@ -286,5 +286,34 @@ describe('CourseOverviewGuard', () => {
 
             expect(navigateSpy).toHaveBeenCalledWith(['/courses/1/iris']);
         });
+
+        it('should not abort the guard stream when identity() rejects; treat unknown user as not opted out', async () => {
+            mockCourse.studentCourseAnalyticsDashboardEnabled = false;
+            mockCourse.irisEnabledInCourse = true;
+            const route = { parent: { paramMap: { get: () => '1' } }, routeConfig: { path: CourseOverviewRoutePath.DASHBOARD } } as unknown as ActivatedRouteSnapshot;
+            vi.spyOn(courseStorageService, 'getCourse').mockReturnValue(mockCourse);
+            vi.spyOn(courseManagementService, 'findOneForDashboard').mockReturnValue(of(responseFakeCourse));
+            vi.spyOn(accountService, 'identity').mockRejectedValue(new Error('network error'));
+            const navigateSpy = vi.spyOn(router, 'navigate');
+
+            let resultValue: boolean | undefined;
+            let errored = false;
+            await new Promise<void>((resolve) => {
+                guard.canActivate(route).subscribe({
+                    next: (value) => {
+                        resultValue = value;
+                    },
+                    error: () => {
+                        errored = true;
+                        resolve();
+                    },
+                    complete: () => resolve(),
+                });
+            });
+
+            expect(errored).toBe(false);
+            expect(resultValue).toBe(false);
+            expect(navigateSpy).toHaveBeenCalledWith(['/courses/1/iris']);
+        });
     });
 });

--- a/src/main/webapp/app/core/course/overview/course-overview/course-overview-guard.spec.ts
+++ b/src/main/webapp/app/core/course/overview/course-overview/course-overview-guard.spec.ts
@@ -16,6 +16,8 @@ import { MockProvider } from 'ng-mocks';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from 'test/helpers/mocks/service/mock-account.service';
 import { AlertService } from 'app/shared/service/alert.service';
+import { LLMSelectionDecision } from 'app/core/user/shared/dto/updateLLMSelectionDecision.dto';
+import { User } from 'app/core/user/user.model';
 
 describe('CourseOverviewGuard', () => {
     setupTestBed({ zoneless: true });
@@ -23,6 +25,7 @@ describe('CourseOverviewGuard', () => {
     let guard: CourseOverviewGuard;
     let courseStorageService: CourseStorageService;
     let courseManagementService: CourseManagementService;
+    let accountService: AccountService;
     let router: Router;
 
     const visibleRealExam = {
@@ -45,6 +48,7 @@ describe('CourseOverviewGuard', () => {
         guard = TestBed.inject(CourseOverviewGuard);
         courseStorageService = TestBed.inject(CourseStorageService);
         courseManagementService = TestBed.inject(CourseManagementService);
+        accountService = TestBed.inject(AccountService);
         router = TestBed.inject(Router);
         vi.spyOn(router, 'navigate').mockReturnValue(Promise.resolve(true));
     });
@@ -202,6 +206,34 @@ describe('CourseOverviewGuard', () => {
             expect(navigateSpy).toHaveBeenCalledWith(['/courses/1/iris']);
         });
 
+        it('should redirect to iris when dashboard is denied, iris is enabled, and the user accepted cloud AI', () => {
+            mockCourse.studentCourseAnalyticsDashboardEnabled = false;
+            mockCourse.irisEnabledInCourse = true;
+            const navigateSpy = vi.spyOn(router, 'navigate');
+            guard.handleReturn(mockCourse, CourseOverviewRoutePath.DASHBOARD, { selectedLLMUsage: LLMSelectionDecision.CLOUD_AI } as User);
+            expect(navigateSpy).toHaveBeenCalledWith(['/courses/1/iris']);
+        });
+
+        it('should redirect to exercises when dashboard is denied, iris is enabled, but the user opted out of AI', () => {
+            mockCourse.studentCourseAnalyticsDashboardEnabled = false;
+            mockCourse.irisEnabledInCourse = true;
+            const navigateSpy = vi.spyOn(router, 'navigate');
+            guard.handleReturn(mockCourse, CourseOverviewRoutePath.DASHBOARD, { selectedLLMUsage: LLMSelectionDecision.NO_AI } as User);
+            expect(navigateSpy).toHaveBeenCalledWith(['/courses/1/exercises']);
+        });
+
+        it('should still grant dashboard access to a user who opted out of AI when the dashboard is enabled', () => {
+            mockCourse.studentCourseAnalyticsDashboardEnabled = true;
+            mockCourse.irisEnabledInCourse = true;
+            const navigateSpy = vi.spyOn(router, 'navigate');
+            let resultValue = false;
+            guard.handleReturn(mockCourse, CourseOverviewRoutePath.DASHBOARD, { selectedLLMUsage: LLMSelectionDecision.NO_AI } as User).subscribe((value) => {
+                resultValue = value;
+            });
+            expect(resultValue).toBe(true);
+            expect(navigateSpy).not.toHaveBeenCalled();
+        });
+
         it('should redirect to exercises when dashboard is denied and iris is not enabled', () => {
             mockCourse.studentCourseAnalyticsDashboardEnabled = false;
             mockCourse.irisEnabledInCourse = false;
@@ -214,6 +246,45 @@ describe('CourseOverviewGuard', () => {
             const navigateSpy = vi.spyOn(router, 'navigate');
             guard.handleReturn(mockCourse, 'unknown');
             expect(navigateSpy).toHaveBeenCalledWith(['/courses/1/exercises']);
+        });
+    });
+
+    describe('canActivate for dashboard path', () => {
+        it('should resolve user identity and redirect opted-out users to exercises on cold start', async () => {
+            mockCourse.studentCourseAnalyticsDashboardEnabled = false;
+            mockCourse.irisEnabledInCourse = true;
+            const route = { parent: { paramMap: { get: () => '1' } }, routeConfig: { path: CourseOverviewRoutePath.DASHBOARD } } as unknown as ActivatedRouteSnapshot;
+            vi.spyOn(courseStorageService, 'getCourse').mockReturnValue(mockCourse);
+            vi.spyOn(courseManagementService, 'findOneForDashboard').mockReturnValue(of(responseFakeCourse));
+            vi.spyOn(accountService, 'identity').mockResolvedValue({ selectedLLMUsage: LLMSelectionDecision.NO_AI } as User);
+            const navigateSpy = vi.spyOn(router, 'navigate');
+
+            let resultValue: boolean | undefined;
+            await new Promise<void>((resolve) => {
+                guard.canActivate(route).subscribe((value) => {
+                    resultValue = value;
+                    resolve();
+                });
+            });
+
+            expect(resultValue).toBe(false);
+            expect(navigateSpy).toHaveBeenCalledWith(['/courses/1/exercises']);
+        });
+
+        it('should redirect to iris for a non-opted-out user even when identity is only resolved asynchronously', async () => {
+            mockCourse.studentCourseAnalyticsDashboardEnabled = false;
+            mockCourse.irisEnabledInCourse = true;
+            const route = { parent: { paramMap: { get: () => '1' } }, routeConfig: { path: CourseOverviewRoutePath.DASHBOARD } } as unknown as ActivatedRouteSnapshot;
+            vi.spyOn(courseStorageService, 'getCourse').mockReturnValue(mockCourse);
+            vi.spyOn(courseManagementService, 'findOneForDashboard').mockReturnValue(of(responseFakeCourse));
+            vi.spyOn(accountService, 'identity').mockResolvedValue({ selectedLLMUsage: LLMSelectionDecision.CLOUD_AI } as User);
+            const navigateSpy = vi.spyOn(router, 'navigate');
+
+            await new Promise<void>((resolve) => {
+                guard.canActivate(route).subscribe(() => resolve());
+            });
+
+            expect(navigateSpy).toHaveBeenCalledWith(['/courses/1/iris']);
         });
     });
 });

--- a/src/main/webapp/app/core/course/overview/course-overview/course-overview-guard.ts
+++ b/src/main/webapp/app/core/course/overview/course-overview/course-overview-guard.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
-import { Observable, forkJoin, from, of, switchMap } from 'rxjs';
+import { Observable, catchError, forkJoin, from, of, switchMap } from 'rxjs';
 import { CourseStorageService } from 'app/core/course/manage/services/course-storage.service';
 import { CourseManagementService } from 'app/core/course/manage/services/course-management.service';
 import { Course, isCommunicationEnabled } from 'app/core/course/shared/entities/course.model';
@@ -37,7 +37,9 @@ export class CourseOverviewGuard implements CanActivate {
             return of(false);
         }
         // Resolving the current user is only needed for the dashboard fallback; other paths don't depend on it.
-        const user$: Observable<User | undefined> = path === CourseOverviewRoutePath.DASHBOARD ? from(this.accountService.identity()) : of(undefined);
+        // If identity() rejects (e.g. transient network error), treat it as unknown — this falls back to today's Iris-or-exercises behavior.
+        const user$: Observable<User | undefined> =
+            path === CourseOverviewRoutePath.DASHBOARD ? from(this.accountService.identity()).pipe(catchError(() => of(undefined))) : of(undefined);
         //we need to load the course from the server to check if the user has access to the requested route. The course in the cache might not be sufficient (e.g. misses exams or lectures)
         return forkJoin({
             courseRes: this.courseManagementService.findOneForDashboard(courseIdNumber),

--- a/src/main/webapp/app/core/course/overview/course-overview/course-overview-guard.ts
+++ b/src/main/webapp/app/core/course/overview/course-overview/course-overview-guard.ts
@@ -1,12 +1,15 @@
 import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
-import { Observable, of, switchMap } from 'rxjs';
+import { Observable, forkJoin, from, of, switchMap } from 'rxjs';
 import { CourseStorageService } from 'app/core/course/manage/services/course-storage.service';
 import { CourseManagementService } from 'app/core/course/manage/services/course-management.service';
 import { Course, isCommunicationEnabled } from 'app/core/course/shared/entities/course.model';
 import dayjs from 'dayjs/esm';
 import { ArtemisServerDateService } from 'app/shared/service/server-date.service';
 import { CourseOverviewRoutePath } from 'app/core/course/overview/courses.route';
+import { AccountService } from 'app/core/auth/account.service';
+import { User } from 'app/core/user/user.model';
+import { LLMSelectionDecision } from 'app/core/user/shared/dto/updateLLMSelectionDecision.dto';
 
 @Injectable({
     providedIn: 'root',
@@ -14,6 +17,7 @@ import { CourseOverviewRoutePath } from 'app/core/course/overview/courses.route'
 export class CourseOverviewGuard implements CanActivate {
     private courseStorageService = inject(CourseStorageService);
     private courseManagementService = inject(CourseManagementService);
+    private accountService = inject(AccountService);
     private router = inject(Router);
     private serverDateService = inject(ArtemisServerDateService);
 
@@ -32,20 +36,25 @@ export class CourseOverviewGuard implements CanActivate {
         if (!path) {
             return of(false);
         }
+        // Resolving the current user is only needed for the dashboard fallback; other paths don't depend on it.
+        const user$: Observable<User | undefined> = path === CourseOverviewRoutePath.DASHBOARD ? from(this.accountService.identity()) : of(undefined);
         //we need to load the course from the server to check if the user has access to the requested route. The course in the cache might not be sufficient (e.g. misses exams or lectures)
-        return this.courseManagementService.findOneForDashboard(courseIdNumber).pipe(
-            switchMap((res) => {
-                if (res.body) {
+        return forkJoin({
+            courseRes: this.courseManagementService.findOneForDashboard(courseIdNumber),
+            user: user$,
+        }).pipe(
+            switchMap(({ courseRes, user }) => {
+                if (courseRes.body) {
                     // Store course in cache
-                    this.courseStorageService.updateCourse(res.body);
+                    this.courseStorageService.updateCourse(courseRes.body);
                 }
                 // Flatten the result to return Observable<boolean> directly
-                return this.handleReturn(this.courseStorageService.getCourse(courseIdNumber), path);
+                return this.handleReturn(this.courseStorageService.getCourse(courseIdNumber), path, user);
             }),
         );
     }
 
-    handleReturn = (course?: Course, type?: string): Observable<boolean> => {
+    handleReturn = (course?: Course, type?: string, user?: User): Observable<boolean> => {
         let hasAccess: boolean;
         switch (type) {
             // Should always be accessible
@@ -87,7 +96,8 @@ export class CourseOverviewGuard implements CanActivate {
                 hasAccess = false;
         }
         if (!hasAccess) {
-            if (type === CourseOverviewRoutePath.DASHBOARD && course?.irisEnabledInCourse) {
+            const hasOptedOutOfAI = user?.selectedLLMUsage === LLMSelectionDecision.NO_AI;
+            if (type === CourseOverviewRoutePath.DASHBOARD && course?.irisEnabledInCourse && !hasOptedOutOfAI) {
                 this.router.navigate([`/courses/${course?.id}/iris`]);
             } else {
                 this.router.navigate([`/courses/${course?.id}/exercises`]);

--- a/src/main/webapp/app/iris/overview/course-iris/course-iris.component.spec.ts
+++ b/src/main/webapp/app/iris/overview/course-iris/course-iris.component.spec.ts
@@ -2,10 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { Component, input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { CourseIrisComponent } from './course-iris.component';
 import { CourseChatbotComponent } from 'app/iris/overview/course-chatbot/course-chatbot.component';
+import { IrisChatService } from 'app/iris/overview/services/iris-chat.service';
+import { MockProvider } from 'ng-mocks';
 
 @Component({
     selector: 'jhi-course-chatbot',
@@ -24,9 +26,12 @@ describe('CourseIrisComponent', () => {
     let component: CourseIrisComponent;
     let fixture: ComponentFixture<CourseIrisComponent>;
     let paramMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+    let llmOptedOutSubject: Subject<void>;
+    let router: Router;
 
     beforeEach(async () => {
         paramMapSubject = new BehaviorSubject(convertToParamMap({ courseId: '123' }));
+        llmOptedOutSubject = new Subject<void>();
 
         await TestBed.configureTestingModule({
             imports: [CourseIrisComponent],
@@ -39,6 +44,9 @@ describe('CourseIrisComponent', () => {
                         },
                     },
                 },
+                MockProvider(IrisChatService, {
+                    llmOptedOut$: llmOptedOutSubject.asObservable(),
+                }),
             ],
         })
             .overrideComponent(CourseIrisComponent, {
@@ -49,6 +57,8 @@ describe('CourseIrisComponent', () => {
 
         fixture = TestBed.createComponent(CourseIrisComponent);
         component = fixture.componentInstance;
+        router = TestBed.inject(Router);
+        vi.spyOn(router, 'navigate').mockResolvedValue(true);
         fixture.detectChanges();
     });
 
@@ -89,5 +99,31 @@ describe('CourseIrisComponent', () => {
 
     it('should initialize isCollapsed to false', () => {
         expect(component.isCollapsed).toBe(false);
+    });
+
+    it('should navigate to exercises when the user opts out of AI via the chat service', async () => {
+        await fixture.whenStable();
+
+        llmOptedOutSubject.next();
+
+        expect(router.navigate).toHaveBeenCalledWith(['/courses', 123, 'exercises']);
+    });
+
+    it('should not navigate if the course id is not resolved yet when the opt-out event fires', async () => {
+        paramMapSubject.next(convertToParamMap({}));
+        await fixture.whenStable();
+
+        llmOptedOutSubject.next();
+
+        expect(router.navigate).not.toHaveBeenCalled();
+    });
+
+    it('should not navigate on opt-out after the component is destroyed', async () => {
+        await fixture.whenStable();
+        fixture.destroy();
+
+        llmOptedOutSubject.next();
+
+        expect(router.navigate).not.toHaveBeenCalled();
     });
 });

--- a/src/main/webapp/app/iris/overview/course-iris/course-iris.component.ts
+++ b/src/main/webapp/app/iris/overview/course-iris/course-iris.component.ts
@@ -1,9 +1,12 @@
-import { ChangeDetectionStrategy, Component, computed, inject, viewChild } from '@angular/core';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ChangeDetectionStrategy, Component, DestroyRef, computed, inject, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { map } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { CourseChatbotComponent } from 'app/iris/overview/course-chatbot/course-chatbot.component';
+import { IrisChatService } from 'app/iris/overview/services/iris-chat.service';
+import { CourseOverviewRoutePath } from 'app/core/course/overview/courses.route';
 
 @Component({
     selector: 'jhi-course-iris',
@@ -14,6 +17,9 @@ import { CourseChatbotComponent } from 'app/iris/overview/course-chatbot/course-
 })
 export class CourseIrisComponent {
     private readonly route = inject(ActivatedRoute);
+    private readonly router = inject(Router);
+    private readonly irisChatService = inject(IrisChatService);
+    private readonly destroyRef = inject(DestroyRef);
     private readonly courseChatbot = viewChild('courseChatbot', { read: CourseChatbotComponent });
 
     private readonly courseIdParam = toSignal((this.route.parent?.paramMap ?? of(convertToParamMap({}))).pipe(map((params) => params.get('courseId') ?? undefined)), {
@@ -30,6 +36,17 @@ export class CourseIrisComponent {
     });
 
     isCollapsed = false;
+
+    constructor() {
+        // When the user opts out of AI from the chat's LLM selection modal while on this page,
+        // the Iris course page is no longer useful — send them to the exercises page.
+        this.irisChatService.llmOptedOut$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+            const id = this.courseId();
+            if (id !== undefined) {
+                this.router.navigate(['/courses', id, CourseOverviewRoutePath.EXERCISES]);
+            }
+        });
+    }
 
     toggleSidebar(): void {
         this.courseChatbot()?.toggleChatHistory();

--- a/src/main/webapp/app/iris/overview/services/iris-chat.service.spec.ts
+++ b/src/main/webapp/app/iris/overview/services/iris-chat.service.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { TestBed } from '@angular/core/testing';
-import { Observable, filter, firstValueFrom, of, throwError } from 'rxjs';
+import { Observable, Subject, filter, firstValueFrom, of, throwError } from 'rxjs';
 import { ChatServiceMode, IrisChatService } from 'app/iris/overview/services/iris-chat.service';
 import { IrisChatHttpService } from 'app/iris/overview/services/iris-chat-http.service';
 import { IrisWebsocketService } from 'app/iris/overview/services/iris-websocket.service';
@@ -55,6 +55,7 @@ describe('IrisChatService', () => {
     };
     const userMock = {
         acceptExternalLLMUsage: vi.fn(),
+        updateLLMSelectionDecision: vi.fn().mockReturnValue(of(new HttpResponse<void>())),
     };
 
     const waitForSessionId = () => firstValueFrom(service.currentSessionId().pipe(filter((value): value is number => value !== undefined)));
@@ -558,6 +559,56 @@ describe('IrisChatService', () => {
             const courseId = service.getCourseId();
 
             expect(courseId).toBeUndefined();
+        });
+    });
+
+    describe('updateLLMUsageConsent', () => {
+        beforeEach(() => {
+            userMock.updateLLMSelectionDecision.mockReset();
+            userMock.updateLLMSelectionDecision.mockReturnValue(of(new HttpResponse<void>()));
+        });
+
+        it('should emit llmOptedOut$ once after NO_AI is persisted successfully', () => {
+            let emissions = 0;
+            service.llmOptedOut$.subscribe(() => emissions++);
+
+            service.updateLLMUsageConsent(LLMSelectionDecision.NO_AI);
+
+            expect(emissions).toBe(1);
+        });
+
+        it('should not emit llmOptedOut$ when NO_AI persistence fails', () => {
+            userMock.updateLLMSelectionDecision.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
+            let emissions = 0;
+            service.llmOptedOut$.subscribe(() => emissions++);
+
+            service.updateLLMUsageConsent(LLMSelectionDecision.NO_AI);
+
+            expect(emissions).toBe(0);
+        });
+
+        it('should not emit llmOptedOut$ when the user accepts cloud AI', () => {
+            let emissions = 0;
+            service.llmOptedOut$.subscribe(() => emissions++);
+
+            service.updateLLMUsageConsent(LLMSelectionDecision.CLOUD_AI);
+
+            expect(emissions).toBe(0);
+        });
+
+        it('should cancel an in-flight NO_AI request when a second NO_AI call starts, emitting only once', () => {
+            const inFlight = new Subject<HttpResponse<void>>();
+            userMock.updateLLMSelectionDecision.mockReturnValueOnce(inFlight.asObservable()).mockReturnValueOnce(of(new HttpResponse<void>()));
+            let emissions = 0;
+            service.llmOptedOut$.subscribe(() => emissions++);
+
+            service.updateLLMUsageConsent(LLMSelectionDecision.NO_AI);
+            service.updateLLMUsageConsent(LLMSelectionDecision.NO_AI);
+            // The first request completes after the second was started; its subscription must have been cancelled.
+            inFlight.next(new HttpResponse<void>());
+            inFlight.complete();
+
+            expect(emissions).toBe(1);
         });
     });
 });

--- a/src/main/webapp/app/iris/overview/services/iris-chat.service.ts
+++ b/src/main/webapp/app/iris/overview/services/iris-chat.service.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { IrisErrorMessageKey } from 'app/iris/shared/entities/iris-errors.model';
 import { IrisAssistantMessage, IrisMessage, IrisSender, IrisUserMessage } from 'app/iris/shared/entities/iris-message.model';
 import { IrisMessageResponseDTO } from 'app/iris/shared/entities/iris-message-response-dto.model';
-import { BehaviorSubject, Observable, Subscription, catchError, map, of, tap, throwError } from 'rxjs';
+import { BehaviorSubject, Observable, Subject, Subscription, catchError, map, of, tap, throwError } from 'rxjs';
 import { IrisChatHttpService } from 'app/iris/overview/services/iris-chat-http.service';
 import { IrisExerciseChatSession } from 'app/iris/shared/entities/iris-exercise-chat-session.model';
 import { IrisStageDTO } from 'app/iris/shared/entities/iris-stage-dto.model';
@@ -104,6 +104,9 @@ export class IrisChatService implements OnDestroy {
 
     private shouldReopenChatSubject = new BehaviorSubject<boolean>(false);
     public shouldReopenChat$ = this.shouldReopenChatSubject.asObservable();
+
+    private llmOptedOutSubject = new Subject<void>();
+    public llmOptedOut$ = this.llmOptedOutSubject.asObservable();
 
     hasJustAcceptedLLMUsage = false;
 
@@ -301,9 +304,10 @@ export class IrisChatService implements OnDestroy {
         if (accepted === LLMSelectionDecision.NO_AI) {
             this.hasJustAcceptedLLMUsage = false;
             this.acceptSubscription?.unsubscribe();
-            this.userService.updateLLMSelectionDecision(accepted).subscribe({
+            this.acceptSubscription = this.userService.updateLLMSelectionDecision(accepted).subscribe({
                 next: () => {
                     this.accountService.setUserLLMSelectionDecision(accepted);
+                    this.llmOptedOutSubject.next();
                     this.close();
                 },
                 error: () => {


### PR DESCRIPTION
### Summary
When the student analytics dashboard is disabled for a course, Artemis previously redirected students to the Iris chat page whenever Iris was enabled in the course, regardless of the user's AI usage decision. A user who explicitly opted out of AI (`selectedLLMUsage === NO_AI`) is now routed to the exercises page instead. Additionally, if a user picks "No AI" in the LLM selection modal while already on the course Iris page, they are navigated away to the exercises page.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
Users who declined AI usage for themselves were still landed on the Iris chat page as the default course page. The Iris chat is not useful to these users — it forces the consent modal to appear again. This change respects the user's AI opt-out in the default-landing-page logic.

### Description
- **`CourseOverviewGuard`**: For the `dashboard` path, the guard now resolves `AccountService.identity()` in parallel with `findOneForDashboard()` via `forkJoin`. When the dashboard access check fails and the user has `selectedLLMUsage === NO_AI`, the Iris fallback is skipped and the user is redirected to the exercises page. Non-dashboard routes keep their previous behavior and do not trigger an extra identity request.
- **`IrisChatService`**: Added a new `llmOptedOut$: Observable<void>` that emits once from the `NO_AI` success branch of `updateLLMUsageConsent`. The subscription is now tracked in `acceptSubscription` to avoid overlapping requests leaking state.
- **`CourseIrisComponent`**: Subscribes to `llmOptedOut$` with `takeUntilDestroyed` and, on emission, navigates to `/courses/:id/exercises` when a course id is available.

### Behavior summary after the change
| Dashboard | Iris in course | User AI state | Landing page |
|---|---|---|---|
| enabled | — | — | dashboard |
| disabled | enabled | not `NO_AI` | iris |
| disabled | enabled | `NO_AI` | **exercises** (new) |
| disabled | disabled | — | exercises |

Additionally: on `/courses/:id/iris`, selecting `NO_AI` in the modal → navigates to exercises.

### Steps for Testing
Prerequisites:
- 1 Student account
- 1 Course with the Student Analytics Dashboard disabled (`studentCourseAnalyticsDashboardEnabled = false`) and Iris enabled in the course
- Either: the student has a persisted `NO_AI` decision (set via the LLM usage settings page) or a fresh student who has not yet picked an LLM option

1. Log in as the student.
2. Navigate to `/courses/<courseId>`.
3. Expected (opted-out user): you land on the exercises page, not Iris.
4. Expected (user without a decision yet): you still land on the Iris page as before; accepting cloud or local AI keeps you there; picking `No AI` navigates you to the exercises page.
5. Navigate directly to `/courses/<courseId>/iris` as a logged-in student who has not yet made an LLM choice. In the modal, pick `No AI`. Expected: you are navigated to the exercises page.
6. Enable the student analytics dashboard for the course and repeat step 2 with a `NO_AI` user. Expected: the dashboard is shown as before (no regression).

#### Exam Mode Testing
Not applicable — this PR does not touch exam-mode components or routes.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| course-overview-guard.ts | 90.74% | 106 | 27 | 25.5 |
| course-iris.component.ts | 100.00% | 47 | 11 | 23.4 |
| iris-chat.service.ts | 86.04% | 588 | 62 | 10.5 |

_Last updated: 2026-04-17 17:30:29 UTC_


### Screenshots
Not applicable — no UI changes; only navigation logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opting out of AI triggers immediate navigation away from AI chat to the course exercises when applicable.
  * Dashboard access now considers user AI choice to determine whether users are sent to Iris or Exercises.

* **Bug Fixes**
  * Routing now consistently respects user AI opt-in/opt-out, preventing access to AI areas when opted out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->