### PR TITLE
`Development`: Bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,12 @@ gitProperties {
     }
 }
 
+// Override Spring Boot BOM versions to patched releases addressing known CVEs
+// thymeleaf 3.1.4.RELEASE: GHSA-7rgv-g3jm-rvv4, GHSA-vjp2-6m4m-cv5q
+// tomcat 11.0.21: GHSA-h9fx-5mv3-gmh6, GHSA-6q54-28g2-vpgm, GHSA-55j7-cm8x-wvmh
+ext["thymeleaf.version"] = "3.1.4.RELEASE"
+ext["tomcat.version"] = "11.0.21"
+
 configurations {
     mockitoAgent
 }
@@ -430,9 +436,11 @@ dependencies {
     runtimeOnly "io.jsonwebtoken:jjwt-impl:${jwt_version}"
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jwt_version}"
 
-    // required by sshd-git
-    implementation "org.bouncycastle:bcpkix-jdk18on:1.83"
-    implementation "org.bouncycastle:bcprov-jdk18on:1.83"
+    // required by sshd-git; 1.84 fixes GHSA-4jwv-qpf8-5w8v, GHSA-6w4m-2xhg-2658, GHSA-fwcp-hj66-p6g3
+    implementation "org.bouncycastle:bcpkix-jdk18on:1.84"
+    implementation "org.bouncycastle:bcprov-jdk18on:1.84"
+    // pulled transitively by sshd-git; pin to patched version
+    implementation "org.bouncycastle:bcpg-jdk18on:1.84"
 
     // required for database connections
     implementation "com.mysql:mysql-connector-j:${mysql_connector_version}"

--- a/documentation/package-lock.json
+++ b/documentation/package-lock.json
@@ -9951,9 +9951,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -45,6 +45,7 @@
         "typescript": "6.0.2"
     },
     "overrides": {
+        "follow-redirects": "1.16.0",
         "js-yaml": "4.1.1",
         "minimatch": "10.2.4",
         "qs": "6.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15272,9 +15272,9 @@
             "license": "MIT"
         },
         "node_modules/hono": {
-            "version": "4.12.12",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-            "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+            "version": "4.12.14",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+            "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
         "esbuild": "0.28.0",
         "express": "5.2.1",
         "globals": "17.4.0",
-        "hono": "4.12.12",
+        "hono": "4.12.14",
         "@hono/node-server": "1.19.13",
         "js-yaml": "4.1.1",
         "jsdom": "29.0.2",


### PR DESCRIPTION
### Summary
Routine dependency maintenance: bumps several runtime and tooling dependencies to their latest compatible patch releases. No functional behaviour changes.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
Keeping third-party dependencies current with upstream patch releases.

### Description
- Bump Bouncy Castle `bcpkix-jdk18on` and `bcprov-jdk18on` from 1.83 → 1.84, and pin the transitive `bcpg-jdk18on` (pulled via `sshd-git`) to 1.84 for consistency.
- Override the Spring Boot BOM to pin Thymeleaf to 3.1.4.RELEASE via `ext["thymeleaf.version"]`.
- Override the Spring Boot BOM to pin Tomcat embed to 11.0.21 via `ext["tomcat.version"]`.
- Bump `hono` 4.12.12 → 4.12.14 in the root `overrides`.
- Add `follow-redirects` 1.16.0 to `documentation/package.json` overrides.

Resolved versions were verified via `./gradlew dependencyInsight` and `./gradlew compileJava -x webapp` (compiles cleanly).

### Steps for Testing
Prerequisites: Docker running, local dev environment.

1. Pull the branch and run `./gradlew bootRun -x webapp` — application starts cleanly.
2. Run `npm install` — lockfile installs without warnings/errors.
3. Smoke test a login flow (Thymeleaf email templates) and a git-based programming exercise (Bouncy Castle via sshd-git).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration dependencies and framework versions (Thymeleaf 3.1.4.RELEASE and Tomcat 11.0.21) across the build process.
  * Updated security-related library module versions to 1.84.
  * Updated npm package dependencies including Hono (4.12.14), Follow-Redirects (1.16.0), and related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->