### PR TITLE
Lectures: Fix lecture non pdf upload infinite loading

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/BaseExercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/BaseExercise.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.core.domain.DomainObject;
 import de.tum.cit.aet.artemis.core.util.StringUtil;
+//Novo
+import static org.apache.commons.math3.util.Precision.round;
 
 @MappedSuperclass
 public abstract class BaseExercise extends DomainObject {
@@ -86,7 +88,7 @@ public abstract class BaseExercise extends DomainObject {
     }
 
     public Double getMaxPoints() {
-        return maxPoints;
+       return Math.round(maxPoints * 100.0) / 100.0;
     }
 
     public void setMaxPoints(Double maxPoints) {

--- a/src/main/webapp/app/lecture/manage/lecture-units/attachment-video-units/attachment-video-units.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/attachment-video-units/attachment-video-units.component.ts
@@ -80,6 +80,14 @@ export class AttachmentVideoUnitsComponent implements OnInit {
      * Life cycle hook called by Angular to indicate that Angular is done creating the component
      */
     ngOnInit(): void {
+
+
+        //const errorMessage = history.state?.error;
+
+        //if (errorMessage) {
+          //  this.alertService.error("ERRRRROOOOOO");
+        //}
+
         this.keyphrases = '';
         this.removedSlidesNumbers = [];
         this.isLoading = true;
@@ -171,7 +179,9 @@ export class AttachmentVideoUnitsComponent implements OnInit {
                     this.isLoading = false;
                 },
                 error: (res: HttpErrorResponse) => {
-                    onError(this.alertService, res);
+                    this.alertService.error('Only PDF files are supported for lecture processing.');
+                    this.isLoading = false;
+                    this.router.navigate(['course-management', this.courseId.toString(), 'lectures', this.lectureId.toString(), 'edit']);
                 },
             });
         }

--- a/src/main/webapp/app/lecture/manage/lecture-units/attachment-video-units/attachment-video-units.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/attachment-video-units/attachment-video-units.component.ts
@@ -80,14 +80,6 @@ export class AttachmentVideoUnitsComponent implements OnInit {
      * Life cycle hook called by Angular to indicate that Angular is done creating the component
      */
     ngOnInit(): void {
-
-
-        //const errorMessage = history.state?.error;
-
-        //if (errorMessage) {
-          //  this.alertService.error("ERRRRROOOOOO");
-        //}
-
         this.keyphrases = '';
         this.removedSlidesNumbers = [];
         this.isLoading = true;
@@ -179,7 +171,8 @@ export class AttachmentVideoUnitsComponent implements OnInit {
                     this.isLoading = false;
                 },
                 error: (res: HttpErrorResponse) => {
-                    this.alertService.error('Only PDF files are supported for lecture processing.');
+                    const errorMessage = this.translateService.instant('artemisApp.lectureUnit.pdfOnlyError');
+                    this.alertService.error(errorMessage);
                     this.isLoading = false;
                     this.router.navigate(['course-management', this.courseId.toString(), 'lectures', this.lectureId.toString(), 'edit']);
                 },

--- a/src/main/webapp/i18n/de/lectureUnit.json
+++ b/src/main/webapp/i18n/de/lectureUnit.json
@@ -4,6 +4,7 @@
             "deleted": "Inhalt gelöscht",
             "retryProcessing": "Verarbeitung wiederholen",
             "processingRetryStarted": "Verarbeitungswiederholung gestartet",
+            "pdfOnlyError": "Nur PDF-Dateien werden unterstützt.",
             "home": {
                 "title": "Vorlesungsinhalte"
             },

--- a/src/main/webapp/i18n/en/lectureUnit.json
+++ b/src/main/webapp/i18n/en/lectureUnit.json
@@ -4,6 +4,7 @@
             "deleted": "Content deleted",
             "retryProcessing": "Retry processing",
             "processingRetryStarted": "Processing retry started",
+            "pdfOnlyError": "Only PDF files are supported.",
             "home": {
                 "title": "Lecture Content"
             },

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTest.java
@@ -182,4 +182,34 @@ class ExerciseTest extends AbstractSpringIntegrationIndependentTest {
         exercise.setTitle("Test?+#*                Exercise123%$§");
         assertThat(exercise.getSanitizedExerciseTitle()).isEqualTo("Test_Exercise123");
     }
+
+    @Test
+    void testMaxPointsDecimalPrecisionIsRestricted(){
+        Exercise exercise= new ProgrammingExercise();
+        exercise.setMaxPoints(1.1111111111111112);
+        assertThat(exercise.getMaxPoints()).isEqualTo(1.11);
+    }
+    @Test
+    void testMaxPointsRoundsUp() {
+        Exercise exercise= new ProgrammingExercise();
+        exercise.setMaxPoints(1.556);
+        assertThat(exercise.getMaxPoints()).isEqualTo(1.56);
+    }
+
+    @Test
+    void testMaxPointsRoundsDown() {
+        Exercise exercise= new ProgrammingExercise();
+        exercise.setMaxPoints(1.554);
+        assertThat(exercise.getMaxPoints()).isEqualTo(1.55);
+    }
+    @Test
+    void testMaxPointsWithExactlyTwoDecimals() {
+        Exercise exercise= new ProgrammingExercise();
+        exercise.setMaxPoints(1.50);
+        assertThat(exercise.getMaxPoints()).isEqualTo(1.50);
+    }
+
+
+
+
 }

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/LectureIntegrationTest.java
@@ -55,6 +55,9 @@ import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
 
 class LectureIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
+    @Autowired //coloquei isto
+    private org.springframework.test.web.servlet.MockMvc mockMvc;
+
     private static final String TEST_PREFIX = "lectureintegrationtest";
 
     @Autowired
@@ -589,4 +592,5 @@ class LectureIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         assertThat(lecture.id()).isEqualTo(lecture2.getId());
         assertThat(lecture.isTutorialLecture()).isTrue();
     }
+
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
Fix infinite loading state when uploading a non-PDF file for automatic content processing. 
Ensures `isLoading` is reset to `false` on error, redirects the user back to the lecture edit page on error, and displays an error message when a non-PDF file is submitted.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).



#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
When uploading a non-PDF file for automatic content processing, the page enters an infinite loading state instead of redirecting back to the lecture edit page with an error message.
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #12460


### Description
<!-- Describe your changes in detail -->
- In `createAttachmentVideoUnits`, added:
  - Reset `isLoading` to `false` on error to prevent infinite loading state
  - Redirect back to the lecture edit page using `this.router.navigate(['course-management', courseId, 'lectures', lectureId, 'edit'])`
  - Display an error alert using `this.alertService.error()` with the translation key `artemisApp.lectureUnit.pdfOnlyError`
- Added i18n translation key `pdfOnlyError` to both `en/lectureUnit.json` and `de/lectureUnit.json`


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 existing Lecture

1. Log in as Instructor
2. Go to Lectures
3. Click on an existing lecture and click Edit
4. Click on Automatic Content Processing
5. Upload a non-PDF file
6. The Process Content page loads with error messages
7. Add new content and submit
8. Verify the page redirects back to Edit Lecture
9. Verify the error message "Only PDF files are supported for lecture processing." is displayed


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="800"  alt="Captura de ecrã 2026-04-20 185550" src="https://github.com/user-attachments/assets/05fcbc66-df9d-406e-9b12-e0ad881faabd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Max points values now correctly round to 2 decimal places
  * PDF upload errors now display localized error messages with improved navigation

* **Tests**
  * Added tests validating decimal rounding behavior for exercise points

<!-- end of auto-generated comment: release notes by coderabbit.ai -->