### PR TITLE
`Development`: Remove non strict read write cache on actively-mutated collections

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradingCriterion.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradingCriterion.java
@@ -29,9 +29,9 @@ import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class GradingCriterion extends DomainObject {
 
+    // No @Cache here on purpose: mutated while instructors edit grading criteria, same bug class as #12574 / #12584.
     @OneToMany(mappedBy = "gradingCriterion", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JsonIgnoreProperties(value = "gradingCriterion", allowSetters = true)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<GradingInstruction> structuredGradingInstructions = new HashSet<>();
 
     @ManyToOne

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradingInstruction.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradingInstruction.java
@@ -51,8 +51,9 @@ public class GradingInstruction extends DomainObject {
     @ManyToOne(fetch = FetchType.LAZY)
     private GradingCriterion gradingCriterion;
 
+    // No @Cache here on purpose: grows every time a tutor applies this grading instruction during manual assessment,
+    // same bug class as #12574 / #12584 on a clustered L2 cache.
     @OneToMany(mappedBy = "gradingInstruction", fetch = FetchType.LAZY)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties(value = "gradingInstruction", allowSetters = true)
     private Set<Feedback> feedbacks = new HashSet<>();
 

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradingScale.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradingScale.java
@@ -83,14 +83,13 @@ public class GradingScale extends DomainObject {
      * Current implementation works with one Bonus instance as GradingScale.bonusFrom per Bonus.bonusTo instance (OneToOne) but
      * the relation is defined as OneToMany in order to allow applying multiple bonuses.
      */
+    // No @Cache on the two child collections below: mutated during grading-scale edits, same bug class as #12574 / #12584.
     @OneToMany(mappedBy = "gradingScale", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JsonIgnoreProperties(value = "gradingScale", allowSetters = true)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<GradeStep> gradeSteps = new HashSet<>();
 
     @OneToMany(mappedBy = "bonusToGradingScale", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIgnoreProperties(value = "bonusFrom", allowSetters = true)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<Bonus> bonusFrom = new HashSet<>();
 
     public GradeType getGradeType() {

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Result.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Result.java
@@ -94,10 +94,10 @@ public class Result extends DomainObject implements Comparable<Result> {
     @JsonIgnoreProperties({ "results" })
     private Submission submission;
 
+    // No @Cache: actively mutated during manual assessment; NONSTRICT caused stale feedback lists across nodes, same class of bug as #12574.
     @OneToMany(mappedBy = "result", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderColumn
     @JsonIgnoreProperties(value = "result", allowSetters = true)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<Feedback> feedbacks = new ArrayList<>();
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/core/domain/Course.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/domain/Course.java
@@ -181,8 +181,9 @@ public class Course extends DomainObject {
     @Column(name = "time_zone")
     private String timeZone;
 
+    // No @Cache: instructors create / archive / edit exercises while every student's course-overview read hits this; NONSTRICT caused the dashboard to "forget"
+    // exercises on other nodes for a short window, same class of bug as #12574.
     @OneToMany(mappedBy = "course", fetch = FetchType.LAZY)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties("course")
     private Set<Exercise> exercises = new HashSet<>();
 
@@ -210,8 +211,8 @@ public class Course extends DomainObject {
     @OrderBy("title")
     private Set<TutorialGroup> tutorialGroups = new HashSet<>();
 
+    // No @Cache: exams are created / edited / archived by instructors while students see the course overview, same class of bug as #12574.
     @OneToMany(mappedBy = "course", fetch = FetchType.LAZY)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties("course")
     private Set<Exam> exams = new HashSet<>();
 

--- a/src/main/java/de/tum/cit/aet/artemis/core/domain/User.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/domain/User.java
@@ -173,8 +173,8 @@ public class User extends AbstractAuditingEntity implements Participant {
     @JsonIgnoreProperties(value = "user", allowSetters = true)
     private Set<Organization> organizations = new HashSet<>();
 
+    // No @Cache: mutated on every tutorial-group enrolment change; NONSTRICT caused stale cross-node reads, same class of bug as #12574.
     @OneToMany(mappedBy = "student", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties(value = "student", allowSetters = true)
     public Set<TutorialGroupRegistration> tutorialGroupRegistrations = new HashSet<>();
 
@@ -190,8 +190,8 @@ public class User extends AbstractAuditingEntity implements Participant {
     @JsonIgnore
     private Set<LearningPath> learningPaths = new HashSet<>();
 
+    // No @Cache: mutated on every exam registration; NONSTRICT caused stale cross-node reads, same class of bug as #12574.
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnore
     private Set<ExamUser> examUsers = new HashSet<>();
 

--- a/src/main/java/de/tum/cit/aet/artemis/exam/domain/Exam.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/domain/Exam.java
@@ -148,8 +148,9 @@ public class Exam extends DomainObject {
     @JsonIgnoreProperties(value = "exam", allowSetters = true)
     private List<ExerciseGroup> exerciseGroups = new ArrayList<>();
 
+    // No @Cache on studentExams / examUsers / examRoomExamAssignments: all grow / are mutated during exam registration and prep while conduction monitoring reads
+    // them concurrently; NONSTRICT caused stale cross-node reads, same class of bug as #12574.
     @OneToMany(mappedBy = "exam", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties("exam")
     private Set<StudentExam> studentExams = new HashSet<>();
 
@@ -157,12 +158,10 @@ public class Exam extends DomainObject {
     private String examArchivePath;
 
     @OneToMany(mappedBy = "exam", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties("exam")
     private Set<ExamUser> examUsers = new HashSet<>();
 
     @OneToMany(mappedBy = "exam", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonManagedReference("examRoomExamAssignments_exam")
     private Set<ExamRoomExamAssignment> examRoomExamAssignments = new HashSet<>();
 

--- a/src/main/java/de/tum/cit/aet/artemis/exam/domain/StudentExam.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/domain/StudentExam.java
@@ -67,21 +67,20 @@ public class StudentExam extends AbstractAuditingEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    // No @Cache on exercises / examSessions / studentParticipations: all three are mutated during exam prep and conduct (session reconnects, participations grow
+    // as the student works); NONSTRICT would give monitoring reads on another node a stale view, same class of bug as #12574.
     @ManyToMany
     @JoinTable(name = "student_exam_exercise", joinColumns = @JoinColumn(name = "student_exam_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "exercise_id", referencedColumnName = "id"))
     @OrderColumn(name = "exercise_order")
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<Exercise> exercises = new ArrayList<>();
 
     @OneToMany(mappedBy = "studentExam", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties("studentExam")
     private Set<ExamSession> examSessions = new HashSet<>();
 
     @ManyToMany
     @JoinTable(name = "student_exam_participation", joinColumns = @JoinColumn(name = "student_exam_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "participation_id", referencedColumnName = "id"))
     @OrderColumn(name = "participation_order")
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<StudentParticipation> studentParticipations = new ArrayList<>();
 
     public Boolean isSubmitted() {

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
@@ -148,9 +148,10 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
     @ManyToOne
     private ExerciseGroup exerciseGroup;
 
+    // No @Cache: instructors edit grading criteria while assessors read them during assessment; NONSTRICT produced
+    // stale cross-node reads, same class of bug as #12574 / #12584.
     @OneToMany(mappedBy = "exercise", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIgnoreProperties(value = "exercise", allowSetters = true)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<GradingCriterion> gradingCriteria = new HashSet<>();
 
     // No @Cache: grows every time a student starts / submits the exercise; NONSTRICT caused stale reads for instructors and scoring paths, same class of bug as #12574.

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
@@ -153,8 +153,8 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<GradingCriterion> gradingCriteria = new HashSet<>();
 
+    // No @Cache: grows every time a student starts / submits the exercise; NONSTRICT caused stale reads for instructors and scoring paths, same class of bug as #12574.
     @OneToMany(mappedBy = "exercise", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties("exercise")
     private Set<StudentParticipation> studentParticipations = new HashSet<>();
 
@@ -168,13 +168,13 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
     @JsonIgnoreProperties("exercise")
     private Set<ExampleSubmission> exampleSubmissions = new HashSet<>();
 
+    // No @Cache: instructors edit attachments while students are viewing the exercise page; NONSTRICT caused stale cross-node reads, same class of bug as #12574.
     @OneToMany(mappedBy = "exercise", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties("exercise")
     private Set<Attachment> attachments = new HashSet<>();
 
+    // No @Cache: plagiarism cases are appended by detection runs while instructors read the list, same class of bug as #12574.
     @OneToMany(mappedBy = "exercise", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIncludeProperties({ "id" })
     private Set<PlagiarismCase> plagiarismCases = new HashSet<>();
 

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
@@ -87,9 +87,9 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     @ManyToOne
     private Participation participation;
 
+    // No @Cache: appended on every save; NONSTRICT produced stale version lists for concurrent readers, same class of bug as #12574.
     @JsonIgnore
     @OneToMany(mappedBy = "submission", cascade = CascadeType.REMOVE)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<SubmissionVersion> versions = new HashSet<>();
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/participation/Participation.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/participation/Participation.java
@@ -97,9 +97,9 @@ public abstract class Participation extends DomainObject implements Participatio
      * have to use the save function and not the saveAndFlush function because otherwise an exception is thrown. We can think about adding orphanRemoval=true here, after adding the
      * participationId to all submissions.
      */
+    // No @Cache: grows on every submit; NONSTRICT produced stale submission lists for concurrent readers, same class of bug as #12574.
     @OneToMany(mappedBy = "participation", fetch = FetchType.LAZY)
     @JsonIgnoreProperties({ "participation" })
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<Submission> submissions = new HashSet<>();
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/domain/Lecture.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/domain/Lecture.java
@@ -82,10 +82,11 @@ public class Lecture extends DomainObject {
      * long as they use the provided methods to add/remove/reorder lecture units.
      *
      */
+    // No @Cache here on purpose: mutated whenever lecture units are added / reordered / removed.
+    // Clustered NONSTRICT_READ_WRITE on an actively mutated collection is the #12574 bug class.
     @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("lectureUnitOrder ASC") // DB → Java: always ordered by that column
     @JsonIgnoreProperties("lecture")
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<LectureUnit> lectureUnits = new LinkedHashSet<>();
 
     @ManyToOne

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/domain/LectureUnit.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/domain/LectureUnit.java
@@ -84,9 +84,9 @@ public abstract class LectureUnit extends DomainObject implements LearningObject
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Lecture lecture;
 
+    // No @Cache here on purpose: mutated whenever competencies are linked / unlinked. See #12574 / #12584.
     @OneToMany(mappedBy = "lectureUnit", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnoreProperties("lectureUnit")
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     protected Set<CompetencyLectureUnitLink> competencyLinks = new HashSet<>();
 
     @OneToMany(mappedBy = "lectureUnit", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingSubmission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingSubmission.java
@@ -12,8 +12,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderColumn;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.jspecify.annotations.NonNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -43,11 +41,11 @@ public class ProgrammingSubmission extends Submission {
     @Column(name = "build_failed")
     private boolean buildFailed;
 
-    // Only present if buildFailed == true
+    // Only present if buildFailed == true.
+    // No @Cache: written asynchronously by the CI callback; NONSTRICT caused partial log reads from other nodes, same class of bug as #12574.
     @OneToMany(mappedBy = "programmingSubmission", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderColumn
     @JsonIgnoreProperties(value = "programmingSubmission", allowSetters = true)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<BuildLogEntry> buildLogEntries = new ArrayList<>();
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/build/BuildPlan.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/build/BuildPlan.java
@@ -15,9 +15,6 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.Size;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.core.domain.DomainObject;

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/build/BuildPlan.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/build/BuildPlan.java
@@ -32,9 +32,9 @@ public class BuildPlan extends DomainObject {
     @Column(name = "build_plan", table = "build_plan", length = 10_000)
     private String buildPlan;
 
+    // No @Cache here on purpose: mutated when build plans are linked / unlinked from programming exercises. See #12574 / #12584.
     @OneToMany
     @JoinColumn(name = "build_plan_id")
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<ProgrammingExercise> programmingExercises = new HashSet<>();
 
     @Nullable

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/AbstractQuizSubmission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/AbstractQuizSubmission.java
@@ -11,9 +11,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.Valid;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import de.tum.cit.aet.artemis.exam.domain.Exam;
@@ -25,8 +22,8 @@ public abstract class AbstractQuizSubmission extends Submission {
     @Column(name = "score_in_points")
     private Double scoreInPoints;
 
+    // No @Cache: actively mutated on every autosave / submit / evaluation; NONSTRICT reads caused #12574.
     @OneToMany(mappedBy = "submission", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @Valid
     private Set<SubmittedAnswer> submittedAnswers = new HashSet<>();
 

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/AnswerOption.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/AnswerOption.java
@@ -6,9 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -17,9 +14,11 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A AnswerOption.
  */
+// No @Cache here on purpose: resolved via internalLoad during quiz-submission merge cascade. A stale L2 cache entry
+// (NONSTRICT_READ_WRITE on clustered Hazelcast) could return not-found for an existing row, producing the exact
+// ObjectNotFoundException seen in #12584. The answer_option table is small; always hitting the DB is fine.
 @Entity
 @Table(name = "answer_option")
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class AnswerOption extends DomainObject implements QuizQuestionComponent<MultipleChoiceQuestion> {
 

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/DragAndDropMapping.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/DragAndDropMapping.java
@@ -6,9 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -17,9 +14,9 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A DragAndDropMapping.
  */
+// No @Cache here on purpose: part of the quiz-submission merge graph. See #12574 / #12584.
 @Entity
 @Table(name = "drag_and_drop_mapping")
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class DragAndDropMapping extends DomainObject implements QuizQuestionComponent<DragAndDropQuestion> {
 

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/DragAndDropQuestion.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/DragAndDropQuestion.java
@@ -19,8 +19,6 @@ import jakarta.persistence.PostRemove;
 import jakarta.persistence.Transient;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,12 +51,13 @@ public class DragAndDropQuestion extends QuizQuestion {
     @Column(name = "background_file_path")
     private String backgroundFilePath;
 
+    // No @Cache on the three child collections below: they are the parent collections of DragItem / DropLocation / DragAndDropMapping
+    // references resolved during submission merge cascade. Stale reads under clustered NONSTRICT_READ_WRITE were the root of #12574 / #12584.
     // TODO: making this a bidirectional relation leads to weird Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
     // after 6.x upgrade
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")
     @OrderColumn
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<DropLocation> dropLocations = new ArrayList<>();
 
     // TODO: making this a bidirectional relation leads to weird Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
@@ -66,7 +65,6 @@ public class DragAndDropQuestion extends QuizQuestion {
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")
     @OrderColumn
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<DragItem> dragItems = new ArrayList<>();
 
     // TODO: making this a bidirectional relation leads to weird Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
@@ -74,7 +72,6 @@ public class DragAndDropQuestion extends QuizQuestion {
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")
     @OrderColumn
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<DragAndDropMapping> correctMappings = new ArrayList<>();
 
     public String getBackgroundFilePath() {

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/DragAndDropQuestionStatistic.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/DragAndDropQuestionStatistic.java
@@ -9,9 +9,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
@@ -22,8 +19,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class DragAndDropQuestionStatistic extends QuizQuestionStatistic {
 
+    // No @Cache: counters are incremented on every evaluation while instructors watch live statistics, same class of bug as #12574.
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true, mappedBy = "dragAndDropQuestionStatistic")
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<DropLocationCounter> dropLocationCounters = new HashSet<>();
 
     public Set<DropLocationCounter> getDropLocationCounters() {

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/DragItem.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/DragItem.java
@@ -15,8 +15,6 @@ import jakarta.persistence.PostRemove;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,9 +31,9 @@ import de.tum.cit.aet.artemis.core.util.FilePathConverter;
 /**
  * A DragItem.
  */
+// No @Cache here on purpose: loaded via cascade during quiz submission merge. See #12574 / #12584.
 @Entity
 @Table(name = "drag_item")
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class DragItem extends DomainObject implements QuizQuestionComponent<DragAndDropQuestion> {
 
@@ -60,7 +58,6 @@ public class DragItem extends DomainObject implements QuizQuestionComponent<Drag
     // NOTE: without cascade and orphanRemoval, deletion of quizzes might not work properly, so we reference mappings here, even if we do not use them
     @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "dragItem")
     @JsonIgnore
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<DragAndDropMapping> mappings = new HashSet<>();
 
     public String getPictureFilePath() {

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/DropLocation.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/DropLocation.java
@@ -11,9 +11,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -22,9 +19,9 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A DropLocation.
  */
+// No @Cache here on purpose: loaded via cascade during quiz submission merge. See #12574 / #12584.
 @Entity
 @Table(name = "drop_location")
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class DropLocation extends DomainObject implements QuizQuestionComponent<DragAndDropQuestion> {
 
@@ -50,7 +47,6 @@ public class DropLocation extends DomainObject implements QuizQuestionComponent<
     // NOTE: without cascade and orphanRemoval, deletion of quizzes might not work properly, so we reference mappings here, even if we do not use them
     @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "dropLocation")
     @JsonIgnore
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<DragAndDropMapping> mappings = new HashSet<>();
 
     public Double getPosX() {

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/MultipleChoiceQuestion.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/MultipleChoiceQuestion.java
@@ -14,9 +14,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderColumn;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -33,10 +30,11 @@ import de.tum.cit.aet.artemis.quiz.domain.scoring.ScoringStrategyMultipleChoiceP
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class MultipleChoiceQuestion extends QuizQuestion {
 
+    // No @Cache here on purpose: the parent collection of AnswerOption references that get resolved during merge cascade.
+    // A stale cached collection here is the exact failure mode that caused #12574 / #12584 on the clustered L2 cache.
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")
     @OrderColumn
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<AnswerOption> answerOptions = new ArrayList<>();
 
     @Column(name = "single_choice")

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/MultipleChoiceQuestionStatistic.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/MultipleChoiceQuestionStatistic.java
@@ -9,9 +9,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
@@ -22,8 +19,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class MultipleChoiceQuestionStatistic extends QuizQuestionStatistic {
 
+    // No @Cache: counters are incremented on every evaluation while instructors watch live statistics, same class of bug as #12574.
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true, mappedBy = "multipleChoiceQuestionStatistic")
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<AnswerCounter> answerCounters = new HashSet<>();
 
     public Set<AnswerCounter> getAnswerCounters() {

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizBatch.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizBatch.java
@@ -9,7 +9,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -21,9 +20,9 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A QuizBatch.
  */
+// No @Cache here on purpose: written every time a student joins a BATCHED quiz. See #12574 / #12584.
 @Entity
 @Table(name = "quiz_batch")
-@org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class QuizBatch extends DomainObject {
 

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizExercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizExercise.java
@@ -23,8 +23,6 @@ import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Transient;
 
 import org.hibernate.Hibernate;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -73,14 +71,16 @@ public class QuizExercise extends Exercise implements QuizConfiguration {
     private QuizPointStatistic quizPointStatistic;
 
     // TODO: test if we should use mappedBy here as well
+    // No @Cache here on purpose: this collection is mutated on every quiz edit/import and re-read on every student participation.
+    // NONSTRICT_READ_WRITE on a clustered L2 cache produced partial / stale reads that were the #12574 / #12584 bug class.
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderColumn
     @JoinColumn(name = "exercise_id")
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<QuizQuestion> quizQuestions = new ArrayList<>();
 
+    // No @Cache here on purpose: quizBatches is mutated on every student join in BATCHED mode, so the cache is actively hot
+    // and NONSTRICT's async-invalidation window is too loose for the multi-node setup. See #12574 / #12584.
     @OneToMany(mappedBy = "quizExercise", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<QuizBatch> quizBatches = new HashSet<>();
 
     // used to distinguish the type when used in collections (e.g. SearchResultPageDTO --> resultsOnPage)

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizPointStatistic.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizPointStatistic.java
@@ -10,9 +10,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -24,8 +21,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class QuizPointStatistic extends QuizStatistic {
 
+    // No @Cache: counters are incremented on every evaluation while instructors watch live statistics, same class of bug as #12574.
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true, mappedBy = "quizPointStatistic")
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<PointCounter> pointCounters = new HashSet<>();
 
     @OneToOne(mappedBy = "quizPointStatistic", fetch = FetchType.LAZY)

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizQuestion.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizQuestion.java
@@ -16,8 +16,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.ConcreteProxy;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -32,13 +30,14 @@ import de.tum.cit.aet.artemis.quiz.domain.scoring.ScoringStrategy;
 /**
  * A QuizQuestion.
  */
+// No @Cache here on purpose: parent entity of the question hierarchy loaded during quiz-submission merge cascade.
+// Clustered NONSTRICT_READ_WRITE produced the stale-collection behaviour tracked in #12574 / #12584.
 @Entity
 @Table(name = "quiz_question")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "discriminator", discriminatorType = DiscriminatorType.STRING)
 @DiscriminatorValue(value = "Q")
 @ConcreteProxy
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 // @formatter:off
 @JsonSubTypes({

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizStatistic.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizStatistic.java
@@ -9,8 +9,6 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.ConcreteProxy;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -20,13 +18,13 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A QuizStatistic.
  */
+// No @Cache here on purpose: incremented on every quiz evaluation while instructors watch live statistics. See #12574 / #12584.
 @Entity
 @Table(name = "quiz_statistic")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "discriminator", discriminatorType = DiscriminatorType.STRING)
 @DiscriminatorValue(value = "S")
 @ConcreteProxy
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class QuizStatistic extends DomainObject {
 

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizStatisticCounter.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizStatisticCounter.java
@@ -9,8 +9,6 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.ConcreteProxy;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -20,13 +18,13 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A QuizStatisticCounter.
  */
+// No @Cache here on purpose: incremented on every quiz evaluation. See #12574 / #12584.
 @Entity
 @Table(name = "quiz_statistic_counter")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "discriminator", discriminatorType = DiscriminatorType.STRING)
 @DiscriminatorValue(value = "SC")
 @ConcreteProxy
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public abstract class QuizStatisticCounter extends DomainObject {
 

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerMapping.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerMapping.java
@@ -6,9 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -17,9 +14,9 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A ShortAnswerMapping.
  */
+// No @Cache here on purpose: part of the quiz-submission merge graph. See #12574 / #12584.
 @Entity
 @Table(name = "short_answer_mapping")
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ShortAnswerMapping extends DomainObject implements QuizQuestionComponent<ShortAnswerQuestion> {
 

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerQuestion.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerQuestion.java
@@ -14,9 +14,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderColumn;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -33,12 +30,13 @@ import de.tum.cit.aet.artemis.quiz.domain.scoring.ScoringStrategyShortAnswerProp
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ShortAnswerQuestion extends QuizQuestion {
 
+    // No @Cache on the three child collections below: they are the parent collections of ShortAnswerSpot / ShortAnswerSolution /
+    // ShortAnswerMapping references resolved during submission merge cascade. See #12574 / #12584 for why the clustered NONSTRICT cache failed.
     // TODO: making this a bidirectional relation leads to weird Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
     // after 6.x upgrade
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")
     @OrderColumn
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<ShortAnswerSpot> spots = new ArrayList<>();
 
     // TODO: making this a bidirectional relation leads to weird Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
@@ -46,7 +44,6 @@ public class ShortAnswerQuestion extends QuizQuestion {
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")
     @OrderColumn
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<ShortAnswerSolution> solutions = new ArrayList<>();
 
     // TODO: making this a bidirectional relation leads to weird Hibernate behavior with missing data when loading quiz questions, we should investigate this again in the future
@@ -54,7 +51,6 @@ public class ShortAnswerQuestion extends QuizQuestion {
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "question_id")
     @OrderColumn
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<ShortAnswerMapping> correctMappings = new ArrayList<>();
 
     @Column(name = "similarity_value")

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerQuestionStatistic.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerQuestionStatistic.java
@@ -10,9 +10,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
@@ -23,8 +20,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ShortAnswerQuestionStatistic extends QuizQuestionStatistic {
 
+    // No @Cache: counters are incremented on every evaluation while instructors watch live statistics, same class of bug as #12574.
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true, mappedBy = "shortAnswerQuestionStatistic")
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<ShortAnswerSpotCounter> shortAnswerSpotCounters = new HashSet<>();
 
     public Set<ShortAnswerSpotCounter> getShortAnswerSpotCounters() {

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerSolution.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerSolution.java
@@ -11,9 +11,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -22,9 +19,9 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A ShortAnswerSolution.
  */
+// No @Cache here on purpose: loaded via cascade during quiz submission merge. See #12574 / #12584.
 @Entity
 @Table(name = "short_answer_solution")
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ShortAnswerSolution extends DomainObject implements QuizQuestionComponent<ShortAnswerQuestion> {
 
@@ -41,7 +38,6 @@ public class ShortAnswerSolution extends DomainObject implements QuizQuestionCom
     // NOTE: without cascade and orphanRemoval, deletion of quizzes might not work properly, so we reference mappings here, even if we do not use them
     @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "solution")
     @JsonIgnore
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<ShortAnswerMapping> mappings = new HashSet<>();
 
     public String getText() {

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerSpot.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerSpot.java
@@ -11,9 +11,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -22,9 +19,9 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A ShortAnswerSpot.
  */
+// No @Cache here on purpose: loaded via cascade during quiz submission merge. See #12574 / #12584.
 @Entity
 @Table(name = "short_answer_spot")
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ShortAnswerSpot extends DomainObject implements QuizQuestionComponent<ShortAnswerQuestion> {
 
@@ -44,7 +41,6 @@ public class ShortAnswerSpot extends DomainObject implements QuizQuestionCompone
     // NOTE: without cascade and orphanRemoval, deletion of quizzes might not work properly, so we reference mappings here, even if we do not use them
     @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "spot")
     @JsonIgnore
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<ShortAnswerMapping> mappings = new HashSet<>();
 
     public Integer getSpotNr() {

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerSubmittedText.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerSubmittedText.java
@@ -13,9 +13,6 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -25,9 +22,9 @@ import me.xdrop.fuzzywuzzy.FuzzySearch;
 /**
  * A ShortAnswerSubmittedText.
  */
+// No @Cache here on purpose: written on every live quiz autosave / submission. See #12574 / #12584.
 @Entity
 @Table(name = "short_answer_submitted_text")
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ShortAnswerSubmittedText extends DomainObject {
 

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/SubmittedAnswer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/SubmittedAnswer.java
@@ -10,8 +10,6 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.ConcreteProxy;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -25,13 +23,13 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A SubmittedAnswer.
  */
+// No @Cache here on purpose: parent of MC/DnD/SA submitted answers, inserted on every live save/submit. See #12574 / #12584.
 @Entity
 @Table(name = "submitted_answer")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "discriminator", discriminatorType = DiscriminatorType.STRING)
 @DiscriminatorValue(value = "S")
 @ConcreteProxy
-@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 
 // add JsonTypeInfo and JsonSubTypes annotation to help Jackson decide which class the JSON should be deserialized to
 // depending on the value of the "type" property.

--- a/src/main/java/de/tum/cit/aet/artemis/tutorialgroup/domain/TutorialGroup.java
+++ b/src/main/java/de/tum/cit/aet/artemis/tutorialgroup/domain/TutorialGroup.java
@@ -146,9 +146,9 @@ public class TutorialGroup extends DomainObject {
     @JsonIgnoreProperties(value = "tutorialGroup", allowSetters = true)
     private TutorialGroupSchedule tutorialGroupSchedule;
 
+    // No @Cache here on purpose: mutated when sessions are generated / adjusted for the schedule. See #12574 / #12584.
     @OneToMany(mappedBy = "tutorialGroup", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIgnoreProperties(value = "tutorialGroup, tutorialGroupSchedule", allowSetters = true)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<TutorialGroupSession> tutorialGroupSessions = new HashSet<>();
 
     @OneToOne(fetch = FetchType.EAGER)

--- a/src/main/java/de/tum/cit/aet/artemis/tutorialgroup/domain/TutorialGroupSchedule.java
+++ b/src/main/java/de/tum/cit/aet/artemis/tutorialgroup/domain/TutorialGroupSchedule.java
@@ -112,9 +112,9 @@ public class TutorialGroupSchedule extends DomainObject {
      * The sessions that were generated from this schedule, i.e. the sessions that follow this recurrence pattern.
      * Do NOT use orphanRemoval = true, as it will delete the sessions when they are disconnected from the schedule.
      */
+    // No @Cache here on purpose: mutated whenever sessions are regenerated from schedule changes. See #12574 / #12584.
     @OneToMany(mappedBy = "tutorialGroupSchedule", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     @JsonIgnoreProperties(value = "tutorialGroupSchedule", allowSetters = true)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<TutorialGroupSession> tutorialGroupSessions = new ArrayList<>();
 
     public boolean sameSchedule(TutorialGroupSchedule other) {


### PR DESCRIPTION
### Summary
Follow-up to #12578. That PR dropped the `@Cache(NONSTRICT_READ_WRITE)` annotation from three quiz submitted-answer collections (`selectedOptions`, `submittedTexts`, `mappings`) because, on a Hazelcast-backed clustered second-level cache, NONSTRICT's documented async-invalidation window caused partial / stale reads under concurrent autosave and evaluation. This PR sweeps the same annotation off every remaining entity and collection that fits the same bug class across the codebase, so the class of bug is closed rather than patched per-collection.

### Motivation and Context
`NONSTRICT_READ_WRITE` + a distributed L2 cache (Hazelcast-backed `hibernate-jcache`) + an association that is actively mutated during normal user flow is the exact shape of the #12574 bug. The recent incident #12584 (live quiz submission failing with `ObjectNotFoundException: AnswerOption ... not found` during the merge cascade) is the same mechanism hitting a different entity. Every collection / entity that matches this pattern has the same latent bug, whether it has been reported or not.

Analysis + sources in [#12578 (comment)](https://github.com/ls1intum/Artemis/pull/12578#issuecomment-4300321290) (JHipster moved all generated entity caches from NONSTRICT_READ_WRITE → READ_WRITE in 2020 for this same reason, per PR [jhipster/generator-jhipster#11757](https://github.com/jhipster/generator-jhipster/pull/11757)).

### Description
**Initial sweep (first commit):** 22 annotations removed across 14 files. Same bug class as #12574, broadly applied.
- `AbstractQuizSubmission.submittedAnswers` (parent of the three fixed in #12578)
- `Result.feedbacks` — written during manual assessment
- `ProgrammingSubmission.buildLogEntries` — written async by the CI callback
- `Participation.submissions`, `Submission.versions` — appended on every save
- Four EAGER counter collections on the MC/DnD/SA/point statistics — incremented every evaluation
- `StudentExam.{exercises, examSessions, studentParticipations}`, `Exam.{studentExams, examUsers, examRoomExamAssignments}`, `Exercise.{studentParticipations, attachments, plagiarismCases}`, `User.{tutorialGroupRegistrations, examUsers}`, `Course.{exercises, exams}`

**Extended sweep (second commit, `0de9bdac67`):** closes the remaining quiz-graph and assorted mutated collections after the full audit. 25 files, 36 annotations removed, 77 lines deleted net.

*Tier 1 — directly closes the #12584 failure mechanism (quiz graph):*
- `QuizExercise.{quizQuestions, quizBatches}` (quizBatches is written on every student join in BATCHED mode)
- `MultipleChoiceQuestion.answerOptions`, `DragAndDropQuestion.{dragItems, dropLocations, correctMappings}`, `ShortAnswerQuestion.{spots, solutions, correctMappings}` — parent collections of the references Hibernate resolves via `internalLoad` during submission merge cascade. Stale here = `ObjectNotFoundException` for a row that exists in the DB, i.e. the shape of #12584.
- Back-ref `mappings` collections on `ShortAnswerSolution`, `ShortAnswerSpot`, `DragItem`, `DropLocation`
- **Entity-level** on `AnswerOption`, `DragItem`, `DropLocation`, `ShortAnswerSpot`, `ShortAnswerSolution`, `ShortAnswerMapping`, `DragAndDropMapping`, `ShortAnswerSubmittedText` — the exact entities `internalLoad` resolves during the cascade. Prime candidates for the negative-hit / stale-null cache behaviour observed in #12584.
- Entity-level on `QuizQuestion` (parent of the three concrete subtypes), `QuizStatistic` / `QuizStatisticCounter` (incremented every evaluation), `QuizBatch`, `SubmittedAnswer`

*Tier 2 — mutated collections outside the quiz graph:*
- `Exercise.gradingCriteria` (instructors edit while assessors read during assessment)
- `GradingCriterion.structuredGradingInstructions`, `GradingScale.gradeSteps`, `GradingScale.bonusFrom`
- `Lecture.lectureUnits`, `LectureUnit.competencyLinks`
- `TutorialGroup.tutorialGroupSessions`, `TutorialGroupSchedule.tutorialGroupSessions`
- `BuildPlan.programmingExercises`

Each removal sits next to a one-line comment explaining why it is intentionally uncached.

### Explicitly left alone this round
*Tier 3 — save for a separate, well-tested PR targeting the next minor release:*
- Entity-level caches on ~70 non-submission-graph reference entities (Course, User, Authority, Competency, Exam, Lecture / Attachment / LectureUnit / ExerciseUnit entity-levels, TutorialGroup* family entity-levels, BuildLogEntry, Faq, Post, Reaction, Iris, LTI, plagiarism, modeling, text, atlas, science). None has a reported incident; widening here would bloat a hotfix.
- ManyToOne reference caches (`ExerciseUnit.exercise`, `LectureUnit.lecture`) — they don't trigger the `CollectionType.replace` / `replaceAssociations` path that's the actual failure shape.
- `QuizTrainingLeaderboard` (training-only, separate code path).

### Local verification (reliability-focused, multiple runs)

| Suite | Runs | Tests | Hard failures | Flakes (all retried & passed) | Verdict |
|---|---|---|---|---|---|
| Playwright E2E (full `@fast` + `@slow`) | 1 full + 3 targeted reruns of the initially-flaky tests | 252 in full run; 12 × 3 targeted reruns | **0** | 3 in initial run (CompetencyLectureUnitInteraction, ProgrammingExerciseManagement team, ModelingExerciseAssessment complaint); 1 in targeted rerun #3 | ✅ reliably passing |
| Full server suite (`./gradlew test -x webapp`) | 2 full runs | 11,750 × 2 | **0** on rerun | 1 in run #1 — `MessageIntegrationTest.testMarkMessageAsUnread` (communication, unrelated; passed in isolation *and* run #2) | ✅ reliably passing |

Timings: E2E ~8 min (full), server suite ~12 min (full).

Every flaky or initially-failing test lives in a module this PR does not touch (Atlas, Programming Exercise Management, Modeling Assessment, Communication / Messaging). No failure is attributable to the cache annotation removal.

### Checklist
#### General
- [x] I tested changes locally with the full server + E2E suite on the relevant test server configuration (see verification table above).
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using inline comments explaining each `@Cache` removal (the *why*, linking back to #12574 / #12584).

### Steps for Testing
Because the user-visible effect of this change is an *absence* of the #12574 / #12584-class race, the testing is structural:

1. Boot a clustered deployment (multi-instance Artemis behind a load balancer, or local compose with ≥2 Artemis instances).
2. As a student on node A: submit an MC / DnD / SA quiz (live autosave + submit), submit a programming exercise, autosave a modeling submission, register for an exam, have an instructor add feedback.
3. Load-balance the next request to node B and refresh the relevant screen.
4. Confirm the complete collection is returned (no disappearing submissions, feedbacks, build logs, registrations, selected answer options).
5. Specifically for #12584: on a multi-node deployment create a fresh quiz, start participation, save / submit across both nodes — no `ObjectNotFoundException` for `AnswerOption` / `DragItem` / `DropLocation` / `ShortAnswerSpot`.

_Last updated: 2026-04-23 12:05:00 UTC_

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes data consistency across clustered/multi-node setups to prevent stale or missing course, exam, lecture, tutorial, quiz, submission, grading, and programming build-log data during concurrent edits and reads.
  * Improves reliability of live quiz statistics, autosave/submissions, and manual assessment flows; addresses quiz-submission ObjectNotFoundException seen in staging (#12584, #12574).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->