### PR TITLE
`Quiz exercises`: Remove temporary Apollon drag-and-drop feature flag

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/service/feature/Feature.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/feature/Feature.java
@@ -3,5 +3,5 @@ package de.tum.cit.aet.artemis.core.service.feature;
 // Must be the same as FeatureToggle in feature-toggle.service.ts on the client side
 public enum Feature {
     ProgrammingExercises, PlagiarismChecks, Exports, LearningPaths, Science, StandardizedCompetencies, StudentCourseAnalyticsDashboard, TutorSuggestions, AtlasML, AtlasAgent,
-    Memiris, LectureContentProcessing, RateLimit, GlobalSearch, AutonomousTutor, ApollonQuizDragAndDrop
+    Memiris, LectureContentProcessing, RateLimit, GlobalSearch, AutonomousTutor
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/feature/FeatureToggleService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/feature/FeatureToggleService.java
@@ -95,8 +95,7 @@ public class FeatureToggleService {
         // starts up
         for (Feature feature : Feature.values()) {
             if (!features.containsKey(feature) && feature != Feature.Science && feature != Feature.TutorSuggestions && feature != Feature.AtlasML && feature != Feature.AtlasAgent
-                    && feature != Feature.Memiris && feature != Feature.RateLimit && feature != Feature.GlobalSearch && feature != Feature.AutonomousTutor
-                    && feature != Feature.ApollonQuizDragAndDrop) {
+                    && feature != Feature.Memiris && feature != Feature.RateLimit && feature != Feature.GlobalSearch && feature != Feature.AutonomousTutor) {
                 features.put(feature, true);
             }
         }
@@ -128,11 +127,6 @@ public class FeatureToggleService {
         if (!features.containsKey(Feature.AutonomousTutor)) {
             features.put(Feature.AutonomousTutor, false);
         }
-
-        if (!features.containsKey(Feature.ApollonQuizDragAndDrop)) {
-            features.put(Feature.ApollonQuizDragAndDrop, false);
-        }
-
         // Disable LectureContentProcessing in dev profile to avoid issues with local file system access
         if (profileService.isDevActive() && !lectureContentProcessingEnabledOnStart) {
             features.put(Feature.LectureContentProcessing, false);

--- a/src/main/webapp/app/core/admin/features/admin-feature-toggle.component.spec.ts
+++ b/src/main/webapp/app/core/admin/features/admin-feature-toggle.component.spec.ts
@@ -51,7 +51,7 @@ describe('AdminFeatureToggleComponentTest', () => {
         it('ngOnInit should load all feature toggles', () => {
             expect(comp.featureToggles()).toHaveLength(0);
             comp.ngOnInit();
-            expect(comp.featureToggles()).toHaveLength(16);
+            expect(comp.featureToggles()).toHaveLength(15);
         });
 
         it('ngOnInit should set isActive based on active toggles', () => {

--- a/src/main/webapp/app/quiz/manage/list-edit/quiz-question-list-edit.component.html
+++ b/src/main/webapp/app/quiz/manage/list-edit/quiz-question-list-edit.component.html
@@ -72,7 +72,7 @@
                     <span jhiTranslate="artemisApp.quizExercise.addDragAndDropQuestion"></span>
                 </button>
             </div>
-            <div class="col-12 col-sm-6 col-xl mb-1" [jhiFeatureToggleHide]="ApollonQuizDragAndDrop">
+            <div class="col-12 col-sm-6 col-xl mb-1">
                 <button id="quiz-import-apollon-dnd-question" class="btn btn-block btn-success" (click)="importApollonDragAndDropQuestion()">
                     <fa-icon [icon]="faPlus" />
                     <span jhiTranslate="artemisApp.quizExercise.addApollonDragAndDropQuestion"></span>

--- a/src/main/webapp/app/quiz/manage/list-edit/quiz-question-list-edit.component.ts
+++ b/src/main/webapp/app/quiz/manage/list-edit/quiz-question-list-edit.component.ts
@@ -12,8 +12,6 @@ import { DragAndDropQuestionEditComponent } from 'app/quiz/manage/drag-and-drop-
 import { ShortAnswerQuestionEditComponent } from 'app/quiz/manage/short-answer-question/short-answer-question-edit.component';
 import { ApollonDiagramImportDialogComponent } from 'app/quiz/manage/apollon-diagrams/import-dialog/apollon-diagram-import-dialog.component';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
-import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
-import { FeatureToggleHideDirective } from 'app/shared/feature-toggle/feature-toggle-hide.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { NgClass } from '@angular/common';
 import { QuizQuestionListEditExistingComponent } from '../list-edit-existing/quiz-question-list-edit-existing.component';
@@ -34,7 +32,6 @@ import { QuizAiQuestionRefinementPanelComponent } from 'app/quiz/manage/quiz-ai-
         NgClass,
         QuizQuestionListEditExistingComponent,
         QuizAiQuestionRefinementPanelComponent,
-        FeatureToggleHideDirective,
     ],
 })
 export class QuizQuestionListEditComponent {
@@ -58,7 +55,6 @@ export class QuizQuestionListEditComponent {
     readonly DRAG_AND_DROP = QuizQuestionType.DRAG_AND_DROP;
     readonly MULTIPLE_CHOICE = QuizQuestionType.MULTIPLE_CHOICE;
     readonly SHORT_ANSWER = QuizQuestionType.SHORT_ANSWER;
-    readonly ApollonQuizDragAndDrop = FeatureToggle.ApollonQuizDragAndDrop;
 
     faPlus = faPlus;
 

--- a/src/main/webapp/app/shared/feature-toggle/feature-toggle.service.ts
+++ b/src/main/webapp/app/shared/feature-toggle/feature-toggle.service.ts
@@ -26,7 +26,6 @@ export enum FeatureToggle {
     RateLimit = 'RateLimit',
     AutonomousTutor = 'AutonomousTutor',
     GlobalSearch = 'GlobalSearch',
-    ApollonQuizDragAndDrop = 'ApollonQuizDragAndDrop',
 }
 export type ActiveFeatureToggles = Array<FeatureToggle>;
 

--- a/src/main/webapp/i18n/de/featureToggles.json
+++ b/src/main/webapp/i18n/de/featureToggles.json
@@ -193,11 +193,6 @@
                     "name": "Globale Suche",
                     "description": "Aktiviert eine einheitliche Suchoberfläche, die über Cmd+K/Strg+K erreichbar ist und es Nutzer:innen ermöglicht, schnell über Kurse, Aufgaben, Vorlesungen und andere Inhalte zu suchen.",
                     "disableWarning": "Nutzer:innen haben keinen Zugriff auf die globale Suchfunktion und müssen manuell durch die Oberfläche navigieren."
-                },
-                "ApollonQuizDragAndDrop": {
-                    "name": "Apollon-Quiz-Drag-and-Drop-Import",
-                    "description": "Ermöglicht Lehrenden, im Quiz-Editor Apollon-basierte Drag-and-Drop-Fragen hinzuzufügen.",
-                    "disableWarning": "Lehrende können im Quiz-Editor keine neuen Apollon-basierten Drag-and-Drop-Fragen erstellen."
                 }
             }
         }

--- a/src/main/webapp/i18n/en/featureToggles.json
+++ b/src/main/webapp/i18n/en/featureToggles.json
@@ -193,11 +193,6 @@
                     "name": "Global Search",
                     "description": "Enables a unified search interface accessible via Cmd+K/Ctrl+K that allows users to quickly search across courses, exercises, lectures, and other content.",
                     "disableWarning": "Users will not have access to the global search functionality and must navigate manually through the interface."
-                },
-                "ApollonQuizDragAndDrop": {
-                    "name": "Apollon Quiz Drag-and-Drop Import",
-                    "description": "Allows instructors to add Apollon-based drag-and-drop quiz questions from the quiz editor.",
-                    "disableWarning": "Instructors will not be able to create new Apollon-based drag-and-drop quiz questions from the quiz editor."
                 }
             }
         }

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/FeatureToggleServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/FeatureToggleServiceTest.java
@@ -15,8 +15,8 @@ import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTe
 
 class FeatureToggleServiceTest extends AbstractSpringIntegrationIndependentTest {
 
-    // science, TutorSuggestions, AtlasAgent, AtlasML, Memiris, RateLimit, GlobalSearch, AutonomousTutor, ApollonQuizDragAndDrop disabled by default
-    private static final int FEATURES_DISABLED_DEFAULT = 9;
+    // science, TutorSuggestions, AtlasAgent, AtlasML, Memiris, RateLimit, GlobalSearch, AutonomousTutor disabled by default
+    private static final int FEATURES_DISABLED_DEFAULT = 8;
 
     @Autowired
     private FeatureToggleService featureToggleService;
@@ -40,8 +40,6 @@ class FeatureToggleServiceTest extends AbstractSpringIntegrationIndependentTest 
         assertThat(featureToggleService.isFeatureEnabled(Feature.Memiris)).isFalse();
         assertThat(featureToggleService.isFeatureEnabled(Feature.RateLimit)).isFalse();
         assertThat(featureToggleService.isFeatureEnabled(Feature.GlobalSearch)).isFalse();
-        assertThat(featureToggleService.isFeatureEnabled(Feature.ApollonQuizDragAndDrop)).isFalse();
-
     }
 
     private void resetToDefaultState() {
@@ -61,7 +59,6 @@ class FeatureToggleServiceTest extends AbstractSpringIntegrationIndependentTest 
         featureToggleService.disableFeature(Feature.RateLimit);
         featureToggleService.disableFeature(Feature.GlobalSearch);
         featureToggleService.disableFeature(Feature.Memiris);
-        featureToggleService.disableFeature(Feature.ApollonQuizDragAndDrop);
     }
 
     @Test


### PR DESCRIPTION
### Summary
Remove the temporary feature flag that was introduced in #12484 to hide the Apollon drag-and-drop quiz import. The underlying quiz exercise work has now been merged, so the import action should always be available again.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
PR #12484 introduced a temporary runtime flag (`ApollonQuizDragAndDrop`) to hide the Apollon-based drag-and-drop quiz import while the feature was still gated. That flag is now obsolete because the feature PR has been merged.

### Description
- remove `ApollonQuizDragAndDrop` from the server and client feature toggle enums and default toggle handling
- remove the temporary admin feature-toggle translation entries and test assumptions
- always show the Apollon drag-and-drop import action in the quiz question editor
- update the affected tests for the reduced feature-toggle set

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Course with quiz exercise edit permissions

1. Log in to Artemis as an instructor.
2. Open an existing quiz exercise or create a new one.
3. Navigate to the question editor.
4. Verify that the "Add Apollon Drag-and-Drop Question" action is visible without any feature toggle configuration.
5. Open the admin feature toggle page and verify that there is no `ApollonQuizDragAndDrop` toggle anymore.
6. Run `npm run vitest:run -- src/main/webapp/app/core/admin/features/admin-feature-toggle.component.spec.ts src/main/webapp/app/quiz/manage/list-edit/quiz-question-list-edit.component.spec.ts`.

#### Exam Mode Testing
Not affected. This change only removes a temporary feature-flag gate from the quiz editor and feature-toggle inventory.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| quiz-question-list-edit.component.ts | 71.29% | 198 | 18 | 9.1 |
| feature-toggle.service.ts | 64.44% | 75 | 15 | 20.0 |

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| Feature.java | 100.00% | 5 |
| FeatureToggleService.java | 75.31% | 161 |

_Last updated: 2026-04-23 11:01:51 UTC_

