### PR TITLE
Quiz exercises: Fix drag-and-drop quiz update, isEditable response, and post-save navigation

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizExerciseCreationUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizExerciseCreationUpdateResource.java
@@ -128,7 +128,8 @@ public class QuizExerciseCreationUpdateResource {
 
         QuizExercise result = quizExerciseService.createQuizExercise(quizExercise, files, true, quizExerciseDTO.competencyLinks());
         exerciseVersionService.createExerciseVersion(result);
-        QuizExerciseWithStatisticsDTO resultDTO = QuizExerciseWithStatisticsDTO.of(result);
+        boolean isEditable = quizExerciseService.isEditable(result);
+        QuizExerciseWithStatisticsDTO resultDTO = QuizExerciseWithStatisticsDTO.of(result, isEditable);
         return ResponseEntity.created(new URI("/api/quiz/quiz-exercises/" + result.getId()))
                 .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getId().toString())).body(resultDTO);
     }
@@ -168,7 +169,8 @@ public class QuizExerciseCreationUpdateResource {
 
         exerciseVersionService.createExerciseVersion(result);
 
-        QuizExerciseWithStatisticsDTO resultDTO = QuizExerciseWithStatisticsDTO.of(result);
+        boolean isCourseQuizEditable = quizExerciseService.isEditable(result);
+        QuizExerciseWithStatisticsDTO resultDTO = QuizExerciseWithStatisticsDTO.of(result, isCourseQuizEditable);
         return ResponseEntity.created(new URI("/api/quiz/quiz-exercises/" + result.getId()))
                 .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getId().toString())).body(resultDTO);
     }
@@ -210,7 +212,8 @@ public class QuizExerciseCreationUpdateResource {
         notifyAtlasML(result, OperationTypeDTO.UPDATE, "quiz exercise update");
         exerciseVersionService.createExerciseVersion(result);
 
-        QuizExerciseWithStatisticsDTO resultDTO = QuizExerciseWithStatisticsDTO.of(result);
+        boolean isUpdatedQuizEditable = quizExerciseService.isEditable(result);
+        QuizExerciseWithStatisticsDTO resultDTO = QuizExerciseWithStatisticsDTO.of(result, isUpdatedQuizEditable);
 
         return ResponseEntity.ok(resultDTO);
     }


### PR DESCRIPTION
### Summary

Fixes three bugs in the quiz exercise editor:
1. Saving a quiz with drag-and-drop questions fails with "Could not resolve drag and drop mappings" (HTTP 400)
2. After saving, the quiz incorrectly shows "The quiz has started. No more changes allowed." even with a future start date
3. After saving, navigate back to the exercises list instead of staying on the edit page (which caused a jarring scroll-to-top)

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).

### Motivation and Context

Closes #12572
Closes #12582

When editing a quiz exercise with drag-and-drop questions, the client sends the old entity-style JSON (with nested `dragItem`/`dropLocation` objects in mappings), but the server expects the new DTO format (with flat `dragItemTempId`/`dropLocationTempId` fields). This mismatch causes a 400 error on every save attempt.

Additionally, the create and update endpoints do not return `isEditable` in the response DTO, causing the client to always treat the quiz as non-editable after saving.

### Description

**Fix 1 — DnD mapping resolution (client):**
- New file `quiz-question-from-editor-dto.model.ts` defines TypeScript interfaces matching the server's `QuizQuestionFromEditorDTO` wire format and conversion functions for each question type
- Updated `toQuizExerciseUpdateDTO()` to convert questions via `convertQuizQuestionToEditorDTO()` instead of passing raw entity objects
- For persisted items, uses `tempID ?? id` as the effective ID for mapping references, matching the server's `effectiveId()` logic

**Fix 2 — isEditable not returned (server):**
- All three endpoints in `QuizExerciseCreationUpdateResource` (exam create, course create, update) now compute `isEditable` via `quizExerciseService.isEditable(result)` and pass it to `QuizExerciseWithStatisticsDTO.of(result, isEditable)`
- Previously they used the single-arg `of(result)` which passes `null`, causing the client-side `isEditable && isQuizEditable()` check to always evaluate to `false`

**Fix 3 — Post-save navigation (client):**
- After successful save, navigate back to the exercises list via `previousState()` instead of staying on the edit page
- Removed unused `Location` import and injection

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Course with a quiz exercise containing drag-and-drop questions

1. Log in as Instructor
2. Import or create a quiz exercise with at least one drag-and-drop question with correct mappings
3. Open the quiz for editing
4. Click Save
5. Verify: no "Could not resolve drag and drop mappings" error appears
6. Verify: after saving, you are navigated back to the exercises list
7. Re-open the quiz for editing
8. Verify: the editor is in edit mode (not showing "The quiz has started")
9. Make a change and save again — verify it works without errors

#### Exam Mode Testing

Prerequisites:
- 1 Instructor
- 1 Exam with a quiz exercise containing drag-and-drop questions (exam start date in the future)

1. Open the exam quiz for editing
2. Save the quiz
3. Verify: no error, navigates back, and re-opening shows edit mode

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
Before:
<img width="3308" height="708" alt="image" src="https://github.com/user-attachments/assets/01a67bae-18f1-4726-be1b-f39eebc40377" />

After:
It should not lead to the Quiz has started page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed editability status display for quiz exercises to accurately reflect edit permissions across creation, updates, and result views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->