### PR TITLE
`Development`: Update pmd to 7.22.0 in Java exercise templates

### DIFF
--- a/src/main/resources/templates/java/maven_maven/test/projectTemplate/pom.xml
+++ b/src/main/resources/templates/java/maven_maven/test/projectTemplate/pom.xml
@@ -142,12 +142,12 @@
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-core</artifactId>
-                        <version>7.2.0</version>
+                        <version>7.22.0</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-java</artifactId>
-                        <version>7.2.0</version>
+                        <version>7.22.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/main/resources/templates/java/test/blackbox/projectTemplate/pom.xml
+++ b/src/main/resources/templates/java/test/blackbox/projectTemplate/pom.xml
@@ -76,12 +76,12 @@
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-core</artifactId>
-                        <version>7.2.0</version>
+                        <version>7.22.0</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-java</artifactId>
-                        <version>7.2.0</version>
+                        <version>7.22.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/main/resources/templates/java/test/maven/projectTemplate/pom.xml
+++ b/src/main/resources/templates/java/test/maven/projectTemplate/pom.xml
@@ -137,12 +137,12 @@
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-core</artifactId>
-                        <version>7.2.0</version>
+                        <version>7.22.0</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-java</artifactId>
-                        <version>7.2.0</version>
+                        <version>7.22.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
### Summary
Bumps the `pmd-core` and `pmd-java` overrides used by the `maven-pmd-plugin` in the Java programming-exercise project templates from `7.2.0` to `7.22.0` to resolve six open Dependabot advisories.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


### Motivation and Context
The Java exercise templates pin PMD `7.2.0` as a plugin dependency for the `maven-pmd-plugin`. This version is affected by two GitHub security advisories that Dependabot has been flagging on `develop`:

| GHSA | Severity | Issue | Patched in |
|---|---|---|---|
| [GHSA-88m4-h43f-wx84](https://github.com/advisories/GHSA-88m4-h43f-wx84) | Critical | PMD Designer's release key passphrase (GPG) was published to Maven Central in cleartext | 7.10.0 |
| [GHSA-8rr6-2qw5-pc7r](https://github.com/advisories/GHSA-8rr6-2qw5-pc7r) | Medium | Stored XSS in PMD's `VBHTMLRenderer` and `YAHTMLRenderer` via unescaped violation messages | 7.22.0 |

Each advisory triggers one alert per affected `pom.xml` template (3 templates × 2 advisories = 6 alerts).

These templates are copied verbatim into student programming-exercise repositories and run on the CI executor during static-code analysis, so they are real exposure paths for instructors and students, not just internal build dependencies.

### Description
- Updated `pmd-core` from `7.2.0` to `7.22.0` in:
  - `src/main/resources/templates/java/test/maven/projectTemplate/pom.xml`
  - `src/main/resources/templates/java/test/blackbox/projectTemplate/pom.xml`
  - `src/main/resources/templates/java/maven_maven/test/projectTemplate/pom.xml`
- Updated `pmd-java` from `7.2.0` to `7.22.0` in the same three files (kept in sync, as required by PMD).
- The `maven-pmd-plugin` version (`3.22.0`) is not flagged and was intentionally left unchanged to keep the diff minimal.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Java programming exercise that has Static Code Analysis enabled (any of the three template flavors: plain Maven, blackbox, or `maven_maven`)

1. Log in to Artemis as the instructor.
2. Create a new Java programming exercise with Static Code Analysis enabled.
3. Open the generated test repository and confirm that `pom.xml` declares `pmd-core` and `pmd-java` at version `7.22.0` under the `maven-pmd-plugin` dependencies.
4. Trigger a student submission (or run the template participation) and verify the build still succeeds and PMD findings are reported as before — i.e., no behavioural regression compared to `7.2.0`.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2