### PR TITLE
`Development`: Copy selected components for quiz edit design migration

### DIFF
--- a/src/main/webapp/app/atlas/shared/competency-selection-primeng/atlasml-competency-suggestions.integration.spec.ts
+++ b/src/main/webapp/app/atlas/shared/competency-selection-primeng/atlasml-competency-suggestions.integration.spec.ts
@@ -1,0 +1,492 @@
+import { vi } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { Competency } from 'app/atlas/shared/entities/competency.model';
+import { delay, of, throwError } from 'rxjs';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
+import { By } from '@angular/platform-browser';
+import { CourseStorageService } from 'app/core/course/manage/services/course-storage.service';
+import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
+import { TranslateService } from '@ngx-translate/core';
+import { MockProvider } from 'ng-mocks';
+import { AccountService } from 'app/core/auth/account.service';
+import { MockAccountService } from 'test/helpers/mocks/service/mock-account.service';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
+import { ProfileInfo } from 'app/core/layouts/profiles/profile-info.model';
+import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
+import { MODULE_FEATURE_ATLAS } from 'app/app.constants';
+import { CompetencySelectionPrimengComponent } from 'app/atlas/shared/competency-selection-primeng/competency-selection-primeng.component';
+import { FeatureToggle, FeatureToggleService } from 'app/shared/feature-toggle/feature-toggle.service';
+import { MockFeatureToggleService } from 'test/helpers/mocks/service/mock-feature-toggle.service';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { ButtonComponent } from 'app/shared/components/buttons/button/button.component';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+/**
+ * Integration test suite for AtlasML Competency Suggestion Feature
+ *
+ * This test suite covers the user stories:
+ * 1. When creating an exercise, show a lightbulb button for AI suggestions
+ * 2. When clicked, suggest competencies based on exercise description
+ * 3. Show lightbulb icons next to suggested competencies
+ * 4. Handle various edge cases and error scenarios
+ */
+describe('AtlasML Competency Suggestions Integration Tests', () => {
+    setupTestBed({ zoneless: true });
+    let fixture: ComponentFixture<CompetencySelectionPrimengComponent>;
+    let component: CompetencySelectionPrimengComponent;
+    let courseStorageService: CourseStorageService;
+    let httpClient: HttpClient;
+    let profileService: ProfileService;
+    let mockFeatureToggleService: MockFeatureToggleService;
+
+    // Sample competencies for testing
+    const sampleCompetencies: Competency[] = [
+        { id: 1, title: 'Programming Fundamentals', description: 'Basic programming concepts', optional: false } as Competency,
+        { id: 2, title: 'Data Structures', description: 'Arrays, lists, trees, etc.', optional: false } as Competency,
+        { id: 3, title: 'Algorithms', description: 'Sorting and searching algorithms', optional: false } as Competency,
+        { id: 4, title: 'Object-Oriented Programming', description: 'OOP concepts and patterns', optional: false } as Competency,
+        { id: 5, title: 'Database Design', description: 'Relational database concepts', optional: false } as Competency,
+    ];
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            providers: [
+                {
+                    provide: ActivatedRoute,
+                    useValue: {
+                        snapshot: {
+                            paramMap: convertToParamMap({ courseId: 1 }),
+                        },
+                    } as any as ActivatedRoute,
+                },
+                { provide: TranslateService, useClass: MockTranslateService },
+                { provide: AccountService, useClass: MockAccountService },
+                { provide: ProfileService, useClass: MockProfileService },
+                { provide: FeatureToggleService, useClass: MockFeatureToggleService },
+                MockProvider(CourseStorageService),
+                provideHttpClient(),
+                provideHttpClientTesting(),
+            ],
+        }).compileComponents();
+
+        // Initialize feature toggles subject in mock BEFORE component creation so directives can subscribe safely
+        mockFeatureToggleService = TestBed.inject(FeatureToggleService) as unknown as MockFeatureToggleService;
+        mockFeatureToggleService.getFeatureToggles();
+
+        fixture = TestBed.createComponent(CompetencySelectionPrimengComponent);
+        component = fixture.componentInstance;
+        courseStorageService = fixture.debugElement.injector.get(CourseStorageService);
+        httpClient = fixture.debugElement.injector.get(HttpClient);
+        profileService = fixture.debugElement.injector.get(ProfileService);
+
+        vi.spyOn(httpClient, 'post').mockReturnValue(of({ competencies: [] }));
+
+        // Enable Atlas module feature
+        const profileInfo = new ProfileInfo();
+        profileInfo.activeModuleFeatures = [MODULE_FEATURE_ATLAS];
+        const getProfileInfoMock = vi.spyOn(profileService, 'getProfileInfo');
+        getProfileInfoMock.mockReturnValue(profileInfo);
+
+        // Setup mock competencies
+        vi.spyOn(courseStorageService, 'getCourse').mockReturnValue({ competencies: sampleCompetencies });
+
+        // Setup exercise description for suggestions
+        fixture.componentRef.setInput('exerciseDescription', 'Create a Java program that implements a binary search tree with insertion and deletion operations');
+        fixture.detectChanges();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('UI Component Visibility', () => {
+        it('should display lightbulb suggestion button when AtlasML is enabled', () => {
+            const btnDe = fixture.debugElement.query(By.directive(ButtonComponent));
+            expect(btnDe).toBeTruthy();
+            const btn = btnDe.componentInstance as ButtonComponent;
+            expect(btn.disabled()).toBeFalsy();
+        });
+
+        it('should hide lightbulb button when AtlasML feature is disabled', () => {
+            // Disable AtlasML feature toggle
+            mockFeatureToggleService.setFeatureToggleState(FeatureToggle.AtlasML, false).subscribe();
+            fixture.detectChanges();
+
+            const btnDe = fixture.debugElement.query(By.directive(ButtonComponent));
+            expect(btnDe.nativeElement.classList.contains('d-none')).toBeTruthy();
+        });
+
+        it('should show proper tooltip for lightbulb button', () => {
+            const btnDe = fixture.debugElement.query(By.directive(ButtonComponent));
+            const btn = btnDe.componentInstance as ButtonComponent;
+            expect(btn.tooltip()).toBe('artemisApp.courseCompetency.relations.suggestions.getAiSuggestionsTooltip');
+        });
+
+        it('should disable lightbulb button when exercise description is empty', () => {
+            fixture.componentRef.setInput('exerciseDescription', '');
+            fixture.detectChanges();
+
+            const btnDe = fixture.debugElement.query(By.directive(ButtonComponent));
+            const btn = btnDe.componentInstance as ButtonComponent;
+            expect(btn.disabled).toBeTruthy();
+        });
+
+        it('should disable lightbulb button when exercise description contains only whitespace', () => {
+            fixture.componentRef.setInput('exerciseDescription', '   \n\t  ');
+            fixture.detectChanges();
+
+            const btnDe = fixture.debugElement.query(By.directive(ButtonComponent));
+            const btn = btnDe.componentInstance as ButtonComponent;
+            expect(btn.disabled).toBeTruthy();
+        });
+    });
+
+    describe('API Integration', () => {
+        it('should call AtlasML API with correct parameters', () => {
+            const mockResponse = { competencies: [{ id: 1, title: 'Programming Fundamentals' }] };
+            const httpPostSpy = vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+
+            component.suggestCompetencies();
+
+            expect(httpPostSpy).toHaveBeenCalledWith('/api/atlas/competencies/suggest', {
+                description: 'Create a Java program that implements a binary search tree with insertion and deletion operations',
+                course_id: '1',
+            });
+        });
+
+        it('should handle successful API response', () => {
+            vi.useFakeTimers();
+            try {
+                const mockResponse = {
+                    competencies: [
+                        { id: 1, title: 'Programming Fundamentals' },
+                        { id: 2, title: 'Data Structures' },
+                    ],
+                };
+                vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse).pipe(delay(100)));
+
+                component.suggestCompetencies();
+                expect(component.isSuggesting).toBeTruthy();
+
+                vi.advanceTimersByTime(100);
+                fixture.detectChanges();
+
+                expect(component.isSuggesting).toBeFalsy();
+                expect(component.suggestedCompetencyIds.has(1)).toBeTruthy();
+                expect(component.suggestedCompetencyIds.has(2)).toBeTruthy();
+                expect(component.suggestedCompetencyIds.has(3)).toBeFalsy();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('should handle API errors gracefully', () => {
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+            vi.spyOn(httpClient, 'post').mockReturnValue(throwError(() => ({ status: 500, message: 'Server Error' })));
+
+            component.suggestCompetencies();
+            // After error, isSuggesting should be false due to finalize operator
+            fixture.detectChanges();
+
+            expect(component.isSuggesting).toBeFalsy();
+            expect(component.suggestedCompetencyIds.size).toBe(0);
+            consoleSpy.mockRestore();
+        });
+
+        it('should handle network timeout', () => {
+            vi.spyOn(httpClient, 'post').mockReturnValue(throwError(() => ({ name: 'TimeoutError' })));
+
+            component.suggestCompetencies();
+
+            expect(component.isSuggesting).toBeFalsy();
+            expect(component.suggestedCompetencyIds.size).toBe(0);
+        });
+    });
+
+    describe('Suggestion Display and Interaction', () => {
+        beforeEach(() => {
+            const mockResponse = {
+                competencies: [
+                    { id: 2, title: 'Data Structures' },
+                    { id: 3, title: 'Algorithms' },
+                ],
+            };
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+            component.suggestCompetencies();
+            fixture.detectChanges();
+        });
+
+        it('should display lightbulb icons next to suggested competencies', () => {
+            const suggestedIcons = fixture.debugElement.queryAll(By.css('fa-icon.text-warning.ms-2'));
+            expect(suggestedIcons).toHaveLength(2); // Two suggested competencies
+
+            // Verify tooltips
+            suggestedIcons.forEach((icon) => {
+                const tooltip = icon.injector.get(NgbTooltip, null);
+                // Expect translation key to be present (translated by pipe in template)
+                expect(tooltip?.ngbTooltip).toBe('artemisApp.competency.suggestion.tooltip');
+            });
+        });
+
+        it('should sort suggested competencies to the top of the list', () => {
+            // Verify that suggested competencies (id 2 and 3) are at the top
+            const competencyCheckboxes = fixture.debugElement.queryAll(By.css('input[type="checkbox"]'));
+
+            expect(competencyCheckboxes[0].attributes['id']).toContain('competency-2'); // Data Structures
+            expect(competencyCheckboxes[1].attributes['id']).toContain('competency-3'); // Algorithms
+        });
+
+        it('should maintain suggested status when toggling competencies', () => {
+            const dataStructuresLink = component.competencyLinks?.find((link) => link.competency?.id === 2);
+            expect(dataStructuresLink).toBeTruthy();
+
+            // Toggle competency on/off - suggestion status should persist
+            if (dataStructuresLink) {
+                component.toggleCompetency(dataStructuresLink);
+                expect(component.isSuggested(2)).toBeTruthy();
+
+                component.toggleCompetency(dataStructuresLink);
+                expect(component.isSuggested(2)).toBeTruthy();
+            }
+        });
+
+        it('should clear previous suggestions when making new request', () => {
+            expect(component.suggestedCompetencyIds.has(2)).toBeTruthy();
+            expect(component.suggestedCompetencyIds.has(3)).toBeTruthy();
+
+            // Mock new response with different suggestions
+            const newMockResponse = { competencies: [{ id: 1, title: 'Programming Fundamentals' }] };
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(newMockResponse));
+
+            component.suggestCompetencies();
+
+            expect(component.suggestedCompetencyIds.has(1)).toBeTruthy();
+            expect(component.suggestedCompetencyIds.has(2)).toBeFalsy(); // Cleared
+            expect(component.suggestedCompetencyIds.has(3)).toBeFalsy(); // Cleared
+        });
+    });
+
+    describe('Loading States', () => {
+        it('should show spinner during API call', () => {
+            vi.useFakeTimers();
+            try {
+                vi.spyOn(httpClient, 'post').mockReturnValue(of({ competencies: [] }).pipe(delay(200)));
+
+                component.suggestCompetencies();
+                fixture.detectChanges();
+
+                // Should show spinner
+                // Loading is now handled by jhi-button isLoading; spinner element is not directly in DOM here
+                const btnDe = fixture.debugElement.query(By.directive(ButtonComponent));
+                const btn = btnDe.componentInstance as ButtonComponent;
+                expect(btn.isLoading).toBeTruthy();
+
+                // Should not show lightbulb icon (hidden when loading)
+                const lightbulbIcon = btnDe.query(By.css('.jhi-btn__icon'));
+                expect(lightbulbIcon).toBeFalsy();
+                // Spinner should be visible on the button while loading
+                const spinnerIcon = btnDe.query(By.css('.jhi-btn__loading'));
+                expect(spinnerIcon).toBeTruthy();
+
+                vi.advanceTimersByTime(200);
+                fixture.detectChanges();
+
+                // After completion, spinner should be gone
+                const spinnerAfter = fixture.debugElement.query(By.css('.spinner-border-sm'));
+                expect(spinnerAfter).toBeFalsy();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('should disable button during API call', () => {
+            vi.useFakeTimers();
+            try {
+                vi.spyOn(httpClient, 'post').mockReturnValue(of({ competencies: [] }).pipe(delay(100)));
+
+                let btnDe = fixture.debugElement.query(By.directive(ButtonComponent));
+                let btn = btnDe.componentInstance as ButtonComponent;
+                expect(btn.disabled()).toBeFalsy();
+
+                component.suggestCompetencies();
+                fixture.detectChanges();
+
+                btnDe = fixture.debugElement.query(By.directive(ButtonComponent));
+                btn = btnDe.componentInstance as ButtonComponent;
+                expect(btn.disabled()).toBeTruthy();
+
+                vi.advanceTimersByTime(100);
+                fixture.detectChanges();
+
+                btnDe = fixture.debugElement.query(By.directive(ButtonComponent));
+                btn = btnDe.componentInstance as ButtonComponent;
+                expect(btn.disabled()).toBeFalsy();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+    });
+
+    describe('Exercise Type Integration', () => {
+        const exerciseScenarios = [
+            {
+                type: 'Programming',
+                description: 'Implement a hash table with collision resolution using chaining',
+                expectedSuggestions: [1, 2], // Programming + Data Structures
+            },
+            {
+                type: 'Text',
+                description: 'Write an essay comparing different sorting algorithms and their time complexities',
+                expectedSuggestions: [3], // Algorithms
+            },
+            {
+                type: 'Modeling',
+                description: 'Create a UML class diagram for a library management system using object-oriented principles',
+                expectedSuggestions: [4], // Object-Oriented Programming
+            },
+            {
+                type: 'Quiz',
+                description: 'Multiple choice questions about database normalization and entity-relationship modeling',
+                expectedSuggestions: [5], // Database Design
+            },
+        ];
+
+        exerciseScenarios.forEach((scenario) => {
+            it(`should work correctly for ${scenario.type} exercises`, () => {
+                fixture.componentRef.setInput('exerciseDescription', scenario.description);
+
+                const mockResponse = {
+                    competencies: scenario.expectedSuggestions.map((id) => ({ id, title: sampleCompetencies[id - 1].title })),
+                };
+                vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+
+                component.suggestCompetencies();
+                fixture.detectChanges();
+
+                // Verify correct competencies are suggested
+                scenario.expectedSuggestions.forEach((competencyId) => {
+                    expect(component.isSuggested(competencyId)).toBeTruthy();
+                });
+
+                // Verify API was called with correct description
+                expect(httpClient.post).toHaveBeenCalledWith('/api/atlas/competencies/suggest', {
+                    description: scenario.description,
+                    course_id: '1',
+                });
+            });
+        });
+    });
+
+    describe('Edge Cases and Error Handling', () => {
+        it('should handle empty competency list from API', () => {
+            const mockResponse = { competencies: [] };
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+
+            component.suggestCompetencies();
+
+            expect(component.suggestedCompetencyIds.size).toBe(0);
+            expect(component.isSuggesting).toBeFalsy();
+        });
+
+        it('should handle malformed API response', () => {
+            const mockResponse = { invalid: 'response', competencies: [] };
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+
+            expect(() => component.suggestCompetencies()).not.toThrow();
+            expect(component.suggestedCompetencyIds.size).toBe(0);
+        });
+
+        it('should handle competency suggestions with non-existent IDs', () => {
+            const mockResponse = {
+                competencies: [
+                    { id: 999, title: 'Non-existent Competency' },
+                    { id: 1, title: 'Valid Competency' },
+                    { id: 888, title: 'Another Non-existent' },
+                ],
+            };
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+
+            component.suggestCompetencies();
+
+            // Only valid competency should be marked as suggested
+            expect(component.isSuggested(1)).toBeTruthy();
+            expect(component.isSuggested(999)).toBeFalsy();
+            expect(component.isSuggested(888)).toBeFalsy();
+        });
+
+        it('should not make API call if description is null or undefined', () => {
+            const httpPostSpy = vi.spyOn(httpClient, 'post');
+
+            fixture.componentRef.setInput('exerciseDescription', null as any);
+            component.suggestCompetencies();
+            expect(httpPostSpy).not.toHaveBeenCalled();
+
+            fixture.componentRef.setInput('exerciseDescription', undefined);
+            component.suggestCompetencies();
+            expect(httpPostSpy).not.toHaveBeenCalled();
+        });
+
+        it('should handle very long exercise descriptions', () => {
+            const longDescription = 'A'.repeat(10000); // 10k character description
+            fixture.componentRef.setInput('exerciseDescription', longDescription);
+
+            const mockResponse = { competencies: [{ id: 1, title: 'Test' }] };
+            const httpPostSpy = vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+
+            component.suggestCompetencies();
+
+            expect(httpPostSpy).toHaveBeenCalledWith('/api/atlas/competencies/suggest', {
+                description: longDescription,
+                course_id: '1',
+            });
+        });
+    });
+
+    describe('User Workflow Integration', () => {
+        it('should maintain user selections when suggestions are made', () => {
+            // User selects some competencies first
+            const competency1 = component.competencyLinks?.[0];
+            const competency4 = component.competencyLinks?.[3];
+
+            if (competency1 && competency4) {
+                component.toggleCompetency(competency1);
+                component.toggleCompetency(competency4);
+
+                const initialSelections = component.selectedCompetencyLinks?.length || 0;
+                expect(initialSelections).toBe(2);
+
+                // Then get suggestions
+                const mockResponse = { competencies: [{ id: 2, title: 'Data Structures' }] };
+                vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+                component.suggestCompetencies();
+
+                // User selections should be preserved
+                expect(component.selectedCompetencyLinks?.length).toBe(2);
+                expect(component.checkboxStates[1]).toBeTruthy();
+                expect(component.checkboxStates[4]).toBeTruthy();
+
+                // But suggestions should still be shown
+                expect(component.isSuggested(2)).toBeTruthy();
+            }
+        });
+
+        it('should allow users to select suggested competencies', () => {
+            // Get suggestions first
+            const mockResponse = { competencies: [{ id: 2, title: 'Data Structures' }] };
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+            component.suggestCompetencies();
+            fixture.detectChanges();
+
+            // User clicks on suggested competency
+            const suggestedCompetency = component.competencyLinks?.find((link) => link.competency?.id === 2);
+            if (suggestedCompetency) {
+                component.toggleCompetency(suggestedCompetency);
+                expect(component.checkboxStates[2]).toBeTruthy();
+                expect(component.selectedCompetencyLinks).toContainEqual(suggestedCompetency);
+                expect(component.isSuggested(2)).toBeTruthy(); // Should still be marked as suggested
+            }
+        });
+    });
+});

--- a/src/main/webapp/app/atlas/shared/competency-selection-primeng/competency-selection-primeng.component.html
+++ b/src/main/webapp/app/atlas/shared/competency-selection-primeng/competency-selection-primeng.component.html
@@ -1,0 +1,79 @@
+@if (isLoading || competencyLinks?.length) {
+    <div>
+        <div class="d-flex align-items-center mb-1">
+            @if (labelName()) {
+                <label for="competency-selector">
+                    {{ labelName() }}
+                </label>
+            }
+            @if (labelTooltip()) {
+                <fa-stack class="text-secondary icon-full-size" [ngbTooltip]="labelTooltip()">
+                    <fa-icon [icon]="faQuestionCircle" stackItemSize="1x" />
+                </fa-stack>
+            }
+            @if (competencyLinks && competencyLinks.length > 0) {
+                <jhi-button
+                    [btnType]="ButtonType.WARNING"
+                    [disabled]="isSuggesting || disabled || !exerciseDescription()?.trim()"
+                    (onClick)="suggestCompetencies()"
+                    [tooltip]="'artemisApp.courseCompetency.relations.suggestions.getAiSuggestionsTooltip'"
+                    [jhiFeatureToggleHide]="FeatureToggle.AtlasML"
+                    [btnSize]="ButtonSize.SMALL"
+                    [icon]="faLightbulb"
+                    [isLoading]="isSuggesting"
+                    class="ms-2"
+                />
+            }
+        </div>
+        @if (isLoading) {
+            <div>
+                <div class="spinner-border" role="status">
+                    <span class="visually-hidden" jhiTranslate="loading"></span>
+                </div>
+            </div>
+        } @else {
+            <div class="competency-selector p-2" id="competency-selector">
+                @for (competencyLink of competencyLinks; track competencyLink) {
+                    @if (competencyLink && competencyLink.competency && competencyLink.competency.id) {
+                        <div class="mb-1">
+                            <div class="d-flex align-items-center">
+                                <input
+                                    id="competency-{{ competencyLink.competency.id }}"
+                                    type="checkbox"
+                                    [ngModel]="checkboxStates[competencyLink.competency.id]"
+                                    (ngModelChange)="toggleCompetency(competencyLink)"
+                                    [disabled]="disabled"
+                                    class="me-2"
+                                />
+                                <label for="competency-{{ competencyLink.competency.id }}" class="d-flex align-items-center m-0">
+                                    <fa-icon [icon]="getIcon(competencyLink.competency.taxonomy)" [fixedWidth]="true" />
+                                    <span class="ms-1">{{ competencyLink.competency.title }}</span>
+                                </label>
+                                @if (isSuggested(competencyLink.competency.id)) {
+                                    <fa-icon [icon]="faLightbulb" class="text-warning ms-2" [ngbTooltip]="'artemisApp.competency.suggestion.tooltip' | artemisTranslate" />
+                                }
+                            </div>
+                            @if (checkboxStates[competencyLink.competency.id]) {
+                                <select
+                                    [ngModel]="
+                                        competencyLink.weight < LOW_COMPETENCY_LINK_WEIGHT_CUT_OFF
+                                            ? LOW_COMPETENCY_LINK_WEIGHT
+                                            : competencyLink.weight < MEDIUM_COMPETENCY_LINK_WEIGHT_CUT_OFF
+                                              ? MEDIUM_COMPETENCY_LINK_WEIGHT
+                                              : HIGH_COMPETENCY_LINK_WEIGHT
+                                    "
+                                    (ngModelChange)="updateLinkWeight(competencyLink, $event)"
+                                    [ngbTooltip]="'artemisApp.competency.link.weightTooltip' | artemisTranslate"
+                                >
+                                    <option [ngValue]="LOW_COMPETENCY_LINK_WEIGHT" jhiTranslate="artemisApp.competency.link.weightLabels.low"></option>
+                                    <option [ngValue]="MEDIUM_COMPETENCY_LINK_WEIGHT" jhiTranslate="artemisApp.competency.link.weightLabels.medium"></option>
+                                    <option [ngValue]="HIGH_COMPETENCY_LINK_WEIGHT" jhiTranslate="artemisApp.competency.link.weightLabels.high"></option>
+                                </select>
+                            }
+                        </div>
+                    }
+                }
+            </div>
+        }
+    </div>
+}

--- a/src/main/webapp/app/atlas/shared/competency-selection-primeng/competency-selection-primeng.component.scss
+++ b/src/main/webapp/app/atlas/shared/competency-selection-primeng/competency-selection-primeng.component.scss
@@ -1,0 +1,14 @@
+.competency-selector {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    column-gap: 24px;
+    max-height: 200px;
+    overflow-x: auto;
+    border: var(--bs-border-width) solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+
+    label {
+        display: contents;
+    }
+}

--- a/src/main/webapp/app/atlas/shared/competency-selection-primeng/competency-selection-primeng.component.spec.ts
+++ b/src/main/webapp/app/atlas/shared/competency-selection-primeng/competency-selection-primeng.component.spec.ts
@@ -1,0 +1,444 @@
+import { vi } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { Competency, CompetencyLearningObjectLink } from 'app/atlas/shared/entities/competency.model';
+import { of, throwError } from 'rxjs';
+import { HttpClient, HttpResponse, provideHttpClient } from '@angular/common/http';
+import { By } from '@angular/platform-browser';
+import { CourseStorageService } from 'app/core/course/manage/services/course-storage.service';
+import { ChangeDetectorRef } from '@angular/core';
+import { CourseCompetencyService } from 'app/atlas/shared/services/course-competency.service';
+import { Prerequisite } from 'app/atlas/shared/entities/prerequisite.model';
+import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
+import { TranslateService } from '@ngx-translate/core';
+import { MockProvider } from 'ng-mocks';
+import { AccountService } from 'app/core/auth/account.service';
+import { MockAccountService } from 'test/helpers/mocks/service/mock-account.service';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
+import { ProfileInfo } from 'app/core/layouts/profiles/profile-info.model';
+import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
+import { MODULE_FEATURE_ATLAS } from 'app/app.constants';
+import { CompetencySelectionPrimengComponent } from 'app/atlas/shared/competency-selection-primeng/competency-selection-primeng.component';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+describe('CompetencySelection', () => {
+    setupTestBed({ zoneless: true });
+    let fixture: ComponentFixture<CompetencySelectionPrimengComponent>;
+    let component: CompetencySelectionPrimengComponent;
+    let courseStorageService: CourseStorageService;
+    let courseCompetencyService: CourseCompetencyService;
+    let httpClient: HttpClient;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [CompetencySelectionPrimengComponent],
+            providers: [
+                {
+                    provide: ActivatedRoute,
+                    useValue: {
+                        snapshot: {
+                            paramMap: convertToParamMap({ courseId: 1 }),
+                        },
+                    } as any as ActivatedRoute,
+                },
+                { provide: TranslateService, useClass: MockTranslateService },
+                { provide: AccountService, useClass: MockAccountService },
+                { provide: ProfileService, useClass: MockProfileService },
+                MockProvider(CourseStorageService, {
+                    getCourse: () => ({ id: 1, competencies: [] }),
+                }),
+                MockProvider(CourseCompetencyService, {
+                    getAllForCourse: () => of(new HttpResponse({ body: [] })),
+                }),
+                provideHttpClient(),
+                provideHttpClientTesting(),
+            ],
+        });
+
+        fixture = TestBed.createComponent(CompetencySelectionPrimengComponent);
+        component = fixture.componentInstance;
+        courseStorageService = TestBed.inject(CourseStorageService);
+        courseCompetencyService = TestBed.inject(CourseCompetencyService);
+        httpClient = TestBed.inject(HttpClient);
+        const profileService = TestBed.inject(ProfileService);
+
+        const profileInfo = { activeModuleFeatures: [MODULE_FEATURE_ATLAS] } as ProfileInfo;
+        const getProfileInfoMock = vi.spyOn(profileService, 'getProfileInfo');
+        getProfileInfoMock.mockReturnValue(profileInfo);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should get competencies from cache', () => {
+        const nonOptional = { id: 1, optional: false } as Competency;
+        const optional = { id: 2, optional: true } as Competency;
+        const getCourseSpy = vi.spyOn(courseStorageService, 'getCourse').mockReturnValue({ competencies: [nonOptional, optional] });
+        const getAllForCourseSpy = vi.spyOn(courseCompetencyService, 'getAllForCourse');
+
+        fixture.detectChanges();
+
+        const selector = fixture.debugElement.nativeElement.querySelector('#competency-selector');
+        expect(component.selectedCompetencyLinks).toBeUndefined();
+        expect(getCourseSpy).toHaveBeenCalledOnce();
+        expect(getAllForCourseSpy).not.toHaveBeenCalled();
+        expect(component.isLoading).toBeFalsy();
+        expect(component.competencyLinks).toHaveLength(2);
+        expect(selector).not.toBeNull();
+    });
+
+    it('should get competencies from service', () => {
+        const nonOptional = { id: 1, optional: false } as Competency;
+        const optional = { id: 2, optional: true } as Competency;
+        const getCourseSpy = vi.spyOn(courseStorageService, 'getCourse').mockReturnValue({ competencies: undefined });
+        const getAllForCourseSpy = vi.spyOn(courseCompetencyService, 'getAllForCourse').mockReturnValue(of(new HttpResponse({ body: [nonOptional, optional] })));
+
+        fixture.detectChanges();
+
+        expect(getCourseSpy).toHaveBeenCalledOnce();
+        expect(getAllForCourseSpy).toHaveBeenCalledOnce();
+        expect(component.isLoading).toBeFalsy();
+        expect(component.competencyLinks).toHaveLength(2);
+        expect(component.competencyLinks?.first()?.competency?.course).toBeUndefined();
+        expect(component.competencyLinks?.first()?.competency?.userProgress).toBeUndefined();
+    });
+
+    it('should set disabled when error during loading', () => {
+        const getCourseSpy = vi.spyOn(courseStorageService, 'getCourse').mockReturnValue({ competencies: undefined });
+        const getAllForCourseSpy = vi.spyOn(courseCompetencyService, 'getAllForCourse').mockReturnValue(throwError(() => ({ status: 404 })));
+
+        fixture.detectChanges();
+
+        expect(getCourseSpy).toHaveBeenCalledOnce();
+        expect(getAllForCourseSpy).toHaveBeenCalledOnce();
+        expect(component.isLoading).toBeFalsy();
+        expect(component.disabled).toBeTruthy();
+    });
+
+    it('should be hidden when no competencies', () => {
+        const getCourseSpy = vi.spyOn(courseStorageService, 'getCourse').mockReturnValue({ competencies: [] });
+        const getAllForCourseSpy = vi.spyOn(courseCompetencyService, 'getAllForCourse').mockReturnValue(of(new HttpResponse({ body: [] })));
+
+        fixture.detectChanges();
+
+        const select = fixture.debugElement.query(By.css('select'));
+        expect(getCourseSpy).toHaveBeenCalledOnce();
+        expect(getAllForCourseSpy).toHaveBeenCalledOnce();
+        expect(component.isLoading).toBeFalsy();
+        expect(component.competencyLinks).toHaveLength(0);
+        expect(select).toBeNull();
+    });
+
+    it('should select competencies when value is written', () => {
+        vi.spyOn(courseStorageService, 'getCourse').mockReturnValue({ competencies: [{ id: 1, title: 'test' } as Competency] });
+
+        fixture.detectChanges();
+
+        component.writeValue([new CompetencyLearningObjectLink({ id: 1, title: 'other' } as Competency, 1)]);
+        expect(component.selectedCompetencyLinks).toHaveLength(1);
+        expect(component.selectedCompetencyLinks?.first()?.competency?.title).toBe('test');
+    });
+
+    it('should update link weight when value is written', () => {
+        vi.spyOn(courseStorageService, 'getCourse').mockReturnValue({
+            competencies: [{ id: 1, title: 'test' } as Competency, { id: 2, title: 'testAgain' } as Prerequisite, { id: 3, title: 'testMore' } as Competency],
+        });
+
+        fixture.detectChanges();
+
+        component.writeValue([
+            new CompetencyLearningObjectLink({ id: 1, title: 'other' } as Competency, 0.5),
+            new CompetencyLearningObjectLink({ id: 3, title: 'otherMore' } as Competency, 1),
+        ]);
+        expect(component.selectedCompetencyLinks).toHaveLength(2);
+        expect(component.selectedCompetencyLinks?.first()?.weight).toBe(0.5);
+        expect(component.selectedCompetencyLinks?.last()?.weight).toBe(1);
+    });
+
+    it('should trigger change detection after loading competencies', () => {
+        vi.spyOn(courseStorageService, 'getCourse').mockReturnValue({ competencies: undefined });
+        const changeDetector = fixture.debugElement.injector.get(ChangeDetectorRef);
+        const detectChangesStub = vi.spyOn(changeDetector.constructor.prototype, 'detectChanges');
+
+        fixture.detectChanges();
+
+        expect(detectChangesStub).toHaveBeenCalled();
+    });
+
+    it('should select / unselect competencies', () => {
+        const competency1 = { id: 1, optional: false } as Competency;
+        const competency2 = { id: 2, optional: true } as Competency;
+        const competency3 = { id: 3, optional: false } as Competency;
+        vi.spyOn(courseStorageService, 'getCourse').mockReturnValue({ competencies: [competency1, competency2, competency3] });
+
+        fixture.detectChanges();
+        expect(component.selectedCompetencyLinks).toBeUndefined();
+
+        component.toggleCompetency(new CompetencyLearningObjectLink(competency1, 1));
+        component.toggleCompetency(new CompetencyLearningObjectLink(competency2, 1));
+        component.toggleCompetency(new CompetencyLearningObjectLink(competency3, 1));
+
+        expect(component.selectedCompetencyLinks).toHaveLength(3);
+        expect(component.selectedCompetencyLinks).toContainEqual(new CompetencyLearningObjectLink(competency3, 1));
+
+        component.toggleCompetency(new CompetencyLearningObjectLink(competency2, 1));
+
+        expect(component.selectedCompetencyLinks).toHaveLength(2);
+        expect(component.selectedCompetencyLinks).not.toContainEqual(new CompetencyLearningObjectLink(competency2, 1));
+
+        component.toggleCompetency(new CompetencyLearningObjectLink(competency1, 1));
+        component.toggleCompetency(new CompetencyLearningObjectLink(competency3, 1));
+
+        expect(component.selectedCompetencyLinks).toBeUndefined();
+    });
+
+    it('should register onchange', () => {
+        component.checkboxStates = {};
+        const registerSpy = vi.fn();
+        component.registerOnChange(registerSpy);
+        component.toggleCompetency(new CompetencyLearningObjectLink({ id: 1 }, 1));
+        expect(registerSpy).toHaveBeenCalled();
+    });
+
+    it('should set disabled state', () => {
+        component.disabled = true;
+        component.setDisabledState?.(false);
+        expect(component.disabled).toBeFalsy();
+    });
+
+    describe('AtlasML Competency Suggestions', () => {
+        beforeEach(() => {
+            const competency1 = { id: 1, title: 'Programming Basics', optional: false } as Competency;
+            const competency2 = { id: 2, title: 'Data Structures', optional: false } as Competency;
+            const competency3 = { id: 3, title: 'Algorithms', optional: false } as Competency;
+            vi.spyOn(courseStorageService, 'getCourse').mockReturnValue({ competencies: [competency1, competency2, competency3] });
+
+            fixture.componentRef.setInput('exerciseDescription', 'Create a Java program that implements a sorting algorithm');
+            fixture.changeDetectorRef.detectChanges();
+        });
+
+        it('should show lightbulb button for competency suggestions', () => {
+            fixture.changeDetectorRef.detectChanges();
+            const btnDe = fixture.debugElement.query(By.css('jhi-button'));
+            expect(btnDe).not.toBeNull();
+            // Disabled state is controlled by input binding
+            const cmp = btnDe.componentInstance;
+            expect(cmp.disabled()).toBeFalsy();
+        });
+
+        it('should disable lightbulb button when no exercise description', () => {
+            fixture.componentRef.setInput('exerciseDescription', '');
+            fixture.changeDetectorRef.detectChanges();
+
+            const btnDe = fixture.debugElement.query(By.css('jhi-button'));
+            const cmp = btnDe.componentInstance;
+            expect(cmp.disabled()).toBeTruthy();
+        });
+
+        it('should call API and show suggestions when lightbulb button is clicked', () => {
+            const mockSuggestionResponse = {
+                competencies: [
+                    { id: 1, title: 'Programming Basics' },
+                    { id: 3, title: 'Algorithms' },
+                ],
+            };
+
+            const httpPostSpy = vi.spyOn(httpClient, 'post').mockReturnValue(of(mockSuggestionResponse));
+
+            component.suggestCompetencies();
+
+            expect(httpPostSpy).toHaveBeenCalledWith('/api/atlas/competencies/suggest', {
+                description: 'Create a Java program that implements a sorting algorithm',
+                course_id: '1',
+            });
+            expect(component.suggestedCompetencyIds.has(1)).toBeTruthy();
+            expect(component.suggestedCompetencyIds.has(3)).toBeTruthy();
+            expect(component.suggestedCompetencyIds.has(2)).toBeFalsy();
+            expect(component.isSuggesting).toBeFalsy();
+        });
+
+        it('should show spinner while suggesting competencies', () => {
+            component.isSuggesting = true;
+            fixture.changeDetectorRef.detectChanges();
+
+            const btnDe = fixture.debugElement.query(By.css('jhi-button'));
+            const spinnerIcon = btnDe?.query(By.css('.jhi-btn__loading'));
+            const lightbulbIcon = btnDe?.query(By.css('.jhi-btn__icon'));
+
+            expect(spinnerIcon).not.toBeNull();
+            expect(lightbulbIcon).toBeNull(); // Should not show lightbulb icon when showing spinner
+        });
+
+        it('should display lightbulb icon next to suggested competencies', () => {
+            const mockSuggestionResponse = {
+                competencies: [{ id: 1, title: 'Programming Basics' }],
+            };
+
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(mockSuggestionResponse));
+
+            component.suggestCompetencies();
+            fixture.changeDetectorRef.detectChanges();
+
+            expect(component.isSuggested(1)).toBeTruthy();
+            expect(component.isSuggested(2)).toBeFalsy();
+
+            // Check for lightbulb icons with warning color next to competencies
+            const suggestedLightbulbs = fixture.debugElement.queryAll(By.css('fa-icon.text-warning.ms-2'));
+            expect(suggestedLightbulbs.length).toBeGreaterThan(0);
+        });
+
+        it('should sort suggested competencies to the top', () => {
+            const mockSuggestionResponse = {
+                competencies: [{ id: 3, title: 'Algorithms' }],
+            };
+
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(mockSuggestionResponse));
+
+            component.suggestCompetencies();
+
+            const firstCompetency = component.competencyLinks?.[0];
+            expect(firstCompetency?.competency?.id).toBe(3);
+            expect(component.isSuggested(3)).toBeTruthy();
+        });
+
+        it('should handle API error gracefully', () => {
+            vi.spyOn(httpClient, 'post').mockReturnValue(throwError(() => ({ status: 500 })));
+
+            component.suggestCompetencies();
+
+            expect(component.isSuggesting).toBeFalsy();
+            expect(component.suggestedCompetencyIds.size).toBe(0);
+        });
+
+        it('should not call API if description is empty or whitespace only', () => {
+            const httpPostSpy = vi.spyOn(httpClient, 'post');
+
+            fixture.componentRef.setInput('exerciseDescription', '');
+            component.suggestCompetencies();
+            expect(httpPostSpy).not.toHaveBeenCalled();
+
+            fixture.componentRef.setInput('exerciseDescription', '   ');
+            component.suggestCompetencies();
+            expect(httpPostSpy).not.toHaveBeenCalled();
+        });
+
+        it('should clear previous suggestions when making new request', () => {
+            // First suggestion
+            component.suggestedCompetencyIds.add(1);
+            component.suggestedCompetencyIds.add(2);
+
+            const mockResponse = { competencies: [{ id: 3, title: 'New Suggestion' }] };
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+
+            component.suggestCompetencies();
+
+            expect(component.suggestedCompetencyIds.has(1)).toBeFalsy();
+            expect(component.suggestedCompetencyIds.has(2)).toBeFalsy();
+            expect(component.suggestedCompetencyIds.has(3)).toBeTruthy();
+        });
+
+        it('should handle empty response from API', () => {
+            const mockResponse = { competencies: [] };
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+
+            component.suggestCompetencies();
+
+            expect(component.suggestedCompetencyIds.size).toBe(0);
+            expect(component.isSuggesting).toBeFalsy();
+        });
+
+        it('should disable lightbulb button while suggesting', () => {
+            component.isSuggesting = true;
+            fixture.changeDetectorRef.detectChanges();
+
+            const btnDe = fixture.debugElement.query(By.css('jhi-button'));
+            const cmp = btnDe.componentInstance;
+            expect(cmp.disabled()).toBeTruthy();
+        });
+
+        it('should show lightbulb tooltip', () => {
+            fixture.changeDetectorRef.detectChanges();
+            const btnDe = fixture.debugElement.query(By.css('jhi-button'));
+            const cmp = btnDe.componentInstance;
+            expect(cmp.tooltip()).toBe('artemisApp.courseCompetency.relations.suggestions.getAiSuggestionsTooltip');
+        });
+
+        it('should show AI suggested competency tooltip', () => {
+            const mockSuggestionResponse = {
+                competencies: [{ id: 1, title: 'Programming Basics' }],
+            };
+
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(mockSuggestionResponse));
+
+            component.suggestCompetencies();
+            fixture.changeDetectorRef.detectChanges();
+
+            const suggestedIcon = fixture.debugElement.query(By.css('fa-icon.text-warning.ms-2'));
+            expect(suggestedIcon).toBeTruthy();
+            const tooltip = suggestedIcon.injector.get(NgbTooltip, null);
+            expect(tooltip).toBeTruthy();
+            expect(tooltip?.ngbTooltip).toBe('artemisApp.competency.suggestion.tooltip');
+        });
+
+        it('should match competencies by ID when processing suggestions', () => {
+            const mockResponse = {
+                competencies: [
+                    { id: 1, title: 'Different Title' }, // ID matches but title is different
+                    { id: 999, title: 'Non-existent' }, // ID doesn't match any competency
+                ],
+            };
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+
+            component.suggestCompetencies();
+
+            expect(component.suggestedCompetencyIds.has(1)).toBeTruthy(); // Should match by ID
+            expect(component.suggestedCompetencyIds.has(999)).toBeFalsy(); // Should not match non-existent ID
+        });
+    });
+
+    // Additional test suite for exercise creation integration
+    describe('Exercise Creation Integration', () => {
+        it('should accept exercise description as input', () => {
+            const testDescription = 'Test exercise description for suggestions';
+            fixture.componentRef.setInput('exerciseDescription', testDescription);
+            expect(component.exerciseDescription()).toBe(testDescription);
+        });
+
+        it('should emit value changes when competency is toggled', () => {
+            const competency = { id: 1, title: 'Test Competency', optional: false } as Competency;
+            vi.spyOn(courseStorageService, 'getCourse').mockReturnValue({ competencies: [competency] });
+
+            const emitSpy = vi.spyOn(component.valueChange, 'emit');
+
+            fixture.detectChanges();
+
+            component.toggleCompetency(new CompetencyLearningObjectLink(competency, 1));
+
+            expect(emitSpy).toHaveBeenCalled();
+        });
+
+        it('should work with different exercise types', () => {
+            // Test that the component works regardless of the exercise type
+            // by testing with different descriptions
+            const descriptions = [
+                'Programming exercise: implement bubble sort',
+                'Text exercise: write an essay about algorithms',
+                'Modeling exercise: create UML diagrams',
+                'Quiz exercise: multiple choice questions',
+            ];
+
+            descriptions.forEach((desc) => {
+                fixture.componentRef.setInput('exerciseDescription', desc);
+                expect(component.exerciseDescription()?.trim()).toBeTruthy();
+
+                // Button should be enabled for non-empty descriptions
+                fixture.changeDetectorRef.detectChanges();
+                const lightbulbButton = fixture.debugElement.query(By.css('button[ngbTooltip="Get AI Suggestions"]'));
+                expect(lightbulbButton?.nativeElement.disabled).toBeFalsy();
+            });
+        });
+    });
+});

--- a/src/main/webapp/app/atlas/shared/competency-selection-primeng/competency-selection-primeng.component.ts
+++ b/src/main/webapp/app/atlas/shared/competency-selection-primeng/competency-selection-primeng.component.ts
@@ -1,0 +1,313 @@
+import { ChangeDetectorRef, Component, OnInit, forwardRef, inject, input, output } from '@angular/core';
+import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { faLightbulb, faQuestionCircle, faStar } from '@fortawesome/free-solid-svg-icons';
+import { HttpClient } from '@angular/common/http';
+import {
+    CompetencyLearningObjectLink,
+    CourseCompetency,
+    HIGH_COMPETENCY_LINK_WEIGHT,
+    LOW_COMPETENCY_LINK_WEIGHT,
+    LOW_COMPETENCY_LINK_WEIGHT_CUT_OFF,
+    MEDIUM_COMPETENCY_LINK_WEIGHT,
+    MEDIUM_COMPETENCY_LINK_WEIGHT_CUT_OFF,
+    getIcon,
+} from 'app/atlas/shared/entities/competency.model';
+import { ActivatedRoute } from '@angular/router';
+import { CourseStorageService } from 'app/core/course/manage/services/course-storage.service';
+import { finalize } from 'rxjs';
+import { CourseCompetencyService } from 'app/atlas/shared/services/course-competency.service';
+import { FaIconComponent, FaStackComponent, FaStackItemSizeDirective } from '@fortawesome/angular-fontawesome';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
+import { MODULE_FEATURE_ATLAS } from 'app/app.constants';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { FeatureToggleHideDirective } from 'app/shared/feature-toggle/feature-toggle-hide.directive';
+import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
+import { ButtonComponent, ButtonSize, ButtonType } from 'app/shared/components/buttons/button/button.component';
+
+@Component({
+    selector: 'jhi-competency-selection-primeng',
+    templateUrl: './competency-selection-primeng.component.html',
+    styleUrls: ['./competency-selection-primeng.component.scss'],
+    providers: [
+        {
+            provide: NG_VALUE_ACCESSOR,
+            multi: true,
+            useExisting: forwardRef(() => CompetencySelectionPrimengComponent),
+        },
+    ],
+    imports: [
+        FaStackComponent,
+        NgbTooltip,
+        FaIconComponent,
+        FaStackItemSizeDirective,
+        FormsModule,
+        TranslateDirective,
+        ArtemisTranslatePipe,
+        FeatureToggleHideDirective,
+        ButtonComponent,
+    ],
+})
+export class CompetencySelectionPrimengComponent implements OnInit, ControlValueAccessor {
+    private route = inject(ActivatedRoute);
+    private courseStorageService = inject(CourseStorageService);
+    private courseCompetencyService = inject(CourseCompetencyService);
+    private changeDetector = inject(ChangeDetectorRef);
+    private profileService = inject(ProfileService);
+    private http = inject(HttpClient);
+
+    labelName = input<string>('');
+    labelTooltip = input<string>('');
+    exerciseDescription = input<string | undefined>(undefined);
+
+    valueChange = output<CompetencyLearningObjectLink[] | undefined>();
+
+    disabled: boolean;
+    // selected competencies
+    selectedCompetencyLinks?: CompetencyLearningObjectLink[];
+    // all course competencies
+    competencyLinks?: CompetencyLearningObjectLink[];
+
+    isLoading = false;
+    isSuggesting = false;
+    checkboxStates: Record<number, boolean>;
+    suggestedCompetencyIds = new Set<number>();
+    /** Pending links received via refreshWithLinks before competency loading finished. */
+    private pendingRefreshLinks?: CompetencyLearningObjectLink[];
+
+    getIcon = getIcon;
+    faQuestionCircle = faQuestionCircle;
+    faStar = faStar;
+    faLightbulb = faLightbulb;
+
+    protected readonly FeatureToggle = FeatureToggle;
+
+    _onChange = (_value: any) => {};
+
+    protected readonly HIGH_COMPETENCY_LINK_WEIGHT = HIGH_COMPETENCY_LINK_WEIGHT;
+    protected readonly MEDIUM_COMPETENCY_LINK_WEIGHT = MEDIUM_COMPETENCY_LINK_WEIGHT;
+    protected readonly LOW_COMPETENCY_LINK_WEIGHT = LOW_COMPETENCY_LINK_WEIGHT;
+    protected readonly LOW_COMPETENCY_LINK_WEIGHT_CUT_OFF = LOW_COMPETENCY_LINK_WEIGHT_CUT_OFF; // halfway between low and medium
+    protected readonly MEDIUM_COMPETENCY_LINK_WEIGHT_CUT_OFF = MEDIUM_COMPETENCY_LINK_WEIGHT_CUT_OFF;
+    // halfway between medium and high
+
+    protected readonly ButtonType = ButtonType;
+    protected readonly ButtonSize = ButtonSize;
+
+    ngOnInit(): void {
+        // it's an explicit design decision to not clutter every component that uses this component with the need to check if the atlas profile is enabled
+        if (this.profileService.isModuleFeatureActive(MODULE_FEATURE_ATLAS)) {
+            this.initialize();
+        }
+    }
+
+    initialize(): void {
+        const courseId = Number(this.route.snapshot.paramMap.get('courseId'));
+        if (!this.competencyLinks && courseId) {
+            const course = this.courseStorageService.getCourse(courseId);
+            // an empty array is used as fallback, if a course is cached, where no competencies have been queried
+            if (course?.competencies?.length || course?.prerequisites?.length) {
+                this.setCompetencyLinks([...(course.competencies ?? []), ...(course.prerequisites ?? [])]);
+            } else {
+                this.isLoading = true;
+                this.courseCompetencyService
+                    .getAllForCourse(courseId)
+                    .pipe(
+                        finalize(() => {
+                            this.isLoading = false;
+
+                            // trigger change detection manually
+                            // necessary because quiz exercises use ChangeDetectionStrategy.OnPush
+                            this.changeDetector.detectChanges();
+                        }),
+                    )
+                    .subscribe({
+                        next: (response) => {
+                            this.setCompetencyLinks(response.body!);
+                            // Apply any links that arrived via refreshWithLinks() while still loading
+                            if (this.pendingRefreshLinks) {
+                                this.refreshWithLinks(this.pendingRefreshLinks);
+                                this.pendingRefreshLinks = undefined;
+                            } else {
+                                this.writeValue(this.selectedCompetencyLinks);
+                            }
+                        },
+                        error: () => {
+                            this.disabled = true;
+                        },
+                    });
+            }
+        }
+    }
+
+    /**
+     * Set the available competencyLinks for selection
+     * @param competencies The competencies of the course
+     */
+    setCompetencyLinks(competencies: CourseCompetency[]) {
+        this.competencyLinks = competencies.map((competency) => {
+            // Remove unnecessary properties
+            competency.course = undefined;
+            competency.userProgress = undefined;
+            return new CompetencyLearningObjectLink(competency, MEDIUM_COMPETENCY_LINK_WEIGHT);
+        });
+        this.checkboxStates = this.competencyLinks.reduce(
+            (states, competencyLink) => {
+                if (competencyLink.competency?.id) {
+                    states[competencyLink.competency.id] = !!this.selectedCompetencyLinks?.find((value) => value.competency?.id === competencyLink.competency?.id);
+                }
+                return states;
+            },
+            {} as Record<number, boolean>,
+        );
+    }
+
+    toggleCompetency(newValue: CompetencyLearningObjectLink) {
+        if (newValue.competency?.id) {
+            if (this.checkboxStates[newValue.competency.id]) {
+                this.selectedCompetencyLinks = this.selectedCompetencyLinks?.filter((value) => value.competency?.id !== newValue.competency?.id);
+            } else {
+                this.selectedCompetencyLinks = [...(this.selectedCompetencyLinks ?? []), newValue];
+            }
+
+            this.checkboxStates[newValue.competency.id] = !this.checkboxStates[newValue.competency.id];
+
+            // make sure to do not send an empty list to server
+            if (!this.selectedCompetencyLinks?.length) {
+                this.selectedCompetencyLinks = undefined;
+            }
+
+            this._onChange(this.selectedCompetencyLinks);
+            this.valueChange.emit(this.selectedCompetencyLinks);
+        }
+    }
+
+    updateLinkWeight(link: CompetencyLearningObjectLink, value: number) {
+        link.weight = value;
+
+        this._onChange(this.selectedCompetencyLinks);
+        this.valueChange.emit(this.selectedCompetencyLinks);
+    }
+
+    writeValue(value?: CompetencyLearningObjectLink[]): void {
+        this.competencyLinks?.forEach((link) => {
+            const selectedLink = value?.find((value) => value.competency?.id === link.competency?.id);
+            link.weight = selectedLink?.weight ?? MEDIUM_COMPETENCY_LINK_WEIGHT;
+        });
+
+        if (value && this.competencyLinks) {
+            // Compare the ids of the competencies instead of the whole objects
+            const ids = value.map((el) => el.competency?.id);
+            this.selectedCompetencyLinks = this.competencyLinks.filter((competencyLink) => ids.includes(competencyLink.competency?.id));
+        } else {
+            this.selectedCompetencyLinks = value ?? [];
+        }
+    }
+
+    /** Merges new competencies from the given links into the available list and rebuilds selection/checkbox state. */
+    refreshWithLinks(links: CompetencyLearningObjectLink[]): void {
+        if (!links) return;
+
+        // If competencies haven't loaded yet, store the links so they can be applied once loading finishes
+        if (!this.competencyLinks) {
+            this.pendingRefreshLinks = links;
+            return;
+        }
+
+        // Add any new competencies to the available list that aren't there yet
+        const availableIds = new Set(this.competencyLinks.map((l) => l.competency?.id).filter(Boolean));
+        const newLinks = links
+            .filter((link) => link.competency?.id && !availableIds.has(link.competency.id))
+            .map((link) => new CompetencyLearningObjectLink(link.competency, link.weight ?? MEDIUM_COMPETENCY_LINK_WEIGHT));
+        if (newLinks.length > 0) {
+            this.competencyLinks = [...this.competencyLinks, ...newLinks];
+        }
+
+        // Update selection state
+        this.writeValue(links);
+
+        // Notify the form control of the change to maintain ControlValueAccessor contract
+        if (this._onChange) {
+            this._onChange(this.selectedCompetencyLinks);
+        }
+        this.valueChange.emit(this.selectedCompetencyLinks);
+
+        // Rebuild checkbox states to match the current selection
+        const selectedIds = new Set((this.selectedCompetencyLinks ?? []).map((l) => l.competency?.id).filter(Boolean));
+        this.checkboxStates = this.competencyLinks.reduce(
+            (states, cl) => {
+                if (cl.competency?.id) {
+                    states[cl.competency.id] = selectedIds.has(cl.competency.id);
+                }
+                return states;
+            },
+            {} as Record<number, boolean>,
+        );
+    }
+
+    registerOnChange(fn: any): void {
+        this._onChange = fn;
+    }
+
+    registerOnTouched(_fn: any): void {}
+
+    suggestCompetencies(): void {
+        if (!this.exerciseDescription()?.trim()) {
+            return;
+        }
+
+        this.isSuggesting = true;
+        this.suggestedCompetencyIds.clear();
+
+        const courseId = Number(this.route.snapshot.paramMap.get('courseId'));
+        const requestBody = { description: this.exerciseDescription(), course_id: courseId?.toString() };
+
+        this.http
+            .post<{ competencies: any[] }>('/api/atlas/competencies/suggest', requestBody)
+            .pipe(
+                finalize(() => {
+                    this.isSuggesting = false;
+                    this.changeDetector.detectChanges();
+                }),
+            )
+            .subscribe({
+                next: (response) => {
+                    response.competencies.forEach((suggestion) => {
+                        const matchingLink = this.competencyLinks?.find((link) => link.competency?.id === Number(suggestion.id));
+                        if (matchingLink?.competency?.id) {
+                            this.suggestedCompetencyIds.add(matchingLink.competency.id);
+                        }
+                    });
+                    this.sortCompetenciesBySuggestion();
+                },
+                error: (error) => {
+                    // console.error('Error getting competency suggestions:', error);
+                },
+            });
+    }
+
+    isSuggested(competencyId: number): boolean {
+        return this.suggestedCompetencyIds.has(competencyId);
+    }
+
+    sortCompetenciesBySuggestion(): void {
+        if (this.competencyLinks) {
+            this.competencyLinks.sort((a, b) => {
+                const aIsSuggested = a.competency?.id ? this.isSuggested(a.competency.id) : false;
+                const bIsSuggested = b.competency?.id ? this.isSuggested(b.competency.id) : false;
+
+                // Sort suggested competencies to the top
+                if (aIsSuggested && !bIsSuggested) return -1;
+                if (!aIsSuggested && bIsSuggested) return 1;
+
+                // Keep original order for items with same suggestion status
+                return 0;
+            });
+        }
+    }
+
+    setDisabledState?(isDisabled: boolean): void {
+        this.disabled = isDisabled;
+    }
+}

--- a/src/main/webapp/app/atlas/shared/competency-selection-primeng/exercise-competency-suggestion.spec.ts
+++ b/src/main/webapp/app/atlas/shared/competency-selection-primeng/exercise-competency-suggestion.spec.ts
@@ -1,0 +1,414 @@
+import { vi } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CUSTOM_ELEMENTS_SCHEMA, Component, viewChild } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { HttpClient, provideHttpClient } from '@angular/common/http';
+import { By } from '@angular/platform-browser';
+import { delay, of, throwError } from 'rxjs';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { CompetencySelectionPrimengComponent } from 'app/atlas/shared/competency-selection-primeng/competency-selection-primeng.component';
+import { CourseStorageService } from 'app/core/course/manage/services/course-storage.service';
+import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
+import { TranslateService } from '@ngx-translate/core';
+import { AccountService } from 'app/core/auth/account.service';
+
+import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
+import { MockAccountService } from 'test/helpers/mocks/service/mock-account.service';
+import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
+import { MockProvider } from 'ng-mocks';
+import { MODULE_FEATURE_ATLAS } from 'app/app.constants';
+import { ProfileInfo } from 'app/core/layouts/profiles/profile-info.model';
+import { Competency } from 'app/atlas/shared/entities/competency.model';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+/**
+ * Test component that simulates an exercise creation form
+ * This mimics how the competency selection component is used in real exercise forms
+ */
+@Component({
+    imports: [FormsModule, CompetencySelectionPrimengComponent],
+    template: `
+        <form #exerciseForm="ngForm">
+            <div class="form-group">
+                <label for="title">Exercise Title</label>
+                <input type="text" id="title" name="title" class="form-control" [(ngModel)]="exercise.title" required />
+            </div>
+
+            <div class="form-group">
+                <label for="description">Exercise Description</label>
+                <textarea id="description" name="description" class="form-control" [(ngModel)]="exercise.description" rows="4" required></textarea>
+            </div>
+
+            <!-- This is where the competency selection component is integrated -->
+            <jhi-competency-selection-primeng
+                [exerciseDescription]="exercise.description"
+                [labelName]="'Select Competencies'"
+                [labelTooltip]="'Choose competencies that this exercise will assess'"
+                [(ngModel)]="exercise.competencies"
+                name="competencies"
+            >
+            </jhi-competency-selection-primeng>
+
+            <div class="form-actions">
+                <button type="submit" class="btn btn-primary" [disabled]="!exerciseForm.valid" (click)="saveExercise()">Save Exercise</button>
+            </div>
+        </form>
+    `,
+})
+class TestExerciseFormComponent {
+    competencySelection = viewChild.required<CompetencySelectionPrimengComponent>(CompetencySelectionPrimengComponent);
+
+    exercise = {
+        title: '',
+        description: '',
+        competencies: [],
+    };
+
+    saveExercise(): void {
+        // Mock save functionality
+    }
+}
+
+/**
+ * End-to-End test suite for competency suggestions in exercise creation workflow
+ *
+ * Tests the complete user journey:
+ * 1. User creates an exercise
+ * 2. Enters exercise description
+ * 3. Clicks lightbulb to get AI suggestions
+ * 4. Views suggested competencies with lightbulb icons
+ * 5. Selects competencies (including suggested ones)
+ * 6. Saves the exercise
+ */
+describe('Exercise Creation with Competency Suggestions - E2E', () => {
+    setupTestBed({ zoneless: true });
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+    let fixture: ComponentFixture<TestExerciseFormComponent>;
+    let component: TestExerciseFormComponent;
+    let httpClient: HttpClient;
+    let courseStorageService: CourseStorageService;
+
+    const sampleCompetencies: Competency[] = [
+        { id: 1, title: 'Java Programming', description: 'Object-oriented programming in Java', optional: false } as Competency,
+        { id: 2, title: 'Data Structures', description: 'Arrays, LinkedLists, Trees, Graphs', optional: false } as Competency,
+        { id: 3, title: 'Algorithm Analysis', description: 'Big-O notation and complexity analysis', optional: false } as Competency,
+        { id: 4, title: 'Software Testing', description: 'Unit testing and test-driven development', optional: false } as Competency,
+        { id: 5, title: 'Design Patterns', description: 'Common software design patterns', optional: false } as Competency,
+    ];
+
+    beforeEach(() => {
+        consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [TestExerciseFormComponent],
+            providers: [
+                {
+                    provide: ActivatedRoute,
+                    useValue: {
+                        snapshot: {
+                            paramMap: convertToParamMap({ courseId: 123 }),
+                        },
+                    },
+                },
+                { provide: TranslateService, useClass: MockTranslateService },
+                { provide: AccountService, useClass: MockAccountService },
+                { provide: ProfileService, useClass: MockProfileService },
+                MockProvider(CourseStorageService),
+                provideHttpClient(),
+                provideHttpClientTesting(),
+            ],
+            schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestExerciseFormComponent);
+        component = fixture.componentInstance;
+        httpClient = TestBed.inject(HttpClient);
+        courseStorageService = TestBed.inject(CourseStorageService);
+
+        // Setup Atlas feature enabled
+        const profileService = TestBed.inject(ProfileService);
+        const profileInfo = new ProfileInfo();
+        profileInfo.activeModuleFeatures = [MODULE_FEATURE_ATLAS];
+        vi.spyOn(profileService, 'getProfileInfo').mockReturnValue(profileInfo);
+
+        // Mock course with competencies
+        vi.spyOn(courseStorageService, 'getCourse').mockReturnValue({
+            id: 123,
+            competencies: sampleCompetencies,
+        });
+    });
+
+    afterEach(() => {
+        consoleErrorSpy?.mockRestore();
+        vi.restoreAllMocks();
+    });
+
+    describe('Template compatibility', () => {
+        it('should render without template binding errors', () => {
+            expect(() => fixture.detectChanges()).not.toThrow();
+            expect(consoleErrorSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Complete Exercise Creation Workflow', () => {
+        it('should allow user to create programming exercise with AI-suggested competencies', () => {
+            // Step 1: User fills out basic exercise information
+            component.exercise.title = 'Binary Search Tree Implementation';
+            component.exercise.description = 'Implement a binary search tree class in Java with insert, delete, and search methods. Include proper error handling and unit tests.';
+
+            fixture.detectChanges(false);
+
+            // Step 2: Verify competency selection component is rendered
+            const competencySelection = fixture.debugElement.query(By.directive(CompetencySelectionPrimengComponent));
+            expect(competencySelection).toBeTruthy();
+
+            // Step 3: Verify lightbulb button host (jhi-button) is present
+            const lightbulbButton = fixture.debugElement.query(By.css('jhi-button'));
+            expect(lightbulbButton).toBeTruthy();
+
+            // Step 4: Mock API response for suggestions
+            const suggestionResponse = {
+                competencies: [
+                    { id: 1, title: 'Java Programming' },
+                    { id: 2, title: 'Data Structures' },
+                    { id: 3, title: 'Algorithm Analysis' },
+                ],
+            };
+            vi.useFakeTimers();
+            try {
+                const httpSpy = vi.spyOn(httpClient, 'post').mockReturnValue(of(suggestionResponse).pipe(delay(0)));
+
+                // Step 5: Trigger suggestions via component API to avoid jhi-button internals
+                component.competencySelection().suggestCompetencies();
+                vi.runAllTimers();
+
+                // Step 6: Verify API was called with correct parameters
+                expect(httpSpy).toHaveBeenCalledWith('/api/atlas/competencies/suggest', {
+                    description: component.exercise.description,
+                    course_id: '123',
+                });
+
+                // Step 7: Verify suggested competencies are highlighted
+                const suggestedIcons = fixture.debugElement.queryAll(By.css('fa-icon.text-warning.ms-2'));
+                expect(suggestedIcons).toHaveLength(3);
+
+                // Step 8: Verify suggested competencies are sorted to top
+                const competencyCheckboxes = fixture.debugElement.queryAll(By.css('input[type="checkbox"]'));
+                expect(competencyCheckboxes[0].attributes['id']).toContain('competency-1');
+                expect(competencyCheckboxes[1].attributes['id']).toContain('competency-2');
+                expect(competencyCheckboxes[2].attributes['id']).toContain('competency-3');
+
+                // Step 9: Select suggested competencies via component API for reliability
+                const compForSelect = component.competencySelection();
+                const linkJava = compForSelect.competencyLinks?.find((l) => l.competency?.id === 1);
+                const linkDS = compForSelect.competencyLinks?.find((l) => l.competency?.id === 2);
+                expect(linkJava).toBeTruthy();
+                expect(linkDS).toBeTruthy();
+                if (linkJava) {
+                    compForSelect.toggleCompetency(linkJava);
+                }
+                if (linkDS) {
+                    compForSelect.toggleCompetency(linkDS);
+                }
+                fixture.detectChanges(false);
+            } finally {
+                vi.useRealTimers();
+            }
+
+            // Step 10: Verify form is valid and save button is enabled
+            const form = fixture.debugElement.query(By.css('form'));
+            const saveButton = fixture.debugElement.query(By.css('button[type="submit"]'));
+            expect(form).toBeTruthy();
+            expect(saveButton.nativeElement.disabled).toBeFalsy();
+
+            // Step 11: Verify competency selection component has correct value
+            const competencyComponent = component.competencySelection();
+            expect(competencyComponent.selectedCompetencyLinks?.length).toBe(2);
+            expect(competencyComponent.isSuggested(1)).toBeTruthy();
+            expect(competencyComponent.isSuggested(2)).toBeTruthy();
+        });
+
+        it('should handle mixed selection of suggested and non-suggested competencies', () => {
+            component.exercise.description = 'Create a comprehensive testing strategy for a Java application';
+            fixture.detectChanges(false);
+
+            // Mock suggestions for testing-related competencies
+            const suggestionResponse = {
+                competencies: [
+                    { id: 4, title: 'Software Testing' }, // Only testing is suggested
+                ],
+            };
+            vi.useFakeTimers();
+            try {
+                vi.spyOn(httpClient, 'post').mockReturnValue(of(suggestionResponse).pipe(delay(0)));
+
+                // Get suggestions via component API
+                const comp = component.competencySelection();
+                comp.suggestCompetencies();
+                vi.runAllTimers();
+
+                // Select both suggested and non-suggested via component API
+                const compMixed = component.competencySelection();
+                const linkTesting = compMixed.competencyLinks?.find((l) => l.competency?.id === 4);
+                const linkPatterns = compMixed.competencyLinks?.find((l) => l.competency?.id === 5);
+                expect(linkTesting).toBeTruthy();
+                expect(linkPatterns).toBeTruthy();
+                if (linkTesting) {
+                    compMixed.toggleCompetency(linkTesting);
+                }
+                if (linkPatterns) {
+                    compMixed.toggleCompetency(linkPatterns);
+                }
+                fixture.detectChanges(false);
+            } finally {
+                vi.useRealTimers();
+            }
+
+            // Verify both are selected but only one is marked as suggested
+            const competencyComponent = component.competencySelection();
+            expect(competencyComponent.selectedCompetencyLinks?.length).toBe(2);
+            expect(competencyComponent.isSuggested(4)).toBeTruthy(); // Suggested
+            expect(competencyComponent.isSuggested(5)).toBeFalsy(); // Not suggested
+
+            // Verify lightbulb icon only appears next to suggested competency
+            const suggestedIcons = fixture.debugElement.queryAll(By.css('fa-icon.text-warning.ms-2'));
+            expect(suggestedIcons).toHaveLength(1);
+        });
+    });
+
+    describe('Different Exercise Types Integration', () => {
+        const exerciseTypes = [
+            {
+                type: 'Programming',
+                title: 'Sorting Algorithm Implementation',
+                description: 'Implement quicksort and mergesort algorithms in Python and compare their performance',
+                expectedSuggestions: [1, 2, 3], // Programming, Data Structures, Algorithms
+            },
+            {
+                type: 'Text',
+                title: 'Software Architecture Essay',
+                description: 'Write an analysis of different design patterns and their applications in modern software development',
+                expectedSuggestions: [5], // Design Patterns
+            },
+            {
+                type: 'Quiz',
+                title: 'Java Fundamentals Quiz',
+                description: 'Multiple choice questions covering object-oriented programming concepts, inheritance, and polymorphism in Java',
+                expectedSuggestions: [1], // Java Programming
+            },
+        ];
+
+        exerciseTypes.forEach((exerciseType) => {
+            it(`should provide relevant suggestions for ${exerciseType.type} exercises`, () => {
+                // Setup exercise
+                component.exercise.title = exerciseType.title;
+                component.exercise.description = exerciseType.description;
+                fixture.detectChanges();
+
+                // Mock API response
+                const suggestionResponse = {
+                    competencies: exerciseType.expectedSuggestions.map((id) => ({
+                        id,
+                        title: sampleCompetencies[id - 1].title,
+                    })),
+                };
+                vi.spyOn(httpClient, 'post').mockReturnValue(of(suggestionResponse));
+
+                // Request suggestions via component API
+                const comp = component.competencySelection();
+                comp.suggestCompetencies();
+                fixture.detectChanges();
+
+                // Verify correct suggestions
+                const competencyComponent = component.competencySelection();
+                exerciseType.expectedSuggestions.forEach((competencyId) => {
+                    expect(competencyComponent.isSuggested(competencyId)).toBeTruthy();
+                });
+
+                // Verify correct number of suggestion icons
+                const suggestedIcons = fixture.debugElement.queryAll(By.css('fa-icon.text-warning.ms-2'));
+                expect(suggestedIcons).toHaveLength(exerciseType.expectedSuggestions.length);
+            });
+        });
+    });
+
+    describe('Error Handling in Exercise Creation', () => {
+        beforeEach(() => {
+            component.exercise.title = 'Test Exercise';
+            component.exercise.description = 'Test description for suggestions';
+            fixture.detectChanges(false);
+        });
+
+        it('should handle API errors gracefully without breaking exercise creation', () => {
+            // Mock API error
+            vi.spyOn(httpClient, 'post').mockReturnValue(throwError(() => ({ status: 500, message: 'Server Error' })));
+
+            const comp = component.competencySelection();
+            comp.suggestCompetencies();
+            fixture.detectChanges(false);
+
+            // Exercise creation should still work
+            const saveButton = fixture.debugElement.query(By.css('button[type="submit"]'));
+            expect(saveButton.nativeElement.disabled).toBeFalsy();
+
+            // No suggestions should be shown, but component should still function
+            const competencyComponent = component.competencySelection();
+            expect(competencyComponent.suggestedCompetencyIds.size).toBe(0);
+            expect(competencyComponent.isSuggesting).toBeFalsy();
+
+            // User should still be able to manually select competencies
+            const checkboxes = fixture.debugElement.queryAll(By.css('input[type="checkbox"]'));
+            checkboxes[0].nativeElement.click();
+            fixture.detectChanges();
+
+            expect(competencyComponent.selectedCompetencyLinks?.length).toBe(1);
+        });
+
+        it('should work when AtlasML feature is disabled', () => {
+            // Disable Atlas feature
+            const profileService = TestBed.inject(ProfileService);
+            const profileInfo = new ProfileInfo();
+            profileInfo.activeModuleFeatures = [];
+            vi.spyOn(profileService, 'getProfileInfo').mockReturnValue(profileInfo);
+
+            // Recreate component with disabled feature
+            component.competencySelection().ngOnInit();
+            fixture.detectChanges();
+
+            // Exercise creation should still work without suggestions
+            const saveButton = fixture.debugElement.query(By.css('button[type="submit"]'));
+            expect(saveButton.nativeElement.disabled).toBeFalsy();
+
+            // Lightbulb button should be hidden but competency selection should work
+            const checkboxes = fixture.debugElement.queryAll(By.css('input[type="checkbox"]'));
+            expect(checkboxes.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe('Form Validation Integration', () => {
+        it('should maintain form validation when using competency suggestions', () => {
+            // Start with valid form (both title and description provided)
+            component.exercise.title = 'Valid Title';
+            component.exercise.description = 'Valid description for testing';
+            fixture.detectChanges();
+
+            let saveButton = fixture.debugElement.query(By.css('button[type="submit"]'));
+            expect(saveButton.nativeElement.disabled).toBeFalsy(); // Should be enabled
+
+            // Using suggestions shouldn't affect form validation
+            const mockResponse = { competencies: [{ id: 1, title: 'Test' }] };
+            vi.spyOn(httpClient, 'post').mockReturnValue(of(mockResponse));
+
+            const comp = component.competencySelection();
+            comp.suggestCompetencies();
+            fixture.detectChanges();
+
+            saveButton = fixture.debugElement.query(By.css('button[type="submit"]'));
+            expect(saveButton.nativeElement.disabled).toBeFalsy(); // Should still be enabled
+        });
+    });
+});

--- a/src/main/webapp/app/shared/category-selector-primeng/category-selector-primeng.component.html
+++ b/src/main/webapp/app/shared/category-selector-primeng/category-selector-primeng.component.html
@@ -1,0 +1,36 @@
+<mat-form-field class="category-chip-list" appearance="outline">
+    <mat-chip-grid #chipList aria-label="Category selection">
+        @for (category of categories; track category) {
+            <mat-chip-row (removed)="onItemRemove(category)" class="category-chip">
+                <div class="custom-tag" [ngStyle]="{ backgroundColor: category.color }">
+                    <span class="category-name" (click)="openColorSelector($event, category)">
+                        {{ category.category }}
+                    </span>
+                    <button matChipRemove class="remove-button">
+                        <fa-icon [icon]="faTimes" class="category-chip-remove" />
+                    </button>
+                </div>
+            </mat-chip-row>
+        }
+        <input
+            id="field_categories"
+            [hidden]="categories && categories.length >= 2"
+            class="category-chip-input"
+            #categoryInput
+            [placeholder]="'artemisApp.exercise.tagPlaceholder' | artemisTranslate"
+            [formControl]="categoryCtrl"
+            [matAutocomplete]="auto"
+            [matChipInputFor]="chipList"
+            [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+            (matChipInputTokenEnd)="onItemAdd($event)"
+        />
+    </mat-chip-grid>
+    <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onItemSelect($event)">
+        @for (category of uniqueCategoriesForAutocomplete | async; track category) {
+            <mat-option [value]="category" class="tag-option">
+                {{ category }}
+            </mat-option>
+        }
+    </mat-autocomplete>
+</mat-form-field>
+<jhi-color-selector [tagColors]="categoryColors" (selectedColor)="onSelectedColor($event)" />

--- a/src/main/webapp/app/shared/category-selector-primeng/category-selector-primeng.component.scss
+++ b/src/main/webapp/app/shared/category-selector-primeng/category-selector-primeng.component.scss
@@ -1,0 +1,106 @@
+jhi-category-selector-primeng {
+    display: block;
+    margin-bottom: 1rem;
+
+    .category-chip-list {
+        width: 100%;
+
+        /* Hide Material's notched outline */
+        .mdc-notched-outline {
+            display: none !important;
+        }
+
+        /* Add Bootstrap-like border to the flex container */
+        .mat-mdc-form-field-flex {
+            border: 1px solid var(--bs-border-color);
+            border-radius: var(--bs-border-radius);
+
+            &:hover {
+                border-color: var(--bs-secondary-color);
+            }
+        }
+
+        &.mat-focused .mat-mdc-form-field-flex {
+            border-color: var(--bs-primary);
+            box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb), 0.25);
+        }
+
+        .mat-mdc-form-field-infix {
+            padding: 0.25rem 0.75rem !important;
+            min-height: 0 !important;
+        }
+
+        .mat-mdc-chip-grid {
+            margin: 0 !important;
+        }
+
+        .category-chip {
+            padding: 0 !important;
+            height: 22px !important;
+            border-radius: 0.25rem !important;
+            background: transparent !important;
+            margin: 2px 4px 2px 0 !important;
+
+            .custom-tag {
+                position: relative;
+                padding: 0.1rem 0 0.1rem 0.4rem;
+                background: #ccc;
+                border-radius: 0.25rem;
+                color: #fff;
+                display: flex;
+                align-items: center;
+                font-size: 0.8rem;
+                height: 100%;
+
+                &:hover {
+                    opacity: 0.8;
+                }
+
+                .category-chip-remove {
+                    color: #fff;
+                    font-size: 0.7rem;
+                    margin-left: 0.25rem;
+                }
+            }
+        }
+
+        /* Remove extra padding from chip action */
+        .mat-mdc-standard-chip.mdc-evolution-chip--with-trailing-action .mdc-evolution-chip__action--primary {
+            padding-left: 0 !important;
+            padding-right: 0 !important;
+        }
+
+        /* Remove additional border from custom tags */
+        .mat-mdc-standard-chip .mdc-evolution-chip__action--primary::before {
+            border-style: none !important;
+        }
+
+        /* Ensure consistent input height */
+        input.category-chip-input {
+            height: 22px;
+            margin: 2px 0;
+        }
+    }
+
+    .category-chip-input {
+        color: var(--text-editor-color);
+    }
+
+    /* Hide subscript wrapper to prevent extra spacing */
+    .mat-mdc-form-field-subscript-wrapper {
+        display: none;
+    }
+
+    /* Prevent x icon from jumping when opening colorpicker */
+    .remove-button::before {
+        position: absolute;
+    }
+}
+
+.tag-option {
+    background: var(--bs-body-bg);
+
+    &:hover {
+        background: var(--bs-secondary-bg);
+    }
+}

--- a/src/main/webapp/app/shared/category-selector-primeng/category-selector-primeng.component.spec.ts
+++ b/src/main/webapp/app/shared/category-selector-primeng/category-selector-primeng.component.spec.ts
@@ -1,0 +1,200 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CategorySelectorPrimengComponent } from 'app/shared/category-selector-primeng/category-selector-primeng.component';
+import { MockComponent, MockPipe } from 'ng-mocks';
+import { ColorSelectorComponent } from 'app/shared/color-selector/color-selector.component';
+import { MatAutocompleteModule, MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatChipInput, MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
+import { MatSelectModule } from '@angular/material/select';
+import { ExerciseCategory } from 'app/exercise/shared/entities/exercise/exercise-category.model';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+
+describe('CategorySelectorPrimengComponent', () => {
+    let comp: CategorySelectorPrimengComponent;
+    let fixture: ComponentFixture<CategorySelectorPrimengComponent>;
+    let emitSpy: jest.SpyInstance;
+
+    const category1 = {
+        color: '#6ae8ac',
+        category: 'category1',
+    } as ExerciseCategory;
+    const category2 = {
+        color: '#9dca53',
+        category: 'category2',
+    } as ExerciseCategory;
+    const category3 = {
+        color: '#94a11c',
+        category: 'category3',
+    } as ExerciseCategory;
+    const category4 = {
+        color: '#691b0b',
+        category: 'category4',
+    } as ExerciseCategory;
+    const category5 = {
+        color: '#ad5658',
+        category: 'category5',
+    } as ExerciseCategory;
+    const category6 = {
+        color: '#1b97ca',
+        category: 'category6',
+    } as ExerciseCategory;
+    const category7 = {
+        color: '#0d3cc2',
+        category: 'category7',
+    } as ExerciseCategory;
+    const category8 = {
+        color: '#0ab84f',
+        category: 'category8',
+    } as ExerciseCategory;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [MatAutocompleteModule, MatFormFieldModule, MatChipsModule, MatSelectModule, ReactiveFormsModule, FormsModule],
+            declarations: [CategorySelectorPrimengComponent, MockComponent(ColorSelectorComponent), MockPipe(ArtemisTranslatePipe)],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(CategorySelectorPrimengComponent);
+        comp = fixture.componentInstance;
+
+        emitSpy = jest.spyOn(comp.selectedCategories, 'emit');
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should remove category', () => {
+        fixture.detectChanges();
+        comp.categories = [category1, category2, category3];
+        fixture.changeDetectorRef.detectChanges();
+        const cancelColorSelectorSpy = jest.spyOn(comp.colorSelector, 'cancelColorSelector');
+        comp.onItemRemove(category2);
+
+        expect(comp.categories).toEqual([category1, category3]);
+        expect(cancelColorSelectorSpy).toHaveBeenCalledOnce();
+        expect(emitSpy).toHaveBeenCalledWith([category1, category3]);
+    });
+
+    it('should open color selector', () => {
+        fixture.detectChanges();
+        const mouseEvent = new MouseEvent('click', {
+            clientX: 1,
+            clientY: 2,
+        });
+
+        const openColorSelectorSpy = jest.spyOn(comp.colorSelector, 'openColorSelector');
+        comp.openColorSelector(mouseEvent, category5);
+
+        expect(comp.selectedCategory).toEqual(category5);
+        expect(openColorSelectorSpy).toHaveBeenCalledWith(mouseEvent, undefined, 150);
+    });
+
+    it('should select color for category', () => {
+        comp.categories = [category1, category2, category3];
+        comp.selectedCategory = category2;
+        comp.onSelectedColor('#fff');
+        const expected = { category: 'category2', color: '#fff' };
+
+        expect(comp.selectedCategory).toEqual(expected);
+        expect(comp.categories).toEqual([category1, expected, category3]);
+        expect(emitSpy).toHaveBeenCalledWith([category1, expected, category3]);
+    });
+
+    it('should create new item on select', () => {
+        comp.categories = [category6];
+        comp.existingCategories = [category6, category7, category8];
+        fixture.changeDetectorRef.detectChanges();
+        const event = { option: { value: 'category9' } } as MatAutocompleteSelectedEvent;
+        comp.onItemSelect(event);
+
+        const categoryColor = comp.categories[1].color;
+        expect(comp.categories).toEqual([category6, { category: 'category9', color: categoryColor }]);
+        expect(emitSpy).toHaveBeenCalledWith([category6, { category: 'category9', color: categoryColor }]);
+        expect(comp.categoryInput.nativeElement.value).toBe('');
+        expect(comp.categoryCtrl.value).toBeNull();
+    });
+
+    it('should not create new item on select', () => {
+        comp.categories = [category6];
+        comp.existingCategories = [category7, category8];
+        fixture.changeDetectorRef.detectChanges();
+        const event = { option: { value: 'category7' } } as MatAutocompleteSelectedEvent;
+        comp.onItemSelect(event);
+
+        expect(comp.categories).toEqual([category6, category7]);
+        expect(emitSpy).toHaveBeenCalledWith([category6, category7]);
+        expect(comp.categoryInput.nativeElement.value).toBe('');
+        expect(comp.categoryCtrl.value).toBeNull();
+    });
+
+    it('should not create duplicate item on add', () => {
+        comp.categories = [category6];
+        fixture.changeDetectorRef.detectChanges();
+        const event = { value: 'category6', chipInput: { clear: () => {} } as MatChipInput } as MatChipInputEvent;
+        comp.onItemAdd(event);
+
+        expect(comp.categories).toEqual([category6]);
+        expect(emitSpy).not.toHaveBeenCalled();
+        expect(comp.categoryCtrl.value).toBeNull();
+    });
+
+    it('should save exiting category on add', () => {
+        comp.categories = [category6];
+        comp.existingCategories = [category7, category8];
+        fixture.changeDetectorRef.detectChanges();
+        const event = { value: 'category8', chipInput: { clear: () => {} } as MatChipInput } as MatChipInputEvent;
+        comp.onItemAdd(event);
+
+        expect(comp.categories).toEqual([category6, category8]);
+        expect(emitSpy).toHaveBeenCalledWith([category6, category8]);
+        expect(comp.categoryCtrl.value).toBeNull();
+    });
+
+    it('should create new item on add for existing categories', () => {
+        comp.categories = [category6];
+        comp.existingCategories = [];
+        fixture.changeDetectorRef.detectChanges();
+        const event = { value: 'category9', chipInput: { clear: () => {} } as MatChipInput } as MatChipInputEvent;
+        comp.onItemAdd(event);
+
+        const categoryColor = comp.categories[1].color;
+        expect(comp.categories).toEqual([category6, { category: 'category9', color: categoryColor }]);
+        expect(emitSpy).toHaveBeenCalledWith([category6, { category: 'category9', color: categoryColor }]);
+        expect(comp.categoryCtrl.value).toBeNull();
+    });
+
+    it('should create new item on add for empty categories', () => {
+        comp.existingCategories = [];
+        fixture.changeDetectorRef.detectChanges();
+        const event = { value: 'category6', chipInput: { clear: () => {} } as MatChipInput } as MatChipInputEvent;
+        comp.onItemAdd(event);
+
+        const categoryColor = comp.categories[0].color;
+        expect(comp.categories).toEqual([{ category: 'category6', color: categoryColor }]);
+        expect(emitSpy).toHaveBeenCalledWith([{ category: 'category6', color: categoryColor }]);
+        expect(comp.categoryCtrl.value).toBeNull();
+    });
+
+    it('should set categories for autocomplete on changes', () => {
+        comp.existingCategories = [category3, category4, category5];
+        comp.categories = [category3];
+        comp.ngOnChanges();
+
+        let result;
+        comp.uniqueCategoriesForAutocomplete.subscribe((value) => (result = value));
+        expect(result).toEqual(['category4', 'category5']);
+    });
+
+    it('should filter categories for autocomplete on changes', () => {
+        comp.existingCategories = [category3, category4, category5];
+        comp.categories = [category3];
+        comp.ngOnChanges();
+
+        let result;
+        comp.uniqueCategoriesForAutocomplete.subscribe((value) => (result = value));
+        comp.categoryCtrl.setValue('category4');
+        comp.categoryCtrl.updateValueAndValidity();
+        expect(result).toEqual(['category4']);
+    });
+});

--- a/src/main/webapp/app/shared/category-selector-primeng/category-selector-primeng.component.ts
+++ b/src/main/webapp/app/shared/category-selector-primeng/category-selector-primeng.component.ts
@@ -1,0 +1,190 @@
+import { Component, ElementRef, EventEmitter, Input, OnChanges, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { ColorSelectorComponent } from 'app/shared/color-selector/color-selector.component';
+import { ExerciseCategory } from 'app/exercise/shared/entities/exercise/exercise-category.model';
+import { MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger } from '@angular/material/autocomplete';
+import { COMMA, ENTER, TAB } from '@angular/cdk/keycodes';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatChipGrid, MatChipInput, MatChipInputEvent, MatChipRemove, MatChipRow } from '@angular/material/chips';
+import { Observable, map, startWith } from 'rxjs';
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { FaqCategory } from 'app/communication/shared/entities/faq-category.model';
+import { MatFormField } from '@angular/material/form-field';
+import { AsyncPipe, NgStyle } from '@angular/common';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { MatOption } from '@angular/material/core';
+import { ArtemisTranslatePipe } from '../pipes/artemis-translate.pipe';
+
+const DEFAULT_COLORS = ['#6ae8ac', '#9dca53', '#94a11c', '#691b0b', '#ad5658', '#1b97ca', '#0d3cc2', '#0ab84f'];
+
+@Component({
+    selector: 'jhi-category-selector-primeng',
+    templateUrl: './category-selector-primeng.component.html',
+    styleUrls: ['./category-selector-primeng.component.scss'],
+    encapsulation: ViewEncapsulation.None,
+    imports: [
+        MatFormField,
+        MatChipGrid,
+        MatChipRow,
+        NgStyle,
+        MatChipRemove,
+        FaIconComponent,
+        FormsModule,
+        MatAutocompleteTrigger,
+        MatChipInput,
+        ReactiveFormsModule,
+        MatAutocomplete,
+        MatOption,
+        ColorSelectorComponent,
+        AsyncPipe,
+        ArtemisTranslatePipe,
+    ],
+})
+export class CategorySelectorPrimengComponent implements OnChanges {
+    protected readonly faTimes = faTimes;
+    protected readonly separatorKeysCodes = [ENTER, COMMA, TAB];
+    private readonly COLOR_SELECTOR_HEIGHT = 150;
+
+    /** the selected categories, which can be manipulated by the user in the UI */
+    @Input() categories: ExerciseCategory[] | FaqCategory[];
+    /** the existing categories used for auto-completion, might include duplicates */
+    @Input() existingCategories: ExerciseCategory[] | FaqCategory[];
+
+    @ViewChild(ColorSelectorComponent, { static: false }) colorSelector: ColorSelectorComponent;
+    @ViewChild('categoryInput') categoryInput: ElementRef<HTMLInputElement>;
+    @ViewChild(MatAutocompleteTrigger) autocompleteTrigger: MatAutocompleteTrigger;
+
+    @Output() selectedCategories = new EventEmitter<ExerciseCategory[]>();
+
+    categoryColors = DEFAULT_COLORS;
+    selectedCategory: ExerciseCategory;
+    uniqueCategoriesForAutocomplete: Observable<string[]>;
+
+    categoryCtrl = new FormControl<string | undefined>(undefined);
+
+    ngOnChanges() {
+        this.uniqueCategoriesForAutocomplete = this.categoryCtrl.valueChanges.pipe(
+            startWith(undefined),
+            map((userInput: string | undefined) => (userInput ? this.filterCategories(userInput) : this.existingCategoriesAsStringArray().slice())),
+            // remove duplicated values
+            map((categories: string[]) => [...new Set(categories)]),
+            // remove categories that have already been selected in the exercise
+            map((categories: string[]) => categories.filter((category) => !this.categoriesAsStringArray().includes(category.toLowerCase()))),
+        );
+    }
+
+    private categoriesAsStringArray(): string[] {
+        if (!this.categories) {
+            return [];
+        }
+        return this.categories.map((exerciseCategory) => exerciseCategory.category?.toLowerCase() ?? '');
+    }
+
+    private existingCategoriesAsStringArray(): string[] {
+        if (!this.existingCategories) {
+            return [];
+        }
+        return this.existingCategories.map((exerciseCategory) => exerciseCategory.category?.toLowerCase() ?? '');
+    }
+
+    // if the user types in something, we need to filter for the matching categories
+    private filterCategories(value: string): string[] {
+        const filterValue = value.toLowerCase();
+        return this.existingCategories.filter((category) => category.category!.toLowerCase().includes(filterValue)).map((category) => category.category!.toLowerCase());
+    }
+
+    /**
+     * open colorSelector for tagItem
+     * @param {MouseEvent} event
+     * @param {ExerciseCategory} tagItem
+     */
+    openColorSelector(event: MouseEvent, tagItem: ExerciseCategory) {
+        this.selectedCategory = tagItem;
+        this.colorSelector.openColorSelector(event, undefined, this.COLOR_SELECTOR_HEIGHT);
+    }
+
+    /**
+     * set color of selected category
+     * @param {string} selectedColor
+     */
+    onSelectedColor(selectedColor: string): void {
+        this.selectedCategory.color = selectedColor;
+        this.categories = this.categories.map((category) => {
+            if (category.category === this.selectedCategory.category) {
+                return this.selectedCategory;
+            }
+            return category;
+        });
+        this.selectedCategories.emit(this.categories);
+    }
+
+    /**
+     * set color if not selected and add exerciseCategory
+     * @param event a new category was added
+     */
+    onItemAdd(event: MatChipInputEvent) {
+        const categoryString = (event.value || '').trim();
+        // prevent adding duplicated categories
+        const categoryArray = this.categoriesAsStringArray();
+        if (categoryString && !categoryArray.includes(categoryString) && categoryArray.length < 2) {
+            let category = this.findExistingCategory(categoryString);
+            if (!category) {
+                category = this.createCategory(categoryString);
+            }
+            category.category = categoryString;
+            if (!category.color) {
+                category.color = this.chooseRandomColor();
+            }
+            if (this.categories) {
+                this.categories.push(category);
+            } else {
+                this.categories = [category];
+            }
+            this.selectedCategories.emit(this.categories);
+        }
+        // Clear the input value
+        event.chipInput!.clear();
+        this.categoryCtrl.setValue(null);
+        this.autocompleteTrigger.closePanel();
+    }
+
+    private createCategory(categoryString: string): ExerciseCategory {
+        return new ExerciseCategory(categoryString, this.chooseRandomColor());
+    }
+
+    private chooseRandomColor(): string {
+        const randomIndex = Math.floor(Math.random() * this.categoryColors.length);
+        return this.categoryColors[randomIndex];
+    }
+
+    // only invoked for autocomplete
+    onItemSelect(event: MatAutocompleteSelectedEvent): void {
+        const categoryString = (event.option.value || '').trim();
+        const categoryArray = this.categoriesAsStringArray();
+        if (categoryString && !categoryArray.includes(categoryString) && categoryArray.length < 2) {
+            // check if there is an existing category and reuse the same color
+            let category = this.findExistingCategory(categoryString);
+            if (!category) {
+                category = this.createCategory(categoryString);
+            }
+
+            this.categories.push(category);
+            this.selectedCategories.emit(this.categories);
+        }
+        this.categoryInput.nativeElement.value = '';
+        this.categoryCtrl.setValue(null);
+    }
+
+    private findExistingCategory(categoryString: string): ExerciseCategory | undefined {
+        return this.existingCategories.find((existingCategory) => existingCategory.category?.toLowerCase() === categoryString.toLowerCase());
+    }
+
+    /**
+     * cancel colorSelector and remove exerciseCategory
+     * @param {ExerciseCategory} categoryToRemove
+     */
+    onItemRemove(categoryToRemove: ExerciseCategory): void {
+        this.colorSelector.cancelColorSelector();
+        this.categories = this.categories.filter((exerciseCategory) => exerciseCategory.category !== categoryToRemove.category);
+        this.selectedCategories.emit(this.categories);
+    }
+}

--- a/src/main/webapp/app/shared/form/title-channel-name-primeng/title-channel-name-primeng.component.html
+++ b/src/main/webapp/app/shared/form/title-channel-name-primeng/title-channel-name-primeng.component.html
@@ -1,0 +1,58 @@
+<div class="row">
+    @if (!this.isEditFieldDisplayedRecord() || this.isEditFieldDisplayedRecord()?.title) {
+        <div class="form-group col-12" [class.col-lg-6]="isChannelFieldDisplayed()">
+            @if (!hideTitleLabel()) {
+                <div>
+                    <label [class]="'form-control-label' + (emphasizeLabels() ? ' emphasized-label' : '')" jhiTranslate="artemisApp.lecture.title" for="field_title"></label>
+                    @if (titleHelpIconText()) {
+                        <jhi-help-icon [text]="titleHelpIconText()!" />
+                    }
+                </div>
+            }
+            <input
+                #field_title="ngModel"
+                required
+                [minlength]="minTitleLength() ?? null"
+                [pattern]="titlePattern() ?? ''"
+                type="text"
+                class="form-control"
+                name="title"
+                id="field_title"
+                [ngModel]="title()"
+                (ngModelChange)="updateTitle($event)"
+                notIncludedIn
+                [disallowedValues]="alreadyUsedTitles()"
+            />
+            @if (field_title?.control?.errors?.disallowedValue) {
+                <div class="alert alert-danger" jhiTranslate="artemisApp.exercise.form.title.disallowedValue"></div>
+            }
+        </div>
+    }
+    @if (isChannelFieldDisplayed()) {
+        <div class="form-group col-lg-6">
+            @if (!hideChannelNameLabel()) {
+                <div>
+                    <label
+                        [class]="'form-control-label' + (emphasizeLabels() ? ' emphasized-label' : '')"
+                        jhiTranslate="artemisApp.lecture.channelName"
+                        for="field_channel_name"
+                    ></label>
+                    @if (channelNameHelpIconText()) {
+                        <jhi-help-icon [text]="channelNameHelpIconText()!" />
+                    }
+                </div>
+            }
+            <input
+                #field_channel_name="ngModel"
+                required
+                type="text"
+                class="form-control"
+                name="channelName"
+                id="field_channel_name"
+                [ngModel]="channelName()"
+                (ngModelChange)="formatChannelName($event)"
+                maxlength="30"
+            />
+        </div>
+    }
+</div>

--- a/src/main/webapp/app/shared/form/title-channel-name-primeng/title-channel-name-primeng.component.spec.ts
+++ b/src/main/webapp/app/shared/form/title-channel-name-primeng/title-channel-name-primeng.component.spec.ts
@@ -1,0 +1,161 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { FormsModule, NgForm } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+import { TitleChannelNamePrimengComponent } from 'app/shared/form/title-channel-name-primeng/title-channel-name-primeng.component';
+import { CustomNotIncludedInValidatorDirective } from '../../validators/custom-not-included-in-validator.directive';
+import { MockDirective } from 'ng-mocks';
+import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
+import { TranslateService } from '@ngx-translate/core';
+
+const CHANNEL_NAME_PREFIX = '-- -!?-p --()';
+
+describe('TitleChannelNamePrimengComponent', () => {
+    let component: TitleChannelNamePrimengComponent;
+    let fixture: ComponentFixture<TitleChannelNamePrimengComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [FormsModule],
+            declarations: [TitleChannelNamePrimengComponent, MockDirective(CustomNotIncludedInValidatorDirective)],
+            providers: [NgForm, { provide: TranslateService, useClass: MockTranslateService }],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TitleChannelNamePrimengComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should display title and channel name input fields with correct content', fakeAsync(() => {
+        fixture.componentRef.setInput('title', 'Test');
+        fixture.componentRef.setInput('channelName', 'test');
+
+        fixture.changeDetectorRef.detectChanges();
+        tick();
+
+        fixture.whenStable().then(() => {
+            const titleInput = fixture.debugElement.query(By.css('#field_title'));
+            expect(titleInput).not.toBeNull();
+            expect(titleInput.nativeElement.value).toBe(component.title);
+
+            const channelNameInput = fixture.debugElement.query(By.css('#field_channel_name'));
+            expect(channelNameInput).not.toBeNull();
+            expect(channelNameInput.nativeElement.value).toBe(component.channelName);
+        });
+    }));
+
+    it('should only display title input field if channel name is hidden', () => {
+        fixture.componentRef.setInput('hideChannelName', true);
+        fixture.changeDetectorRef.detectChanges();
+
+        const titleInput = fixture.debugElement.query(By.css('#field_title'));
+        expect(titleInput).not.toBeNull();
+
+        const channelNameInput = fixture.debugElement.query(By.css('#field_channel_name'));
+        expect(channelNameInput).toBeNull();
+    });
+
+    it('should update channel name on title change', () => {
+        fixture.componentRef.setInput('title', 'test');
+        fixture.componentRef.setInput('channelName', 'test');
+        fixture.changeDetectorRef.detectChanges();
+
+        const newTitle = 'New 0123 @()[]{} !?.-_ $%& too long name that is more than 30 characters';
+        const titleInput = fixture.debugElement.query(By.css('#field_title'));
+        titleInput.nativeElement.value = newTitle;
+        titleInput.nativeElement.dispatchEvent(new Event('input'));
+
+        fixture.changeDetectorRef.detectChanges();
+
+        expect(component.title()).toBe(newTitle);
+        expect(component.channelName()).toBe('new-0123-too-long-name-that-is');
+    });
+
+    it('init prefix if undefined', () => {
+        component.ngOnInit();
+
+        expect(component.channelNamePrefix()).toBe('');
+    });
+
+    it('init channel name based on prefix and title', fakeAsync(() => {
+        fixture.componentRef.setInput('title', 'Test');
+        fixture.componentRef.setInput('channelNamePrefix', 'prefix-');
+
+        component.ngOnInit();
+        tick();
+
+        expect(component.channelName()).toBe('prefix-test');
+    }));
+
+    it('init channel name based on prefix if title is undefined', fakeAsync(() => {
+        fixture.componentRef.setInput('channelNamePrefix', 'prefix-');
+
+        component.ngOnInit();
+        tick();
+
+        expect(component.channelName()).toBe('prefix-');
+    }));
+
+    it('remove special characters and trailing hyphens from channel name on init with non-empty title', fakeAsync(() => {
+        fixture.componentRef.setInput('title', '-- -  t--=*+ -- ');
+        fixture.componentRef.setInput('channelNamePrefix', CHANNEL_NAME_PREFIX);
+
+        component.ngOnInit();
+        tick();
+
+        expect(component.channelName()).toBe('-p-t');
+    }));
+
+    it("don't remove trailing hyphens from channel name on init with empty title", fakeAsync(() => {
+        fixture.componentRef.setInput('title', '');
+        fixture.componentRef.setInput('channelNamePrefix', CHANNEL_NAME_PREFIX);
+
+        component.ngOnInit();
+        tick();
+
+        expect(component.channelName()).toBe('-p-');
+    }));
+
+    it("don't remove trailing hyphens from channel name on init with undefined title", fakeAsync(() => {
+        fixture.componentRef.setInput('title', undefined);
+        fixture.componentRef.setInput('channelNamePrefix', CHANNEL_NAME_PREFIX + '-');
+
+        component.ngOnInit();
+        tick();
+
+        expect(component.channelName()).toBe('-p-');
+    }));
+
+    it('remove trailing hyphens from channel name on title edit', () => {
+        fixture.componentRef.setInput('channelNamePrefix', CHANNEL_NAME_PREFIX);
+
+        component.updateTitle('--t--(%&');
+
+        expect(component.channelName()).toBe('-p-t');
+    });
+
+    it("don't remove trailing hyphens from channel name on title edit if title empty", () => {
+        fixture.componentRef.setInput('channelNamePrefix', CHANNEL_NAME_PREFIX);
+
+        component.updateTitle('');
+
+        expect(component.channelName()).toBe('-p-');
+    });
+
+    it("don't remove trailing hyphens from channel name on channel name edit", () => {
+        fixture.componentRef.setInput('channelNamePrefix', CHANNEL_NAME_PREFIX + '-');
+
+        component.formatChannelName('-p--t--');
+
+        expect(component.channelName()).toBe('-p--t--');
+    });
+
+    it("don't init channel name if not allowed", () => {
+        fixture.componentRef.setInput('title', 't');
+        fixture.componentRef.setInput('channelNamePrefix', 'p-');
+        fixture.componentRef.setInput('initChannelName', false);
+
+        component.ngOnInit();
+
+        expect(component.channelName()).toBeUndefined();
+    });
+});

--- a/src/main/webapp/app/shared/form/title-channel-name-primeng/title-channel-name-primeng.component.ts
+++ b/src/main/webapp/app/shared/form/title-channel-name-primeng/title-channel-name-primeng.component.ts
@@ -1,0 +1,124 @@
+import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild, computed, effect, input, model, output, signal, viewChild } from '@angular/core';
+import { ControlContainer, FormsModule, NgForm, NgModel } from '@angular/forms';
+import { Subscription } from 'rxjs';
+import { ProgrammingExerciseInputField } from 'app/programming/manage/update/programming-exercise-update.helper';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { CustomNotIncludedInValidatorDirective } from '../../validators/custom-not-included-in-validator.directive';
+import { HelpIconComponent } from '../../components/help-icon/help-icon.component';
+
+@Component({
+    selector: 'jhi-title-channel-name-primeng',
+    templateUrl: './title-channel-name-primeng.component.html',
+    viewProviders: [{ provide: ControlContainer, useExisting: NgForm }],
+    imports: [TranslateDirective, FormsModule, CustomNotIncludedInValidatorDirective, HelpIconComponent],
+})
+export class TitleChannelNamePrimengComponent implements AfterViewInit, OnDestroy, OnInit {
+    title = model<string | undefined>(undefined);
+    channelName = model<string | undefined>(undefined);
+    channelNamePrefix = input<string | undefined>('');
+    titlePattern = input<string>();
+    hideTitleLabel = input<boolean>(false);
+    hideChannelNameLabel = input<boolean>(false);
+    titleHelpIconText = input<string>();
+    channelNameHelpIconText = input<string>('artemisApp.programmingExercise.channelNameTooltip');
+    emphasizeLabels = input<boolean>(false);
+    minTitleLength = input<number>();
+    initChannelName = input<boolean>(true);
+    hideChannelName = input<boolean>();
+    isEditFieldDisplayedRecord = input<Record<ProgrammingExerciseInputField, boolean>>();
+    alreadyUsedTitles = input<Set<string>>(new Set());
+
+    titleOnPageLoad = signal<string | undefined>(undefined);
+
+    @ViewChild('field_title') field_title: NgModel;
+    field_channel_name = viewChild<NgModel>('field_channel_name');
+
+    titleChange = output<string>();
+    channelNameChange = output<string>();
+
+    isValid = signal<boolean>(false);
+
+    fieldTitleSubscription?: Subscription;
+    fieldChannelNameSubscription?: Subscription;
+
+    isChannelFieldDisplayed = computed(() => {
+        return !this.hideChannelName() && (!this.isEditFieldDisplayedRecord() || this.isEditFieldDisplayedRecord()?.channelName);
+    });
+
+    constructor() {
+        effect(() => {
+            this.isEditFieldDisplayedRecord(); // triggers effect on change
+            this.registerChangeListeners();
+        });
+
+        effect(
+            function removeInitialTitleInEditFromForbiddenTitles() {
+                if (this.titleOnPageLoad()) {
+                    this.alreadyUsedTitles().delete(this.titleOnPageLoad());
+                }
+            }.bind(this),
+        );
+    }
+
+    ngAfterViewInit() {
+        this.registerChangeListeners();
+    }
+
+    ngOnInit(): void {
+        if (this.initChannelName()) {
+            // Defer updating the channel name into the next change detection cycle to avoid the
+            // "NG0100: Expression has changed after it was checked" error
+            setTimeout(() => {
+                this.updateChannelName();
+            });
+        }
+
+        this.titleOnPageLoad.set(this.title());
+    }
+
+    private registerChangeListeners() {
+        this.fieldTitleSubscription = this.field_title?.valueChanges?.subscribe(() => this.calculateFormValid());
+        this.fieldChannelNameSubscription = this.field_channel_name()?.valueChanges?.subscribe(() => this.calculateFormValid());
+    }
+
+    ngOnDestroy() {
+        this.fieldTitleSubscription?.unsubscribe();
+        this.fieldChannelNameSubscription?.unsubscribe();
+    }
+
+    calculateFormValid(): void {
+        const updatedFormValidValue = Boolean(this.field_title.valid && (!this.isChannelFieldDisplayed() || this.field_channel_name()?.valid));
+        this.isValid.set(updatedFormValidValue);
+    }
+
+    updateTitle(newTitle: string) {
+        this.title.set(newTitle);
+        this.titleChange.emit(this.title() ?? '');
+        this.updateChannelName();
+    }
+
+    updateChannelName() {
+        this.formatChannelName((this.channelNamePrefix() ?? '') + (this.title() ?? ''), false, !!this.title());
+    }
+
+    /**
+     * Formats a channel name by applying specific transformations based on the provided options.
+     *
+     * @param {string} newName - The new channel name to be formatted.
+     * @param {boolean} [allowDuplicateHyphens=true] - Flag indicating whether duplicate hyphens should be allowed in the formatted name.
+     * @param {boolean} [removeTrailingHyphens=false] - Flag indicating whether trailing hyphens should be removed from the formatted name.
+     * @return {void} This method does not return a value but emits the formatted channel name.
+     */
+    formatChannelName(newName: string, allowDuplicateHyphens: boolean = true, removeTrailingHyphens: boolean = false): void {
+        const REMOVE_SPECIAL_CHARACTERS_ALLOW_HYPHENS = /[^a-z0-9-]+/g;
+        const REMOVE_SPECIAL_CHARACTERS_NO_HYPHENS = /[^a-z0-9]+/g;
+        const TRAILING_HYPHENS = /-$/;
+        const removeSpecialCharactersRegEx: RegExp = allowDuplicateHyphens ? REMOVE_SPECIAL_CHARACTERS_ALLOW_HYPHENS : REMOVE_SPECIAL_CHARACTERS_NO_HYPHENS;
+
+        const nameWithoutSpecialCharacters = newName.toLowerCase().replaceAll(removeSpecialCharactersRegEx, '-');
+        const formattedName = removeTrailingHyphens ? nameWithoutSpecialCharacters.replace(TRAILING_HYPHENS, '') : nameWithoutSpecialCharacters;
+
+        this.channelName.set(formattedName.slice(0, 30));
+        this.channelNameChange.emit(this.channelName() ?? '');
+    }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -57,6 +57,8 @@ export default defineConfig({
             'src/main/webapp/app/programming/manage/services/problem-statement.service.spec.ts', // include problem statement service tests
             'src/main/webapp/app/programming/manage/shared/problem-statement.utils.spec.ts', // include problem statement utils tests
             'src/main/webapp/app/shared/monaco-editor/inline-refinement-button/*.spec.ts', // include inline refinement button tests
+            'src/main/webapp/app/shared/category-selector-primeng/**/*.spec.ts', // include category-selector-primeng tests
+            'src/main/webapp/app/shared/form/title-channel-name-primeng/**/*.spec.ts', // include title-channel-name-primeng tests
             'src/main/webapp/app/exercise/exercise-headers/**/*.spec.ts', // include exercise headers tests
             'src/main/webapp/app/exercise/synchronization/**/*.spec.ts', // include exercise synchronization tests
             'src/main/webapp/app/exercise/version-history/**/*.spec.ts', // include exercise version history tests
@@ -102,6 +104,8 @@ export default defineConfig({
                 'src/main/webapp/app/programming/manage/services/problem-statement.service.ts', // include problem statement service for code coverage
                 'src/main/webapp/app/programming/manage/shared/problem-statement.utils.ts', // include problem statement utils for code coverage
                 'src/main/webapp/app/shared/monaco-editor/inline-refinement-button/*.ts', // include inline refinement button for code coverage
+                'src/main/webapp/app/shared/category-selector-primeng/**/*.ts', // include category-selector-primeng for code coverage
+                'src/main/webapp/app/shared/form/title-channel-name-primeng/**/*.ts', // include title-channel-name-primeng for code coverage
                 'src/main/webapp/app/exercise/exercise-headers/**/*.ts', // include exercise headers for code coverage
                 'src/main/webapp/app/exercise/synchronization/**/*.ts', // include exercise synchronization for code coverage
                 'src/main/webapp/app/exercise/version-history/**/*.ts', // include exercise version history for code coverage

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -57,8 +57,6 @@ export default defineConfig({
             'src/main/webapp/app/programming/manage/services/problem-statement.service.spec.ts', // include problem statement service tests
             'src/main/webapp/app/programming/manage/shared/problem-statement.utils.spec.ts', // include problem statement utils tests
             'src/main/webapp/app/shared/monaco-editor/inline-refinement-button/*.spec.ts', // include inline refinement button tests
-            'src/main/webapp/app/shared/category-selector-primeng/**/*.spec.ts', // include category-selector-primeng tests
-            'src/main/webapp/app/shared/form/title-channel-name-primeng/**/*.spec.ts', // include title-channel-name-primeng tests
             'src/main/webapp/app/exercise/exercise-headers/**/*.spec.ts', // include exercise headers tests
             'src/main/webapp/app/exercise/synchronization/**/*.spec.ts', // include exercise synchronization tests
             'src/main/webapp/app/exercise/version-history/**/*.spec.ts', // include exercise version history tests
@@ -104,8 +102,6 @@ export default defineConfig({
                 'src/main/webapp/app/programming/manage/services/problem-statement.service.ts', // include problem statement service for code coverage
                 'src/main/webapp/app/programming/manage/shared/problem-statement.utils.ts', // include problem statement utils for code coverage
                 'src/main/webapp/app/shared/monaco-editor/inline-refinement-button/*.ts', // include inline refinement button for code coverage
-                'src/main/webapp/app/shared/category-selector-primeng/**/*.ts', // include category-selector-primeng for code coverage
-                'src/main/webapp/app/shared/form/title-channel-name-primeng/**/*.ts', // include title-channel-name-primeng for code coverage
                 'src/main/webapp/app/exercise/exercise-headers/**/*.ts', // include exercise headers for code coverage
                 'src/main/webapp/app/exercise/synchronization/**/*.ts', // include exercise synchronization for code coverage
                 'src/main/webapp/app/exercise/version-history/**/*.ts', // include exercise version history for code coverage


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
This PR is part one of the quiz editor design migration and creates copies of the required components and places them under a new primeng suffix name. No functionality is changed. The files are exact copies except the new name.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
To avoid breaking existing consumers of shared form components during the transition of the quiz editor, new PrimeNG-targeted copies are introduced alongside the originals. Existing consumers remain on the originals until their editor is migrated. This was a decision of the Maintainer Meeting on 20.04.26.
The second PR will convert these components to the new design.

### Description
 Creates PrimeNG variants of three shared components, each in its own folder following the existing convention.
                                                                                                                                                                           
  - app/shared/category-selector-primeng/ — copy of category-selector                                                                                                      
  - app/shared/form/title-channel-name-primeng/ — copy of title-channel-name
  - app/atlas/shared/competency-selection-primeng/ — copy of competency-selection                                                                                          
                                                                                                                                                                           
Each copy includes all associated spec files with updated import paths and component references. No functionality is changed. The files are exact copies except the new name.

### Steps for Testing
 This PR introduces no visible UI or behavioral changes. Verification is purely structural:                                                                               
   
  1. Confirm the three new component folders exist alongside the originals.                                                                                                
  2. Confirm the new components compile without errors (npm run webapp:build).
  3. Run the copied test suites and confirm all pass:                                                                                                                      
    - npm run test:one -- --test-path-pattern='category-selector-primeng'                                                                                                  
    - npm run test:one -- --test-path-pattern='title-channel-name-primeng'                                                                                                 
    - npm run vitest:run -- competency-selection-primeng      

If you want to verify that noting else changed than the name, you can run the following command (with the changes checked out):
 ```
BASE=src/main/webapp/app

for pair in \
    "$BASE/shared/category-selector/category-selector.component.ts $BASE/shared/category-selector-primeng/category-selector-primeng.component.ts" \
    "$BASE/shared/category-selector/category-selector.component.html $BASE/shared/category-selector-primeng/category-selector-primeng.component.html" \
    "$BASE/shared/category-selector/category-selector.component.scss $BASE/shared/category-selector-primeng/category-selector-primeng.component.scss" \
    "$BASE/shared/category-selector/category-selector.component.spec.ts $BASE/shared/category-selector-primeng/category-selector-primeng.component.spec.ts" \
    "$BASE/shared/form/title-channel-name/title-channel-name.component.ts $BASE/shared/form/title-channel-name-primeng/title-channel-name-primeng.component.ts" \
    "$BASE/shared/form/title-channel-name/title-channel-name.component.html $BASE/shared/form/title-channel-name-primeng/title-channel-name-primeng.component.html" \
    "$BASE/shared/form/title-channel-name/title-channel-name.component.spec.ts $BASE/shared/form/title-channel-name-primeng/title-channel-name-primeng.component.spec.ts" \
    "$BASE/atlas/shared/competency-selection/competency-selection.component.ts $BASE/atlas/shared/competency-selection-primeng/competency-selection-primeng.component.ts" \
    "$BASE/atlas/shared/competency-selection/competency-selection.component.html $BASE/atlas/shared/competency-selection-primeng/competency-selection-primeng.component.html" \
    "$BASE/atlas/shared/competency-selection/competency-selection.component.scss $BASE/atlas/shared/competency-selection-primeng/competency-selection-primeng.component.scss" \
    "$BASE/atlas/shared/competency-selection/competency-selection.component.spec.ts $BASE/atlas/shared/competency-selection-primeng/competency-selection-primeng.component.spec.ts" \
    "$BASE/atlas/shared/competency-selection/atlasml-competency-suggestions.integration.spec.ts $BASE/atlas/shared/competency-selection-primeng/atlasml-competency-suggestions.integration.spec.ts" \
    "$BASE/atlas/shared/competency-selection/exercise-competency-suggestion.spec.ts $BASE/atlas/shared/competency-selection-primeng/exercise-competency-suggestion.spec.ts"
do
    orig=$(echo $pair | cut -d' ' -f1)
    copy=$(echo $pair | cut -d' ' -f2)
    echo "=== $(basename $orig) ==="
    diff "$orig" "$copy"
    echo ""
done
```
   
### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| competency-selection-primeng.component.ts | 79.13% | 249 | 70 | 28.1 |
| category-selector-primeng.component.ts | 97.33% | 144 | 30 | 20.8 |
| title-channel-name-primeng.component.ts | 98.21% | 94 | 18 | 19.1 |

_Last updated: 2026-04-25 22:40:02 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added competency selection component with AI-powered suggestion functionality that intelligently ranks and highlights recommended competencies.
  * Added category selector component with color customization and autocomplete matching.
  * Added title and channel name form component with automatic formatting and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->