### PR TITLE
`General`: Allow admin to configure course request short name freely and show history

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/domain/CourseRequest.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/domain/CourseRequest.java
@@ -28,7 +28,7 @@ public class CourseRequest extends DomainObject {
     @Column(name = "title", nullable = false)
     private String title;
 
-    @Column(name = "short_name", nullable = false, unique = true)
+    @Column(name = "short_name")
     private String shortName;
 
     @Column(name = "semester")

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/CourseRequestAcceptDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/CourseRequestAcceptDTO.java
@@ -3,11 +3,14 @@ package de.tum.cit.aet.artemis.core.dto;
 import java.time.ZonedDateTime;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import de.tum.cit.aet.artemis.core.config.Constants;
+
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record CourseRequestAcceptDTO(@NotBlank @Size(max = 255) String title, @NotBlank String shortName, @NotBlank String semester, ZonedDateTime startDate, ZonedDateTime endDate,
-        boolean testCourse) {
+public record CourseRequestAcceptDTO(@NotBlank @Size(max = 255) String title, @NotBlank @Size(min = 3) @Pattern(regexp = Constants.SHORT_NAME_REGEX) String shortName,
+        @NotBlank String semester, ZonedDateTime startDate, ZonedDateTime endDate, boolean testCourse) {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/CourseRequestAcceptDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/CourseRequestAcceptDTO.java
@@ -8,6 +8,6 @@ import jakarta.validation.constraints.Size;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record CourseRequestCreateDTO(@NotBlank @Size(max = 255) String title, @NotBlank String semester, ZonedDateTime startDate, ZonedDateTime endDate, boolean testCourse,
-        @NotBlank String reason) {
+public record CourseRequestAcceptDTO(@NotBlank @Size(max = 255) String title, @NotBlank String shortName, @NotBlank String semester, ZonedDateTime startDate, ZonedDateTime endDate,
+        boolean testCourse) {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/RequesterCourseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/RequesterCourseDTO.java
@@ -1,0 +1,15 @@
+package de.tum.cit.aet.artemis.core.dto;
+
+import java.time.ZonedDateTime;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.core.domain.Course;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RequesterCourseDTO(String title, String shortName, String semester, ZonedDateTime startDate, ZonedDateTime endDate) {
+
+    public static RequesterCourseDTO of(Course course) {
+        return new RequesterCourseDTO(course.getTitle(), course.getShortName(), course.getSemester(), course.getStartDate(), course.getEndDate());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/repository/CourseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/repository/CourseRepository.java
@@ -691,4 +691,19 @@ public interface CourseRepository extends ArtemisJpaRepository<Course, Long> {
             WHERE c.instructorGroupName IN :userGroups
             """)
     long countCoursesForInstructorWithGroups(@Param("userGroups") Set<String> userGroups);
+
+    /**
+     * Finds the most recent courses where the user is an instructor, ordered by course ID descending.
+     *
+     * @param userGroups the groups the user belongs to
+     * @param pageable   pagination information (use PageRequest.of(0, 10) for top 10)
+     * @return list of courses where the user is an instructor
+     */
+    @Query("""
+            SELECT c
+            FROM Course c
+            WHERE c.instructorGroupName IN :userGroups
+            ORDER BY c.id DESC
+            """)
+    List<Course> findRecentInstructorCourses(@Param("userGroups") Set<String> userGroups, Pageable pageable);
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/course/CourseRequestService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/course/CourseRequestService.java
@@ -26,10 +26,12 @@ import de.tum.cit.aet.artemis.core.domain.CourseInformationSharingConfiguration;
 import de.tum.cit.aet.artemis.core.domain.CourseRequest;
 import de.tum.cit.aet.artemis.core.domain.CourseRequestStatus;
 import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.core.dto.CourseRequestAcceptDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestCreateDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestRequesterDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestsAdminOverviewDTO;
+import de.tum.cit.aet.artemis.core.dto.RequesterCourseDTO;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
 import de.tum.cit.aet.artemis.core.repository.CourseRepository;
@@ -46,6 +48,8 @@ public class CourseRequestService {
     private static final Logger log = LoggerFactory.getLogger(CourseRequestService.class);
 
     private static final int MAX_TITLE_LENGTH = 255;
+
+    private static final int MAX_REQUESTER_COURSES = 10;
 
     private final ResourceLoaderService resourceLoaderService;
 
@@ -83,22 +87,18 @@ public class CourseRequestService {
      */
     public CourseRequestDTO createCourseRequest(CourseRequestCreateDTO createDTO) {
         var requester = userRepository.getUserWithGroupsAndAuthorities();
-        validateShortNameUniqueness(createDTO.shortName(), createDTO.title(), createDTO.semester(), null);
 
         if (createDTO.title().length() > MAX_TITLE_LENGTH) {
             throw new BadRequestAlertException("The course title is too long", CourseRequest.ENTITY_NAME, "courseRequestTitleTooLong");
         }
 
         Course validationCourse = new Course();
-        validationCourse.setShortName(createDTO.shortName());
-        validationCourse.validateShortName();
         validationCourse.setStartDate(createDTO.startDate());
         validationCourse.setEndDate(createDTO.endDate());
         validationCourse.validateStartAndEndDate();
 
         CourseRequest courseRequest = new CourseRequest();
         courseRequest.setTitle(createDTO.title());
-        courseRequest.setShortName(createDTO.shortName());
         courseRequest.setSemester(createDTO.semester());
         courseRequest.setStartDate(createDTO.startDate());
         courseRequest.setEndDate(createDTO.endDate());
@@ -118,23 +118,28 @@ public class CourseRequestService {
     }
 
     /**
-     * Accepts the course request and creates a course.
+     * Accepts the course request and creates a course using the provided accept data.
      *
      * @param requestId the request id
+     * @param acceptDTO the course data provided by the admin (title, shortName, semester, dates, testCourse)
      * @return the updated course request DTO
      */
-    public CourseRequestDTO acceptRequest(long requestId) {
+    public CourseRequestDTO acceptRequest(long requestId, CourseRequestAcceptDTO acceptDTO) {
         CourseRequest courseRequest = getRequestWithRequesterElseThrow(requestId);
         if (courseRequest.getStatus() != CourseRequestStatus.PENDING) {
             throw new BadRequestAlertException("The course request has already been processed", CourseRequest.ENTITY_NAME, "courseRequestProcessed");
         }
 
-        validateShortNameUniqueness(courseRequest.getShortName(), courseRequest.getTitle(), courseRequest.getSemester(), courseRequest.getId());
+        if (acceptDTO.title().length() > MAX_TITLE_LENGTH) {
+            throw new BadRequestAlertException("The course title is too long", CourseRequest.ENTITY_NAME, "courseRequestTitleTooLong");
+        }
+
+        validateShortNameUniqueness(acceptDTO.shortName());
 
         // Save eagerly loaded requester before save() which calls merge() and replaces the association with an uninitialized lazy proxy
         User requester = courseRequest.getRequester();
 
-        Course createdCourse = createCourseFromRequest(courseRequest);
+        Course createdCourse = createCourseFromAcceptDTO(acceptDTO, requester);
         courseRequest.setCreatedCourseId(createdCourse.getId());
         courseRequest.setStatus(CourseRequestStatus.ACCEPTED);
         courseRequest.setDecisionReason(null);
@@ -177,132 +182,50 @@ public class CourseRequestService {
     }
 
     /**
-     * Updates a pending course request. Only admins can update requests.
+     * Returns the most recent courses (up to 10) where the requester of a given course request is instructor.
      *
-     * @param requestId the request id
-     * @param updateDTO the updated course request data
-     * @return the updated course request DTO
+     * @param requestId the course request id
+     * @return list of requester course DTOs
      */
-    public CourseRequestDTO updateCourseRequest(long requestId, CourseRequestCreateDTO updateDTO) {
+    public List<RequesterCourseDTO> getRequesterCourses(long requestId) {
         CourseRequest courseRequest = getRequestWithRequesterElseThrow(requestId);
-        if (courseRequest.getStatus() != CourseRequestStatus.PENDING) {
-            throw new BadRequestAlertException("The course request has already been processed", CourseRequest.ENTITY_NAME, "courseRequestProcessed");
+        User requester = courseRequest.getRequester();
+        if (requester == null || requester.getId() == null) {
+            return List.of();
         }
 
-        validateShortNameUniqueness(updateDTO.shortName(), updateDTO.title(), updateDTO.semester(), requestId);
-
-        if (updateDTO.title().length() > MAX_TITLE_LENGTH) {
-            throw new BadRequestAlertException("The course title is too long", CourseRequest.ENTITY_NAME, "courseRequestTitleTooLong");
+        // Re-fetch with groups to avoid LazyInitializationException
+        requester = userRepository.findByIdWithGroupsAndAuthoritiesElseThrow(requester.getId());
+        Set<String> groups = requester.getGroups();
+        if (groups == null || groups.isEmpty()) {
+            return List.of();
         }
 
-        // Validate date range if both dates are provided
-        if (updateDTO.startDate() != null && updateDTO.endDate() != null) {
-            Course validationCourse = new Course();
-            validationCourse.setStartDate(updateDTO.startDate());
-            validationCourse.setEndDate(updateDTO.endDate());
-            validationCourse.validateStartAndEndDate();
-        }
-
-        courseRequest.setTitle(updateDTO.title());
-        courseRequest.setShortName(updateDTO.shortName());
-        courseRequest.setSemester(updateDTO.semester());
-        courseRequest.setStartDate(updateDTO.startDate());
-        courseRequest.setEndDate(updateDTO.endDate());
-        courseRequest.setTestCourse(updateDTO.testCourse());
-        courseRequest.setReason(updateDTO.reason());
-
-        courseRequest = courseRequestRepository.save(courseRequest);
-        // Re-fetch with eager loading to avoid LazyInitializationException when converting to DTO
-        courseRequest = getRequestWithRequesterElseThrow(courseRequest.getId());
-        return toDto(courseRequest);
+        var pageable = PageRequest.of(0, MAX_REQUESTER_COURSES);
+        List<Course> courses = courseRepository.findRecentInstructorCourses(groups, pageable);
+        return courses.stream().map(RequesterCourseDTO::of).toList();
     }
 
     private CourseRequest getRequestWithRequesterElseThrow(long requestId) {
         return courseRequestRepository.findOneWithEagerRelationshipsById(requestId).orElseThrow(() -> new EntityNotFoundException(CourseRequest.ENTITY_NAME, requestId));
     }
 
-    private void validateShortNameUniqueness(String shortName, String title, String semester, Long currentRequestId) {
+    private void validateShortNameUniqueness(String shortName) {
         boolean existsInCourse = courseRepository.existsByShortNameIgnoreCase(shortName);
-        var existingRequest = courseRequestRepository.findOneByShortNameIgnoreCase(shortName);
-        boolean existsInRequest = existingRequest.isPresent() && (currentRequestId == null || !existingRequest.get().getId().equals(currentRequestId));
-
-        if (existsInCourse || existsInRequest) {
-            String suggestedShortName = generateUniqueShortName(title, semester);
-            String errorKey = existsInCourse ? "courseShortNameExists" : "courseRequestShortNameExists";
-            throw new BadRequestAlertException("A course or request with the same short name already exists", CourseRequest.ENTITY_NAME, errorKey,
-                    Map.of("suggestedShortName", suggestedShortName));
+        if (existsInCourse) {
+            throw new BadRequestAlertException("A course with the same short name already exists", CourseRequest.ENTITY_NAME, "courseShortNameExists");
         }
     }
 
-    /**
-     * Generates a unique short name based on the first letters of the title words and the semester number.
-     * If the generated short name already exists, appends an incrementing number until a unique one is found.
-     *
-     * @param title    the course title
-     * @param semester the semester (e.g., "WS25/26", "SS24")
-     * @return a unique short name suggestion
-     */
-    private String generateUniqueShortName(String title, String semester) {
-        // Extract first letters from title words (only alphanumeric characters)
-        StringBuilder baseShortName = new StringBuilder();
-        if (title != null && !title.isBlank()) {
-            String[] words = title.split("\\s+");
-            for (String word : words) {
-                if (!word.isEmpty()) {
-                    char firstChar = Character.toUpperCase(word.charAt(0));
-                    if (Character.isLetterOrDigit(firstChar)) {
-                        baseShortName.append(firstChar);
-                    }
-                }
-            }
-        }
-
-        // Extract semester number (digits only)
-        if (semester != null && !semester.isBlank()) {
-            String semesterDigits = semester.replaceAll("[^0-9]", "");
-            if (!semesterDigits.isEmpty()) {
-                baseShortName.append(semesterDigits);
-            }
-        }
-
-        // Ensure minimum length of 3 characters by appending random uppercase letters
-        String base = baseShortName.toString();
-        if (base.length() < 3) {
-            base = base + generateRandomLetters(3 - base.length());
-        }
-
-        // Find a unique short name by appending a number if necessary
-        String candidate = base;
-        int counter = 1;
-        while (isShortNameTaken(candidate)) {
-            candidate = base + counter;
-            counter++;
-        }
-
-        return candidate;
-    }
-
-    private boolean isShortNameTaken(String shortName) {
-        return courseRepository.existsByShortNameIgnoreCase(shortName) || courseRequestRepository.findOneByShortNameIgnoreCase(shortName).isPresent();
-    }
-
-    private String generateRandomLetters(int length) {
-        StringBuilder sb = new StringBuilder(length);
-        for (int i = 0; i < length; i++) {
-            sb.append((char) ('A' + (int) (Math.random() * 26)));
-        }
-        return sb.toString();
-    }
-
-    private Course createCourseFromRequest(CourseRequest request) {
+    private Course createCourseFromAcceptDTO(CourseRequestAcceptDTO acceptDTO, User requester) {
         Course course = new Course();
 
-        course.setTitle(request.getTitle());
-        course.setShortName(request.getShortName());
-        course.setSemester(request.getSemester());
-        course.setStartDate(request.getStartDate());
-        course.setEndDate(request.getEndDate());
-        course.setTestCourse(request.isTestCourse());
+        course.setTitle(acceptDTO.title());
+        course.setShortName(acceptDTO.shortName());
+        course.setSemester(acceptDTO.semester());
+        course.setStartDate(acceptDTO.startDate());
+        course.setEndDate(acceptDTO.endDate());
+        course.setTestCourse(acceptDTO.testCourse());
         course.setOnlineCourse(Boolean.FALSE);
         course.setEnrollmentEnabled(Boolean.FALSE);
         course.setLearningPathsEnabled(false);
@@ -339,8 +262,8 @@ public class CourseRequestService {
         Course createdCourse = courseRepository.save(course);
         channelService.createDefaultChannels(createdCourse);
 
-        if (request.getRequester() != null) {
-            User requesterWithGroups = userRepository.findByIdWithGroupsAndAuthoritiesElseThrow(request.getRequester().getId());
+        if (requester != null) {
+            User requesterWithGroups = userRepository.findByIdWithGroupsAndAuthoritiesElseThrow(requester.getId());
             courseAccessService.addUserToGroup(requesterWithGroups, createdCourse.getInstructorGroupName(), createdCourse);
         }
         return createdCourse;

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/admin/AdminCourseRequestResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/admin/AdminCourseRequestResource.java
@@ -2,6 +2,8 @@ package de.tum.cit.aet.artemis.core.web.admin;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
+import java.util.List;
+
 import jakarta.validation.Valid;
 
 import org.slf4j.Logger;
@@ -12,16 +14,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import de.tum.cit.aet.artemis.core.dto.CourseRequestCreateDTO;
+import de.tum.cit.aet.artemis.core.dto.CourseRequestAcceptDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestDecisionDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestsAdminOverviewDTO;
+import de.tum.cit.aet.artemis.core.dto.RequesterCourseDTO;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAdmin;
 import de.tum.cit.aet.artemis.core.service.course.CourseRequestService;
 
@@ -56,14 +58,16 @@ public class AdminCourseRequestResource {
 
     /**
      * POST /course-requests/{requestId}/accept : accept a course request and create a course.
+     * The admin provides the final course data (title, short name, semester, dates) via the request body.
      *
      * @param requestId the request id
+     * @param acceptDTO the course data to use when creating the course
      * @return the updated course request DTO
      */
     @PostMapping("course-requests/{requestId}/accept")
-    public ResponseEntity<CourseRequestDTO> accept(@PathVariable long requestId) {
-        log.debug("REST request to accept course request {}", requestId);
-        return ResponseEntity.ok(courseRequestService.acceptRequest(requestId));
+    public ResponseEntity<CourseRequestDTO> accept(@PathVariable long requestId, @Valid @RequestBody CourseRequestAcceptDTO acceptDTO) {
+        log.debug("REST request to accept course request {} with short name {}", requestId, acceptDTO.shortName());
+        return ResponseEntity.ok(courseRequestService.acceptRequest(requestId, acceptDTO));
     }
 
     /**
@@ -80,16 +84,15 @@ public class AdminCourseRequestResource {
     }
 
     /**
-     * PUT /course-requests/{requestId} : update a pending course request.
-     * Allows admins to edit the course request before accepting it.
+     * GET /course-requests/{requestId}/requester-courses : get the most recent courses where the requester is instructor.
+     * Returns up to 10 courses ordered by course ID descending.
      *
-     * @param requestId the request id
-     * @param updateDTO the updated course request data
-     * @return the updated course request DTO
+     * @param requestId the course request id
+     * @return list of requester course DTOs
      */
-    @PutMapping("course-requests/{requestId}")
-    public ResponseEntity<CourseRequestDTO> update(@PathVariable long requestId, @Valid @RequestBody CourseRequestCreateDTO updateDTO) {
-        log.debug("REST request to update course request {}", requestId);
-        return ResponseEntity.ok(courseRequestService.updateCourseRequest(requestId, updateDTO));
+    @GetMapping("course-requests/{requestId}/requester-courses")
+    public ResponseEntity<List<RequesterCourseDTO>> getRequesterCourses(@PathVariable long requestId) {
+        log.debug("REST request to get requester courses for course request {}", requestId);
+        return ResponseEntity.ok(courseRequestService.getRequesterCourses(requestId));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/course/CourseRequestResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/course/CourseRequestResource.java
@@ -45,7 +45,7 @@ public class CourseRequestResource {
     @PostMapping("course-requests")
     @EnforceAtLeastStudent
     public ResponseEntity<CourseRequestDTO> createCourseRequest(@Valid @RequestBody CourseRequestCreateDTO courseRequest) throws URISyntaxException {
-        log.debug("REST request to create course request for course {}", courseRequest.shortName());
+        log.debug("REST request to create course request for course {}", courseRequest.title());
         CourseRequestDTO result = courseRequestService.createCourseRequest(courseRequest);
         return ResponseEntity.created(new URI("/api/core/course-requests/" + result.id())).body(result);
     }

--- a/src/main/resources/config/liquibase/changelog/20260427120000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260427120000_changelog.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+    Course requests no longer track the short name. The admin provides it when accepting.
+    Drop the NOT NULL constraint and unique constraint on short_name.
+    -->
+    <changeSet id="20260427-01-drop-course-request-short-name-unique" author="claudia">
+        <dropUniqueConstraint tableName="course_request" constraintName="uk_course_request_short_name"/>
+    </changeSet>
+
+    <changeSet id="20260427-02-drop-course-request-short-name-not-null" author="claudia">
+        <dropNotNullConstraint tableName="course_request" columnName="short_name" columnDataType="varchar(255)"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -11,6 +11,7 @@
     <include file="classpath:config/liquibase/changelog/20260327190000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260330120000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260407120000_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20260427120000_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command "date '+%Y%m%d%H%M%S'" to get the current date and time in the correct format -->

--- a/src/main/resources/templates/mail/courseRequestContactEmail.html
+++ b/src/main/resources/templates/mail/courseRequestContactEmail.html
@@ -16,7 +16,7 @@
                 <span class="bold-text" th:text="#{email.courseRequest.label.title}">Title</span>:
                 <span th:text="${courseRequest.title}">Title</span>
             </li>
-            <li>
+            <li th:if="${courseRequest.shortName != null}">
                 <span class="bold-text" th:text="#{email.courseRequest.label.shortName}">Short name</span>:
                 <span th:text="${courseRequest.shortName}">short-name</span>
             </li>

--- a/src/main/resources/templates/mail/courseRequestReceivedEmail.html
+++ b/src/main/resources/templates/mail/courseRequestReceivedEmail.html
@@ -19,7 +19,7 @@
                 <span class="bold-text" th:text="#{email.courseRequest.label.title}">Title</span>:
                 <span th:text="${courseRequest.title}">Title</span>
             </li>
-            <li>
+            <li th:if="${courseRequest.shortName != null}">
                 <span class="bold-text" th:text="#{email.courseRequest.label.shortName}">Short name</span>:
                 <span th:text="${courseRequest.shortName}">short-name</span>
             </li>

--- a/src/main/webapp/app/core/admin/course-requests/course-requests.component.html
+++ b/src/main/webapp/app/core/admin/course-requests/course-requests.component.html
@@ -33,7 +33,6 @@
                     <tr>
                         <td>
                             <div class="fw-semibold">{{ request.title }}</div>
-                            <div class="text-muted">{{ request.shortName }}</div>
                             @if (request.testCourse) {
                                 <span class="badge bg-info" jhiTranslate="artemisApp.courseRequest.admin.testCourse"></span>
                             }
@@ -73,17 +72,10 @@
                         <td class="text-end">
                             <div class="d-flex justify-content-end gap-2">
                                 <jhi-button
-                                    [btnType]="ButtonType.SECONDARY"
-                                    [btnSize]="ButtonSize.SMALL"
-                                    [icon]="faEdit"
-                                    (click)="openEditModal(request)"
-                                    [title]="'artemisApp.courseRequest.admin.edit'"
-                                />
-                                <jhi-button
                                     [btnType]="ButtonType.SUCCESS"
                                     [btnSize]="ButtonSize.SMALL"
                                     [icon]="faCheck"
-                                    (click)="accept(request)"
+                                    (click)="openAcceptModal(request)"
                                     [title]="'artemisApp.courseRequest.admin.accept'"
                                 />
                                 <jhi-button
@@ -125,7 +117,9 @@
                     <tr>
                         <td>
                             <div class="fw-semibold">{{ request.title }}</div>
-                            <div class="text-muted">{{ request.shortName }}</div>
+                            @if (request.shortName) {
+                                <div class="text-muted">{{ request.shortName }}</div>
+                            }
                             @if (request.testCourse) {
                                 <span class="badge bg-info" jhiTranslate="artemisApp.courseRequest.admin.testCourse"></span>
                             }
@@ -225,18 +219,95 @@
 </p-dialog>
 
 <p-dialog
-    [(visible)]="editModalVisible"
+    [(visible)]="acceptModalVisible"
     [modal]="true"
     [draggable]="false"
     [appendTo]="'body'"
-    [style]="{ width: '50dvw' }"
-    header="{{ 'artemisApp.courseRequest.admin.editTitle' | artemisTranslate }}"
+    [style]="{ width: '60dvw' }"
+    header="{{ 'artemisApp.courseRequest.admin.acceptTitle' | artemisTranslate }}"
 >
-    <form [formGroup]="editForm" novalidate>
-        <jhi-course-request-form [form]="editForm" [semesters]="semesters" [dateRangeInvalid]="editDateRangeInvalid()" [showReasonPlaceholder]="false" idPrefix="edit" />
+    <form [formGroup]="acceptForm" novalidate>
+        <!-- Section 1: Course Data -->
+        <h5 class="mb-3" jhiTranslate="artemisApp.courseRequest.admin.acceptCourseDataSection"></h5>
+        <jhi-course-request-form [form]="acceptForm" [semesters]="semesters" [dateRangeInvalid]="acceptDateRangeInvalid()" [showReasonPlaceholder]="false" idPrefix="accept" />
+
+        <!-- Section 2: Short Name with Instructor Course History -->
+        <h5 class="mb-3 mt-4" jhiTranslate="artemisApp.courseRequest.admin.acceptShortNameSection"></h5>
+
+        <!-- Instructor Course History Table -->
+        @if (loadingRequesterCourses()) {
+            <div class="text-center text-muted mb-3">
+                <span jhiTranslate="artemisApp.courseRequest.admin.loadingCourses"></span>
+            </div>
+        } @else if (requesterCourses().length > 0) {
+            <div class="table-responsive mb-3">
+                <p class="text-secondary mb-2" jhiTranslate="artemisApp.courseRequest.admin.requesterCoursesHint"></p>
+                <table class="table table-sm table-striped align-middle">
+                    <thead>
+                        <tr>
+                            <th scope="col" jhiTranslate="artemisApp.courseRequest.admin.courseName"></th>
+                            <th scope="col" jhiTranslate="artemisApp.courseRequest.form.shortName"></th>
+                            <th scope="col" jhiTranslate="artemisApp.courseRequest.admin.semester"></th>
+                            <th scope="col" jhiTranslate="artemisApp.courseRequest.admin.dates"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @for (course of requesterCourses(); track course.shortName) {
+                            <tr>
+                                <td>{{ course.title }}</td>
+                                <td class="fw-semibold">{{ course.shortName }}</td>
+                                <td>{{ course.semester }}</td>
+                                <td>
+                                    @if (course.startDate) {
+                                        {{ course.startDate | artemisDate: 'short' }}
+                                    }
+                                    @if (course.startDate && course.endDate) {
+                                        —
+                                    }
+                                    @if (course.endDate) {
+                                        {{ course.endDate | artemisDate: 'short' }}
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        } @else {
+            <p class="text-muted mb-3" jhiTranslate="artemisApp.courseRequest.admin.noPreviousCourses"></p>
+        }
+
+        <!-- Short Name Input -->
+        <div class="mb-3">
+            <label class="form-label fw-semibold" for="acceptShortName" jhiTranslate="artemisApp.courseRequest.form.shortName"></label>
+            <input
+                id="acceptShortName"
+                type="text"
+                class="form-control"
+                formControlName="shortName"
+                [pattern]="SHORT_NAME_PATTERN.source"
+                [class.is-invalid]="acceptForm.get('shortName')?.invalid && acceptForm.get('shortName')?.touched"
+            />
+            <small class="form-text text-secondary" jhiTranslate="artemisApp.courseRequest.admin.shortNameHint"></small>
+            @if (acceptForm.get('shortName')?.touched) {
+                @if (acceptForm.get('shortName')?.hasError('required')) {
+                    <div class="text-danger small" jhiTranslate="entity.validation.required"></div>
+                } @else if (acceptForm.get('shortName')?.hasError('minlength')) {
+                    <div class="text-danger small" jhiTranslate="artemisApp.courseRequest.form.shortNameTooShort"></div>
+                } @else if (acceptForm.get('shortName')?.hasError('regexInvalid') || acceptForm.get('shortName')?.hasError('pattern')) {
+                    <div class="text-danger small" jhiTranslate="artemisApp.courseRequest.form.shortNameInvalid"></div>
+                }
+            }
+        </div>
     </form>
     <ng-template #footer>
-        <jhi-button [btnType]="ButtonType.SECONDARY" (click)="editModalVisible.set(false)" [title]="'entity.action.cancel'" />
-        <jhi-button [btnType]="ButtonType.PRIMARY" [icon]="faCheck" (click)="saveEdit()" [disabled]="isSubmittingEdit()" [title]="'entity.action.save'" />
+        <jhi-button [btnType]="ButtonType.SECONDARY" (click)="acceptModalVisible.set(false)" [title]="'entity.action.cancel'" />
+        <jhi-button
+            [btnType]="ButtonType.SUCCESS"
+            [icon]="faCheck"
+            (click)="submitAccept()"
+            [disabled]="isSubmittingAccept()"
+            [title]="'artemisApp.courseRequest.admin.acceptConfirm'"
+        />
     </ng-template>
 </p-dialog>

--- a/src/main/webapp/app/core/admin/course-requests/course-requests.component.spec.ts
+++ b/src/main/webapp/app/core/admin/course-requests/course-requests.component.spec.ts
@@ -73,7 +73,6 @@ describe('CourseRequestsComponent', () => {
     };
 
     beforeEach(async () => {
-        vi.restoreAllMocks();
         vi.clearAllMocks();
 
         await TestBed.configureTestingModule({
@@ -249,8 +248,8 @@ describe('CourseRequestsComponent', () => {
 
         it('should handle other errors using onError', () => {
             const errorResponse = new HttpErrorResponse({
-                error: { message: 'Server error' },
-                status: 500,
+                error: { message: 'Bad request error' },
+                status: 400,
             });
             mockCourseRequestService.acceptRequest.mockReturnValue(throwError(() => errorResponse));
             component.acceptForm.patchValue({
@@ -263,6 +262,8 @@ describe('CourseRequestsComponent', () => {
             component.submitAccept();
 
             expect(component.isSubmittingAccept()).toBe(false);
+            expect(alertService.warning).not.toHaveBeenCalledWith('artemisApp.courseRequest.admin.shortNameConflictAccept');
+            expect(alertService.error).toHaveBeenCalled();
         });
     });
 

--- a/src/main/webapp/app/core/admin/course-requests/course-requests.component.spec.ts
+++ b/src/main/webapp/app/core/admin/course-requests/course-requests.component.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Vitest tests for CourseRequestsComponent.
  * Tests the admin view for managing course creation requests including
- * accept, reject, edit functionality and form validation.
+ * accept modal, reject, and form validation.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
@@ -29,10 +29,10 @@ describe('CourseRequestsComponent', () => {
     const mockRequest: CourseRequest = {
         id: 1,
         title: 'Test Course',
-        shortName: 'TC',
         testCourse: false,
         reason: 'Test reason',
         status: CourseRequestStatus.PENDING,
+        semester: 'WS25/26',
     };
 
     /** Sample accepted course request */
@@ -50,7 +50,6 @@ describe('CourseRequestsComponent', () => {
     const mockRejectedRequest: CourseRequest = {
         id: 1,
         title: 'Test Course',
-        shortName: 'TC',
         testCourse: false,
         reason: 'Test reason',
         status: CourseRequestStatus.REJECTED,
@@ -63,7 +62,7 @@ describe('CourseRequestsComponent', () => {
         findAdminOverview: vi.fn(),
         acceptRequest: vi.fn(),
         rejectRequest: vi.fn(),
-        updateRequest: vi.fn(),
+        getRequesterCourses: vi.fn(),
     };
 
     /** Mock AlertService with spy functions */
@@ -97,6 +96,7 @@ describe('CourseRequestsComponent', () => {
             totalDecidedCount: 0,
         };
         mockCourseRequestService.findAdminOverview.mockReturnValue(of(mockOverview));
+        mockCourseRequestService.getRequesterCourses.mockReturnValue(of([]));
 
         const fixture = TestBed.createComponent(CourseRequestsComponent);
         component = fixture.componentInstance;
@@ -131,37 +131,138 @@ describe('CourseRequestsComponent', () => {
         });
     });
 
-    describe('accept', () => {
-        it('should accept a request and move it to decided list', () => {
+    describe('openAcceptModal', () => {
+        it('should open modal and populate form with request data', () => {
+            const requestWithDates: CourseRequest = {
+                ...mockRequest,
+                startDate: dayjs('2025-10-01'),
+                endDate: dayjs('2026-03-31'),
+            };
+
+            component.openAcceptModal(requestWithDates);
+
+            expect(component.selectedRequest()).toBe(requestWithDates);
+            expect(component.acceptDateRangeInvalid()).toBe(false);
+            expect(component.isSubmittingAccept()).toBe(false);
+            expect(component.acceptForm.get('title')?.value).toBe('Test Course');
+            expect(component.acceptForm.get('semester')?.value).toBe('WS25/26');
+            expect(component.acceptForm.get('shortName')?.value).toBe('');
+            expect(component.acceptForm.get('reason')?.value).toBe('Test reason');
+            expect(component.acceptModalVisible()).toBe(true);
+        });
+
+        it('should load requester courses when opening modal', () => {
+            const mockCourses = [{ title: 'Course A', shortName: 'CA', semester: 'WS2024' }];
+            mockCourseRequestService.getRequesterCourses.mockReturnValue(of(mockCourses));
+
+            component.openAcceptModal(mockRequest);
+
+            expect(courseRequestService.getRequesterCourses).toHaveBeenCalledWith(1);
+            expect(component.requesterCourses()).toEqual(mockCourses);
+            expect(component.loadingRequesterCourses()).toBe(false);
+        });
+    });
+
+    describe('submitAccept', () => {
+        beforeEach(() => {
+            component.selectedRequest.set(mockRequest);
+            component.acceptModalVisible.set(true);
+        });
+
+        it('should accept request with form data and move to decided list', () => {
             mockCourseRequestService.acceptRequest.mockReturnValue(of(mockAcceptedRequest));
             component.pendingRequests.set([mockRequest]);
             component.decidedRequests.set([]);
             component.totalDecidedCount.set(0);
+            component.acceptForm.patchValue({
+                title: 'Test Course',
+                shortName: 'TC001',
+                semester: 'WS25/26',
+                reason: 'Test reason',
+            });
 
-            component.accept(mockRequest);
+            component.submitAccept();
 
-            expect(courseRequestService.acceptRequest).toHaveBeenCalledWith(1);
+            expect(courseRequestService.acceptRequest).toHaveBeenCalledWith(
+                1,
+                expect.objectContaining({
+                    title: 'Test Course',
+                    shortName: 'TC001',
+                    semester: 'WS25/26',
+                }),
+            );
             expect(component.pendingRequests()).toHaveLength(0);
             expect(component.decidedRequests()[0].status).toBe(CourseRequestStatus.ACCEPTED);
             expect(component.totalDecidedCount()).toBe(1);
-            expect(alertService.success).toHaveBeenCalledWith('artemisApp.courseRequest.admin.acceptSuccess', { title: 'Test Course', shortName: 'TC' });
+            expect(alertService.success).toHaveBeenCalledWith('artemisApp.courseRequest.admin.acceptSuccess', { title: 'Test Course', shortName: 'TC001' });
+            expect(component.acceptModalVisible()).toBe(false);
         });
 
-        it('should not call service if request has no id', () => {
-            const requestWithoutId: CourseRequest = { title: 'Test', shortName: 'T', testCourse: false, reason: 'reason' };
+        it('should not submit when form is invalid (missing short name)', () => {
+            component.acceptForm.patchValue({
+                title: 'Test Course',
+                shortName: '', // Invalid - required
+                semester: 'WS25/26',
+                reason: 'Test reason',
+            });
 
-            component.accept(requestWithoutId);
+            component.submitAccept();
 
+            expect(courseRequestService.acceptRequest).not.toHaveBeenCalled();
+            expect(component.acceptForm.get('shortName')?.touched).toBe(true);
+        });
+
+        it('should set dateRangeInvalid when end date is before start date', () => {
+            component.acceptForm.patchValue({
+                title: 'Test Course',
+                shortName: 'TC001',
+                semester: 'WS25/26',
+                reason: 'Test reason',
+                startDate: dayjs('2025-02-01'),
+                endDate: dayjs('2025-01-01'),
+            });
+
+            component.submitAccept();
+
+            expect(component.acceptDateRangeInvalid()).toBe(true);
             expect(courseRequestService.acceptRequest).not.toHaveBeenCalled();
         });
 
-        it('should handle error when accepting fails', () => {
-            const error = { status: 500, message: 'Server error' };
-            mockCourseRequestService.acceptRequest.mockReturnValue(throwError(() => error));
+        it('should handle short name conflict error', () => {
+            const errorResponse = new HttpErrorResponse({
+                error: { errorKey: 'courseShortNameExists' },
+                status: 400,
+            });
+            mockCourseRequestService.acceptRequest.mockReturnValue(throwError(() => errorResponse));
+            component.acceptForm.patchValue({
+                title: 'Test Course',
+                shortName: 'EXISTING',
+                semester: 'WS25/26',
+                reason: 'Test reason',
+            });
 
-            component.accept(mockRequest);
+            component.submitAccept();
 
-            expect(courseRequestService.acceptRequest).toHaveBeenCalledWith(1);
+            expect(alertService.warning).toHaveBeenCalledWith('artemisApp.courseRequest.admin.shortNameConflictAccept');
+            expect(component.isSubmittingAccept()).toBe(false);
+        });
+
+        it('should handle other errors using onError', () => {
+            const errorResponse = new HttpErrorResponse({
+                error: { message: 'Server error' },
+                status: 500,
+            });
+            mockCourseRequestService.acceptRequest.mockReturnValue(throwError(() => errorResponse));
+            component.acceptForm.patchValue({
+                title: 'Test Course',
+                shortName: 'TC001',
+                semester: 'WS25/26',
+                reason: 'Test reason',
+            });
+
+            component.submitAccept();
+
+            expect(component.isSubmittingAccept()).toBe(false);
         });
     });
 
@@ -220,7 +321,7 @@ describe('CourseRequestsComponent', () => {
         });
 
         it('should not call service if selectedRequest has no id', () => {
-            component.selectedRequest.set({ title: 'Test', shortName: 'T', testCourse: false, reason: 'reason' });
+            component.selectedRequest.set({ title: 'Test', testCourse: false, reason: 'reason' });
             component.decisionReason.set('Valid reason');
 
             component.reject();
@@ -277,191 +378,6 @@ describe('CourseRequestsComponent', () => {
 
         it('should return "Yes (count)" for positive count', () => {
             expect(component.formatInstructorCount(3)).toBe('Yes (3)');
-        });
-    });
-
-    describe('openEditModal', () => {
-        it('should open modal and populate form with request data', () => {
-            const requestWithDates: CourseRequest = {
-                ...mockRequest,
-                semester: 'WS25/26',
-                startDate: dayjs('2025-10-01'),
-                endDate: dayjs('2026-03-31'),
-            };
-
-            component.openEditModal(requestWithDates);
-
-            expect(component.selectedRequest()).toBe(requestWithDates);
-            expect(component.editDateRangeInvalid()).toBe(false);
-            expect(component.isSubmittingEdit()).toBe(false);
-            expect(component.editForm.get('title')?.value).toBe('Test Course');
-            expect(component.editForm.get('shortName')?.value).toBe('TC');
-            expect(component.editForm.get('semester')?.value).toBe('WS25/26');
-            expect(component.editForm.get('reason')?.value).toBe('Test reason');
-            expect(component.editModalVisible()).toBe(true);
-        });
-    });
-
-    describe('saveEdit', () => {
-        beforeEach(() => {
-            component.selectedRequest.set(mockRequest);
-            component.editModalVisible.set(true);
-        });
-
-        it('should update request and refresh list on success', () => {
-            const updatedRequest: CourseRequest = { ...mockRequest, title: 'Updated Course' };
-            mockCourseRequestService.updateRequest.mockReturnValue(of(updatedRequest));
-            component.pendingRequests.set([mockRequest]);
-            component.editForm.patchValue({
-                title: 'Updated Course',
-                shortName: 'UC1',
-                semester: 'WS25/26',
-                reason: 'Updated reason',
-            });
-
-            component.saveEdit();
-
-            expect(courseRequestService.updateRequest).toHaveBeenCalledWith(
-                1,
-                expect.objectContaining({
-                    title: 'Updated Course',
-                    shortName: 'UC1',
-                }),
-            );
-            expect(component.pendingRequests()[0].title).toBe('Updated Course');
-            expect(alertService.success).toHaveBeenCalledWith('artemisApp.courseRequest.admin.editSuccess');
-            expect(component.editModalVisible()).toBe(false);
-            expect(component.isSubmittingEdit()).toBe(false);
-            expect(component.selectedRequest()).toBeUndefined();
-        });
-
-        it('should not submit when form is invalid', () => {
-            component.editForm.patchValue({
-                title: '', // Invalid - required
-                shortName: 'TC',
-                reason: 'Valid reason',
-            });
-
-            component.saveEdit();
-
-            expect(courseRequestService.updateRequest).not.toHaveBeenCalled();
-            expect(component.editForm.get('title')?.touched).toBe(true);
-        });
-
-        it('should not submit when selectedRequest has no id', () => {
-            component.selectedRequest.set({ title: 'Test', shortName: 'T', testCourse: false, reason: 'reason' });
-            component.editForm.patchValue({
-                title: 'Test',
-                shortName: 'TST',
-                semester: 'WS25/26',
-                reason: 'Valid reason',
-            });
-
-            component.saveEdit();
-
-            expect(courseRequestService.updateRequest).not.toHaveBeenCalled();
-        });
-
-        it('should set dateRangeInvalid when end date is before start date', () => {
-            component.editForm.patchValue({
-                title: 'Test Course',
-                shortName: 'TC1',
-                semester: 'WS25/26',
-                reason: 'Valid reason',
-                startDate: dayjs('2025-02-01'),
-                endDate: dayjs('2025-01-01'),
-            });
-
-            component.saveEdit();
-
-            expect(component.editDateRangeInvalid()).toBe(true);
-            expect(courseRequestService.updateRequest).not.toHaveBeenCalled();
-        });
-
-        it('should handle short name conflict error and apply suggested short name', () => {
-            const suggestedShortName = 'TC2025';
-            const errorResponse = new HttpErrorResponse({
-                error: {
-                    errorKey: 'courseShortNameExists',
-                    params: { suggestedShortName },
-                },
-                status: 400,
-            });
-            mockCourseRequestService.updateRequest.mockReturnValue(throwError(() => errorResponse));
-            component.editForm.patchValue({
-                title: 'Test Course',
-                shortName: 'EXISTING',
-                semester: 'WS25/26',
-                reason: 'Valid reason',
-            });
-
-            component.saveEdit();
-
-            expect(alertService.warning).toHaveBeenCalledWith('artemisApp.courseRequest.form.shortNameNotUnique', { suggestedShortName });
-            expect(component.editForm.get('shortName')?.value).toBe(suggestedShortName);
-            expect(component.isSubmittingEdit()).toBe(false);
-        });
-
-        it('should handle courseRequestShortNameExists error', () => {
-            const suggestedShortName = 'TC2025';
-            const errorResponse = new HttpErrorResponse({
-                error: {
-                    errorKey: 'courseRequestShortNameExists',
-                    params: { suggestedShortName },
-                },
-                status: 400,
-            });
-            mockCourseRequestService.updateRequest.mockReturnValue(throwError(() => errorResponse));
-            component.editForm.patchValue({
-                title: 'Test Course',
-                shortName: 'EXISTING',
-                semester: 'WS25/26',
-                reason: 'Valid reason',
-            });
-
-            component.saveEdit();
-
-            expect(alertService.warning).toHaveBeenCalledWith('artemisApp.courseRequest.form.shortNameNotUnique', { suggestedShortName });
-            expect(component.editForm.get('shortName')?.value).toBe(suggestedShortName);
-        });
-
-        it('should handle other errors using onError', () => {
-            const errorResponse = new HttpErrorResponse({
-                error: { message: 'Server error' },
-                status: 500,
-            });
-            mockCourseRequestService.updateRequest.mockReturnValue(throwError(() => errorResponse));
-            component.editForm.patchValue({
-                title: 'Test Course',
-                shortName: 'TC1',
-                semester: 'WS25/26',
-                reason: 'Valid reason',
-            });
-
-            component.saveEdit();
-
-            expect(component.isSubmittingEdit()).toBe(false);
-        });
-    });
-
-    describe('accept error handling', () => {
-        it('should show warning for short name conflict on accept', () => {
-            const suggestedShortName = 'TC2025';
-            const errorResponse = new HttpErrorResponse({
-                error: {
-                    errorKey: 'courseShortNameExists',
-                    params: { suggestedShortName },
-                },
-                status: 400,
-            });
-            mockCourseRequestService.acceptRequest.mockReturnValue(throwError(() => errorResponse));
-
-            component.accept(mockRequest);
-
-            expect(alertService.warning).toHaveBeenCalledWith('artemisApp.courseRequest.admin.shortNameConflict', {
-                suggestedShortName,
-                shortName: 'TC',
-            });
         });
     });
 });

--- a/src/main/webapp/app/core/admin/course-requests/course-requests.component.spec.ts
+++ b/src/main/webapp/app/core/admin/course-requests/course-requests.component.spec.ts
@@ -178,8 +178,15 @@ describe('CourseRequestsComponent', () => {
             component.acceptModalVisible.set(true);
         });
 
-        it('should accept request with form data and move to decided list', () => {
+        it('should accept request with form data and reload overview', () => {
             mockCourseRequestService.acceptRequest.mockReturnValue(of(mockAcceptedRequest));
+            // After accept, load() is called which fetches the overview again
+            const updatedOverview: CourseRequestsAdminOverview = {
+                pendingRequests: [],
+                decidedRequests: [mockAcceptedRequest],
+                totalDecidedCount: 1,
+            };
+            mockCourseRequestService.findAdminOverview.mockReturnValue(of(updatedOverview));
             component.pendingRequests.set([mockRequest]);
             component.decidedRequests.set([]);
             component.totalDecidedCount.set(0);
@@ -200,6 +207,7 @@ describe('CourseRequestsComponent', () => {
                     semester: 'WS25/26',
                 }),
             );
+            expect(courseRequestService.findAdminOverview).toHaveBeenCalled();
             expect(component.pendingRequests()).toHaveLength(0);
             expect(component.decidedRequests()[0].status).toBe(CourseRequestStatus.ACCEPTED);
             expect(component.totalDecidedCount()).toBe(1);
@@ -294,8 +302,15 @@ describe('CourseRequestsComponent', () => {
             component.rejectModalVisible.set(true);
         });
 
-        it('should reject a request with a reason and move it to decided list', () => {
+        it('should reject a request with a reason and reload overview', () => {
             mockCourseRequestService.rejectRequest.mockReturnValue(of(mockRejectedRequest));
+            // After reject, load() is called which fetches the overview again
+            const updatedOverview: CourseRequestsAdminOverview = {
+                pendingRequests: [],
+                decidedRequests: [mockRejectedRequest],
+                totalDecidedCount: 1,
+            };
+            mockCourseRequestService.findAdminOverview.mockReturnValue(of(updatedOverview));
             component.pendingRequests.set([mockRequest]);
             component.decidedRequests.set([]);
             component.totalDecidedCount.set(0);
@@ -304,6 +319,7 @@ describe('CourseRequestsComponent', () => {
             component.reject();
 
             expect(courseRequestService.rejectRequest).toHaveBeenCalledWith(1, 'Not approved');
+            expect(courseRequestService.findAdminOverview).toHaveBeenCalled();
             expect(component.pendingRequests()).toHaveLength(0);
             expect(component.decidedRequests()[0].status).toBe(CourseRequestStatus.REJECTED);
             expect(component.totalDecidedCount()).toBe(1);

--- a/src/main/webapp/app/core/admin/course-requests/course-requests.component.spec.ts
+++ b/src/main/webapp/app/core/admin/course-requests/course-requests.component.spec.ts
@@ -160,6 +160,16 @@ describe('CourseRequestsComponent', () => {
             expect(component.requesterCourses()).toEqual(mockCourses);
             expect(component.loadingRequesterCourses()).toBe(false);
         });
+
+        it('should surface error when loading requester courses fails', () => {
+            const errorResponse = new HttpErrorResponse({ status: 403, statusText: 'Forbidden' });
+            mockCourseRequestService.getRequesterCourses.mockReturnValue(throwError(() => errorResponse));
+
+            component.openAcceptModal(mockRequest);
+
+            expect(component.loadingRequesterCourses()).toBe(false);
+            expect(alertService.error).toHaveBeenCalled();
+        });
     });
 
     describe('submitAccept', () => {

--- a/src/main/webapp/app/core/admin/course-requests/course-requests.component.ts
+++ b/src/main/webapp/app/core/admin/course-requests/course-requests.component.ts
@@ -2,12 +2,12 @@ import { NgClass } from '@angular/common';
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
 import { DialogModule } from 'primeng/dialog';
-import { faCheck, faEdit, faExternalLinkAlt, faSync, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faExternalLinkAlt, faSync, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { RouterLink } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 
-import { BaseCourseRequest, CourseRequest, CourseRequestStatus } from 'app/core/shared/entities/course-request.model';
+import { CourseRequest, CourseRequestAcceptPayload, CourseRequestStatus, RequesterCourse } from 'app/core/shared/entities/course-request.model';
 import { CourseRequestService } from 'app/core/course/request/course-request.service';
 import { CourseRequestFormComponent } from 'app/core/course/request/course-request-form.component';
 import { AlertService } from 'app/shared/service/alert.service';
@@ -25,7 +25,7 @@ import { AdminTitleBarActionsDirective } from 'app/core/admin/shared/admin-title
 
 /**
  * Admin component for managing course creation requests.
- * Allows administrators to review, accept, reject, or edit pending course requests.
+ * Allows administrators to review, accept, or reject pending course requests.
  */
 @Component({
     selector: 'jhi-course-requests-admin',
@@ -59,7 +59,6 @@ export class CourseRequestsComponent implements OnInit {
     protected readonly faTimes = faTimes;
     protected readonly faExternalLinkAlt = faExternalLinkAlt;
     protected readonly faSync = faSync;
-    protected readonly faEdit = faEdit;
     protected readonly SHORT_NAME_PATTERN = SHORT_NAME_PATTERN;
     protected readonly semesters = getCurrentAndFutureSemesters();
 
@@ -84,23 +83,27 @@ export class CourseRequestsComponent implements OnInit {
     readonly reasonInvalid = signal(false);
     /** Whether the reject modal dialog is visible */
     readonly rejectModalVisible = signal(false);
-    /** Whether the edit modal dialog is visible */
-    readonly editModalVisible = signal(false);
+    /** Whether the accept modal dialog is visible */
+    readonly acceptModalVisible = signal(false);
+    /** Whether accept is being submitted */
+    readonly isSubmittingAccept = signal(false);
+    /** Requester's instructor courses for the accept modal */
+    readonly requesterCourses = signal<RequesterCourse[]>([]);
+    /** Whether requester courses are loading */
+    readonly loadingRequesterCourses = signal(false);
 
-    // Edit form
-    editForm = this.fb.group({
+    // Accept form (course data + short name)
+    acceptForm = this.fb.group({
         title: ['', [Validators.required, Validators.maxLength(255)]],
-        shortName: ['', [Validators.required, Validators.minLength(3), regexValidator(SHORT_NAME_PATTERN)]],
         semester: ['', [Validators.required]],
         startDate: [undefined as any],
         endDate: [undefined as any],
         testCourse: [false],
-        reason: ['', [Validators.required]],
+        reason: [''],
+        shortName: ['', [Validators.required, Validators.minLength(3), regexValidator(SHORT_NAME_PATTERN)]],
     });
-    /** Whether edit date range is invalid */
-    readonly editDateRangeInvalid = signal(false);
-    /** Whether edit is being submitted */
-    readonly isSubmittingEdit = signal(false);
+    /** Whether accept date range is invalid */
+    readonly acceptDateRangeInvalid = signal(false);
 
     ngOnInit() {
         this.load();
@@ -127,29 +130,84 @@ export class CourseRequestsComponent implements OnInit {
         this.load();
     }
 
-    accept(request: CourseRequest) {
-        if (!request.id) {
+    openAcceptModal(request: CourseRequest) {
+        this.selectedRequest.set(request);
+        this.acceptDateRangeInvalid.set(false);
+        this.isSubmittingAccept.set(false);
+        this.requesterCourses.set([]);
+        this.acceptForm.reset({
+            title: request.title,
+            semester: request.semester ?? '',
+            startDate: request.startDate,
+            endDate: request.endDate,
+            testCourse: request.testCourse ?? false,
+            reason: request.reason,
+            shortName: '',
+        });
+        this.acceptModalVisible.set(true);
+
+        // Load requester's courses
+        if (request.id) {
+            this.loadingRequesterCourses.set(true);
+            this.courseRequestService.getRequesterCourses(request.id).subscribe({
+                next: (courses) => {
+                    this.requesterCourses.set(courses);
+                    this.loadingRequesterCourses.set(false);
+                },
+                error: () => {
+                    this.loadingRequesterCourses.set(false);
+                },
+            });
+        }
+    }
+
+    submitAccept() {
+        this.acceptDateRangeInvalid.set(false);
+        const currentRequest = this.selectedRequest();
+        if (this.acceptForm.invalid || !currentRequest?.id) {
+            this.acceptForm.markAllAsTouched();
             return;
         }
-        this.courseRequestService.acceptRequest(request.id).subscribe({
+
+        const startDate = this.acceptForm.get('startDate')!.value;
+        const endDate = this.acceptForm.get('endDate')!.value;
+        if (startDate && endDate && !startDate.isBefore(endDate)) {
+            this.acceptDateRangeInvalid.set(true);
+            return;
+        }
+
+        const payload: CourseRequestAcceptPayload = {
+            title: this.acceptForm.get('title')!.value!,
+            shortName: this.acceptForm.get('shortName')!.value!,
+            semester: this.acceptForm.get('semester')!.value ?? undefined,
+            startDate,
+            endDate,
+            testCourse: this.acceptForm.get('testCourse')!.value ?? false,
+        };
+
+        this.isSubmittingAccept.set(true);
+        this.courseRequestService.acceptRequest(currentRequest.id, payload).subscribe({
             next: (updated) => {
                 // Move from pending to decided
                 this.pendingRequests.update((reqs) => reqs.filter((req) => req.id !== updated.id));
                 this.decidedRequests.update((reqs) => [updated, ...reqs]);
                 this.totalDecidedCount.update((count) => count + 1);
-                this.alertService.success('artemisApp.courseRequest.admin.acceptSuccess', { title: updated.title, shortName: updated.shortName });
+                this.alertService.success('artemisApp.courseRequest.admin.acceptSuccess', { title: updated.title, shortName: payload.shortName });
+                this.acceptModalVisible.set(false);
+                this.isSubmittingAccept.set(false);
+                this.selectedRequest.set(undefined);
             },
-            error: (error: HttpErrorResponse) => this.handleAcceptError(error, request),
+            error: (error: HttpErrorResponse) => {
+                this.handleAcceptError(error);
+                this.isSubmittingAccept.set(false);
+            },
         });
     }
 
-    private handleAcceptError(error: HttpErrorResponse, request: CourseRequest): void {
+    private handleAcceptError(error: HttpErrorResponse): void {
         const errorKey = error.error?.errorKey;
-        const isShortNameConflict = errorKey === 'courseShortNameExists' || errorKey === 'courseRequestShortNameExists';
-
-        if (isShortNameConflict) {
-            const suggestedShortName = error.error?.params?.suggestedShortName;
-            this.alertService.warning('artemisApp.courseRequest.admin.shortNameConflict', { suggestedShortName: suggestedShortName ?? '', shortName: request.shortName });
+        if (errorKey === 'courseShortNameExists') {
+            this.alertService.warning('artemisApp.courseRequest.admin.shortNameConflictAccept');
             return;
         }
 
@@ -211,87 +269,5 @@ export class CourseRequestsComponent implements OnInit {
             return 'No';
         }
         return `Yes (${count})`;
-    }
-
-    openEditModal(request: CourseRequest) {
-        this.selectedRequest.set(request);
-        this.editDateRangeInvalid.set(false);
-        this.isSubmittingEdit.set(false);
-        this.editForm.reset({
-            title: request.title,
-            shortName: request.shortName,
-            semester: request.semester ?? '',
-            startDate: request.startDate,
-            endDate: request.endDate,
-            testCourse: request.testCourse ?? false,
-            reason: request.reason,
-        });
-        this.editModalVisible.set(true);
-    }
-
-    saveEdit() {
-        this.editDateRangeInvalid.set(false);
-        const currentRequest = this.selectedRequest();
-        if (this.editForm.invalid || !currentRequest?.id) {
-            this.editForm.markAllAsTouched();
-            return;
-        }
-
-        const startDate = this.editForm.get('startDate')!.value;
-        const endDate = this.editForm.get('endDate')!.value;
-        if (startDate && endDate && !startDate.isBefore(endDate)) {
-            this.editDateRangeInvalid.set(true);
-            return;
-        }
-
-        const payload: BaseCourseRequest = {
-            title: this.editForm.get('title')!.value!,
-            shortName: this.editForm.get('shortName')!.value!,
-            semester: this.editForm.get('semester')!.value ?? undefined,
-            startDate,
-            endDate,
-            testCourse: this.editForm.get('testCourse')!.value ?? false,
-            reason: this.editForm.get('reason')!.value!,
-        };
-
-        this.isSubmittingEdit.set(true);
-        this.courseRequestService.updateRequest(currentRequest.id, payload).subscribe({
-            next: (updated) => {
-                // Update the request in the list
-                this.pendingRequests.update((reqs) => {
-                    const index = reqs.findIndex((req) => req.id === updated.id);
-                    if (index !== -1) {
-                        const newReqs = [...reqs];
-                        newReqs[index] = updated;
-                        return newReqs;
-                    }
-                    return reqs;
-                });
-                this.alertService.success('artemisApp.courseRequest.admin.editSuccess');
-                this.editModalVisible.set(false);
-                this.isSubmittingEdit.set(false);
-                this.selectedRequest.set(undefined);
-            },
-            error: (error: HttpErrorResponse) => {
-                this.handleEditError(error);
-                this.isSubmittingEdit.set(false);
-            },
-        });
-    }
-
-    private handleEditError(error: HttpErrorResponse): void {
-        const errorKey = error.error?.errorKey;
-        const isShortNameConflict = errorKey === 'courseShortNameExists' || errorKey === 'courseRequestShortNameExists';
-
-        if (isShortNameConflict) {
-            const suggestedShortName = error.error?.params?.suggestedShortName;
-            this.alertService.warning('artemisApp.courseRequest.form.shortNameNotUnique', { suggestedShortName: suggestedShortName ?? '' });
-            if (suggestedShortName) {
-                this.editForm.patchValue({ shortName: suggestedShortName });
-            }
-            return;
-        }
-
-        onError(this.alertService, error);
     }
 }

--- a/src/main/webapp/app/core/admin/course-requests/course-requests.component.ts
+++ b/src/main/webapp/app/core/admin/course-requests/course-requests.component.ts
@@ -149,13 +149,20 @@ export class CourseRequestsComponent implements OnInit {
 
         // Load requester's courses
         if (request.id) {
+            const requestId = request.id;
             this.loadingRequesterCourses.set(true);
-            this.courseRequestService.getRequesterCourses(request.id).subscribe({
+            this.courseRequestService.getRequesterCourses(requestId).subscribe({
                 next: (courses) => {
+                    if (this.selectedRequest()?.id !== requestId) {
+                        return;
+                    }
                     this.requesterCourses.set(courses);
                     this.loadingRequesterCourses.set(false);
                 },
                 error: (error) => {
+                    if (this.selectedRequest()?.id !== requestId) {
+                        return;
+                    }
                     this.loadingRequesterCourses.set(false);
                     onError(this.alertService, error);
                 },
@@ -190,14 +197,11 @@ export class CourseRequestsComponent implements OnInit {
         this.isSubmittingAccept.set(true);
         this.courseRequestService.acceptRequest(currentRequest.id, payload).subscribe({
             next: (updated) => {
-                // Move from pending to decided
-                this.pendingRequests.update((reqs) => reqs.filter((req) => req.id !== updated.id));
-                this.decidedRequests.update((reqs) => [updated, ...reqs]);
-                this.totalDecidedCount.update((count) => count + 1);
                 this.alertService.success('artemisApp.courseRequest.admin.acceptSuccess', { title: updated.title, shortName: payload.shortName });
                 this.acceptModalVisible.set(false);
                 this.isSubmittingAccept.set(false);
                 this.selectedRequest.set(undefined);
+                this.load();
             },
             error: (error: HttpErrorResponse) => {
                 this.handleAcceptError(error);
@@ -234,14 +238,11 @@ export class CourseRequestsComponent implements OnInit {
         }
         this.courseRequestService.rejectRequest(currentRequest.id, this.decisionReason()).subscribe({
             next: (updated) => {
-                // Move from pending to decided
-                this.pendingRequests.update((reqs) => reqs.filter((req) => req.id !== updated.id));
-                this.decidedRequests.update((reqs) => [updated, ...reqs]);
-                this.totalDecidedCount.update((count) => count + 1);
                 this.alertService.success('artemisApp.courseRequest.admin.rejectSuccess', { title: updated.title });
                 this.rejectModalVisible.set(false);
                 this.reasonInvalid.set(false);
                 this.selectedRequest.set(undefined);
+                this.load();
             },
             error: (error) => onError(this.alertService, error),
         });

--- a/src/main/webapp/app/core/admin/course-requests/course-requests.component.ts
+++ b/src/main/webapp/app/core/admin/course-requests/course-requests.component.ts
@@ -181,8 +181,8 @@ export class CourseRequestsComponent implements OnInit {
             title: this.acceptForm.get('title')!.value!,
             shortName: this.acceptForm.get('shortName')!.value!,
             semester: this.acceptForm.get('semester')!.value ?? undefined,
-            startDate,
-            endDate,
+            startDate: startDate ?? undefined,
+            endDate: endDate ?? undefined,
             testCourse: this.acceptForm.get('testCourse')!.value ?? false,
         };
 

--- a/src/main/webapp/app/core/admin/course-requests/course-requests.component.ts
+++ b/src/main/webapp/app/core/admin/course-requests/course-requests.component.ts
@@ -170,20 +170,20 @@ export class CourseRequestsComponent implements OnInit {
             return;
         }
 
-        const startDate = this.acceptForm.get('startDate')!.value;
-        const endDate = this.acceptForm.get('endDate')!.value;
+        const startDate = this.acceptForm.controls.startDate.value ?? undefined;
+        const endDate = this.acceptForm.controls.endDate.value ?? undefined;
         if (startDate && endDate && !startDate.isBefore(endDate)) {
             this.acceptDateRangeInvalid.set(true);
             return;
         }
 
         const payload: CourseRequestAcceptPayload = {
-            title: this.acceptForm.get('title')!.value!,
-            shortName: this.acceptForm.get('shortName')!.value!,
-            semester: this.acceptForm.get('semester')!.value ?? undefined,
-            startDate: startDate ?? undefined,
-            endDate: endDate ?? undefined,
-            testCourse: this.acceptForm.get('testCourse')!.value ?? false,
+            title: this.acceptForm.controls.title.value!,
+            shortName: this.acceptForm.controls.shortName.value!,
+            semester: this.acceptForm.controls.semester.value ?? undefined,
+            startDate,
+            endDate,
+            testCourse: this.acceptForm.controls.testCourse.value ?? false,
         };
 
         this.isSubmittingAccept.set(true);

--- a/src/main/webapp/app/core/admin/course-requests/course-requests.component.ts
+++ b/src/main/webapp/app/core/admin/course-requests/course-requests.component.ts
@@ -15,7 +15,8 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ButtonComponent, ButtonSize, ButtonType } from 'app/shared/components/buttons/button/button.component';
-import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import dayjs from 'dayjs/esm';
 import { onError } from 'app/shared/util/global.utils';
 import { regexValidator } from 'app/shared/form/shortname-validator.directive';
 import { getCurrentAndFutureSemesters } from 'app/shared/util/semester-utils';
@@ -96,8 +97,8 @@ export class CourseRequestsComponent implements OnInit {
     acceptForm = this.fb.group({
         title: ['', [Validators.required, Validators.maxLength(255)]],
         semester: ['', [Validators.required]],
-        startDate: [undefined as any],
-        endDate: [undefined as any],
+        startDate: new FormControl<dayjs.Dayjs | undefined>(undefined),
+        endDate: new FormControl<dayjs.Dayjs | undefined>(undefined),
         testCourse: [false],
         reason: [''],
         shortName: ['', [Validators.required, Validators.minLength(3), regexValidator(SHORT_NAME_PATTERN)]],

--- a/src/main/webapp/app/core/admin/course-requests/course-requests.component.ts
+++ b/src/main/webapp/app/core/admin/course-requests/course-requests.component.ts
@@ -155,8 +155,9 @@ export class CourseRequestsComponent implements OnInit {
                     this.requesterCourses.set(courses);
                     this.loadingRequesterCourses.set(false);
                 },
-                error: () => {
+                error: (error) => {
                     this.loadingRequesterCourses.set(false);
+                    onError(this.alertService, error);
                 },
             });
         }

--- a/src/main/webapp/app/core/course/request/course-request-form.component.html
+++ b/src/main/webapp/app/core/course/request/course-request-form.component.html
@@ -14,32 +14,6 @@
         }
     </div>
 
-    <div class="mb-3">
-        <label class="form-label fw-semibold" [for]="idPrefix() + 'shortName'" jhiTranslate="artemisApp.courseRequest.form.shortName"></label>
-        <input
-            [id]="idPrefix() + 'shortName'"
-            type="text"
-            class="form-control"
-            formControlName="shortName"
-            [pattern]="SHORT_NAME_PATTERN.source"
-            [class.is-invalid]="form().get('shortName')?.invalid && form().get('shortName')?.touched"
-            maxlength="10"
-        />
-        <div class="d-flex justify-content-between align-items-start mt-1">
-            <small class="form-text text-secondary" jhiTranslate="artemisApp.courseRequest.form.shortNameHint"></small>
-            <button type="button" class="btn btn-sm btn-outline-secondary" (click)="generateShortName()" jhiTranslate="artemisApp.courseRequest.form.generate"></button>
-        </div>
-        @if (form().get('shortName')?.touched) {
-            @if (form().get('shortName')?.hasError('required')) {
-                <div class="text-danger small" jhiTranslate="entity.validation.required"></div>
-            } @else if (form().get('shortName')?.hasError('minlength')) {
-                <div class="text-danger small" jhiTranslate="artemisApp.courseRequest.form.shortNameTooShort"></div>
-            } @else if (form().get('shortName')?.hasError('regexInvalid') || form().get('shortName')?.hasError('pattern')) {
-                <div class="text-danger small" jhiTranslate="artemisApp.courseRequest.form.shortNameInvalid"></div>
-            }
-        }
-    </div>
-
     <div class="row g-3 mb-3">
         <div class="col-md">
             <label class="form-label mb-0 fw-semibold" [for]="idPrefix() + 'semester'" jhiTranslate="artemisApp.courseRequest.form.semester"></label>

--- a/src/main/webapp/app/core/course/request/course-request-form.component.spec.ts
+++ b/src/main/webapp/app/core/course/request/course-request-form.component.spec.ts
@@ -9,8 +9,6 @@ import { CourseRequestFormComponent } from 'app/core/course/request/course-reque
 import { FormDateTimePickerComponent } from 'app/shared/date-time-picker/date-time-picker.component';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
-import { SHORT_NAME_PATTERN } from 'app/shared/constants/input.constants';
-import { regexValidator } from 'app/shared/form/shortname-validator.directive';
 
 describe('CourseRequestFormComponent', () => {
     setupTestBed({ zoneless: true });
@@ -23,7 +21,6 @@ describe('CourseRequestFormComponent', () => {
         const fb = new FormBuilder();
         form = fb.group({
             title: ['', [Validators.required, Validators.maxLength(255)]],
-            shortName: ['', [Validators.required, Validators.minLength(3), regexValidator(SHORT_NAME_PATTERN)]],
             semester: ['WS25/26', [Validators.required]],
             startDate: [undefined],
             endDate: [undefined],
@@ -44,7 +41,6 @@ describe('CourseRequestFormComponent', () => {
         fixture = TestBed.createComponent(CourseRequestFormComponent);
         component = fixture.componentInstance;
 
-        // Set required inputs using component input setters
         fixture.componentRef.setInput('form', form);
         fixture.componentRef.setInput('semesters', ['WS25/26', 'SS26', 'WS26/27']);
         fixture.componentRef.setInput('dateRangeInvalid', false);
@@ -60,105 +56,6 @@ describe('CourseRequestFormComponent', () => {
 
     it('should create', () => {
         expect(component).toBeTruthy();
-    });
-
-    it('should generate short name from title and semester', () => {
-        form.patchValue({
-            title: 'Introduction To Programming',
-            semester: 'WS25/26',
-        });
-
-        component.generateShortName();
-
-        // "ITP" from title + "2526" from "WS25/26"
-        expect(form.get('shortName')?.value).toBe('ITP2526');
-    });
-
-    it('should generate short name with minimum length padding', () => {
-        form.patchValue({
-            title: 'AI',
-            semester: '',
-        });
-
-        component.generateShortName();
-
-        // 'AI' as a single word contributes only 'A' (first letter of each word)
-        // Then padding: 'A' + 'CRS'.substring(0, 3-1) = 'A' + 'CR' = 'ACR'
-        expect(form.get('shortName')?.value).toBe('ACR');
-    });
-
-    it('should generate short name with all digits from semester', () => {
-        form.patchValue({
-            title: 'Test Course',
-            semester: 'WS25/26',
-        });
-
-        component.generateShortName();
-
-        // "TC" from title + "2526" from "WS25/26"
-        expect(form.get('shortName')?.value).toBe('TC2526');
-    });
-
-    it('should generate short name with summer semester', () => {
-        form.patchValue({
-            title: 'Data Structures',
-            semester: 'SS25',
-        });
-
-        component.generateShortName();
-
-        // "DS" from title + "25" from "SS25"
-        expect(form.get('shortName')?.value).toBe('DS25');
-    });
-
-    it('should generate short name ignoring non-alphanumeric first characters', () => {
-        form.patchValue({
-            title: '123 Test Course',
-            semester: 'WS25/26',
-        });
-
-        component.generateShortName();
-
-        // "1TC" from title (1 from "123", T from "Test", C from "Course") + "2526"
-        expect(form.get('shortName')?.value).toBe('1TC2526');
-    });
-
-    it('should generate short name with empty title', () => {
-        form.patchValue({
-            title: '',
-            semester: 'WS25/26',
-        });
-
-        component.generateShortName();
-
-        // No title letters, just semester digits, but needs minimum 3 chars
-        // "2526" from semester
-        expect(form.get('shortName')?.value).toBe('2526');
-    });
-
-    it('should generate short name with empty semester', () => {
-        form.patchValue({
-            title: 'Programming',
-            semester: '',
-        });
-
-        component.generateShortName();
-
-        // Just "P" from title, needs padding to 3 chars
-        expect(form.get('shortName')?.value).toBe('PCR');
-    });
-
-    it('should emit formChange event when generating short name', () => {
-        const formChangeSpy = vi.spyOn(component.formChange, 'emit');
-
-        form.patchValue({
-            title: 'Test Course',
-            semester: 'WS25/26',
-        });
-
-        component.generateShortName();
-
-        expect(formChangeSpy).toHaveBeenCalled();
     });
 
     it('should use idPrefix for element IDs', () => {

--- a/src/main/webapp/app/core/course/request/course-request-form.component.ts
+++ b/src/main/webapp/app/core/course/request/course-request-form.component.ts
@@ -4,8 +4,6 @@ import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { FormDateTimePickerComponent } from 'app/shared/date-time-picker/date-time-picker.component';
-import { SHORT_NAME_PATTERN } from 'app/shared/constants/input.constants';
-import { generateCourseShortName } from 'app/shared/util/semester-utils';
 
 @Component({
     selector: 'jhi-course-request-form',
@@ -30,15 +28,4 @@ export class CourseRequestFormComponent {
 
     /** Emitted when the form values change */
     formChange = output<void>();
-
-    protected readonly SHORT_NAME_PATTERN = SHORT_NAME_PATTERN;
-
-    generateShortName(): void {
-        const formGroup = this.form();
-        const title = formGroup.get('title')?.value ?? '';
-        const semester = formGroup.get('semester')?.value ?? '';
-        const shortName = generateCourseShortName(title, semester);
-        formGroup.patchValue({ shortName });
-        this.formChange.emit();
-    }
 }

--- a/src/main/webapp/app/core/course/request/course-request.component.spec.ts
+++ b/src/main/webapp/app/core/course/request/course-request.component.spec.ts
@@ -3,12 +3,12 @@ import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { HttpErrorResponse } from '@angular/common/http';
 import { TranslateModule } from '@ngx-translate/core';
 import { MockComponent, MockDirective } from 'ng-mocks';
 import { CourseRequest } from 'app/core/shared/entities/course-request.model';
 import dayjs from 'dayjs/esm';
 import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
 
 import { CourseRequestComponent } from 'app/core/course/request/course-request.component';
 import { CourseRequestService } from 'app/core/course/request/course-request.service';
@@ -73,7 +73,6 @@ describe('CourseRequestComponent', () => {
     it('should mark invalid date ranges and not submit', () => {
         component.form.patchValue({
             title: 'New Course',
-            shortName: 'ABC',
             reason: 'A valid reason for the request',
             startDate: dayjs('2025-01-10'),
             endDate: dayjs('2025-01-05'),
@@ -89,7 +88,6 @@ describe('CourseRequestComponent', () => {
         courseRequestService.create.mockReturnValue(of({} as CourseRequest));
         component.form.patchValue({
             title: 'New Course',
-            shortName: 'ABC',
             reason: 'A valid reason for the request',
             startDate: dayjs('2025-01-01'),
             endDate: dayjs('2025-02-01'),
@@ -102,62 +100,31 @@ describe('CourseRequestComponent', () => {
         expect(courseRequestService.create).toHaveBeenCalledWith(
             expect.objectContaining({
                 title: 'New Course',
-                shortName: 'ABC',
                 testCourse: true,
             }),
         );
         expect(alertService.success).toHaveBeenCalled();
     });
 
-    it('should handle short name conflict error and apply suggested short name', () => {
-        const suggestedShortName = 'NC2025';
+    it('should handle generic error on submit', () => {
         const errorResponse = new HttpErrorResponse({
-            error: {
-                errorKey: 'courseShortNameExists',
-                params: { suggestedShortName },
-            },
-            status: 400,
+            error: { message: 'Server error' },
+            status: 500,
         });
         courseRequestService.create.mockReturnValue(throwError(() => errorResponse));
         component.form.patchValue({
             title: 'New Course',
-            shortName: 'EXISTING',
             reason: 'A valid reason for the request',
         });
 
         component.submit();
 
-        expect(alertService.warning).toHaveBeenCalledWith('artemisApp.courseRequest.form.shortNameNotUnique', { suggestedShortName });
-        expect(component.form.get('shortName')?.value).toBe(suggestedShortName);
         expect(component.isSubmitting).toBe(false);
-    });
-
-    it('should handle course request short name conflict error', () => {
-        const suggestedShortName = 'NC2025';
-        const errorResponse = new HttpErrorResponse({
-            error: {
-                errorKey: 'courseRequestShortNameExists',
-                params: { suggestedShortName },
-            },
-            status: 400,
-        });
-        courseRequestService.create.mockReturnValue(throwError(() => errorResponse));
-        component.form.patchValue({
-            title: 'New Course',
-            shortName: 'EXISTING',
-            reason: 'A valid reason for the request',
-        });
-
-        component.submit();
-
-        expect(alertService.warning).toHaveBeenCalledWith('artemisApp.courseRequest.form.shortNameNotUnique', { suggestedShortName });
-        expect(component.form.get('shortName')?.value).toBe(suggestedShortName);
     });
 
     it('should not submit when semester is empty', () => {
         component.form.patchValue({
             title: 'New Course',
-            shortName: 'ABC',
             semester: '',
             reason: 'A valid reason for the request',
         });
@@ -169,7 +136,6 @@ describe('CourseRequestComponent', () => {
     });
 
     it('should have semester pre-filled with default value', () => {
-        // The semester should be pre-filled based on the default semester logic
         expect(component.form.get('semester')?.value).toBeTruthy();
         expect(component.form.get('semester')?.value).toMatch(/^(WS|SS)\d+/);
     });
@@ -178,14 +144,12 @@ describe('CourseRequestComponent', () => {
         courseRequestService.create.mockReturnValue(of({} as CourseRequest));
         component.form.patchValue({
             title: 'New Course',
-            shortName: 'ABC',
             reason: 'A valid reason for the request',
         });
 
         component.submit();
 
         expect(component.form.get('title')?.value).toBe('');
-        expect(component.form.get('shortName')?.value).toBe('');
         expect(component.form.get('reason')?.value).toBe('');
         expect(component.isSubmitting).toBe(false);
     });
@@ -193,7 +157,6 @@ describe('CourseRequestComponent', () => {
     it('should not submit when form is invalid', () => {
         component.form.patchValue({
             title: '', // Invalid - required
-            shortName: 'ABC',
             reason: 'A valid reason',
         });
 

--- a/src/main/webapp/app/core/course/request/course-request.component.ts
+++ b/src/main/webapp/app/core/course/request/course-request.component.ts
@@ -2,7 +2,6 @@ import { Component, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons';
-import dayjs from 'dayjs/esm';
 
 import { CourseRequestService } from 'app/core/course/request/course-request.service';
 import { CourseRequestFormComponent } from 'app/core/course/request/course-request-form.component';
@@ -10,10 +9,8 @@ import { BaseCourseRequest } from 'app/core/shared/entities/course-request.model
 import { AlertService } from 'app/shared/service/alert.service';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { getCurrentAndFutureSemesters, getDefaultSemester } from 'app/shared/util/semester-utils';
-import { regexValidator } from 'app/shared/form/shortname-validator.directive';
 import { onError } from 'app/shared/util/global.utils';
 import { ButtonComponent, ButtonSize, ButtonType } from 'app/shared/components/buttons/button/button.component';
-import { SHORT_NAME_PATTERN } from 'app/shared/constants/input.constants';
 
 @Component({
     selector: 'jhi-course-request',
@@ -35,10 +32,9 @@ export class CourseRequestComponent {
 
     form = this.fb.group({
         title: ['', [Validators.required, Validators.maxLength(255)]],
-        shortName: ['', [Validators.required, Validators.minLength(3), regexValidator(SHORT_NAME_PATTERN)]],
         semester: [getDefaultSemester(), [Validators.required]],
-        startDate: [undefined as dayjs.Dayjs | undefined],
-        endDate: [undefined as dayjs.Dayjs | undefined],
+        startDate: [undefined as any],
+        endDate: [undefined as any],
         testCourse: [false],
         reason: ['', [Validators.required]],
     });
@@ -58,7 +54,6 @@ export class CourseRequestComponent {
 
         const payload: BaseCourseRequest = {
             title: this.form.get('title')!.value!,
-            shortName: this.form.get('shortName')!.value!,
             semester: this.form.get('semester')!.value ?? undefined,
             startDate,
             endDate,
@@ -72,7 +67,6 @@ export class CourseRequestComponent {
                 this.alertService.success('artemisApp.courseRequest.success');
                 this.form.reset({
                     title: '',
-                    shortName: '',
                     semester: getDefaultSemester(),
                     startDate: undefined,
                     endDate: undefined,
@@ -83,25 +77,9 @@ export class CourseRequestComponent {
                 this.isSubmitting = false;
             },
             error: (error: HttpErrorResponse) => {
-                this.handleSubmitError(error);
+                onError(this.alertService, error);
                 this.isSubmitting = false;
             },
         });
-    }
-
-    private handleSubmitError(error: HttpErrorResponse): void {
-        const errorKey = error.error?.errorKey;
-        const isShortNameConflict = errorKey === 'courseShortNameExists' || errorKey === 'courseRequestShortNameExists';
-
-        if (isShortNameConflict) {
-            const suggestedShortName = error.error?.params?.suggestedShortName;
-            this.alertService.warning('artemisApp.courseRequest.form.shortNameNotUnique', { suggestedShortName: suggestedShortName ?? '' });
-            if (suggestedShortName) {
-                this.form.patchValue({ shortName: suggestedShortName });
-            }
-            return;
-        }
-
-        onError(this.alertService, error);
     }
 }

--- a/src/main/webapp/app/core/course/request/course-request.component.ts
+++ b/src/main/webapp/app/core/course/request/course-request.component.ts
@@ -46,20 +46,20 @@ export class CourseRequestComponent {
             this.form.markAllAsTouched();
             return;
         }
-        const startDate = this.form.get('startDate')!.value ?? undefined;
-        const endDate = this.form.get('endDate')!.value ?? undefined;
+        const startDate = this.form.controls.startDate.value ?? undefined;
+        const endDate = this.form.controls.endDate.value ?? undefined;
         if (startDate && endDate && !startDate.isBefore(endDate)) {
             this.dateRangeInvalid = true;
             return;
         }
 
         const payload: BaseCourseRequest = {
-            title: this.form.get('title')!.value!,
-            semester: this.form.get('semester')!.value ?? undefined,
+            title: this.form.controls.title.value!,
+            semester: this.form.controls.semester.value ?? undefined,
             startDate,
             endDate,
-            testCourse: this.form.get('testCourse')!.value ?? false,
-            reason: this.form.get('reason')!.value!,
+            testCourse: this.form.controls.testCourse.value ?? false,
+            reason: this.form.controls.reason.value!,
         };
 
         this.isSubmitting = true;

--- a/src/main/webapp/app/core/course/request/course-request.component.ts
+++ b/src/main/webapp/app/core/course/request/course-request.component.ts
@@ -1,7 +1,8 @@
 import { Component, inject } from '@angular/core';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons';
+import dayjs from 'dayjs/esm';
 
 import { CourseRequestService } from 'app/core/course/request/course-request.service';
 import { CourseRequestFormComponent } from 'app/core/course/request/course-request-form.component';
@@ -33,8 +34,8 @@ export class CourseRequestComponent {
     form = this.fb.group({
         title: ['', [Validators.required, Validators.maxLength(255)]],
         semester: [getDefaultSemester(), [Validators.required]],
-        startDate: [undefined as any],
-        endDate: [undefined as any],
+        startDate: new FormControl<dayjs.Dayjs | undefined>(undefined),
+        endDate: new FormControl<dayjs.Dayjs | undefined>(undefined),
         testCourse: [false],
         reason: ['', [Validators.required]],
     });

--- a/src/main/webapp/app/core/course/request/course-request.service.spec.ts
+++ b/src/main/webapp/app/core/course/request/course-request.service.spec.ts
@@ -6,7 +6,7 @@ import { provideHttpClient } from '@angular/common/http';
 import dayjs from 'dayjs/esm';
 
 import { CourseRequestService } from 'app/core/course/request/course-request.service';
-import { BaseCourseRequest, CourseRequestStatus } from 'app/core/shared/entities/course-request.model';
+import { BaseCourseRequest, CourseRequestAcceptPayload, CourseRequestStatus } from 'app/core/shared/entities/course-request.model';
 
 describe('CourseRequestService', () => {
     setupTestBed({ zoneless: true });
@@ -35,7 +35,6 @@ describe('CourseRequestService', () => {
         it('should create a course request and convert dates', () => {
             const baseCourseRequest: BaseCourseRequest = {
                 title: 'Test Course',
-                shortName: 'TC001',
                 semester: 'WS2025',
                 startDate: dayjs('2025-01-01'),
                 endDate: dayjs('2025-06-30'),
@@ -46,7 +45,6 @@ describe('CourseRequestService', () => {
             const mockResponse = {
                 id: 1,
                 title: 'Test Course',
-                shortName: 'TC001',
                 semester: 'WS2025',
                 startDate: '2025-01-01T00:00:00Z',
                 endDate: '2025-06-30T00:00:00Z',
@@ -60,7 +58,6 @@ describe('CourseRequestService', () => {
             service.create(baseCourseRequest).subscribe((result) => {
                 expect(result.id).toBe(1);
                 expect(result.title).toBe('Test Course');
-                expect(result.shortName).toBe('TC001');
                 expect(result.semester).toBe('WS2025');
                 expect(result.status).toBe(CourseRequestStatus.PENDING);
                 expect(result.startDate).toBeDefined();
@@ -71,12 +68,13 @@ describe('CourseRequestService', () => {
 
             const req = httpMock.expectOne({ method: 'POST', url: resourceUrl });
             expect(req.request.body.title).toBe('Test Course');
-            expect(req.request.body.shortName).toBe('TC001');
             expect(req.request.body.semester).toBe('WS2025');
             expect(req.request.body.testCourse).toBe(false);
             expect(req.request.body.reason).toBe('I need this course for teaching.');
             expect(req.request.body.startDate).toBeDefined();
             expect(req.request.body.endDate).toBeDefined();
+            // shortName should not be in the request body
+            expect(req.request.body.shortName).toBeUndefined();
 
             req.flush(mockResponse);
         });
@@ -84,7 +82,6 @@ describe('CourseRequestService', () => {
         it('should create a course request without optional fields', () => {
             const baseCourseRequest: BaseCourseRequest = {
                 title: 'Minimal Course',
-                shortName: 'MC001',
                 testCourse: true,
                 reason: 'Testing purpose.',
             };
@@ -92,7 +89,6 @@ describe('CourseRequestService', () => {
             const mockResponse = {
                 id: 2,
                 title: 'Minimal Course',
-                shortName: 'MC001',
                 testCourse: true,
                 reason: 'Testing purpose.',
                 status: CourseRequestStatus.PENDING,
@@ -119,7 +115,6 @@ describe('CourseRequestService', () => {
                     {
                         id: 1,
                         title: 'Course 1',
-                        shortName: 'C1',
                         testCourse: false,
                         reason: 'Reason 1',
                         status: CourseRequestStatus.PENDING,
@@ -195,8 +190,16 @@ describe('CourseRequestService', () => {
     });
 
     describe('acceptRequest', () => {
-        it('should accept a course request', () => {
+        it('should accept a course request with payload', () => {
             const courseRequestId = 1;
+            const payload: CourseRequestAcceptPayload = {
+                title: 'Accepted Course',
+                shortName: 'AC001',
+                semester: 'WS2025',
+                startDate: dayjs('2025-01-01'),
+                endDate: dayjs('2025-06-30'),
+                testCourse: false,
+            };
             const mockResponse = {
                 id: 1,
                 title: 'Accepted Course',
@@ -210,7 +213,7 @@ describe('CourseRequestService', () => {
                 requester: { id: 1, login: 'instructor1' },
             };
 
-            service.acceptRequest(courseRequestId).subscribe((result) => {
+            service.acceptRequest(courseRequestId, payload).subscribe((result) => {
                 expect(result.id).toBe(1);
                 expect(result.status).toBe(CourseRequestStatus.ACCEPTED);
                 expect(result.processedDate).toBeDefined();
@@ -218,7 +221,9 @@ describe('CourseRequestService', () => {
             });
 
             const req = httpMock.expectOne({ method: 'POST', url: `${adminResourceUrl}/${courseRequestId}/accept` });
-            expect(req.request.body).toEqual({});
+            expect(req.request.body.title).toBe('Accepted Course');
+            expect(req.request.body.shortName).toBe('AC001');
+            expect(req.request.body.semester).toBe('WS2025');
             req.flush(mockResponse);
         });
     });
@@ -230,7 +235,6 @@ describe('CourseRequestService', () => {
             const mockResponse = {
                 id: 2,
                 title: 'Rejected Course',
-                shortName: 'RC001',
                 testCourse: false,
                 reason: 'Original reason',
                 status: CourseRequestStatus.REJECTED,
@@ -254,6 +258,28 @@ describe('CourseRequestService', () => {
         });
     });
 
+    describe('getRequesterCourses', () => {
+        it('should retrieve requester courses', () => {
+            const courseRequestId = 1;
+            const mockResponse = [
+                { title: 'Course A', shortName: 'CA', semester: 'WS2025', startDate: '2025-10-01T00:00:00Z', endDate: '2026-03-31T00:00:00Z' },
+                { title: 'Course B', shortName: 'CB', semester: 'SS2025' },
+            ];
+
+            service.getRequesterCourses(courseRequestId).subscribe((result) => {
+                expect(result).toHaveLength(2);
+                expect(result[0].title).toBe('Course A');
+                expect(result[0].shortName).toBe('CA');
+                expect(result[0].startDate).toBeDefined();
+                expect(result[1].title).toBe('Course B');
+                expect(result[1].startDate).toBeUndefined();
+            });
+
+            const req = httpMock.expectOne({ method: 'GET', url: `${adminResourceUrl}/${courseRequestId}/requester-courses` });
+            req.flush(mockResponse);
+        });
+    });
+
     describe('date conversion', () => {
         it('should properly convert dates from server response', () => {
             const mockResponse = {
@@ -261,7 +287,6 @@ describe('CourseRequestService', () => {
                     {
                         id: 1,
                         title: 'Date Test Course',
-                        shortName: 'DTC',
                         testCourse: false,
                         reason: 'Testing dates',
                         status: CourseRequestStatus.PENDING,
@@ -291,7 +316,6 @@ describe('CourseRequestService', () => {
                     {
                         id: 1,
                         title: 'No Dates Course',
-                        shortName: 'NDC',
                         testCourse: false,
                         reason: 'No dates provided',
                         status: CourseRequestStatus.PENDING,

--- a/src/main/webapp/app/core/course/request/course-request.service.ts
+++ b/src/main/webapp/app/core/course/request/course-request.service.ts
@@ -2,13 +2,19 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable, map } from 'rxjs';
 
-import { BaseCourseRequest, CourseRequest, CourseRequestStatus, CourseRequestsAdminOverview } from 'app/core/shared/entities/course-request.model';
+import {
+    BaseCourseRequest,
+    CourseRequest,
+    CourseRequestAcceptPayload,
+    CourseRequestStatus,
+    CourseRequestsAdminOverview,
+    RequesterCourse,
+} from 'app/core/shared/entities/course-request.model';
 import { User } from 'app/core/user/user.model';
 import { convertDateFromClient, convertDateStringFromServer } from 'app/shared/util/date.utils';
 
 interface BaseCourseRequestDTO {
     title: string;
-    shortName: string;
     semester?: string;
     startDate?: string;
     endDate?: string;
@@ -18,6 +24,7 @@ interface BaseCourseRequestDTO {
 
 interface CourseRequestDTO extends BaseCourseRequestDTO {
     id?: number;
+    shortName?: string;
     status?: CourseRequestStatus;
     createdDate?: string;
     processedDate?: string;
@@ -31,6 +38,23 @@ interface CourseRequestsAdminOverviewDTO {
     pendingRequests: CourseRequestDTO[];
     decidedRequests: CourseRequestDTO[];
     totalDecidedCount: number;
+}
+
+interface CourseRequestAcceptDTO {
+    title: string;
+    shortName: string;
+    semester?: string;
+    startDate?: string;
+    endDate?: string;
+    testCourse: boolean;
+}
+
+interface RequesterCourseDTO {
+    title?: string;
+    shortName?: string;
+    semester?: string;
+    startDate?: string;
+    endDate?: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -59,23 +83,39 @@ export class CourseRequestService {
             );
     }
 
-    acceptRequest(courseRequestId: number): Observable<CourseRequest> {
-        return this.http.post<CourseRequestDTO>(`${this.adminResourceUrl}/${courseRequestId}/accept`, {}).pipe(map((res) => this.convertDTOToResponse(res)));
+    acceptRequest(courseRequestId: number, payload: CourseRequestAcceptPayload): Observable<CourseRequest> {
+        const dto: CourseRequestAcceptDTO = {
+            title: payload.title,
+            shortName: payload.shortName,
+            semester: payload.semester,
+            startDate: convertDateFromClient(payload.startDate),
+            endDate: convertDateFromClient(payload.endDate),
+            testCourse: payload.testCourse,
+        };
+        return this.http.post<CourseRequestDTO>(`${this.adminResourceUrl}/${courseRequestId}/accept`, dto).pipe(map((res) => this.convertDTOToResponse(res)));
     }
 
     rejectRequest(courseRequestId: number, reason: string): Observable<CourseRequest> {
         return this.http.post<CourseRequestDTO>(`${this.adminResourceUrl}/${courseRequestId}/reject`, { reason }).pipe(map((res) => this.convertDTOToResponse(res)));
     }
 
-    updateRequest(courseRequestId: number, courseRequest: BaseCourseRequest): Observable<CourseRequest> {
-        const dto = this.convertRequestToDTO(courseRequest);
-        return this.http.put<CourseRequestDTO>(`${this.adminResourceUrl}/${courseRequestId}`, dto).pipe(map((res) => this.convertDTOToResponse(res)));
+    getRequesterCourses(courseRequestId: number): Observable<RequesterCourse[]> {
+        return this.http.get<RequesterCourseDTO[]>(`${this.adminResourceUrl}/${courseRequestId}/requester-courses`).pipe(
+            map((dtos) =>
+                dtos.map((dto) => ({
+                    title: dto.title,
+                    shortName: dto.shortName,
+                    semester: dto.semester,
+                    startDate: convertDateStringFromServer(dto.startDate),
+                    endDate: convertDateStringFromServer(dto.endDate),
+                })),
+            ),
+        );
     }
 
     private convertRequestToDTO(courseRequest: BaseCourseRequest): BaseCourseRequestDTO {
         const dto: BaseCourseRequestDTO = {
             title: courseRequest.title,
-            shortName: courseRequest.shortName,
             testCourse: courseRequest.testCourse,
             reason: courseRequest.reason,
         };
@@ -88,11 +128,11 @@ export class CourseRequestService {
     private convertDTOToResponse(dto: CourseRequestDTO): CourseRequest {
         const response: CourseRequest = {
             title: dto.title,
-            shortName: dto.shortName,
             testCourse: dto.testCourse,
             reason: dto.reason,
         };
         response.id = dto.id;
+        response.shortName = dto.shortName;
         response.semester = dto.semester;
         response.startDate = convertDateStringFromServer(dto.startDate);
         response.endDate = convertDateStringFromServer(dto.endDate);

--- a/src/main/webapp/app/core/shared/entities/course-request.model.ts
+++ b/src/main/webapp/app/core/shared/entities/course-request.model.ts
@@ -18,7 +18,6 @@ export interface CourseRequestRequester {
 
 export interface BaseCourseRequest {
     title: string;
-    shortName: string;
     semester?: string;
     startDate?: dayjs.Dayjs;
     endDate?: dayjs.Dayjs;
@@ -28,6 +27,7 @@ export interface BaseCourseRequest {
 
 export interface CourseRequest extends BaseCourseRequest {
     id?: number;
+    shortName?: string;
     status?: CourseRequestStatus;
     createdDate?: dayjs.Dayjs;
     processedDate?: dayjs.Dayjs;
@@ -41,4 +41,21 @@ export interface CourseRequestsAdminOverview {
     pendingRequests: CourseRequest[];
     decidedRequests: CourseRequest[];
     totalDecidedCount: number;
+}
+
+export interface CourseRequestAcceptPayload {
+    title: string;
+    shortName: string;
+    semester?: string;
+    startDate?: dayjs.Dayjs;
+    endDate?: dayjs.Dayjs;
+    testCourse: boolean;
+}
+
+export interface RequesterCourse {
+    title?: string;
+    shortName?: string;
+    semester?: string;
+    startDate?: dayjs.Dayjs;
+    endDate?: dayjs.Dayjs;
 }

--- a/src/main/webapp/i18n/de/courseRequest.json
+++ b/src/main/webapp/i18n/de/courseRequest.json
@@ -49,7 +49,7 @@
                 "acceptConfirm": "Kurs erstellen",
                 "reject": "Ablehnen",
                 "rejectReasonLabel": "Ablehnungsgrund",
-                "rejectReasonPlaceholder": "Geben Sie einen Grund für die Ablehnung an",
+                "rejectReasonPlaceholder": "Gib einen Grund für die Ablehnung an",
                 "rejectConfirm": "Ablehnung senden",
                 "noRequests": "Aktuell liegen keine Kursanfragen vor.",
                 "noPendingRequests": "Keine offenen Anfragen.",
@@ -57,9 +57,9 @@
                 "acceptSuccess": "Kursanfrage \"{{ title }}\" akzeptiert. Kurs {{ shortName }} erstellt.",
                 "rejectSuccess": "Kursanfrage \"{{ title }}\" abgelehnt.",
                 "link": "Kurs öffnen",
-                "shortNameConflictAccept": "Ein Kurs mit diesem Kürzel existiert bereits. Bitte wählen Sie ein anderes Kürzel.",
+                "shortNameConflictAccept": "Ein Kurs mit diesem Kürzel existiert bereits. Bitte wähle ein anderes Kürzel.",
                 "shortNameHint": "Muss eindeutig sein, mindestens 3 Zeichen, nur Buchstaben und Zahlen. Es gelten die gleichen Regeln wie bei der normalen Kurserstellung.",
-                "requesterCoursesHint": "Der Anfragende ist Kursleiter in folgenden Kursen. Nutzen Sie dies zur Bestimmung des Kürzels:",
+                "requesterCoursesHint": "Der Anfragende ist Kursleiter in folgenden Kursen. Nutze dies zur Bestimmung des Kürzels:",
                 "loadingCourses": "Lade Kursleiterkurse...",
                 "noPreviousCourses": "Der Anfragende ist kein Kursleiter bestehender Kurse."
             }

--- a/src/main/webapp/i18n/de/courseRequest.json
+++ b/src/main/webapp/i18n/de/courseRequest.json
@@ -6,11 +6,8 @@
             "form": {
                 "title": "Kurstitel",
                 "shortName": "Kürzel",
-                "shortNameHint": "Muss eindeutig sein, 3-7 Zeichen empfohlen, nur Buchstaben und Zahlen.",
                 "shortNameTooShort": "Das Kürzel muss mindestens 3 Zeichen lang sein.",
                 "shortNameInvalid": "Das Kürzel darf nur Buchstaben und Zahlen enthalten, ohne Leerzeichen.",
-                "shortNameNotUnique": "Dieses Kürzel wird bereits verwendet. Wir haben \"{{ suggestedShortName }}\" als Alternative vorgeschlagen.",
-                "generate": "Generieren",
                 "semester": "Semester",
                 "startDate": "Startdatum",
                 "endDate": "Enddatum",
@@ -34,6 +31,7 @@
                 "decidedTitle": "Bearbeitete Anfragen",
                 "requester": "Anfragender",
                 "course": "Kurs",
+                "courseName": "Kursname",
                 "semester": "Semester",
                 "dates": "Daten",
                 "reason": "Grund des Nutzers",
@@ -45,6 +43,10 @@
                 "testCourse": "Testkurs",
                 "previousInstructor": "Bisheriger Kursleiter",
                 "accept": "Akzeptieren",
+                "acceptTitle": "Kursanfrage akzeptieren",
+                "acceptCourseDataSection": "Kursdaten",
+                "acceptShortNameSection": "Kürzel",
+                "acceptConfirm": "Kurs erstellen",
                 "reject": "Ablehnen",
                 "rejectReasonLabel": "Ablehnungsgrund",
                 "rejectReasonPlaceholder": "Geben Sie einen Grund für die Ablehnung an",
@@ -55,10 +57,11 @@
                 "acceptSuccess": "Kursanfrage \"{{ title }}\" akzeptiert. Kurs {{ shortName }} erstellt.",
                 "rejectSuccess": "Kursanfrage \"{{ title }}\" abgelehnt.",
                 "link": "Kurs öffnen",
-                "edit": "Bearbeiten",
-                "editTitle": "Kursanfrage bearbeiten",
-                "editSuccess": "Kursanfrage erfolgreich aktualisiert.",
-                "shortNameConflict": "Das Kürzel \"{{ shortName }}\" wird bereits verwendet. Bitte bearbeite die Anfrage und verwende ein eindeutiges Kürzel wie z.B. \"{{ suggestedShortName }}\"."
+                "shortNameConflictAccept": "Ein Kurs mit diesem Kürzel existiert bereits. Bitte wählen Sie ein anderes Kürzel.",
+                "shortNameHint": "Muss eindeutig sein, mindestens 3 Zeichen, nur Buchstaben und Zahlen. Es gelten die gleichen Regeln wie bei der normalen Kurserstellung.",
+                "requesterCoursesHint": "Der Anfragende ist Kursleiter in folgenden Kursen. Nutzen Sie dies zur Bestimmung des Kürzels:",
+                "loadingCourses": "Lade Kursleiterkurse...",
+                "noPreviousCourses": "Der Anfragende ist kein Kursleiter bestehender Kurse."
             }
         }
     }

--- a/src/main/webapp/i18n/en/courseRequest.json
+++ b/src/main/webapp/i18n/en/courseRequest.json
@@ -6,11 +6,8 @@
             "form": {
                 "title": "Course title",
                 "shortName": "Short name",
-                "shortNameHint": "Must be unique, 3-7 characters recommended, letters and numbers only.",
                 "shortNameTooShort": "The short name must be at least 3 characters long.",
                 "shortNameInvalid": "The short name must only contain letters and numbers, without spaces.",
-                "shortNameNotUnique": "This short name is already in use. We have suggested \"{{ suggestedShortName }}\" as an alternative.",
-                "generate": "Generate",
                 "semester": "Semester",
                 "startDate": "Start date",
                 "endDate": "End date",
@@ -34,6 +31,7 @@
                 "decidedTitle": "Decided Requests",
                 "requester": "Requester",
                 "course": "Course",
+                "courseName": "Course Name",
                 "semester": "Semester",
                 "dates": "Dates",
                 "reason": "Requester reason",
@@ -45,6 +43,10 @@
                 "testCourse": "Test course",
                 "previousInstructor": "Previous Instructor",
                 "accept": "Accept",
+                "acceptTitle": "Accept Course Request",
+                "acceptCourseDataSection": "Course Data",
+                "acceptShortNameSection": "Short Name",
+                "acceptConfirm": "Create course",
                 "reject": "Reject",
                 "rejectReasonLabel": "Rejection reason",
                 "rejectReasonPlaceholder": "Provide a reason for rejecting the request",
@@ -55,10 +57,11 @@
                 "acceptSuccess": "Course request \"{{ title }}\" accepted. Course {{ shortName }} created.",
                 "rejectSuccess": "Course request \"{{ title }}\" rejected.",
                 "link": "Open course",
-                "edit": "Edit",
-                "editTitle": "Edit course request",
-                "editSuccess": "Course request updated successfully.",
-                "shortNameConflict": "The short name \"{{ shortName }}\" is already in use. Please edit the request and use a unique short name such as \"{{ suggestedShortName }}\"."
+                "shortNameConflictAccept": "A course with this short name already exists. Please choose a different short name.",
+                "shortNameHint": "Must be unique, at least 3 characters, letters and numbers only. Same rules as normal course creation apply.",
+                "requesterCoursesHint": "The requester is instructor in the following courses. Use this to determine the short name pattern:",
+                "loadingCourses": "Loading instructor courses...",
+                "noPreviousCourses": "The requester is not an instructor of any existing courses."
             }
         }
     }

--- a/src/test/java/de/tum/cit/aet/artemis/core/CourseRequestIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/CourseRequestIntegrationTest.java
@@ -24,8 +24,8 @@ import de.tum.cit.aet.artemis.core.dto.CourseRequestDecisionDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestsAdminOverviewDTO;
 import de.tum.cit.aet.artemis.core.dto.RequesterCourseDTO;
 import de.tum.cit.aet.artemis.core.repository.CourseRequestRepository;
-import de.tum.cit.aet.artemis.core.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.test_repository.CourseTestRepository;
+import de.tum.cit.aet.artemis.core.test_repository.UserTestRepository;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
 class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentTest {
@@ -41,7 +41,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     private CourseTestRepository courseRepository;
 
     @Autowired
-    private UserRepository userRepository;
+    private UserTestRepository userRepository;
 
     private User student;
 

--- a/src/test/java/de/tum/cit/aet/artemis/core/CourseRequestIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/CourseRequestIntegrationTest.java
@@ -3,7 +3,9 @@ package de.tum.cit.aet.artemis.core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.ZonedDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,6 +24,7 @@ import de.tum.cit.aet.artemis.core.dto.CourseRequestDecisionDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestsAdminOverviewDTO;
 import de.tum.cit.aet.artemis.core.dto.RequesterCourseDTO;
 import de.tum.cit.aet.artemis.core.repository.CourseRequestRepository;
+import de.tum.cit.aet.artemis.core.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.test_repository.CourseTestRepository;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
@@ -29,11 +32,16 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
 
     private static final String TEST_PREFIX = "courserequest";
 
+    private static final ZonedDateTime FIXED_NOW = ZonedDateTime.parse("2026-01-15T10:00:00Z");
+
     @Autowired
     private CourseRequestRepository courseRequestRepository;
 
     @Autowired
     private CourseTestRepository courseRepository;
+
+    @Autowired
+    private UserRepository userRepository;
 
     private User student;
 
@@ -49,7 +57,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void createCourseRequest_asStudent_shouldSucceed() throws Exception {
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "WS2025", ZonedDateTime.now(), ZonedDateTime.now().plusMonths(3), false,
+        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "WS2025", FIXED_NOW, FIXED_NOW.plusMonths(3), false,
                 "I need this course for teaching purposes.");
 
         CourseRequestDTO result = request.postWithResponseBody("/api/core/course-requests", createDTO, CourseRequestDTO.class, HttpStatus.CREATED);
@@ -125,7 +133,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     void acceptCourseRequest_asAdmin_shouldSucceed() throws Exception {
         CourseRequest courseRequest = createTestCourseRequest("Accept Test");
 
-        CourseRequestAcceptDTO acceptDTO = new CourseRequestAcceptDTO("Accept Test", "ACPTST", "WS2025", ZonedDateTime.now(), ZonedDateTime.now().plusMonths(3), false);
+        CourseRequestAcceptDTO acceptDTO = new CourseRequestAcceptDTO("Accept Test", "ACPTST", "WS2025", FIXED_NOW, FIXED_NOW.plusMonths(3), false);
 
         CourseRequestDTO result = request.postWithResponseBody("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", acceptDTO, CourseRequestDTO.class,
                 HttpStatus.OK);
@@ -202,7 +210,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
 
         CourseRequest acceptedRequest = createTestCourseRequest("Accepted Test");
         acceptedRequest.setStatus(CourseRequestStatus.ACCEPTED);
-        acceptedRequest.setProcessedDate(ZonedDateTime.now());
+        acceptedRequest.setProcessedDate(FIXED_NOW);
         courseRequestRepository.save(acceptedRequest);
 
         CourseRequestsAdminOverviewDTO result = request.get("/api/core/admin/course-requests/overview", HttpStatus.OK, CourseRequestsAdminOverviewDTO.class);
@@ -224,8 +232,8 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void createCourseRequest_withInvalidDates_shouldReturnBadRequest() throws Exception {
-        ZonedDateTime startDate = ZonedDateTime.now().plusMonths(3);
-        ZonedDateTime endDate = ZonedDateTime.now(); // End before start
+        ZonedDateTime startDate = FIXED_NOW.plusMonths(3);
+        ZonedDateTime endDate = FIXED_NOW; // End before start
 
         CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "WS2025", startDate, endDate, false, "Reason for request.");
 
@@ -237,7 +245,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     void acceptCourseRequest_alreadyAccepted_shouldReturnBadRequest() throws Exception {
         CourseRequest courseRequest = createTestCourseRequest("Already Accepted");
         courseRequest.setStatus(CourseRequestStatus.ACCEPTED);
-        courseRequest.setProcessedDate(ZonedDateTime.now());
+        courseRequest.setProcessedDate(FIXED_NOW);
         courseRequestRepository.save(courseRequest);
 
         CourseRequestAcceptDTO acceptDTO = new CourseRequestAcceptDTO("Already Accepted", "ALRACPT", "WS2025", null, null, false);
@@ -250,7 +258,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     void acceptCourseRequest_alreadyRejected_shouldReturnBadRequest() throws Exception {
         CourseRequest courseRequest = createTestCourseRequest("Already Rejected");
         courseRequest.setStatus(CourseRequestStatus.REJECTED);
-        courseRequest.setProcessedDate(ZonedDateTime.now());
+        courseRequest.setProcessedDate(FIXED_NOW);
         courseRequest.setDecisionReason("Previous rejection");
         courseRequestRepository.save(courseRequest);
 
@@ -264,7 +272,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     void rejectCourseRequest_alreadyAccepted_shouldReturnBadRequest() throws Exception {
         CourseRequest courseRequest = createTestCourseRequest("Already Accepted For Reject");
         courseRequest.setStatus(CourseRequestStatus.ACCEPTED);
-        courseRequest.setProcessedDate(ZonedDateTime.now());
+        courseRequest.setProcessedDate(FIXED_NOW);
         courseRequestRepository.save(courseRequest);
 
         CourseRequestDecisionDTO decision = new CourseRequestDecisionDTO("Late rejection reason");
@@ -277,13 +285,22 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     void rejectCourseRequest_alreadyRejected_shouldReturnBadRequest() throws Exception {
         CourseRequest courseRequest = createTestCourseRequest("Already Rejected For Reject");
         courseRequest.setStatus(CourseRequestStatus.REJECTED);
-        courseRequest.setProcessedDate(ZonedDateTime.now());
+        courseRequest.setProcessedDate(FIXED_NOW);
         courseRequest.setDecisionReason("Previous rejection");
         courseRequestRepository.save(courseRequest);
 
         CourseRequestDecisionDTO decision = new CourseRequestDecisionDTO("Another rejection reason");
 
         request.post("/api/core/admin/course-requests/" + courseRequest.getId() + "/reject", decision, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
+    void acceptCourseRequest_withInvalidShortName_shouldReturnBadRequest() throws Exception {
+        CourseRequest courseRequest = createTestCourseRequest("Invalid Short Name");
+        CourseRequestAcceptDTO acceptDTO = new CourseRequestAcceptDTO("Invalid Short Name", "AB", "WS2025", null, null, false);
+
+        request.post("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", acceptDTO, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -305,8 +322,8 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void createCourseRequest_withAllFields_shouldSucceed() throws Exception {
-        ZonedDateTime startDate = ZonedDateTime.now();
-        ZonedDateTime endDate = ZonedDateTime.now().plusMonths(6);
+        ZonedDateTime startDate = FIXED_NOW;
+        ZonedDateTime endDate = FIXED_NOW.plusMonths(6);
 
         CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Complete Course", "SS2025", startDate, endDate, true,
                 "A comprehensive reason for requesting this test course.");
@@ -324,7 +341,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void getAdminOverview_withMultiplePendingRequests_shouldReturnAll() throws Exception {
-        ZonedDateTime baseTime = ZonedDateTime.now();
+        ZonedDateTime baseTime = FIXED_NOW;
         createTestCourseRequest("First Request", baseTime);
         createTestCourseRequest("Second Request", baseTime.plusSeconds(1));
         createTestCourseRequest("Third Request", baseTime.plusSeconds(2));
@@ -343,7 +360,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
         for (int i = 0; i < 3; i++) {
             CourseRequest cr = createTestCourseRequest("Decided " + i);
             cr.setStatus(CourseRequestStatus.REJECTED);
-            cr.setProcessedDate(ZonedDateTime.now());
+            cr.setProcessedDate(FIXED_NOW);
             cr.setDecisionReason("Rejection reason " + i);
             courseRequestRepository.save(cr);
         }
@@ -386,11 +403,48 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
+    void getRequesterCourses_shouldReturnRecentInstructorCourses() throws Exception {
+        // Add the student (requester) to an instructor group
+        String instructorGroup = TEST_PREFIX + "test-instructors";
+        student = userRepository.findByIdWithGroupsAndAuthoritiesElseThrow(student.getId());
+        Set<String> groups = new HashSet<>(student.getGroups());
+        groups.add(instructorGroup);
+        student.setGroups(groups);
+        userRepository.save(student);
+
+        // Create 12 courses where the student is instructor (only 10 most recent should be returned)
+        for (int i = 0; i < 12; i++) {
+            Course course = new Course();
+            course.setTitle("Instructor Course " + i);
+            course.setShortName("IC" + String.format("%03d", i));
+            course.setInstructorGroupName(instructorGroup);
+            courseRepository.save(course);
+        }
+
+        // Create a course with a different instructor group (should NOT be returned)
+        Course otherCourse = new Course();
+        otherCourse.setTitle("Other Instructor Course");
+        otherCourse.setShortName("OTHERIC");
+        otherCourse.setInstructorGroupName("other-instructor-group");
+        courseRepository.save(otherCourse);
+
+        CourseRequest courseRequest = createTestCourseRequest("Requester Courses Test");
+
+        List<RequesterCourseDTO> result = request.getList("/api/core/admin/course-requests/" + courseRequest.getId() + "/requester-courses", HttpStatus.OK,
+                RequesterCourseDTO.class);
+
+        assertThat(result).hasSize(10);
+        assertThat(result).allSatisfy(dto -> assertThat(dto.title()).startsWith("Instructor Course"));
+        assertThat(result).noneMatch(dto -> "Other Instructor Course".equals(dto.title()));
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void acceptCourseRequest_withModifiedData_shouldCreateCourseWithModifiedData() throws Exception {
         CourseRequest courseRequest = createTestCourseRequest("Original Title");
 
-        ZonedDateTime startDate = ZonedDateTime.now();
-        ZonedDateTime endDate = ZonedDateTime.now().plusMonths(6);
+        ZonedDateTime startDate = FIXED_NOW;
+        ZonedDateTime endDate = FIXED_NOW.plusMonths(6);
         CourseRequestAcceptDTO acceptDTO = new CourseRequestAcceptDTO("Modified Title", "MODTITL", "SS2026", startDate, endDate, true);
 
         CourseRequestDTO result = request.postWithResponseBody("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", acceptDTO, CourseRequestDTO.class,
@@ -411,7 +465,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     }
 
     private CourseRequest createTestCourseRequest(String title) {
-        return createTestCourseRequest(title, ZonedDateTime.now());
+        return createTestCourseRequest(title, FIXED_NOW);
     }
 
     private CourseRequest createTestCourseRequest(String title, ZonedDateTime createdDate) {

--- a/src/test/java/de/tum/cit/aet/artemis/core/CourseRequestIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/CourseRequestIntegrationTest.java
@@ -1,32 +1,26 @@
 package de.tum.cit.aet.artemis.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.domain.CourseRequest;
 import de.tum.cit.aet.artemis.core.domain.CourseRequestStatus;
 import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.core.dto.CourseRequestAcceptDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestCreateDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestDecisionDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestsAdminOverviewDTO;
+import de.tum.cit.aet.artemis.core.dto.RequesterCourseDTO;
 import de.tum.cit.aet.artemis.core.repository.CourseRequestRepository;
 import de.tum.cit.aet.artemis.core.test_repository.CourseTestRepository;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
@@ -55,7 +49,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void createCourseRequest_asStudent_shouldSucceed() throws Exception {
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "TSTCRS", "WS2025", ZonedDateTime.now(), ZonedDateTime.now().plusMonths(3), false,
+        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "WS2025", ZonedDateTime.now(), ZonedDateTime.now().plusMonths(3), false,
                 "I need this course for teaching purposes.");
 
         CourseRequestDTO result = request.postWithResponseBody("/api/core/course-requests", createDTO, CourseRequestDTO.class, HttpStatus.CREATED);
@@ -63,7 +57,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
         assertThat(result).isNotNull();
         assertThat(result.id()).isNotNull();
         assertThat(result.title()).isEqualTo("Test Course");
-        assertThat(result.shortName()).isEqualTo("TSTCRS");
+        assertThat(result.shortName()).isNull();
         assertThat(result.status()).isEqualTo(CourseRequestStatus.PENDING);
         assertThat(result.requester()).isNotNull();
         assertThat(result.requester().login()).isEqualTo(TEST_PREFIX + "student1");
@@ -71,7 +65,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
 
     @Test
     void createCourseRequest_asAnonymous_shouldReturnUnauthorized() throws Exception {
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "TSTCRS2", "WS2025", null, null, false, "Reason for the request.");
+        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "WS2025", null, null, false, "Reason for the request.");
 
         request.post("/api/core/course-requests", createDTO, HttpStatus.UNAUTHORIZED);
     }
@@ -79,7 +73,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void createCourseRequest_withBlankTitle_shouldReturnBadRequest() throws Exception {
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("", "TSTCRS3", "WS2025", null, null, false, "Reason for the request.");
+        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("", "WS2025", null, null, false, "Reason for the request.");
 
         request.post("/api/core/course-requests", createDTO, HttpStatus.BAD_REQUEST);
     }
@@ -87,7 +81,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void createCourseRequest_withBlankReason_shouldReturnBadRequest() throws Exception {
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "TSTCRS4", "WS2025", null, null, false, "");
+        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "WS2025", null, null, false, "");
 
         request.post("/api/core/course-requests", createDTO, HttpStatus.BAD_REQUEST);
     }
@@ -95,7 +89,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void createCourseRequest_withBlankSemester_shouldReturnBadRequest() throws Exception {
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "TSTCRS5", "", null, null, false, "Reason for request.");
+        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "", null, null, false, "Reason for request.");
 
         request.post("/api/core/course-requests", createDTO, HttpStatus.BAD_REQUEST);
     }
@@ -105,14 +99,13 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void getAdminOverview_asAdmin_shouldReturnPendingRequests() throws Exception {
-        // Create a course request first
-        createTestCourseRequest("Admin Test", "ADMTST");
+        createTestCourseRequest("Admin Test");
 
         CourseRequestsAdminOverviewDTO result = request.get("/api/core/admin/course-requests/overview", HttpStatus.OK, CourseRequestsAdminOverviewDTO.class);
 
         assertThat(result).isNotNull();
         assertThat(result.pendingRequests()).isNotEmpty();
-        assertThat(result.pendingRequests()).anyMatch(dto -> dto.shortName().equals("ADMTST"));
+        assertThat(result.pendingRequests()).anyMatch(dto -> dto.title().equals("Admin Test"));
     }
 
     @Test
@@ -130,9 +123,12 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void acceptCourseRequest_asAdmin_shouldSucceed() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Accept Test", "ACPTST");
+        CourseRequest courseRequest = createTestCourseRequest("Accept Test");
 
-        CourseRequestDTO result = request.postWithResponseBody("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", null, CourseRequestDTO.class, HttpStatus.OK);
+        CourseRequestAcceptDTO acceptDTO = new CourseRequestAcceptDTO("Accept Test", "ACPTST", "WS2025", ZonedDateTime.now(), ZonedDateTime.now().plusMonths(3), false);
+
+        CourseRequestDTO result = request.postWithResponseBody("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", acceptDTO, CourseRequestDTO.class,
+                HttpStatus.OK);
 
         assertThat(result).isNotNull();
         assertThat(result.status()).isEqualTo(CourseRequestStatus.ACCEPTED);
@@ -143,21 +139,25 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void acceptCourseRequest_asInstructor_shouldReturnForbidden() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Accept Forbidden Test", "ACPFBD");
+        CourseRequest courseRequest = createTestCourseRequest("Accept Forbidden Test");
 
-        request.post("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", null, HttpStatus.FORBIDDEN);
+        CourseRequestAcceptDTO acceptDTO = new CourseRequestAcceptDTO("Accept Forbidden Test", "ACPFBD", "WS2025", null, null, false);
+
+        request.post("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", acceptDTO, HttpStatus.FORBIDDEN);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void acceptCourseRequest_nonExistent_shouldReturnNotFound() throws Exception {
-        request.post("/api/core/admin/course-requests/99999/accept", null, HttpStatus.NOT_FOUND);
+        CourseRequestAcceptDTO acceptDTO = new CourseRequestAcceptDTO("Nonexistent", "NONEX1", "WS2025", null, null, false);
+
+        request.post("/api/core/admin/course-requests/99999/accept", acceptDTO, HttpStatus.NOT_FOUND);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void rejectCourseRequest_asAdmin_shouldSucceed() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Reject Test", "REJTST");
+        CourseRequest courseRequest = createTestCourseRequest("Reject Test");
         CourseRequestDecisionDTO decision = new CourseRequestDecisionDTO("The course already exists under a different name.");
 
         CourseRequestDTO result = request.postWithResponseBody("/api/core/admin/course-requests/" + courseRequest.getId() + "/reject", decision, CourseRequestDTO.class,
@@ -172,7 +172,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void rejectCourseRequest_asInstructor_shouldReturnForbidden() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Reject Forbidden Test", "REJFBD");
+        CourseRequest courseRequest = createTestCourseRequest("Reject Forbidden Test");
         CourseRequestDecisionDTO decision = new CourseRequestDecisionDTO("Rejection reason");
 
         request.post("/api/core/admin/course-requests/" + courseRequest.getId() + "/reject", decision, HttpStatus.FORBIDDEN);
@@ -181,7 +181,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void rejectCourseRequest_withBlankReason_shouldReturnBadRequest() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Reject Bad Request Test", "REJBAD");
+        CourseRequest courseRequest = createTestCourseRequest("Reject Bad Request Test");
         CourseRequestDecisionDTO decision = new CourseRequestDecisionDTO("");
 
         request.post("/api/core/admin/course-requests/" + courseRequest.getId() + "/reject", decision, HttpStatus.BAD_REQUEST);
@@ -198,10 +198,9 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void getAdminOverview_asAdmin_shouldReturnBothPendingAndDecidedRequests() throws Exception {
-        // Create pending and decided requests
-        createTestCourseRequest("Pending Test", "PNDTST");
+        createTestCourseRequest("Pending Test");
 
-        CourseRequest acceptedRequest = createTestCourseRequest("Accepted Test", "ACPTST1");
+        CourseRequest acceptedRequest = createTestCourseRequest("Accepted Test");
         acceptedRequest.setStatus(CourseRequestStatus.ACCEPTED);
         acceptedRequest.setProcessedDate(ZonedDateTime.now());
         courseRequestRepository.save(acceptedRequest);
@@ -209,103 +208,15 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
         CourseRequestsAdminOverviewDTO result = request.get("/api/core/admin/course-requests/overview", HttpStatus.OK, CourseRequestsAdminOverviewDTO.class);
 
         assertThat(result).isNotNull();
-        assertThat(result.pendingRequests()).anyMatch(dto -> dto.shortName().equals("PNDTST"));
-        assertThat(result.decidedRequests()).anyMatch(dto -> dto.shortName().equals("ACPTST1"));
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void createCourseRequest_withExistingCourseShortName_shouldReturnBadRequestWithSuggestion() throws Exception {
-        // Create an existing course with the same short name
-        Course existingCourse = new Course();
-        existingCourse.setShortName("EXISTCRS");
-        existingCourse.setTitle("Existing Course");
-        courseRepository.save(existingCourse);
-
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("New Course", "EXISTCRS", "WS2025", null, null, false, "Reason for request.");
-
-        Map<String, Object> errorResponse = performPostAndGetErrorResponse(createDTO);
-
-        assertThat(errorResponse).containsKey("errorKey");
-        assertThat(errorResponse.get("errorKey")).isEqualTo("courseShortNameExists");
-        assertThat(errorResponse).containsKey("params");
-        @SuppressWarnings("unchecked")
-        Map<String, Object> params = (Map<String, Object>) errorResponse.get("params");
-        assertThat(params).containsKey("suggestedShortName");
-        String suggestedShortName = (String) params.get("suggestedShortName");
-        // Suggested short name should be based on title "New Course" -> "NC" + semester "2025" -> "NC2025"
-        assertThat(suggestedShortName).isEqualTo("NC2025");
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void createCourseRequest_withExistingRequestShortName_shouldReturnBadRequestWithSuggestion() throws Exception {
-        // Create an existing course request with the same short name
-        createTestCourseRequest("Existing Request", "EXISTREQ");
-
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("My New Course", "EXISTREQ", "SS2024", null, null, false, "Reason for request.");
-
-        Map<String, Object> errorResponse = performPostAndGetErrorResponse(createDTO);
-
-        assertThat(errorResponse).containsKey("errorKey");
-        assertThat(errorResponse.get("errorKey")).isEqualTo("courseRequestShortNameExists");
-        assertThat(errorResponse).containsKey("params");
-        @SuppressWarnings("unchecked")
-        Map<String, Object> params = (Map<String, Object>) errorResponse.get("params");
-        assertThat(params).containsKey("suggestedShortName");
-        String suggestedShortName = (String) params.get("suggestedShortName");
-        // Suggested short name should be based on title "My New Course" -> "MNC" + semester "2024" -> "MNC2024"
-        assertThat(suggestedShortName).isEqualTo("MNC2024");
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void createCourseRequest_withConflict_shouldSuggestIncrementedShortName() throws Exception {
-        // Create existing course that takes the first suggested name
-        Course existingCourse = new Course();
-        existingCourse.setShortName("TC2025");
-        existingCourse.setTitle("Some Course");
-        courseRepository.save(existingCourse);
-
-        // Create another existing course that takes the same requested short name
-        Course conflictingCourse = new Course();
-        conflictingCourse.setShortName("CONFLICT");
-        conflictingCourse.setTitle("Conflict Course");
-        courseRepository.save(conflictingCourse);
-
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "CONFLICT", "WS2025", null, null, false, "Reason for request.");
-
-        Map<String, Object> errorResponse = performPostAndGetErrorResponse(createDTO);
-
-        @SuppressWarnings("unchecked")
-        Map<String, Object> params = (Map<String, Object>) errorResponse.get("params");
-        String suggestedShortName = (String) params.get("suggestedShortName");
-        // TC2025 is taken, so should suggest TC20251
-        assertThat(suggestedShortName).isEqualTo("TC20251");
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> performPostAndGetErrorResponse(CourseRequestCreateDTO createDTO) throws Exception {
-        ObjectMapper mapper = request.getObjectMapper();
-        String jsonBody = mapper.writeValueAsString(createDTO);
-        MvcResult result = request.performMvcRequest(MockMvcRequestBuilders.post(new URI("/api/core/course-requests")).contentType(MediaType.APPLICATION_JSON).content(jsonBody))
-                .andExpect(status().isBadRequest()).andReturn();
-        return mapper.readValue(result.getResponse().getContentAsString(), Map.class);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void createCourseRequest_withInvalidShortName_shouldReturnBadRequest() throws Exception {
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "invalid-name!", "WS2025", null, null, false, "Reason for request.");
-
-        request.post("/api/core/course-requests", createDTO, HttpStatus.BAD_REQUEST);
+        assertThat(result.pendingRequests()).anyMatch(dto -> dto.title().equals("Pending Test"));
+        assertThat(result.decidedRequests()).anyMatch(dto -> dto.title().equals("Accepted Test"));
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void createCourseRequest_withTitleTooLong_shouldReturnBadRequest() throws Exception {
         String longTitle = "A".repeat(256);
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO(longTitle, "LNGTITLE", "WS2025", null, null, false, "Reason for request.");
+        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO(longTitle, "WS2025", null, null, false, "Reason for request.");
 
         request.post("/api/core/course-requests", createDTO, HttpStatus.BAD_REQUEST);
     }
@@ -316,7 +227,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
         ZonedDateTime startDate = ZonedDateTime.now().plusMonths(3);
         ZonedDateTime endDate = ZonedDateTime.now(); // End before start
 
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "INVDATES", "WS2025", startDate, endDate, false, "Reason for request.");
+        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Test Course", "WS2025", startDate, endDate, false, "Reason for request.");
 
         request.post("/api/core/course-requests", createDTO, HttpStatus.BAD_REQUEST);
     }
@@ -324,30 +235,34 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void acceptCourseRequest_alreadyAccepted_shouldReturnBadRequest() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Already Accepted", "ALRACPT");
+        CourseRequest courseRequest = createTestCourseRequest("Already Accepted");
         courseRequest.setStatus(CourseRequestStatus.ACCEPTED);
         courseRequest.setProcessedDate(ZonedDateTime.now());
         courseRequestRepository.save(courseRequest);
 
-        request.post("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", null, HttpStatus.BAD_REQUEST);
+        CourseRequestAcceptDTO acceptDTO = new CourseRequestAcceptDTO("Already Accepted", "ALRACPT", "WS2025", null, null, false);
+
+        request.post("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", acceptDTO, HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void acceptCourseRequest_alreadyRejected_shouldReturnBadRequest() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Already Rejected", "ALRREJT");
+        CourseRequest courseRequest = createTestCourseRequest("Already Rejected");
         courseRequest.setStatus(CourseRequestStatus.REJECTED);
         courseRequest.setProcessedDate(ZonedDateTime.now());
         courseRequest.setDecisionReason("Previous rejection");
         courseRequestRepository.save(courseRequest);
 
-        request.post("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", null, HttpStatus.BAD_REQUEST);
+        CourseRequestAcceptDTO acceptDTO = new CourseRequestAcceptDTO("Already Rejected", "ALRREJT", "WS2025", null, null, false);
+
+        request.post("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", acceptDTO, HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void rejectCourseRequest_alreadyAccepted_shouldReturnBadRequest() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Already Accepted For Reject", "ALRACPT2");
+        CourseRequest courseRequest = createTestCourseRequest("Already Accepted For Reject");
         courseRequest.setStatus(CourseRequestStatus.ACCEPTED);
         courseRequest.setProcessedDate(ZonedDateTime.now());
         courseRequestRepository.save(courseRequest);
@@ -360,7 +275,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void rejectCourseRequest_alreadyRejected_shouldReturnBadRequest() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Already Rejected For Reject", "ALRREJ2");
+        CourseRequest courseRequest = createTestCourseRequest("Already Rejected For Reject");
         courseRequest.setStatus(CourseRequestStatus.REJECTED);
         courseRequest.setProcessedDate(ZonedDateTime.now());
         courseRequest.setDecisionReason("Previous rejection");
@@ -374,15 +289,17 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void acceptCourseRequest_withShortNameConflict_shouldReturnBadRequest() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Conflicting Accept", "CNFLCT");
+        CourseRequest courseRequest = createTestCourseRequest("Conflicting Accept");
 
-        // Create a course with the same short name after the request was created
+        // Create a course with the same short name
         Course existingCourse = new Course();
         existingCourse.setShortName("CNFLCT");
         existingCourse.setTitle("Conflicting Course");
         courseRepository.save(existingCourse);
 
-        request.post("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", null, HttpStatus.BAD_REQUEST);
+        CourseRequestAcceptDTO acceptDTO = new CourseRequestAcceptDTO("Conflicting Accept", "CNFLCT", "WS2025", null, null, false);
+
+        request.post("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", acceptDTO, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -391,14 +308,13 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
         ZonedDateTime startDate = ZonedDateTime.now();
         ZonedDateTime endDate = ZonedDateTime.now().plusMonths(6);
 
-        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Complete Course", "CMPLCRS", "SS2025", startDate, endDate, true,
+        CourseRequestCreateDTO createDTO = new CourseRequestCreateDTO("Complete Course", "SS2025", startDate, endDate, true,
                 "A comprehensive reason for requesting this test course.");
 
         CourseRequestDTO result = request.postWithResponseBody("/api/core/course-requests", createDTO, CourseRequestDTO.class, HttpStatus.CREATED);
 
         assertThat(result).isNotNull();
         assertThat(result.title()).isEqualTo("Complete Course");
-        assertThat(result.shortName()).isEqualTo("CMPLCRS");
         assertThat(result.semester()).isEqualTo("SS2025");
         assertThat(result.testCourse()).isTrue();
         assertThat(result.startDate()).isNotNull();
@@ -408,30 +324,28 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void getAdminOverview_withMultiplePendingRequests_shouldReturnAll() throws Exception {
-        // Create multiple pending requests with different timestamps
         ZonedDateTime baseTime = ZonedDateTime.now();
-        createTestCourseRequest("First Request", "FIRST1", baseTime);
-        createTestCourseRequest("Second Request", "SECOND1", baseTime.plusSeconds(1));
-        createTestCourseRequest("Third Request", "THIRD1", baseTime.plusSeconds(2));
+        createTestCourseRequest("First Request", baseTime);
+        createTestCourseRequest("Second Request", baseTime.plusSeconds(1));
+        createTestCourseRequest("Third Request", baseTime.plusSeconds(2));
 
         CourseRequestsAdminOverviewDTO result = request.get("/api/core/admin/course-requests/overview", HttpStatus.OK, CourseRequestsAdminOverviewDTO.class);
 
         assertThat(result).isNotNull();
         assertThat(result.pendingRequests()).hasSizeGreaterThanOrEqualTo(3);
-        List<String> shortNames = result.pendingRequests().stream().map(CourseRequestDTO::shortName).toList();
-        assertThat(shortNames).containsAll(List.of("FIRST1", "SECOND1", "THIRD1"));
+        List<String> titles = result.pendingRequests().stream().map(CourseRequestDTO::title).toList();
+        assertThat(titles).containsAll(List.of("First Request", "Second Request", "Third Request"));
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void getAdminOverview_withPagination_shouldReturnCorrectDecidedRequests() throws Exception {
-        // Create decided requests
         for (int i = 0; i < 3; i++) {
-            CourseRequest request = createTestCourseRequest("Decided " + i, "DCDD" + i);
-            request.setStatus(CourseRequestStatus.REJECTED);
-            request.setProcessedDate(ZonedDateTime.now());
-            request.setDecisionReason("Rejection reason " + i);
-            courseRequestRepository.save(request);
+            CourseRequest cr = createTestCourseRequest("Decided " + i);
+            cr.setStatus(CourseRequestStatus.REJECTED);
+            cr.setProcessedDate(ZonedDateTime.now());
+            cr.setDecisionReason("Rejection reason " + i);
+            courseRequestRepository.save(cr);
         }
 
         CourseRequestsAdminOverviewDTO result = request.get("/api/core/admin/course-requests/overview?decidedPage=0&decidedPageSize=2", HttpStatus.OK,
@@ -442,109 +356,65 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
         assertThat(result.totalDecidedCount()).isGreaterThanOrEqualTo(3);
     }
 
-    // ==================== Update Endpoint Tests ====================
+    // ==================== Requester Courses Endpoint Tests ====================
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
-    void updateCourseRequest_asAdmin_shouldSucceed() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Original Title", "ORIGTIT");
+    void getRequesterCourses_shouldReturnEmptyWhenNoInstructorCourses() throws Exception {
+        CourseRequest courseRequest = createTestCourseRequest("No Courses Test");
 
-        CourseRequestCreateDTO updateDTO = new CourseRequestCreateDTO("Updated Title", "UPDTTIT", "SS2025", ZonedDateTime.now(), ZonedDateTime.now().plusMonths(3), true,
-                "Updated reason for the course request.");
-
-        CourseRequestDTO result = request.putWithResponseBody("/api/core/admin/course-requests/" + courseRequest.getId(), updateDTO, CourseRequestDTO.class, HttpStatus.OK);
+        List<RequesterCourseDTO> result = request.getList("/api/core/admin/course-requests/" + courseRequest.getId() + "/requester-courses", HttpStatus.OK,
+                RequesterCourseDTO.class);
 
         assertThat(result).isNotNull();
-        assertThat(result.id()).isEqualTo(courseRequest.getId());
-        assertThat(result.title()).isEqualTo("Updated Title");
-        assertThat(result.shortName()).isEqualTo("UPDTTIT");
-        assertThat(result.semester()).isEqualTo("SS2025");
-        assertThat(result.testCourse()).isTrue();
-        assertThat(result.reason()).isEqualTo("Updated reason for the course request.");
-        assertThat(result.status()).isEqualTo(CourseRequestStatus.PENDING);
+        assertThat(result).isEmpty();
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
-    void updateCourseRequest_alreadyProcessed_shouldReturnBadRequest() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Processed Request", "PROCSSD");
-        courseRequest.setStatus(CourseRequestStatus.ACCEPTED);
-        courseRequest.setProcessedDate(ZonedDateTime.now());
-        courseRequestRepository.save(courseRequest);
-
-        CourseRequestCreateDTO updateDTO = new CourseRequestCreateDTO("Updated Title", "UPDTTIT2", "SS2025", null, null, false, "Updated reason.");
-
-        request.put("/api/core/admin/course-requests/" + courseRequest.getId(), updateDTO, HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
-    void updateCourseRequest_withShortNameConflict_shouldReturnBadRequest() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Request to Update", "REQUPD");
-
-        // Create a course with the same short name we want to update to
-        Course existingCourse = new Course();
-        existingCourse.setShortName("UPDEXST");
-        existingCourse.setTitle("Existing Course for Update Test");
-        courseRepository.save(existingCourse);
-
-        CourseRequestCreateDTO updateDTO = new CourseRequestCreateDTO("Updated Title", "UPDEXST", "SS2025", null, null, false, "Updated reason.");
-
-        request.put("/api/core/admin/course-requests/" + courseRequest.getId(), updateDTO, HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
-    void updateCourseRequest_keepSameShortName_shouldSucceed() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Original Title", "KEEPSN");
-
-        // Update only title, keeping the same short name
-        CourseRequestCreateDTO updateDTO = new CourseRequestCreateDTO("Updated Title", "KEEPSN", "SS2025", null, null, false, "Updated reason.");
-
-        CourseRequestDTO result = request.putWithResponseBody("/api/core/admin/course-requests/" + courseRequest.getId(), updateDTO, CourseRequestDTO.class, HttpStatus.OK);
-
-        assertThat(result).isNotNull();
-        assertThat(result.shortName()).isEqualTo("KEEPSN");
-        assertThat(result.title()).isEqualTo("Updated Title");
+    void getRequesterCourses_nonExistent_shouldReturnNotFound() throws Exception {
+        request.get("/api/core/admin/course-requests/99999/requester-courses", HttpStatus.NOT_FOUND, List.class);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void updateCourseRequest_asInstructor_shouldReturnForbidden() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Request For Instructor", "REQINST");
+    void getRequesterCourses_asInstructor_shouldReturnForbidden() throws Exception {
+        CourseRequest courseRequest = createTestCourseRequest("Instructor Forbidden Test");
 
-        CourseRequestCreateDTO updateDTO = new CourseRequestCreateDTO("Updated Title", "UPDTINST", "SS2025", null, null, false, "Updated reason.");
-
-        request.put("/api/core/admin/course-requests/" + courseRequest.getId(), updateDTO, HttpStatus.FORBIDDEN);
+        request.get("/api/core/admin/course-requests/" + courseRequest.getId() + "/requester-courses", HttpStatus.FORBIDDEN, List.class);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
-    void updateCourseRequest_withInvalidData_shouldReturnBadRequest() throws Exception {
-        CourseRequest courseRequest = createTestCourseRequest("Request to Update Invalid", "REQINV");
+    void acceptCourseRequest_withModifiedData_shouldCreateCourseWithModifiedData() throws Exception {
+        CourseRequest courseRequest = createTestCourseRequest("Original Title");
 
-        // Empty title should fail validation
-        CourseRequestCreateDTO updateDTO = new CourseRequestCreateDTO("", "UPDTINV", "SS2025", null, null, false, "Updated reason.");
+        ZonedDateTime startDate = ZonedDateTime.now();
+        ZonedDateTime endDate = ZonedDateTime.now().plusMonths(6);
+        CourseRequestAcceptDTO acceptDTO = new CourseRequestAcceptDTO("Modified Title", "MODTITL", "SS2026", startDate, endDate, true);
 
-        request.put("/api/core/admin/course-requests/" + courseRequest.getId(), updateDTO, HttpStatus.BAD_REQUEST);
+        CourseRequestDTO result = request.postWithResponseBody("/api/core/admin/course-requests/" + courseRequest.getId() + "/accept", acceptDTO, CourseRequestDTO.class,
+                HttpStatus.OK);
+
+        assertThat(result).isNotNull();
+        assertThat(result.status()).isEqualTo(CourseRequestStatus.ACCEPTED);
+        assertThat(result.createdCourseId()).isNotNull();
+
+        // Verify the created course has the modified data
+        Course createdCourse = courseRepository.findById(result.createdCourseId()).orElseThrow();
+        assertThat(createdCourse.getTitle()).isEqualTo("Modified Title");
+        assertThat(createdCourse.getShortName()).isEqualTo("MODTITL");
+        assertThat(createdCourse.getSemester()).isEqualTo("SS2026");
+        assertThat(createdCourse.isTestCourse()).isTrue();
     }
 
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
-    void updateCourseRequest_notFound_shouldReturnNotFound() throws Exception {
-        CourseRequestCreateDTO updateDTO = new CourseRequestCreateDTO("Updated Title", "NOTFND", "SS2025", null, null, false, "Updated reason.");
-
-        request.put("/api/core/admin/course-requests/999999", updateDTO, HttpStatus.NOT_FOUND);
+    private CourseRequest createTestCourseRequest(String title) {
+        return createTestCourseRequest(title, ZonedDateTime.now());
     }
 
-    private CourseRequest createTestCourseRequest(String title, String shortName) {
-        return createTestCourseRequest(title, shortName, ZonedDateTime.now());
-    }
-
-    private CourseRequest createTestCourseRequest(String title, String shortName, ZonedDateTime createdDate) {
+    private CourseRequest createTestCourseRequest(String title, ZonedDateTime createdDate) {
         CourseRequest courseRequest = new CourseRequest();
         courseRequest.setTitle(title);
-        courseRequest.setShortName(shortName);
         courseRequest.setReason("Test reason for the course request");
         courseRequest.setStatus(CourseRequestStatus.PENDING);
         courseRequest.setCreatedDate(createdDate);

--- a/src/test/java/de/tum/cit/aet/artemis/core/CourseRequestIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/CourseRequestIntegrationTest.java
@@ -406,6 +406,8 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
         assertThat(createdCourse.getShortName()).isEqualTo("MODTITL");
         assertThat(createdCourse.getSemester()).isEqualTo("SS2026");
         assertThat(createdCourse.isTestCourse()).isTrue();
+        assertThat(createdCourse.getStartDate().toInstant()).isEqualTo(startDate.toInstant());
+        assertThat(createdCourse.getEndDate().toInstant()).isEqualTo(endDate.toInstant());
     }
 
     private CourseRequest createTestCourseRequest(String title) {

--- a/src/test/java/de/tum/cit/aet/artemis/core/CourseRequestIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/CourseRequestIntegrationTest.java
@@ -373,7 +373,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "admin", roles = "ADMIN")
     void getRequesterCourses_nonExistent_shouldReturnNotFound() throws Exception {
-        request.get("/api/core/admin/course-requests/99999/requester-courses", HttpStatus.NOT_FOUND, List.class);
+        request.getList("/api/core/admin/course-requests/99999/requester-courses", HttpStatus.NOT_FOUND, RequesterCourseDTO.class);
     }
 
     @Test
@@ -381,7 +381,7 @@ class CourseRequestIntegrationTest extends AbstractSpringIntegrationIndependentT
     void getRequesterCourses_asInstructor_shouldReturnForbidden() throws Exception {
         CourseRequest courseRequest = createTestCourseRequest("Instructor Forbidden Test");
 
-        request.get("/api/core/admin/course-requests/" + courseRequest.getId() + "/requester-courses", HttpStatus.FORBIDDEN, List.class);
+        request.getList("/api/core/admin/course-requests/" + courseRequest.getId() + "/requester-courses", HttpStatus.FORBIDDEN, RequesterCourseDTO.class);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/course/CourseRequestServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/course/CourseRequestServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -41,6 +42,8 @@ import de.tum.cit.aet.artemis.core.test_repository.UserTestRepository;
 
 @ExtendWith(MockitoExtension.class)
 class CourseRequestServiceTest {
+
+    private static final ZonedDateTime FIXED_NOW = ZonedDateTime.of(2025, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
 
     @Mock
     private CourseRequestRepository courseRequestRepository;
@@ -103,7 +106,7 @@ class CourseRequestServiceTest {
         when(courseRequestRepository.save(any(CourseRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(resourceLoaderService.getResource(any())).thenReturn(new ByteArrayResource("code of conduct".getBytes(StandardCharsets.UTF_8)));
 
-        var acceptDTO = new CourseRequestAcceptDTO("Accepted Course", "NEWCRS", "WS25", ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(10), false);
+        var acceptDTO = new CourseRequestAcceptDTO("Accepted Course", "NEWCRS", "WS25", FIXED_NOW.minusDays(1), FIXED_NOW.plusDays(10), false);
         CourseRequestDTO result = courseRequestService.acceptRequest(1L, acceptDTO);
 
         verify(courseAccessService).setDefaultGroupsIfNotSet(courseCaptor.capture());
@@ -164,7 +167,7 @@ class CourseRequestServiceTest {
             return merged;
         });
 
-        var acceptDTO = new CourseRequestAcceptDTO("New Course", "NEWCRS", "WS25", ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(10), false);
+        var acceptDTO = new CourseRequestAcceptDTO("New Course", "NEWCRS", "WS25", FIXED_NOW.minusDays(1), FIXED_NOW.plusDays(10), false);
         courseRequestService.acceptRequest(1L, acceptDTO);
 
         verify(mailSendingService).buildAndSendAsync(userCaptor.capture(), anyString(), eq("mail/courseRequestAcceptedEmail"), anyMap());
@@ -235,7 +238,7 @@ class CourseRequestServiceTest {
             return Optional.of(refetched);
         });
 
-        var createDTO = new CourseRequestCreateDTO("New Course", "WS25", ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(10), false, "Need a course");
+        var createDTO = new CourseRequestCreateDTO("New Course", "WS25", FIXED_NOW.minusDays(1), FIXED_NOW.plusDays(10), false, "Need a course");
         courseRequestService.createCourseRequest(createDTO);
 
         // Verify received email was sent with the original requester, not from the saved entity
@@ -260,8 +263,8 @@ class CourseRequestServiceTest {
         CourseRequest request = new CourseRequest();
         request.setId(1L);
         request.setTitle("New Course");
-        request.setStartDate(ZonedDateTime.now().minusDays(1));
-        request.setEndDate(ZonedDateTime.now().plusDays(10));
+        request.setStartDate(FIXED_NOW.minusDays(1));
+        request.setEndDate(FIXED_NOW.plusDays(10));
         request.setStatus(CourseRequestStatus.PENDING);
         request.setRequester(requester);
         return request;

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/course/CourseRequestServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/course/CourseRequestServiceTest.java
@@ -31,6 +31,7 @@ import de.tum.cit.aet.artemis.core.domain.Course;
 import de.tum.cit.aet.artemis.core.domain.CourseRequest;
 import de.tum.cit.aet.artemis.core.domain.CourseRequestStatus;
 import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.core.dto.CourseRequestAcceptDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestCreateDTO;
 import de.tum.cit.aet.artemis.core.dto.CourseRequestDTO;
 import de.tum.cit.aet.artemis.core.repository.CourseRequestRepository;
@@ -80,22 +81,11 @@ class CourseRequestServiceTest {
     }
 
     @Test
-    void acceptRequestShouldCreateCourseWithDefaultsAndNotify() {
-        CourseRequest pendingRequest = new CourseRequest();
-        pendingRequest.setId(1L);
-        pendingRequest.setTitle("New Course");
-        pendingRequest.setShortName("NEW123");
-        pendingRequest.setStartDate(ZonedDateTime.now().minusDays(1));
-        pendingRequest.setEndDate(ZonedDateTime.now().plusDays(10));
-        User requester = new User();
-        requester.setId(7L);
-        requester.setLogin("instructor1");
-        requester.setEmail("instructor@uni.test");
-        pendingRequest.setRequester(requester);
+    void acceptRequestShouldCreateCourseWithAcceptDTODataAndNotify() {
+        CourseRequest pendingRequest = createPendingRequest(createRequester());
 
         when(courseRequestRepository.findOneWithEagerRelationshipsById(1L)).thenReturn(Optional.of(pendingRequest));
-        when(courseRepository.existsByShortNameIgnoreCase("NEW123")).thenReturn(false);
-        when(courseRequestRepository.findOneByShortNameIgnoreCase("NEW123")).thenReturn(Optional.empty());
+        when(courseRepository.existsByShortNameIgnoreCase("NEWCRS")).thenReturn(false);
         doAnswer(invocation -> {
             Course course = invocation.getArgument(0);
             course.setStudentGroupName(course.getDefaultStudentGroupName());
@@ -109,21 +99,26 @@ class CourseRequestServiceTest {
             course.setId(22L);
             return course;
         });
-        when(userRepository.findByIdWithGroupsAndAuthoritiesElseThrow(7L)).thenReturn(requester);
+        when(userRepository.findByIdWithGroupsAndAuthoritiesElseThrow(7L)).thenReturn(pendingRequest.getRequester());
         when(courseRequestRepository.save(any(CourseRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
         when(resourceLoaderService.getResource(any())).thenReturn(new ByteArrayResource("code of conduct".getBytes(StandardCharsets.UTF_8)));
 
-        CourseRequestDTO result = courseRequestService.acceptRequest(1L);
+        var acceptDTO = new CourseRequestAcceptDTO("Accepted Course", "NEWCRS", "WS25", ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(10), false);
+        CourseRequestDTO result = courseRequestService.acceptRequest(1L, acceptDTO);
 
         verify(courseAccessService).setDefaultGroupsIfNotSet(courseCaptor.capture());
         verify(channelService).createDefaultChannels(courseCaptor.getValue());
-        verify(courseAccessService).addUserToGroup(eq(requester), eq(courseCaptor.getValue().getInstructorGroupName()), eq(courseCaptor.getValue()));
-        verify(mailSendingService).buildAndSendAsync(eq(requester), anyString(), eq("mail/courseRequestAcceptedEmail"), anyMap());
+        verify(courseAccessService).addUserToGroup(eq(pendingRequest.getRequester()), eq(courseCaptor.getValue().getInstructorGroupName()), eq(courseCaptor.getValue()));
+        verify(mailSendingService).buildAndSendAsync(eq(pendingRequest.getRequester()), anyString(), eq("mail/courseRequestAcceptedEmail"), anyMap());
         verify(courseRequestRepository).save(courseRequestCaptor.capture());
 
         assertThat(result.status()).isEqualTo(CourseRequestStatus.ACCEPTED);
         assertThat(result.createdCourseId()).isEqualTo(22L);
         assertThat(courseRequestCaptor.getValue().getProcessedDate()).isNotNull();
+
+        // Verify course was created with accept DTO data, not request data
+        assertThat(courseCaptor.getValue().getTitle()).isEqualTo("Accepted Course");
+        assertThat(courseCaptor.getValue().getShortName()).isEqualTo("NEWCRS");
     }
 
     /**
@@ -138,8 +133,7 @@ class CourseRequestServiceTest {
         CourseRequest pendingRequest = createPendingRequest(requester);
 
         when(courseRequestRepository.findOneWithEagerRelationshipsById(1L)).thenReturn(Optional.of(pendingRequest));
-        when(courseRepository.existsByShortNameIgnoreCase("NEW123")).thenReturn(false);
-        when(courseRequestRepository.findOneByShortNameIgnoreCase("NEW123")).thenReturn(Optional.empty());
+        when(courseRepository.existsByShortNameIgnoreCase("NEWCRS")).thenReturn(false);
         doAnswer(invocation -> {
             Course course = invocation.getArgument(0);
             course.setStudentGroupName(course.getDefaultStudentGroupName());
@@ -170,7 +164,8 @@ class CourseRequestServiceTest {
             return merged;
         });
 
-        courseRequestService.acceptRequest(1L);
+        var acceptDTO = new CourseRequestAcceptDTO("New Course", "NEWCRS", "WS25", ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(10), false);
+        courseRequestService.acceptRequest(1L, acceptDTO);
 
         verify(mailSendingService).buildAndSendAsync(userCaptor.capture(), anyString(), eq("mail/courseRequestAcceptedEmail"), anyMap());
         assertThat(userCaptor.getValue()).isSameAs(requester);
@@ -209,16 +204,12 @@ class CourseRequestServiceTest {
 
     /**
      * Verifies that createCourseRequest sends the received confirmation email with the
-     * eagerly loaded requester User, not from the post-save entity. While new entities
-     * use persist() (which preserves the association), this test ensures the defensive
-     * pattern is in place for consistency with accept/reject.
+     * eagerly loaded requester User, not from the post-save entity.
      */
     @Test
     void createCourseRequestShouldSendReceivedEmailWithCorrectRequester() {
         User requester = createRequester();
         when(userRepository.getUserWithGroupsAndAuthorities()).thenReturn(requester);
-        when(courseRepository.existsByShortNameIgnoreCase("NEW123")).thenReturn(false);
-        when(courseRequestRepository.findOneByShortNameIgnoreCase("NEW123")).thenReturn(Optional.empty());
 
         // save() returns a new entity without requester (simulates merge behavior for defensive testing)
         when(courseRequestRepository.save(any(CourseRequest.class))).thenAnswer(invocation -> {
@@ -226,7 +217,6 @@ class CourseRequestServiceTest {
             CourseRequest saved = new CourseRequest();
             saved.setId(42L);
             saved.setTitle(original.getTitle());
-            saved.setShortName(original.getShortName());
             saved.setSemester(original.getSemester());
             saved.setStartDate(original.getStartDate());
             saved.setEndDate(original.getEndDate());
@@ -240,13 +230,12 @@ class CourseRequestServiceTest {
             CourseRequest refetched = new CourseRequest();
             refetched.setId(42L);
             refetched.setTitle("New Course");
-            refetched.setShortName("NEW123");
             refetched.setStatus(CourseRequestStatus.PENDING);
             refetched.setRequester(requester);
             return Optional.of(refetched);
         });
 
-        var createDTO = new CourseRequestCreateDTO("New Course", "NEW123", "WS25", ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(10), false, "Need a course");
+        var createDTO = new CourseRequestCreateDTO("New Course", "WS25", ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(10), false, "Need a course");
         courseRequestService.createCourseRequest(createDTO);
 
         // Verify received email was sent with the original requester, not from the saved entity
@@ -271,7 +260,6 @@ class CourseRequestServiceTest {
         CourseRequest request = new CourseRequest();
         request.setId(1L);
         request.setTitle("New Course");
-        request.setShortName("NEW123");
         request.setStartDate(ZonedDateTime.now().minusDays(1));
         request.setEndDate(ZonedDateTime.now().plusDays(10));
         request.setStatus(CourseRequestStatus.PENDING);


### PR DESCRIPTION
### Summary 
Refactor course request workflow so instructors no longer provide a short name. Instead, admins configure it freely in a new accept modal that also shows the requester's recent instructor courses for reference.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api#authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
Closes #12249

Admins need full control over the course short name when accepting a request. Instructors should not have to guess a valid short name. The admin also benefits from seeing the requester's existing courses.

### Description

**Server changes:**
- Remove `shortName` from `CourseRequestCreateDTO` — instructors no longer provide it
- Add `CourseRequestAcceptDTO` carrying title, shortName, semester, dates, testCourse
- Add `RequesterCourseDTO` and `GET /api/core/admin/course-requests/{id}/requester-courses` endpoint returning up to 10 most recent instructor courses
- `acceptRequest()` now takes `CourseRequestAcceptDTO` and creates the course from it
- Remove the `updateCourseRequest()` / PUT endpoint entirely
- Liquibase migration drops NOT NULL and unique constraints on `course_request.short_name`
- Email templates conditionally render shortName (handles null for new requests)
- Short name uniqueness validation only checks the Course table

**Client changes:**
- Remove short name field from the instructor's course request form
- Remove the edit modal for pending requests
- Add accept modal with two sections:
  1. Course data (title, semester, dates) — reuses `jhi-course-request-form`
  2. Short name — shows requester's instructor courses table + short name input with validation
- Update `CourseRequestService` with `acceptRequest(id, payload)` and `getRequesterCourses(id)`
- Add `CourseRequestAcceptPayload` and `RequesterCourse` interfaces
- Update i18n strings (EN + DE)

**Tests:**
- 34 server tests (integration + unit) — all pass
- 45 client tests (Vitest) — all pass

### Steps for Testing
Prerequisites:
- 1 Admin
- 1 Instructor (with at least one existing course)

1. Log in as Instructor, navigate to course request form
2. Verify short name field is **not** present
3. Submit a course request with title, semester, reason
4. Log in as Admin, navigate to Server Administration > Course Requests
5. Verify pending request shows no short name column
6. Click "Accept" — a modal should open
7. Verify the modal shows:
   - Course data section (title, semester, dates pre-filled from request)
   - Short name section with a table of the requester's instructor courses
   - Short name input field with validation
8. Enter a valid short name, click "Create course"
9. Verify the course is created and the request moves to decided list
10. Test validation: try an empty short name, try an existing short name
11. Test reject flow: open reject modal, enter reason, confirm

### Screenshots

**Admin Course Requests — Pending requests overview (no short name column, no edit button):**
![Admin Course Requests Overview](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/4ef6ff73-1d1c-4629-a5f6-2f2571706707.png)

**Accept Course Request modal — Course Data section + Short Name section with requester courses:**
![Accept Course Request Modal](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/f8847b6a-aee4-4fc8-99a1-9855cd6bbf52.png)

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Accept modal shows requester's recent instructor courses and submits a structured accept payload (title, short name, semester, dates, test-course).
  - Admin API to fetch requester courses.

* **Improvements**
  - Short name removed from request creation and made optional on requests; supplied and validated during acceptance.
  - Modal-based accept UX replaces edit-for-pending-requests; form inputs and short-name generation removed from request form.
  - Email templates and localization updated to hide absent short names.

* **Tests**
  - Test suites updated to cover the new accept workflow and short-name removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->