### PR TITLE
`General`: Fix untranslated email validation error when creating a new user

### DIFF
--- a/src/main/webapp/app/core/admin/user-management/update/user-management-update.component.spec.ts
+++ b/src/main/webapp/app/core/admin/user-management/update/user-management-update.component.spec.ts
@@ -648,6 +648,19 @@ describe('UserManagementUpdateComponent', () => {
 
             expect(component.editForm.get('internal')?.disabled).toBe(true);
         });
+
+        it('should include email validator on email form control', () => {
+            component.user = new User();
+            // @ts-ignore - accessing private method for testing
+            component.initializeForm();
+
+            const emailControl = component.editForm.get('email')!;
+            emailControl.setValue('not-an-email');
+            expect(emailControl.errors?.email).toBeTruthy();
+
+            emailControl.setValue('valid@email.com');
+            expect(emailControl.errors?.email).toBeFalsy();
+        });
     });
 
     describe('authority management', () => {

--- a/src/main/webapp/app/core/admin/user-management/update/user-management-update.component.ts
+++ b/src/main/webapp/app/core/admin/user-management/update/user-management-update.component.ts
@@ -322,7 +322,7 @@ export class UserManagementUpdateComponent implements OnInit {
             firstName: ['', [Validators.required, Validators.maxLength(USERNAME_MAX_LENGTH)]],
             lastName: ['', [Validators.required, Validators.maxLength(USERNAME_MAX_LENGTH)]],
             password: ['', [Validators.minLength(PASSWORD_MIN_LENGTH), Validators.maxLength(PASSWORD_MAX_LENGTH)]],
-            email: ['', [Validators.required, Validators.minLength(this.EMAIL_MIN_LENGTH), Validators.maxLength(this.EMAIL_MAX_LENGTH)]],
+            email: ['', [Validators.required, Validators.email, Validators.minLength(this.EMAIL_MIN_LENGTH), Validators.maxLength(this.EMAIL_MAX_LENGTH)]],
             visibleRegistrationNumber: ['', [Validators.maxLength(this.REGISTRATION_NUMBER_MAX_LENGTH)]],
             activated: [''],
             langKey: [''],

--- a/src/main/webapp/i18n/de/error.json
+++ b/src/main/webapp/i18n/de/error.json
@@ -58,6 +58,7 @@
         "server.not.reachable": "Server ist nicht erreichbar",
         "url.not.found": "Nicht gefunden",
         "NotNull": "Feld {{fieldName}} darf nicht leer sein!",
+        "Email": "Feld {{fieldName}} muss eine gültige E-Mail-Adresse sein!",
         "size": "Feld {{fieldName}} erfüllt nicht die minimalen/maximalen Längenanforderungen!",
         "userExists": "Login bereits vergeben!",
         "emailExists": "E-Mail wird bereits verwendet!",

--- a/src/main/webapp/i18n/en/error.json
+++ b/src/main/webapp/i18n/en/error.json
@@ -58,6 +58,7 @@
         "server.not.reachable": "Server not reachable",
         "url.not.found": "Not found",
         "NotNull": "Field {{ fieldName }} cannot be empty!",
+        "Email": "Field {{ fieldName }} must be a valid email address!",
         "size": "Field {{ fieldName }} does not meet min/max size requirements!",
         "userExists": "Login name already in use!",
         "emailExists": "Email is already in use!",


### PR DESCRIPTION
### Summary 
When creating a new user as an admin with an invalid email (e.g. "abcde"), the form did not show client-side validation errors and the server returned an untranslated error key `error.Email` instead of a user-friendly message.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
Closes #12187

When an admin creates a new user with an invalid email like "abcde", the Angular form was missing the `Validators.email` validator, so the invalid input was submitted to the server. The server-side Jakarta `@Email` validation then returned an error with constraint code "Email", but no translation existed for the key `error.Email` in the i18n files, resulting in an untranslated error key being displayed to the user.

### Description
**Two changes:**

1. **Client-side validation (root cause fix):** Added `Validators.email` to the email form control in `UserManagementUpdateComponent`. The template already had the corresponding `@if (editForm.get('email')!.errors?.email)` block to display an inline error message (`global.messages.validate.email.invalid`), but the validator was never added to the form, so it could never trigger.

2. **Server-side error translation (defense-in-depth):** Added the `"Email"` translation key to both `en/error.json` and `de/error.json` so that if the server-side `@Email` validation error is ever returned (e.g. from API clients or edge cases), it displays a proper translated message instead of the raw key.

### Steps for Testing
Prerequisites:
- 1 Admin user

1. Log in as an admin
2. Navigate to Server Administration > User Management
3. Click "Create a new user"
4. Fill in required fields (login, name, etc.)
5. Enter an invalid email like `abcde` in the email field
6. **Verify:** The form should show an inline red error message "Your email is invalid." below the email field
7. **Verify:** The Save button should be disabled (form is invalid)
8. Enter a valid email like `test@example.com`
9. **Verify:** The inline error disappears and the form can be submitted

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| user-management-update.component.ts | 99.19% | 292 | 97 | 33.2 |

_Last updated: 2026-04-27 20:25:19 UTC_

