### PR TITLE
`General`: Add Now button to date/time picker to set current date and time

### DIFF
--- a/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.html
+++ b/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.html
@@ -52,7 +52,7 @@
         </button>
     </div>
 
-    <owl-date-time [startAt]="startDate()" #dtDefault />
+    <owl-date-time [startAt]="startDate()" #dtDefault (afterPickerOpen)="onPickerOpen()" (afterPickerClosed)="onPickerClosed()" />
     <owl-date-time [pickerType]="'calendar'" #dtCalendar />
     <owl-date-time [pickerType]="'timer'" #dtTimer />
 </div>

--- a/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.spec.ts
+++ b/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.spec.ts
@@ -138,6 +138,32 @@ describe('FormDateTimePickerComponent', () => {
             expect(mockPicker.confirmSelect).toHaveBeenCalledOnce();
         });
 
+        it('should clamp to minDate when now is before min', () => {
+            const futureMin = new Date(Date.now() + 3600000);
+            const mockPicker = { select: jest.fn(), confirmSelect: jest.fn() };
+            jest.spyOn(component as any, 'dtDefault').mockReturnValue(mockPicker);
+            jest.spyOn(component, 'minDate').mockReturnValue(futureMin);
+            jest.spyOn(component, 'maxDate').mockReturnValue(null);
+
+            component.setNow();
+
+            expect(mockPicker.select).toHaveBeenCalledWith(futureMin);
+            expect(mockPicker.confirmSelect).toHaveBeenCalledOnce();
+        });
+
+        it('should clamp to maxDate when now is after max', () => {
+            const pastMax = new Date(Date.now() - 3600000);
+            const mockPicker = { select: jest.fn(), confirmSelect: jest.fn() };
+            jest.spyOn(component as any, 'dtDefault').mockReturnValue(mockPicker);
+            jest.spyOn(component, 'minDate').mockReturnValue(null);
+            jest.spyOn(component, 'maxDate').mockReturnValue(pastMax);
+
+            component.setNow();
+
+            expect(mockPicker.select).toHaveBeenCalledWith(pastMax);
+            expect(mockPicker.confirmSelect).toHaveBeenCalledOnce();
+        });
+
         it('should not throw when setNow is called without a picker', () => {
             jest.spyOn(component as any, 'dtDefault').mockReturnValue(undefined);
 
@@ -178,6 +204,24 @@ describe('FormDateTimePickerComponent', () => {
 
             component.onPickerClosed();
 
+            expect(buttonsContainer.children).toHaveLength(1);
+
+            document.body.removeChild(buttonsContainer);
+        }));
+
+        it('should clear timeout when picker closes before button injection', fakeAsync(() => {
+            const buttonsContainer = document.createElement('div');
+            buttonsContainer.classList.add('owl-dt-container-buttons');
+            const setButton = document.createElement('button');
+            buttonsContainer.appendChild(setButton);
+            document.body.appendChild(buttonsContainer);
+
+            component.onPickerOpen();
+            // Close immediately before setTimeout fires
+            component.onPickerClosed();
+            tick();
+
+            // Button should not have been injected
             expect(buttonsContainer.children).toHaveLength(1);
 
             document.body.removeChild(buttonsContainer);

--- a/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.spec.ts
+++ b/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.spec.ts
@@ -1,10 +1,11 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { OwlDateTimeModule } from '@danielmoncada/angular-datetime-picker';
 import { FormDateTimePickerComponent } from 'app/shared/date-time-picker/date-time-picker.component';
 import dayjs from 'dayjs/esm';
-import { MockModule, MockPipe } from 'ng-mocks';
+import { MockModule, MockPipe, MockProvider } from 'ng-mocks';
 import { ArtemisTranslatePipe } from '../pipes/artemis-translate.pipe';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateService } from '@ngx-translate/core';
 
 describe('FormDateTimePickerComponent', () => {
     let component: FormDateTimePickerComponent;
@@ -17,6 +18,7 @@ describe('FormDateTimePickerComponent', () => {
         TestBed.configureTestingModule({
             imports: [MockModule(OwlDateTimeModule), MockPipe(ArtemisTranslatePipe), MockModule(NgbTooltipModule)],
             declarations: [FormDateTimePickerComponent],
+            providers: [MockProvider(TranslateService, { instant: jest.fn((key: string) => key) })],
         })
             .compileComponents()
             .then(() => {
@@ -123,5 +125,84 @@ describe('FormDateTimePickerComponent', () => {
 
         expect(resetSpy).toHaveBeenCalledWith(undefined);
         expect(updateSignalsSpy).toHaveBeenCalled();
+    });
+
+    describe('Now button', () => {
+        it('should call select and confirmSelect on the picker when setNow is called', () => {
+            const mockPicker = { select: jest.fn(), confirmSelect: jest.fn() };
+            jest.spyOn(component as any, 'dtDefault').mockReturnValue(mockPicker);
+
+            component.setNow();
+
+            expect(mockPicker.select).toHaveBeenCalledWith(expect.any(Date));
+            expect(mockPicker.confirmSelect).toHaveBeenCalledOnce();
+        });
+
+        it('should not throw when setNow is called without a picker', () => {
+            jest.spyOn(component as any, 'dtDefault').mockReturnValue(undefined);
+
+            expect(() => component.setNow()).not.toThrow();
+        });
+
+        it('should inject a Now button into the container on picker open', fakeAsync(() => {
+            const buttonsContainer = document.createElement('div');
+            buttonsContainer.classList.add('owl-dt-container-buttons');
+            const setButton = document.createElement('button');
+            buttonsContainer.appendChild(setButton);
+            document.body.appendChild(buttonsContainer);
+
+            component.onPickerOpen();
+            tick();
+
+            const nowButton = buttonsContainer.querySelector('button:first-child');
+            expect(nowButton).toBeDefined();
+            expect(nowButton?.getAttribute('aria-label')).toBe('entity.now');
+            expect(buttonsContainer.children).toHaveLength(2);
+
+            // Cleanup
+            component.onPickerClosed();
+            document.body.removeChild(buttonsContainer);
+        }));
+
+        it('should remove the Now button on picker close', fakeAsync(() => {
+            const buttonsContainer = document.createElement('div');
+            buttonsContainer.classList.add('owl-dt-container-buttons');
+            const setButton = document.createElement('button');
+            buttonsContainer.appendChild(setButton);
+            document.body.appendChild(buttonsContainer);
+
+            component.onPickerOpen();
+            tick();
+
+            expect(buttonsContainer.children).toHaveLength(2);
+
+            component.onPickerClosed();
+
+            expect(buttonsContainer.children).toHaveLength(1);
+
+            document.body.removeChild(buttonsContainer);
+        }));
+
+        it('should call setNow when the Now button is clicked', fakeAsync(() => {
+            const buttonsContainer = document.createElement('div');
+            buttonsContainer.classList.add('owl-dt-container-buttons');
+            const setButton = document.createElement('button');
+            buttonsContainer.appendChild(setButton);
+            document.body.appendChild(buttonsContainer);
+
+            const setNowSpy = jest.spyOn(component, 'setNow').mockImplementation();
+
+            component.onPickerOpen();
+            tick();
+
+            const nowButton = buttonsContainer.querySelector('button:first-child') as HTMLButtonElement;
+            nowButton.click();
+
+            expect(setNowSpy).toHaveBeenCalledOnce();
+
+            // Cleanup
+            component.onPickerClosed();
+            document.body.removeChild(buttonsContainer);
+        }));
     });
 });

--- a/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.ts
+++ b/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.ts
@@ -1,13 +1,14 @@
-import { Component, ViewChild, computed, forwardRef, input, model, output, signal } from '@angular/core';
+import { Component, DestroyRef, Renderer2, ViewChild, computed, forwardRef, inject, input, model, output, signal, viewChild } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR, NgModel } from '@angular/forms';
 import { faCalendarAlt, faCircleXmark, faClock, faGlobe, faQuestionCircle, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import dayjs from 'dayjs/esm';
 import { FaIconComponent, FaStackComponent, FaStackItemSizeDirective } from '@fortawesome/angular-fontawesome';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
-import { OwlDateTimeModule } from '@danielmoncada/angular-datetime-picker';
-import { NgClass, NgTemplateOutlet } from '@angular/common';
+import { OwlDateTimeComponent, OwlDateTimeModule } from '@danielmoncada/angular-datetime-picker';
+import { DOCUMENT, NgClass, NgTemplateOutlet } from '@angular/common';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { ArtemisTranslatePipe } from '../pipes/artemis-translate.pipe';
+import { TranslateService } from '@ngx-translate/core';
 
 export enum DateTimePickerType {
     CALENDAR,
@@ -47,7 +48,16 @@ export class FormDateTimePickerComponent implements ControlValueAccessor {
     protected readonly faCircleXmark = faCircleXmark;
     protected readonly faTriangleExclamation = faTriangleExclamation;
 
+    private readonly renderer = inject(Renderer2);
+    private readonly destroyRef = inject(DestroyRef);
+    private readonly document = inject(DOCUMENT);
+    private readonly translateService = inject(TranslateService);
+
     @ViewChild('dateInput', { static: false }) dateInput: NgModel;
+    protected readonly dtDefault = viewChild<OwlDateTimeComponent<Date>>('dtDefault');
+
+    private nowButton: HTMLButtonElement | undefined;
+    private nowButtonClickListener: (() => void) | undefined;
 
     labelName = input<string>();
     hideLabelName = input<boolean>(false);
@@ -162,6 +172,67 @@ export class FormDateTimePickerComponent implements ControlValueAccessor {
             this.onChange(undefined);
         }
         this.updateSignals();
+    }
+
+    /**
+     * Injects a "Now" button into the owl-date-time popup when it opens.
+     */
+    onPickerOpen(): void {
+        // Use setTimeout to let the CDK overlay render first
+        const timeoutId = setTimeout(() => {
+            const buttonsContainer = this.document.querySelector('.owl-dt-container-buttons');
+            if (!buttonsContainer) {
+                return;
+            }
+
+            const button = this.renderer.createElement('button') as HTMLButtonElement;
+            this.renderer.setAttribute(button, 'type', 'button');
+            this.renderer.setAttribute(button, 'title', this.translateService.instant('entity.now'));
+            this.renderer.setAttribute(button, 'aria-label', this.translateService.instant('entity.now'));
+            this.renderer.addClass(button, 'owl-dt-control');
+            this.renderer.addClass(button, 'owl-dt-control-button');
+            this.renderer.addClass(button, 'owl-dt-container-control-button');
+
+            const span = this.renderer.createElement('span');
+            this.renderer.addClass(span, 'owl-dt-control-content');
+            this.renderer.addClass(span, 'owl-dt-control-button-content');
+            this.renderer.setAttribute(span, 'tabindex', '-1');
+            const text = this.renderer.createText(this.translateService.instant('entity.now'));
+            this.renderer.appendChild(span, text);
+            this.renderer.appendChild(button, span);
+
+            // Insert the "Now" button before the "Set" button (last child)
+            const setButton = buttonsContainer.lastElementChild;
+            this.renderer.insertBefore(buttonsContainer, button, setButton);
+
+            this.nowButtonClickListener = this.renderer.listen(button, 'click', () => this.setNow());
+            this.nowButton = button;
+        });
+
+        this.destroyRef.onDestroy(() => clearTimeout(timeoutId));
+    }
+
+    /**
+     * Cleans up the injected "Now" button when the picker closes.
+     */
+    onPickerClosed(): void {
+        this.nowButtonClickListener?.();
+        this.nowButtonClickListener = undefined;
+        if (this.nowButton?.parentNode) {
+            this.renderer.removeChild(this.nowButton.parentNode, this.nowButton);
+        }
+        this.nowButton = undefined;
+    }
+
+    /**
+     * Sets the date/time to the current moment via the owl-date-time component.
+     */
+    setNow(): void {
+        const picker = this.dtDefault();
+        if (picker) {
+            picker.select(new Date());
+            picker.confirmSelect();
+        }
     }
 
     protected readonly DateTimePickerType = DateTimePickerType;

--- a/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.ts
+++ b/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.ts
@@ -58,6 +58,7 @@ export class FormDateTimePickerComponent implements ControlValueAccessor {
 
     private nowButton: HTMLButtonElement | undefined;
     private nowButtonClickListener: (() => void) | undefined;
+    private nowButtonTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
     labelName = input<string>();
     hideLabelName = input<boolean>(false);
@@ -179,8 +180,12 @@ export class FormDateTimePickerComponent implements ControlValueAccessor {
      */
     onPickerOpen(): void {
         // Use setTimeout to let the CDK overlay render first
-        const timeoutId = setTimeout(() => {
-            const buttonsContainer = this.document.querySelector('.owl-dt-container-buttons');
+        this.nowButtonTimeoutId = setTimeout(() => {
+            this.nowButtonTimeoutId = undefined;
+
+            // Use the last matching container to scope to the most recently opened picker overlay
+            const allContainers = this.document.querySelectorAll('.owl-dt-container-buttons');
+            const buttonsContainer = allContainers[allContainers.length - 1];
             if (!buttonsContainer) {
                 return;
             }
@@ -209,13 +214,14 @@ export class FormDateTimePickerComponent implements ControlValueAccessor {
             this.nowButton = button;
         });
 
-        this.destroyRef.onDestroy(() => clearTimeout(timeoutId));
+        this.destroyRef.onDestroy(() => this.clearNowButtonTimeout());
     }
 
     /**
      * Cleans up the injected "Now" button when the picker closes.
      */
     onPickerClosed(): void {
+        this.clearNowButtonTimeout();
         this.nowButtonClickListener?.();
         this.nowButtonClickListener = undefined;
         if (this.nowButton?.parentNode) {
@@ -225,13 +231,30 @@ export class FormDateTimePickerComponent implements ControlValueAccessor {
     }
 
     /**
-     * Sets the date/time to the current moment via the owl-date-time component.
+     * Sets the date/time to the current moment via the owl-date-time component,
+     * clamping to min/max constraints if set.
      */
     setNow(): void {
         const picker = this.dtDefault();
         if (picker) {
-            picker.select(new Date());
+            let now = new Date();
+            const minDate = this.minDate();
+            const maxDate = this.maxDate();
+            if (minDate && now < minDate) {
+                now = minDate;
+            }
+            if (maxDate && now > maxDate) {
+                now = maxDate;
+            }
+            picker.select(now);
             picker.confirmSelect();
+        }
+    }
+
+    private clearNowButtonTimeout(): void {
+        if (this.nowButtonTimeoutId !== undefined) {
+            clearTimeout(this.nowButtonTimeoutId);
+            this.nowButtonTimeoutId = undefined;
         }
     }
 

--- a/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.ts
+++ b/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.ts
@@ -53,6 +53,10 @@ export class FormDateTimePickerComponent implements ControlValueAccessor {
     private readonly document = inject(DOCUMENT);
     private readonly translateService = inject(TranslateService);
 
+    constructor() {
+        this.destroyRef.onDestroy(() => this.clearNowButtonTimeout());
+    }
+
     @ViewChild('dateInput', { static: false }) dateInput: NgModel;
     protected readonly dtDefault = viewChild<OwlDateTimeComponent<Date>>('dtDefault');
 
@@ -213,8 +217,6 @@ export class FormDateTimePickerComponent implements ControlValueAccessor {
             this.nowButtonClickListener = this.renderer.listen(button, 'click', () => this.setNow());
             this.nowButton = button;
         });
-
-        this.destroyRef.onDestroy(() => this.clearNowButtonTimeout());
     }
 
     /**
@@ -240,6 +242,9 @@ export class FormDateTimePickerComponent implements ControlValueAccessor {
             let now = new Date();
             const minDate = this.minDate();
             const maxDate = this.maxDate();
+            if (minDate && maxDate && minDate > maxDate) {
+                return;
+            }
             if (minDate && now < minDate) {
                 now = minDate;
             }

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -463,6 +463,7 @@
             "patternLogin": "Dieses Feld darf nur Buchstaben, Ziffern und E-Mail-Adressen enthalten.",
             "invalidPattern": "Dieses Feld beinhaltet ein ungültiges E-Mail Muster."
         },
+        "now": "Jetzt",
         "timeZoneWarning": "Du befindest dich aktuell in der {{ timeZone }} Zeitzone.",
         "dateMissingOrNotValid": "'{{labelName}}' fehlt/ungültig",
         "startDateError": "'Bearbeitungszeit ab' sollte zwischen 'Sichtbar ab' und 'Bearbeitungszeit bis' liegen",

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -463,6 +463,7 @@
             "patternLogin": "This field may only contain letters, digits and e-mail addresses.",
             "invalidPattern": "This field contains an invalid e-mail pattern."
         },
+        "now": "Now",
         "timeZoneWarning": "You are currently in the {{ timeZone }} time zone.",
         "dateMissingOrNotValid": "'{{labelName}}' is missing/invalid",
         "startDateError": "'Start of working time' should be between 'Visible from' and 'End of working time'",


### PR DESCRIPTION
### Summary
Add a "Now" button to the date/time picker component (`jhi-date-time-picker`) that allows users to set the selected date and time to the current moment with a single click.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
Closes #12179

When setting dates and times in Artemis (e.g., exam visibility dates, exercise due dates), users often need to set the value to the current date and time. Currently, this requires manually navigating the calendar and adjusting hours/minutes, which is tedious and error-prone.

### Description
- Added a "Now" button to the `FormDateTimePickerComponent` that appears in the owl-date-time picker popup between the "Cancel" and "Set" buttons
- The button is dynamically injected into the CDK overlay using `Renderer2` when the picker opens (`afterPickerOpen` event) and cleaned up when it closes (`afterPickerClosed` event)
- Clicking the button calls `select(new Date())` and `confirmSelect()` on the owl-date-time component, setting the date/time to now and confirming the selection
- Only available for the `DEFAULT` picker type (where both date and time are shown)
- Added i18n translations for the button label ("Now" / "Jetzt")
- Includes proper accessibility attributes (`title`, `aria-label`)

### Steps for Testing
Prerequisites:
- 1 Instructor

1. Log in to Artemis as an instructor
2. Navigate to any page with a date/time picker (e.g., exercise creation, exam settings, course settings)
3. Click the calendar icon to open the date/time picker
4. Verify that a "Now" button appears between "Cancel" and "Set" in the popup
5. Click the "Now" button
6. Verify that the date and time are set to the current moment and the picker closes
7. Repeat with a different date/time picker field to verify consistency

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| date-time-picker.component.ts | 97.47% | 191 | 33 | 17.3 |

_Last updated: 2026-04-27 23:04:02 UTC_


### Screenshots
![Date/time picker with Now button](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/c5629e24-9c90-41ca-a5fc-70a7464df319.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Now" button to the date-time picker for quick selection of the current date and time.
  * Button respects existing date range constraints (min/max) and is translated (English/German).

* **Bug Fixes**
  * Prevents stale injections and avoids errors when the picker is not available.

* **Tests**
  * Added unit tests covering button injection, removal, click behavior, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->