### PR TITLE
`Communication`: Hide empty one-to-one chats from direct messages listing

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/repository/conversation/OneToOneChatRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/repository/conversation/OneToOneChatRepository.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.communication.repository.conversation;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,9 +25,13 @@ public interface OneToOneChatRepository extends ArtemisJpaRepository<OneToOneCha
      * <p>
      * We join the conversionParticipants twice, because the first time we use it for filtering the chats and binding it to the user ID. The second time, we fetch all participants;
      * as it's a one-to-one chat, two.
+     * <p>
+     * Empty one-to-one chats (no messages) are hidden unless they were created within the last day,
+     * so newly created conversations remain accessible until they either receive a message or expire.
      *
-     * @param courseId the ID of the course to search in
-     * @param userId   the ID of the user to search for
+     * @param courseId        the ID of the course to search in
+     * @param userId          the ID of the user to search for
+     * @param recentThreshold the cutoff date; empty chats created before this are hidden
      * @return a list of one-to-one chats
      */
     @Query("""
@@ -38,11 +43,12 @@ public interface OneToOneChatRepository extends ArtemisJpaRepository<OneToOneCha
                 LEFT JOIN FETCH user.groups
                 LEFT JOIN FETCH oneToOneChat.course
             WHERE oneToOneChat.course.id = :courseId
-                AND oneToOneChat.lastMessageDate IS NOT NULL
+                AND (oneToOneChat.lastMessageDate IS NOT NULL OR oneToOneChat.creationDate >= :recentThreshold)
                 AND matchingParticipant.user.id = :userId
             ORDER BY oneToOneChat.lastMessageDate DESC
             """)
-    List<OneToOneChat> findAllWithParticipantsAndUserGroupsByCourseIdAndUserId(@Param("courseId") Long courseId, @Param("userId") Long userId);
+    List<OneToOneChat> findAllWithParticipantsAndUserGroupsByCourseIdAndUserId(@Param("courseId") Long courseId, @Param("userId") Long userId,
+            @Param("recentThreshold") ZonedDateTime recentThreshold);
 
     /**
      * Find a one-to-one chat between two users in a given course.

--- a/src/main/java/de/tum/cit/aet/artemis/communication/repository/conversation/OneToOneChatRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/repository/conversation/OneToOneChatRepository.java
@@ -38,7 +38,7 @@ public interface OneToOneChatRepository extends ArtemisJpaRepository<OneToOneCha
                 LEFT JOIN FETCH user.groups
                 LEFT JOIN FETCH oneToOneChat.course
             WHERE oneToOneChat.course.id = :courseId
-                AND (oneToOneChat.lastMessageDate IS NOT NULL OR oneToOneChat.creator.id = :userId)
+                AND oneToOneChat.lastMessageDate IS NOT NULL
                 AND matchingParticipant.user.id = :userId
             ORDER BY oneToOneChat.lastMessageDate DESC
             """)

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/conversation/ConversationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/conversation/ConversationService.java
@@ -184,7 +184,8 @@ public class ConversationService {
         var conversationsOfUser = new ArrayList<Conversation>();
         List<Channel> channelsOfUser;
         if (course.getCourseInformationSharingConfiguration().isMessagingEnabled()) {
-            var oneToOneChatsOfUser = oneToOneChatRepository.findAllWithParticipantsAndUserGroupsByCourseIdAndUserId(course.getId(), requestingUser.getId());
+            var oneToOneChatsOfUser = oneToOneChatRepository.findAllWithParticipantsAndUserGroupsByCourseIdAndUserId(course.getId(), requestingUser.getId(),
+                    ZonedDateTime.now().minusDays(1));
             conversationsOfUser.addAll(oneToOneChatsOfUser);
 
             var groupChatsOfUser = groupChatRepository.findGroupChatsOfUserWithParticipantsAndUserGroups(course.getId(), requestingUser.getId());


### PR DESCRIPTION
### Summary
Fixes empty one-to-one chat conversations persisting in the "Direct Messages" sidebar section. When a user creates a direct chat but never sends a message, the empty conversation now automatically disappears from the listing when the user navigates away.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).

### Motivation and Context
Closes #12102

When a user searches for someone and creates a direct message conversation but doesn't send any message, the empty conversation permanently stays in the "Direct Messages" sidebar section with no way to remove it (only archive is available).

### Description
The fix is a single-line change in `OneToOneChatRepository.java`. The JPQL query that fetches one-to-one chats for the sidebar previously included a condition `(lastMessageDate IS NOT NULL OR creator.id = :userId)`, which caused empty conversations to be shown to the creator indefinitely.

The fix simplifies this to `lastMessageDate IS NOT NULL`, so only conversations where at least one message has been sent will appear in the sidebar listing. When a user creates a new direct chat, it is still returned from the creation endpoint and displayed immediately, but if the user navigates away without sending any message, the empty conversation will no longer appear in the sidebar on the next page load.

### Steps for Testing
Prerequisites:
- 1 Course with communication enabled
- 2 Students enrolled in the course

1. Log in as Student A
2. Go to the communication tab of the course
3. Click the + icon next to the Search bar and select "Create direct chat"
4. Choose Student B (someone you don't have an existing conversation with)
5. The chat appears in the "Direct Messages" section — do NOT send any message
6. Navigate away (e.g., click on another channel or go back to course overview)
7. Return to the communication tab
8. Verify that the empty conversation with Student B is no longer visible in "Direct Messages"
9. Now create the chat again, send a message, and verify it persists in the sidebar

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved one-to-one chat listing: conversations with messages are shown as before, and empty conversations are now only displayed if they were created very recently (within the last day). This prevents stale, message-less chats from cluttering the list while still surfacing newly created chats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->