### PR TITLE
`Communication`: Show Save/Cancel buttons when editing reply posts in threads

### DIFF
--- a/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.html
+++ b/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.html
@@ -10,9 +10,21 @@
                 [isButtonLoading]="isLoading"
                 [isFormGroupValid]="formGroup.valid"
                 [editType]="editType"
-                [showCloseButton]="true"
-                (closeEditor)="close()"
             />
+            <div class="col mt-1 text-end">
+                @if (editType === EditType.UPDATE) {
+                    <button jhi-posting-button [buttonLabel]="'artemisApp.metis.cancel' | artemisTranslate" class="btn btn-sm btn-outline-secondary" (click)="close()"></button>
+                    <button
+                        jhi-posting-button
+                        [buttonLoading]="isLoading"
+                        [disabled]="isLoading || !formGroup.valid"
+                        [buttonLabel]="'artemisApp.conversationsLayout.saveMessage' | artemisTranslate"
+                        class="btn btn-sm btn-outline-primary"
+                        id="save"
+                        type="submit"
+                    ></button>
+                }
+            </div>
         </div>
     </form>
 </ng-template>

--- a/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.html
+++ b/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.html
@@ -13,7 +13,13 @@
             />
             <div class="col mt-1 text-end">
                 @if (editType === EditType.UPDATE) {
-                    <button jhi-posting-button [buttonLabel]="'artemisApp.metis.cancel' | artemisTranslate" class="btn btn-sm btn-outline-secondary" (click)="close()"></button>
+                    <button
+                        jhi-posting-button
+                        [buttonLabel]="'artemisApp.metis.cancel' | artemisTranslate"
+                        class="btn btn-sm btn-outline-secondary"
+                        type="button"
+                        (click)="close()"
+                    ></button>
                     <button
                         jhi-posting-button
                         [buttonLoading]="isLoading"

--- a/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.ts
+++ b/src/main/webapp/app/communication/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.ts
@@ -5,6 +5,8 @@ import { FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { PostContentValidationPattern } from 'app/communication/metis.util';
 import { Posting } from 'app/communication/shared/entities/posting.model';
 import { PostingMarkdownEditorComponent } from 'app/communication/posting-markdown-editor/posting-markdown-editor.component';
+import { PostingButtonComponent } from 'app/communication/posting-button/posting-button.component';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { deepClone } from 'app/shared/util/deep-clone.util';
 
 @Component({
@@ -12,7 +14,7 @@ import { deepClone } from 'app/shared/util/deep-clone.util';
     templateUrl: './answer-post-create-edit-modal.component.html',
     styleUrls: ['answer-post-create-edit-modal.component.scss'],
     encapsulation: ViewEncapsulation.None,
-    imports: [FormsModule, ReactiveFormsModule, PostingMarkdownEditorComponent],
+    imports: [FormsModule, ReactiveFormsModule, PostingMarkdownEditorComponent, PostingButtonComponent, ArtemisTranslatePipe],
 })
 export class AnswerPostCreateEditModalComponent extends PostingCreateEditModalDirective<AnswerPost> {
     createEditAnswerPostContainerRef = input<ViewContainerRef>();


### PR DESCRIPTION
### Summary
Add visible Save and Cancel buttons when editing reply posts (answer posts) in threads, matching the existing behavior of regular post editing. Previously, editing a reply only showed a small close (X) button with no visible Save button, requiring users to press Enter to save — an inconsistent and undiscoverable interaction.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Closes #12090

Editing behavior was inconsistent between regular posts and reply posts (answer posts). When editing a regular post, the interface shows Save and Cancel buttons. When editing a reply, no such buttons were displayed — the user had to press Enter to save, which was undiscoverable.

### Description
The `answer-post-create-edit-modal` component previously used a close (X) button via the markdown editor's `showCloseButton` input. This has been replaced with explicit Save and Cancel buttons (matching the pattern used by `message-inline-input` for regular post editing).

Changes:
- **`answer-post-create-edit-modal.component.html`**: Removed `[showCloseButton]="true"` and `(closeEditor)="close()"` from the markdown editor. Added a Save/Cancel button row that appears when `editType === EditType.UPDATE`, using the same `jhi-posting-button` component and translation keys as the regular post editing flow.
- **`answer-post-create-edit-modal.component.ts`**: Added `PostingButtonComponent` and `ArtemisTranslatePipe` to the component's imports array.

### Steps for Testing
Prerequisites:
- 1 User with access to a course with messaging enabled

1. Log in to Artemis
2. Navigate to a course conversation/channel
3. Post a message, then reply to it in the thread
4. Click the edit button (pencil icon) on the reply
5. Verify that Save and Cancel buttons appear below the editor
6. Click Cancel and verify the edit is discarded
7. Edit the reply again, change the text, and click Save
8. Verify the reply is updated
9. Also verify that editing a regular (non-reply) post still shows Save/Cancel buttons as before

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots

#### Editing a reply post — Save and Cancel buttons visible
![Save and Cancel buttons when editing a reply post](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/7a6196f5-f1f7-42b1-b11c-0037eb27c922.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated answer post modal to show explicit Cancel and Save controls only when editing an existing post.
  * Save now respects form validity and shows a loading indicator during submission.
  * Cancel closes the modal reliably without exposing extra editor controls.
  * Minor template enhancements to support the above UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
