### PR TITLE
`Communication`: Add option to filter out DMs in search

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/dto/PostContextFilterDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/dto/PostContextFilterDTO.java
@@ -9,12 +9,13 @@ import de.tum.cit.aet.artemis.core.dto.SortingOrder;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PostContextFilterDTO(@NotBlank Long courseId, Long plagiarismCaseId, long[] conversationIds, long[] authorIds, String searchText, Boolean filterToCourseWide,
-        Boolean filterToUnresolved, Boolean filterToAnsweredOrReacted, PostSortCriterion postSortCriterion, SortingOrder sortingOrder, Boolean pinnedOnly) {
+        Boolean filterToUnresolved, Boolean filterToAnsweredOrReacted, PostSortCriterion postSortCriterion, SortingOrder sortingOrder, Boolean pinnedOnly,
+        Boolean filterToExcludeDirectMessages) {
 
-    // Overloaded constructor to set pinnedOnly to false by default if not provided.
+    // Overloaded constructor to set pinnedOnly and filterToExcludeDirectMessages to false by default if not provided.
     public PostContextFilterDTO(@NotBlank Long courseId, Long plagiarismCaseId, long[] conversationIds, long[] authorIds, String searchText, Boolean filterToCourseWide,
             Boolean filterToUnresolved, Boolean filterToAnsweredOrReacted, PostSortCriterion postSortCriterion, SortingOrder sortingOrder) {
         this(courseId, plagiarismCaseId, conversationIds, authorIds, searchText, filterToCourseWide, filterToUnresolved, filterToAnsweredOrReacted, postSortCriterion, sortingOrder,
-                false);
+                false, false);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/communication/repository/ConversationMessageRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/repository/ConversationMessageRepository.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.communication.repository;
 import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getAnsweredOrReactedSpecification;
 import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getConversationsSpecification;
 import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getCourseWideChannelsSpecification;
+import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getExcludeDirectMessagesSpecification;
 import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getPinnedSpecification;
 import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getSearchTextAndAuthorSpecification;
 import static de.tum.cit.aet.artemis.communication.repository.MessageSpecs.getSortSpecification;
@@ -59,6 +60,7 @@ public interface ConversationMessageRepository extends ArtemisJpaRepository<Post
             .and(getAnsweredOrReactedSpecification(Boolean.TRUE.equals(postContextFilter.filterToAnsweredOrReacted()), userId))
             .and(getUnresolvedSpecification(Boolean.TRUE.equals(postContextFilter.filterToUnresolved())))
             .and(getPinnedSpecification(Boolean.TRUE.equals(postContextFilter.pinnedOnly())))
+            .and(getExcludeDirectMessagesSpecification(Boolean.TRUE.equals(postContextFilter.filterToExcludeDirectMessages())))
             .and(getSortSpecification(true, postContextFilter.postSortCriterion(), postContextFilter.sortingOrder()));
             // @formatter:on
     }

--- a/src/main/java/de/tum/cit/aet/artemis/communication/repository/MessageSpecs.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/repository/MessageSpecs.java
@@ -24,6 +24,8 @@ import de.tum.cit.aet.artemis.communication.domain.Reaction_;
 import de.tum.cit.aet.artemis.communication.domain.conversation.Channel;
 import de.tum.cit.aet.artemis.communication.domain.conversation.Channel_;
 import de.tum.cit.aet.artemis.communication.domain.conversation.Conversation_;
+import de.tum.cit.aet.artemis.communication.domain.conversation.GroupChat;
+import de.tum.cit.aet.artemis.communication.domain.conversation.OneToOneChat;
 import de.tum.cit.aet.artemis.core.domain.Course_;
 import de.tum.cit.aet.artemis.core.domain.User_;
 import de.tum.cit.aet.artemis.core.dto.SortingOrder;
@@ -284,6 +286,25 @@ public class MessageSpecs {
                 return criteriaBuilder.conjunction();
             }
             return criteriaBuilder.equal(root.get(Post_.DISPLAY_PRIORITY), DisplayPriority.PINNED.name());
+        };
+    }
+
+    /**
+     * Specification to exclude direct messages (OneToOneChat and GroupChat) from results
+     *
+     * @param excludeDirectMessages whether direct messages should be excluded
+     * @return specification used to chain DB operations
+     */
+    @NonNull
+    public static Specification<Post> getExcludeDirectMessagesSpecification(boolean excludeDirectMessages) {
+        return (root, query, criteriaBuilder) -> {
+            if (!excludeDirectMessages) {
+                return criteriaBuilder.conjunction();
+            }
+            final var conversationJoin = root.join(Post_.conversation, JoinType.LEFT);
+            Predicate isNotOneToOneChat = criteriaBuilder.notEqual(conversationJoin.type(), criteriaBuilder.literal(OneToOneChat.class));
+            Predicate isNotGroupChat = criteriaBuilder.notEqual(conversationJoin.type(), criteriaBuilder.literal(GroupChat.class));
+            return criteriaBuilder.and(isNotOneToOneChat, isNotGroupChat);
         };
     }
 }

--- a/src/main/webapp/app/communication/course-conversations-components/course-wide-search/course-wide-search.component.html
+++ b/src/main/webapp/app/communication/course-conversations-components/course-wide-search/course-wide-search.component.html
@@ -60,6 +60,17 @@
                                 />
                                 <label for="filterToAnsweredOrReacted" class="p-0" jhiTranslate="artemisApp.metis.overview.filterToAnsweredOrReacted"></label>
                             </div>
+                            <div class="col-auto p-0 ps-2">
+                                <input
+                                    class="form-check-input"
+                                    type="checkbox"
+                                    formControlName="filterToExcludeDirectMessages"
+                                    name="filterToExcludeDirectMessages"
+                                    id="filterToExcludeDirectMessages"
+                                    (change)="onSelectContext()"
+                                />
+                                <label for="filterToExcludeDirectMessages" class="p-0" jhiTranslate="artemisApp.metis.overview.filterToExcludeDirectMessages"></label>
+                            </div>
                         </div>
                         <!-- sort dropdown -->
                         <div class="d-flex">

--- a/src/main/webapp/app/communication/course-conversations-components/course-wide-search/course-wide-search.component.spec.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/course-wide-search/course-wide-search.component.spec.ts
@@ -59,6 +59,7 @@ describe('CourseWideSearchComponent', () => {
     courseWideSearchConfig.filterToUnresolved = false;
     courseWideSearchConfig.filterToCourseWide = false;
     courseWideSearchConfig.filterToAnsweredOrReacted = false;
+    courseWideSearchConfig.filterToExcludeDirectMessages = false;
     courseWideSearchConfig.sortingOrder = SortDirection.ASCENDING;
     courseWideSearchConfig.selectedConversations = [];
     courseWideSearchConfig.selectedAuthors = [];
@@ -145,6 +146,7 @@ describe('CourseWideSearchComponent', () => {
             authorIds: [],
             filterToCourseWide: false,
             filterToAnsweredOrReacted: false,
+            filterToExcludeDirectMessages: false,
             page: 0,
             pageSize: 50,
             pagingEnabled: true,
@@ -168,6 +170,7 @@ describe('CourseWideSearchComponent', () => {
             filterToCourseWide: courseWideSearchConfig.filterToCourseWide,
             filterToUnresolved: courseWideSearchConfig.filterToUnresolved,
             filterToAnsweredOrReacted: courseWideSearchConfig.filterToAnsweredOrReacted,
+            filterToExcludeDirectMessages: courseWideSearchConfig.filterToExcludeDirectMessages,
             page: 0,
             pageSize: 50,
             pagingEnabled: true,
@@ -201,6 +204,7 @@ describe('CourseWideSearchComponent', () => {
         expect(component.formGroup.get('filterToCourseWide')?.value).toBe(false);
         expect(component.formGroup.get('filterToUnresolved')?.value).toBe(false);
         expect(component.formGroup.get('filterToAnsweredOrReacted')?.value).toBe(false);
+        expect(component.formGroup.get('filterToExcludeDirectMessages')?.value).toBe(false);
     });
 
     it('Should update filter setting when filterToCourseWide checkbox is checked', () => {
@@ -279,6 +283,18 @@ describe('CourseWideSearchComponent', () => {
         fixture.changeDetectorRef.detectChanges();
         expect(component.courseWideSearchConfig()?.filterToUnresolved).toBe(false);
         expect(component.courseWideSearchConfig()?.filterToAnsweredOrReacted).toBe(true);
+    });
+
+    it('Should update filter setting when filterToExcludeDirectMessages checkbox is checked', () => {
+        fixture.changeDetectorRef.detectChanges();
+        component.formGroup.patchValue({
+            filterToExcludeDirectMessages: true,
+        });
+        const filterExcludeDMsCheckbox = getElement(fixture.debugElement, 'input[name=filterToExcludeDirectMessages]');
+        filterExcludeDMsCheckbox.dispatchEvent(new Event('change'));
+        vi.advanceTimersByTime(0);
+        fixture.changeDetectorRef.detectChanges();
+        expect(component.courseWideSearchConfig()?.filterToExcludeDirectMessages).toBe(true);
     });
 
     it('Should update filter setting when all filter checkboxes are checked', () => {

--- a/src/main/webapp/app/communication/course-conversations-components/course-wide-search/course-wide-search.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/course-wide-search/course-wide-search.component.ts
@@ -164,6 +164,7 @@ export class CourseWideSearchComponent implements OnInit, AfterViewInit, OnDestr
             filterToCourseWide: searchConfig.filterToCourseWide,
             filterToUnresolved: searchConfig.filterToUnresolved,
             filterToAnsweredOrReacted: searchConfig.filterToAnsweredOrReacted,
+            filterToExcludeDirectMessages: searchConfig.filterToExcludeDirectMessages,
             sortingOrder: searchConfig.sortingOrder,
             pagingEnabled: true,
             page: this.page - 1,
@@ -209,6 +210,7 @@ export class CourseWideSearchComponent implements OnInit, AfterViewInit, OnDestr
             filterToCourseWide: false,
             filterToUnresolved: false,
             filterToAnsweredOrReacted: false,
+            filterToExcludeDirectMessages: false,
         });
     }
 
@@ -223,6 +225,7 @@ export class CourseWideSearchComponent implements OnInit, AfterViewInit, OnDestr
         searchConfig.filterToCourseWide = this.formGroup.get('filterToCourseWide')?.value;
         searchConfig.filterToUnresolved = this.formGroup.get('filterToUnresolved')?.value;
         searchConfig.filterToAnsweredOrReacted = this.formGroup.get('filterToAnsweredOrReacted')?.value;
+        searchConfig.filterToExcludeDirectMessages = this.formGroup.get('filterToExcludeDirectMessages')?.value;
         searchConfig.sortingOrder = this.sortingOrder;
         this.commandMetisToFetchPosts(true);
     }
@@ -239,5 +242,6 @@ export class CourseWideSearchConfig {
     filterToCourseWide: boolean;
     filterToUnresolved: boolean;
     filterToAnsweredOrReacted: boolean;
+    filterToExcludeDirectMessages: boolean;
     sortingOrder: SortDirection;
 }

--- a/src/main/webapp/app/communication/metis.util.ts
+++ b/src/main/webapp/app/communication/metis.util.ts
@@ -47,6 +47,7 @@ export interface PostContextFilter {
     filterToCourseWide?: boolean;
     filterToUnresolved?: boolean;
     filterToAnsweredOrReacted?: boolean;
+    filterToExcludeDirectMessages?: boolean;
     postSortCriterion?: PostSortCriterion;
     sortingOrder?: SortDirection;
     pagingEnabled?: boolean;

--- a/src/main/webapp/app/communication/post/post.component.spec.ts
+++ b/src/main/webapp/app/communication/post/post.component.spec.ts
@@ -83,6 +83,7 @@ describe('PostComponent', () => {
             filterToCourseWide: false,
             filterToUnresolved: false,
             filterToAnsweredOrReacted: false,
+            filterToExcludeDirectMessages: false,
             sortingOrder: SortDirection.ASCENDING,
         };
 

--- a/src/main/webapp/app/communication/service/metis.service.ts
+++ b/src/main/webapp/app/communication/service/metis.service.ts
@@ -722,6 +722,8 @@ export class MetisService implements OnDestroy {
         const isValidPostContext = !!postConvId && !!this.currentPostContextFilter.conversationIds && this.currentPostContextFilter.conversationIds.length > 0;
         const postIsFromCurrentConversation = isValidPostContext && this.currentPostContextFilter.conversationIds?.includes(postConvId);
         const postIsPrivate = !!this.currentPostContextFilter.filterToCourseWide && !getAsChannelDTO(postDTO.post.conversation)?.isCourseWide;
+        const postIsDirectMessage =
+            !!this.currentPostContextFilter.filterToExcludeDirectMessages && (!!getAsOneToOneChatDTO(postDTO.post.conversation) || !!getAsGroupChatDTO(postDTO.post.conversation));
         const postIsNotFromCurrentPlagiarismCase =
             this.currentPostContextFilter.plagiarismCaseId && postDTO.post.plagiarismCase?.id !== this.currentPostContextFilter.plagiarismCaseId;
 
@@ -729,7 +731,7 @@ export class MetisService implements OnDestroy {
             this.metisConversationService.handleNewMessage(postConvId, postDTO.post.creationDate);
         }
 
-        if (!isValidPostContext || !postIsFromCurrentConversation || postIsNotFromCurrentPlagiarismCase || postIsPrivate) {
+        if (!isValidPostContext || !postIsFromCurrentConversation || postIsNotFromCurrentPlagiarismCase || postIsPrivate || postIsDirectMessage) {
             return;
         }
 

--- a/src/main/webapp/app/communication/service/post.service.ts
+++ b/src/main/webapp/app/communication/service/post.service.ts
@@ -77,6 +77,9 @@ export class PostService extends PostingService<Post> {
         if (postContextFilter.filterToAnsweredOrReacted) {
             params = params.set('filterToAnsweredOrReacted', postContextFilter.filterToAnsweredOrReacted);
         }
+        if (postContextFilter.filterToExcludeDirectMessages) {
+            params = params.set('filterToExcludeDirectMessages', postContextFilter.filterToExcludeDirectMessages);
+        }
         if (postContextFilter.pagingEnabled) {
             params = params.set('pagingEnabled', postContextFilter.pagingEnabled);
             params = params.set('page', postContextFilter.page!);

--- a/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
+++ b/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
@@ -450,6 +450,7 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
         this.courseWideSearchConfig.filterToCourseWide = false;
         this.courseWideSearchConfig.filterToUnresolved = false;
         this.courseWideSearchConfig.filterToAnsweredOrReacted = false;
+        this.courseWideSearchConfig.filterToExcludeDirectMessages = false;
         this.courseWideSearchConfig.sortingOrder = SortDirection.ASCENDING;
         this.courseWideSearchConfig.selectedAuthors = [];
         this.courseWideSearchConfig.selectedConversations = [];

--- a/src/main/webapp/i18n/de/metis.json
+++ b/src/main/webapp/i18n/de/metis.json
@@ -89,6 +89,7 @@
                 "filterToUnresolved": "Ungeklärt",
                 "filterToOwn": "Eigene",
                 "filterToAnsweredOrReacted": "Reagiert",
+                "filterToExcludeDirectMessages": "DMs ausschließen",
                 "courseFilterExplanation": "{{ title }} (Alle Beiträge)",
                 "filterOptGroups": {
                     "general": "Allgemein",

--- a/src/main/webapp/i18n/en/metis.json
+++ b/src/main/webapp/i18n/en/metis.json
@@ -96,6 +96,7 @@
                 "filterToUnresolved": "Unresolved",
                 "filterToOwn": "Own",
                 "filterToAnsweredOrReacted": "Reacted",
+                "filterToExcludeDirectMessages": "Exclude DMs",
                 "sortPostsBy": "Sort by:",
                 "sortDescending": "Descending",
                 "sortAscending": "Ascending",

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -491,6 +491,33 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "USER")
+    void testGetMessagesExcludingDirectMessages() throws Exception {
+        // First query without the filter to get all messages
+        var paramsAll = new LinkedMultiValueMap<String, String>();
+        paramsAll.add("conversationIds", existingConversationIds.stream().map(String::valueOf).collect(Collectors.joining(",")));
+        paramsAll.add("size", "50");
+        List<Post> allPosts = request.getList("/api/communication/courses/" + courseId + "/messages", HttpStatus.OK, Post.class, paramsAll);
+
+        // Now query with the DM exclusion filter
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("conversationIds", existingConversationIds.stream().map(String::valueOf).collect(Collectors.joining(",")));
+        params.add("filterToExcludeDirectMessages", "true");
+        params.add("size", "50");
+
+        List<Post> returnedPosts = request.getList("/api/communication/courses/" + courseId + "/messages", HttpStatus.OK, Post.class, params);
+
+        // All returned posts should belong to channels, not OneToOneChat or GroupChat
+        assertThat(returnedPosts).isNotEmpty();
+        assertThat(returnedPosts).allMatch(post -> post.getConversation() instanceof Channel);
+
+        // The filtered result should have fewer posts than the unfiltered result (since DM posts exist)
+        var dmPosts = allPosts.stream().filter(post -> post.getConversation() instanceof OneToOneChat).toList();
+        assertThat(dmPosts).isNotEmpty();
+        assertThat(returnedPosts).hasSize(allPosts.size() - dmPosts.size());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "USER")
     void testGetCourseWideMessagesFromOneChannel() throws Exception {
         // conversation set will fetch all posts of conversation if the user is involved
         var params = new LinkedMultiValueMap<String, String>();

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -40,6 +40,7 @@ import de.tum.cit.aet.artemis.communication.domain.Post;
 import de.tum.cit.aet.artemis.communication.domain.PostSortCriterion;
 import de.tum.cit.aet.artemis.communication.domain.conversation.Channel;
 import de.tum.cit.aet.artemis.communication.domain.conversation.Conversation;
+import de.tum.cit.aet.artemis.communication.domain.conversation.GroupChat;
 import de.tum.cit.aet.artemis.communication.domain.conversation.OneToOneChat;
 import de.tum.cit.aet.artemis.communication.dto.CreatePostConversationDTO;
 import de.tum.cit.aet.artemis.communication.dto.CreatePostDTO;
@@ -511,7 +512,7 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         assertThat(returnedPosts).allMatch(post -> post.getConversation() instanceof Channel);
 
         // The filtered result should have fewer posts than the unfiltered result (since DM posts exist)
-        var dmPosts = allPosts.stream().filter(post -> post.getConversation() instanceof OneToOneChat).toList();
+        var dmPosts = allPosts.stream().filter(post -> post.getConversation() instanceof OneToOneChat || post.getConversation() instanceof GroupChat).toList();
         assertThat(dmPosts).isNotEmpty();
         assertThat(returnedPosts).hasSize(allPosts.size() - dmPosts.size());
     }

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -508,13 +508,13 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         List<Post> returnedPosts = request.getList("/api/communication/courses/" + courseId + "/messages", HttpStatus.OK, Post.class, params);
 
         // All returned posts should belong to channels, not OneToOneChat or GroupChat
-        assertThat(returnedPosts).isNotEmpty();
         assertThat(returnedPosts).allMatch(post -> post.getConversation() instanceof Channel);
 
         // The filtered result should have fewer posts than the unfiltered result (since DM posts exist)
         var dmPosts = allPosts.stream().filter(post -> post.getConversation() instanceof OneToOneChat || post.getConversation() instanceof GroupChat).toList();
         assertThat(dmPosts).isNotEmpty();
-        assertThat(returnedPosts).hasSize(allPosts.size() - dmPosts.size());
+        var expectedNonDmCount = (int) allPosts.stream().filter(post -> post.getConversation() instanceof Channel).count();
+        assertThat(returnedPosts).hasSize(expectedNonDmCount);
     }
 
     @Test


### PR DESCRIPTION
### Summary 
Add a new filter option "Exclude DMs" to the course-wide message search that allows users to filter out direct messages (one-to-one chats and group chats) from search results. This helps users focus on channel messages when searching through course communications.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I translated all newly inserted strings into English and German.
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Closes #12058

Currently, users can filter messages by specific channels or by "course-wide" channels, but there is no way to exclude direct messages from search results. DMs can clutter search results when users are looking for messages in non-course-wide channels that may need resolution, as DMs typically don't need to be marked as resolved.

### Description
**Server-side changes:**
- Added `filterToExcludeDirectMessages` parameter to `PostContextFilterDTO`
- Added `getExcludeDirectMessagesSpecification()` in `MessageSpecs` that filters out posts belonging to `OneToOneChat` or `GroupChat` conversations using JPA criteria type checks
- Chained the new specification in `ConversationMessageRepository.configureSearchSpecification()`

**Client-side changes:**
- Added `filterToExcludeDirectMessages` field to `PostContextFilter` interface and `CourseWideSearchConfig` class
- Added "Exclude DMs" checkbox to the course-wide search filter bar
- Wired the new filter through the form group, context filter building, and HTTP parameter passing
- Added WebSocket message filtering to exclude DMs when the filter is active
- Added English and German translations

**Tests:**
- Added server integration test `testGetMessagesExcludingDirectMessages` that verifies DM posts are excluded when the filter is enabled
- Added client unit test for the new checkbox filter behavior
- Updated existing assertions to include the new filter field

### Steps for Testing
Prerequisites:
- 1 User with access to a course
- The course should have some messages in channels AND some direct messages

1. Log in to Artemis
2. Navigate to a course's communication/messaging section
3. Open the course-wide search (search across all messages)
4. Verify the new "Exclude DMs" checkbox appears in the filter bar alongside existing filters
5. Perform a search without the filter — verify DM messages appear in results
6. Check the "Exclude DMs" checkbox — verify DM messages are excluded from search results
7. Uncheck the "Exclude DMs" checkbox — verify DM messages reappear
8. Test combining with other filters (course-wide, unresolved, reacted) — verify they work together correctly

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a checkbox to exclude direct messages from course-wide conversation search so only channel posts are shown.

* **Backend**
  * Search endpoints now support excluding direct-message conversations to match the new UI filter.

* **Service**
  * Real-time and fetch flows respect the exclude-DM filter to avoid surfacing direct messages when enabled.

* **Tests**
  * Integration and unit tests added/updated to cover the exclude-DM behavior.

* **Localization**
  * Added translations for the new filter label (EN/DE).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->