### PR TITLE
`Communication`: Fix forward message editor hidden after preview/edit switch

### DIFF
--- a/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/monaco/markdown-editor-monaco.component.html
@@ -16,7 +16,7 @@
                     <a ngbNavLink class="btn-sm text-normal px-2 py-0 m-0"><span jhiTranslate="entity.action.edit"></span></a>
                 }
                 <ng-template ngbNavContent>
-                    <div class="markdown-editor markdown-editor-wrapper flex-column" [ngClass]="{ 'd-flex': inEditMode, 'd-none': !inEditMode }">
+                    <div class="markdown-editor markdown-editor-wrapper flex-column d-flex">
                         @if (mode() === 'diff') {
                             @if (renderSideBySide()) {
                                 <!-- Split-view column headers so users know which side is which -->


### PR DESCRIPTION
### Summary

Fix the markdown editor text field being hidden when switching from Preview back to Edit in the forward message dialog.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.

### Motivation and Context

Closes #11796

When forwarding a message and switching between Preview and Edit tabs, the text input field disappears. This is caused by a race condition where the markdown editor's inner wrapper uses a dynamic `[ngClass]` binding to toggle `d-flex`/`d-none` based on `inEditMode`. When switching back to Edit, `onTabShown()` can fire before Angular has updated the `ngClass` binding, causing the editor to be laid out with zero height.

### Description

Replaced the dynamic `[ngClass]="{ 'd-flex': inEditMode, 'd-none': !inEditMode }"` binding on the markdown editor's inner wrapper div with a static `d-flex` class.

The `d-none`/`d-flex` toggle was redundant because the ngbNav pane already controls tab content visibility through the Bootstrap `.tab-pane.active` mechanism. Removing the dynamic binding eliminates the race condition and ensures the editor is always correctly displayed when the Edit tab is active.

### Steps for Testing

Prerequisites:
- 1 User with access to a course with messaging enabled
- At least 1 existing message in a conversation

1. Log in to Artemis
2. Navigate to a conversation with messages
3. Click on a message and select "Forward"
4. In the forward dialog, write something in the text editor (optional)
5. Click the "Preview" tab
6. Click the "Edit" tab
7. Verify the text editor is visible and functional
8. Repeat steps 5-7 multiple times to confirm consistency

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots

Manual screenshots needed — this fix addresses a race condition that is difficult to reproduce in automated screenshots. The expected behavior after the fix matches the "Expected behavior" screenshot in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted markdown editor layout display to consistently show the content wrapper with flex styling across all editing states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->