### PR TITLE
`General`: Fix inconsistent hover styling between Save and Cancel buttons

### DIFF
--- a/src/main/webapp/app/communication/faq/faq-update.component.html
+++ b/src/main/webapp/app/communication/faq/faq-update.component.html
@@ -47,12 +47,12 @@
                         </div>
                     </div>
                 }
-                <div class="d-flex">
-                    <div class="flex-grow-1">
-                        <button type="button" id="cancel-save" class="btn btn-secondary" (click)="previousState()">
+                <div class="d-flex gap-2">
+                    <div class="flex-grow-1 d-flex gap-2">
+                        <button pButton type="button" id="cancel-save" severity="secondary" (click)="previousState()">
                             <fa-icon [icon]="faBan" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
                         </button>
-                        <button type="submit" id="save-entity" [disabled]="!isAllowedToSave || isSaving" class="btn btn-primary">
+                        <button pButton type="submit" id="save-entity" [disabled]="!isAllowedToSave || isSaving">
                             <fa-icon [icon]="faSave" />&nbsp;<span jhiTranslate="entity.action.save"></span>
                         </button>
                     </div>

--- a/src/main/webapp/app/communication/faq/faq-update.component.ts
+++ b/src/main/webapp/app/communication/faq/faq-update.component.ts
@@ -23,13 +23,14 @@ import { FormsModule } from '@angular/forms';
 import { CategorySelectorComponent } from 'app/shared/category-selector/category-selector.component';
 import { MarkdownEditorMonacoComponent } from 'app/shared/markdown-editor/monaco/markdown-editor-monaco.component';
 import { FaqConsistencyComponent } from 'app/communication/faq/faq-consistency.component';
+import { ButtonDirective } from 'primeng/button';
 import { RewriteResult } from 'app/shared/monaco-editor/model/actions/artemis-intelligence/rewriting-result';
 
 @Component({
     selector: 'jhi-faq-update',
     templateUrl: './faq-update.component.html',
     styleUrls: ['./faq-update.component.scss'],
-    imports: [CategorySelectorComponent, MarkdownEditorMonacoComponent, TranslateDirective, FontAwesomeModule, FormsModule, FaqConsistencyComponent],
+    imports: [CategorySelectorComponent, MarkdownEditorMonacoComponent, TranslateDirective, FontAwesomeModule, FormsModule, FaqConsistencyComponent, ButtonDirective],
 })
 export class FaqUpdateComponent implements OnInit {
     private alertService = inject(AlertService);

--- a/src/main/webapp/app/core/admin/organization-management/organization-management-update.component.html
+++ b/src/main/webapp/app/core/admin/organization-management/organization-management-update.component.html
@@ -86,9 +86,11 @@
                     }
                 </div>
             </div>
-            <div>
-                <button type="button" class="btn btn-secondary" (click)="previousState()"><fa-icon [icon]="faBan" />&nbsp;<span jhiTranslate="entity.action.cancel"></span></button>
-                <button type="submit" [disabled]="editForm.form.invalid || isSaving()" class="btn btn-primary">
+            <div class="d-flex gap-2">
+                <button pButton type="button" severity="secondary" (click)="previousState()">
+                    <fa-icon [icon]="faBan" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
+                </button>
+                <button pButton type="submit" [disabled]="editForm.form.invalid || isSaving()">
                     <fa-icon [icon]="faSave" />&nbsp;<span jhiTranslate="entity.action.save"></span>
                 </button>
             </div>

--- a/src/main/webapp/app/core/admin/organization-management/organization-management-update.component.ts
+++ b/src/main/webapp/app/core/admin/organization-management/organization-management-update.component.ts
@@ -8,6 +8,7 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { CustomPatternValidatorDirective } from 'app/shared/validators/custom-pattern-validator.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { AdminTitleBarTitleDirective } from 'app/core/admin/shared/admin-title-bar-title.directive';
+import { ButtonDirective } from 'primeng/button';
 
 /**
  * Admin component for creating and updating organizations.
@@ -15,7 +16,7 @@ import { AdminTitleBarTitleDirective } from 'app/core/admin/shared/admin-title-b
 @Component({
     selector: 'jhi-organization-management-update',
     templateUrl: './organization-management-update.component.html',
-    imports: [FormsModule, TranslateDirective, CustomPatternValidatorDirective, FaIconComponent, AdminTitleBarTitleDirective],
+    imports: [FormsModule, TranslateDirective, CustomPatternValidatorDirective, FaIconComponent, AdminTitleBarTitleDirective, ButtonDirective],
 })
 export class OrganizationManagementUpdateComponent implements OnInit {
     private readonly route = inject(ActivatedRoute);

--- a/src/main/webapp/app/core/course/manage/update/course-update.component.html
+++ b/src/main/webapp/app/core/course/manage/update/course-update.component.html
@@ -534,8 +534,8 @@
                     </div>
                 }
             </div>
-            <div class="mt-3 d-flex">
-                <button type="button" id="cancel-save" class="btn btn-secondary" (click)="previousState()">
+            <div class="mt-3 d-flex gap-2">
+                <button pButton type="button" id="cancel-save" severity="secondary" (click)="previousState()">
                     <fa-icon [icon]="faBan" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
                 </button>
                 @if (courseForm.invalid) {
@@ -546,7 +546,7 @@
                     <ng-container *ngTemplateOutlet="saveButtonTpl" />
                 }
                 <ng-template #saveButtonTpl>
-                    <button type="submit" id="save-entity" [disabled]="courseForm.invalid || isSaving || !isValidConfiguration" class="btn btn-primary ms-2">
+                    <button pButton type="submit" id="save-entity" [disabled]="courseForm.invalid || isSaving || !isValidConfiguration">
                         <fa-icon [icon]="faSave" />&nbsp;<span jhiTranslate="entity.action.save"></span>
                     </button>
                 </ng-template>

--- a/src/main/webapp/app/core/course/manage/update/course-update.component.ts
+++ b/src/main/webapp/app/core/course/manage/update/course-update.component.ts
@@ -43,6 +43,7 @@ import { MarkdownEditorMonacoComponent } from 'app/shared/markdown-editor/monaco
 import { FeatureToggleHideDirective } from 'app/shared/feature-toggle/feature-toggle-hide.directive';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { RemoveKeysPipe } from 'app/shared/pipes/remove-keys.pipe';
+import { ButtonDirective } from 'primeng/button';
 import { FeatureOverlayComponent } from 'app/shared/components/feature-overlay/feature-overlay.component';
 import { FileService } from 'app/shared/service/file.service';
 import { IS_AT_LEAST_ADMIN } from 'app/shared/constants/authority.constants';
@@ -75,6 +76,7 @@ const DEFAULT_CUSTOM_GROUP_NAME = 'artemis-dev';
         // NOTE: this is actually used in the html template, otherwise *jhiHasAnyAuthority would not work
         HasAnyAuthorityDirective,
         RouterLink,
+        ButtonDirective,
     ],
 })
 export class CourseUpdateComponent implements OnInit {

--- a/src/main/webapp/app/exam/manage/exams/update/exam-update.component.html
+++ b/src/main/webapp/app/exam/manage/exams/update/exam-update.component.html
@@ -313,19 +313,16 @@
                 <label for="startText" jhiTranslate="artemisApp.examManagement.confirmationEndText"></label>
                 <jhi-markdown-editor-monaco id="confirmationEndText" class="markdown-editor" [(markdown)]="exam.confirmationEndText" />
             </div>
-            <div>
-                <button type="button" class="btn btn-secondary" (click)="resetToPreviousState()">
+            <div class="d-flex gap-2">
+                <button pButton type="button" severity="secondary" (click)="resetToPreviousState()">
                     <fa-icon [icon]="faBan" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
                 </button>
-                <jhi-button
-                    id="save-exam"
-                    [btnType]="ButtonType.PRIMARY"
-                    [btnSize]="ButtonSize.MEDIUM"
-                    [disabled]="editForm.form.invalid || !isValidConfiguration"
-                    [isLoading]="isSaving"
-                    [icon]="faSave"
-                    [title]="saveTitle"
-                />
+                <button pButton type="submit" id="save-exam" [disabled]="editForm.form.invalid || !isValidConfiguration" [loading]="isSaving">
+                    @if (!isSaving) {
+                        <fa-icon [icon]="faSave" />
+                    }
+                    &nbsp;<span [jhiTranslate]="saveTitle"></span>
+                </button>
 
                 <ng-template #renderedWarning>
                     <div jhiTranslate="artemisApp.examManagement.reviewDatesInvalidExplanation"></div>

--- a/src/main/webapp/app/exam/manage/exams/update/exam-update.component.spec.ts
+++ b/src/main/webapp/app/exam/manage/exams/update/exam-update.component.spec.ts
@@ -37,7 +37,6 @@ import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service
 import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
 import { MODULE_FEATURE_TEXT } from 'app/app.constants';
 import { CalendarService } from 'app/core/calendar/shared/service/calendar.service';
-import { ButtonComponent } from 'app/shared/components/buttons/button/button.component';
 import { By } from '@angular/platform-browser';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { toGradingScaleDTO } from 'app/assessment/shared/entities/grading-scale-dto.model';
@@ -653,27 +652,24 @@ describe('ExamUpdateComponent', () => {
             expect(component.validateWorkingTime).toBeFalse();
         });
 
-        it('should bind correct title into jhi-button and compute correct save title text', () => {
+        it('should compute correct save title text', () => {
             fixture.detectChanges();
             expect(component.saveTitle).toBe('entity.action.save');
-            const button = fixture.debugElement.query(By.directive(ButtonComponent)).componentInstance;
-            expect(button.title()).toBe('entity.action.save');
         });
 
-        it('should bind isSaving into jhi-button isLoading', () => {
+        it('should show loading state on save button when saving', () => {
             fixture.detectChanges();
 
             component.isSaving = true;
             fixture.changeDetectorRef.detectChanges();
 
-            let button = fixture.debugElement.query(By.directive(ButtonComponent)).componentInstance;
-            expect(button.isLoading()).toBeTrue();
+            const button = fixture.debugElement.query(By.css('#save-exam'));
+            expect(button.nativeElement.classList).toContain('p-button-loading');
 
             component.isSaving = false;
             fixture.changeDetectorRef.detectChanges();
 
-            button = fixture.debugElement.query(By.directive(ButtonComponent)).componentInstance;
-            expect(button.isLoading()).toBeFalse();
+            expect(button.nativeElement.classList).not.toContain('p-button-loading');
         });
 
         it('should toggle save button disabled state based on form validity and configuration validity', fakeAsync(() => {
@@ -690,16 +686,16 @@ describe('ExamUpdateComponent', () => {
 
             //Step 1: Test case where the configuration and the form are valid
             expect(component.isValidConfiguration).toBeTrue();
-            let button = fixture.debugElement.query(By.directive(ButtonComponent)).componentInstance;
-            expect(button.disabled()).toBeFalse();
+            let button = fixture.debugElement.query(By.css('#save-exam')).nativeElement;
+            expect(button.disabled).toBeFalse();
 
             // Step 2: Test case where the configuration is invalid
             examWithoutExercises.startDate = now.add(5, 'hours');
             fixture.changeDetectorRef.detectChanges();
 
             expect(component.isValidConfiguration).toBeFalse();
-            button = fixture.debugElement.query(By.directive(ButtonComponent)).componentInstance;
-            expect(button.disabled()).toBeTrue();
+            button = fixture.debugElement.query(By.css('#save-exam')).nativeElement;
+            expect(button.disabled).toBeTrue();
 
             // Step 3: Test case where the configuration is valid again, but the form is invalid
             examWithoutExercises.startDate = now.add(2, 'hours');
@@ -708,8 +704,8 @@ describe('ExamUpdateComponent', () => {
             fixture.changeDetectorRef.detectChanges();
 
             expect(component.isValidConfiguration).toBeTrue();
-            button = fixture.debugElement.query(By.directive(ButtonComponent)).componentInstance;
-            expect(button.disabled()).toBeTrue();
+            button = fixture.debugElement.query(By.css('#save-exam')).nativeElement;
+            expect(button.disabled).toBeTrue();
         }));
 
         it('should open confirmation modal when dates changed for ongoing exam', fakeAsync(() => {
@@ -1141,11 +1137,9 @@ describe('ExamUpdateComponent', () => {
             expect(alertSpy).toHaveBeenCalledOnce();
         });
 
-        it('should bind correct title into jhi-button and compute correct save title text', () => {
+        it('should compute correct save title text for import', () => {
             fixture.detectChanges();
             expect(component.saveTitle).toBe('entity.action.import');
-            const button = fixture.debugElement.query(By.directive(ButtonComponent)).componentInstance;
-            expect(button.title()).toBe('entity.action.import');
         });
     });
 });

--- a/src/main/webapp/app/exam/manage/exams/update/exam-update.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/update/exam-update.component.ts
@@ -29,7 +29,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { FormDateTimePickerComponent } from 'app/shared/date-time-picker/date-time-picker.component';
 import { MarkdownEditorMonacoComponent } from 'app/shared/markdown-editor/monaco/markdown-editor-monaco.component';
 import { CalendarService } from 'app/core/calendar/shared/service/calendar.service';
-import { ButtonComponent, ButtonSize, ButtonType } from 'app/shared/components/buttons/button/button.component';
+import { ButtonDirective } from 'primeng/button';
 import { ConfirmEntityNameComponent } from 'app/shared/confirm-entity-name/confirm-entity-name.component';
 
 @Component({
@@ -49,7 +49,7 @@ import { ConfirmEntityNameComponent } from 'app/shared/confirm-entity-name/confi
         ExamExerciseImportComponent,
         MarkdownEditorMonacoComponent,
         ArtemisTranslatePipe,
-        ButtonComponent,
+        ButtonDirective,
         ConfirmEntityNameComponent,
     ],
 })
@@ -67,8 +67,6 @@ export class ExamUpdateComponent implements OnInit, OnDestroy, AfterViewInit {
     protected readonly faBan = faBan;
     protected readonly faExclamationTriangle = faExclamationTriangle;
     protected readonly documentationType: DocumentationType = 'Exams';
-    protected readonly ButtonType = ButtonType;
-    protected readonly ButtonSize = ButtonSize;
 
     exam: Exam;
     course: Course;

--- a/src/main/webapp/app/exam/manage/exercise-groups/update/exercise-group-update.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/update/exercise-group-update.component.html
@@ -12,9 +12,9 @@
         <ngb-alert [type]="alertType" [dismissible]="false">
             <span jhiTranslate="artemisApp.examManagement.exerciseGroup.titleInfo"></span>
         </ngb-alert>
-        <div class="mt-3">
-            <button type="button" class="btn btn-secondary" (click)="previousState()"><fa-icon [icon]="faBan" />&nbsp;<span jhiTranslate="entity.action.cancel"></span></button>
-            <button type="submit" id="save-group" [disabled]="editForm.form.invalid || isSaving" class="btn btn-primary">
+        <div class="mt-3 d-flex gap-2">
+            <button pButton type="button" severity="secondary" (click)="previousState()"><fa-icon [icon]="faBan" />&nbsp;<span jhiTranslate="entity.action.cancel"></span></button>
+            <button pButton type="submit" id="save-group" [disabled]="editForm.form.invalid || isSaving">
                 <fa-icon [icon]="faSave" />&nbsp;<span jhiTranslate="entity.action.save"></span>
             </button>
         </div>

--- a/src/main/webapp/app/exam/manage/exercise-groups/update/exercise-group-update.component.ts
+++ b/src/main/webapp/app/exam/manage/exercise-groups/update/exercise-group-update.component.ts
@@ -12,11 +12,12 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { FormsModule } from '@angular/forms';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { ButtonDirective } from 'primeng/button';
 
 @Component({
     selector: 'jhi-exercise-group-update',
     templateUrl: './exercise-group-update.component.html',
-    imports: [TranslateDirective, FormsModule, NgbAlert, FaIconComponent],
+    imports: [TranslateDirective, FormsModule, NgbAlert, FaIconComponent, ButtonDirective],
 })
 export class ExerciseGroupUpdateComponent implements OnInit {
     private route = inject(ActivatedRoute);

--- a/src/main/webapp/app/exam/manage/test-runs/create-test-run-modal/create-test-run-modal.component.html
+++ b/src/main/webapp/app/exam/manage/test-runs/create-test-run-modal/create-test-run-modal.component.html
@@ -60,13 +60,12 @@
                 </tbody>
             </table>
         </div>
-        <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" (click)="cancel()" jhiTranslate="global.form.cancel"></button>
+        <div class="modal-footer d-flex gap-2">
+            <button pButton type="button" severity="secondary" (click)="cancel()" jhiTranslate="global.form.cancel"></button>
             <button
+                pButton
                 id="createTestRunButton"
                 type="button"
-                class="btn btn-primary"
-                data-dismiss="modal"
                 [disabled]="!testRunConfigured"
                 (click)="createTestRun()"
                 jhiTranslate="artemisApp.examManagement.testRun.setup"

--- a/src/main/webapp/app/exam/manage/test-runs/create-test-run-modal/create-test-run-modal.component.ts
+++ b/src/main/webapp/app/exam/manage/test-runs/create-test-run-modal/create-test-run-modal.component.ts
@@ -7,13 +7,14 @@ import { ExerciseGroup } from 'app/exam/shared/entities/exercise-group.model';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ArtemisDurationFromSecondsPipe } from 'app/shared/pipes/artemis-duration-from-seconds.pipe';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
+import { ButtonDirective } from 'primeng/button';
 
 @Component({
     selector: 'jhi-create-test-run-modal',
     templateUrl: './create-test-run-modal.component.html',
     providers: [ArtemisDurationFromSecondsPipe],
     styles: ['.table tr.active td { background-color:#3e8acc; color: white; }'],
-    imports: [TranslateDirective, FormsModule, ReactiveFormsModule],
+    imports: [TranslateDirective, FormsModule, ReactiveFormsModule, ButtonDirective],
 })
 export class CreateTestRunModalComponent implements OnInit {
     private activeModal = inject(NgbActiveModal);

--- a/src/main/webapp/app/exercise/external-submission/external-submission-dialog.component.html
+++ b/src/main/webapp/app/exercise/external-submission/external-submission-dialog.component.html
@@ -105,12 +105,8 @@
             <label for="resultRated" class="form-check-label" jhiTranslate="artemisApp.result.rated"></label>
         </div>
     </div>
-    <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="clear()">
-            <fa-icon [icon]="faBan" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
-        </button>
-        <button type="submit" [disabled]="editForm.invalid || isSaving" class="btn btn-primary">
-            <fa-icon [icon]="faSave" />&nbsp;<span jhiTranslate="entity.action.save"></span>
-        </button>
+    <div class="modal-footer d-flex gap-2">
+        <button pButton type="button" severity="secondary" (click)="clear()"><fa-icon [icon]="faBan" />&nbsp;<span jhiTranslate="entity.action.cancel"></span></button>
+        <button pButton type="submit" [disabled]="editForm.invalid || isSaving"><fa-icon [icon]="faSave" />&nbsp;<span jhiTranslate="entity.action.save"></span></button>
     </div>
 </form>

--- a/src/main/webapp/app/exercise/external-submission/external-submission-dialog.component.ts
+++ b/src/main/webapp/app/exercise/external-submission/external-submission-dialog.component.ts
@@ -16,11 +16,12 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { NgClass } from '@angular/common';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { HtmlForMarkdownPipe } from 'app/shared/pipes/html-for-markdown.pipe';
+import { ButtonDirective } from 'primeng/button';
 
 @Component({
     selector: 'jhi-external-submission-dialog',
     templateUrl: './external-submission-dialog.component.html',
-    imports: [FormsModule, TranslateDirective, NgClass, FaIconComponent, HtmlForMarkdownPipe],
+    imports: [FormsModule, TranslateDirective, NgClass, FaIconComponent, HtmlForMarkdownPipe, ButtonDirective],
 })
 export class ExternalSubmissionDialogComponent implements OnInit {
     private externalSubmissionService = inject(ExternalSubmissionService);

--- a/src/main/webapp/app/lecture/manage/lecture-units/create-exercise-unit/create-exercise-unit.component.html
+++ b/src/main/webapp/app/lecture/manage/lecture-units/create-exercise-unit/create-exercise-unit.component.html
@@ -10,12 +10,14 @@
         </div>
         <div class="col-sm-6 mx-auto text-end">
             @if (hasCancelButton()) {
-                <button type="button" (click)="cancelForm()" class="btn btn-secondary"><fa-icon [icon]="faTimes" />&nbsp;<span jhiTranslate="entity.action.cancel"></span></button>
+                <button pButton type="button" severity="secondary" (click)="cancelForm()">
+                    <fa-icon [icon]="faTimes" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
+                </button>
             }
             <button
+                pButton
                 id="createButton"
                 type="button"
-                class="btn btn-primary"
                 [disabled]="exercisesToCreateUnitFor().length === 0"
                 (click)="createExerciseUnits()"
                 jhiTranslate="entity.action.submit"

--- a/src/main/webapp/app/lecture/manage/lecture-units/create-exercise-unit/create-exercise-unit.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/create-exercise-unit/create-exercise-unit.component.ts
@@ -15,12 +15,13 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { SortDirective } from 'app/shared/sort/directive/sort.directive';
 import { SortByDirective } from 'app/shared/sort/directive/sort-by.directive';
+import { ButtonDirective } from 'primeng/button';
 
 @Component({
     selector: 'jhi-create-exercise-unit',
     templateUrl: './create-exercise-unit.component.html',
     styleUrls: ['./create-exercise-unit.component.scss'],
-    imports: [TranslateDirective, FaIconComponent, SortDirective, SortByDirective],
+    imports: [TranslateDirective, FaIconComponent, SortDirective, SortByDirective, ButtonDirective],
 })
 export class CreateExerciseUnitComponent implements OnInit {
     private readonly activatedRoute = inject(ActivatedRoute);

--- a/src/main/webapp/app/lecture/manage/lecture-update/lecture-update.component.html
+++ b/src/main/webapp/app/lecture/manage/lecture-update/lecture-update.component.html
@@ -49,14 +49,14 @@
                         </div>
                     </div>
                     <jhi-lecture-update-period [lecture]="lecture()" [validateDatesFunction]="onDatesValuesChanged" />
-                    <div class="flex-grow-1 d-flex justify-content-end">
-                        <button type="button" id="cancel-save" class="btn btn-secondary" (click)="previousState()">
+                    <div class="flex-grow-1 d-flex justify-content-end gap-2">
+                        <button pButton type="button" id="cancel-save" severity="secondary" (click)="previousState()">
                             <fa-icon [icon]="faBan" class="me-1" /><span jhiTranslate="entity.action.cancel"></span>
                         </button>
                         <button
+                            pButton
                             type="submit"
                             id="save-entity"
-                            class="btn btn-primary ms-2"
                             [disabled]="editForm.form.invalid || isSaving || processUnitMode || !isChangeMadeToTitleOrPeriodSection || !areSectionsValid()"
                         >
                             <fa-icon [icon]="faSave" class="me-1" /><span jhiTranslate="entity.action.save"></span>

--- a/src/main/webapp/app/lecture/manage/lecture-update/lecture-update.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-update/lecture-update.component.ts
@@ -25,6 +25,7 @@ import { DocumentationButtonComponent, DocumentationType } from 'app/shared/comp
 import { SelectButtonModule } from 'primeng/selectbutton';
 import { CheckboxModule } from 'primeng/checkbox';
 import { TooltipModule } from 'primeng/tooltip';
+import { ButtonDirective } from 'primeng/button';
 import { TranslateService } from '@ngx-translate/core';
 import { CalendarService } from 'app/core/calendar/shared/service/calendar.service';
 import { CourseTitleBarTitleDirective } from 'app/core/course/shared/directives/course-title-bar-title.directive';
@@ -65,6 +66,7 @@ interface CreateLectureOption {
         CheckboxModule,
         TooltipModule,
         CourseTitleBarTitleDirective,
+        ButtonDirective,
     ],
 })
 export class LectureUpdateComponent implements OnInit, OnDestroy, LectureUnsavedChangesComponent {

--- a/src/main/webapp/app/quiz/manage/re-evaluate/warning/quiz-re-evaluate-warning.component.html
+++ b/src/main/webapp/app/quiz/manage/re-evaluate/warning/quiz-re-evaluate-warning.component.html
@@ -98,19 +98,17 @@
         &nbsp;
         <div class="form-group">
             @if (!successful) {
-                <button [disabled]="busy" type="button" class="btn btn-secondary" data-dismiss="modal" (click)="clear()">
+                <button pButton [disabled]="busy" type="button" severity="secondary" (click)="clear()">
                     <fa-icon [icon]="faBan" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
                 </button>
             }
             @if (!successful && !failed) {
-                <button [disabled]="busy" type="submit" (click)="confirmChange()" class="btn btn-primary">
+                <button pButton [disabled]="busy" type="submit" (click)="confirmChange()">
                     <fa-icon [icon]="faCheckCircle" />&nbsp;<span jhiTranslate="artemisApp.quizExercise.re-evaluate.warning.confirm"></span>
                 </button>
             }
             @if (successful && !failed) {
-                <button type="submit" (click)="closeAndNavigate()" class="btn btn-primary">
-                    <fa-icon [icon]="faCheckCircle" />&nbsp;<span jhiTranslate="entity.action.close"></span>
-                </button>
+                <button pButton type="submit" (click)="closeAndNavigate()"><fa-icon [icon]="faCheckCircle" />&nbsp;<span jhiTranslate="entity.action.close"></span></button>
             }
         </div>
     </div>

--- a/src/main/webapp/app/quiz/manage/re-evaluate/warning/quiz-re-evaluate-warning.component.ts
+++ b/src/main/webapp/app/quiz/manage/re-evaluate/warning/quiz-re-evaluate-warning.component.ts
@@ -11,12 +11,13 @@ import { faBan, faCheck, faCheckCircle, faSpinner, faTimes } from '@fortawesome/
 import { ArtemisNavigationUtilService } from 'app/shared/util/navigation.utils';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { ButtonDirective } from 'primeng/button';
 
 @Component({
     selector: 'jhi-quiz-re-evaluate-warning',
     templateUrl: './quiz-re-evaluate-warning.component.html',
     styleUrls: ['../../../shared/quiz.scss'],
-    imports: [TranslateDirective, FaIconComponent],
+    imports: [TranslateDirective, FaIconComponent, ButtonDirective],
 })
 export class QuizReEvaluateWarningComponent implements OnInit {
     private activeModal = inject(NgbActiveModal);


### PR DESCRIPTION
### Summary

Migrate Save/Cancel button pairs from Bootstrap `btn` classes to PrimeNG `pButton` directive across 10 components. Bootstrap buttons had inconsistent hover behavior where Cancel buttons darkened but Save buttons lightened on hover. PrimeNG buttons provide consistent hover styling through the Aura theme system, and this migration aligns with the project convention to use PrimeNG instead of Bootstrap for new UI components.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes #11769

The Save and Cancel buttons across many forms in Artemis had inconsistent hover styling: Cancel buttons (Bootstrap `btn-secondary`) became darker on hover, while Save buttons (using the `jhi-button` component with Bootstrap `btn-primary`) became lighter. This visual inconsistency was reported by multiple users. The root cause is that Bootstrap and the `jhi-button` component applied different styling mechanisms for primary vs secondary buttons.

### Description

Replaced Bootstrap button markup with PrimeNG `pButton` directive in 10 components:

- **exam-update** - Exam create/edit page
- **exercise-group-update** - Exercise group create/edit page
- **lecture-update** - Lecture create/edit page
- **course-update** - Course create/edit page
- **create-test-run-modal** - Test run creation modal
- **faq-update** - FAQ create/edit page
- **organization-management-update** - Organization management page
- **external-submission-dialog** - External submission modal
- **create-exercise-unit** - Exercise unit creation page
- **quiz-re-evaluate-warning** - Quiz re-evaluation warning dialog

For each component:
1. Replaced `<button class="btn btn-default/btn-secondary">` and `<jhi-button>` with `<button pButton>` and `<button pButton severity="secondary">`
2. Added `ButtonDirective` import from `primeng/button` to the component's TypeScript file and `imports` array
3. Updated related tests (exam-update.component.spec.ts) to work with PrimeNG buttons

### Steps for Testing

Prerequisites:
- 1 Instructor account

1. Log in as an instructor
2. Navigate to **Course Management > Create New Course** — verify Cancel and Save buttons have consistent hover styling (both darken slightly on hover)
3. Navigate to **Exam Management > Create New Exam** — verify Cancel and Save buttons hover consistently
4. Navigate to **Lecture Management > Create New Lecture** — verify Cancel and Save buttons hover consistently
5. Open any quiz > Re-evaluate — verify Cancel and Confirm buttons hover consistently
6. Repeat for the other affected pages (exercise group edit, FAQ edit, organization management, test run modal, external submission dialog, exercise unit creation)
7. Verify all button pairs look consistent in **both light and dark themes**

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| faq-update.component.ts | 98.59% | 166 | 22 | 13.3 |
| organization-management-update.component.ts | 89.28% | 62 | 6 | 9.7 |
| course-update.component.ts | 91.42% | 545 | 239 | 43.9 |
| exam-update.component.ts | 93.77% | 415 | 185 | 44.6 |
| exercise-group-update.component.ts | 100.00% | 66 | 11 | 16.7 |
| create-test-run-modal.component.ts | 97.22% | 79 | 13 | 16.5 |
| external-submission-dialog.component.ts | 100.00% | 79 | 23 | 29.1 |
| create-exercise-unit.component.ts | 85.18% | 114 | 8 | 7.0 |
| lecture-update.component.ts | 90.00% | 330 | 37 | 11.2 |
| quiz-re-evaluate-warning.component.ts | 100.00% | 172 | 34 | 19.8 |

_Last updated: 2026-04-28 02:39:31 UTC_


### Screenshots

**Course Settings - Cancel and Save buttons (PrimeNG pButton)**
![Course settings buttons](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/5d70b80d-2ea1-4b82-8d60-52885aca5773.png)

**Exam Creation - Cancel and Save buttons (PrimeNG pButton)**
![Exam creation buttons](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/c2f4f3d3-b801-4883-8276-86f7e166440d.png)