### PR TITLE
`General`: Document course user management for instructors

### DIFF
--- a/documentation/docs/instructor/course-management/index.mdx
+++ b/documentation/docs/instructor/course-management/index.mdx
@@ -7,5 +7,6 @@ Set up and manage your Artemis courses, import content from existing courses, an
 |------|-------------|
 | [Course Requests](/instructor/course-management/course-requests) | Request a new course and learn about the approval process |
 | [Course Configuration](/instructor/course-management/course-configuration) | Configure course settings, enable features, and set up enrollment |
+| [User Management](/instructor/course-management/user-management) | Add and remove students, tutors, editors, and instructors individually or via CSV import |
 | [Import from Course](/instructor/course-management/import-from-course) | Import exercises, lectures, and other content from an existing course |
 | [Exports](/instructor/course-management/exports) | Export course data such as scores, results, and submissions |

--- a/documentation/docs/instructor/course-management/user-management.mdx
+++ b/documentation/docs/instructor/course-management/user-management.mdx
@@ -1,0 +1,93 @@
+---
+title: User Management
+sidebar_label: User Management
+---
+
+import Callout from "../../../src/components/Callout/Callout";
+import {CalloutVariant} from "../../../src/components/Callout/Callout.types";
+
+# User Management
+
+Each course has four participant groups: **Students**, **Tutors**, **Editors**, and **Instructors**. Users can be added one at a time or imported in bulk from a CSV file. See [Access Rights](/admin/access-rights) for the permissions associated with each role.
+
+<Callout variant={CalloutVariant.info}>
+Only users with the **Instructor** role on the course can add or remove participants. Tutors and Editors can view the lists but not modify them.
+</Callout>
+
+---
+
+## Opening User Management
+
+Open the **Course Management** view and select your course. You can reach the user management screens in two ways:
+
+- **Quick Actions**: Use the **User Management** dropdown in the Quick Actions bar and select the role you want to manage (Add Student, Add Tutor, Add Editor, Add Instructor). Next to the dropdown, the participant counters (Students, Tutors, Editors, Instructors) link directly to the corresponding management page.
+- **Direct URL**: Navigate to `/course-management/<course-id>/groups/<group>`, where `<group>` is one of `students`, `tutors`, `editors`, or `instructors` (e.g. `/course-management/42/groups/students`).
+
+Each page lists the current members of the selected group together with their ID, profile picture, login, registration number, full name, and email address. You can search the list with the search field at the top and sort by any column header.
+
+---
+
+## Adding a Single User
+
+1. Open the management page for the role you want to assign (Students, Tutors, Editors, or Instructors).
+2. Type the user's **login** or **name** into the search field at the top of the participant table. Matching users are suggested as you type.
+3. Select the desired user from the suggestion list. The user is added to the group immediately and appears in the table.
+
+To assign multiple roles to the same user (for example, a teaching assistant who is also enrolled as a student), repeat the steps on the corresponding management pages.
+
+<Callout variant={CalloutVariant.info}>
+The user must already exist in Artemis. If they have never logged in, they need to be created first either through self-registration, single sign-on, or by an administrator. See [User Registration](/admin/user-registration) for details.
+</Callout>
+
+---
+
+## Importing Multiple Users via CSV
+
+To add many users at once, click the **Import Users** button at the top of any role's management page. A dialog opens where you can upload a CSV file.
+
+### CSV Format
+
+The first row of the file must contain headers. Each subsequent row must contain a value for **at least one** of `login`, `registration number`, or `email` &mdash; this is what Artemis uses to look up the existing user account. Additional columns are optional.
+
+| Column                | Accepted header names                                                  | Required |
+|-----------------------|------------------------------------------------------------------------|----------|
+| Login                 | `login`, `user`, `username`, `benutzer`, `benutzername`                | Yes\*    |
+| Registration number   | `registrationnumber`, `matriculationnumber`, `matrikelnummer`, `number`| Yes\*    |
+| Email                 | `email`, `e-mail`, `mail`                                              | Yes\*    |
+| First name            | `firstname`, `firstnameofstudent`, `givenname`, `forename`, `vorname`  | No       |
+| Last name             | `familyname`, `lastname`, `familynameofstudent`, `surname`, `nachname`, `familienname`, `name` | No |
+
+\* At least one of *Login*, *Registration number*, or *Email* must be present in each row. Headers are case-insensitive and ignore spaces and underscores.
+
+### Example
+
+```csv
+login,email,registrationnumber,firstname,lastname
+user_1,,,Alice,Smith
+,user_2@artemis.org,,Bob,Jones
+,,11712345,Carol,Müller
+```
+
+After selecting the CSV file, Artemis displays a preview of the parsed users. Click **Import** to add them to the selected role. The dialog reports how many users were imported successfully and how many were not found.
+
+<Callout variant={CalloutVariant.warning}>
+Registration numbers in spreadsheets are often interpreted as numbers, which strips leading zeros (e.g. `01234567` becomes `1234567`). Format the column as **text** in your spreadsheet application before exporting to CSV, otherwise lookups by registration number may fail.
+</Callout>
+
+<Callout variant={CalloutVariant.info}>
+Users that cannot be matched to an existing Artemis account are reported under **Not found** at the end of the import. They are not created automatically. Verify their identifier (login, registration number, or email) and ensure they have an account before re-importing.
+</Callout>
+
+---
+
+## Removing a User
+
+On any role's management page, click the **Remove** button (trash icon) in the user's row. Confirm the action in the dialog. The user is removed from this group, but their existing submissions, results, and participations are preserved.
+
+Removing a user from one group does not affect their membership in other groups of the same course. For example, removing a user from *Tutors* does not remove them from *Students*.
+
+---
+
+## Exporting Participants
+
+To export the current list of a role, open its management page and click the **Export CSV** button at the top right. The download contains the displayed columns (ID, login, registration number, name, email) for every user currently in the group.

--- a/documentation/sidebar-instructors.ts
+++ b/documentation/sidebar-instructors.ts
@@ -13,6 +13,7 @@ const sidebars: SidebarsConfig = {
             items: [
                 'course-management/course-requests',
                 'course-management/course-configuration',
+                'course-management/user-management',
                 'course-management/import-from-course',
                 'course-management/exports',
             ],


### PR DESCRIPTION
### Summary
Adds a dedicated **User Management** documentation page under `instructor/course-management/` covering how instructors add, remove, and import course participants (Students, Tutors, Editors, Instructors).

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
Closes #10313

The instructor documentation under `course-management/` did not explain how instructors actually manage course participants. The admin docs only mentioned that "Students, Tutors, Editors and Instructors can be added via Course Details" without describing the process. Instructors had no on-platform reference for individual role assignment or the bulk CSV import flow that the UI exposes via the **User Management** dropdown and the **Import Users** dialog.

### Description
- Adds `documentation/docs/instructor/course-management/user-management.mdx` with sections on:
  - Participant groups and which role can manage them (with a link to `/admin/access-rights`).
  - Two ways to reach the management screens (Quick Actions dropdown vs. the `/course-management/<id>/groups/<group>` URL pattern).
  - Adding a single user via the search field.
  - Importing many users via CSV — including a complete table of accepted header names (mirroring `read-users-from-csv.ts`), the "at least one of login/registration number/email" rule, an example CSV, leading-zero warning for spreadsheet exports, and "not found" behavior.
  - Removing users (preserving submissions) and exporting the participant list.
- Adds the new page to `documentation/docs/instructor/course-management/index.mdx` and to `documentation/sidebar-instructors.ts` so it appears in the sidebar in the natural reading order.

The PR is intentionally narrow — only documentation files. Note: a previous attempt at this issue (#12211) was closed by `@bassner` after going out of scope. This PR keeps the change tightly focused on the issue's two acceptance criteria (individual role assignment + import feature).

### Steps for Testing
Prerequisites:
- Local Docusaurus build environment (`documentation/`)

1. `cd documentation && npm install`
2. `npx docusaurus start` — open the instructor docs.
3. Verify **Course Management → User Management** appears in the left sidebar between *Course Configuration* and *Import from Course*.
4. Open the page and verify:
   - The role/permissions paragraph and Instructor-only callout render.
   - The CSV format table renders with the `Yes*/No` column and the footnote below clarifies the asterisk.
   - The example CSV code block renders correctly.
   - The two callouts (leading-zero warning, not-found info) render with the correct variants.
   - Internal links (`/admin/access-rights`, `/admin/user-registration`) resolve.
5. From `course-management/index.mdx`, click the new **User Management** row and confirm the link opens the new page.

### Screenshots
Documentation-only change — no UI screenshots required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new User Management guide for instructors covering participant roles and permissions, individual and bulk user management (CSV import/export), and user removal workflows with data preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->