### PR TITLE
`Development`: Improve server code

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Result.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Result.java
@@ -9,7 +9,6 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -306,30 +305,12 @@ public class Result extends DomainObject implements Comparable<Result> {
      * <p>
      * Returned as a {@link Set} on purpose: feedback ordering is not semantically meaningful for the
      * domain. Callers that need a specific presentation order (by credits, FeedbackType, reference, ...)
-     * should sort explicitly via {@link #getFeedbacksSorted()} or a custom comparator.
+     * should sort explicitly with a custom comparator.
      *
      * @return the live {@link Set} of feedbacks; mutations are persisted by the Hibernate session
      */
     public Set<Feedback> getFeedbacks() {
         return feedbacks;
-    }
-
-    /**
-     * Convenience accessor that returns a snapshot of the feedbacks sorted by id (insertion order under
-     * the IDENTITY generator). Use when a deterministic ordering is required for tests, JSON output, or
-     * comparison logic.
-     * <p>
-     * Marked {@link JsonIgnore}: Jackson would otherwise auto-detect this getter as a "feedbacksSorted"
-     * JSON property and iterate the underlying {@link Set}, triggering a {@link org.hibernate.LazyInitializationException}
-     * when the set is an uninitialized {@code PersistentSet} and the Hibernate session has already closed.
-     * Serialization goes through the {@code feedbacks} field, which is correctly handled by the
-     * {@link com.fasterxml.jackson.datatype.hibernate7.Hibernate7Module} via {@code REPLACE_PERSISTENT_COLLECTIONS}.
-     *
-     * @return a new list containing the feedbacks sorted by id (nulls last)
-     */
-    @JsonIgnore
-    public List<Feedback> getFeedbacksSorted() {
-        return feedbacks.stream().filter(Objects::nonNull).sorted(Comparator.comparing(Feedback::getId, Comparator.nullsLast(Comparator.naturalOrder()))).toList();
     }
 
     public Result feedbacks(Collection<Feedback> feedbacks) {

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ExampleSubmissionRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ExampleSubmissionRepository.java
@@ -3,7 +3,6 @@ package de.tum.cit.aet.artemis.assessment.repository;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphType.LOAD;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -64,24 +63,24 @@ public interface ExampleSubmissionRepository extends ArtemisJpaRepository<Exampl
      * Given the id of an example submission, it returns the results of the linked submission, if any
      *
      * @param exampleSubmissionId the id of the example submission we want to retrieve
-     * @return list of feedback for an example submission
+     * @return set of feedback for an example submission
      */
-    default List<Feedback> getFeedbackForExampleSubmission(long exampleSubmissionId) {
+    default Set<Feedback> getFeedbackForExampleSubmission(long exampleSubmissionId) {
         var exampleSubmission = getValueElseThrow(findByIdWithResultsAndFeedback(exampleSubmissionId), exampleSubmissionId);
         var submission = exampleSubmission.getSubmission();
 
         if (submission == null) {
-            return List.of();
+            return Set.of();
         }
 
         Result result = submission.getLatestResult();
 
         // result.isExampleResult() can have 3 values: null, false, true. We return if it is not true
         if (result == null || !Boolean.TRUE.equals(result.isExampleResult())) {
-            return List.of();
+            return Set.of();
         }
 
-        return result.getFeedbacksSorted();
+        return result.getFeedbacks();
     }
 
     default ExampleSubmission findByIdWithEagerResultAndFeedbackElseThrow(long exampleSubmissionId) {

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/TutorParticipationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/TutorParticipationService.java
@@ -7,6 +7,7 @@ import static de.tum.cit.aet.artemis.tutorialgroup.domain.TutorParticipationStat
 import static de.tum.cit.aet.artemis.tutorialgroup.domain.TutorParticipationStatus.REVIEWED_INSTRUCTIONS;
 import static de.tum.cit.aet.artemis.tutorialgroup.domain.TutorParticipationStatus.TRAINED;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -147,7 +148,7 @@ public class TutorParticipationService {
         return Optional.empty();
     }
 
-    private Optional<FeedbackCorrectionErrorType> checkTutorFeedbackForErrors(Feedback tutorFeedback, List<Feedback> instructorFeedback) {
+    private Optional<FeedbackCorrectionErrorType> checkTutorFeedbackForErrors(Feedback tutorFeedback, Collection<Feedback> instructorFeedback) {
         List<Feedback> matchingInstructorFeedback = instructorFeedback.stream().filter(feedback -> {
             // If tutor feedback is unreferenced, then instructor feedback is a potential match if it is also unreferenced
             if (tutorFeedback.getType() == MANUAL_UNREFERENCED) {

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/TutorParticipationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/TutorParticipationService.java
@@ -8,7 +8,6 @@ import static de.tum.cit.aet.artemis.tutorialgroup.domain.TutorParticipationStat
 import static de.tum.cit.aet.artemis.tutorialgroup.domain.TutorParticipationStatus.TRAINED;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -149,11 +148,12 @@ public class TutorParticipationService {
         return Optional.empty();
     }
 
-    private Optional<FeedbackCorrectionErrorType> checkTutorFeedbackForErrors(Feedback tutorFeedback, Collection<Feedback> instructorFeedback) {
-        // The MANUAL_UNREFERENCED branch below mutates instructorFeedback via remove(...) to track which instructor feedbacks are still
-        // available for matching. Callers may pass an immutable view (Set.of()) or a Hibernate-managed PersistentSet (from
-        // result.getFeedbacks()) — mutating either is unsafe. Work on a defensive copy so removals stay local to this validation pass.
-        List<Feedback> remainingInstructorFeedback = new ArrayList<>(instructorFeedback);
+    /**
+     * The {@code remainingInstructorFeedback} list MUST be shared across successive calls for the same tutor example submission, because the
+     * MANUAL_UNREFERENCED branch below removes already-matched instructor feedbacks so they can't match a second tutor feedback. Callers therefore
+     * pass a mutable defensive copy (typically built from {@code result.getFeedbacks()} / the example-submission feedback set) once and reuse it.
+     */
+    private Optional<FeedbackCorrectionErrorType> checkTutorFeedbackForErrors(Feedback tutorFeedback, List<Feedback> remainingInstructorFeedback) {
         List<Feedback> matchingInstructorFeedback = remainingInstructorFeedback.stream().filter(feedback -> {
             // If tutor feedback is unreferenced, then instructor feedback is a potential match if it is also unreferenced
             if (tutorFeedback.getType() == MANUAL_UNREFERENCED) {
@@ -212,12 +212,16 @@ public class TutorParticipationService {
         var unreferencedInstructorFeedbackCount = instructorFeedback.stream().filter(feedback -> feedback.getType() == MANUAL_UNREFERENCED).toList().size();
         var unreferencedTutorFeedback = tutorFeedback.stream().filter(feedback -> feedback.getType() == MANUAL_UNREFERENCED).toList();
 
+        // Build a single mutable defensive copy that checkTutorFeedbackForErrors can prune as it consumes MANUAL_UNREFERENCED matches across tutor feedbacks.
+        // Mutating the original (a Hibernate-managed PersistentSet from result.getFeedbacks() or an immutable Set.of()) would be unsafe.
+        var remainingInstructorFeedback = new ArrayList<>(instructorFeedback);
+
         // If invalid, get all incorrect feedback and send an array of the corresponding `FeedbackCorrectionError`s to the client.
         var wrongFeedback = tutorFeedback.stream().flatMap(feedback -> {
             // If current tutor feedback is unreferenced and there are already more than enough unreferenced feedback provided, mark this feedback as unnecessary.
             var unreferencedTutorFeedbackCount = unreferencedTutorFeedback.indexOf(feedback) + 1;
             var validationError = unreferencedTutorFeedbackCount > unreferencedInstructorFeedbackCount ? Optional.of(UNNECESSARY_FEEDBACK)
-                    : checkTutorFeedbackForErrors(feedback, instructorFeedback);
+                    : checkTutorFeedbackForErrors(feedback, remainingInstructorFeedback);
             if (validationError.isEmpty()) {
                 return Stream.empty();
             }

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/TutorParticipationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/TutorParticipationService.java
@@ -7,6 +7,7 @@ import static de.tum.cit.aet.artemis.tutorialgroup.domain.TutorParticipationStat
 import static de.tum.cit.aet.artemis.tutorialgroup.domain.TutorParticipationStatus.REVIEWED_INSTRUCTIONS;
 import static de.tum.cit.aet.artemis.tutorialgroup.domain.TutorParticipationStatus.TRAINED;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -149,7 +150,11 @@ public class TutorParticipationService {
     }
 
     private Optional<FeedbackCorrectionErrorType> checkTutorFeedbackForErrors(Feedback tutorFeedback, Collection<Feedback> instructorFeedback) {
-        List<Feedback> matchingInstructorFeedback = instructorFeedback.stream().filter(feedback -> {
+        // The MANUAL_UNREFERENCED branch below mutates instructorFeedback via remove(...) to track which instructor feedbacks are still
+        // available for matching. Callers may pass an immutable view (Set.of()) or a Hibernate-managed PersistentSet (from
+        // result.getFeedbacks()) — mutating either is unsafe. Work on a defensive copy so removals stay local to this validation pass.
+        List<Feedback> remainingInstructorFeedback = new ArrayList<>(instructorFeedback);
+        List<Feedback> matchingInstructorFeedback = remainingInstructorFeedback.stream().filter(feedback -> {
             // If tutor feedback is unreferenced, then instructor feedback is a potential match if it is also unreferenced
             if (tutorFeedback.getType() == MANUAL_UNREFERENCED) {
                 return feedback.getType() == MANUAL_UNREFERENCED;
@@ -171,7 +176,7 @@ public class TutorParticipationService {
 
                 // This instructor feedback can not be used to match other tutor unreferenced feedback
                 if (isMatch) {
-                    instructorFeedback.remove(feedback);
+                    remainingInstructorFeedback.remove(feedback);
                 }
                 return isMatch;
             });

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
@@ -425,12 +425,12 @@ public class SubmissionService {
      *
      * @param newResult new result to copy feedback to
      * @param oldResult old result to copy feedback from
-     * @return the list of newly created feedbacks
+     * @return the set of newly created feedbacks
      */
-    public List<Feedback> copyFeedbackToNewResult(Result newResult, Result oldResult) {
+    public Set<Feedback> copyFeedbackToNewResult(Result newResult, Result oldResult) {
         Collection<Feedback> oldFeedback = oldResult.getFeedbacks();
         copyFeedbackToResult(newResult, oldFeedback);
-        return newResult.getFeedbacksSorted();
+        return newResult.getFeedbacks();
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisMessageRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisMessageRepository.java
@@ -21,7 +21,7 @@ import de.tum.cit.aet.artemis.iris.domain.message.IrisMessage;
 @Conditional(IrisEnabled.class)
 public interface IrisMessageRepository extends ArtemisJpaRepository<IrisMessage, Long> {
 
-    List<IrisMessage> findAllBySessionId(long sessionId);
+    List<IrisMessage> findAllBySessionIdOrderBySentAtAsc(long sessionId);
 
     /**
      * Counts the number of LLM responses the user got within the given timeframe.

--- a/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisMessageRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/repository/IrisMessageRepository.java
@@ -21,7 +21,7 @@ import de.tum.cit.aet.artemis.iris.domain.message.IrisMessage;
 @Conditional(IrisEnabled.class)
 public interface IrisMessageRepository extends ArtemisJpaRepository<IrisMessage, Long> {
 
-    List<IrisMessage> findAllBySessionIdOrderBySentAtAsc(long sessionId);
+    List<IrisMessage> findAllBySessionIdOrderBySentAtAscIdAsc(long sessionId);
 
     /**
      * Counts the number of LLM responses the user got within the given timeframe.

--- a/src/main/java/de/tum/cit/aet/artemis/iris/web/IrisMessageResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/web/IrisMessageResource.java
@@ -89,7 +89,7 @@ public class IrisMessageResource {
         IrisSession session = irisSessionRepository.findByIdElseThrow(sessionId);
         irisSessionService.checkIsIrisActivated(session);
         irisSessionService.checkHasAccessToIrisSession(session, null);
-        var messages = irisMessageRepository.findAllBySessionId(sessionId);
+        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(sessionId);
         return ResponseEntity.ok(messages.stream().map(IrisMessageResponseDTO::of).toList());
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/iris/web/IrisMessageResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/web/IrisMessageResource.java
@@ -89,7 +89,7 @@ public class IrisMessageResource {
         IrisSession session = irisSessionRepository.findByIdElseThrow(sessionId);
         irisSessionService.checkIsIrisActivated(session);
         irisSessionService.checkHasAccessToIrisSession(session, null);
-        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(sessionId);
+        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAscIdAsc(sessionId);
         return ResponseEntity.ok(messages.stream().map(IrisMessageResponseDTO::of).toList());
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/dto/ResultDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/dto/ResultDTO.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.programming.dto;
 
 import java.io.Serializable;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.List;
 
 import org.hibernate.Hibernate;
@@ -50,7 +51,7 @@ public record ResultDTO(Long id, ZonedDateTime completionDate, Boolean successfu
     }
 
     public static ResultDTO of(Result result) {
-        return of(result, result.getFeedbacksSorted());
+        return of(result, result.getFeedbacks());
     }
 
     /**
@@ -60,7 +61,7 @@ public record ResultDTO(Long id, ZonedDateTime completionDate, Boolean successfu
      * @param filteredFeedback feedback that should get send to the client, will get converted into {@link FeedbackDTO} objects.
      * @return the converted DTO
      */
-    public static ResultDTO of(Result result, List<Feedback> filteredFeedback) {
+    public static ResultDTO of(Result result, Collection<Feedback> filteredFeedback) {
         SubmissionDTO submissionDTO = null;
         if (Hibernate.isInitialized(result.getSubmission()) && result.getSubmission() != null) {
             submissionDTO = SubmissionDTO.of(result.getSubmission(), false, null, null);

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/ExampleSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/ExampleSubmissionIntegrationTest.java
@@ -351,10 +351,11 @@ class ExampleSubmissionIntegrationTest extends AbstractSpringIntegrationIndepend
         assertThat(exampleSubmission.getId()).isNotNull();
         assertThat(((TextSubmission) exampleSubmission.getSubmission()).getText()).isEqualTo(submission.getText());
         assertThat(exampleSubmission.getSubmission().getLatestResult().getFeedbacks()).isNotEmpty();
-        assertThat(exampleSubmission.getSubmission().getLatestResult().getFeedbacksSorted().getFirst().getCredits()).isEqualTo(feedback.getCredits());
+        Feedback importedFeedback = exampleSubmission.getSubmission().getLatestResult().getFeedbacks().iterator().next();
+        assertThat(importedFeedback.getCredits()).isEqualTo(feedback.getCredits());
         assertThat(copiedTextBlocks).isNotEmpty();
         assertThat(copiedTextBlocks.getFirst().getText()).isEqualTo(textBlock.getText());
-        assertThat(exampleSubmission.getSubmission().getLatestResult().getFeedbacksSorted().getFirst().getReference()).isEqualTo(copiedTextBlocks.getFirst().getId());
+        assertThat(importedFeedback.getReference()).isEqualTo(copiedTextBlocks.getFirst().getId());
     }
 
     @Test
@@ -390,8 +391,8 @@ class ExampleSubmissionIntegrationTest extends AbstractSpringIntegrationIndepend
         Optional<Result> orginalResult = resultRepository.findDistinctWithFeedbackBySubmissionId(originalSubmission.getId());
 
         ExampleSubmission exampleSubmission = importExampleSubmission(exercise.getId(), originalSubmission.getId(), HttpStatus.OK);
-        assertThat(exampleSubmission.getSubmission().getResults().getFirst().getFeedbacksSorted().getFirst().getGradingInstruction().getId())
-                .isEqualTo(orginalResult.orElseThrow().getFeedbacksSorted().getFirst().getGradingInstruction().getId());
+        assertThat(exampleSubmission.getSubmission().getResults().getFirst().getFeedbacks().iterator().next().getGradingInstruction().getId())
+                .isEqualTo(orginalResult.orElseThrow().getFeedbacks().iterator().next().getGradingInstruction().getId());
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
@@ -60,6 +60,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.assessment.domain.BonusStrategy;
+import de.tum.cit.aet.artemis.assessment.domain.Feedback;
 import de.tum.cit.aet.artemis.assessment.domain.GradeType;
 import de.tum.cit.aet.artemis.assessment.domain.GradingScale;
 import de.tum.cit.aet.artemis.assessment.domain.Result;
@@ -1098,8 +1099,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
                     assertThat(result.getScore()).isZero();
                     assertThat(result.getAssessmentType()).isEqualTo(AssessmentType.SEMI_AUTOMATIC);
                     result = resultRepository.findByIdWithEagerFeedbacks(result.getId()).orElseThrow();
-                    assertThat(result.getFeedbacks()).isNotEmpty();
-                    assertThat(result.getFeedbacks().iterator().next().getDetailText()).isEqualTo("You did not submit your exam");
+                    assertThat(result.getFeedbacks()).extracting(Feedback::getDetailText).containsExactly("You did not submit your exam");
                 }
                 else {
                     fail("StudentParticipation which is part of an unsubmitted StudentExam contains no submission or result after automatic assessment of unsubmitted student exams call.");
@@ -1134,8 +1134,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
                         assertThat(result.getScore()).isZero();
                         assertThat(result.getAssessmentType()).isEqualTo(AssessmentType.SEMI_AUTOMATIC);
                         result = resultRepository.findByIdWithEagerFeedbacks(result.getId()).orElseThrow();
-                        assertThat(result.getFeedbacks()).isNotEmpty();
-                        assertThat(result.getFeedbacks().iterator().next().getDetailText()).isEqualTo("You did not submit your exam");
+                        assertThat(result.getFeedbacks()).extracting(Feedback::getDetailText).containsExactly("You did not submit your exam");
                     }
                 }
                 else {
@@ -1176,8 +1175,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
                     assertThat(result.getScore()).isZero();
                     assertThat(result.getAssessmentType()).isEqualTo(AssessmentType.SEMI_AUTOMATIC);
                     result = resultRepository.findByIdWithEagerFeedbacks(result.getId()).orElseThrow();
-                    assertThat(result.getFeedbacks()).isNotEmpty();
-                    assertThat(result.getFeedbacks().iterator().next().getDetailText()).isEqualTo("Empty submission");
+                    assertThat(result.getFeedbacks()).extracting(Feedback::getDetailText).containsExactly("Empty submission");
                 }
                 else {
                     fail("StudentParticipation which is part of an unsubmitted StudentExam contains no submission or result after automatic assessment of unsubmitted student exams call.");
@@ -1218,8 +1216,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
                         assertThat(result.getScore()).isZero();
                         assertThat(result.getAssessmentType()).isEqualTo(AssessmentType.SEMI_AUTOMATIC);
                         result = resultRepository.findByIdWithEagerFeedbacks(result.getId()).orElseThrow();
-                        assertThat(result.getFeedbacks()).isNotEmpty();
-                        assertThat(result.getFeedbacks().iterator().next().getDetailText()).isEqualTo("Empty submission");
+                        assertThat(result.getFeedbacks()).extracting(Feedback::getDetailText).containsExactly("Empty submission");
                     }
                 }
                 else {

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
@@ -1099,7 +1099,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
                     assertThat(result.getAssessmentType()).isEqualTo(AssessmentType.SEMI_AUTOMATIC);
                     result = resultRepository.findByIdWithEagerFeedbacks(result.getId()).orElseThrow();
                     assertThat(result.getFeedbacks()).isNotEmpty();
-                    assertThat(result.getFeedbacksSorted().getFirst().getDetailText()).isEqualTo("You did not submit your exam");
+                    assertThat(result.getFeedbacks().iterator().next().getDetailText()).isEqualTo("You did not submit your exam");
                 }
                 else {
                     fail("StudentParticipation which is part of an unsubmitted StudentExam contains no submission or result after automatic assessment of unsubmitted student exams call.");
@@ -1135,7 +1135,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
                         assertThat(result.getAssessmentType()).isEqualTo(AssessmentType.SEMI_AUTOMATIC);
                         result = resultRepository.findByIdWithEagerFeedbacks(result.getId()).orElseThrow();
                         assertThat(result.getFeedbacks()).isNotEmpty();
-                        assertThat(result.getFeedbacksSorted().getFirst().getDetailText()).isEqualTo("You did not submit your exam");
+                        assertThat(result.getFeedbacks().iterator().next().getDetailText()).isEqualTo("You did not submit your exam");
                     }
                 }
                 else {
@@ -1177,7 +1177,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
                     assertThat(result.getAssessmentType()).isEqualTo(AssessmentType.SEMI_AUTOMATIC);
                     result = resultRepository.findByIdWithEagerFeedbacks(result.getId()).orElseThrow();
                     assertThat(result.getFeedbacks()).isNotEmpty();
-                    assertThat(result.getFeedbacksSorted().getFirst().getDetailText()).isEqualTo("Empty submission");
+                    assertThat(result.getFeedbacks().iterator().next().getDetailText()).isEqualTo("Empty submission");
                 }
                 else {
                     fail("StudentParticipation which is part of an unsubmitted StudentExam contains no submission or result after automatic assessment of unsubmitted student exams call.");
@@ -1219,7 +1219,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
                         assertThat(result.getAssessmentType()).isEqualTo(AssessmentType.SEMI_AUTOMATIC);
                         result = resultRepository.findByIdWithEagerFeedbacks(result.getId()).orElseThrow();
                         assertThat(result.getFeedbacks()).isNotEmpty();
-                        assertThat(result.getFeedbacksSorted().getFirst().getDetailText()).isEqualTo("Empty submission");
+                        assertThat(result.getFeedbacks().iterator().next().getDetailText()).isEqualTo("Empty submission");
                     }
                 }
                 else {

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/SubmissionServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/SubmissionServiceTest.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -695,13 +696,17 @@ class SubmissionServiceTest extends AbstractSpringIntegrationIndependentTest {
         Result newResult = new Result();
         newResult.setExerciseId(examTextExercise.getId());
 
-        List<Feedback> newFeedbacks = submissionService.copyFeedbackToNewResult(newResult, oldResult);
+        Set<Feedback> newFeedbacks = submissionService.copyFeedbackToNewResult(newResult, oldResult);
 
         assertThat(newFeedbacks).containsExactlyInAnyOrderElementsOf(newResult.getFeedbacks()).hasSameSizeAs(oldFeedbacks);
-        assertThat(newFeedbacks.getFirst().isPositive()).isTrue();
-        assertThat(newFeedbacks.get(1).isPositive()).isTrue();
-        assertThat(newFeedbacks.get(2).isPositive()).isTrue();
-        assertThat(newFeedbacks.get(2).getCredits()).isZero();
-        assertThat(newFeedbacks.get(3).isPositive()).isFalse();
+        Feedback positiveCreditsFeedback = newFeedbacks.stream().filter(f -> "Feedback 1".equals(f.getText())).findFirst().orElseThrow();
+        Feedback automaticFeedback = newFeedbacks.stream().filter(f -> f.getType() == FeedbackType.AUTOMATIC).findFirst().orElseThrow();
+        Feedback noCreditsFeedback = newFeedbacks.stream().filter(f -> "test".equals(f.getDetailText())).findFirst().orElseThrow();
+        Feedback negativeCreditsFeedback = newFeedbacks.stream().filter(f -> f.getCredits() != null && f.getCredits() < 0).findFirst().orElseThrow();
+        assertThat(positiveCreditsFeedback.isPositive()).isTrue();
+        assertThat(automaticFeedback.isPositive()).isTrue();
+        assertThat(noCreditsFeedback.isPositive()).isTrue();
+        assertThat(noCreditsFeedback.getCredits()).isZero();
+        assertThat(negativeCreditsFeedback.isPositive()).isFalse();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadAssessmentIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -88,8 +89,8 @@ class FileUploadAssessmentIntegrationTest extends AbstractFileUploadIntegrationT
         assertThat(result.isRated()).isTrue();
         assertThat(result.getScore()).isEqualTo(60); // total score 3P (60%) because gradingInstructionWithLimit was applied twice but only counts once
         assertThat(result.getFeedbacks()).hasSize(4);
-        assertThat(result.getFeedbacksSorted().getFirst().getCredits()).isEqualTo(feedbacks.getFirst().getCredits());
-        assertThat(result.getFeedbacksSorted().get(1).getCredits()).isEqualTo(feedbacks.get(1).getCredits());
+        assertThat(findByReference(result.getFeedbacks(), feedbacks.getFirst().getReference()).getCredits()).isEqualTo(feedbacks.getFirst().getCredits());
+        assertThat(findByReference(result.getFeedbacks(), feedbacks.get(1).getReference()).getCredits()).isEqualTo(feedbacks.get(1).getCredits());
         assertThat(result.getAssessmentNote().getNote()).isEqualTo("text");
         assertThat(result.getAssessor()).isEqualTo(result.getAssessmentNote().getCreator());
 
@@ -218,8 +219,8 @@ class FileUploadAssessmentIntegrationTest extends AbstractFileUploadIntegrationT
         assertThat(result.isRated()).isTrue();
         assertThat(((StudentParticipation) result.getSubmission().getParticipation()).getStudent()).as("student of participation is hidden").isEmpty();
         assertThat(result.getFeedbacks()).hasSize(3);
-        assertThat(result.getFeedbacksSorted().getFirst().getCredits()).isEqualTo(feedbacks.getFirst().getCredits());
-        assertThat(result.getFeedbacksSorted().get(1).getCredits()).isEqualTo(feedbacks.get(1).getCredits());
+        assertThat(findByReference(result.getFeedbacks(), feedbacks.getFirst().getReference()).getCredits()).isEqualTo(feedbacks.getFirst().getCredits());
+        assertThat(findByReference(result.getFeedbacks(), feedbacks.get(1).getReference()).getCredits()).isEqualTo(feedbacks.get(1).getCredits());
     }
 
     @Test
@@ -618,5 +619,9 @@ class FileUploadAssessmentIntegrationTest extends AbstractFileUploadIntegrationT
         submission = submissionRepository.findOneWithEagerResultAndFeedbackAndAssessmentNote(submission.getId());
         assertThat(submission.getResults()).hasSize(2);
         assertThat(submission.getResults().get(1)).isEqualTo(lastResult);
+    }
+
+    private static Feedback findByReference(Collection<Feedback> feedbacks, String reference) {
+        return feedbacks.stream().filter(f -> reference.equals(f.getReference())).findFirst().orElseThrow();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadExerciseIntegrationTest.java
@@ -595,7 +595,7 @@ class FileUploadExerciseIntegrationTest extends AbstractFileUploadIntegrationTes
         assertThat(GradingCriterionUtil.findAnyInstructionWhere(gradingCriteria, instruction -> instruction.getId().equals(usedInstruction.getId())).orElseThrow().getCredits())
                 .isEqualTo(3);
         assertThat(updatedResults.getFirst().getScore()).isEqualTo(60);
-        assertThat(updatedResults.getFirst().getFeedbacksSorted().getFirst().getCredits()).isEqualTo(3);
+        assertThat(updatedResults.getFirst().getFeedbacks().iterator().next().getCredits()).isEqualTo(3);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisProgrammingExerciseChatSessionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisProgrammingExerciseChatSessionIntegrationTest.java
@@ -191,7 +191,7 @@ class IrisProgrammingExerciseChatSessionIntegrationTest extends AbstractIrisInte
         var url = "/api/programming/programming-exercises/" + exercise.getId() + "?deleteStudentReposBuildPlans=false&deleteBaseReposBuildPlans=false";
         request.delete(url, HttpStatus.OK);
         assertThat(irisExerciseChatSessionRepository.findAll().stream().anyMatch(s -> Objects.equals(s.getId(), irisSession.getId()))).isFalse();
-        assertThat(irisMessageRepository.findAllBySessionId(irisSession.getId())).isEmpty();
+        assertThat(irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(irisSession.getId())).isEmpty();
     }
 
     @Test
@@ -210,7 +210,7 @@ class IrisProgrammingExerciseChatSessionIntegrationTest extends AbstractIrisInte
         var url = "/api/programming/programming-exercises/" + exercise.getId() + "?deleteStudentReposBuildPlans=false&deleteBaseReposBuildPlans=false";
         request.delete(url, HttpStatus.OK);
         assertThat(irisExerciseChatSessionRepository.findAll().stream().anyMatch(s -> Objects.equals(s.getId(), irisSession.getId()))).isFalse();
-        assertThat(irisMessageRepository.findAllBySessionId(irisSession.getId())).isEmpty();
+        assertThat(irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(irisSession.getId())).isEmpty();
     }
 
     @Test
@@ -238,7 +238,7 @@ class IrisProgrammingExerciseChatSessionIntegrationTest extends AbstractIrisInte
         // Assert - Verify the session was processed and messages exist
         var updatedSession = irisExerciseChatSessionRepository.findByIdElseThrow(session.getId());
         assertThat(updatedSession).isNotNull();
-        var messages = irisMessageRepository.findAllBySessionId(session.getId());
+        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(session.getId());
         assertThat(messages).isNotEmpty();
         assertThat(messages).hasSizeGreaterThanOrEqualTo(1);
         // Verify we have the USER message
@@ -268,7 +268,7 @@ class IrisProgrammingExerciseChatSessionIntegrationTest extends AbstractIrisInte
         // Assert - Verify the session was processed normally
         var updatedSession = irisExerciseChatSessionRepository.findByIdElseThrow(session.getId());
         assertThat(updatedSession).isNotNull();
-        var messages = irisMessageRepository.findAllBySessionId(session.getId());
+        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(session.getId());
         assertThat(messages).isNotEmpty();
         // Verify we have the USER message
         assertThat(messages.stream().anyMatch(m -> m.getSender() == IrisMessageSender.USER)).isTrue();
@@ -293,7 +293,7 @@ class IrisProgrammingExerciseChatSessionIntegrationTest extends AbstractIrisInte
         // Assert - Verify the session was processed normally
         var updatedSession = irisExerciseChatSessionRepository.findByIdElseThrow(session.getId());
         assertThat(updatedSession).isNotNull();
-        var messages = irisMessageRepository.findAllBySessionId(session.getId());
+        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(session.getId());
         assertThat(messages).isNotEmpty();
         // Verify we have the USER message
         assertThat(messages.stream().anyMatch(m -> m.getSender() == IrisMessageSender.USER)).isTrue();

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisProgrammingExerciseChatSessionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisProgrammingExerciseChatSessionIntegrationTest.java
@@ -191,7 +191,7 @@ class IrisProgrammingExerciseChatSessionIntegrationTest extends AbstractIrisInte
         var url = "/api/programming/programming-exercises/" + exercise.getId() + "?deleteStudentReposBuildPlans=false&deleteBaseReposBuildPlans=false";
         request.delete(url, HttpStatus.OK);
         assertThat(irisExerciseChatSessionRepository.findAll().stream().anyMatch(s -> Objects.equals(s.getId(), irisSession.getId()))).isFalse();
-        assertThat(irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(irisSession.getId())).isEmpty();
+        assertThat(irisMessageRepository.findAllBySessionIdOrderBySentAtAscIdAsc(irisSession.getId())).isEmpty();
     }
 
     @Test
@@ -210,7 +210,7 @@ class IrisProgrammingExerciseChatSessionIntegrationTest extends AbstractIrisInte
         var url = "/api/programming/programming-exercises/" + exercise.getId() + "?deleteStudentReposBuildPlans=false&deleteBaseReposBuildPlans=false";
         request.delete(url, HttpStatus.OK);
         assertThat(irisExerciseChatSessionRepository.findAll().stream().anyMatch(s -> Objects.equals(s.getId(), irisSession.getId()))).isFalse();
-        assertThat(irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(irisSession.getId())).isEmpty();
+        assertThat(irisMessageRepository.findAllBySessionIdOrderBySentAtAscIdAsc(irisSession.getId())).isEmpty();
     }
 
     @Test
@@ -238,7 +238,7 @@ class IrisProgrammingExerciseChatSessionIntegrationTest extends AbstractIrisInte
         // Assert - Verify the session was processed and messages exist
         var updatedSession = irisExerciseChatSessionRepository.findByIdElseThrow(session.getId());
         assertThat(updatedSession).isNotNull();
-        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(session.getId());
+        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAscIdAsc(session.getId());
         assertThat(messages).isNotEmpty();
         assertThat(messages).hasSizeGreaterThanOrEqualTo(1);
         // Verify we have the USER message
@@ -268,7 +268,7 @@ class IrisProgrammingExerciseChatSessionIntegrationTest extends AbstractIrisInte
         // Assert - Verify the session was processed normally
         var updatedSession = irisExerciseChatSessionRepository.findByIdElseThrow(session.getId());
         assertThat(updatedSession).isNotNull();
-        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(session.getId());
+        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAscIdAsc(session.getId());
         assertThat(messages).isNotEmpty();
         // Verify we have the USER message
         assertThat(messages.stream().anyMatch(m -> m.getSender() == IrisMessageSender.USER)).isTrue();
@@ -293,7 +293,7 @@ class IrisProgrammingExerciseChatSessionIntegrationTest extends AbstractIrisInte
         // Assert - Verify the session was processed normally
         var updatedSession = irisExerciseChatSessionRepository.findByIdElseThrow(session.getId());
         assertThat(updatedSession).isNotNull();
-        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(session.getId());
+        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAscIdAsc(session.getId());
         assertThat(messages).isNotEmpty();
         // Verify we have the USER message
         assertThat(messages.stream().anyMatch(m -> m.getSender() == IrisMessageSender.USER)).isTrue();

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisTutorSuggestionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisTutorSuggestionIntegrationTest.java
@@ -153,7 +153,7 @@ class IrisTutorSuggestionIntegrationTest extends AbstractIrisIntegrationTest {
         message.setSender(IrisMessageSender.LLM);
         message.setSession(irisSession);
         irisMessageService.saveMessage(message, irisSession, IrisMessageSender.LLM);
-        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(irisSessionDTO.id());
+        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAscIdAsc(irisSessionDTO.id());
         assertThat(messages).hasSize(1);
         assertThat(messages.getFirst().getContent().getFirst().toString()).contains("Test tutor suggestion request");
         assertThat(messages.getFirst().getSender()).isEqualTo(IrisMessageSender.LLM);
@@ -313,7 +313,7 @@ class IrisTutorSuggestionIntegrationTest extends AbstractIrisIntegrationTest {
                 .isInstanceOf(de.tum.cit.aet.artemis.core.exception.AccessForbiddenException.class).hasMessageContaining("No valid token provided");
 
         // Check if the messages where saved
-        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(irisSession.id());
+        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAscIdAsc(irisSession.id());
         assertThat(messages).hasSize(2);
         assertThat(messages.getFirst().getContent().getFirst().toString()).contains("Test suggestion");
         assertThat(messages.getFirst().getSender()).isEqualTo(IrisMessageSender.ARTIFACT);

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisTutorSuggestionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisTutorSuggestionIntegrationTest.java
@@ -153,7 +153,7 @@ class IrisTutorSuggestionIntegrationTest extends AbstractIrisIntegrationTest {
         message.setSender(IrisMessageSender.LLM);
         message.setSession(irisSession);
         irisMessageService.saveMessage(message, irisSession, IrisMessageSender.LLM);
-        var messages = irisMessageRepository.findAllBySessionId(irisSessionDTO.id());
+        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(irisSessionDTO.id());
         assertThat(messages).hasSize(1);
         assertThat(messages.getFirst().getContent().getFirst().toString()).contains("Test tutor suggestion request");
         assertThat(messages.getFirst().getSender()).isEqualTo(IrisMessageSender.LLM);
@@ -313,7 +313,7 @@ class IrisTutorSuggestionIntegrationTest extends AbstractIrisIntegrationTest {
                 .isInstanceOf(de.tum.cit.aet.artemis.core.exception.AccessForbiddenException.class).hasMessageContaining("No valid token provided");
 
         // Check if the messages where saved
-        var messages = irisMessageRepository.findAllBySessionId(irisSession.id());
+        var messages = irisMessageRepository.findAllBySessionIdOrderBySentAtAsc(irisSession.id());
         assertThat(messages).hasSize(2);
         assertThat(messages.getFirst().getContent().getFirst().toString()).contains("Test suggestion");
         assertThat(messages.getFirst().getSender()).isEqualTo(IrisMessageSender.ARTIFACT);

--- a/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingAssessmentIntegrationTest.java
@@ -526,13 +526,14 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationIndepen
 
         modelingAssessment = resultRepository.findDistinctWithFeedbackBySubmissionId(modelingSubmission2.getId()).orElseThrow();
         assertThat(modelingAssessment.getFeedbacks()).as("assessment is correctly stored").hasSize(1);
-        assertThat(modelingAssessment.getFeedbacksSorted().getFirst().getCredits()).as("feedback credits are correct").isEqualTo(changedFeedback.getCredits());
-        assertThat(modelingAssessment.getFeedbacksSorted().getFirst().getText()).as("feedback text are correct").isEqualTo(changedFeedback.getText());
+        Feedback storedChangedFeedback = modelingAssessment.getFeedbacks().iterator().next();
+        assertThat(storedChangedFeedback.getCredits()).as("feedback credits are correct").isEqualTo(changedFeedback.getCredits());
+        assertThat(storedChangedFeedback.getText()).as("feedback text are correct").isEqualTo(changedFeedback.getText());
         modelingAssessment = resultRepository.findDistinctWithFeedbackBySubmissionId(modelingSubmission.getId()).orElseThrow();
         assertThat(modelingAssessment.getFeedbacks()).as("existing manual assessment has correct amount of feedback").hasSize(1);
-        assertThat(modelingAssessment.getFeedbacksSorted().getFirst().getCredits()).as("existing manual assessment did not change credits")
-                .isEqualTo(originalFeedback.getCredits());
-        assertThat(modelingAssessment.getFeedbacksSorted().getFirst().getText()).as("existing manual assessment did not change text").isEqualTo(originalFeedback.getText());
+        Feedback storedOriginalFeedback = modelingAssessment.getFeedbacks().iterator().next();
+        assertThat(storedOriginalFeedback.getCredits()).as("existing manual assessment did not change credits").isEqualTo(originalFeedback.getCredits());
+        assertThat(storedOriginalFeedback.getText()).as("existing manual assessment did not change text").isEqualTo(originalFeedback.getText());
     }
 
     private void checkAssessmentNotFinished(Result storedResult, User assessor) {

--- a/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingExerciseIntegrationTest.java
@@ -916,7 +916,7 @@ class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationLocalCILo
         List<Result> updatedResults = participationUtilService.getResultsForExercise(updatedModelingExercise);
         assertThat(GradingCriterionUtil.findAnyInstructionWhere(updatedModelingExercise.getGradingCriteria(), instruction -> instruction.getCredits() == 3)).isPresent();
         assertThat(updatedResults.getFirst().getScore()).isEqualTo(60);
-        assertThat(updatedResults.getFirst().getFeedbacksSorted().getFirst().getCredits()).isEqualTo(3);
+        assertThat(updatedResults.getFirst().getFeedbacks().iterator().next().getCredits()).isEqualTo(3);
     }
 
     @Test
@@ -1203,7 +1203,8 @@ class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationLocalCILo
         assertThat(modelingExerciseTestRepository.findById(importedModelingExercise.getId())).isPresent();
 
         var importedExampleSubmission = importedModelingExercise.getExampleSubmissions().stream().findFirst().orElseThrow();
-        GradingInstruction importedFeedbackGradingInstruction = importedExampleSubmission.getSubmission().getLatestResult().getFeedbacksSorted().getFirst().getGradingInstruction();
+        GradingInstruction importedFeedbackGradingInstruction = importedExampleSubmission.getSubmission().getLatestResult().getFeedbacks().iterator().next()
+                .getGradingInstruction();
         assertThat(importedFeedbackGradingInstruction).isNotNull();
 
         // Copy and original should have the same data but not the same ids.
@@ -1218,7 +1219,7 @@ class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationLocalCILo
         var importedModelingExerciseFromDb = modelingExerciseTestRepository.findByIdWithExampleSubmissionsAndResultsAndGradingCriteria(importedModelingExercise.getId())
                 .orElseThrow();
         var importedFeedbackGradingInstructionFromDb = importedModelingExerciseFromDb.getExampleSubmissions().stream().findFirst().orElseThrow().getSubmission().getLatestResult()
-                .getFeedbacksSorted().getFirst().getGradingInstruction();
+                .getFeedbacks().iterator().next().getGradingInstruction();
 
         assertThat(importedFeedbackGradingInstructionFromDb.getGradingCriterion().getId()).isNotEqualTo(gradingInstruction.getGradingCriterion().getId());
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
@@ -485,8 +485,9 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         // Result has to be manual to be updated
         manualResult.setAssessmentType(AssessmentType.SEMI_AUTOMATIC);
 
-        // Remove feedbacks, change text and score.
-        manualResult.setFeedbacks(List.of(manualResult.getFeedbacks().iterator().next()));
+        // Remove feedbacks, change text and score. Keep the "theory" feedback (+2 credits) deterministically so the asserted score below is stable.
+        Feedback keptFeedback = manualResult.getFeedbacks().stream().filter(f -> "theory".equals(f.getReference())).findFirst().orElseThrow();
+        manualResult.setFeedbacks(List.of(keptFeedback));
         double points = manualResult.calculateTotalPointsForProgrammingExercises();
         manualResult.setScore(points);
         manualResult = resultRepository.save(manualResult);
@@ -511,8 +512,10 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         programmingSubmission.setParticipation(programmingExerciseStudentParticipation);
         manualResult.setSubmission(programmingSubmission);
 
-        // Remove feedbacks, change text and score.
-        manualResult.setFeedbacks(List.of(manualResult.getFeedbacks().iterator().next()));
+        // Remove feedbacks, change text and score. Keep the "theory" feedback deterministically; this test only asserts size, but a stable
+        // selection avoids flakes if other parts of the response start depending on the kept feedback.
+        Feedback keptFeedback = manualResult.getFeedbacks().stream().filter(f -> "theory".equals(f.getReference())).findFirst().orElseThrow();
+        manualResult.setFeedbacks(List.of(keptFeedback));
         manualResult.setScore(77D);
         manualResult.rated(true);
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
@@ -486,7 +486,7 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         manualResult.setAssessmentType(AssessmentType.SEMI_AUTOMATIC);
 
         // Remove feedbacks, change text and score.
-        manualResult.setFeedbacks(manualResult.getFeedbacksSorted().subList(0, 1));
+        manualResult.setFeedbacks(List.of(manualResult.getFeedbacks().iterator().next()));
         double points = manualResult.calculateTotalPointsForProgrammingExercises();
         manualResult.setScore(points);
         manualResult = resultRepository.save(manualResult);
@@ -512,7 +512,7 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         manualResult.setSubmission(programmingSubmission);
 
         // Remove feedbacks, change text and score.
-        manualResult.setFeedbacks(manualResult.getFeedbacksSorted().subList(0, 1));
+        manualResult.setFeedbacks(List.of(manualResult.getFeedbacks().iterator().next()));
         manualResult.setScore(77D);
         manualResult.rated(true);
 
@@ -568,7 +568,7 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         result = request.putWithResponseBodyAndParams("/api/programming/participations/" + programmingExerciseStudentParticipation.getId() + "/manual-results", result,
                 Result.class, HttpStatus.OK, params);
 
-        var longFeedbackText = longFeedbackTextRepository.findByFeedbackId(result.getFeedbacksSorted().getFirst().getId());
+        var longFeedbackText = longFeedbackTextRepository.findByFeedbackId(result.getFeedbacks().iterator().next().getId());
         assertThat(longFeedbackText).isPresent();
         assertThat(longFeedbackText.get().getText()).isEqualTo(longText);
     }
@@ -585,7 +585,7 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         result = resultRepository.save(result);
 
         var newLongText = "def".repeat(5000);
-        manualLongFeedback = result.getFeedbacksSorted().getFirst();
+        manualLongFeedback = result.getFeedbacks().iterator().next();
 
         // The actual complete longtext is still stored in the detailText field when the result is sent from the client
         var detailText = Feedback.class.getDeclaredField("detailText");
@@ -597,7 +597,7 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         result = request.putWithResponseBodyAndParams("/api/programming/participations/" + programmingExerciseStudentParticipation.getId() + "/manual-results", result,
                 Result.class, HttpStatus.OK, params);
 
-        var longFeedbackText = longFeedbackTextRepository.findByFeedbackId(result.getFeedbacksSorted().getFirst().getId());
+        var longFeedbackText = longFeedbackTextRepository.findByFeedbackId(result.getFeedbacks().iterator().next().getId());
         assertThat(longFeedbackText).isPresent();
         assertThat(longFeedbackText.get().getText()).isEqualTo(newLongText);
     }

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionAndResultLocalVCJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionAndResultLocalVCJenkinsIntegrationTest.java
@@ -172,7 +172,7 @@ class ProgrammingSubmissionAndResultLocalVCJenkinsIntegrationTest extends Abstra
 
         var result = resultRepository.findFirstWithFeedbacksByParticipationIdOrderByCompletionDateDescElseThrow(participation.getId());
         // Jenkins Setup -> Gradle Feedback is not duplicated and should be kept like this
-        assertThat(result.getFeedbacksSorted().getFirst().getDetailText()).isEqualTo("abc\nmultiline\nfeedback");
+        assertThat(result.getFeedbacks().iterator().next().getDetailText()).isEqualTo("abc\nmultiline\nfeedback");
     }
 
     private Result assertBuildError(Long participationId, String userLogin) throws Exception {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/StaticCodeAnalysisIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/StaticCodeAnalysisIntegrationTest.java
@@ -303,8 +303,9 @@ class StaticCodeAnalysisIntegrationTest extends AbstractProgrammingIntegrationLo
         feedbackCreationService.categorizeScaFeedback(result, feedbacks, programmingExerciseSCAEnabled);
         assertThat(feedbacks).hasSize(1);
         assertThat(result.getFeedbacks()).containsExactlyInAnyOrderElementsOf(feedbacks);
-        assertThat(result.getFeedbacksSorted().getFirst().getStaticCodeAnalysisCategory()).isEqualTo("Bad Practice");
-        assertThat(JsonObjectMapper.get().readValue(result.getFeedbacksSorted().getFirst().getDetailText(), StaticCodeAnalysisIssue.class).penalty()).isEqualTo(3.0);
+        Feedback storedFeedback = result.getFeedbacks().iterator().next();
+        assertThat(storedFeedback.getStaticCodeAnalysisCategory()).isEqualTo("Bad Practice");
+        assertThat(JsonObjectMapper.get().readValue(storedFeedback.getDetailText(), StaticCodeAnalysisIssue.class).penalty()).isEqualTo(3.0);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseResultTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseResultTestService.java
@@ -229,10 +229,10 @@ public class ProgrammingExerciseResultTestService {
         var semiAutoResultId = semiAutoResult.getId();
         semiAutoResult = updatedResults.stream().filter(result -> result.getId().equals(semiAutoResultId)).findFirst().orElseThrow();
         assertThat(semiAutoResult.getAssessmentType()).isEqualTo(AssessmentType.SEMI_AUTOMATIC);
-        // Assert that the SEMI_AUTOMATIC result has two feedbacks whereas the last one is the automatic one
+        // Assert that the SEMI_AUTOMATIC result has two feedbacks: one MANUAL and one AUTOMATIC
         assertThat(semiAutoResult.getFeedbacks()).hasSize(2);
-        assertThat(semiAutoResult.getFeedbacksSorted().getFirst().getType()).isEqualTo(FeedbackType.MANUAL);
-        assertThat(semiAutoResult.getFeedbacksSorted().get(1).getType()).isEqualTo(FeedbackType.AUTOMATIC);
+        assertThat(semiAutoResult.getFeedbacks().stream().filter(f -> f.getType() == FeedbackType.MANUAL).findFirst()).isPresent();
+        assertThat(semiAutoResult.getFeedbacks().stream().filter(f -> f.getType() == FeedbackType.AUTOMATIC).findFirst()).isPresent();
     }
 
     private void postResult(BuildResultNotification requestBodyMap) throws Exception {

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
@@ -1312,7 +1312,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         secondCorrectionFeedback.setCredits(10.0);
         secondCorrectionFeedback.setPositive(true);
         submissionWithoutSecondAssessment.getLatestResult().getFeedbacks().add(secondCorrectionFeedback);
-        textAssessmentDTO.setFeedbacks(submissionWithoutSecondAssessment.getLatestResult().getFeedbacksSorted());
+        textAssessmentDTO.setFeedbacks(new ArrayList<>(submissionWithoutSecondAssessment.getLatestResult().getFeedbacks()));
 
         // assess submission and submit
         Result secondSubmittedManualResult = request.postWithResponseBody("/api/text/participations/" + submissionWithoutFirstAssessment.getParticipation().getId() + "/results/"

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
@@ -1366,7 +1366,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         List<Result> updatedResults = participationUtilService.getResultsForExercise(updatedTextExercise);
         assertThat(GradingCriterionUtil.findAnyInstructionWhere(updatedTextExercise.getGradingCriteria(), instruction -> instruction.getCredits() == 3)).isPresent();
         assertThat(updatedResults.getFirst().getScore()).isEqualTo(60);
-        assertThat(updatedResults.getFirst().getFeedbacksSorted().getFirst().getCredits()).isEqualTo(3);
+        assertThat(updatedResults.getFirst().getFeedbacks().iterator().next().getCredits()).isEqualTo(3);
     }
 
     @Test
@@ -1531,7 +1531,8 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         assertThat(textExerciseRepository.findById(importedTextExercise.getId())).isPresent();
 
         var importedExampleSubmission = importedTextExercise.getExampleSubmissions().stream().findFirst().orElseThrow();
-        GradingInstruction importedFeedbackGradingInstruction = importedExampleSubmission.getSubmission().getLatestResult().getFeedbacksSorted().getFirst().getGradingInstruction();
+        GradingInstruction importedFeedbackGradingInstruction = importedExampleSubmission.getSubmission().getLatestResult().getFeedbacks().iterator().next()
+                .getGradingInstruction();
         assertThat(importedFeedbackGradingInstruction).isNotNull();
 
         // Copy and original should have the same data but not the same ids.
@@ -1545,7 +1546,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
         var importedTextExerciseFromDB = textExerciseRepository.findWithExampleSubmissionsAndResultsById(importedTextExercise.getId()).orElseThrow();
         var importedFeedbackGradingInstructionFromDb = importedTextExerciseFromDB.getExampleSubmissions().stream().findFirst().orElseThrow().getSubmission().getLatestResult()
-                .getFeedbacksSorted().getFirst().getGradingInstruction();
+                .getFeedbacks().iterator().next().getGradingInstruction();
 
         assertThat(importedFeedbackGradingInstructionFromDb.getGradingCriterion().getId()).isNotEqualTo(gradingInstruction.getGradingCriterion().getId());
 

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
@@ -1366,7 +1366,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         List<Result> updatedResults = participationUtilService.getResultsForExercise(updatedTextExercise);
         assertThat(GradingCriterionUtil.findAnyInstructionWhere(updatedTextExercise.getGradingCriteria(), instruction -> instruction.getCredits() == 3)).isPresent();
         assertThat(updatedResults.getFirst().getScore()).isEqualTo(60);
-        assertThat(updatedResults.getFirst().getFeedbacks().iterator().next().getCredits()).isEqualTo(3);
+        assertThat(updatedResults.getFirst().getFeedbacks()).extracting(Feedback::getCredits).containsExactly(3.0);
     }
 
     @Test
@@ -1531,8 +1531,9 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         assertThat(textExerciseRepository.findById(importedTextExercise.getId())).isPresent();
 
         var importedExampleSubmission = importedTextExercise.getExampleSubmissions().stream().findFirst().orElseThrow();
-        GradingInstruction importedFeedbackGradingInstruction = importedExampleSubmission.getSubmission().getLatestResult().getFeedbacks().iterator().next()
-                .getGradingInstruction();
+        var importedFeedbacks = importedExampleSubmission.getSubmission().getLatestResult().getFeedbacks();
+        assertThat(importedFeedbacks).hasSize(1);
+        GradingInstruction importedFeedbackGradingInstruction = importedFeedbacks.iterator().next().getGradingInstruction();
         assertThat(importedFeedbackGradingInstruction).isNotNull();
 
         // Copy and original should have the same data but not the same ids.
@@ -1545,8 +1546,9 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         assertThat(importedFeedbackGradingInstruction.getUsageCount()).isEqualTo(gradingInstruction.getUsageCount());
 
         var importedTextExerciseFromDB = textExerciseRepository.findWithExampleSubmissionsAndResultsById(importedTextExercise.getId()).orElseThrow();
-        var importedFeedbackGradingInstructionFromDb = importedTextExerciseFromDB.getExampleSubmissions().stream().findFirst().orElseThrow().getSubmission().getLatestResult()
-                .getFeedbacks().iterator().next().getGradingInstruction();
+        var importedFeedbacksFromDb = importedTextExerciseFromDB.getExampleSubmissions().stream().findFirst().orElseThrow().getSubmission().getLatestResult().getFeedbacks();
+        assertThat(importedFeedbacksFromDb).hasSize(1);
+        var importedFeedbackGradingInstructionFromDb = importedFeedbacksFromDb.iterator().next().getGradingInstruction();
 
         assertThat(importedFeedbackGradingInstructionFromDb.getGradingCriterion().getId()).isNotEqualTo(gradingInstruction.getGradingCriterion().getId());
 


### PR DESCRIPTION
### Summary
Removes the `Result.getFeedbacksSorted()` helper and migrates all callers to the live `getFeedbacks()` `Set`. Also fixes a latent ordering bug in `IrisMessageRepository.findAllBySessionId` so chat history is always returned in send order.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
After PR #12610 made `Result.feedbacks` an unordered `Set`, `Result.getFeedbacksSorted()` was kept as a convenience that returned a snapshot sorted by id. In practice this duplicated the live collection accessor and created two code paths for the same data. Removing the sorted helper keeps a single source of truth and forces callers to be explicit about their ordering needs (most don't actually have any).

While migrating the callers, an unrelated but real ordering bug surfaced in the Iris module: `IrisMessageRepository.findAllBySessionId` had no `ORDER BY` clause, so the chat history endpoint (`GET /api/iris/sessions/{id}/messages`) and the related integration tests could see messages out of order. This is the root cause of the flaky `IrisTutorSuggestionIntegrationTest.testTutorSuggestionStatusUpdateShouldBeHandled` we have observed in CI.

### Description
- Deleted `Result.getFeedbacksSorted()` and the now-unused `java.util.Comparator` import; updated the JavaDoc on `getFeedbacks()` accordingly.
- Migrated all production callers (`ExampleSubmissionRepository`, `TutorParticipationService`, `SubmissionService`, `ResultDTO`) to work with the `Set`/`Collection` directly. Where the previous code only needed an iterable of feedbacks, signatures were widened to `Collection<Feedback>`.
- Migrated all 12 integration test files. Tests that previously did positional access (`getFirst()`, `get(1)`, `subList(0,1)`) now look feedbacks up by their identifying property (text, type, reference, grading instruction) so they remain deterministic against an unordered `Set`.
- Renamed `IrisMessageRepository.findAllBySessionId` to `findAllBySessionIdOrderBySentAtAsc`, fixing chat-history ordering for both the production endpoint and the affected Iris integration tests.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Tutor
- 1 Student
- 1 Text or Modeling Exercise with at least one assessed submission
- Iris enabled for one course (for the chat-ordering check)

1. Log in as a tutor and open an exercise that has example submissions with feedback. Verify that the example-submission view still shows all feedback items correctly.
2. As a tutor, complete a tutor-training round on an exercise with grading instructions; the matching of tutor feedback against instructor feedback (`TutorParticipationService`) should behave unchanged.
3. As a student in a course with Iris enabled, open an Iris chat session that already has multiple messages and reload it. Messages must appear in chronological send order, oldest first.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Server tests failed. Coverage could not be fully measured. Please check the [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/25153227777).

_Last updated: 2026-04-30 08:14:33 UTC_

