### PR TITLE
`Development`: Patch dependabot alerts and add weaviate health check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -199,8 +199,7 @@ dependencies {
     // Required by Sharing Platform
     implementation "org.codeability:SharingPluginPlatformAPI:1.2.1"
     // Required by Spring cloud
-    // Cannot org.apache.httpcomponents to later version due to compatibility issues
-    implementation "org.apache.httpcomponents.client5:httpclient5:5.5.1"
+    implementation "org.apache.httpcomponents.client5:httpclient5:5.6.1"
     implementation "org.apache.httpcomponents.core5:httpcore5:5.3.6"
     implementation "org.apache.httpcomponents:httpmime:4.5.14"
 

--- a/documentation/docs/admin/extension-services.mdx
+++ b/documentation/docs/admin/extension-services.mdx
@@ -28,6 +28,67 @@ EduTelligence is a comprehensive suite of AI-powered microservices designed to e
 
 ---
 
+## Global Search (Standalone Weaviate)
+
+Artemis can run its global keyword and semantic search directly against Weaviate, **without** Pyris. This is useful for deployments that do not need Iris but still want global search across lectures, exercises, and channels.
+
+### When to use this section
+
+- You want to enable Artemis global search and **do not** run Pyris.
+- You run both Artemis and Pyris and want them to share a single Weaviate instance — read this section first, then continue with the [Iris & Pyris Setup Guide](#iris--pyris-setup-guide). Both consumers can coexist as long as their `collection-prefix` values differ (Artemis defaults to `Artemis_`).
+
+### Deploying Weaviate
+
+The Artemis repository ships its own Weaviate compose files for development; for production, use the same images and reuse the configuration documented in the [Weaviate Setup developer guide](../developer/weaviate-setup.mdx) (env files, vectorizer choice, API-key auth). You do not need any EduTelligence component for this path.
+
+A typical standalone production layout:
+
+- One Weaviate container (e.g. behind Traefik with TLS).
+- Anonymous access disabled, API key authentication enabled (see the developer guide's [Authentication](../developer/weaviate-setup.mdx#authentication) section).
+- Either `text2vec-openai` (OpenAI-compatible API such as Ollama or a TUM GPU server) or self-provided vectors (`vectorizer-module: none`) depending on your embedding strategy.
+
+### Configuring Artemis
+
+In `application-artemis.yml`, enable Weaviate and point it at your server:
+
+```yaml
+artemis:
+  weaviate:
+    enabled: true
+    http-host: weaviate.your-domain.com
+    http-port: 443
+    grpc-port: 50051
+    scheme: https
+    collection-prefix: Artemis_       # Differentiates from a Pyris-managed instance if you share one
+    vectorizer-module: text2vec-openai  # or "none" / "text2vec-transformers"
+    api-key: your-weaviate-api-key
+    # The following two are only needed for vectorizer-module: text2vec-openai
+    open-ai-embedding-model: Qwen/Qwen3-Embedding-8B
+    open-ai-base-url: https://gpu.aet.cit.tum.de/api/
+    gpu-api-key: your-gpu-key
+```
+
+Iris remains independent — `artemis.iris.enabled` does not have to be set for Weaviate to work.
+
+### Verifying
+
+Once Artemis starts, the Weaviate health indicator is registered automatically and shows up under `/management/health` (gated by `artemis.weaviate.enabled`). You can also probe Weaviate directly:
+
+```bash
+curl -H "Authorization: Bearer your-weaviate-api-key" \
+  https://weaviate.your-domain.com/v1/.well-known/ready
+```
+
+### Sharing one Weaviate between Artemis and Pyris
+
+If you already run a Weaviate instance for Pyris and want Artemis global search to use it as well:
+
+- Keep Pyris's `collection-prefix` (it manages its own collections).
+- Set Artemis's `collection-prefix` to a distinct value (default `Artemis_`).
+- Use a single API key with sufficient permissions, or distinct keys if you enable per-user authorization on the Weaviate server.
+
+---
+
 ## Iris & Pyris Setup Guide
 
 <Callout variant={CalloutVariant.info}>

--- a/documentation/docs/admin/extension-services.mdx
+++ b/documentation/docs/admin/extension-services.mdx
@@ -39,12 +39,12 @@ Artemis can run its global keyword and semantic search directly against Weaviate
 
 ### Deploying Weaviate
 
-The Artemis repository ships its own Weaviate compose files for development; for production, use the same images and reuse the configuration documented in the [Weaviate Setup developer guide](../developer/weaviate-setup.mdx) (env files, vectorizer choice, API-key auth). You do not need any EduTelligence component for this path.
+The Artemis repository ships its own Weaviate compose files for development; for production, use the same images and reuse the configuration documented in the [Weaviate Setup developer guide](/developer/weaviate-setup) (env files, vectorizer choice, API-key auth). You do not need any EduTelligence component for this path.
 
 A typical standalone production layout:
 
 - One Weaviate container (e.g. behind Traefik with TLS).
-- Anonymous access disabled, API key authentication enabled (see the developer guide's [Authentication](../developer/weaviate-setup.mdx#authentication) section).
+- Anonymous access disabled, API key authentication enabled (see the developer guide's [Authentication](/developer/weaviate-setup#authentication) section).
 - Either `text2vec-openai` (OpenAI-compatible API such as Ollama or a TUM GPU server) or self-provided vectors (`vectorizer-module: none`) depending on your embedding strategy.
 
 ### Configuring Artemis

--- a/documentation/docs/developer/weaviate-setup.mdx
+++ b/documentation/docs/developer/weaviate-setup.mdx
@@ -4,14 +4,15 @@ import {CalloutVariant} from "../../src/components/Callout/Callout.types";
 # Weaviate Setup
 
 This guide explains how to set up a local Weaviate instance for development with Artemis.
-Weaviate is a vector database that is used by the EduTelligence suite (Iris/Pyris) for storing and retrieving embeddings.
+Weaviate is a vector database used by Artemis in two independent ways:
 
-In the future Artemis will also directly communicate with Weaviate to offer a global keyword and semantic search across all entities (lectures, exercises, chats, ...).
+- **Global search (Artemis-native)** — Artemis connects to Weaviate directly to offer keyword and semantic search across entities (lectures, exercises, chats, ...). This is gated by the `artemis.weaviate.enabled` flag and works without Pyris.
+- **Iris / Pyris (EduTelligence)** — When running Iris, Pyris uses Weaviate to store and retrieve embeddings. Pyris connects with its own configuration; both consumers can share a single Weaviate instance as long as their `collection-prefix` values differ (Artemis defaults to `Artemis_`).
 
 <Callout variant={CalloutVariant.info}>
 
-  Setting up Weaviate is only required when running Pyris locally for Iris functionality or developing the global search feature.
-If you only need basic Artemis features without AI assistance, you can skip this setup.
+  Setting up Weaviate is only required if you enable the global search in Artemis or if you run Pyris locally for Iris functionality.
+If you only need basic Artemis features without AI assistance and without global search, you can skip this setup.
 
 </Callout>
 
@@ -493,7 +494,7 @@ WEAVIATE_GRPC_PORT=50052
 WEAVIATE_SERVER_VERSION=1.34.14
 ```
 
-Remember to update the Pyris configuration accordingly.
+If you also run Pyris against the same Weaviate instance, remember to update the Pyris configuration accordingly.
 
 ### Container Not Starting
 

--- a/src/main/java/de/tum/cit/aet/artemis/globalsearch/config/WeaviateHealthIndicator.java
+++ b/src/main/java/de/tum/cit/aet/artemis/globalsearch/config/WeaviateHealthIndicator.java
@@ -1,0 +1,39 @@
+package de.tum.cit.aet.artemis.globalsearch.config;
+
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+import io.weaviate.client6.v1.api.WeaviateClient;
+
+/**
+ * Health indicator for the Weaviate vector database used by the global search feature.
+ * Only registered when Weaviate is configured to be active (see {@link WeaviateEnabled}).
+ */
+@Lazy
+@Conditional(WeaviateEnabled.class)
+@Component
+public class WeaviateHealthIndicator implements HealthIndicator {
+
+    private final WeaviateClient client;
+
+    private final WeaviateConfigurationProperties properties;
+
+    public WeaviateHealthIndicator(WeaviateClient client, WeaviateConfigurationProperties properties) {
+        this.client = client;
+        this.properties = properties;
+    }
+
+    @Override
+    public Health health() {
+        String address = properties.scheme() + "://" + properties.httpHost() + ":" + properties.httpPort();
+        try {
+            return client.isReady() ? Health.up().withDetail("Address", address).build() : Health.down().withDetail("Address", address).withDetail("ready", false).build();
+        }
+        catch (Exception e) {
+            return Health.down(e).withDetail("Address", address).build();
+        }
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/globalsearch/config/WeaviateHealthIndicator.java
+++ b/src/main/java/de/tum/cit/aet/artemis/globalsearch/config/WeaviateHealthIndicator.java
@@ -30,7 +30,10 @@ public class WeaviateHealthIndicator implements HealthIndicator {
     public Health health() {
         String address = properties.scheme() + "://" + properties.httpHost() + ":" + properties.httpPort();
         try {
-            return client.isReady() ? Health.up().withDetail("Address", address).build() : Health.down().withDetail("Address", address).withDetail("ready", false).build();
+            if (client.isReady()) {
+                return Health.up().withDetail("Address", address).build();
+            }
+            return Health.down().withDetail("Address", address).withDetail("ready", false).build();
         }
         catch (Exception e) {
             return Health.down(e).withDetail("Address", address).build();

--- a/src/test/java/de/tum/cit/aet/artemis/globalsearch/config/WeaviateHealthIndicatorTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/globalsearch/config/WeaviateHealthIndicatorTest.java
@@ -33,7 +33,7 @@ class WeaviateHealthIndicatorTest {
     }
 
     @Test
-    void healthUp_whenWeaviateReports_ready() throws Exception {
+    void healthUp_whenWeaviateReportsReady() throws Exception {
         when(client.isReady()).thenReturn(true);
 
         Health health = healthIndicator.health();
@@ -43,7 +43,7 @@ class WeaviateHealthIndicatorTest {
     }
 
     @Test
-    void healthDown_whenWeaviateReports_notReady() throws Exception {
+    void healthDown_whenWeaviateReportsNotReady() throws Exception {
         when(client.isReady()).thenReturn(false);
 
         Health health = healthIndicator.health();

--- a/src/test/java/de/tum/cit/aet/artemis/globalsearch/config/WeaviateHealthIndicatorTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/globalsearch/config/WeaviateHealthIndicatorTest.java
@@ -1,0 +1,66 @@
+package de.tum.cit.aet.artemis.globalsearch.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+import io.weaviate.client6.v1.api.WeaviateClient;
+
+/**
+ * Unit tests for {@link WeaviateHealthIndicator}.
+ */
+@ExtendWith(MockitoExtension.class)
+class WeaviateHealthIndicatorTest {
+
+    private static final String EXPECTED_ADDRESS = "http://localhost:8001";
+
+    @Mock
+    private WeaviateClient client;
+
+    private WeaviateHealthIndicator healthIndicator;
+
+    @BeforeEach
+    void setUp() {
+        WeaviateConfigurationProperties properties = new WeaviateConfigurationProperties(true, "localhost", 8001, 50051, "http", "Artemis_", "none", null, null, null, null);
+        healthIndicator = new WeaviateHealthIndicator(client, properties);
+    }
+
+    @Test
+    void healthUp_whenWeaviateReports_ready() throws Exception {
+        when(client.isReady()).thenReturn(true);
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("Address", EXPECTED_ADDRESS);
+    }
+
+    @Test
+    void healthDown_whenWeaviateReports_notReady() throws Exception {
+        when(client.isReady()).thenReturn(false);
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("Address", EXPECTED_ADDRESS);
+        assertThat(health.getDetails()).containsEntry("ready", false);
+    }
+
+    @Test
+    void healthDown_whenIsReadyThrows() throws Exception {
+        when(client.isReady()).thenThrow(new RuntimeException("Connection refused"));
+
+        Health health = healthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("Address", EXPECTED_ADDRESS);
+        assertThat(health.getDetails()).containsKey("error");
+    }
+}

--- a/supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt
+++ b/supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.32.5
-gitpython==3.1.46
+gitpython==3.1.47
 beautifulsoup4==4.14.3
 pyperclip==1.11.0
 python-dotenv==1.2.2


### PR DESCRIPTION
### Summary
Patches the three open high-severity Dependabot alerts (#475, #468, #469), adds a Spring Boot health indicator for Weaviate that surfaces under `/management/health` only when the integration is enabled, and clarifies the documentation so that admins running Artemis without Pyris can deploy Weaviate as a standalone dependency for global search.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I documented the Java code using JavaDoc style.
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
GitHub Dependabot reports three open high-severity alerts on `develop`:

| # | Package | Vulnerable | Patched | CVE |
|---|---|---|---|---|
| 475 | `org.apache.httpcomponents.client5:httpclient5` | `>= 5.6-alpha1, < 5.6.1` | 5.6.1 | CVE-2026-40542 (SCRAM-SHA-256 mutual-auth bypass) |
| 469 | `gitpython` | `>= 3.1.30, < 3.1.47` | 3.1.47 | Command injection via Git options bypass |
| 468 | `gitpython` | `< 3.1.47` | 3.1.47 | Unsafe option check before `shlex.split` |

While auditing the Weaviate dependency surface (the source of the transitive `httpclient5:5.6` request that triggered alert #475) it became clear that the `WeaviateClient` bean was created and validated at startup but had no observability afterwards. Adding a health indicator gives admins a clear signal whether the configured Weaviate instance is reachable, which is especially important now that Weaviate is also used outside of Pyris for the new global search.

The documentation still framed Weaviate as a Pyris-only dependency ("In the future Artemis will also directly communicate with Weaviate…") even though the global search code already exists. The doc edits remove that ambiguity and add a dedicated standalone deployment section so other universities can run Artemis + Weaviate without Pyris.

### Description
**Dependency bumps**
- `build.gradle`: `httpclient5` 5.5.1 → 5.6.1 — closes Dependabot #475. The previous "Cannot upgrade" comment was stale (it was added without an actual version change); 5.6.1 compiles cleanly and resolves all transitive `5.6` requests.
- `supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt`: `gitpython` 3.1.46 → 3.1.47 — closes #468 and #469.

**New `WeaviateHealthIndicator`**
- New file `src/main/java/de/tum/cit/aet/artemis/globalsearch/config/WeaviateHealthIndicator.java`. Annotated with `@Conditional(WeaviateEnabled.class)` so the bean is only created (and therefore only exposed via `/management/health`) when `artemis.weaviate.enabled=true`. Calls `client.isReady()` and reports `UP`/`DOWN` with the Weaviate address, mirroring the existing `RedisHealthIndicator` / `JHipsterRegistryHealthIndicator` pattern.
- New file `src/test/java/de/tum/cit/aet/artemis/globalsearch/config/WeaviateHealthIndicatorTest.java` covering the three branches (ready / not ready / exception).

**Documentation**
- `documentation/docs/developer/weaviate-setup.mdx`: rewrites the introduction to describe Artemis-native global search and Pyris as two independent consumers of Weaviate, removes the outdated "in the future" wording, and scopes the "update Pyris configuration" reminder so it only applies when Pyris is actually present.
- `documentation/docs/admin/extension-services.mdx`: adds a new "Global Search (Standalone Weaviate)" section before the Iris & Pyris guide, explaining how to deploy Weaviate just for Artemis global search, including the `application-artemis.yml` config and notes on sharing one Weaviate instance between Artemis and Pyris via distinct `collection-prefix` values.

Weaviate client (`6.1.0`) and server (`1.34.14`) versions are intentionally **not** bumped in this PR — the client/server compatibility matrix and prod's current `1.34.0` deployment make any Weaviate version bump a separate decision.

### Steps for Testing
Prerequisites:
- 1 Admin
- A Weaviate Docker container reachable from the running Artemis instance (use `docker compose -f docker/weaviate.yml up -d`)

1. With `artemis.weaviate.enabled=false` (default), start Artemis and visit `/management/health`. Confirm there is **no** `weaviate` entry — the indicator must not be registered.
2. Set `artemis.weaviate.enabled=true` and configure host/port for your local Weaviate. Restart Artemis.
3. Visit `/management/health` — confirm a `weaviate` block appears with `status: UP` and an `Address` detail matching your config.
4. Stop the Weaviate container. Wait a few seconds and refresh `/management/health` — confirm the `weaviate` block now reports `status: DOWN` (and the overall health is degraded accordingly).
5. Build verification: `./gradlew compileJava compileTestJava spotlessCheck checkstyleMain -x webapp` succeeds locally.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| WeaviateHealthIndicator.java | 100.00% | 31 |

_Last updated: 2026-05-01 10:46:03 UTC_

