### PR TITLE
`Lectures`: Validate course ownership before applying edits

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/LectureResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/LectureResource.java
@@ -220,11 +220,16 @@ public class LectureResource {
         if (updatedLectureDto.id() == null) {
             throw new BadRequestAlertException("Invalid id", ENTITY_NAME, "idNull");
         }
-        Course course = courseRepository.findByIdElseThrow(updatedLectureDto.course.id());
-        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, null);
-
         // This explicitly does NOT change any relationships such as attachments or lecture units
         Lecture originalLecture = lectureRepository.findByIdElseThrow(updatedLectureDto.id());
+        Course course = originalLecture.getCourse();
+        if (course == null) {
+            throw new BadRequestAlertException("Lecture is not part of a course", ENTITY_NAME, "courseMissing");
+        }
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, null);
+        if (updatedLectureDto.course == null || !course.getId().equals(updatedLectureDto.course.id())) {
+            throw new BadRequestAlertException("Lecture does not belong to the specified course", ENTITY_NAME, "courseMismatch");
+        }
         updateLectureAttributesFromDTO(originalLecture, updatedLectureDto);
 
         channelService.updateLectureChannel(originalLecture, updatedLectureDto.channelName());

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/LectureIntegrationTest.java
@@ -261,6 +261,40 @@ class LectureIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateLecture_lectureFromUnauthorizedCourseWithAuthorizedCourseInBody_shouldReturnForbidden() throws Exception {
+        Course otherCourse = courseUtilService.addEmptyCourse("other-students", "other-tutors", "other-editors", "other-instructors");
+        Lecture otherLecture = lectureUtilService.createLecture(otherCourse);
+        String originalDescription = otherLecture.getDescription();
+
+        LectureResource.SimpleLectureDTO lectureDto = new LectureResource.SimpleLectureDTO(otherLecture.getId(), "Malicious Update", "Updated from another course",
+                ZonedDateTime.now().plusMonths(3), ZonedDateTime.now().plusMonths(4), true, "attacker-renamed-channel", LectureResource.SimpleLectureDTO.CourseDTO.from(course1));
+
+        request.putWithResponseBody("/api/lecture/lectures", lectureDto, LectureResource.SimpleLectureDTO.class, HttpStatus.FORBIDDEN);
+
+        Lecture unchangedLecture = lectureRepository.findByIdElseThrow(otherLecture.getId());
+        assertThat(unchangedLecture.getDescription()).isEqualTo(originalDescription);
+        assertThat(unchangedLecture.getTitle()).isEqualTo(otherLecture.getTitle());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateLecture_mismatchedCourseInBody_shouldReturnBadRequest() throws Exception {
+        Course otherAuthorizedCourse = courseUtilService.addEmptyCourse();
+        Lecture originalLecture = lectureRepository.findByIdElseThrow(lecture1.getId());
+
+        LectureResource.SimpleLectureDTO lectureDto = new LectureResource.SimpleLectureDTO(originalLecture.getId(), "Mismatched Update", "Updated with mismatched course",
+                ZonedDateTime.now().plusMonths(3), ZonedDateTime.now().plusMonths(4), true, "mismatched-channel",
+                LectureResource.SimpleLectureDTO.CourseDTO.from(otherAuthorizedCourse));
+
+        request.putWithResponseBody("/api/lecture/lectures", lectureDto, LectureResource.SimpleLectureDTO.class, HttpStatus.BAD_REQUEST);
+
+        Lecture unchangedLecture = lectureRepository.findByIdElseThrow(originalLecture.getId());
+        assertThat(unchangedLecture.getDescription()).isEqualTo(originalLecture.getDescription());
+        assertThat(unchangedLecture.getTitle()).isEqualTo(originalLecture.getTitle());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void updateLecture_NoId_shouldReturnBadRequest() throws Exception {
         Lecture originalLecture = lectureRepository.findByIdWithLectureUnitsAndAttachments(lecture1.getId()).orElseThrow();
         originalLecture.setId(null);

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/LectureIntegrationTest.java
@@ -295,6 +295,21 @@ class LectureIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateLecture_nullCourseInBody_shouldReturnBadRequest() throws Exception {
+        Lecture originalLecture = lectureRepository.findByIdElseThrow(lecture1.getId());
+
+        LectureResource.SimpleLectureDTO lectureDto = new LectureResource.SimpleLectureDTO(originalLecture.getId(), "Null Course Update", "Updated with null course",
+                ZonedDateTime.now().plusMonths(3), ZonedDateTime.now().plusMonths(4), true, "null-course-channel", null);
+
+        request.putWithResponseBody("/api/lecture/lectures", lectureDto, LectureResource.SimpleLectureDTO.class, HttpStatus.BAD_REQUEST);
+
+        Lecture unchangedLecture = lectureRepository.findByIdElseThrow(originalLecture.getId());
+        assertThat(unchangedLecture.getDescription()).isEqualTo(originalLecture.getDescription());
+        assertThat(unchangedLecture.getTitle()).isEqualTo(originalLecture.getTitle());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void updateLecture_NoId_shouldReturnBadRequest() throws Exception {
         Lecture originalLecture = lectureRepository.findByIdWithLectureUnitsAndAttachments(lecture1.getId()).orElseThrow();
         originalLecture.setId(null);


### PR DESCRIPTION
## Summary
- Fixes `PUT /api/lecture/lectures` so authorization is checked against the lecture’s persisted course instead of trusting the client-supplied course ID.
- Rejects mismatched course data in the request body with a bad request response.
- Adds regression coverage for the cross-course update path and the course-mismatch case.

## Testing
- `./gradlew test --tests LectureIntegrationTest -x webapp`
- `./gradlew checkstyleMain -x webapp`
- Negative check confirmed the new regression tests fail against the vulnerable implementation and pass with the fix restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger validation when updating lectures so the lecture’s course must match the persisted course; updates with missing, mismatched, or unauthorized course are rejected to prevent unintended changes.
* **Tests**
  * Added integration tests covering authorization and course-validation scenarios to ensure invalid update attempts are blocked and lecture content remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Steps for Testing

1. Log in to Artemis-test-server with your own test account.

2. Copy your session JWT from the browser storage/cookies.
   Use it as `YOUR_SESSION_TOKEN` in the curl request below.

3. Find an attacker-controlled course ID:
   - Open a course that your account owns or can manage.
   - Copy the course ID from the URL:
     ```text
     $BASE_URL/courses/$id
     ```
   - Use this value as `<ATTACKER_CONTROLLED_COURSE_ID>`.

4. Find the target lecture ID:
   - Open the lecture that should not be editable through your attacker-controlled course.
   - Copy the lecture ID from the URL:
     ```text
     $BASE_URL/courses/130/lectures/$id
     ```
   - Use this value as `<TARGET_LECTURE_ID>`.

5. Optional: verify the exploit on another test system before testing the fix.
   - Use a test deployment that does not contain the current fix.
   - Repeat steps 1-4 on that system.
   - Send the request from step 6.
   - Confirm that the target lecture is incorrectly updated there.
   - This establishes that the request reproduces the original vulnerability.

6. Send the malicious update request against the fixed system:

   ```bash
   curl "$BASE_URL/api/lecture/lectures" \
     -X PUT \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json' \
     -H 'Cookie: jwt=YOUR_SESSION_TOKEN' \
     --data-raw '{
       "id": <TARGET_LECTURE_ID>,
       "title": "This Title was changed maliciously",
       "description": "Modified from another course",
       "startDate": "2027-04-07T10:00:00.000Z",
       "endDate": "2027-04-07T12:00:00.000Z",
       "isTutorialLecture": true,
       "channelName": "attacker-renamed-channel",
       "course": {
         "id": <ATTACKER_CONTROLLED_COURSE_ID>
       }
     }'
   ```

7. Verify the result:
   - The request should be rejected.
   - The target lecture must not be updated.
   - Reopen the target lecture in the UI and confirm that the title, description, dates, tutorial flag, and channel name are unchanged.
