### PR TITLE
`Assessment`: Support local LLM choice for feedback generation

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaFeedbackSuggestionsService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaFeedbackSuggestionsService.java
@@ -188,7 +188,11 @@ public class AthenaFeedbackSuggestionsService {
             return null;
         }
 
-        return studentParticipation.getStudent().map(User::getSelectedLLMUsage).orElse(null);
+        var selection = studentParticipation.getStudent().map(User::getSelectedLLMUsage).orElse(null);
+        if (selection == null || selection == AiSelectionDecision.NO_AI) {
+            throw new BadRequestAlertException("AI feedback requires an accepted LLM selection", "submission", "llmSelectionRequired", true);
+        }
+        return selection;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaFeedbackSuggestionsService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaFeedbackSuggestionsService.java
@@ -33,6 +33,7 @@ import de.tum.cit.aet.artemis.atlas.api.LearnerProfileApi;
 import de.tum.cit.aet.artemis.atlas.domain.profile.LearnerProfile;
 import de.tum.cit.aet.artemis.atlas.dto.CourseCompetencyDTO;
 import de.tum.cit.aet.artemis.atlas.dto.LearnerProfileDTO;
+import de.tum.cit.aet.artemis.core.domain.AiSelectionDecision;
 import de.tum.cit.aet.artemis.core.domain.LLMRequest;
 import de.tum.cit.aet.artemis.core.domain.LLMServiceType;
 import de.tum.cit.aet.artemis.core.domain.User;
@@ -108,7 +109,7 @@ public class AthenaFeedbackSuggestionsService {
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private record RequestDTO(@NonNull ExerciseBaseDTO exercise, @NonNull SubmissionBaseDTO submission, @Nullable LearnerProfileDTO learnerProfile, @NonNull boolean isGraded,
-            @Nullable SubmissionBaseDTO latestSubmission, @Nullable List<CourseCompetencyDTO> competencies) {
+            @Nullable AiSelectionDecision selection, @Nullable SubmissionBaseDTO latestSubmission, @Nullable List<CourseCompetencyDTO> competencies) {
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -170,6 +171,27 @@ public class AthenaFeedbackSuggestionsService {
     }
 
     /**
+     * Extract the student's LLM selection for preliminary Athena feedback requests.
+     *
+     * @param submission the submission to extract the selection from
+     * @param isGraded   whether the Athena request is for graded feedback
+     * @return the student's LLM selection or null if it should not be forwarded
+     */
+    @Nullable
+    private AiSelectionDecision extractSelectedLLMUsage(Submission submission, boolean isGraded) {
+        if (isGraded) {
+            return null;
+        }
+
+        if (!(submission.getParticipation() instanceof StudentParticipation studentParticipation)) {
+            log.debug("Cannot extract LLM selection: submission is not from a student participation");
+            return null;
+        }
+
+        return studentParticipation.getStudent().map(User::getSelectedLLMUsage).orElse(null);
+    }
+
+    /**
      * Calls the remote Athena service to get feedback suggestions for a given submission.
      *
      * @param exercise   the {@link TextExercise} the suggestions are fetched for
@@ -196,7 +218,7 @@ public class AthenaFeedbackSuggestionsService {
         List<CourseCompetencyDTO> competencies = courseCompetencyApi.map(api -> api.findAllByExerciseId(exercise.getId()).stream().map(CourseCompetencyDTO::of).toList())
                 .orElse(null);
         final RequestDTO request = new RequestDTO(athenaDTOConverterService.ofExercise(exercise), athenaDTOConverterService.ofSubmission(exercise.getId(), submission),
-                LearnerProfileDTO.of(extractLearnerProfile(submission)), isGraded, latestSubmissionDTO, competencies);
+                LearnerProfileDTO.of(extractLearnerProfile(submission)), isGraded, extractSelectedLLMUsage(submission, isGraded), latestSubmissionDTO, competencies);
         ResponseDTOText response = textAthenaConnector.invokeWithRetry(athenaModuleService.getAthenaModuleUrl(exercise) + "/feedback_suggestions", request, 0);
         log.info("Athena responded to '{}' feedback suggestions request: {}", isGraded ? "Graded" : "Non Graded", response.data);
         storeTokenUsage(exercise, submission, response.meta, !isGraded);
@@ -221,7 +243,7 @@ public class AthenaFeedbackSuggestionsService {
         }
 
         final RequestDTO request = new RequestDTO(athenaDTOConverterService.ofExercise(exercise), athenaDTOConverterService.ofSubmission(exercise.getId(), submission), null,
-                isGraded, null, null);
+                isGraded, extractSelectedLLMUsage(submission, isGraded), null, null);
         ResponseDTOProgramming response = programmingAthenaConnector.invokeWithRetry(athenaModuleService.getAthenaModuleUrl(exercise) + "/feedback_suggestions", request, 0);
         log.info("Athena responded to '{}' feedback suggestions request: {}", isGraded ? "Graded" : "Non Graded", response.data);
         storeTokenUsage(exercise, submission, response.meta, !isGraded);
@@ -250,7 +272,7 @@ public class AthenaFeedbackSuggestionsService {
         }
 
         final RequestDTO request = new RequestDTO(athenaDTOConverterService.ofExercise(exercise), athenaDTOConverterService.ofSubmission(exercise.getId(), submission), null,
-                isGraded, null, null);
+                isGraded, extractSelectedLLMUsage(submission, isGraded), null, null);
         ResponseDTOModeling response = modelingAthenaConnector.invokeWithRetry(athenaModuleService.getAthenaModuleUrl(exercise) + "/feedback_suggestions", request, 0);
         log.info("Athena responded to '{}' feedback suggestions request: {}", isGraded ? "Graded" : "Non Graded", response.data);
         storeTokenUsage(exercise, submission, response.meta, !isGraded);

--- a/src/main/webapp/app/core/course/overview/exercise-details/request-feedback-button/request-feedback-button.component.spec.ts
+++ b/src/main/webapp/app/core/course/overview/exercise-details/request-feedback-button/request-feedback-button.component.spec.ts
@@ -345,6 +345,14 @@ describe('RequestFeedbackButtonComponent', () => {
         expect(component.hasUserAcceptedLLMUsage).toBe(true);
     });
 
+    it('should set hasUserAcceptedLLMUsage to true when selectedLLMUsage is LOCAL_AI', () => {
+        vi.spyOn(accountService, 'userIdentity').mockReturnValue({ selectedLLMUsage: LLMSelectionDecision.LOCAL_AI } as any);
+
+        component.setUserAcceptedLLMUsage();
+
+        expect(component.hasUserAcceptedLLMUsage).toBe(true);
+    });
+
     it('should set hasUserAcceptedLLMUsage to false when user identity is undefined', () => {
         vi.spyOn(accountService, 'userIdentity').mockReturnValue(undefined);
 
@@ -353,8 +361,8 @@ describe('RequestFeedbackButtonComponent', () => {
         expect(component.hasUserAcceptedLLMUsage).toBe(false);
     });
 
-    it('should set hasUserAcceptedLLMUsage to false when selectedLLMUsage is not CLOUD_AI', () => {
-        vi.spyOn(accountService, 'userIdentity').mockReturnValue({ selectedLLMUsage: LLMSelectionDecision.LOCAL_AI } as any);
+    it('should set hasUserAcceptedLLMUsage to false when selectedLLMUsage is NO_AI', () => {
+        vi.spyOn(accountService, 'userIdentity').mockReturnValue({ selectedLLMUsage: LLMSelectionDecision.NO_AI } as any);
 
         component.setUserAcceptedLLMUsage();
 
@@ -412,12 +420,15 @@ describe('RequestFeedbackButtonComponent', () => {
         vi.spyOn(llmModalService, 'open').mockResolvedValue(LLMSelectionDecision.LOCAL_AI);
         vi.spyOn(userService, 'updateLLMSelectionDecision').mockReturnValue(of(new HttpResponse<void>({})));
         vi.spyOn(accountService, 'setUserLLMSelectionDecision');
+        vi.spyOn(courseExerciseService, 'requestFeedback').mockReturnValue(of({} as StudentParticipation));
 
         await component.showLLMSelectionModal();
         await vi.advanceTimersByTimeAsync(0);
 
         expect(userService.updateLLMSelectionDecision).toHaveBeenCalledWith(LLMSelectionDecision.LOCAL_AI);
+        expect(component.hasUserAcceptedLLMUsage).toBe(true);
         expect(accountService.setUserLLMSelectionDecision).toHaveBeenCalledWith(LLMSelectionDecision.LOCAL_AI);
+        expect(courseExerciseService.requestFeedback).toHaveBeenCalledWith(exercise.id, participation.id);
     });
 
     it('should handle no_ai choice from modal', async () => {
@@ -431,12 +442,14 @@ describe('RequestFeedbackButtonComponent', () => {
         vi.spyOn(llmModalService, 'open').mockResolvedValue(LLMSelectionDecision.NO_AI);
         vi.spyOn(userService, 'updateLLMSelectionDecision').mockReturnValue(of(new HttpResponse<void>({})));
         vi.spyOn(accountService, 'setUserLLMSelectionDecision');
+        vi.spyOn(courseExerciseService, 'requestFeedback').mockReturnValue(of({} as StudentParticipation));
 
         await component.showLLMSelectionModal();
         await vi.advanceTimersByTimeAsync(0);
 
         expect(userService.updateLLMSelectionDecision).toHaveBeenCalledWith(LLMSelectionDecision.NO_AI);
         expect(accountService.setUserLLMSelectionDecision).toHaveBeenCalledWith(LLMSelectionDecision.NO_AI);
+        expect(courseExerciseService.requestFeedback).not.toHaveBeenCalled();
     });
 
     it('should not update when modal returns none', async () => {

--- a/src/main/webapp/app/core/course/overview/exercise-details/request-feedback-button/request-feedback-button.component.ts
+++ b/src/main/webapp/app/core/course/overview/exercise-details/request-feedback-button/request-feedback-button.component.ts
@@ -66,6 +66,10 @@ export class RequestFeedbackButtonComponent implements OnInit, OnDestroy {
     private athenaResultUpdateListener?: Subscription;
     private acceptSubscription?: Subscription;
 
+    private isAcceptedLLMSelection(selection?: LLMSelectionDecision): boolean {
+        return selection === LLMSelectionDecision.CLOUD_AI || selection === LLMSelectionDecision.LOCAL_AI;
+    }
+
     ngOnInit() {
         this.athenaEnabled = this.profileService.isProfileActive(PROFILE_ATHENA);
         this.isExamExercise = isExamExercise(this.exercise());
@@ -107,7 +111,7 @@ export class RequestFeedbackButtonComponent implements OnInit, OnDestroy {
 
     setUserAcceptedLLMUsage(): void {
         const selection = this.accountService.userIdentity()?.selectedLLMUsage;
-        this.hasUserAcceptedLLMUsage = selection === LLMSelectionDecision.CLOUD_AI;
+        this.hasUserAcceptedLLMUsage = this.isAcceptedLLMSelection(selection);
     }
 
     async showLLMSelectionModal(): Promise<void> {
@@ -133,7 +137,7 @@ export class RequestFeedbackButtonComponent implements OnInit, OnDestroy {
         this.acceptSubscription?.unsubscribe();
 
         this.acceptSubscription = this.userService.updateLLMSelectionDecision(decision).subscribe(() => {
-            const hasAccepted = decision === LLMSelectionDecision.CLOUD_AI;
+            const hasAccepted = this.isAcceptedLLMSelection(decision);
 
             this.hasUserAcceptedLLMUsage = hasAccepted;
             this.accountService.setUserLLMSelectionDecision(decision);

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header-actions/exercise-header-actions.component.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header-actions/exercise-header-actions.component.ts
@@ -202,7 +202,7 @@ export class ExerciseHeaderActionsComponent {
     readonly userLLMSelection = computed(() => this.accountService.userIdentity()?.selectedLLMUsage);
     readonly hasUserAcceptedLLM = computed(() => {
         const selection = this.userLLMSelection();
-        return selection === LLMSelectionDecision.CLOUD_AI;
+        return selection === LLMSelectionDecision.CLOUD_AI || selection === LLMSelectionDecision.LOCAL_AI;
     });
     readonly showFeedbackPopover = computed(() => !this.examMode() && (this.exercise().allowFeedbackRequests ?? false) && this.hasUserAcceptedLLM());
 

--- a/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSuggestionsServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSuggestionsServiceTest.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.artemis.athena.service.connectors;
 
+import static de.tum.cit.aet.artemis.core.connector.AthenaRequestMockProvider.ATHENA_MODULE_MODELING_TEST;
 import static de.tum.cit.aet.artemis.core.connector.AthenaRequestMockProvider.ATHENA_MODULE_PROGRAMMING_TEST;
 import static de.tum.cit.aet.artemis.core.connector.AthenaRequestMockProvider.ATHENA_MODULE_TEXT_TEST;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,6 +27,7 @@ import de.tum.cit.aet.artemis.athena.dto.TextFeedbackDTO;
 import de.tum.cit.aet.artemis.athena.service.AthenaFeedbackSuggestionsService;
 import de.tum.cit.aet.artemis.atlas.api.LearnerProfileApi;
 import de.tum.cit.aet.artemis.atlas.domain.profile.LearnerProfile;
+import de.tum.cit.aet.artemis.core.domain.AiSelectionDecision;
 import de.tum.cit.aet.artemis.core.domain.User;
 import de.tum.cit.aet.artemis.core.exception.ConflictException;
 import de.tum.cit.aet.artemis.core.exception.NetworkingException;
@@ -78,6 +80,10 @@ class AthenaFeedbackSuggestionsServiceTest extends AbstractAthenaTest {
         textSubmission = new TextSubmission(2L).text("This is a text submission");
         StudentParticipation textParticipation = new StudentParticipation().exercise(textExercise);
         textParticipation.setId(1L);
+        User textStudent = new User();
+        textStudent.setId(11L);
+        textStudent.setSelectedLLMUsage(AiSelectionDecision.LOCAL_AI);
+        textParticipation.setParticipant(textStudent);
         textSubmission.setParticipation(textParticipation);
 
         programmingExercise = programmingExerciseUtilService.createSampleProgrammingExercise();
@@ -86,15 +92,23 @@ class AthenaFeedbackSuggestionsServiceTest extends AbstractAthenaTest {
         programmingSubmission.setId(3L);
         StudentParticipation programmingParticipation = new StudentParticipation().exercise(programmingExercise);
         programmingParticipation.setId(2L);
+        User programmingStudent = new User();
+        programmingStudent.setId(12L);
+        programmingStudent.setSelectedLLMUsage(AiSelectionDecision.CLOUD_AI);
+        programmingParticipation.setParticipant(programmingStudent);
         programmingSubmission.setParticipation(programmingParticipation);
 
         modelingExercise = new ModelingExercise();
         modelingExercise.setId(5L);
-        modelingExercise.setFeedbackSuggestionModule(ATHENA_MODULE_PROGRAMMING_TEST);
+        modelingExercise.setFeedbackSuggestionModule(ATHENA_MODULE_MODELING_TEST);
         modelingSubmission = new ModelingSubmission();
         modelingSubmission.setId(6L);
         StudentParticipation modelingParticipation = new StudentParticipation().exercise(modelingExercise);
         modelingParticipation.setId(4L);
+        User modelingStudent = new User();
+        modelingStudent.setId(13L);
+        modelingStudent.setSelectedLLMUsage(AiSelectionDecision.LOCAL_AI);
+        modelingParticipation.setParticipant(modelingStudent);
         modelingSubmission.setParticipation(modelingParticipation);
     }
 
@@ -103,7 +117,7 @@ class AthenaFeedbackSuggestionsServiceTest extends AbstractAthenaTest {
     void testFeedbackSuggestionsText() throws NetworkingException {
         athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("text", jsonPath("$.exercise.id").value(textExercise.getId()),
                 jsonPath("$.exercise.title").value(textExercise.getTitle()), jsonPath("$.submission.id").value(textSubmission.getId()),
-                jsonPath("$.submission.text").value(textSubmission.getText()));
+                jsonPath("$.submission.text").value(textSubmission.getText()), jsonPath("$.selection").doesNotExist());
         List<TextFeedbackDTO> suggestions = athenaFeedbackSuggestionsService.getTextFeedbackSuggestions(textExercise, textSubmission, true);
         assertThat(suggestions.getFirst().title()).isEqualTo("Not so good");
         assertThat(suggestions.getFirst().indexStart()).isEqualTo(3);
@@ -157,11 +171,64 @@ class AthenaFeedbackSuggestionsServiceTest extends AbstractAthenaTest {
     void testFeedbackSuggestionsProgramming() throws NetworkingException {
         athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("programming", jsonPath("$.exercise.id").value(programmingExercise.getId()),
                 jsonPath("$.exercise.title").value(programmingExercise.getTitle()), jsonPath("$.submission.id").value(programmingSubmission.getId()),
-                jsonPath("$.submission.repositoryUri")
-                        .value(serverUrl + "/api/athena/internal/programming-exercises/" + programmingExercise.getId() + "/submissions/3/repository"));
+                jsonPath("$.submission.repositoryUri").value(serverUrl + "/api/athena/internal/programming-exercises/" + programmingExercise.getId() + "/submissions/3/repository"),
+                jsonPath("$.selection").doesNotExist());
         List<ProgrammingFeedbackDTO> suggestions = athenaFeedbackSuggestionsService.getProgrammingFeedbackSuggestions(programmingExercise, programmingSubmission, true);
         assertThat(suggestions.getFirst().title()).isEqualTo("Not so good");
         assertThat(suggestions.getFirst().lineStart()).isEqualTo(3);
+        athenaRequestMockProvider.verify();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
+    void testFeedbackSuggestionsModelingDoesNotIncludeSelectionForGradedRequest() throws NetworkingException {
+        athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("modeling", jsonPath("$.exercise.id").value(modelingExercise.getId()),
+                jsonPath("$.submission.id").value(modelingSubmission.getId()), jsonPath("$.selection").doesNotExist());
+
+        List<ModelingFeedbackDTO> suggestions = athenaFeedbackSuggestionsService.getModelingFeedbackSuggestions(modelingExercise, modelingSubmission, true);
+
+        assertThat(suggestions.getFirst().title()).isEqualTo("Not so good");
+        athenaRequestMockProvider.verify();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testFeedbackSuggestionsTextIncludesSelectionForNonGradedRequest() throws NetworkingException {
+        athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("text", jsonPath("$.exercise.id").value(textExercise.getId()),
+                jsonPath("$.exercise.title").value(textExercise.getTitle()), jsonPath("$.submission.id").value(textSubmission.getId()),
+                jsonPath("$.submission.text").value(textSubmission.getText()), jsonPath("$.selection").value(AiSelectionDecision.LOCAL_AI.name()));
+
+        List<TextFeedbackDTO> suggestions = athenaFeedbackSuggestionsService.getTextFeedbackSuggestions(textExercise, textSubmission, false);
+
+        assertThat(suggestions.getFirst().title()).isEqualTo("Not so good");
+        assertThat(suggestions.getFirst().indexStart()).isEqualTo(3);
+        athenaRequestMockProvider.verify();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testFeedbackSuggestionsProgrammingIncludesSelectionForNonGradedRequest() throws NetworkingException {
+        athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("programming", jsonPath("$.exercise.id").value(programmingExercise.getId()),
+                jsonPath("$.exercise.title").value(programmingExercise.getTitle()), jsonPath("$.submission.id").value(programmingSubmission.getId()),
+                jsonPath("$.submission.repositoryUri").value(serverUrl + "/api/athena/internal/programming-exercises/" + programmingExercise.getId() + "/submissions/3/repository"),
+                jsonPath("$.selection").value(AiSelectionDecision.CLOUD_AI.name()));
+
+        List<ProgrammingFeedbackDTO> suggestions = athenaFeedbackSuggestionsService.getProgrammingFeedbackSuggestions(programmingExercise, programmingSubmission, false);
+
+        assertThat(suggestions.getFirst().title()).isEqualTo("Not so good");
+        assertThat(suggestions.getFirst().lineStart()).isEqualTo(3);
+        athenaRequestMockProvider.verify();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testFeedbackSuggestionsModelingIncludesSelectionForNonGradedRequest() throws NetworkingException {
+        athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("modeling", jsonPath("$.exercise.id").value(modelingExercise.getId()),
+                jsonPath("$.submission.id").value(modelingSubmission.getId()), jsonPath("$.selection").value(AiSelectionDecision.LOCAL_AI.name()));
+
+        List<ModelingFeedbackDTO> suggestions = athenaFeedbackSuggestionsService.getModelingFeedbackSuggestions(modelingExercise, modelingSubmission, false);
+
+        assertThat(suggestions.getFirst().title()).isEqualTo("Not so good");
         athenaRequestMockProvider.verify();
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSuggestionsServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/athena/service/connectors/AthenaFeedbackSuggestionsServiceTest.java
@@ -29,6 +29,7 @@ import de.tum.cit.aet.artemis.atlas.api.LearnerProfileApi;
 import de.tum.cit.aet.artemis.atlas.domain.profile.LearnerProfile;
 import de.tum.cit.aet.artemis.core.domain.AiSelectionDecision;
 import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.exception.ConflictException;
 import de.tum.cit.aet.artemis.core.exception.NetworkingException;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
@@ -230,6 +231,22 @@ class AthenaFeedbackSuggestionsServiceTest extends AbstractAthenaTest {
 
         assertThat(suggestions.getFirst().title()).isEqualTo("Not so good");
         athenaRequestMockProvider.verify();
+    }
+
+    @Test
+    void testFeedbackSuggestionsTextRejectsNoAiSelectionForNonGradedRequest() {
+        ((StudentParticipation) textSubmission.getParticipation()).getStudent().ifPresent(student -> student.setSelectedLLMUsage(AiSelectionDecision.NO_AI));
+
+        assertThatExceptionOfType(BadRequestAlertException.class)
+                .isThrownBy(() -> athenaFeedbackSuggestionsService.getTextFeedbackSuggestions(textExercise, textSubmission, false));
+    }
+
+    @Test
+    void testFeedbackSuggestionsTextRejectsMissingSelectionForNonGradedRequest() {
+        ((StudentParticipation) textSubmission.getParticipation()).getStudent().ifPresent(student -> student.setSelectedLLMUsage(null));
+
+        assertThatExceptionOfType(BadRequestAlertException.class)
+                .isThrownBy(() -> athenaFeedbackSuggestionsService.getTextFeedbackSuggestions(textExercise, textSubmission, false));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In #11845, support for local LLM modules and users' AI preferences was added to Iris. With this PR, we now also enable the support of local LLMs for AI feedback generation.

This PR is dependent on Athena`s API changes introduced in this PR: https://github.com/ls1intum/edutelligence/pull/538

### Description
<!-- Describe your changes in detail -->
This PR adds the user`s AI preference to the Athena feedback request. In the client, the button to request AI feedback is now also shown when a local LLM preference is selected, not just for the Cloud LLM preference.

The corresponding tests were adapted, and new tests for this were added.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- Artemis Testserver 1-3
- 1 Student
- 1 Modeling/Text/Programming Exercise with AI Feedback Requests enabled


###### Cloud AI Preference

1. Set the AI Preference for your user to **Cloud AI** in the user settings
2. Navigate to Exercise
3. Participate in the exercise
4. Submit the exercise
5. You should be able to request AI Feedback for your submission
6. View the Athena logs at https://athena-test1.ase.cit.tum.de/logs (credentials for the log viewer are here: https://outline.aet.cit.tum.de/doc/deployments-test-server-BHipUJOj68#h-api-secrets-and-log-credentials)
7. Search for the latest feedback request  (log line begins with predict_and_parse) and make sure the used model is _azure_openai_gpt-4o_
8. Feedback should be generated successfully and displayed in Artemis

###### Local AI Preference

1. Set the AI Preference for your user to **Local AI** in the user settings
2. Navigate to Exercise
3. Participate in the exercise
4. Submit the exercise
5. You should be able to request AI Feedback for your submission
6. View the Athena logs at https://athena-test1.ase.cit.tum.de/logs (credentials for the log viewer are here: https://outline.aet.cit.tum.de/doc/deployments-test-server-BHipUJOj68#h-api-secrets-and-log-credentials)
7. Search for the latest feedback request (log line begins with predict_and_parse) and make sure the used model is _logos_openai_gpt-oss-120b_
8. Feedback should be generated successfully and displayed in Artemis

###### No AI Preference

1. Set the AI Preference for your user to **no AI** in the user settings
2. Navigate to Exercise
3. Participate in the exercise
4. Submit the exercise
5. Make sure there is no pop-up allowing the user to request feedback


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| request-feedback-button.component.ts | 96.00% | 205 | 53 | 25.9 |
| exercise-header-actions.component.ts | not found (modified) | 470 | ? | ? |

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| AthenaFeedbackSuggestionsService.java | 76.64% | 223 |

_Last updated: 2026-05-06 12:01:00 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LOCAL_AI is now accepted alongside CLOUD_AI for requesting feedback.

* **Improvements**
  * The feedback flow forwards the user's AI selection to the feedback service so preferred usage is respected.

* **Behavior**
  * Feedback requests proceed only when an accepted AI option is chosen; choosing NO_AI prevents the request.

* **Tests**
  * Expanded tests cover AI selection across text, programming, and modeling, including graded vs non-graded scenarios and modal flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->