### PR TITLE
`Development`: Patch Thymeleaf SSTI advisory and document httpclient5 pin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,9 +102,9 @@ gitProperties {
 }
 
 // Override Spring Boot BOM versions to patched releases addressing known CVEs
-// thymeleaf 3.1.4.RELEASE: GHSA-7rgv-g3jm-rvv4, GHSA-vjp2-6m4m-cv5q
+// thymeleaf 3.1.5.RELEASE: GHSA-7rgv-g3jm-rvv4, GHSA-vjp2-6m4m-cv5q, GHSA-c9ph-gxww-7744
 // tomcat 11.0.21: GHSA-h9fx-5mv3-gmh6, GHSA-6q54-28g2-vpgm, GHSA-55j7-cm8x-wvmh
-ext["thymeleaf.version"] = "3.1.4.RELEASE"
+ext["thymeleaf.version"] = "3.1.5.RELEASE"
 ext["tomcat.version"] = "11.0.21"
 
 configurations {
@@ -198,8 +198,14 @@ dependencies {
 
     // Required by Sharing Platform
     implementation "org.codeability:SharingPluginPlatformAPI:1.2.1"
-    // Required by Spring cloud
-    // Cannot org.apache.httpcomponents to later version due to compatibility issues
+    // Required by Spring cloud.
+    // Pinned to 5.5.1: not vulnerable to CVE-2026-40542 / GHSA-v468-qcjx-r72w (vulnerable range >= 5.6-alpha1, < 5.6.1).
+    // The CVE affects the SCRAM-SHA-256 authentication scheme that was first introduced in 5.6; that code path does not
+    // exist in 5.5.x, and Artemis does not use SCRAM-SHA-256 anywhere. A transitive request for httpclient5:5.6 from
+    // io.weaviate:client6 (and httpclient5:5.5.2 from httpclient5-cache via the Spring BOM / Shibboleth) is resolved
+    // down to 5.5.1 by this explicit pin.
+    // We cannot upgrade to 5.6.1 (the patched release) because it breaks Hazelcast cluster formation; the bump was
+    // reverted in commit 732b1c9b32 (PR #12652).
     implementation "org.apache.httpcomponents.client5:httpclient5:5.5.1"
     implementation "org.apache.httpcomponents.core5:httpcore5:5.3.6"
     implementation "org.apache.httpcomponents:httpmime:4.5.14"

--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ dependencies {
     // io.weaviate:client6 (and httpclient5:5.5.2 from httpclient5-cache via the Spring BOM / Shibboleth) is resolved
     // down to 5.5.1 by this explicit pin.
     // We cannot upgrade to 5.6.1 (the patched release) because it breaks Hazelcast cluster formation; the bump was
-    // reverted in commit 732b1c9b32 (PR #12652).
+    // reverted in PR #12652.
     implementation "org.apache.httpcomponents.client5:httpclient5:5.5.1"
     implementation "org.apache.httpcomponents.core5:httpcore5:5.3.6"
     implementation "org.apache.httpcomponents:httpmime:4.5.14"


### PR DESCRIPTION
### Summary
Bumps Thymeleaf from 3.1.4.RELEASE to 3.1.5.RELEASE to patch the critical sandboxed-expression / SSTI advisory (GHSA-c9ph-gxww-7744 / CVE-2026-41901), and expands the comment around the existing `httpclient5:5.5.1` pin to record why the pin is *not* affected by CVE-2026-40542 and why we cannot move forward to the patched 5.6.1 (Hazelcast cluster formation regression, see PR #12652).

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
This PR closes Dependabot alerts **#476** (org.thymeleaf:thymeleaf) and **#477** (org.thymeleaf:thymeleaf-spring6), and documents the rationale for the dismissal of Dependabot alert **#475** (org.apache.httpcomponents.client5:httpclient5).

- **Thymeleaf — actually vulnerable, must patch.** 3.1.4.RELEASE is affected by **GHSA-c9ph-gxww-7744 / CVE-2026-41901** (critical, CVSS 9.0): sandboxed Thymeleaf expressions can be bypassed and lead to Server-Side Template Injection. Upstream advises upgrading to 3.1.5.RELEASE. We use Thymeleaf only for server-controlled mail templates with fixed template names, so the live attack surface in Artemis is limited, but the patch is still the correct hygienic action.
- **httpclient5 — false positive, but worth documenting.** Alert #475 fires on a transitive request for `httpclient5:5.6` from `io.weaviate:client6:6.1.0` (and `5.5.2` from `httpclient5-cache` via the Spring Boot BOM / Shibboleth). Both are resolved down to our explicit pin **5.5.1**, which is *outside* the vulnerable range `>= 5.6-alpha1, < 5.6.1`. The vulnerable code path is the SCRAM-SHA-256 authentication scheme that was *first introduced in 5.6*; it does not exist in 5.5.x, and a repository-wide grep confirms Artemis does not configure or use SCRAM-SHA-256 anywhere. The forward bump to the patched 5.6.1 was attempted on 2026-05-02 but had to be reverted on 2026-05-05 because it broke Hazelcast cluster formation (PR #12652). Alert #475 was dismissed as `inaccurate`; this PR records the rationale next to the pin so future contributors do not re-trigger the regression.

### Description
- `build.gradle` (BOM override block): bumped `ext["thymeleaf.version"]` from `3.1.4.RELEASE` to `3.1.5.RELEASE` and added the new GHSA id to the override comment. The Spring Boot BOM override propagates to every `org.thymeleaf:*` artifact pulled in transitively. Verified via `./gradlew dependencyInsight --configuration runtimeClasspath` that both `org.thymeleaf:thymeleaf` and `org.thymeleaf:thymeleaf-spring6` resolve to `3.1.5.RELEASE` and that no other `org.thymeleaf:*` artifact lingers at an older version.
- `build.gradle` (httpclient5 pin): replaced the previous terse "compatibility issues" note next to `org.apache.httpcomponents.client5:httpclient5:5.5.1` with a detailed comment that records the vulnerable range, the source of the transitive 5.6 request, why our runtime is not affected (5.5.1 outside the range, SCRAM-SHA-256 unused), and the link back to PR #12652 for the Hazelcast incompatibility.

### Steps for Testing
This is a server-only build configuration change (BOM version override + comment). There are no functional behavior changes, so verification is at build / dependency-resolution / build-CI level rather than UI.

Prerequisites:
- A local checkout of this branch
- Docker (for the optional Spring integration tests)

1. Pull the branch and run `./gradlew dependencyInsight --configuration runtimeClasspath --dependency thymeleaf` — confirm `org.thymeleaf:thymeleaf:3.1.5.RELEASE` is selected.
2. Run `./gradlew dependencyInsight --configuration runtimeClasspath --dependency thymeleaf-spring6` — confirm `org.thymeleaf:thymeleaf-spring6:3.1.5.RELEASE` is selected.
3. Run `./gradlew dependencyInsight --configuration runtimeClasspath --dependency httpclient5` — confirm `httpclient5:5.5.1` is selected. The transitive `5.6` request from `io.weaviate:client6` and `5.5.2` from `httpclient5-cache` should both be downgraded to `5.5.1` by our explicit pin.
4. Run the email-template integration tests, which exercise Thymeleaf rendering end-to-end:
   - `./gradlew test -x webapp --tests MailServiceEmailIntegrationTest`
   - `./gradlew test -x webapp --tests CourseNotificationEmailIntegrationTest`
   - `./gradlew test -x webapp --tests MaintenanceEmailIntegrationTest`
5. Confirm CI build is green (no Spotless / Checkstyle / server-tests regression).

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Thymeleaf dependency to a newer stable version.
  * Expanded HTTP client dependency documentation with detailed notes explaining current version selection and upgrade considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->