### PR TITLE
`General`: Fix SAML2 login landing on landing page instead of dashboard

### DIFF
--- a/src/main/webapp/app/app.config.ts
+++ b/src/main/webapp/app/app.config.ts
@@ -85,10 +85,18 @@ export const appConfig: ApplicationConfig = {
             const hasSaml2FlowCookie = /(?:^|;\s*)SAML2flow=/.test(document.cookie);
             const completeSaml2 = hasSaml2FlowCookie
                 ? lastValueFrom(authServerProvider.loginSAML2(true))
-                      .catch(() => undefined)
+                      // The .catch is load-bearing: Promise.all below short-circuits on the first
+                      // rejection, so any error here would abort APP_INITIALIZER and prevent the SPA
+                      // from booting. We log so the failure is observable but recover by rendering
+                      // the landing page (or sign-in if the user navigates there manually).
+                      .catch((error) => {
+                          // eslint-disable-next-line no-undef
+                          console.warn('SAML2 second-step exchange failed during app initialization', error);
+                          return undefined;
+                      })
                       .finally(() => {
-                          // Path=/ matches the implicit default browsers assign when the cookie is set from
-                          // /sign-in, so the deletion reliably removes it regardless of the current document path.
+                          // Path=/ must match the path the cookie was set with in Saml2LoginComponent so the
+                          // deletion reliably removes it regardless of the document path the SPA boots from.
                           document.cookie = 'SAML2flow=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Lax;';
                       })
                 : Promise.resolve();

--- a/src/main/webapp/app/app.config.ts
+++ b/src/main/webapp/app/app.config.ts
@@ -24,6 +24,8 @@ import { ErrorHandlerInterceptor } from 'app/core/interceptor/errorhandler.inter
 import { NotificationInterceptor } from 'app/core/interceptor/notification.interceptor';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { AccountService } from 'app/core/auth/account.service';
+import { AuthServerProvider } from 'app/core/auth/auth-jwt.service';
+import { lastValueFrom } from 'rxjs';
 import { SentryErrorHandler } from 'app/core/sentry/sentry.error-handler';
 import { OwlNativeDateTimeModule } from '@danielmoncada/angular-datetime-picker';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
@@ -71,12 +73,24 @@ export const appConfig: ApplicationConfig = {
         provideAppInitializer(() => {
             const profileService = inject(ProfileService);
             const accountService = inject(AccountService);
+            const authServerProvider = inject(AuthServerProvider);
             inject(TraceService);
             // Ensure the service is initialized before any routing happens
             inject(ArtemisNavigationUtilService);
+            // If the IdP just redirected the user back to Artemis, complete the SAML2 second-step
+            // exchange (turn the SAML2 HttpSession into an Artemis JWT cookie) before resolving the
+            // user identity. This way the regular route guards see an authenticated user and route
+            // them to /courses, instead of the public landing page rendered for unauthenticated visitors.
+            const completeSaml2 = document.cookie.includes('SAML2flow=')
+                ? lastValueFrom(authServerProvider.loginSAML2(true))
+                      .catch(() => undefined)
+                      .finally(() => {
+                          document.cookie = 'SAML2flow=; expires=Thu, 01 Jan 1970 00:00:00 UTC; SameSite=Lax;';
+                      })
+                : Promise.resolve();
             // Load profile info and resolve user identity in parallel to minimize startup time.
             // Profile info is required for all components; identity resolution avoids a sequential HTTP call in route guards.
-            return Promise.all([profileService.loadProfileInfo(), accountService.identity().catch(() => undefined)]).then(() => undefined);
+            return Promise.all([profileService.loadProfileInfo(), completeSaml2.then(() => accountService.identity().catch(() => undefined))]).then(() => undefined);
         }),
         /**
          * @description Interceptor declarations:

--- a/src/main/webapp/app/app.config.ts
+++ b/src/main/webapp/app/app.config.ts
@@ -81,11 +81,15 @@ export const appConfig: ApplicationConfig = {
             // exchange (turn the SAML2 HttpSession into an Artemis JWT cookie) before resolving the
             // user identity. This way the regular route guards see an authenticated user and route
             // them to /courses, instead of the public landing page rendered for unauthenticated visitors.
-            const completeSaml2 = document.cookie.includes('SAML2flow=')
+            // Match the cookie name exactly so a name that merely ends with 'SAML2flow' cannot trigger this branch.
+            const hasSaml2FlowCookie = /(?:^|;\s*)SAML2flow=/.test(document.cookie);
+            const completeSaml2 = hasSaml2FlowCookie
                 ? lastValueFrom(authServerProvider.loginSAML2(true))
                       .catch(() => undefined)
                       .finally(() => {
-                          document.cookie = 'SAML2flow=; expires=Thu, 01 Jan 1970 00:00:00 UTC; SameSite=Lax;';
+                          // Path=/ matches the implicit default browsers assign when the cookie is set from
+                          // /sign-in, so the deletion reliably removes it regardless of the current document path.
+                          document.cookie = 'SAML2flow=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Lax;';
                       })
                 : Promise.resolve();
             // Load profile info and resolve user identity in parallel to minimize startup time.

--- a/src/main/webapp/app/app.routes.ts
+++ b/src/main/webapp/app/app.routes.ts
@@ -23,7 +23,10 @@ const routes: Routes = [
             (): boolean | UrlTree => {
                 const accountService = inject(AccountService);
                 const router = inject(Router);
-                // Identity is already resolved by the APP_INITIALIZER, so check synchronously
+                // Identity is already resolved by the APP_INITIALIZER, so check synchronously.
+                // Note: when returning from a SAML2 IdP, the initializer also completes the
+                // second-step JWT exchange before this guard runs, so userIdentity() is already
+                // populated and no SAML-specific branch is needed here.
                 if (accountService.userIdentity()) {
                     return router.parseUrl('/courses');
                 }

--- a/src/main/webapp/app/core/home/saml2-login/saml2-login.component.ts
+++ b/src/main/webapp/app/core/home/saml2-login/saml2-login.component.ts
@@ -23,7 +23,7 @@ export class Saml2LoginComponent implements OnInit {
         // If SAML2 flow was started, retry login.
         if (document.cookie.indexOf('SAML2flow=') >= 0) {
             // remove cookie
-            document.cookie = 'SAML2flow=; expires=Thu, 01 Jan 1970 00:00:00 UTC; ; SameSite=Lax;';
+            document.cookie = 'SAML2flow=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Lax;';
             this.loginSAML2();
         }
     }
@@ -39,8 +39,9 @@ export class Saml2LoginComponent implements OnInit {
             })
             .catch((error: HttpErrorResponse) => {
                 if (error.status === 401) {
-                    // (re)set cookie
-                    document.cookie = 'SAML2flow=true; max-age=120; SameSite=Lax;';
+                    // (re)set cookie. path=/ matches the deletion in ngOnInit and APP_INITIALIZER so the
+                    // cookie can be reliably cleared from the document root after the IdP round-trip.
+                    document.cookie = 'SAML2flow=true; max-age=120; path=/; SameSite=Lax;';
                     // arbitrary by SAML2 HTTP Filter Chain secured URL
                     window.location.replace('/saml2/authenticate');
                 } else if (error.status === 403) {

--- a/src/main/webapp/app/core/landing/landing-route-guard.spec.ts
+++ b/src/main/webapp/app/core/landing/landing-route-guard.spec.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Router, UrlTree, provideRouter } from '@angular/router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -6,27 +6,23 @@ import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from 'test/helpers/mocks/service/mock-account.service';
 import { User } from 'app/core/user/user.model';
-import { inject } from '@angular/core';
 
 @Component({ template: '', standalone: true })
 class DummyComponent {}
 
 /**
- * Extracted root route guard matching the one in app.routes.ts.
- * Authenticated users are redirected to /courses; unauthenticated users see the landing page.
+ * Extracted root route guard mirroring the one in app.routes.ts.
+ * The APP_INITIALIZER resolves the user identity (and, when returning from a SAML2 IdP, also
+ * completes the second-step JWT exchange) before this guard runs, so a synchronous read on
+ * userIdentity() is enough.
  */
-const rootRouteGuard = (): Promise<boolean | UrlTree> => {
+const rootRouteGuard = (): boolean | UrlTree => {
     const accountService = inject(AccountService);
     const router = inject(Router);
-    return accountService
-        .identity()
-        .then((account) => {
-            if (account) {
-                return router.parseUrl('/courses');
-            }
-            return true;
-        })
-        .catch(() => true);
+    if (accountService.userIdentity()) {
+        return router.parseUrl('/courses');
+    }
+    return true;
 };
 
 describe('Landing page route guard', () => {
@@ -55,7 +51,7 @@ describe('Landing page route guard', () => {
     });
 
     it('should redirect authenticated users to /courses', async () => {
-        vi.spyOn(accountService, 'identity').mockResolvedValue({ id: 1, login: 'user' } as User);
+        accountService.userIdentity.set({ id: 1, login: 'user' } as User);
 
         await router.navigateByUrl('/');
 
@@ -63,15 +59,7 @@ describe('Landing page route guard', () => {
     });
 
     it('should allow unauthenticated users to access the landing page', async () => {
-        vi.spyOn(accountService, 'identity').mockResolvedValue(undefined);
-
-        await router.navigateByUrl('/');
-
-        expect(router.url).toBe('/');
-    });
-
-    it('should allow access when identity call fails', async () => {
-        vi.spyOn(accountService, 'identity').mockRejectedValue(new Error('Network error'));
+        accountService.userIdentity.set(undefined);
 
         await router.navigateByUrl('/');
 


### PR DESCRIPTION
### Summary
Restores the dashboard redirect after SAML2 login. Since the public landing page started rendering at `/`, users returning from their IdP got stranded on it because the second-step JWT exchange only fired inside `HomeComponent` (which moved to `/sign-in`). The exchange now happens in `APP_INITIALIZER` before any route activates, so the existing "logged-in user → /courses" guard works for SAML2 users without any SAML-specific routing branch.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
After #12356 introduced the public landing page at `/`, SAML2 users no longer end up on their dashboard after logging in — they land on the marketing page with a "Log in" button, looking as if the SSO flow failed. Closes #12656.

The two-step nature of Artemis' SAML2 login is the cause: the IdP redirect lands on `/`, but a JWT only exists after `Saml2LoginComponent` detects the `SAML2flow=` cookie and POSTs `/api/core/public/saml2` to exchange the SAML2 HttpSession for a JWT cookie. That component is rendered by `HomeComponent`, which now lives at `/sign-in`, not `/`. Without the exchange, `accountService.userIdentity()` is empty in the root-route guard, so the landing page is shown.

LDAP/password login is not affected, because it completes the JWT issuance synchronously inside `HomeComponent.login()` and then calls `router.navigate(['courses'])` — no third-party redirect, no transient JWT-less state for the landing page to misinterpret.

### Description
- Move the SAML2flow second-step exchange into `APP_INITIALIZER` (`app.config.ts`):
  - If the `SAML2flow=` cookie is present, `POST /api/core/public/saml2` runs in parallel with profile loading and *before* `accountService.identity()`.
  - The cookie is cleared in `.finally(...)` with explicit `path=/` so a stale cookie can never loop, regardless of the path the cookie was originally set under.
  - On failure (e.g. expired SAML2 server session) the error is logged via `console.warn` for observability and the user falls back to the landing page; they can retry from `/sign-in`.
  - The `.catch` is load-bearing for `Promise.all` — without it, a SAML 401 would abort bootstrap entirely. Comment in code explains this.
- `Saml2LoginComponent` now creates and clears the `SAML2flow` cookie with explicit `path=/`, matching the APP_INITIALIZER deletion. Previously the cookie path defaulted to the document directory, which only happened to be `/` because `/sign-in` lives at the document root.
- Root-route guard in `app.routes.ts` stays minimal: still just checks `userIdentity()` synchronously. By the time it runs, the initializer has already populated identity for SAML2 returns, so the guard naturally redirects to `/courses` — no SAML-specific branch, no hardcoded `/sign-in`.
- `landing-route-guard.spec.ts` realigned with the actual guard (was previously testing a slightly different async variant).

### Steps for Testing
Prerequisites:
- Test server with SAML2 enabled (e.g. using Helios).
- 1 user that authenticates via SAML2.
- 1 user that authenticates via LDAP/password.

1. Open the test server in an incognito window so no JWT or `SAML2flow` cookie is leftover.
2. Click "Login with SAML2" on the sign-in page.
3. Authenticate at the IdP.
4. **Expected**: After the IdP returns, the address bar settles on `/courses` and the dashboard renders. The public landing page must not flash and `/sign-in` must not be shown again.
5. Open the same test server in a regular tab while still logged in and navigate to `/`.
6. **Expected**: You are redirected to `/courses` (existing behaviour, unchanged).
7. Log out and navigate to `/`.
8. **Expected**: The public landing page renders (existing behaviour, unchanged).
9. (LDAP/password regression check) Log in with username/password on `/sign-in`.
10. **Expected**: Direct navigation to `/courses` works as before — no extra HTTP calls or delays compared to current `develop`.
11. (Failure mode check) In DevTools, set a `SAML2flow=true; path=/` cookie on the Artemis origin while not authenticated, then refresh `/`. The cookie should be cleared automatically, a `console.warn` should appear about the failed second-step exchange, and the public landing page should render. The user can then click "Log in" normally.

#### Exam Mode Testing
The change touches the global authentication bootstrap path, so a smoke test that exam entry still works after a SAML2 login is worthwhile:

Prerequisites:
- 1 SAML2 student.
- 1 Exam (any exercise type) with the SAML2 student registered, in conduction window.

1. SAML2 student logs in (from a logged-out state) and navigates to the exam.
2. **Expected**: Exam start screen renders normally, no missing identity, no token issues, no double-login required.
3. Continue through the exam start, do at least one submission, hand in early.
4. **Expected**: All steps work as on `develop`.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment. A SAML2-enabled test server is required to exercise the actual fix path.

### Review Progress
#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [x] Test 1 (SAML2 round-trip lands on `/courses`)
- [x] Test 2 (LDAP/password regression check)

#### Exam Mode Test
- [x] Test 1 (SAML2 student can enter and submit an exam)

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| saml2-login.component.ts | 100.00% | 48 | 17 | 35.4 |

_Last updated: 2026-05-06 07:29:29 UTC_


### Screenshots
N/A — no UI changes; the change is in routing/initialization behaviour only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized authentication initialization to attempt and await SAML2 login completion before resolving user identity.
  * Simplified landing route guard to use a synchronous identity check for faster routing decisions.
* **Bug Fixes**
  * Improved SAML2 flow cookie handling (consistent path/SameSite) to reduce retry and redirect issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->