### PR TITLE
`Development`: Add fast multi-node E2E runner that launches nodes from WAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,8 @@ deferredEagerBeanInstantiationViolations.dot
 # Fast local E2E runner
 ######################
 /.e2e-local/
+/.e2e-local-multinode-fast/
+/.e2e-local-multinode/
 
 ######################
 # Claude Code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,21 @@ npm run test:one -- --test-path-pattern='src/main/webapp/app/path/to/spec\.ts$'
 ./run-e2e-tests-local-multinode.sh --filter "Quiz"         # Multi-node, filtered
 ./run-e2e-tests-local-multinode.sh --skip-build --skip-up  # Quick re-run against an already-running stack
 ./run-e2e-tests-local-multinode.sh --stop                  # Tear everything down
+
+# Multi-node E2E (fast variant) — same topology, host-launched JVMs instead of Docker images
+# Skips the Docker image build that dominates the slow path (~5–8 min). Reuses the WAR built by
+# Gradle and runs 3 java -jar processes on the host; Postgres/Eureka/ActiveMQ/nginx still run as
+# containers. Use this for server-side iteration on multi-node bugs. Cold ~1–2 min, warm ~30 s.
+./run-e2e-tests-local-multinode-fast.sh                       # Full run (build WAR + infra + 3 host JVMs + tests)
+./run-e2e-tests-local-multinode-fast.sh --filter "Quiz"       # Filter to a subset of tests
+./run-e2e-tests-local-multinode-fast.sh --skip-build --skip-up  # Re-run tests against the running stack
+./run-e2e-tests-local-multinode-fast.sh --stop                # Tear everything down
 ```
+
+**Which E2E runner should I use?**
+- `run-e2e-tests-local-fast.sh` — single node, Angular dev server. Best for client (UI) iteration.
+- `run-e2e-tests-local-multinode-fast.sh` — multi-node, WAR run from host. Best for server iteration that needs the cluster (Hazelcast, ActiveMQ STOMP, LB).
+- `run-e2e-tests-local-multinode.sh` — full Docker image build, prod-faithful. Use this to reproduce a CI-only failure or before pushing a multi-node-sensitive change.
 
 ## Project Structure
 

--- a/docker/artemis/config/node1-fast.env
+++ b/docker/artemis/config/node1-fast.env
@@ -1,0 +1,12 @@
+# node-1: Hazelcast member with core + scheduling profiles. HTTP :8080, Hazelcast :5701.
+SPRING_PROFILES_ACTIVE="prod,localvc,localci,core,scheduling,docker"
+EUREKA_INSTANCE_INSTANCEID="Artemis:1"
+SERVER_PORT="8080"
+SPRING_HAZELCAST_PORT="5701"
+SPRING_HAZELCAST_INTERFACE="127.0.0.1"
+ARTEMIS_VERSIONCONTROL_SSHPORT="7921"
+# Pre-populate Eureka metadata so peers can read this node's Hazelcast endpoint immediately
+# without waiting for the post-startup registerActualHazelcastAddress() metadata propagation
+# (which can take up to 90s and was empirically not landing reliably on the host stack).
+EUREKA_INSTANCE_METADATAMAP_HAZELCAST_HOST="127.0.0.1"
+EUREKA_INSTANCE_METADATAMAP_HAZELCAST_PORT="5701"

--- a/docker/artemis/config/node2-fast.env
+++ b/docker/artemis/config/node2-fast.env
@@ -1,0 +1,10 @@
+# node-2: Hazelcast member + build agent. Hosts LocalVC. HTTP :8081, Hazelcast :5702.
+SPRING_PROFILES_ACTIVE="prod,localvc,localci,buildagent,core,docker"
+EUREKA_INSTANCE_INSTANCEID="Artemis:2"
+SERVER_PORT="8081"
+SPRING_HAZELCAST_PORT="5702"
+SPRING_HAZELCAST_INTERFACE="127.0.0.1"
+ARTEMIS_VERSIONCONTROL_SSHPORT="7922"
+# Pre-populate Eureka metadata so peers can read this node's Hazelcast endpoint immediately.
+EUREKA_INSTANCE_METADATAMAP_HAZELCAST_HOST="127.0.0.1"
+EUREKA_INSTANCE_METADATAMAP_HAZELCAST_PORT="5702"

--- a/docker/artemis/config/node3-fast.env
+++ b/docker/artemis/config/node3-fast.env
@@ -1,0 +1,5 @@
+# node-3: Hazelcast client + build agent only. Connects to the cluster through node-1/node-2 by
+# discovering them via Eureka. No Hazelcast bind port — runs as a Hazelcast client.
+SPRING_PROFILES_ACTIVE="prod,buildagent"
+EUREKA_INSTANCE_INSTANCEID="Artemis:3"
+SERVER_PORT="8082"

--- a/docker/artemis/config/prod-multinode-fast.env
+++ b/docker/artemis/config/prod-multinode-fast.env
@@ -2,8 +2,9 @@
 # Shared Artemis configuration for the fast multi-node E2E runner.
 #
 # Loaded into each of the 3 host JVMs by run-e2e-tests-local-multinode-fast.sh via
-# `set -a; source <file>; set +a`. Every line must therefore be POSIX-shell compatible
-# (KEY="VALUE" with no inline comments after the value).
+# `set -a; source <file>; set +a`. Every line must therefore be POSIX-shell compatible:
+# either KEY="VALUE" (string) or KEY=value (bare, no whitespace), with no inline `# comment`
+# after the value. Existing prod-multinode.env follows the same convention.
 #
 # Differences from prod-multinode.env / playwright.env:
 #   - Service hostnames point at localhost (host JVMs reach containers via published ports).

--- a/docker/artemis/config/prod-multinode-fast.env
+++ b/docker/artemis/config/prod-multinode-fast.env
@@ -1,0 +1,89 @@
+# ----------------------------------------------------------------------------------------------------------------------
+# Shared Artemis configuration for the fast multi-node E2E runner.
+#
+# Loaded into each of the 3 host JVMs by run-e2e-tests-local-multinode-fast.sh via
+# `set -a; source <file>; set +a`. Every line must therefore be POSIX-shell compatible
+# (KEY="VALUE" with no inline comments after the value).
+#
+# Differences from prod-multinode.env / playwright.env:
+#   - Service hostnames point at localhost (host JVMs reach containers via published ports).
+#   - Eureka registers each instance with EUREKA_INSTANCE_IPADDRESS=127.0.0.1 so peer discovery is
+#     deterministic on macOS (where utun*/VPN interfaces would otherwise be picked).
+#   - SPRING_HAZELCAST_PORT_AUTOINCREMENT=false makes a port collision fail loudly instead of
+#     silently shifting to 5703.
+#   - SERVER_URL points at the nginx LB on the host (https://localhost), matching the slow runner.
+# ----------------------------------------------------------------------------------------------------------------------
+
+# Secrets / dev defaults
+ARTEMIS_ATHENA_SECRET="abcdefg12345"
+ARTEMIS_USERMANAGEMENT_INTERNALADMIN_USERNAME="artemis_admin"
+ARTEMIS_USERMANAGEMENT_INTERNALADMIN_PASSWORD="artemis_admin"
+ARTEMIS_USERMANAGEMENT_USEEXTERNAL="false"
+ARTEMIS_USERMANAGEMENT_LOGIN_ACCOUNTNAME="TUM"
+
+SPRING_DATASOURCE_URL="jdbc:postgresql://localhost:5432/Artemis?sslmode=disable"
+SPRING_DATASOURCE_USERNAME="Artemis"
+SPRING_DATASOURCE_PASSWORD=""
+SPRING_DATASOURCE_HIKARI_MAXIMUMPOOLSIZE="100"
+
+SPRING_MAIL_USERNAME=""
+SPRING_MAIL_PASSWORD=""
+
+# Websocket broker (ActiveMQ STOMP) — host port 61613 maps to container :61616
+SPRING_WEBSOCKET_BROKER_USERNAME="guest"
+SPRING_WEBSOCKET_BROKER_PASSWORD="guest"
+SPRING_WEBSOCKET_BROKER_ADDRESSES="localhost:61613"
+
+# Eureka — pin to 127.0.0.1 so peer discovery does not pick a VPN/utun interface on macOS
+EUREKA_CLIENT_ENABLED=true
+EUREKA_CLIENT_SERVICEURL_DEFAULTZONE="http://admin:admin@localhost:8761/eureka/"
+EUREKA_INSTANCE_PREFERIPADDRESS=true
+EUREKA_INSTANCE_IPADDRESS="127.0.0.1"
+EUREKA_INSTANCE_APPNAME="Artemis"
+# Aggressive cache refresh so a freshly registered peer is seen quickly. Default is 30s, which is
+# too slow when 3 JVMs come up sequentially on the same host: node-2 would form a solo Hazelcast
+# cluster before its DiscoveryClient cache picked up node-1. 5s makes the worst-case discovery lag
+# match the HazelcastClusterManager's @Scheduled retry cadence.
+EUREKA_CLIENT_REGISTRYFETCHINTERVALSECONDS="5"
+EUREKA_INSTANCE_LEASERENEWALINTERVALINSECONDS="5"
+
+JHIPSTER_REGISTRY_PASSWORD="admin"
+JHIPSTER_SECURITY_AUTHENTICATION_JWT_BASE64SECRET="bXktc2VjcmV0LWtleS13aGljaC1zaG91bGQtYmUtY2hhbmdlZC1pbi1wcm9kdWN0aW9uLWFuZC1iZS1iYXNlNjQtZW5jb2RlZAo="
+JHIPSTER_SECURITY_AUTHENTICATION_JWT_TOKENVALIDITYINSECONDS="259200"
+JHIPSTER_SECURITY_AUTHENTICATION_JWT_TOKENVALIDITYINSECONDSFORREMEMBERME="2592000"
+
+# LocalVC lives on node-2 in this topology
+ARTEMIS_VERSIONCONTROL_URL="http://localhost:8081"
+ARTEMIS_VERSIONCONTROL_USER="artemis_admin"
+ARTEMIS_VERSIONCONTROL_PASSWORD="artemis_admin"
+ARTEMIS_VERSIONCONTROL_BUILDAGENTGITUSERNAME="buildjob_user"
+ARTEMIS_VERSIONCONTROL_BUILDAGENTGITPASSWORD="buildjob_password"
+
+ARTEMIS_CONTINUOUSINTEGRATION_ARTEMISAUTHENTICATIONTOKENVALUE="demo"
+ARTEMIS_CONTINUOUSINTEGRATION_DOCKERCONNECTIONURI="unix:///var/run/docker.sock"
+ARTEMIS_CONTINUOUSINTEGRATION_EMPTYCOMMITNECESSARY="true"
+ARTEMIS_CONTINUOUSINTEGRATION_BUILD_IMAGES_C_DEFAULT="ls1tum/artemis-c-minimal-docker:1.0.0"
+
+ARTEMIS_GIT_NAME="artemis"
+ARTEMIS_GIT_EMAIL="artemis@example.com"
+
+ARTEMIS_BCRYPTSALTROUNDS="4"
+
+ARTEMIS_APOLLON_CONVERSIONSERVICEURL="https://apollon.ase.in.tum.de/api/converter"
+ARTEMIS_TELEMETRY_ENABLED="false"
+
+# Hazelcast: each host JVM gets a distinct port via node{N}-fast.env. Disable autoincrement so a
+# port collision (e.g. another Artemis dev stack on the same machine) fails loudly.
+SPRING_HAZELCAST_PORT_AUTOINCREMENT="false"
+
+# Surface URL — Playwright reaches the nginx LB on the host
+SERVER_URL="https://localhost"
+
+# Test-server flags + e2e seed data
+INFO_TESTSERVER="true"
+INFO_TEXTASSESSMENTANALYTICSENABLED="true"
+INFO_STUDENTEXAMSTORESESSIONDATA="true"
+INFO_OPERATORNAME="TUM"
+SPRING_LIQUIBASE_CONTEXTS="prod,e2e"
+
+MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED="true"

--- a/docker/nginx/artemis-ssh-upstream-multi-node-fast.conf
+++ b/docker/nginx/artemis-ssh-upstream-multi-node-fast.conf
@@ -1,0 +1,2 @@
+server host.docker.internal:7921;
+server host.docker.internal:7922;

--- a/docker/nginx/artemis-upstream-multi-node-fast.conf
+++ b/docker/nginx/artemis-upstream-multi-node-fast.conf
@@ -1,0 +1,2 @@
+server host.docker.internal:8080;
+server host.docker.internal:8081;

--- a/docker/playwright-E2E-tests-multi-node-fast.yml
+++ b/docker/playwright-E2E-tests-multi-node-fast.yml
@@ -1,0 +1,87 @@
+# ----------------------------------------------------------------------------------------------------------------------
+# Fast multi-node E2E support stack (Postgres + Eureka + ActiveMQ + nginx LB only)
+#
+# Companion to run-e2e-tests-local-multinode-fast.sh: this compose brings up only the supporting
+# infrastructure. The 3 Artemis JVMs run on the host (java -jar against the WAR built by gradle)
+# and nginx routes to them via host.docker.internal:8080 / :8081.
+#
+# For the prod-faithful Docker-image-based stack, use docker/playwright-E2E-tests-multi-node.yml.
+# ----------------------------------------------------------------------------------------------------------------------
+
+services:
+  jhipster-registry:
+    extends:
+      file: ./broker-registry.yml
+      service: jhipster-registry
+    networks:
+      - artemis
+
+  activemq-broker:
+    extends:
+      file: ./broker-registry.yml
+      service: activemq-broker
+    networks:
+      - artemis
+
+  postgres:
+    extends:
+      file: ./postgres.yml
+      service: postgres
+    restart: always
+
+  # nginx is defined inline (not via `extends: ./nginx.yml`) because `extends` merges the parent's
+  # `ports` list rather than replacing it. The parent binds 7921:7921 on the host, but our host
+  # node-1 JVM already listens on :7921, so the nginx container would fail to start. Inline def
+  # lets us drop 7921 cleanly. Keep field set in sync with docker/nginx.yml's `nginx` service.
+  nginx:
+    container_name: artemis-nginx
+    image: docker.io/library/nginx:${NGINX_VERSION}${NGINX_IMAGE_VARIANT}
+    pull_policy: missing
+    restart: always
+    # Resolve host.docker.internal to the docker bridge gateway on Linux. Harmless on macOS Docker
+    # Desktop (which already maps the name natively).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ulimits:
+      nofile:
+        soft: 50000
+        hard: 1048576
+    ports:
+      - "80:80"
+      - "443:443/tcp"
+      - "443:443/udp"
+      - "54321:54321"
+    expose:
+      - "80"
+      - "443"
+    healthcheck:
+      test: wget -q --spider --no-check-certificate https://127.0.0.1 || exit 1
+      start_period: 60s
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/timeouts.conf:/etc/nginx/conf.d/timeouts.conf:ro
+      - ./nginx/artemis-nginx.conf:/etc/nginx/conf.d/artemis-nginx.conf:ro
+      - ./nginx/artemis-server.conf:/etc/nginx/includes/artemis-server.conf:ro
+      - ./nginx/dhparam.pem:/etc/nginx/dhparam.pem:ro
+      - ./nginx/nginx_503.html:/usr/share/nginx/html/503.html:ro
+      - ./nginx/70-artemis-setup.sh:/docker-entrypoint.d/70-artemis-setup.sh
+      - ./nginx/artemis-upstream-multi-node-fast.conf:/etc/nginx/includes/artemis-upstream.conf:ro
+      - ./nginx/artemis-ssh-upstream-multi-node-fast.conf:/etc/nginx/includes/artemis-ssh-upstream.conf:ro
+      - ./nginx/artemis-nginx-playwright.conf:/etc/nginx/conf.d/artemis-nginx-playwright.conf:ro
+      - type: bind
+        source: ${NGINX_PROXY_SSL_CERTIFICATE_PATH:-../src/test/playwright/certs/artemis-nginx+4.pem}
+        target: "/certs/fullchain.pem"
+      - type: bind
+        source: ${NGINX_PROXY_SSL_CERTIFICATE_KEY_PATH:-../src/test/playwright/certs/artemis-nginx+4-key.pem}
+        target: "/certs/priv_key.pem"
+    networks:
+      - artemis
+
+networks:
+  artemis:
+    driver: "bridge"
+    name: artemis
+
+volumes:
+  artemis-postgres-data:
+    name: artemis-postgres-data

--- a/run-e2e-tests-local-multinode-fast.sh
+++ b/run-e2e-tests-local-multinode-fast.sh
@@ -1,0 +1,523 @@
+#!/bin/bash
+set -e
+
+# =============================================================================
+# Fast Multi-Node Local E2E Test Runner for Artemis
+# =============================================================================
+# Runs the same 3-node multi-node topology as run-e2e-tests-local-multinode.sh
+# but launches the Artemis nodes directly from the WAR (java -jar) on the host
+# instead of building a Docker image. The supporting infrastructure (Postgres,
+# JHipster Registry / Eureka, ActiveMQ broker, nginx LB) still runs in Docker.
+#
+# Use this for fast iteration on multi-node-sensitive server changes.
+# Use ./run-e2e-tests-local-multinode.sh when you need full prod-faithful CI parity
+# (Docker image, container isolation, etc.).
+#
+# Stack layout (host network):
+#   - node-1 (core, scheduling)              http :8080  hazelcast :5701  ssh :7921
+#   - node-2 (core, buildagent)              http :8081  hazelcast :5702  ssh :7922
+#   - node-3 (buildagent only, hz client)    http :8082
+#   - postgres   container                  127.0.0.1:5432
+#   - jhipster-registry (Eureka) container          :8761
+#   - activemq-broker container                     :61613
+#   - nginx LB container                            :443 (HTTPS), :54321 (HTTP)
+#
+# Usage:
+#   ./run-e2e-tests-local-multinode-fast.sh [options]
+#
+# Options:
+#   --stop              Tear everything down (host JVMs + infra containers)
+#   --filter <pattern>  Run only tests matching the pattern (e.g., "Quiz")
+#   --skip-build        Reuse the existing WAR in build/libs (do not rebuild)
+#   --skip-up           Reuse already-running infra containers and host JVMs
+#   --debug             Tee server logs to stdout (normally only in log files)
+#   --help              Show this help message
+# =============================================================================
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Defaults
+STOP=false
+SKIP_BUILD=false
+SKIP_UP=false
+DEBUG=false
+TEST_FILTER=""
+PLAYWRIGHT_EXTRA_ARGS=()
+export PLAYWRIGHT_VIDEO_MODE="${PLAYWRIGHT_VIDEO_MODE:-off}"
+export PLAYWRIGHT_COVERAGE="${PLAYWRIGHT_COVERAGE:-off}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --stop) STOP=true; shift ;;
+        --skip-build) SKIP_BUILD=true; shift ;;
+        --skip-up) SKIP_UP=true; shift ;;
+        --debug) DEBUG=true; shift ;;
+        --filter)
+            if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
+                echo -e "${RED}ERROR: --filter requires a non-empty pattern argument${NC}"
+                echo "Usage: --filter <pattern>"
+                exit 1
+            fi
+            TEST_FILTER="$2"
+            shift 2
+            ;;
+        --help) head -36 "$0" | tail -32; exit 0 ;;
+        *) echo -e "${RED}Unknown option: $1${NC}"; exit 1 ;;
+    esac
+done
+
+cd "$(dirname "$0")"
+LOCAL_DIR=".e2e-local-multinode-fast"
+COMPOSE_FILE="docker/playwright-E2E-tests-multi-node-fast.yml"
+
+# Per-node port allocation. Indexes match node1/node2/node3 below.
+HTTP_PORTS=(8080 8081 8082)
+HZ_PORTS=(5701 5702)            # node-3 has no Hazelcast bind port (client)
+SSH_PORTS=(7921 7922)            # node-3 has no Git SSH
+
+# All host ports the script claims; freed during preflight + --stop.
+ALL_PORTS=(8080 8081 8082 5701 5702 7921 7922)
+
+# Kill a process and all its children (portable, works on macOS and Linux)
+kill_tree() {
+    local pid=$1
+    for child in $(pgrep -P "$pid" 2>/dev/null); do
+        kill_tree "$child"
+    done
+    kill "$pid" 2>/dev/null || true
+}
+
+# Free a port if a leftover process holds it. Mirrors run-e2e-tests-local-fast.sh:92-117.
+check_port_available() {
+    local port=$1
+    local service_name=$2
+    local listeners
+    listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
+    if [ -n "$listeners" ]; then
+        echo -e "${YELLOW}Port ${port} (${service_name}) is in use — killing existing process...${NC}"
+        local pids
+        pids=$(echo "$listeners" | awk 'NR>1 {print $2}' | sort -u)
+        for pid in $pids; do
+            echo "  Killing PID $pid..."
+            kill_tree "$pid"
+        done
+        sleep 2
+        listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
+        if [ -n "$listeners" ]; then
+            echo -e "${RED}ERROR: Port ${port} is still in use after killing processes.${NC}"
+            echo "$listeners"
+            exit 1
+        fi
+        echo -e "${GREEN}Port ${port} is now free.${NC}"
+    fi
+}
+
+# =============================================================================
+# --stop: Tear everything down
+# =============================================================================
+if [ "$STOP" = true ]; then
+    echo -e "${BLUE}Stopping fast multi-node E2E stack...${NC}"
+    for n in 1 2 3; do
+        if [ -f "$LOCAL_DIR/server-${n}.pid" ]; then
+            PID=$(cat "$LOCAL_DIR/server-${n}.pid")
+            if kill -0 "$PID" 2>/dev/null; then
+                echo "Stopping node-${n} (PID $PID)..."
+                kill_tree "$PID"
+            fi
+        fi
+    done
+    for port in "${ALL_PORTS[@]}"; do
+        check_port_available "$port" "leftover process"
+    done
+    echo "Stopping infra containers..."
+    docker compose --env-file .env -f "$COMPOSE_FILE" down -v 2>/dev/null || true
+    rm -rf "$LOCAL_DIR"
+    echo -e "${GREEN}All services stopped.${NC}"
+    exit 0
+fi
+
+# =============================================================================
+# Banner
+# =============================================================================
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}  Artemis Fast Multi-Node E2E Runner${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# =============================================================================
+# Step 0: Prerequisites + port preflight
+# =============================================================================
+echo -e "${BLUE}Step 0: Checking prerequisites...${NC}"
+MISSING=""
+command -v docker >/dev/null 2>&1 || MISSING="$MISSING docker"
+command -v java >/dev/null 2>&1   || MISSING="$MISSING java"
+command -v node >/dev/null 2>&1   || MISSING="$MISSING node"
+command -v npm >/dev/null 2>&1    || MISSING="$MISSING npm"
+command -v unzip >/dev/null 2>&1  || MISSING="$MISSING unzip"
+if [ -n "$MISSING" ]; then
+    echo -e "${RED}ERROR: Missing required commands:$MISSING${NC}"
+    exit 1
+fi
+
+mkdir -p "$LOCAL_DIR"
+
+# Pre-clear ports we will claim. --skip-up still benefits from this (orphan from a prior crash).
+for port in "${ALL_PORTS[@]}"; do
+    check_port_available "$port" "Artemis host JVM"
+done
+echo -e "${GREEN}Prerequisites OK${NC}"
+
+# =============================================================================
+# Step 1: Build the WAR (unless --skip-build)
+# =============================================================================
+WAR_GLOB=(build/libs/Artemis-*.war)
+if [ "$SKIP_BUILD" = false ]; then
+    echo ""
+    echo -e "${BLUE}Step 1: Building WAR (./gradlew -Pprod -Pwar bootWar -x test)...${NC}"
+    ./gradlew -Pprod -Pwar bootWar -x test
+else
+    echo ""
+    echo -e "${YELLOW}Step 1: Skipping WAR build (--skip-build)${NC}"
+fi
+
+# Resolve the WAR path after build (glob expanded post-hoc so --skip-build still works).
+WAR_FILES=( "${WAR_GLOB[@]}" )
+if [ ! -e "${WAR_FILES[0]}" ]; then
+    echo -e "${RED}ERROR: No WAR found at build/libs/Artemis-*.war. Drop --skip-build to build it.${NC}"
+    exit 1
+fi
+WAR_FILE="${WAR_FILES[0]}"
+
+# Sanity-check the Angular bundle is in the WAR (nginx serves it from there). Without -Pprod the
+# bootWar task may produce a JSP-less, asset-less artifact.
+if ! unzip -l "$WAR_FILE" | grep -q 'WEB-INF/classes/static/index.html'; then
+    echo -e "${RED}ERROR: $WAR_FILE does not contain WEB-INF/classes/static/index.html.${NC}"
+    echo "Re-build with: ./gradlew -Pprod -Pwar bootWar -x test"
+    exit 1
+fi
+echo -e "${GREEN}Using WAR: $WAR_FILE${NC}"
+
+# =============================================================================
+# Step 2: Bring up infra containers (postgres + eureka + activemq)
+# =============================================================================
+if [ "$SKIP_UP" = false ]; then
+    echo ""
+    echo -e "${BLUE}Step 2: Starting infra containers (postgres, jhipster-registry, activemq-broker)...${NC}"
+    docker compose --env-file .env -f "$COMPOSE_FILE" up -d postgres jhipster-registry activemq-broker
+
+    echo "Waiting for Postgres..."
+    TIMEOUT=120; ELAPSED=0
+    until docker exec artemis-postgres pg_isready -U Artemis -d Artemis >/dev/null 2>&1; do
+        [ $ELAPSED -ge $TIMEOUT ] && { echo -e "${RED}Postgres not ready after ${TIMEOUT}s${NC}"; exit 1; }
+        sleep 2; ELAPSED=$((ELAPSED + 2))
+    done
+    echo -e "${GREEN}Postgres ready (${ELAPSED}s)${NC}"
+
+    echo "Waiting for Eureka registry..."
+    TIMEOUT=180; ELAPSED=0
+    until curl -sf http://localhost:8761/actuator/health >/dev/null 2>&1; do
+        [ $ELAPSED -ge $TIMEOUT ] && { echo -e "${RED}Eureka not ready after ${TIMEOUT}s${NC}"; exit 1; }
+        sleep 2; ELAPSED=$((ELAPSED + 2))
+    done
+    echo -e "${GREEN}Eureka ready (${ELAPSED}s)${NC}"
+else
+    echo ""
+    echo -e "${YELLOW}Step 2: Skipping infra (--skip-up). Assuming postgres/eureka/activemq are running.${NC}"
+fi
+
+# =============================================================================
+# Step 3: Detect Docker socket + ARM
+# =============================================================================
+if [ -S "/var/run/docker.sock" ]; then
+    DOCKER_SOCK="/var/run/docker.sock"
+elif [ -S "$HOME/.docker/run/docker.sock" ]; then
+    DOCKER_SOCK="$HOME/.docker/run/docker.sock"
+else
+    echo -e "${YELLOW}WARNING: Could not find Docker socket; LocalCI builds may fail${NC}"
+    DOCKER_SOCK="/var/run/docker.sock"
+fi
+
+ARM_OVERRIDES=""
+if [ "$(uname -m)" = "arm64" ]; then
+    ARM_OVERRIDES="export ARTEMIS_CONTINUOUSINTEGRATION_IMAGEARCHITECTURE=arm64"
+    echo "Detected ARM64 — exercise images will use arm64 variants"
+fi
+
+# =============================================================================
+# Step 4: Launch 3 Artemis JVMs
+# =============================================================================
+launch_node() {
+    local n=$1
+    local http_port=${HTTP_PORTS[$((n - 1))]}
+    local log_file="$LOCAL_DIR/server-${n}.log"
+    local pid_file="$LOCAL_DIR/server-${n}.pid"
+
+    if [ "$SKIP_UP" = true ] && [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null; then
+        echo "node-${n} already running (PID $(cat "$pid_file")), reusing."
+        return
+    fi
+
+    echo "Launching node-${n} (http :${http_port}) -> $log_file"
+
+    (
+        set -a
+        # shellcheck disable=SC1091
+        source docker/artemis/config/prod-multinode-fast.env
+        # shellcheck disable=SC1091
+        source "docker/artemis/config/node${n}-fast.env"
+        set +a
+        export ARTEMIS_CONTINUOUSINTEGRATION_DOCKERCONNECTIONURI="unix://$DOCKER_SOCK"
+        eval "$ARM_OVERRIDES"
+
+        # Each JVM gets its own working dir for transient on-disk state (Liquibase locks, local
+        # repos). Using a per-node dir avoids cross-process contention.
+        mkdir -p "$LOCAL_DIR/node${n}/local-repos"
+        export ARTEMIS_REPO_BASEPATH="$LOCAL_DIR/node${n}/local-repos"
+
+        if [ "$DEBUG" = true ]; then
+            exec java -Xmx2g -XX:+UseG1GC -Dfile.encoding=UTF-8 \
+                 -jar "$WAR_FILE" 2>&1 | tee "$log_file"
+        else
+            exec java -Xmx2g -XX:+UseG1GC -Dfile.encoding=UTF-8 \
+                 -jar "$WAR_FILE" > "$log_file" 2>&1
+        fi
+    ) &
+    echo $! > "$pid_file"
+}
+
+# =============================================================================
+# Step 4 / 5: Serial node startup
+#
+# Liquibase + the artemis_version row insert race if multiple JVMs initialise concurrently
+# against the same database (PSQLException: duplicate key value violates unique constraint
+# "artemis_version_pkey"). The Docker multi-node compose avoids this with
+# `depends_on: artemis-app-node-1: condition: service_healthy`. We mirror that here by
+# launching each node only after the previous one is reachable on /management/health.
+# =============================================================================
+wait_for_node() {
+    local n=$1
+    local port=${HTTP_PORTS[$((n - 1))]}
+    local pid_file="$LOCAL_DIR/server-${n}.pid"
+    local log_file="$LOCAL_DIR/server-${n}.log"
+    local pid; pid=$(cat "$pid_file")
+
+    echo "Waiting for node-${n} on http://localhost:${port}/management/health ..."
+    local TIMEOUT=420 ELAPSED=0
+    until curl -sf "http://localhost:${port}/management/health" >/dev/null 2>&1; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo -e "${RED}ERROR: node-${n} (PID $pid) died. Last 20 lines of $log_file:${NC}"
+            tail -20 "$log_file"
+            exit 1
+        fi
+        if [ $ELAPSED -ge $TIMEOUT ]; then
+            echo -e "${RED}ERROR: node-${n} not ready after ${TIMEOUT}s. Last 20 lines of $log_file:${NC}"
+            tail -20 "$log_file"
+            exit 1
+        fi
+        sleep 5; ELAPSED=$((ELAPSED + 5))
+    done
+    echo -e "${GREEN}node-${n} ready (${ELAPSED}s)${NC}"
+}
+
+wait_for_eureka_registration() {
+    local instance_id=$1
+    echo "Waiting for Eureka to publish ${instance_id} in its registry..."
+    local TIMEOUT=60 ELAPSED=0
+    until curl -s -u admin:admin "http://localhost:8761/eureka/apps/ARTEMIS" 2>/dev/null \
+            | grep -q "<instanceId>${instance_id}</instanceId>"; do
+        [ $ELAPSED -ge $TIMEOUT ] && {
+            echo -e "${RED}WARNING: ${instance_id} not visible in Eureka after ${TIMEOUT}s; continuing anyway${NC}"
+            return 0
+        }
+        sleep 2; ELAPSED=$((ELAPSED + 2))
+    done
+    # Add a small buffer so subsequent nodes' first registry fetch (5s default) picks up this one.
+    sleep 5
+    echo -e "${GREEN}${instance_id} visible in Eureka (${ELAPSED}s)${NC}"
+}
+
+echo ""
+echo -e "${BLUE}Step 4: Launching 3 host JVMs (serial — Liquibase requires it)...${NC}"
+for n in 1 2 3; do
+    launch_node "$n"
+    wait_for_node "$n"
+    # Ensure the just-started node is visible in the Eureka registry before launching the next one.
+    # Without this, node-N+1 forms a solo Hazelcast cluster because its initial registry fetch did
+    # not yet include node-N (cache lag), and Hazelcast does not auto-merge two existing clusters.
+    wait_for_eureka_registration "Artemis:${n}"
+done
+
+# =============================================================================
+# Step 4b: Wait for Hazelcast split-brain merge
+# =============================================================================
+# When 3 host JVMs come up sequentially they each form a solo Hazelcast cluster (TcpIpConfig is
+# empty at HazelcastInstance creation; peers are added afterwards by HazelcastClusterManager
+# from Eureka). Hazelcast's split-brain MERGE task is what actually consolidates the solo
+# clusters into one. It is configured at MERGE_FIRST_RUN_DELAY=30s + MERGE_NEXT_RUN_DELAY=30s
+# in HazelcastConfiguration.configureSplitBrainProtection(). The slow runner happens to wait
+# this long because Docker image+container startup takes longer than 60s; we need to wait it
+# out explicitly. Poll node-1's cluster size via the admin API and wait until it reaches the
+# expected count, with a generous timeout.
+echo ""
+echo -e "${BLUE}Step 4b: Waiting for Hazelcast split-brain merge (cluster size = ${EXPECTED_CLUSTER_NODE_COUNT:-2})...${NC}"
+EXPECTED_CLUSTER=${EXPECTED_CLUSTER_NODE_COUNT:-2}
+TIMEOUT=180; ELAPSED=0
+COOKIE=$(mktemp)
+trap 'rm -f "$COOKIE"' EXIT
+
+# Login via node-1 directly (HTTP, no nginx required for this preflight check).
+curl -s -c "$COOKIE" -X POST 'http://localhost:8080/api/core/public/authenticate' \
+    -H 'Content-Type: application/json' \
+    -d '{"username":"artemis_admin","password":"artemis_admin","rememberMe":true}' \
+    -o /dev/null
+
+while true; do
+    SIZE=$(curl -s -b "$COOKIE" 'http://localhost:8080/api/core/admin/websocket/nodes' \
+            | python3 -c 'import sys,json;
+try:
+    d=json.load(sys.stdin); print(len(d))
+except Exception:
+    print(0)' 2>/dev/null)
+    [ "${SIZE:-0}" -ge "$EXPECTED_CLUSTER" ] && { echo -e "${GREEN}Cluster reached ${SIZE} members (${ELAPSED}s)${NC}"; break; }
+    [ $ELAPSED -ge $TIMEOUT ] && { echo -e "${YELLOW}WARNING: cluster only reached ${SIZE:-0}/${EXPECTED_CLUSTER} members within ${TIMEOUT}s; running tests anyway${NC}"; break; }
+    sleep 5; ELAPSED=$((ELAPSED + 5))
+done
+
+# =============================================================================
+# Step 5: Start nginx LB (after upstreams are alive so DNS resolves cleanly)
+# =============================================================================
+if [ "$SKIP_UP" = false ]; then
+    echo ""
+    echo -e "${BLUE}Step 5: Starting nginx LB...${NC}"
+    docker compose --env-file .env -f "$COMPOSE_FILE" up -d nginx
+
+    echo "Waiting for nginx to be healthy..."
+    TIMEOUT=60; ELAPSED=0
+    until docker inspect --format='{{.State.Health.Status}}' artemis-nginx 2>/dev/null | grep -q '^healthy$'; do
+        [ $ELAPSED -ge $TIMEOUT ] && { echo -e "${YELLOW}WARNING: nginx healthcheck did not pass within ${TIMEOUT}s; continuing anyway${NC}"; break; }
+        sleep 2; ELAPSED=$((ELAPSED + 2))
+    done
+    echo -e "${GREEN}nginx LB ready${NC}"
+fi
+
+# =============================================================================
+# Step 6: Run Playwright (host mode, BASE_URL=https://localhost)
+# =============================================================================
+echo ""
+echo -e "${BLUE}Step 6: Running Playwright tests...${NC}"
+
+export BASE_URL="https://localhost"
+export NODE_TLS_REJECT_UNAUTHORIZED=0  # nginx self-signed cert
+export ADMIN_USERNAME="artemis_admin"
+export ADMIN_PASSWORD="artemis_admin"
+export ALLOW_GROUP_CUSTOMIZATION="true"
+export STUDENT_GROUP_NAME="students"
+export TUTOR_GROUP_NAME="tutors"
+export EDITOR_GROUP_NAME="editors"
+export INSTRUCTOR_GROUP_NAME="instructors"
+export EXERCISE_REPO_DIRECTORY="test-exercise-repos"
+export TEST_WORKERS="${TEST_WORKERS:-${FAST_SLOW_WORKERS:-4}}"
+export TEST_RETRIES="${TEST_RETRIES:-1}"
+export FAST_TEST_TIMEOUT_SECONDS="${FAST_TEST_TIMEOUT_SECONDS:-60}"
+export SLOW_TEST_TIMEOUT_SECONDS="${SLOW_TEST_TIMEOUT_SECONDS:-180}"
+export BUILD_RESULT_TIMEOUT_MS="${BUILD_RESULT_TIMEOUT_MS:-180000}"
+export BUILD_FINISH_TIMEOUT_MS="${BUILD_FINISH_TIMEOUT_MS:-120000}"
+export EXAM_DASHBOARD_TIMEOUT_MS="${EXAM_DASHBOARD_TIMEOUT_MS:-120000}"
+# Activate the @multi-node project and tell HazelcastCluster.spec.ts what topology to expect.
+export EXPECTED_CLUSTER_NODE_COUNT="2"
+export EXPECTED_MIN_BUILD_AGENTS="1"
+
+cd src/test/playwright
+npm run playwright:setup-local 2>/dev/null
+
+rm -f test-reports/results*.xml
+rm -rf test-reports/monocart-report*/
+
+BASE_ARGS=(e2e)
+if [ -n "$TEST_FILTER" ]; then
+    BASE_ARGS+=(--grep "$TEST_FILTER")
+fi
+BASE_ARGS+=("${PLAYWRIGHT_EXTRA_ARGS[@]}")
+
+TEST_START=$(date +%s)
+EXIT_CODE=0
+echo -e "${BLUE}Running fast/slow/multi-node tests with $TEST_WORKERS workers...${NC}"
+export PLAYWRIGHT_TEST_TYPE="parallel"
+TEST_CMD=(npx playwright test "${BASE_ARGS[@]}" \
+          --project=fast-tests --project=slow-tests --project=multi-node-tests \
+          --workers="$TEST_WORKERS")
+echo "Running: ${TEST_CMD[*]}"
+echo ""
+
+set +e
+"${TEST_CMD[@]}"
+TEST_EXIT=$?
+set -e
+[ $TEST_EXIT -ne 0 ] && EXIT_CODE=$TEST_EXIT
+
+TEST_END=$(date +%s)
+TEST_DURATION=$((TEST_END - TEST_START))
+TEST_MINS=$((TEST_DURATION / 60))
+TEST_SECS=$((TEST_DURATION % 60))
+
+cd ../../..
+
+# =============================================================================
+# Step 7: Report results
+# =============================================================================
+REPORT_DIR="src/test/playwright/test-reports"
+
+XML_FILES=()
+if [ -f "$REPORT_DIR/results.xml" ]; then
+    XML_FILES=("$REPORT_DIR/results.xml")
+else
+    for f in "$REPORT_DIR"/results-parallel.xml "$REPORT_DIR"/results-multinode.xml "$REPORT_DIR"/results-sequential.xml; do
+        [ -f "$f" ] && XML_FILES+=("$f")
+    done
+fi
+
+TOTAL_TESTS=0; TOTAL_FAILURES=0; TOTAL_ERRORS=0; TOTAL_SKIPPED=0
+for xml_file in "${XML_FILES[@]}"; do
+    while IFS= read -r line; do
+        tests=$(echo "$line"     | grep -o 'tests="[0-9]*"'    | grep -o '[0-9]*')
+        failures=$(echo "$line"  | grep -o 'failures="[0-9]*"' | grep -o '[0-9]*')
+        errors=$(echo "$line"    | grep -o 'errors="[0-9]*"'   | grep -o '[0-9]*')
+        skipped=$(echo "$line"   | grep -o 'skipped="[0-9]*"'  | grep -o '[0-9]*')
+        TOTAL_TESTS=$((TOTAL_TESTS + ${tests:-0}))
+        TOTAL_FAILURES=$((TOTAL_FAILURES + ${failures:-0}))
+        TOTAL_ERRORS=$((TOTAL_ERRORS + ${errors:-0}))
+        TOTAL_SKIPPED=$((TOTAL_SKIPPED + ${skipped:-0}))
+    done < <(grep '<testsuite ' "$xml_file")
+done
+
+TOTAL_PASSED=$((TOTAL_TESTS - TOTAL_FAILURES - TOTAL_ERRORS - TOTAL_SKIPPED))
+
+echo ""
+echo -e "${BLUE}========================================${NC}"
+if [ $((TOTAL_FAILURES + TOTAL_ERRORS)) -eq 0 ] && [ $EXIT_CODE -eq 0 ]; then
+    echo -e "${GREEN}  ALL TESTS PASSED (multi-node fast)${NC}"
+else
+    echo -e "${RED}  SOME TESTS FAILED (multi-node fast)${NC}"
+fi
+echo -e "${BLUE}========================================${NC}"
+if [ $TOTAL_TESTS -gt 0 ]; then
+    echo -e "  ${GREEN}Passed:${NC}  $TOTAL_PASSED"
+    [ $((TOTAL_FAILURES + TOTAL_ERRORS)) -gt 0 ] && echo -e "  ${RED}Failed:${NC}  $((TOTAL_FAILURES + TOTAL_ERRORS))" || echo "  Failed:  0"
+    [ $TOTAL_SKIPPED -gt 0 ] && echo "  Skipped: $TOTAL_SKIPPED"
+    echo "  Total:   $TOTAL_TESTS"
+    echo ""
+    echo "  Playwright duration: ${TEST_MINS}m ${TEST_SECS}s"
+fi
+
+echo ""
+echo -e "${BLUE}Stack is still running. Quick re-run (reuse everything):${NC}"
+echo "  ./run-e2e-tests-local-multinode-fast.sh --skip-build --skip-up [--filter \"...\"]"
+echo ""
+echo -e "${BLUE}To stop:${NC}  ./run-e2e-tests-local-multinode-fast.sh --stop"
+
+exit $EXIT_CODE

--- a/run-e2e-tests-local-multinode-fast.sh
+++ b/run-e2e-tests-local-multinode-fast.sh
@@ -249,6 +249,27 @@ if [ "$(uname -m)" = "arm64" ]; then
 fi
 
 # =============================================================================
+# Step 3b: Create the shared data directory tree the application would normally
+# write to /opt/artemis/data inside the Docker image. The `docker` Spring profile
+# (active on all 3 nodes) hardcodes /opt/artemis/data/* paths in
+# application-docker.yml — these must be overridden to a host-writable path or
+# course-icon uploads, file-upload exercises, LocalVC pushes etc. all 500.
+#
+# Mirror the docker-named-volume model where ALL nodes share the same data tree
+# (LocalVC bare repos pushed by node-2 must be readable by node-1 etc.).
+# =============================================================================
+ARTEMIS_DATA_DIR="$(pwd)/$LOCAL_DIR/data"
+mkdir -p \
+    "$ARTEMIS_DATA_DIR/course-archives" \
+    "$ARTEMIS_DATA_DIR/repos" \
+    "$ARTEMIS_DATA_DIR/repos-download" \
+    "$ARTEMIS_DATA_DIR/uploads" \
+    "$ARTEMIS_DATA_DIR/exports" \
+    "$ARTEMIS_DATA_DIR/legal" \
+    "$ARTEMIS_DATA_DIR/build-logs" \
+    "$ARTEMIS_DATA_DIR/local-vcs-repos"
+
+# =============================================================================
 # Step 4: Launch 3 Artemis JVMs
 # =============================================================================
 launch_node() {
@@ -274,10 +295,18 @@ launch_node() {
         export ARTEMIS_CONTINUOUSINTEGRATION_DOCKERCONNECTIONURI="unix://$DOCKER_SOCK"
         eval "$ARM_OVERRIDES"
 
-        # Each JVM gets its own working dir for transient on-disk state (Liquibase locks, local
-        # repos). Using a per-node dir avoids cross-process contention.
-        mkdir -p "$LOCAL_DIR/node${n}/local-repos"
-        export ARTEMIS_REPO_BASEPATH="$LOCAL_DIR/node${n}/local-repos"
+        # Override the /opt/artemis/data/* paths from application-docker.yml so the JVM writes to
+        # the host-side shared data tree we just created. Without this, any endpoint that touches
+        # the filesystem (course icon upload, file-upload exercise, LocalVC project create, ...)
+        # fails with java.nio.file.AccessDeniedException: /opt/artemis.
+        export ARTEMIS_COURSEARCHIVESPATH="$ARTEMIS_DATA_DIR/course-archives"
+        export ARTEMIS_REPOCLONEPATH="$ARTEMIS_DATA_DIR/repos"
+        export ARTEMIS_REPODOWNLOADCLONEPATH="$ARTEMIS_DATA_DIR/repos-download"
+        export ARTEMIS_FILEUPLOADPATH="$ARTEMIS_DATA_DIR/uploads"
+        export ARTEMIS_SUBMISSIONEXPORTPATH="$ARTEMIS_DATA_DIR/exports"
+        export ARTEMIS_LEGALPATH="$ARTEMIS_DATA_DIR/legal"
+        export ARTEMIS_BUILDLOGSPATH="$ARTEMIS_DATA_DIR/build-logs"
+        export ARTEMIS_VERSIONCONTROL_LOCALVCSREPOPATH="$ARTEMIS_DATA_DIR/local-vcs-repos"
 
         if [ "$DEBUG" = true ]; then
             exec java -Xmx2g -XX:+UseG1GC -Dfile.encoding=UTF-8 \
@@ -411,7 +440,11 @@ fi
 echo ""
 echo -e "${BLUE}Step 6: Running Playwright tests...${NC}"
 
-export BASE_URL="https://localhost"
+# IPv4 explicit. macOS resolves `localhost` to `::1` first, but Docker publishes 443 only on
+# IPv4 (no `::` binding). Under parallel test load this manifested as ECONNREFUSED on ::1:443
+# and ECONNRESET cascades — the slow runner does not hit this because Playwright lives inside
+# a container on the docker bridge and reaches nginx via `https://artemis-nginx`.
+export BASE_URL="https://127.0.0.1"
 export NODE_TLS_REJECT_UNAUTHORIZED=0  # nginx self-signed cert
 export ADMIN_USERNAME="artemis_admin"
 export ADMIN_PASSWORD="artemis_admin"

--- a/run-e2e-tests-local-multinode-fast.sh
+++ b/run-e2e-tests-local-multinode-fast.sh
@@ -154,11 +154,15 @@ echo ""
 # =============================================================================
 echo -e "${BLUE}Step 0: Checking prerequisites...${NC}"
 MISSING=""
-command -v docker >/dev/null 2>&1 || MISSING="$MISSING docker"
-command -v java >/dev/null 2>&1   || MISSING="$MISSING java"
-command -v node >/dev/null 2>&1   || MISSING="$MISSING node"
-command -v npm >/dev/null 2>&1    || MISSING="$MISSING npm"
-command -v unzip >/dev/null 2>&1  || MISSING="$MISSING unzip"
+command -v docker >/dev/null 2>&1  || MISSING="$MISSING docker"
+command -v java >/dev/null 2>&1    || MISSING="$MISSING java"
+command -v node >/dev/null 2>&1    || MISSING="$MISSING node"
+command -v npm >/dev/null 2>&1     || MISSING="$MISSING npm"
+command -v unzip >/dev/null 2>&1   || MISSING="$MISSING unzip"
+command -v lsof >/dev/null 2>&1    || MISSING="$MISSING lsof"
+command -v pgrep >/dev/null 2>&1   || MISSING="$MISSING pgrep"
+command -v python3 >/dev/null 2>&1 || MISSING="$MISSING python3"
+command -v curl >/dev/null 2>&1    || MISSING="$MISSING curl"
 if [ -n "$MISSING" ]; then
     echo -e "${RED}ERROR: Missing required commands:$MISSING${NC}"
     exit 1
@@ -175,7 +179,6 @@ echo -e "${GREEN}Prerequisites OK${NC}"
 # =============================================================================
 # Step 1: Build the WAR (unless --skip-build)
 # =============================================================================
-WAR_GLOB=(build/libs/Artemis-*.war)
 if [ "$SKIP_BUILD" = false ]; then
     echo ""
     echo -e "${BLUE}Step 1: Building WAR (./gradlew -Pprod -Pwar bootWar -x test)...${NC}"
@@ -185,8 +188,10 @@ else
     echo -e "${YELLOW}Step 1: Skipping WAR build (--skip-build)${NC}"
 fi
 
-# Resolve the WAR path after build (glob expanded post-hoc so --skip-build still works).
-WAR_FILES=( "${WAR_GLOB[@]}" )
+# Glob the WAR path AFTER the build step so a freshly produced artifact (or a renamed one after a
+# version bump) is picked up. Doing this before the build would store the literal pattern on a
+# clean checkout and the existence check below would fire even on a successful build.
+WAR_FILES=(build/libs/Artemis-*.war)
 if [ ! -e "${WAR_FILES[0]}" ]; then
     echo -e "${RED}ERROR: No WAR found at build/libs/Artemis-*.war. Drop --skip-build to build it.${NC}"
     exit 1
@@ -243,9 +248,11 @@ else
 fi
 
 ARM_OVERRIDES=""
-if [ "$(uname -m)" = "arm64" ]; then
+HOST_ARCH=$(uname -m)
+# `arm64` on macOS Apple Silicon, `aarch64` on Linux ARM. Both need the arm64 image override.
+if [ "$HOST_ARCH" = "arm64" ] || [ "$HOST_ARCH" = "aarch64" ]; then
     ARM_OVERRIDES="export ARTEMIS_CONTINUOUSINTEGRATION_IMAGEARCHITECTURE=arm64"
-    echo "Detected ARM64 — exercise images will use arm64 variants"
+    echo "Detected ARM64 (uname -m=$HOST_ARCH) — exercise images will use arm64 variants"
 fi
 
 # =============================================================================

--- a/src/test/playwright/e2e/atlas/LearningPathManagement.spec.ts
+++ b/src/test/playwright/e2e/atlas/LearningPathManagement.spec.ts
@@ -18,7 +18,7 @@ test.describe('Learning Path Management', { tag: '@fast' }, () => {
     test('Instructor enables learning paths via activation card', async ({ page }) => {
         // Arrange: course initially without learning paths enabled
         await page.goto(`/course-management/${course.id}/learning-path-management`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         // Wait for the loading spinner to disappear before checking for the activation card
         const spinner = page.locator('.spinner-border');
@@ -36,7 +36,7 @@ test.describe('Learning Path Management', { tag: '@fast' }, () => {
     test('Instructor enables learning paths via course settings', async ({ page }) => {
         // Arrange: course initially without learning paths enabled
         await page.goto(`/course-management/${course.id}`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         await page.getByRole('link', { name: 'Settings' }).click();
 
@@ -46,7 +46,7 @@ test.describe('Learning Path Management', { tag: '@fast' }, () => {
         await page.locator('#save-entity').click();
 
         await page.goto(`/course-management/${course.id}/learning-path-management`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         // Wait for loading to complete
         const spinner = page.locator('.spinner-border');
@@ -58,7 +58,7 @@ test.describe('Learning Path Management', { tag: '@fast' }, () => {
 
     test('Instructor disables learning paths via course settings', async ({ page }) => {
         await page.goto(`/course-management/${course.id}`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         await page.getByRole('link', { name: 'Settings' }).click();
 
@@ -71,7 +71,7 @@ test.describe('Learning Path Management', { tag: '@fast' }, () => {
         await page.locator('#save-entity').click();
 
         await page.goto(`/course-management/${course.id}/learning-path-management`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         // Wait for loading to complete
         const spinner = page.locator('.spinner-border');
@@ -83,7 +83,7 @@ test.describe('Learning Path Management', { tag: '@fast' }, () => {
     test('Create simple learning path', async ({ page, courseManagementAPIRequests }) => {
         // Enable learning paths first
         await page.goto(`/course-management/${course.id}/learning-path-management`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         // Wait for loading to complete
         const spinner = page.locator('.spinner-border');
@@ -117,7 +117,7 @@ test.describe('Learning Path Management', { tag: '@fast' }, () => {
         await courseManagementAPIRequests.createCompetencyRelation(course, comp5.id, comp6.id, 'ASSUMES');
 
         await page.reload();
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         const reloadSpinner = page.locator('.spinner-border');
         await expect(reloadSpinner).not.toBeVisible({ timeout: 30000 });
         await expect(page.locator('.learning-paths-analytics-container')).toBeVisible({ timeout: 30000 });

--- a/src/test/playwright/e2e/course/CourseExercise.spec.ts
+++ b/src/test/playwright/e2e/course/CourseExercise.spec.ts
@@ -22,7 +22,7 @@ test.describe('Course exercise', { tag: '@fast' }, () => {
 
         test('Filters exercises based on title', async ({ page, courseOverview }) => {
             await page.goto(`/courses/${course.id}/exercises`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             // All quiz exercises should be hidden initially, as the default accordion status is collapsed when there is no due date.
             await expect(courseOverview.getExercise(exercise1.title!)).toBeHidden();
             await expect(courseOverview.getExercise(exercise2.title!)).toBeHidden();

--- a/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
@@ -189,7 +189,7 @@ test.describe('Exam assessment', () => {
                 await page.waitForTimeout(graceEnd.diff(dayjs(), 'ms') + 5000);
             }
             await page.goto(`/course-management/${course.id}/exams/${exam.id}/assessment-dashboard`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             const response = await courseAssessment.clickEvaluateQuizzes();
             expect(response.status()).toBe(200);
             if (dayjs().isBefore(resultDate)) {
@@ -223,7 +223,7 @@ test.describe('Exam grading', { tag: '@slow' }, () => {
         test('Set exam gradings', async ({ login, page, examManagement, examGrading }) => {
             await login(instructor);
             await page.goto(`/course-management/${course.id}/exams/${exam.id}`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await examManagement.openGradingKey();
             await examGrading.addGradeStep(40, '5.0');
             await examGrading.addGradeStep(15, '4.0');
@@ -325,10 +325,10 @@ test.describe('Exam statistics', { tag: '@slow' }, () => {
     test('Check exam statistics', async ({ login, page, examManagement, examAPIRequests }) => {
         await login(instructor);
         await page.goto(`/course-management/${course.id}/exams/${exam.id}`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await examManagement.openScoresPage();
         await page.waitForURL(`**/exams/${exam.id}/scores`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         const examScores = new ExamScoresPage(page);
         await examScores.checkExamStatistics(examStatisticsSample.statistics);
         await examScores.checkGradeDistributionChart(examStatisticsSample.gradeDistribution);

--- a/src/test/playwright/e2e/exam/ExamChecklists.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamChecklists.spec.ts
@@ -291,7 +291,7 @@ async function createExam(course: any, page: Page, customConfig?: any) {
 
 async function navigateToExamDetailsPage(page: Page, course: any, exam: Exam) {
     await page.goto(`/course-management/${course.id}/exams/${exam.id}`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 }
 
 async function addExamExerciseGroup(examExerciseGroups: ExamExerciseGroupsPage, examExerciseGroupCreation: ExamExerciseGroupCreationPage, isMandatory?: boolean) {

--- a/src/test/playwright/e2e/exam/ExamDateVerification.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamDateVerification.spec.ts
@@ -36,10 +36,10 @@ test.describe('Exam date verification', { tag: '@fast' }, () => {
             exam = await examAPIRequests.createExam(examConfig);
             await login(studentOne);
             await page.goto(`/courses`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await expect(page.getByText(examTitle)).not.toBeVisible();
             await page.goto(`/courses/${course.id}`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await expect(page.getByText(examTitle)).not.toBeVisible();
         });
 
@@ -55,7 +55,7 @@ test.describe('Exam date verification', { tag: '@fast' }, () => {
             await examAPIRequests.registerStudentForExam(exam, studentOne);
             await login(studentOne);
             await page.goto(`/courses/${course.id}`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await courseOverview.openExamsTab();
             await page.waitForURL(`**/exams/${exam.id}`);
         });
@@ -120,7 +120,7 @@ test.describe('Exam date verification', { tag: '@fast' }, () => {
             await examAPIRequests.prepareExerciseStartForExam(exam);
             await login(studentOne);
             await page.goto(`/courses/${course.id}/exams/${exam.id}`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await page.waitForURL(`**/exams/${exam.id}`);
             await expect(page.getByText(exam.title!).first()).toBeVisible();
             await examStartEnd.startExam();

--- a/src/test/playwright/e2e/exam/ExamParticipation.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamParticipation.spec.ts
@@ -396,7 +396,7 @@ test.describe('Exam participation', () => {
         test('Instructor sends an announcement message and all participants receive it', { tag: '@slow' }, async ({ browser, login, page, examManagement }) => {
             await login(instructor);
             await page.goto(`/course-management/${course.id}/exams/${exam.id!}`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
 
             const studentPages = [];
 
@@ -413,7 +413,7 @@ test.describe('Exam participation', () => {
 
             // Wait for WebSocket connections to be established on student pages
             for (const studentPage of studentPages) {
-                await studentPage.waitForLoadState('networkidle');
+                await studentPage.waitForLoadState('domcontentloaded');
             }
 
             const announcement = 'Important announcement!';
@@ -434,7 +434,7 @@ test.describe('Exam participation', () => {
         test('Instructor changes working time and all participants are informed', { tag: '@slow' }, async ({ browser, login, page, examManagement }) => {
             await login(instructor);
             await page.goto(`/course-management/${course.id}/exams/${exam.id!}`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
 
             const studentPages = [];
 
@@ -473,7 +473,7 @@ test.describe('Exam participation', () => {
             async ({ browser, login, page, examExerciseGroups, examDetails, textExerciseCreation }) => {
                 await login(instructor);
                 await page.goto(`/course-management/${course.id}/exams/${exam.id!}`);
-                await page.waitForLoadState('networkidle');
+                await page.waitForLoadState('domcontentloaded');
 
                 const studentPages = [];
 

--- a/src/test/playwright/e2e/exam/ExamResults.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamResults.spec.ts
@@ -161,7 +161,7 @@ test.describe.serial('Exam Results', { tag: '@slow' }, () => {
         const exercise = exercises['text'];
         await login(studentOne);
         await page.goto(`/courses/${course.id}/exams/${exam.id}`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await examParticipation.checkResultScore('70%', exercise.id!);
         await examResultsPage.checkTextExerciseContent(exercise.id!, exercise.additionalData!.textFixture!);
         await examResultsPage.checkAdditionalFeedback(exercise.id!, 7, 'Good job');
@@ -171,7 +171,7 @@ test.describe.serial('Exam Results', { tag: '@slow' }, () => {
         const exercise = exercises['programming'];
         await login(studentOne);
         await page.goto(`/courses/${course.id}/exams/${exam.id}`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await examParticipation.checkResultScore('50%', exercise.id!);
         await examResultsPage.checkProgrammingExerciseAssessments(exercise.id!, 'Wrong', 4);
         await examResultsPage.checkProgrammingExerciseAssessments(exercise.id!, 'Correct', 4);
@@ -187,7 +187,7 @@ test.describe.serial('Exam Results', { tag: '@slow' }, () => {
         const exercise = exercises['quiz'];
         await login(studentOne);
         await page.goto(`/courses/${course.id}/exams/${exam.id}`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await examParticipation.checkResultScore('50%', exercise.id!);
         await examResultsPage.checkQuizExerciseScore(exercise.id!, 5, 10);
         const studentAnswers = [true, false, true, false];
@@ -199,7 +199,7 @@ test.describe.serial('Exam Results', { tag: '@slow' }, () => {
         const exercise = exercises['modeling'];
         await login(studentOne);
         await page.goto(`/courses/${course.id}/exams/${exam.id}`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await examParticipation.checkResultScore('40%', exercise.id!);
         await examResultsPage.checkAdditionalFeedback(exercise.id!, 5, 'Good');
         await examResultsPage.checkModellingExerciseAssessment(exercise.id!, 'class TestClass', 'Wrong', -1);
@@ -209,7 +209,7 @@ test.describe.serial('Exam Results', { tag: '@slow' }, () => {
     test('Check exam result overview', async ({ page, login, examAPIRequests, examResultsPage }) => {
         await login(studentOne);
         await page.goto(`/courses/${course.id}/exams/${exam.id}`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         const gradeSummary = await examAPIRequests.getGradeSummary(exam, studentExam);
         await examResultsPage.checkGradeSummary(gradeSummary);
     });
@@ -227,7 +227,7 @@ test.describe.serial('Exam Results', { tag: '@slow' }, () => {
 async function navigateToExerciseAssessment(page: import('@playwright/test').Page, courseId: number, examId: number, exerciseId: number) {
     const url = `/course-management/${courseId}/exams/${examId}/assessment-dashboard/${exerciseId}`;
     await page.goto(url);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Click "I have read the instructions" to register tutor participation (persisted server-side).
     // After this, reloads will show the submissions table directly.

--- a/src/test/playwright/e2e/exam/test-exam/TestExamManagement.spec.ts
+++ b/src/test/playwright/e2e/exam/test-exam/TestExamManagement.spec.ts
@@ -79,7 +79,7 @@ test.describe('Test Exam management', { tag: '@fast' }, () => {
 
         test('Adds a programming exercise', async ({ page, examExerciseGroups, programmingExerciseCreation }) => {
             await page.goto(`/course-management/${course.id}/exams/${exam.id!}/exercise-groups`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await examExerciseGroups.clickAddProgrammingExercise(exerciseGroup.id!);
             const programmingExerciseTitle = 'programming' + uid;
             await programmingExerciseCreation.changeEditMode();

--- a/src/test/playwright/e2e/exercise/file-upload/FileUploadExerciseManagement.spec.ts
+++ b/src/test/playwright/e2e/exercise/file-upload/FileUploadExerciseManagement.spec.ts
@@ -33,7 +33,7 @@ test.describe('File upload exercise management', { tag: '@fast' }, () => {
 
         // Make sure file upload exercise is shown in exercises list
         await page.goto(`/course-management/${course.id}/exercises`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await expect(courseManagementExercises.getExercise(exercise.id!)).toBeVisible();
     });
 

--- a/src/test/playwright/e2e/exercise/modeling/ModelingExerciseManagement.spec.ts
+++ b/src/test/playwright/e2e/exercise/modeling/ModelingExerciseManagement.spec.ts
@@ -17,7 +17,7 @@ test.describe('Modeling Exercise Management', { tag: '@fast' }, () => {
         test('Create a new modeling exercise', async ({ login, page, courseManagementExercises, modelingExerciseCreation, modelingExerciseEditor, modelingExerciseAssessment }) => {
             await login(instructor);
             await page.goto(`/course-management/${course.id}/exercises`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await courseManagementExercises.createModelingExercise();
             await modelingExerciseCreation.setTitle('Modeling ' + generateUUID());
             await modelingExerciseCreation.addCategories(['e2e-testing', 'test2']);
@@ -26,13 +26,13 @@ test.describe('Modeling Exercise Management', { tag: '@fast' }, () => {
             modelingExercise = await response.json();
             await expect(courseManagementExercises.getExerciseTitle(modelingExercise.title!)).toBeAttached();
             await page.goto(`/course-management/${course.id}/modeling-exercises/${modelingExercise.id}/edit`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await modelingExerciseEditor.addComponentToExampleSolutionModel(1);
             await expect(page.locator('.react-flow__node').first()).toBeAttached();
             await modelingExerciseCreation.save();
 
             await page.goto(`/course-management/${course.id}/modeling-exercises/${modelingExercise.id}/example-submissions`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await modelingExerciseEditor.clickCreateExampleSubmission();
             await modelingExerciseEditor.addComponentToExampleSolutionModel(1);
             await modelingExerciseEditor.addComponentToExampleSolutionModel(2);
@@ -47,7 +47,7 @@ test.describe('Modeling Exercise Management', { tag: '@fast' }, () => {
             await modelingExerciseAssessment.assessComponent(0, 'Unnecessary');
             await modelingExerciseAssessment.submitExample();
             await page.goto(`/course-management/${course.id}/modeling-exercises/${modelingExercise.id}/edit`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await modelingExerciseEditor.waitForExampleSolutionEditor();
             await expect(modelingExerciseEditor.getModelingCanvas()).toBeVisible();
         });

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseManagement.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseManagement.spec.ts
@@ -54,7 +54,7 @@ test.describe('Programming Exercise Management', { tag: '@fast' }, () => {
             await courseManagement.openExercisesOfCourse(course.id!);
             await courseManagementExercises.createProgrammingExercise();
             await page.waitForURL('**/programming-exercises/new**');
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await programmingExerciseCreation.changeEditMode();
 
             const firstSectionHeadline = 'General';

--- a/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseAssessment.spec.ts
+++ b/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseAssessment.spec.ts
@@ -18,7 +18,7 @@ test.describe('Quiz Exercise Assessment', { tag: '@fast' }, () => {
             await exerciseAPIRequests.startExerciseParticipation(quizExercise.id!);
             await exerciseAPIRequests.createMultipleChoiceSubmission(quizExercise, [0, 2]);
             await page.goto(`/courses/${course.id}/exercises/${quizExercise.id}`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await exerciseResult.shouldShowScore(50);
         });
     });
@@ -34,7 +34,7 @@ test.describe('Quiz Exercise Assessment', { tag: '@fast' }, () => {
             await exerciseAPIRequests.startExerciseParticipation(quizExercise.id!);
             await exerciseAPIRequests.createShortAnswerSubmission(quizExercise, ['give', 'let', 'run', 'desert']);
             await page.goto(`/courses/${course.id}/exercises/${quizExercise.id}`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await exerciseResult.shouldShowScore(66.7);
         });
     });

--- a/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseManagement.spec.ts
+++ b/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseManagement.spec.ts
@@ -36,7 +36,7 @@ test.describe('Quiz Exercise Management', { tag: '@fast' }, () => {
             const quiz: QuizExercise = await quizResponse.json();
             createdQuizId = quiz.id;
             await page.goto(`/course-management/${course.id}/quiz-exercises/${quiz.id}/preview`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await expect(page.getByText(title)).toBeVisible();
         });
 
@@ -50,7 +50,7 @@ test.describe('Quiz Exercise Management', { tag: '@fast' }, () => {
             const quiz: QuizExercise = await quizResponse.json();
             createdQuizId = quiz.id;
             await page.goto(`/course-management/${course.id}/quiz-exercises/${quiz.id}/preview`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await expect(page.getByText(title)).toBeVisible();
             for (const answerOption of answerOptions) {
                 await expect(page.getByText(answerOption)).toBeVisible();
@@ -64,7 +64,7 @@ test.describe('Quiz Exercise Management', { tag: '@fast' }, () => {
             const quiz: QuizExercise = await quizResponse.json();
             createdQuizId = quiz.id;
             await page.goto(`/course-management/${course.id}/quiz-exercises/${quiz.id}/preview`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await expect(page.getByText(title)).toBeVisible();
         });
 
@@ -75,7 +75,7 @@ test.describe('Quiz Exercise Management', { tag: '@fast' }, () => {
             const quiz = await response.json();
             createdQuizId = quiz.id;
             await page.goto(`/course-management/${course.id}/quiz-exercises/${quiz.id}/preview`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await expect(page.getByText(quizQuestionTitle)).toBeVisible();
         });
     });

--- a/src/test/playwright/e2e/exercise/text/TextExerciseManagement.spec.ts
+++ b/src/test/playwright/e2e/exercise/text/TextExerciseManagement.spec.ts
@@ -61,7 +61,7 @@ test.describe('Text exercise management', { tag: '@slow' }, () => {
 
             // Make sure text exercise is shown in exercises list
             await page.goto(`/course-management/${course.id}/exercises`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await expect(courseManagementExercises.getExercise(exercise.id!)).toBeVisible();
         });
 

--- a/src/test/playwright/e2e/lecture/LectureManagement.spec.ts
+++ b/src/test/playwright/e2e/lecture/LectureManagement.spec.ts
@@ -75,7 +75,7 @@ test.describe('Lecture management', { tag: '@fast' }, () => {
             await login(instructor);
             lecture = lastCreatedLecture = await courseManagementAPIRequests.createLecture(course);
             await page.goto(`/course-management/${course.id}/lectures`);
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
         });
 
         test('Deletes an existing lecture', async ({ lectureManagement }) => {

--- a/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
@@ -75,7 +75,7 @@ export class CourseManagementExercisesPage {
             await expect(this.getExercise(exercise.id!)).not.toBeAttached({ timeout: 5000 });
         } catch {
             await this.page.reload();
-            await this.page.waitForLoadState('networkidle');
+            await this.page.waitForLoadState('domcontentloaded');
         }
     }
 

--- a/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
@@ -76,6 +76,9 @@ export class CourseManagementExercisesPage {
         } catch {
             await this.page.reload();
             await this.page.waitForLoadState('domcontentloaded');
+            // Re-assert after the reload so a still-present card surfaces as a real test failure
+            // instead of being silently swallowed by the catch.
+            await expect(this.getExercise(exercise.id!)).not.toBeAttached({ timeout: 5000 });
         }
     }
 

--- a/src/test/playwright/support/pageobjects/course/CourseManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementPage.ts
@@ -41,7 +41,11 @@ export class CourseManagementPage {
      * @param courseID the id of the course
      */
     async openExercisesOfCourse(courseID: number) {
-        await this.getCourse(courseID).locator('#course-card-open-exercises').click();
+        // Wait for the course card and its open-exercises link to be visible. The course list is
+        // hydrated asynchronously after navigation, so the bare .click() races the render.
+        const link = this.getCourse(courseID).locator('#course-card-open-exercises');
+        await link.waitFor({ state: 'visible', timeout: 30_000 });
+        await link.click();
         await this.page.waitForURL('**/exercises**');
     }
 
@@ -58,7 +62,11 @@ export class CourseManagementPage {
      * @param courseID
      */
     async openCourse(courseID: number) {
-        await this.getCourse(courseID).locator('#course-card-header').click();
+        // Wait for the course card header to be visible before clicking; the course list renders
+        // asynchronously and the bare .click() races the render under parallel test load.
+        const header = this.getCourse(courseID).locator('#course-card-header');
+        await header.waitFor({ state: 'visible', timeout: 30_000 });
+        await header.click();
     }
 
     private async assertCourseSummary(expectedCourseSummary: CourseSummary) {

--- a/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
@@ -28,7 +28,11 @@ export class CourseOverviewPage {
      * @param exerciseId The ID of the exercise to start.
      */
     async startExercise(exerciseId: number) {
-        await this.getStartExerciseButton(exerciseId).click();
+        // Wait for the start-exercise button to be visible before clicking; the exercise list is
+        // populated asynchronously and the bare .click() races the render under parallel load.
+        const button = this.getStartExerciseButton(exerciseId);
+        await button.waitFor({ state: 'visible', timeout: 30_000 });
+        await button.click();
     }
 
     /**

--- a/src/test/playwright/support/pageobjects/exam/ExamManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamManagementPage.ts
@@ -65,7 +65,7 @@ export class ExamManagementPage {
      */
     async openAssessmentDashboard(courseID: number, examID: number, timeout = EXAM_DASHBOARD_TIMEOUT) {
         await this.page.goto(`/course-management/${courseID}/exams/${examID}/assessment-dashboard`);
-        await this.page.waitForLoadState('networkidle');
+        await this.page.waitForLoadState('domcontentloaded');
     }
 
     /**
@@ -91,7 +91,7 @@ export class ExamManagementPage {
 
     async verifySubmitted(courseID: number, examID: number, username: string) {
         await this.page.goto(`/course-management/${courseID}/exams/${examID}/students`);
-        await this.page.waitForLoadState('networkidle');
+        await this.page.waitForLoadState('domcontentloaded');
         const row = this.page.locator('tbody tr', { hasText: username }).first();
         await row.waitFor({ state: 'visible' });
         await expect(row).toContainText('Submitted');
@@ -99,7 +99,7 @@ export class ExamManagementPage {
 
     async checkQuizSubmission(courseID: number, examID: number, username: string, score: string) {
         await this.page.goto(`/course-management/${courseID}/exams/${examID}/students`);
-        await this.page.waitForLoadState('networkidle');
+        await this.page.waitForLoadState('domcontentloaded');
         const row = this.page.locator('tbody tr', { hasText: username }).first();
         await row.waitFor({ state: 'visible' });
         await row.getByRole('link', { name: 'View exam' }).click();

--- a/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseOverviewPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseOverviewPage.ts
@@ -41,7 +41,7 @@ export class ProgrammingExerciseOverviewPage {
         // Try up to 6 full navigations over ~90s (each with 15s wait for score to appear)
         for (let attempt = 0; attempt < 6; attempt++) {
             await this.page.goto(url);
-            await this.page.waitForLoadState('networkidle');
+            await this.page.waitForLoadState('domcontentloaded');
             try {
                 await expect(resultScore).toContainText(textPattern, { timeout: 15000 });
                 return; // Success
@@ -52,7 +52,7 @@ export class ProgrammingExerciseOverviewPage {
 
         // Final attempt with longer timeout
         await this.page.goto(url);
-        await this.page.waitForLoadState('networkidle');
+        await this.page.waitForLoadState('domcontentloaded');
         await expect(resultScore).toContainText(textPattern, { timeout: 30000 });
     }
 
@@ -84,7 +84,12 @@ export class ProgrammingExerciseOverviewPage {
         await codeButtonLocator.click();
         await this.page.locator('.popover-body').waitFor({ state: 'visible' });
         await this.page.locator('.https-or-ssh-button').click();
-        await this.page.locator(gitCloneMethodSelector[cloneMethod]).click();
+        // The clone-method dropdown re-renders after .https-or-ssh-button is clicked. Wait for the
+        // chosen option to be both attached and visible before clicking, otherwise Playwright
+        // occasionally hits the previous render and gets "element was detached from the DOM".
+        const cloneMethodOption = this.page.locator(gitCloneMethodSelector[cloneMethod]);
+        await cloneMethodOption.waitFor({ state: 'visible' });
+        await cloneMethodOption.click();
     }
 
     async getCloneUrl() {


### PR DESCRIPTION
### Summary
Add a third E2E runner, \`run-e2e-tests-local-multinode-fast.sh\`, that exercises the same 3-node Hazelcast / ActiveMQ / nginx multi-node topology as the slow runner but launches the Artemis nodes as plain \`java -jar\` processes on the host instead of building a Docker image. Cuts the iteration loop from ~5–10 min to ~30–60 s for server-side multi-node debugging.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
The slow runner \`./run-e2e-tests-local-multinode.sh\` rebuilds the WAR + Docker image on every iteration. On ARM Macs that is 5–8 min before any test runs, which dominates the dev loop when you are iterating on a server-side multi-node bug (Hazelcast cache coherence, ActiveMQ STOMP relay, nginx LB rotation). The single-node \`./run-e2e-tests-local-fast.sh\` runs server from source but cannot exercise those concerns.

### Description
New runner \`run-e2e-tests-local-multinode-fast.sh\`:

- reuses the WAR built by Gradle (\`-Pprod -Pwar bootWar\`, no \`clean\`, no \`-x webapp\` — incremental rebuilds finish in ~30–60 s),
- launches the 3 Artemis nodes as host \`java -jar\` processes with distinct HTTP / Hazelcast / SSH ports,
- keeps Postgres, JHipster Registry, ActiveMQ broker, and nginx as containers (new compose file \`docker/playwright-E2E-tests-multi-node-fast.yml\` brings only those four up),
- drives Playwright on the host against \`https://localhost\` (the existing \`playwright.config.ts\` already has \`ignoreHTTPSErrors=true\`).

Topology mirrors the slow runner exactly:

| Node | Profiles | HTTP | Hazelcast | SSH |
|------|----------|------|-----------|-----|
| node-1 | \`core, scheduling\` | 8080 | 5701 | 7921 |
| node-2 | \`core, buildagent\` (LocalVC host) | 8081 | 5702 | 7922 |
| node-3 | \`buildagent\` (Hazelcast client) | 8082 | — | — |

Three subtleties worth calling out for future readers:

1. **Liquibase race**: the \`artemis_version\` row insert collides if two JVMs run their Liquibase changelog simultaneously against the same database. Nodes are therefore launched serially — wait for \`/management/health\` on node-N before starting node-N+1, mirroring the docker compose \`service_healthy\` dependency.
2. **Eureka client cache lag**: a node's DiscoveryClient first fetches the registry shortly after Spring Boot start. With three JVMs coming up in quick succession, the next node's first fetch may not yet contain the previous one. After \`wait_for_node\`, also poll the Eureka SERVER until the just-launched instance is visible. \`EUREKA_CLIENT_REGISTRYFETCHINTERVALSECONDS=5\` shortens that window.
3. **Hazelcast peer metadata**: \`HazelcastConfiguration.registerActualHazelcastAddress()\` updates Eureka metadata after the instance starts, but the propagation can take ~90 s and was empirically not landing reliably on the host stack — peers ended up calling the local \`hazelcastPort\` (5702 for node-2) for every instance, so they would 'discover' only themselves. Pre-populate \`hazelcast.host\` / \`hazelcast.port\` in \`EUREKA_INSTANCE_METADATAMAP\` per node so the metadata is in Eureka from the first registration.

The new compose defines nginx inline (instead of \`extends: nginx.yml\`) because compose's \`extends\` merges the parent's \`ports\` list rather than overriding it; we need to drop 7921 since the host node-1 JVM owns that port. The Linux \`host-gateway\` alias is added so \`host.docker.internal\` resolves on Linux without \`/etc/hosts\` changes.

\`CLAUDE.md\` gets a short 'When to use which E2E runner' section.

### Steps for Testing
This PR adds a developer tool only. Existing scripts are unchanged.

Local verification performed:
- \`./run-e2e-tests-local-multinode-fast.sh --filter \"HazelcastCluster\"\` → 2/2 pass; cluster size 2 reported via \`/api/core/admin/websocket/nodes\`, ≥1 build agent reported via \`/api/core/admin/build-agents\`.
- \`./run-e2e-tests-local-multinode-fast.sh --skip-build --skip-up --filter \"HazelcastCluster|Create a new modeling exercise\"\` → 3/3 pass in 7 s.
- \`./run-e2e-tests-local-multinode-fast.sh --stop\` → all 3 host JVMs and 4 infra containers torn down; ports \`8080/8081/8082/5701/5702/7921/7922\` free.

Reviewers should run \`./run-e2e-tests-local-multinode-fast.sh --filter \"HazelcastCluster\"\` and confirm both tests pass; the slow runner remains unchanged so re-running \`./run-e2e-tests-local-multinode.sh\` should still work.

### Testserver States
Not applicable.

### Review Progress

#### Server
- [ ] Code review (developer tool — review focuses on the script + compose + env files)

#### Client
- [ ] Code review (no client changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a fast local multi-node E2E runner for 3-node local test runs with start/stop, skip-build/up, debug, filter and aggregated reporting; added supporting Docker, nginx and environment config and updated .gitignore for local multi-node artifacts.

* **Documentation**
  * Added usage and guidance for the new multi-node fast runner.

* **Tests**
  * Improved Playwright test synchronization and stability across many e2e specs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->