### PR TITLE
`General`: Hide graded/practice mode badge when no submission exists

### DIFF
--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.html
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.html
@@ -42,8 +42,8 @@
             class="ms-auto flex-shrink-0"
             [mode]="participationMode()"
             (modeChange)="participationMode.set($event)"
-            [hasPractice]="hasParticipation()"
-            [hasBoth]="hasBothParticipations()"
+            [hasPractice]="hasPracticeSubmission()"
+            [hasGraded]="hasGradedSubmission()"
         />
     </div>
 </div>

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
@@ -105,7 +105,7 @@ describe('ExerciseHeaderComponent', () => {
         expect(fixture.debugElement.query(By.css('#submit-exercise'))).not.toBeNull();
     });
 
-    describe('hasGradedParticipation', () => {
+    describe('hasGradedSubmission', () => {
         it('should be false when there is no student participation', () => {
             const exercise = new ModelingExercise(UMLDiagramType.ClassDiagram, undefined, undefined);
             exercise.type = ExerciseType.MODELING;
@@ -148,7 +148,7 @@ describe('ExerciseHeaderComponent', () => {
         });
     });
 
-    describe('hasPracticeParticipation', () => {
+    describe('hasPracticeSubmission', () => {
         it('should be false when there is no practice participation and mode is graded', () => {
             const exercise = new ModelingExercise(UMLDiagramType.ClassDiagram, undefined, undefined);
             exercise.type = ExerciseType.MODELING;

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
@@ -11,6 +11,7 @@ import { ExerciseHeadersInformationComponent } from 'app/exercise/exercise-heade
 import { ParticipationModeToggleComponent } from 'app/exercise/exercise-headers/participation-mode-toggle/participation-mode-toggle.component';
 import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { ModelingExercise } from 'app/modeling/shared/entities/modeling-exercise.model';
+import { QuizExercise } from 'app/quiz/shared/entities/quiz-exercise.model';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { UMLDiagramType } from '@tumaet/apollon';
 import { QuizExerciseService } from 'app/quiz/manage/service/quiz-exercise.service';
@@ -102,5 +103,90 @@ describe('ExerciseHeaderComponent', () => {
         fixture.detectChanges();
 
         expect(fixture.debugElement.query(By.css('#submit-exercise'))).not.toBeNull();
+    });
+
+    describe('hasGradedParticipation', () => {
+        it('should be false when there is no student participation', () => {
+            const exercise = new ModelingExercise(UMLDiagramType.ClassDiagram, undefined, undefined);
+            exercise.type = ExerciseType.MODELING;
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.hasGradedSubmission()).toBe(false);
+        });
+
+        it('should be false when student participation has no submitted submissions', () => {
+            const exercise = new QuizExercise(undefined, undefined);
+            exercise.type = ExerciseType.QUIZ;
+            exercise.dueDate = dayjs().subtract(1, 'hours');
+            const participation = new StudentParticipation();
+            participation.submissions = [{ submitted: false }];
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('studentParticipation', participation);
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.hasGradedSubmission()).toBe(false);
+        });
+
+        it('should be true when student participation has a submitted submission', () => {
+            const exercise = new QuizExercise(undefined, undefined);
+            exercise.type = ExerciseType.QUIZ;
+            exercise.dueDate = dayjs().subtract(1, 'hours');
+            const participation = new StudentParticipation();
+            participation.submissions = [{ submitted: true }];
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('studentParticipation', participation);
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.hasGradedSubmission()).toBe(true);
+        });
+    });
+
+    describe('hasPracticeParticipation', () => {
+        it('should be false when there is no practice participation and mode is graded', () => {
+            const exercise = new ModelingExercise(UMLDiagramType.ClassDiagram, undefined, undefined);
+            exercise.type = ExerciseType.MODELING;
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.hasPracticeSubmission()).toBe(false);
+        });
+
+        it('should be true when practice participation has a submitted submission', () => {
+            const exercise = new ModelingExercise(UMLDiagramType.ClassDiagram, undefined, undefined);
+            exercise.type = ExerciseType.MODELING;
+            const practiceParticipation = new StudentParticipation();
+            practiceParticipation.submissions = [{ submitted: true }];
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('practiceParticipation', practiceParticipation);
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.hasPracticeSubmission()).toBe(true);
+        });
+
+        it('should be true when mode is practice even without a practice participation', () => {
+            const exercise = new QuizExercise(undefined, undefined);
+            exercise.type = ExerciseType.QUIZ;
+            const gradedParticipation = new StudentParticipation();
+            gradedParticipation.submissions = [{ submitted: true }];
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('studentParticipation', gradedParticipation);
+            fixture.componentRef.setInput('participationMode', 'practice');
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.hasPracticeSubmission()).toBe(true);
+        });
     });
 });

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.ts
@@ -43,18 +43,15 @@ export class ExerciseHeaderComponent {
         return this.practiceParticipation() ?? this.localPracticeParticipation();
     });
 
-    readonly hasParticipation = computed(() => {
-        return !!this.studentParticipation() || !!this.effectivePracticeParticipation();
+    readonly hasGradedSubmission = computed(() => {
+        return !!this.studentParticipation()?.submissions?.some((s) => s.submitted);
     });
 
-    readonly hasBothParticipations = computed(() => {
-        // Also show both toggle buttons when the mode is explicitly set to 'practice'
-        // with a graded participation, even if the practice participation hasn't been
-        // created yet (e.g. quiz practice just started).
-        if (this.participationMode() === 'practice' && !!this.studentParticipation()) {
-            return true;
-        }
-        return !!this.studentParticipation() && !!this.effectivePracticeParticipation();
+    // Also treat practice as present when the mode is explicitly set to 'practice'
+    // with a graded participation, even if the practice participation hasn't been
+    // created yet (e.g. quiz practice just started).
+    readonly hasPracticeSubmission = computed(() => {
+        return !!this.effectivePracticeParticipation()?.submissions?.some((s) => s.submitted) || this.participationMode() === 'practice';
     });
 
     readonly activeParticipation = computed(() => {

--- a/src/main/webapp/app/exercise/exercise-headers/participation-mode-toggle/participation-mode-toggle.component.html
+++ b/src/main/webapp/app/exercise/exercise-headers/participation-mode-toggle/participation-mode-toggle.component.html
@@ -1,7 +1,8 @@
-@if (hasPractice()) {
-    @if (hasBoth()) {
-        <div class="segmented-control">
+@if (hasPractice() || hasGraded()) {
+    @if (hasPractice() && hasGraded()) {
+        <div id="participation-mode-toggle" class="segmented-control">
             <button
+                id="practice-mode-button"
                 class="segmented-control__button"
                 [class.segmented-control__button--active]="mode() === 'practice'"
                 [class.segmented-control__button--practice]="mode() === 'practice'"
@@ -11,6 +12,7 @@
                 <span jhiTranslate="artemisApp.exerciseActions.mode.practice"></span>
             </button>
             <button
+                id="graded-mode-button"
                 class="segmented-control__button"
                 [class.segmented-control__button--active]="mode() === 'graded'"
                 [class.segmented-control__button--graded]="mode() === 'graded'"
@@ -21,14 +23,15 @@
             </button>
         </div>
     } @else {
-        <div class="segmented-control">
+        <div id="participation-mode-badge" class="segmented-control">
             <span
+                id="mode-badge"
                 class="segmented-control__button segmented-control__button--active"
-                [class.segmented-control__button--practice]="mode() === 'practice'"
-                [class.segmented-control__button--graded]="mode() === 'graded'"
+                [class.segmented-control__button--practice]="hasPractice()"
+                [class.segmented-control__button--graded]="hasGraded()"
             >
-                <fa-icon [icon]="mode() === 'practice' ? faBook : faGraduationCap" />
-                @if (mode() === 'practice') {
+                <fa-icon [icon]="hasPractice() ? faBook : faGraduationCap" />
+                @if (hasPractice()) {
                     <span jhiTranslate="artemisApp.exerciseActions.mode.practice"></span>
                 } @else {
                     <span jhiTranslate="artemisApp.exerciseActions.mode.graded"></span>

--- a/src/main/webapp/app/exercise/exercise-headers/participation-mode-toggle/participation-mode-toggle.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/participation-mode-toggle/participation-mode-toggle.component.spec.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockDirective } from 'ng-mocks';
+import { ParticipationModeToggleComponent } from 'app/exercise/exercise-headers/participation-mode-toggle/participation-mode-toggle.component';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
+
+describe('ParticipationModeToggleComponent', () => {
+    setupTestBed({ zoneless: true });
+
+    let fixture: ComponentFixture<ParticipationModeToggleComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ParticipationModeToggleComponent],
+        });
+
+        TestBed.overrideComponent(ParticipationModeToggleComponent, {
+            remove: { imports: [TranslateDirective] },
+            add: { imports: [MockDirective(TranslateDirective)] },
+        });
+
+        fixture = TestBed.createComponent(ParticipationModeToggleComponent);
+        fixture.componentRef.setInput('mode', 'graded');
+        fixture.detectChanges();
+    });
+
+    it('should render nothing when neither hasPractice nor hasGraded', () => {
+        fixture.componentRef.setInput('hasPractice', false);
+        fixture.componentRef.setInput('hasGraded', false);
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('#participation-mode-toggle')).toBeNull();
+        expect(fixture.nativeElement.querySelector('#participation-mode-badge')).toBeNull();
+    });
+
+    it('should render only the graded badge when only hasGraded is true', () => {
+        fixture.componentRef.setInput('hasPractice', false);
+        fixture.componentRef.setInput('hasGraded', true);
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('#participation-mode-toggle')).toBeNull();
+        expect(fixture.nativeElement.querySelector('#participation-mode-badge')).not.toBeNull();
+        expect(fixture.nativeElement.querySelector('#practice-mode-button')).toBeNull();
+        expect(fixture.nativeElement.querySelector('#graded-mode-button')).toBeNull();
+    });
+
+    it('should render only the practice badge when only hasPractice is true', () => {
+        fixture.componentRef.setInput('mode', 'practice');
+        fixture.componentRef.setInput('hasPractice', true);
+        fixture.componentRef.setInput('hasGraded', false);
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('#participation-mode-toggle')).toBeNull();
+        expect(fixture.nativeElement.querySelector('#participation-mode-badge')).not.toBeNull();
+        expect(fixture.nativeElement.querySelector('#practice-mode-button')).toBeNull();
+        expect(fixture.nativeElement.querySelector('#graded-mode-button')).toBeNull();
+    });
+
+    it('should render two clickable buttons when both hasPractice and hasGraded are true', () => {
+        fixture.componentRef.setInput('hasPractice', true);
+        fixture.componentRef.setInput('hasGraded', true);
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('#participation-mode-toggle')).not.toBeNull();
+        expect(fixture.nativeElement.querySelector('#practice-mode-button')).not.toBeNull();
+        expect(fixture.nativeElement.querySelector('#graded-mode-button')).not.toBeNull();
+        expect(fixture.nativeElement.querySelector('#participation-mode-badge')).toBeNull();
+    });
+
+    it('should mark graded button as active when mode is graded', () => {
+        fixture.componentRef.setInput('hasPractice', true);
+        fixture.componentRef.setInput('hasGraded', true);
+        fixture.componentRef.setInput('mode', 'graded');
+        fixture.detectChanges();
+
+        const practiceButton: HTMLButtonElement = fixture.nativeElement.querySelector('#practice-mode-button');
+        const gradedButton: HTMLButtonElement = fixture.nativeElement.querySelector('#graded-mode-button');
+        expect(practiceButton.classList).not.toContain('segmented-control__button--active');
+        expect(gradedButton.classList).toContain('segmented-control__button--active');
+    });
+
+    it('should mark practice button as active when mode is practice', () => {
+        fixture.componentRef.setInput('hasPractice', true);
+        fixture.componentRef.setInput('hasGraded', true);
+        fixture.componentRef.setInput('mode', 'practice');
+        fixture.detectChanges();
+
+        const practiceButton: HTMLButtonElement = fixture.nativeElement.querySelector('#practice-mode-button');
+        const gradedButton: HTMLButtonElement = fixture.nativeElement.querySelector('#graded-mode-button');
+        expect(practiceButton.classList).toContain('segmented-control__button--active');
+        expect(gradedButton.classList).not.toContain('segmented-control__button--active');
+    });
+
+    it('should switch to practice mode when practice button is clicked', () => {
+        fixture.componentRef.setInput('hasPractice', true);
+        fixture.componentRef.setInput('hasGraded', true);
+        fixture.componentRef.setInput('mode', 'graded');
+        fixture.detectChanges();
+
+        fixture.nativeElement.querySelector('#practice-mode-button').click();
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.mode()).toBe('practice');
+    });
+
+    it('should switch to graded mode when graded button is clicked', () => {
+        fixture.componentRef.setInput('hasPractice', true);
+        fixture.componentRef.setInput('hasGraded', true);
+        fixture.componentRef.setInput('mode', 'practice');
+        fixture.detectChanges();
+
+        fixture.nativeElement.querySelector('#graded-mode-button').click();
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance.mode()).toBe('graded');
+    });
+});

--- a/src/main/webapp/app/exercise/exercise-headers/participation-mode-toggle/participation-mode-toggle.component.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/participation-mode-toggle/participation-mode-toggle.component.ts
@@ -14,7 +14,7 @@ export type ParticipationMode = 'practice' | 'graded';
 export class ParticipationModeToggleComponent {
     readonly mode = model.required<ParticipationMode>();
     readonly hasPractice = input(false);
-    readonly hasBoth = input(false);
+    readonly hasGraded = input(false);
 
     readonly faBook = faBook;
     readonly faGraduationCap = faGraduationCap;


### PR DESCRIPTION
### Summary

Fixed a confusing situation where students who didn't submit a quiz in time still saw a \"Graded\" badge in the exercise header, making it look like they had a graded submission when they actually didn't. The same logic now applies consistently to practice participations as well.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).

### Motivation and Context

Closes #12664.

A student who opened a quiz but didn't submit in time ended up with an empty graded participation. The server creates a participation record as soon as the quiz starts, but without a submission. The participation-mode toggle was checking purely for the existence of a participation, so it showed the \"Graded\" badge regardless. This was misleading, especially combined with the message telling the student they missed the deadline.

### Description

The toggle's inputs were renamed from `hasPractice`/`hasBoth` to `hasPractice`/`hasGraded`, allowing each mode to be controlled independently. The parent component (`ExerciseHeaderComponent`) now computes `hasGradedSubmission` and `hasPracticeSubmission` by checking whether the participation contains at least one submitted submission, rather than just whether participation exists.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Student
- 1 Quiz exercise (synchronized, with a due date in the past)

1. Log in as the student and navigate to the quiz
2. Open the quiz but **do not submit** — let the deadline pass (or use a quiz that has already ended)
3. Navigate to the exercise detail page
4. Verify that **no mode badge is shown** in the exercise header
5. Verify that the message "You did not submit this quiz in time. You can still practice it using the Start practice button." is still displayed
6. Click "Start Practice" and verify that the Practice badge appears
7. Submit the practice quiz and verify that the Practice badge is shown correctly
8. Repeat with a student who **did** submit the graded quiz. Verify the Graded badge is shown as before and a toggle appears when starting practice after the deadline.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| exercise-header.component.ts | not found (modified) | 79 | 8 | 10.1 |
| participation-mode-toggle.component.ts | not found (modified) | 21 | 20 | 95.2 |

_Last updated: 2026-05-11 06:10:52 UTC_



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed participation mode toggle to accurately display available submission options
  * Improved submission state detection for graded and practice submissions

* **Refactor**
  * Streamlined submission availability logic in participation mode component

* **Tests**
  * Added comprehensive test coverage for submission state detection and mode selector rendering

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Artemis/pull/12683)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->