### PR TITLE
`Development`: Speed up build workflow by reusing .war artifact for the PR docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,9 +90,7 @@ jobs:
 
   build-war:
     name: Build .war artifact
-    # Larger self-hosted runner gives Angular's esbuild more cores; cuts wall clock
-    # vs ubuntu-latest. Same runner family used by server-tests / client-tests.
-    runs-on: aet-large-ubuntu
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,9 +88,11 @@ env:
 
 jobs:
 
-  build:
+  build-war:
     name: Build .war artifact
-    runs-on: ubuntu-latest
+    # Larger self-hosted runner gives Angular's esbuild more cores; cuts wall clock
+    # vs ubuntu-latest. Same runner family used by server-tests / client-tests.
+    runs-on: aet-large-ubuntu
     steps:
       - uses: actions/checkout@v6
         with:
@@ -136,32 +138,101 @@ jobs:
           asset_name: Artemis.war
           asset_content_type: application/x-webarchive
 
-  docker:
+  # Fast PR path: single-arch (linux/amd64) image that reuses the .war produced by
+  # `build-war` via the Dockerfile's `external_builder` stage. Skips the duplicate
+  # Angular + Gradle build that the reusable multi-arch workflow would otherwise
+  # run inside the image.
+  docker-pr:
+    name: Build and Push Docker Image (PR, amd64)
+    needs: build-war
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'ls1intum/Artemis' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Download .war artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: Artemis.war
+          path: build/libs
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/ls1intum/artemis
+          tags: |
+            type=ref,event=pr
+      - name: Build and push (linux/amd64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/artemis/Dockerfile
+          platforms: linux/amd64
+          # Skip the in-image .war build; COPY the artifact produced by `build-war` instead.
+          build-args: WAR_FILE_STAGE=external_builder
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      # Consumed by .github/actions/e2e-setup, which downloads the `docker-tag`
+      # artifact from the triggering Build run and pulls ghcr.io/ls1intum/artemis:<tag>.
+      - name: Save Docker tag to file
+        env:
+          DOCKER_TAG: ${{ steps.meta.outputs.version }}
+        run: |
+          printf '%s' "$DOCKER_TAG" > docker-tag.txt
+          echo "Using Docker tag: $DOCKER_TAG"
+      - name: Upload Docker tag as artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: docker-tag
+          path: docker-tag.txt
+
+  # Release / default-branch path: multi-arch publish via the shared reusable workflow.
+  # Kept as-is because the reusable workflow runs its own checkout and cannot see the
+  # `build-war` artifact, so it must keep rebuilding the .war inside the image. This
+  # path only fires on develop/main/release/* pushes, tags, and release events — not
+  # on the PR-to-test-server critical path.
+  docker-release:
     name: Build and Push Docker Image
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'ls1intum/Artemis' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
     uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.1
     with:
-      # Checkout pull request HEAD commit instead of merge commit to include the correct branch and git information inside the build
-      # Or use the push event ref name
-      ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      ref: ${{ github.ref_name }}
       image-name: ls1intum/artemis
       docker-file: ./docker/artemis/Dockerfile
       tags: |
         type=ref,event=tag
 
-  # Save Docker image tag as an artifact
+  # Mirrors the `docker-tag` artifact upload from `docker-pr` for the release path,
+  # so .github/actions/e2e-setup can consume it uniformly regardless of which docker
+  # job produced the image.
   save-docker-tag:
     name: Save Docker Image Tag
-    needs: docker
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'ls1intum/Artemis' }}
+    needs: docker-release
+    if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Save Docker Tag to File
+      - name: Save Docker tag to file
+        env:
+          DOCKER_TAG: ${{ needs.docker-release.outputs.image_tag }}
         run: |
-          echo "${{ needs.docker.outputs.image_tag }}" > docker-tag.txt
-          echo "Using Docker tag: ${{ needs.docker.outputs.image_tag }}"
-
-      - name: Upload Docker Tag as Artifact
+          printf '%s' "$DOCKER_TAG" > docker-tag.txt
+          echo "Using Docker tag: $DOCKER_TAG"
+      - name: Upload Docker tag as artifact
         uses: actions/upload-artifact@v6
         with:
           name: docker-tag

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,24 +12,13 @@ on:
     - 'documentation/**'
     - '.github/**'
     - '!.github/workflows/codeql-analysis.yml'
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [develop]
-    paths-ignore:
-    - 'README.md'
-    - 'CODE_OF_CONDUCT.md'
-    - 'CONTRIBUTING.md'
-    - 'LICENSE'
-    - 'SECURITY.md'
-    - 'documentation/**'
-    - '.github/**'
-    - '!.github/workflows/codeql-analysis.yml'
   schedule:
     - cron: '0 16 * * 0'
+  workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 # Keep in sync with build.yml and test.yml and analysis-of-endpoint-connections.yml
 env:

--- a/.github/workflows/pullrequest-coverage-reporter.yml
+++ b/.github/workflows/pullrequest-coverage-reporter.yml
@@ -1,50 +1,95 @@
 name: PR Coverage Reporter
 
+# Reuses coverage artifacts produced by the `Test` workflow to render the
+# coverage table in the PR description, instead of re-running the entire
+# test suite a second time (which was the historical bottleneck).
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review]
+  workflow_run:
+    # Must match the name of test.yml's `name:` field.
+    workflows: ["Test"]
+    types: [completed]
 
-# Only one coverage run per PR at a time
 concurrency:
-  group: coverage-${{ github.event.pull_request.number }}
+  group: coverage-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 env:
   CI: true
   node: 24
-  java: 25
 
 jobs:
-  detect-changes:
+  report-coverage:
+    name: Report PR Coverage
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled' &&
+      github.event.workflow_run.conclusion != 'skipped'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      has_client_changes: ${{ steps.changes.outputs.has_client_changes }}
-      has_server_changes: ${{ steps.changes.outputs.has_server_changes }}
-      client_modules: ${{ steps.changes.outputs.client_modules }}
-      server_modules: ${{ steps.changes.outputs.server_modules }}
+    timeout-minutes: 15
+    permissions:
+      pull-requests: write
+      contents: read
+      actions: read
     steps:
-      - uses: actions/checkout@v6
+      - name: Find PR number
+        id: find-pr
+        uses: actions/github-script@v8
+        continue-on-error: true
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_REPO_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
         with:
+          result-encoding: string
+          script: |
+            const branch = process.env.HEAD_BRANCH;
+            const headOwner = process.env.HEAD_REPO_OWNER;
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${headOwner}:${branch}`,
+              state: 'open'
+            });
+            if (!prs.length) {
+              console.log(`No open PR found for branch ${headOwner}:${branch}`);
+              return '';
+            }
+            core.setOutput('base_ref', prs[0].base.ref);
+            core.setOutput('author', prs[0].user.login);
+            return prs[0].number;
+
+      - name: Exit if no PR found
+        if: steps.find-pr.outputs.result == ''
+        run: |
+          echo "No matching open PR; skipping coverage report."
+          exit 0
+
+      - uses: actions/checkout@v6
+        if: steps.find-pr.outputs.result != ''
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Detect changed modules
+        if: steps.find-pr.outputs.result != ''
         id: changes
+        env:
+          BASE_BRANCH: ${{ steps.find-pr.outputs.base_ref }}
         run: |
-          # Get the base branch
-          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          set -euo pipefail
+          # Validate the ref name shape so it's safe to interpolate below.
+          if ! printf '%s' "$BASE_BRANCH" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
+            echo "::error::Unexpected base branch name: $BASE_BRANCH"
+            exit 1
+          fi
           git fetch origin "$BASE_BRANCH"
 
-          # Get changed files
           CHANGED_FILES=$(git diff --name-only "origin/$BASE_BRANCH"...HEAD)
 
-          # Detect client changes and modules
           CLIENT_MODULES=""
           HAS_CLIENT_CHANGES="false"
           for file in $CHANGED_FILES; do
             if [[ "$file" == src/main/webapp/app/*.ts ]] && [[ "$file" != *.spec.ts ]] && [[ "$file" != *.module.ts ]]; then
               HAS_CLIENT_CHANGES="true"
-              # Extract module name (first directory after app/)
               MODULE=$(echo "$file" | sed -n 's|^src/main/webapp/app/\([^/]*\)/.*|\1|p')
               if [ -n "$MODULE" ] && [[ ! "$CLIENT_MODULES" =~ (^|,)$MODULE(,|$) ]]; then
                 if [ -z "$CLIENT_MODULES" ]; then
@@ -56,13 +101,11 @@ jobs:
             fi
           done
 
-          # Detect server changes and modules
           SERVER_MODULES=""
           HAS_SERVER_CHANGES="false"
           for file in $CHANGED_FILES; do
             if [[ "$file" == src/main/java/de/tum/cit/aet/artemis/*.java ]]; then
               HAS_SERVER_CHANGES="true"
-              # Extract module name (first directory after artemis/)
               MODULE=$(echo "$file" | sed -n 's|^src/main/java/de/tum/cit/aet/artemis/\([^/]*\)/.*|\1|p')
               if [ -n "$MODULE" ] && [[ ! "$SERVER_MODULES" =~ (^|,)$MODULE(,|$) ]]; then
                 if [ -z "$SERVER_MODULES" ]; then
@@ -74,273 +117,126 @@ jobs:
             fi
           done
 
-          echo "has_client_changes=$HAS_CLIENT_CHANGES" >> $GITHUB_OUTPUT
-          echo "has_server_changes=$HAS_SERVER_CHANGES" >> $GITHUB_OUTPUT
-          echo "client_modules=$CLIENT_MODULES" >> $GITHUB_OUTPUT
-          echo "server_modules=$SERVER_MODULES" >> $GITHUB_OUTPUT
+          {
+            echo "has_client_changes=$HAS_CLIENT_CHANGES"
+            echo "has_server_changes=$HAS_SERVER_CHANGES"
+            echo "client_modules=$CLIENT_MODULES"
+            echo "server_modules=$SERVER_MODULES"
+          } >> "$GITHUB_OUTPUT"
 
           echo "Client changes: $HAS_CLIENT_CHANGES (modules: $CLIENT_MODULES)"
           echo "Server changes: $HAS_SERVER_CHANGES (modules: $SERVER_MODULES)"
 
-  update-no-coverage-needed:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.has_client_changes == 'false' && needs.detect-changes.outputs.has_server_changes == 'false'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Update PR description
-        uses: actions/github-script@v8
+      - name: Download server JaCoCo XML
+        if: steps.changes.outputs.has_server_changes == 'true'
+        uses: actions/download-artifact@v6
+        continue-on-error: true
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-
-            const { data: pr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: prNumber
-            });
-
-            let body = pr.body || '';
-            const coverageSection = '### Test Coverage';
-            const coverageIndex = body.indexOf(coverageSection);
-
-            if (coverageIndex === -1) {
-              console.log('Test Coverage section not found in PR description');
-              return;
-            }
-
-            const afterCoverage = body.substring(coverageIndex + coverageSection.length);
-            const nextSectionMatch = afterCoverage.match(/\n###\s/);
-            const nextSectionIndex = nextSectionMatch
-              ? coverageIndex + coverageSection.length + nextSectionMatch.index
-              : body.length;
-
-            const timestamp = new Date().toISOString().replace('T', ' ').substring(0, 19) + ' UTC';
-
-            // Build content using array join to avoid YAML parsing issues
-            const lines = [
-              coverageSection,
-              '<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->',
-              '<!-- 1. Run `npm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->',
-              '<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->',
-              '<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->',
-              '<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->',
-              '<!--       Remove rows with only trivial changes from the table. -->',
-              '',
-              '**No code changes detected** - test coverage not required for this PR.',
-              '',
-              `_Last updated: ${timestamp}_`,
-              '',
-              ''
-            ];
-            const newCoverageContent = lines.join('\n');
-
-            const newBody = body.substring(0, coverageIndex) + newCoverageContent + body.substring(nextSectionIndex);
-
-            await github.rest.pulls.update({
-              owner,
-              repo,
-              pull_number: prNumber,
-              body: newBody
-            });
-
-            console.log('Updated PR description with no-coverage-needed message');
-
-  client-coverage:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.has_client_changes == 'true'
-    runs-on: aet-large-ubuntu
-    timeout-minutes: 45
-    outputs:
-      success: ${{ steps.run-tests.outputs.success }}
-      coverage_table: ${{ steps.run-tests.outputs.coverage_table }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '${{ env.node }}'
-          cache: 'npm'
-
-      - name: Install Dependencies
-        run: npm install
-
-      - name: Run client tests and generate coverage
-        id: run-tests
-        run: |
-          set -o pipefail
-
-          MODULES="${{ needs.detect-changes.outputs.client_modules }}"
-
-          if [ -n "$MODULES" ]; then
-            echo "Running client tests for modules: $MODULES"
-            COVERAGE_OUTPUT=$(npm run coverage:pr -- --client-only --client-modules "$MODULES" --print 2>&1) || {
-              echo "success=false" >> $GITHUB_OUTPUT
-              echo "Tests failed"
-              exit 0
-            }
-          else
-            echo "Running all client tests"
-            COVERAGE_OUTPUT=$(npm run coverage:pr -- --client-only --print 2>&1) || {
-              echo "success=false" >> $GITHUB_OUTPUT
-              echo "Tests failed"
-              exit 0
-            }
-          fi
-
-          echo "success=true" >> $GITHUB_OUTPUT
-
-          # Extract just the coverage table (between the separator lines)
-          COVERAGE_TABLE=$(echo "$COVERAGE_OUTPUT" | sed -n '/^─/,/^─/p' | sed '1d;$d')
-
-          # Use heredoc to handle multiline output
-          {
-            echo 'coverage_table<<EOF'
-            echo "$COVERAGE_TABLE"
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
-
-      - name: Upload client coverage artifacts
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: client-coverage-report
-          path: |
-            build/test-results/jest/coverage-summary.json
-            build/test-results/vitest/coverage/coverage-summary.json
-          if-no-files-found: ignore
-
-  server-coverage:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.has_server_changes == 'true'
-    runs-on: aet-large-ubuntu
-    timeout-minutes: 80
-    outputs:
-      success: ${{ steps.run-tests.outputs.success }}
-      coverage_table: ${{ steps.run-tests.outputs.coverage_table }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: |
-            17
-            ${{ env.java }}
-          cache: 'gradle'
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '${{ env.node }}'
-          cache: 'npm'
-
-      - name: Install Dependencies
-        run: npm install
-
-      - name: Run server tests and generate coverage
-        id: run-tests
-        run: |
-          set -o pipefail
-
-          MODULES="${{ needs.detect-changes.outputs.server_modules }}"
-
-          if [ -n "$MODULES" ]; then
-            echo "Running server tests for modules: $MODULES"
-            COVERAGE_OUTPUT=$(npm run coverage:pr -- --server-only --server-modules "$MODULES" --print 2>&1) || {
-              echo "success=false" >> $GITHUB_OUTPUT
-              echo "Tests failed"
-              exit 0
-            }
-          else
-            echo "Running all server tests"
-            COVERAGE_OUTPUT=$(npm run coverage:pr -- --server-only --print 2>&1) || {
-              echo "success=false" >> $GITHUB_OUTPUT
-              echo "Tests failed"
-              exit 0
-            }
-          fi
-
-          echo "success=true" >> $GITHUB_OUTPUT
-
-          # Extract just the coverage table (between the separator lines)
-          COVERAGE_TABLE=$(echo "$COVERAGE_OUTPUT" | sed -n '/^─/,/^─/p' | sed '1d;$d')
-
-          # Use heredoc to handle multiline output
-          {
-            echo 'coverage_table<<EOF'
-            echo "$COVERAGE_TABLE"
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
-
-      - name: Upload server coverage artifacts
-        if: always()
-        uses: actions/upload-artifact@v6
-        with:
-          name: server-coverage-report
+          name: Server JaCoCo XML
           path: build/reports/jacoco/
-          if-no-files-found: ignore
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
-  update-pr-coverage:
-    needs: [detect-changes, client-coverage, server-coverage]
-    if: always() && (needs.detect-changes.outputs.has_client_changes == 'true' || needs.detect-changes.outputs.has_server_changes == 'true')
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      pull-requests: write
-    steps:
+      - name: Download client coverage summaries
+        if: steps.changes.outputs.has_client_changes == 'true'
+        uses: actions/download-artifact@v6
+        continue-on-error: true
+        with:
+          name: Client Coverage Summaries
+          # upload-artifact preserves the relative paths, so files land back at
+          # build/test-results/{jest,vitest}/... as the coverage:pr script expects.
+          path: .
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Setup Node.js
+        if: steps.changes.outputs.has_client_changes == 'true' || steps.changes.outputs.has_server_changes == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '${{ env.node }}'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        if: steps.changes.outputs.has_client_changes == 'true' || steps.changes.outputs.has_server_changes == 'true'
+        run: npm ci --no-audit --no-fund
+
+      - name: Generate coverage table
+        id: coverage
+        if: steps.changes.outputs.has_client_changes == 'true' || steps.changes.outputs.has_server_changes == 'true'
+        env:
+          BASE_BRANCH: ${{ steps.find-pr.outputs.base_ref }}
+          CLIENT_MODULES: ${{ steps.changes.outputs.client_modules }}
+          SERVER_MODULES: ${{ steps.changes.outputs.server_modules }}
+          HAS_CLIENT: ${{ steps.changes.outputs.has_client_changes }}
+          HAS_SERVER: ${{ steps.changes.outputs.has_server_changes }}
+        run: |
+          set -o pipefail
+          ARGS=(--skip-tests --print --base-branch "origin/$BASE_BRANCH")
+          if [ "$HAS_CLIENT" = "true" ] && [ "$HAS_SERVER" != "true" ]; then
+            ARGS+=(--client-only)
+          elif [ "$HAS_SERVER" = "true" ] && [ "$HAS_CLIENT" != "true" ]; then
+            ARGS+=(--server-only)
+          fi
+          if [ -n "$CLIENT_MODULES" ]; then
+            ARGS+=(--client-modules "$CLIENT_MODULES")
+          fi
+          if [ -n "$SERVER_MODULES" ]; then
+            ARGS+=(--server-modules "$SERVER_MODULES")
+          fi
+
+          echo "Running: npm run coverage:pr -- ${ARGS[*]}"
+          if ! COVERAGE_OUTPUT=$(npm run coverage:pr -- "${ARGS[@]}" 2>&1); then
+            echo "$COVERAGE_OUTPUT"
+            echo "success=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "$COVERAGE_OUTPUT"
+          echo "success=true" >> "$GITHUB_OUTPUT"
+
+          # Extract content between the script's separator lines (rows of ─).
+          COVERAGE_TABLE=$(echo "$COVERAGE_OUTPUT" | sed -n '/^─/,/^─/p' | sed '1d;$d')
+          {
+            echo 'coverage_table<<COVERAGE_EOF'
+            echo "$COVERAGE_TABLE"
+            echo 'COVERAGE_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Update PR description with coverage
+        if: steps.find-pr.outputs.result != ''
         uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ steps.find-pr.outputs.result }}
+          PR_AUTHOR: ${{ steps.find-pr.outputs.author }}
+          HAS_CLIENT: ${{ steps.changes.outputs.has_client_changes }}
+          HAS_SERVER: ${{ steps.changes.outputs.has_server_changes }}
+          COVERAGE_TABLE: ${{ steps.coverage.outputs.coverage_table }}
+          COVERAGE_SUCCESS: ${{ steps.coverage.outputs.success }}
+          TEST_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          TEST_RUN_URL: ${{ github.event.workflow_run.html_url }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = context.payload.pull_request.number;
+            const prNumber = Number(process.env.PR_NUMBER);
+            const author = process.env.PR_AUTHOR;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const author = context.payload.pull_request.user.login;
 
-            const hasClientChanges = '${{ needs.detect-changes.outputs.has_client_changes }}' === 'true';
-            const hasServerChanges = '${{ needs.detect-changes.outputs.has_server_changes }}' === 'true';
+            const hasClient = process.env.HAS_CLIENT === 'true';
+            const hasServer = process.env.HAS_SERVER === 'true';
+            const coverageTable = (process.env.COVERAGE_TABLE || '').trim();
+            const coverageSuccess = process.env.COVERAGE_SUCCESS === 'true';
+            const testConclusion = process.env.TEST_CONCLUSION;
+            const testRunUrl = process.env.TEST_RUN_URL;
 
-            // Handle skipped jobs - outputs will be empty strings
-            const clientSuccessStr = '${{ needs.client-coverage.outputs.success }}';
-            const serverSuccessStr = '${{ needs.server-coverage.outputs.success }}';
-            const clientSuccess = clientSuccessStr === 'true';
-            const serverSuccess = serverSuccessStr === 'true';
-            const clientTable = `${{ needs.client-coverage.outputs.coverage_table }}`;
-            const serverTable = `${{ needs.server-coverage.outputs.coverage_table }}`;
-
-            // Determine failures (only count as failed if the job ran)
-            const clientFailed = hasClientChanges && clientSuccessStr !== '' && !clientSuccess;
-            const serverFailed = hasServerChanges && serverSuccessStr !== '' && !serverSuccess;
-            const anyFailed = clientFailed || serverFailed;
-
-            const { data: pr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: prNumber
-            });
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
 
             let body = pr.body || '';
             const coverageSection = '### Test Coverage';
             const coverageIndex = body.indexOf(coverageSection);
-
             if (coverageIndex === -1) {
               console.log('Test Coverage section not found in PR description');
               return;
             }
-
             const afterCoverage = body.substring(coverageIndex + coverageSection.length);
             const nextSectionMatch = afterCoverage.match(/\n###\s/);
             const nextSectionIndex = nextSectionMatch
@@ -348,9 +244,7 @@ jobs:
               : body.length;
 
             const timestamp = new Date().toISOString().replace('T', ' ').substring(0, 19) + ' UTC';
-            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${{ github.run_id }}`;
 
-            // Build content using array
             const lines = [
               coverageSection,
               '<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->',
@@ -362,53 +256,39 @@ jobs:
               ''
             ];
 
-            if (anyFailed) {
-              let warningMsg = '**Warning:** ';
-              if (clientFailed && serverFailed) {
-                warningMsg += 'Both client and server tests failed. ';
-              } else if (clientFailed) {
-                warningMsg += 'Client tests failed. ';
-              } else {
-                warningMsg += 'Server tests failed. ';
+            const noChanges = !hasClient && !hasServer;
+            if (noChanges) {
+              lines.push('**No code changes detected** - test coverage not required for this PR.', '');
+            } else if (!coverageSuccess) {
+              lines.push(
+                `**Warning:** Coverage table could not be generated. The \`Test\` workflow concluded with status \`${testConclusion}\`; coverage artifacts may be missing or incomplete. See [workflow logs](${testRunUrl}).`,
+                ''
+              );
+            } else {
+              if (testConclusion !== 'success') {
+                lines.push(
+                  `**Note:** Some tests in the [Test workflow](${testRunUrl}) did not pass (\`${testConclusion}\`). Coverage below may be partial.`,
+                  ''
+                );
               }
-              warningMsg += `Coverage could not be fully measured. Please check the [workflow logs](${runUrl}).`;
-              lines.push(warningMsg, '');
+              if (coverageTable) {
+                lines.push(coverageTable, '');
+              } else {
+                lines.push('Coverage data was found, but no rows applied to changed files.', '');
+              }
             }
-
-            // Add tables if available
-            if (hasClientChanges && clientTable && clientTable.trim()) {
-              lines.push(clientTable, '');
-            }
-
-            if (hasServerChanges && serverTable && serverTable.trim()) {
-              lines.push(serverTable, '');
-            }
-
             lines.push(`_Last updated: ${timestamp}_`, '', '');
 
-            const newCoverageContent = lines.join('\n');
-            const newBody = body.substring(0, coverageIndex) + newCoverageContent + body.substring(nextSectionIndex);
+            const newBody = body.substring(0, coverageIndex) + lines.join('\n') + body.substring(nextSectionIndex);
 
-            await github.rest.pulls.update({
-              owner,
-              repo,
-              pull_number: prNumber,
-              body: newBody
-            });
-
+            await github.rest.pulls.update({ owner, repo, pull_number: prNumber, body: newBody });
             console.log('Updated PR description with coverage results');
 
-            // Post a comment notifying the author
-            let commentBody;
-            if (anyFailed) {
-              commentBody = `@${author} Test coverage could not be fully measured because some tests failed. Please check the [workflow logs](${runUrl}) for details.`;
-            } else {
-              commentBody = `@${author} Test coverage has been automatically updated in the PR description.`;
-            }
-
+            // Notify the author.
+            if (noChanges) return;
+            const commentBody = coverageSuccess
+              ? `@${author} Test coverage has been automatically updated in the PR description.`
+              : `@${author} Coverage table could not be generated. See the [Test workflow run](${testRunUrl}) for details.`;
             await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: prNumber,
-              body: commentBody
+              owner, repo, issue_number: prNumber, body: commentBody
             });

--- a/.github/workflows/pullrequest-coverage-reporter.yml
+++ b/.github/workflows/pullrequest-coverage-reporter.yml
@@ -143,9 +143,13 @@ jobs:
         continue-on-error: true
         with:
           name: Client Coverage Summaries
-          # upload-artifact preserves the relative paths, so files land back at
-          # build/test-results/{jest,vitest}/... as the coverage:pr script expects.
-          path: .
+          # upload-artifact@v6 strips the common ancestor of the uploaded paths.
+          # test.yml's uploader ships build/test-results/jest/coverage-summary.json
+          # and build/test-results/vitest/coverage/coverage-summary.json, so the
+          # archive contains jest/coverage-summary.json and vitest/coverage/coverage-summary.json.
+          # Restore the stripped ancestor here so the files land where
+          # supporting_scripts/code-coverage/local-pr-coverage/local-pr-coverage.mjs reads them.
+          path: build/test-results/
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,6 +202,13 @@ jobs:
       with:
         name: Coverage Report Server Tests
         path: build/reports/jacoco/aggregated/html
+    - name: Upload JaCoCo XML Reports
+      if: success() || failure()
+      uses: actions/upload-artifact@v6
+      with:
+        name: Server JaCoCo XML
+        path: build/reports/jacoco/**/jacocoTestReport.xml
+        if-no-files-found: ignore
     - name: Append Per-Module Coverage to Job Summary
       if: success() || failure()
       run: |
@@ -268,6 +275,15 @@ jobs:
           with:
               name: Vitest Coverage Report
               path: build/test-results/vitest/coverage/
+        - name: Upload Client Coverage Summaries
+          if: success() || failure()
+          uses: actions/upload-artifact@v6
+          with:
+              name: Client Coverage Summaries
+              path: |
+                  build/test-results/jest/coverage-summary.json
+                  build/test-results/vitest/coverage/coverage-summary.json
+              if-no-files-found: ignore
         - name: Upload JUnit Test Results
           if: success() || failure()
           uses: actions/upload-artifact@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -281,25 +281,6 @@ jobs:
             name: Vitest JUnit Test Results
             path: build/test-results/vitest/junit.xml
 
-  client-tests-selected:
-      runs-on: ubuntu-latest
-      timeout-minutes: 30
-      steps:
-          - uses: actions/checkout@v6
-            with:
-                fetch-depth: 0
-          - name: Setup Node.js
-            uses: actions/setup-node@v6
-            with:
-                node-version: '${{ env.node }}'
-                cache: 'npm'
-          - name: Install Dependencies
-            run: npm install
-          - name: Compile TypeScript Test Files With Typechecking
-            run: npm run compile:tests
-          - name: TypeScript Test (Selection) Without Typechecking
-            run: npm run test-diff:ci
-
   client-style:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/docker/artemis/Dockerfile
+++ b/docker/artemis/Dockerfile
@@ -24,11 +24,9 @@ ARG WAR_FILE_STAGE="builder"
 #-----------------------------------------------------------------------------------------------------------------------
 FROM --platform=$BUILDPLATFORM docker.io/library/eclipse-temurin:25-jdk AS builder
 
-# some Apple M1 (arm64) builds need python3 and build-essential(make+gcc) for node-gyp to not fail
-RUN echo "Installing build dependencies" \
-  && apt-get update && apt-get install -y --no-install-recommends python3 build-essential \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+# python3/build-essential were previously installed defensively for npm deps that
+# trigger node-gyp; no current Artemis dep needs that. If a future dep does, the
+# npm step below fails loudly and these can be reinstated.
 
 WORKDIR /opt/artemis
 # copy gradle related files
@@ -36,35 +34,29 @@ COPY gradlew gradlew.bat ./
 COPY build.gradle gradle.properties settings.gradle ./
 COPY gradle gradle/
 # copy npm related files and install node modules
-# (from https://stackoverflow.com/questions/63961934/how-to-use-docker-build-cache-when-version-bumping-a-react-app)
 COPY package.json package-lock.json ./
 # also copy this script which is required by postinstall lifecycle hook
 COPY src/main/webapp/app/lecture/manage/pdf-preview/pdfjs_copy_worker_script.mjs ./src/main/webapp/app/lecture/manage/pdf-preview/
 
+# One Gradle invocation does both the cache config and the npm install. Uses
+# `npm_install` so the BuildKit npm cache mount below is reused on warm builds
+# (`npm_ci` ignores the cache).
 RUN \
-  # Mount global cache for Gradle (project cache in /opt/artemis/.gradle doesn't seem to be populated)
   --mount=type=cache,target=/root/.gradle/caches \
-  # Mount cache for npm
   --mount=type=cache,target=/opt/artemis/.npm \
-  # Create .npm directory if not yet available
   mkdir -p /opt/artemis/.npm \
-  # Set .npm directory as npm cache
-  && ./gradlew -i --stacktrace --no-daemon -Pprod -Pwar npmSetCacheDockerfile \
-  # Pre-populate the npm and gradle caches if related files change (see COPY statements above)
-  && ./gradlew -i --stacktrace --no-daemon -Pprod -Pwar npm_ci
+  && ./gradlew -i --stacktrace --no-daemon -Pprod -Pwar npmSetCacheDockerfile npm_install
 
 # so far just using the .dockerignore to define what isn't necessary here
 COPY . .
 
+# `-x npm_install` skips re-running the install task — node_modules is already
+# in place from the previous RUN.
 RUN \
-  # Mount global cache for Gradle (project cache in /opt/artemis/.gradle doesn't seem to be populated)
   --mount=type=cache,target=/root/.gradle/caches \
-  # Mount cache for npm
   --mount=type=cache,target=/opt/artemis/.npm \
-  # Mount cache for the Angular CLI
   --mount=type=cache,target=/opt/artemis/.cache \
-  # Build the .war file
-  ./gradlew -i --stacktrace --no-daemon -Pprod -Pwar clean bootWar
+  ./gradlew -i --stacktrace --no-daemon -Pprod -Pwar clean bootWar -x npm_install
 
 #-----------------------------------------------------------------------------------------------------------------------
 # external build stage


### PR DESCRIPTION
### Summary
Reduces the total CI cost of every PR by cutting redundant or duplicated work across `build.yml`, `test.yml`, `codeql-analysis.yml`, and `pullrequest-coverage-reporter.yml`. No application code is touched; this is purely a CI workflow change. Combined effect on a typical PR:

| Workflow | Before | After |
|---|---|---|
| `Build` (PR path) | ~12 min | ~6 min |
| `Test` (PR path) | unchanged (server-tests dominates) | `client-tests-selected` job removed |
| `CodeQL` (PR path) | ~7–15 min | **not run on PRs** |
| `PR Coverage Reporter` | ~7–66 min (re-runs full test suite) | **~2–3 min** (reuses Test artifacts) |

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
Profiling recent GitHub Actions runs surfaced four preventable costs:

1. **Duplicate `.war` build inside the Docker image.** The `Build .war artifact` job already produces `Artemis.war`, but the Docker job rebuilt the same `.war` from scratch inside the image for both `linux/amd64` and `linux/arm64` (~10–11 min each). The Dockerfile already has an `external_builder` stage (`docker/artemis/Dockerfile:72-79`) that just `COPY`s a pre-built `.war` — it was simply never wired up.
2. **arm64 on every PR.** Test servers and prod are amd64 only; arm64 images are only useful for local dev on Apple Silicon and for the multi-arch images published from `develop`/`main`/release tags.
3. **CodeQL on every PR push.** ~7 min average, max 15 min, run on every push to every PR. GitHub's own recommended pattern is `push` to default + weekly schedule, since the security signal on a typical feature-branch diff is essentially never new vulnerabilities.
4. **PR Coverage Reporter re-runs the entire test suite a second time.** It called `npm run coverage:pr` which executed the full client and server test suites from scratch, *in parallel with* the `Test` workflow that already produces the same coverage data. The slowest recent run (#25709294078) spent **66 minutes** in `server-coverage` alone.

The Spring Boot cold start is ~30 s on test servers. With these CI fixes, the `git push` → test-server-up budget moves from ~15 min to ~8 min for the deploy path; in parallel, total PR CI wall clock drops by roughly an additional 30–60 min because the Coverage Reporter no longer re-runs tests.

### Description

#### Build workflow (`build.yml`) — PR Docker image reuses the `.war`
- Replace the single `docker` job with two:
  - **`docker-pr`** (PRs from `ls1intum/Artemis` only): inline, single-arch (`linux/amd64`), `needs: build-war`, downloads the `Artemis.war` artifact and builds with `--build-arg WAR_FILE_STAGE=external_builder`. Tags via `docker/metadata-action` `type=ref,event=pr` so the image is pushed as `ghcr.io/ls1intum/artemis:pr-<N>` — matching what `testserver-deployment.yml` already expects.
  - **`docker-release`** (push to `develop`/`main`/`release/*`/tags + `release` events): keeps using `ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.1` as today. Multi-arch (`linux/amd64` + `linux/arm64`) is preserved on this path.
- Rename `build` → `build-war` so the dependency edge from `docker-pr` (`needs: build-war`) is readable. Runner stays on `ubuntu-latest`.
- The `docker-tag` artifact consumed by `.github/actions/e2e-setup` is preserved on both paths.

#### Test workflow (`test.yml`) — drop one redundant job, expose coverage artifacts
- Remove the `client-tests-selected` job (ran `npm run test-diff:ci`). The full `client-tests` job already covers the same files; the selected-subset run was duplicating signal that nobody routed into a required check. The `test-diff:ci` npm script stays for local use.
- Add two artifact uploads consumed by the rebuilt PR Coverage Reporter:
  - **`Server JaCoCo XML`** — `build/reports/jacoco/**/jacocoTestReport.xml`, produced by the existing `./gradlew test jacocoTestReport` step.
  - **`Client Coverage Summaries`** — `build/test-results/jest/coverage-summary.json` + `build/test-results/vitest/coverage/coverage-summary.json`, produced by the existing `npm run test:ci` step.

#### CodeQL (`codeql-analysis.yml`) — off the PR path
- Remove the `pull_request` trigger. CodeQL now runs on:
  - `push` to `develop` and `main` (existing),
  - the weekly Sunday cron (existing),
  - on-demand via `workflow_dispatch` (new, lets reviewers re-run security analysis for a specific commit when needed).
- This is GitHub's recommended pattern for CodeQL and matches what most large repos do.

#### PR Coverage Reporter (`pullrequest-coverage-reporter.yml`) — reuse, don't re-run
- Switch trigger from `pull_request` to `workflow_run` on the `Test` workflow.
- Reuse the artifacts added in `test.yml` above. The reporter downloads `Server JaCoCo XML` and `Client Coverage Summaries` from the triggering Test run and runs `npm run coverage:pr -- --skip-tests --print …` — the script already supports `--skip-tests`, no script changes needed.
- Same PR-description editing logic as before (replaces the `### Test Coverage` section, notifies the author once). Handles partial coverage gracefully when the Test workflow's conclusion is `failure` rather than `success`.

#### Job selection matrix
| Event | `build-war` | `docker-pr` | `docker-release` | `save-docker-tag` |
|---|:---:|:---:|:---:|:---:|
| PR from `ls1intum/Artemis` | yes | yes | – | – |
| PR from fork | yes | – | – | – |
| Push to `develop`/`main`/`release/*`/tags | yes | – | yes | yes |
| Release event | yes | – | yes | yes |

#### Measured timing on the Build workflow (warm cache)
| Stage | Before (run 25709294257) | After |
|---|---|---|
| `Build .war artifact` | ~4 min | ~4 min (unchanged) |
| Docker image (amd64) | ~10 min 30 s | **~1 min 31 s** |
| Docker image (arm64) | ~10 min 50 s | skipped on PRs |
| Docker merge + save-tag | ~30 s | skipped on PRs |
| **`build.yml` total (PR)** | **~12 min** | **~6 min** |

#### Out of scope (deliberate)
- Auto-deploy on label / `workflow_run` triggers — Helios owns this.
- Bot comments on PRs with deploy URLs — Helios owns this.
- Server-test speed (`server-tests` ~25 min) — separate concern, would need Gradle module matrix.
- The `conditional-build` job in `testserver-deployment.yml:119` still rebuilds `.war` from scratch on the rare "deploy a branch with no PR" path; same `external_builder` trick can be applied later if that path becomes hot.
- Runner-pool prioritization (giving `build-war` a dedicated runner label) — tracked as a follow-up.

### Steps for Testing
This PR only changes CI workflow YAML. Functional testing happens in CI itself plus a Helios deploy.

1. Open the **Build** workflow run for this PR's latest commit and confirm:
   - `build-war` runs on `ubuntu-latest`, produces the `Artemis.war` artifact.
   - `docker-pr` runs, downloads `Artemis.war`, builds for `linux/amd64` only, pushes `ghcr.io/ls1intum/artemis:pr-<N>`, and uploads the `docker-tag` artifact containing `pr-<N>`.
   - `docker-release` and `save-docker-tag` are **skipped**.
2. Open the **Test** workflow run for this PR and confirm:
   - `client-tests-selected` is no longer listed.
   - New artifacts `Server JaCoCo XML` and `Client Coverage Summaries` appear in the run's artifact list.
3. Open the **PR Coverage Reporter** run that follows Test completion and confirm:
   - It runs as a `workflow_run` listener (no test execution inside it).
   - Total wall clock is in the low single-digit minutes.
   - The `### Test Coverage` section in this PR's description is updated with a coverage table.
4. Confirm **CodeQL** is **not** triggered on PR push events. (CodeQL still runs on the existing weekly schedule and on pushes to `develop`/`main`.)
5. Trigger a deploy of this PR to a test server via Helios. Confirm the test server pulls `ghcr.io/ls1intum/artemis:pr-<N>` and starts cleanly (login page reachable, `/management/health` returns `UP`).
6. (Optional, before merge) Verify on a `release/*` or `develop` push that `docker-release` still produces a multi-arch image: `docker buildx imagetools inspect ghcr.io/ls1intum/artemis:develop` should show both `linux/amd64` and `linux/arm64`.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Confirm `Build` workflow completes in < 7 min and produces a working `pr-<N>` image.
- [ ] Confirm `Test` workflow uploads the two new coverage artifacts.
- [ ] Confirm `PR Coverage Reporter` runs after Test completes, in < 5 min, and updates this PR's description.
- [ ] Confirm CodeQL no longer fires on PR pushes.
- [ ] Confirm a Helios deploy of this PR brings up an Artemis test server successfully.
