### PR TITLE
`Development`: Switch version scheme from `major.minor.patch` to `major.patch`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,9 @@ on:
     - develop
     - main
     - release/*
-    tags: '[0-9]+.[0-9]+.[0-9]+'
+    tags:
+    - '[0-9]+.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+'
   release:
     types:
     - created
@@ -55,11 +57,11 @@ on:
 #
 # - Pushes (branches & tags): Each branch or tag runs independently. If a run is in progress for the same branch or tag, it is canceled.
 #   Example: Push to "develop" → "build-refs/heads/develop"
-#   Example: Push to "release/1.2.3" → "build-refs/heads/release/1.2.3"
-#   Example: Tag "v1.2.3" → "build-refs/tags/v1.2.3"
+#   Example: Push to "release/9.2" → "build-refs/heads/release/9.2"
+#   Example: Tag "9.2" → "build-refs/tags/9.2"
 #
 # - Releases: Each release runs independently.
-#   Example: Release for "v1.2.3" → "build-release-v1.2.3"
+#   Example: Release for "9.2" → "build-release-9.2"
 #
 # - Default fallback: Ensures the workflow always has a concurrency group.
 #   Example: Unexpected event type → "build-default"

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -16,7 +16,9 @@ on:
       - develop
       - main
       - release/*
-    tags: '[0-9]+.[0-9]+.[0-9]+'
+    tags:
+      - '[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+'
     paths-ignore:
       - 'README.md'
       - 'CODE_OF_CONDUCT.md'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,9 @@ on:
     - develop
     - main
     - release/*
-    tags: '[0-9]+.[0-9]+.[0-9]+'
+    tags:
+    - '[0-9]+.[0-9]+'
+    - '[0-9]+.[0-9]+.[0-9]+'
     paths-ignore:
     - 'README.md'
     - 'CODE_OF_CONDUCT.md'

--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -1,0 +1,21 @@
+name: Version Consistency
+
+on:
+  pull_request:
+    paths:
+    - 'build.gradle'
+    - 'openapi/openapi.yaml'
+    - 'README.md'
+    - 'supporting_scripts/update_version.sh'
+    - '.github/workflows/version-consistency.yml'
+  push:
+    branches:
+    - develop
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Verify version is consistent across build.gradle, openapi.yaml and README.md
+      run: bash supporting_scripts/update_version.sh --check

--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -16,6 +16,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Verify version is consistent across build.gradle, openapi.yaml and README.md
       run: bash supporting_scripts/update_version.sh --check

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Refer to [Using JHipster in production](http://www.jhipster.tech/production) for
 The following command can automate the deployment to a server. The example shows the deployment to the main Artemis test server (which runs a virtual machine):
 
 ```shell
-./artemis-server-cli deploy username@artemis-test0.artemis.in.tum.de -w build/libs/Artemis-9.1.3.war
+./artemis-server-cli deploy username@artemis-test0.artemis.in.tum.de -w build/libs/Artemis-9.2.war
 ```
 
 ## Architecture

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ envProperties.each { key, value ->
 }
 
 group = "de.tum.cit.aet.artemis"
-version = "9.1.3"
+version = "9.2"
 description = "Interactive Learning with Individual Feedback"
 
 java {

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Artemis Application Server API
   contact: {name: Stephan Krusche, email: krusche@tum.de}
-  version: "9.1.3"
+  version: "9.2"
 servers:
 - {url: 'http://localhost:8080', description: Generated server url}
 paths:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Artemis Application Server API
   contact: {name: Stephan Krusche, email: krusche@tum.de}
-  version: 9.1.2
+  version: "9.1.3"
 servers:
 - {url: 'http://localhost:8080', description: Generated server url}
 paths:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
     "packages": {
         "": {
             "name": "artemis",
-            "version": "9.1.3",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
     "name": "artemis",
-    "version": "9.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
     "name": "artemis",
-    "version": "9.1.3",
     "description": "Interactive Learning with Individual Feedback",
     "private": true,
     "license": "MIT",

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/migration/DatabaseMigration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/migration/DatabaseMigration.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vdurmont.semver4j.Semver;
 
+import de.tum.cit.aet.artemis.core.util.ArtemisVersionUtil;
 import de.tum.cit.aet.helios.HeliosClient;
 
 /**
@@ -54,8 +55,8 @@ class MigrationPath {
      *                            after earliestNewVersion.
      */
     public MigrationPath(String requiredVersion) {
-        this.upgradeVersion = new Semver(requiredVersion).nextMajor();
-        this.requiredVersion = new Semver(requiredVersion);
+        this.requiredVersion = ArtemisVersionUtil.parseForComparison(requiredVersion);
+        this.upgradeVersion = this.requiredVersion.nextMajor();
         this.nextUpgradeVersion = upgradeVersion.nextMajor();
         this.errorMessage = "Cannot start Artemis because the migration path was not followed. Please deploy and start the release " + requiredVersion
                 + " first, otherwise the migration will fail";
@@ -122,7 +123,7 @@ public class DatabaseMigration {
      * and up-to-date before proceeding with the application startup.
      */
     public void checkMigrationPath() {
-        var currentVersion = new Semver(currentVersionString);
+        var currentVersion = ArtemisVersionUtil.parseForComparison(currentVersionString);
         previousVersionString = getPreviousVersionElseThrow();
 
         if (previousVersionString == null) {
@@ -131,7 +132,7 @@ public class DatabaseMigration {
             return;
         }
 
-        var previousVersion = new Semver(previousVersionString);
+        var previousVersion = ArtemisVersionUtil.parseForComparison(previousVersionString);
 
         for (MigrationPath path : migrationPaths) {
             if (currentVersion.isGreaterThanOrEqualTo(path.upgradeVersion) && currentVersion.isLowerThan(path.nextUpgradeVersion)) {
@@ -141,7 +142,7 @@ public class DatabaseMigration {
                     System.exit(15);
                 }
                 else if (previousVersion.isGreaterThanOrEqualTo(path.requiredVersion) && !isSchemaConsolidationCompleted()) {
-                    updateInitialChecksum(path.upgradeVersion.toString());
+                    updateInitialChecksum(currentVersionString);
                     log.info("Successfully cleaned up initial schema during migration");
                     break; // Exit after handling the required migration step
                 }
@@ -214,11 +215,12 @@ public class DatabaseMigration {
      * that the checksum update operation has failed. This failure needs to be addressed to ensure
      * the integrity and consistency of the database schema migration process.
      *
-     * @param newVersion The new version of the application for which the initial schema checksum needs to be updated.
+     * @param currentVersion The current application version string (as configured in {@code build.gradle},
+     *                           e.g. {@code "9.2"}) that will be persisted in the DATABASECHANGELOG description.
      * @throws RuntimeException If updating the checksum fails due to an SQLException, encapsulating the original exception.
      */
-    private void updateInitialChecksum(String newVersion) {
-        String description = "Initial schema generation for version " + newVersion;
+    private void updateInitialChecksum(String currentVersion) {
+        String description = "Initial schema generation for version " + currentVersion;
 
         // Nullify checksums for all existing initial schema changesets (ID pattern 0000000000000%)
         // so that Liquibase recalculates them instead of reporting a checksum mismatch.

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/ArtemisVersionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/ArtemisVersionService.java
@@ -25,6 +25,7 @@ import com.vdurmont.semver4j.Semver;
 import com.vdurmont.semver4j.SemverException;
 
 import de.tum.cit.aet.artemis.core.dto.ArtemisVersionDTO;
+import de.tum.cit.aet.artemis.core.util.ArtemisVersionUtil;
 
 /**
  * Service for checking the latest Artemis version from GitHub releases.
@@ -195,15 +196,16 @@ public class ArtemisVersionService {
 
         try {
             String normalizedCurrent = normalizeVersion(current);
-            Semver currentSemver = new Semver(normalizedCurrent, Semver.SemverType.NPM);
-            Semver latestSemver = new Semver(latest, Semver.SemverType.NPM);
+            Semver currentSemver = ArtemisVersionUtil.parseForComparison(normalizedCurrent);
+            Semver latestSemver = ArtemisVersionUtil.parseForComparison(latest);
 
             return latestSemver.isGreaterThan(currentSemver);
         }
         catch (SemverException e) {
             log.debug("Failed to compare versions '{}' and '{}': {}", current, latest, e.getMessage());
-            // Fall back to string comparison if semver parsing fails
-            return !normalizeVersion(current).equals(latest);
+            // Malformed inputs must not falsely report "update available"; surface unparseable
+            // versions as "no update" rather than guessing via string comparison.
+            return false;
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/ArtemisVersionUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/ArtemisVersionUtil.java
@@ -24,12 +24,16 @@ public final class ArtemisVersionUtil {
     /**
      * Parses an Artemis version string for comparison.
      * <p>
-     * Two-part inputs are padded to {@code x.y.0} internally; three-part inputs pass through.
+     * Accepts exactly two ({@code "9.2"}) or three ({@code "10.4.1"}) numeric dot-separated components.
+     * Two-part inputs are padded to {@code x.y.0} internally so strict semver4j semantics hold;
+     * three-part inputs pass through unchanged. Anything else — empty strings, non-numeric segments,
+     * or extra dotted segments like {@code "9.2.3.4"} — is rejected, because semver4j's strict mode
+     * silently tolerates trailing build-metadata-like segments which we do not want.
      *
      * @param version the version string, e.g. {@code "9.2"} or {@code "10.4.1"}
      * @return a strict {@link Semver} suitable for comparison
      * @throws NullPointerException if {@code version} is null
-     * @throws SemverException      if {@code version} cannot be parsed even after padding
+     * @throws SemverException      if {@code version} is not exactly two or three numeric components
      */
     public static Semver parseForComparison(String version) {
         String trimmed = Objects.requireNonNull(version, "version must not be null").trim();

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/ArtemisVersionUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/ArtemisVersionUtil.java
@@ -1,0 +1,46 @@
+package de.tum.cit.aet.artemis.core.util;
+
+import java.util.Objects;
+
+import com.vdurmont.semver4j.Semver;
+import com.vdurmont.semver4j.SemverException;
+
+/**
+ * Utility for parsing Artemis version strings into {@link Semver} objects.
+ * <p>
+ * Artemis canonical versions are two-part (e.g. {@code "9.2"}), with optional three-part
+ * hotfixes (e.g. {@code "10.4.1"}). The semver4j library requires three components in strict mode;
+ * this helper pads two-part inputs to {@code x.y.0} internally so strict semantics hold.
+ * <p>
+ * <b>For comparison only.</b> Never use {@link Semver#toString()} on the returned object for display,
+ * storage, headers, release tags, or any observable output — the padded form would leak. Pass the
+ * original version string through to anything user-visible or persisted.
+ */
+public final class ArtemisVersionUtil {
+
+    private ArtemisVersionUtil() {
+    }
+
+    /**
+     * Parses an Artemis version string for comparison.
+     * <p>
+     * Two-part inputs are padded to {@code x.y.0} internally; three-part inputs pass through.
+     *
+     * @param version the version string, e.g. {@code "9.2"} or {@code "10.4.1"}
+     * @return a strict {@link Semver} suitable for comparison
+     * @throws NullPointerException if {@code version} is null
+     * @throws SemverException      if {@code version} cannot be parsed even after padding
+     */
+    public static Semver parseForComparison(String version) {
+        String trimmed = Objects.requireNonNull(version, "version must not be null").trim();
+        if (trimmed.matches("\\d+\\.\\d+")) {
+            return new Semver(trimmed + ".0");
+        }
+        // semver4j's strict mode silently tolerates trailing dotted segments (e.g. "9.2.3.4");
+        // reject anything that is not exactly three dotted numeric components before delegating.
+        if (!trimmed.matches("\\d+\\.\\d+\\.\\d+")) {
+            throw new SemverException("Invalid Artemis version: " + version);
+        }
+        return new Semver(trimmed);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/config/migration/DatabaseMigrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/config/migration/DatabaseMigrationTest.java
@@ -1,0 +1,125 @@
+package de.tum.cit.aet.artemis.core.config.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Unit tests for {@link DatabaseMigration}.
+ * <p>
+ * Verifies that the migration logic accepts two-part canonical versions (e.g. {@code "9.2"})
+ * and three-part hotfix versions (e.g. {@code "9.2.1"}), and that the user-facing current
+ * version (not the internally padded semver) lands in the {@code DATABASECHANGELOG} description.
+ */
+class DatabaseMigrationTest {
+
+    private DataSource dataSource;
+
+    private Connection connection;
+
+    private Statement statement;
+
+    private PreparedStatement preparedStatement;
+
+    private ResultSet versionResultSet;
+
+    private ResultSet consolidationResultSet;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dataSource = mock(DataSource.class);
+        connection = mock(Connection.class);
+        statement = mock(Statement.class);
+        preparedStatement = mock(PreparedStatement.class);
+        versionResultSet = mock(ResultSet.class);
+        consolidationResultSet = mock(ResultSet.class);
+
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        // SELECT * FROM DATABASECHANGELOG returns an empty result set (just needs to succeed).
+        ResultSet changelogProbe = mock(ResultSet.class);
+        when(statement.executeQuery("SELECT * FROM DATABASECHANGELOG;")).thenReturn(changelogProbe);
+        when(statement.executeQuery("SELECT latest_version FROM artemis_version;")).thenReturn(versionResultSet);
+        lenient().when(statement.executeQuery("SELECT COUNT(*) FROM DATABASECHANGELOG WHERE ID = '20260406120000';")).thenReturn(consolidationResultSet);
+        lenient().when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+    }
+
+    @Test
+    void doesNothingWhenNoPreviousVersionRecorded() throws Exception {
+        when(versionResultSet.next()).thenReturn(false);
+
+        DatabaseMigration migration = new DatabaseMigration("9.2", dataSource, Optional.empty());
+        migration.checkMigrationPath();
+
+        assertThat(migration.getPreviousVersionString()).isNull();
+        verify(connection, never()).prepareStatement(anyString());
+    }
+
+    @Test
+    void doesNothingWhenPreviousAndCurrentAreInSameMajorWindow() throws Exception {
+        when(versionResultSet.next()).thenReturn(true);
+        when(versionResultSet.getString("latest_version")).thenReturn("9.1.3");
+        // Consolidation already completed so no checksum work either.
+        when(consolidationResultSet.next()).thenReturn(true);
+        when(consolidationResultSet.getInt(1)).thenReturn(1);
+
+        DatabaseMigration migration = new DatabaseMigration("9.2", dataSource, Optional.empty());
+        migration.checkMigrationPath();
+
+        assertThat(migration.getPreviousVersionString()).isEqualTo("9.1.3");
+        verify(connection, never()).prepareStatement(anyString());
+    }
+
+    @Test
+    void updatesChecksumWithUserFacingTwoPartVersionWhenUpgradingMajor() throws Exception {
+        when(versionResultSet.next()).thenReturn(true);
+        when(versionResultSet.getString("latest_version")).thenReturn("8.8.6");
+        // Consolidation not yet completed → updateInitialChecksum should run.
+        when(consolidationResultSet.next()).thenReturn(true);
+        when(consolidationResultSet.getInt(1)).thenReturn(0);
+
+        DatabaseMigration migration = new DatabaseMigration("9.2", dataSource, Optional.empty());
+        migration.checkMigrationPath();
+
+        ArgumentCaptor<String> descriptionCaptor = ArgumentCaptor.forClass(String.class);
+        verify(preparedStatement, atLeastOnce()).setString(eq(1), descriptionCaptor.capture());
+        // The DESCRIPTION must contain the user-facing "9.2", not the internal "9.0.0" or "9.2.0".
+        assertThat(descriptionCaptor.getValue()).isEqualTo("Initial schema generation for version 9.2");
+        verify(preparedStatement, times(1)).executeUpdate();
+        verify(connection, times(1)).commit();
+    }
+
+    @Test
+    void hotfixUpgradeIsNoOpWhenConsolidationAlreadyCompleted() throws Exception {
+        when(versionResultSet.next()).thenReturn(true);
+        when(versionResultSet.getString("latest_version")).thenReturn("9.2");
+        when(consolidationResultSet.next()).thenReturn(true);
+        when(consolidationResultSet.getInt(1)).thenReturn(1);
+
+        DatabaseMigration migration = new DatabaseMigration("9.2.1", dataSource, Optional.empty());
+        migration.checkMigrationPath();
+
+        assertThat(migration.getPreviousVersionString()).isEqualTo("9.2");
+        verify(connection, never()).prepareStatement(anyString());
+    }
+
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/config/migration/DatabaseMigrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/config/migration/DatabaseMigrationTest.java
@@ -122,4 +122,16 @@ class DatabaseMigrationTest {
         verify(connection, never()).prepareStatement(anyString());
     }
 
+    @Test
+    void migrationPathAcceptsTwoPartRequiredVersion() {
+        MigrationPath path = new MigrationPath("9.2");
+
+        assertThat(path.requiredVersion.getMajor()).isEqualTo(9);
+        assertThat(path.requiredVersion.getMinor()).isEqualTo(2);
+        assertThat(path.upgradeVersion.getMajor()).isEqualTo(10);
+        assertThat(path.upgradeVersion.getMinor()).isEqualTo(0);
+        assertThat(path.nextUpgradeVersion.getMajor()).isEqualTo(11);
+        assertThat(path.nextUpgradeVersion.getMinor()).isEqualTo(0);
+    }
+
 }

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/ArtemisVersionServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/ArtemisVersionServiceTest.java
@@ -1,0 +1,66 @@
+package de.tum.cit.aet.artemis.core.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.CacheManager;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Unit tests for {@link ArtemisVersionService#isNewerVersionAvailable(String, String)}.
+ * <p>
+ * Verifies that the version comparison accepts both the new two-part canonical scheme
+ * ({@code "9.2"}) and the legacy three-part hotfix scheme ({@code "10.4.1"}), and that
+ * malformed inputs fall back to "no update available" instead of producing a false positive.
+ */
+class ArtemisVersionServiceTest {
+
+    private ArtemisVersionService service;
+
+    private Method isNewerVersionAvailable;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        service = new ArtemisVersionService(mock(RestTemplate.class), mock(CacheManager.class));
+        isNewerVersionAvailable = ArtemisVersionService.class.getDeclaredMethod("isNewerVersionAvailable", String.class, String.class);
+        isNewerVersionAvailable.setAccessible(true);
+    }
+
+    private boolean call(String current, String latest) throws Exception {
+        return (boolean) isNewerVersionAvailable.invoke(service, current, latest);
+    }
+
+    @Test
+    void detectsUpdateWhenLatestMinorIsHigherTwoPart() throws Exception {
+        assertThat(call("9.2", "9.3")).isTrue();
+    }
+
+    @Test
+    void noUpdateWhenVersionsMatchTwoPart() throws Exception {
+        assertThat(call("9.2", "9.2")).isFalse();
+    }
+
+    @Test
+    void detectsUpdateAcrossMajor() throws Exception {
+        assertThat(call("9.2", "10.0")).isTrue();
+    }
+
+    @Test
+    void detectsUpdateFromHotfixToNextMinor() throws Exception {
+        assertThat(call("10.4.1", "10.5")).isTrue();
+    }
+
+    @Test
+    void fallsBackToNoUpdateOnMalformedLatest() throws Exception {
+        assertThat(call("9.2", "garbage")).isFalse();
+    }
+
+    @Test
+    void stripsLeadingVPrefixInCurrent() throws Exception {
+        assertThat(call("v9.2", "9.3")).isTrue();
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/ArtemisVersionUtilTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/ArtemisVersionUtilTest.java
@@ -1,0 +1,70 @@
+package de.tum.cit.aet.artemis.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import org.junit.jupiter.api.Test;
+
+import com.vdurmont.semver4j.Semver;
+import com.vdurmont.semver4j.SemverException;
+
+class ArtemisVersionUtilTest {
+
+    @Test
+    void parsesTwoPartVersion() {
+        Semver semver = ArtemisVersionUtil.parseForComparison("9.2");
+        assertThat(semver.getMajor()).isEqualTo(9);
+        assertThat(semver.getMinor()).isEqualTo(2);
+        assertThat(semver.getPatch()).isEqualTo(0);
+    }
+
+    @Test
+    void parsesThreePartHotfixVersion() {
+        Semver semver = ArtemisVersionUtil.parseForComparison("10.4.1");
+        assertThat(semver.getMajor()).isEqualTo(10);
+        assertThat(semver.getMinor()).isEqualTo(4);
+        assertThat(semver.getPatch()).isEqualTo(1);
+    }
+
+    @Test
+    void parsesZeroMajorTwoPart() {
+        Semver semver = ArtemisVersionUtil.parseForComparison("0.5");
+        assertThat(semver.getMajor()).isEqualTo(0);
+        assertThat(semver.getMinor()).isEqualTo(5);
+        assertThat(semver.getPatch()).isEqualTo(0);
+    }
+
+    @Test
+    void trimsWhitespace() {
+        Semver semver = ArtemisVersionUtil.parseForComparison("  9.2  ");
+        assertThat(semver.getMajor()).isEqualTo(9);
+        assertThat(semver.getMinor()).isEqualTo(2);
+        assertThat(semver.getPatch()).isEqualTo(0);
+    }
+
+    @Test
+    void rejectsNull() {
+        assertThatNullPointerException().isThrownBy(() -> ArtemisVersionUtil.parseForComparison(null));
+    }
+
+    @Test
+    void rejectsGarbage() {
+        assertThatExceptionOfType(SemverException.class).isThrownBy(() -> ArtemisVersionUtil.parseForComparison("garbage"));
+    }
+
+    @Test
+    void rejectsTooManyParts() {
+        assertThatExceptionOfType(SemverException.class).isThrownBy(() -> ArtemisVersionUtil.parseForComparison("9.2.3.4"));
+    }
+
+    @Test
+    void comparesAcrossTwoAndThreePart() {
+        assertThat(ArtemisVersionUtil.parseForComparison("10.5").isGreaterThan(ArtemisVersionUtil.parseForComparison("10.4.1"))).isTrue();
+    }
+
+    @Test
+    void treatsTwoPartAndPaddedThreePartAsEqual() {
+        assertThat(ArtemisVersionUtil.parseForComparison("9.2").isEqualTo(ArtemisVersionUtil.parseForComparison("9.2.0"))).isTrue();
+    }
+}

--- a/supporting_scripts/update_version.sh
+++ b/supporting_scripts/update_version.sh
@@ -1,93 +1,171 @@
 #!/bin/bash
 
-# Script to update version in specified files and locations
-# Usage: ./update_version.sh [major|minor|bugfix]
+# Script to bump the Artemis version across build.gradle, openapi/openapi.yaml and README.md.
+#
+# Canonical Artemis versions are two-part (X.Y, e.g. "9.2"). A three-part hotfix release
+# (X.Y.Z with Z >= 1, e.g. "10.4.1") is allowed as an exception; "X.Y.0" is NOT a valid
+# canonical form. build.gradle is the single source of truth — package.json no longer
+# carries an Artemis version.
+#
+# Usage:
+#   ./update_version.sh major     # next major: X.Y[.Z] -> (X+1).0
+#   ./update_version.sh patch     # bump minor: X.Y[.Z] -> X.(Y+1)
+#   ./update_version.sh hotfix    # bump/introduce third component: X.Y -> X.Y.1, X.Y.Z -> X.Y.(Z+1)
+#   ./update_version.sh --check   # verify build.gradle, openapi.yaml, README.md all agree on a canonical version
+
+set -euo pipefail
+
+USAGE="Usage: $0 [major|patch|hotfix|--check]"
 
 if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 [major|minor|bugfix]"
+    echo "$USAGE" >&2
     exit 1
 fi
 
-INCREMENT_TYPE=$1
+ACTION=$1
 
-# Validate the argument
-if [[ "$INCREMENT_TYPE" != "major" && "$INCREMENT_TYPE" != "minor" && "$INCREMENT_TYPE" != "bugfix" ]]; then
-    echo "Error: Invalid argument. Use one of [major, minor, bugfix]. No other values are allowed."
-    exit 1
-fi
+BUILD_GRADLE_REGEX='^version = "[0-9]+\.[0-9]+(\.[1-9][0-9]*)?"$'
+CANONICAL_REGEX='^[0-9]+\.[0-9]+(\.[1-9][0-9]*)?$'
 
-# Function to increment version
-increment_version() {
-    local version=$1
-    local type=$2
-
-    IFS='.' read -r major minor bugfix <<< "$version"
-
-    case $type in
-        major)
-            major=$((major + 1))
-            minor=0
-            bugfix=0
-            ;;
-        minor)
-            minor=$((minor + 1))
-            bugfix=0
-            ;;
-        bugfix)
-            bugfix=$((bugfix + 1))
-            ;;
-    esac
-
-    echo "$major.$minor.$bugfix"
+read_build_gradle_version() {
+    local raw
+    raw=$(grep -E "$BUILD_GRADLE_REGEX" build.gradle | head -n 1 || true)
+    if [[ -z "$raw" ]]; then
+        echo "Could not find a valid 'version = \"X.Y[.Z]\"' line in build.gradle (X.Y.0 is rejected)." >&2
+        exit 1
+    fi
+    # Strip the `version = "..."` wrapper.
+    echo "$raw" | sed -E 's/^version = "(.*)"$/\1/'
 }
 
-# Read the current version from the first valid `version = "x.y.z"` in build.gradle
-CURRENT_VERSION=$(awk -F'"' '/^version = "[0-9]+\.[0-9]+\.[0-9]+"/ {print $2; exit}' build.gradle)
+read_openapi_version() {
+    local raw
+    raw=$(grep -E '^  version: "[^"]+"' openapi/openapi.yaml | head -n 1 || true)
+    if [[ -z "$raw" ]]; then
+        echo "Could not find a quoted 'version: \"X.Y[.Z]\"' line in openapi/openapi.yaml." >&2
+        exit 1
+    fi
+    echo "$raw" | sed -E 's/^  version: "(.*)"$/\1/'
+}
 
-if [[ -z "$CURRENT_VERSION" ]]; then
-    echo "Could not find a valid version in build.gradle."
-    exit 1
-fi
+read_readme_version() {
+    local raw
+    raw=$(grep -E 'Artemis-[0-9]+\.[0-9]+(\.[0-9]+)?\.war' README.md | head -n 1 || true)
+    if [[ -z "$raw" ]]; then
+        echo "Could not find an 'Artemis-X.Y[.Z].war' reference in README.md." >&2
+        exit 1
+    fi
+    echo "$raw" | sed -E 's/.*Artemis-([0-9]+\.[0-9]+(\.[0-9]+)?)\.war.*/\1/'
+}
 
-# Get the new version
-NEW_VERSION=$(increment_version "$CURRENT_VERSION" "$INCREMENT_TYPE")
+check_consistency() {
+    local gradle_version openapi_version readme_version
+    gradle_version=$(read_build_gradle_version)
+    openapi_version=$(read_openapi_version)
+    readme_version=$(read_readme_version)
 
-# Update files
-echo "Updating version from $CURRENT_VERSION to $NEW_VERSION..."
+    if ! [[ "$gradle_version" =~ $CANONICAL_REGEX ]]; then
+        echo "build.gradle version '$gradle_version' is not a canonical Artemis version (X.Y or X.Y.Z with Z>=1)." >&2
+        exit 1
+    fi
 
-# Update build.gradle
-sed -i '' "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" build.gradle
+    if [[ "$openapi_version" != "$gradle_version" ]]; then
+        echo "Version drift: build.gradle=$gradle_version but openapi/openapi.yaml=$openapi_version" >&2
+        exit 1
+    fi
+    if [[ "$readme_version" != "$gradle_version" ]]; then
+        echo "Version drift: build.gradle=$gradle_version but README.md=Artemis-$readme_version.war" >&2
+        exit 1
+    fi
 
-# Update package.json to only update the version when the previous line is `"name": "artemis"`
-awk -v old_version="$CURRENT_VERSION" -v new_version="$NEW_VERSION" '
-    BEGIN {found_name = 0}
-    /"name": "artemis"/ {found_name = 1}
-    found_name && /"version": ".*"/ {
-        sub("\"version\": \"" old_version "\"", "\"version\": \"" new_version "\"")
-        found_name = 0
-    }
-    {print}
-' package.json > package.json.tmp && mv package.json.tmp package.json
+    echo "Version check passed: $gradle_version"
+}
 
-# Update package-lock.json to only update the version when the previous line is `"name": "artemis"`
-awk -v old_version="$CURRENT_VERSION" -v new_version="$NEW_VERSION" '
-    BEGIN {found_name = 0}
-    /"name": "artemis"/ {found_name = 1}
-    found_name && /"version": ".*"/ {
-        sub("\"version\": \"" old_version "\"", "\"version\": \"" new_version "\"")
-        found_name = 0
-    }
-    {print}
-' package-lock.json > package-lock.json.tmp && mv package-lock.json.tmp package-lock.json
+compute_new_version() {
+    local current=$1
+    local action=$2
+    local major minor patch
+    IFS='.' read -r major minor patch <<< "$current"
 
-# Update README.md
-sed -i '' "s/Artemis-$CURRENT_VERSION.war/Artemis-$NEW_VERSION.war/" README.md
+    case "$action" in
+        major)
+            echo "$((major + 1)).0"
+            ;;
+        patch)
+            echo "$major.$((minor + 1))"
+            ;;
+        hotfix)
+            if [[ -z "${patch:-}" ]]; then
+                echo "$major.$minor.1"
+            else
+                local next=$((patch + 1))
+                if [[ "$next" -lt 1 ]]; then
+                    echo "Refusing to emit hotfix with patch < 1." >&2
+                    exit 1
+                fi
+                echo "$major.$minor.$next"
+            fi
+            ;;
+        *)
+            echo "$USAGE" >&2
+            exit 1
+            ;;
+    esac
+}
 
-# Add changes to git and commit
-echo "Staging changes for git..."
-git add build.gradle package.json README.md package-lock.json
+stamp_file() {
+    local file=$1
+    local pattern=$2
+    local replacement=$3
+    if ! grep -qE "$pattern" "$file"; then
+        echo "Expected pattern '$pattern' not found in $file; aborting." >&2
+        exit 1
+    fi
+    # macOS / BSD sed: -i '' for in-place edits.
+    sed -i '' -E "s|$pattern|$replacement|" "$file"
+}
 
-echo "Creating git commit..."
-git commit -m "Development: Bump version to $NEW_VERSION ($INCREMENT_TYPE update)"
+bump_version() {
+    local action=$1
+    local current new
 
-echo "Version update and git commit complete. New version: $NEW_VERSION"
+    current=$(read_build_gradle_version)
+    if ! [[ "$current" =~ $CANONICAL_REGEX ]]; then
+        echo "Refusing to bump from non-canonical version '$current'." >&2
+        exit 1
+    fi
+
+    new=$(compute_new_version "$current" "$action")
+
+    if ! [[ "$new" =~ $CANONICAL_REGEX ]]; then
+        echo "Computed new version '$new' is not canonical." >&2
+        exit 1
+    fi
+
+    echo "Updating version from $current to $new..."
+
+    stamp_file build.gradle "^version = \"$current\"$" "version = \"$new\""
+    stamp_file openapi/openapi.yaml "^  version: \"$current\"$" "  version: \"$new\""
+    stamp_file README.md "Artemis-$current\\.war" "Artemis-$new.war"
+
+    echo "Staging changes for git..."
+    git add build.gradle openapi/openapi.yaml README.md
+
+    echo "Creating git commit..."
+    git commit -m "Development: Bump version to $new ($action update)"
+
+    echo "Version update and git commit complete. New version: $new"
+}
+
+case "$ACTION" in
+    --check)
+        check_consistency
+        ;;
+    major|patch|hotfix)
+        bump_version "$ACTION"
+        ;;
+    *)
+        echo "$USAGE" >&2
+        exit 1
+        ;;
+esac

--- a/supporting_scripts/update_version.sh
+++ b/supporting_scripts/update_version.sh
@@ -121,8 +121,12 @@ stamp_file() {
         echo "Expected pattern '$pattern' not found in $file; aborting." >&2
         exit 1
     fi
-    # macOS / BSD sed: -i '' for in-place edits.
-    sed -i '' -E "s|$pattern|$replacement|" "$file"
+    # Portable in-place edit: BSD sed (macOS) and GNU sed (Linux) disagree on -i syntax,
+    # so write to a temp sibling and atomically move it back.
+    local tmp
+    tmp=$(mktemp "$file.XXXXXX")
+    sed -E "s|$pattern|$replacement|" "$file" > "$tmp"
+    mv "$tmp" "$file"
 }
 
 bump_version() {

--- a/supporting_scripts/update_version.sh
+++ b/supporting_scripts/update_version.sh
@@ -39,23 +39,33 @@ read_build_gradle_version() {
 }
 
 read_openapi_version() {
-    local raw
+    local raw version
     raw=$(grep -E '^  version: "[^"]+"' openapi/openapi.yaml | head -n 1 || true)
     if [[ -z "$raw" ]]; then
         echo "Could not find a quoted 'version: \"X.Y[.Z]\"' line in openapi/openapi.yaml." >&2
         exit 1
     fi
-    echo "$raw" | sed -E 's/^  version: "(.*)"$/\1/'
+    version=$(echo "$raw" | sed -E 's/^  version: "(.*)"$/\1/')
+    if ! [[ "$version" =~ $CANONICAL_REGEX ]]; then
+        echo "openapi/openapi.yaml version '$version' is not a canonical Artemis version (X.Y or X.Y.Z with Z>=1)." >&2
+        exit 1
+    fi
+    echo "$version"
 }
 
 read_readme_version() {
-    local raw
-    raw=$(grep -E 'Artemis-[0-9]+\.[0-9]+(\.[0-9]+)?\.war' README.md | head -n 1 || true)
+    local raw version
+    raw=$(grep -E 'Artemis-[0-9]+\.[0-9]+(\.[1-9][0-9]*)?\.war' README.md | head -n 1 || true)
     if [[ -z "$raw" ]]; then
         echo "Could not find an 'Artemis-X.Y[.Z].war' reference in README.md." >&2
         exit 1
     fi
-    echo "$raw" | sed -E 's/.*Artemis-([0-9]+\.[0-9]+(\.[0-9]+)?)\.war.*/\1/'
+    version=$(echo "$raw" | sed -E 's/.*Artemis-([0-9]+\.[0-9]+(\.[1-9][0-9]*)?)\.war.*/\1/')
+    if ! [[ "$version" =~ $CANONICAL_REGEX ]]; then
+        echo "README.md version '$version' is not a canonical Artemis version (X.Y or X.Y.Z with Z>=1)." >&2
+        exit 1
+    fi
+    echo "$version"
 }
 
 check_consistency() {


### PR DESCRIPTION
### Summary
Adopts a two-part version scheme (`X.Y`, e.g. `9.2`) with the rare three-part hotfix (`X.Y.Z` where `Z ≥ 1`) tolerated as an exception. Bumps Artemis from `9.1.3` (dev) directly to `9.2`. Mostly build/release-tooling changes, with one load-bearing Java fix in the `DatabaseMigration` startup check.

### Motivation and Context
We agreed to drop the patch component going forward. `update_version.sh` and the strict-mode `new Semver(...)` in `DatabaseMigration.checkMigrationPath()` were both hardwired to three parts, so a two-part version like `9.2` would crash every node on startup. This PR introduces `ArtemisVersionUtil.parseForComparison` — a centralized 2-or-3-part parser that pads two-part inputs internally for strict comparison without leaking the padded form back into observable state (DB column, HTTP headers, OpenAPI doc, etc.).

The plan was reviewed by codex across multiple rounds. The final implementation was code-reviewed by codex with an explicit sign-off (minor non-blocking notes addressed in the last two commits).

### Description
- **`ArtemisVersionUtil.parseForComparison(String)`** — comparison-only helper. Pads `9.2` to `9.2.0` internally; rejects malformed or extra-component inputs (e.g. `9.2.3.4`). Never leaks the padded form.
- **`DatabaseMigration`** — all four `new Semver(...)` call sites routed through the helper. `updateInitialChecksum` now receives the original `currentVersionString` so `DATABASECHANGELOG.DESCRIPTION` carries the user-facing `9.2`, not internal `9.0.0` / `9.2.0`.
- **`ArtemisVersionService`** — switched to the helper; malformed-tag fallback now returns `false` instead of comparing strings.
- **`package.json`** — `version` field removed (npm rejects `9.2` as a valid SemVer; package is `"private": true` so this is safe). `package-lock.json` top-level `version` also stripped.
- **`openapi/openapi.yaml`** — quoted and bumped (also fixes an existing `9.1.2` vs `9.1.3` drift).
- **`supporting_scripts/update_version.sh`** — rewritten: `major | patch | hotfix | --check`, canonical regex `^[0-9]+\.[0-9]+(\.[1-9][0-9]*)?$` (rejects `X.Y.0`). Sed portable for BSD and GNU.
- **`.github/workflows/{build,test-android,test}.yml`** — tag filters accept both two-part and three-part.
- **New `.github/workflows/version-consistency.yml`** — runs `update_version.sh --check` on every PR; the guardrail against drift recurring.

### Steps for Testing
1. Run `./gradlew test --tests ArtemisVersionUtilTest --tests DatabaseMigrationTest --tests ArtemisVersionServiceTest -x webapp` — expect 20 passing tests.
2. Run `bash supporting_scripts/update_version.sh --check` — expect exit 0 and \"Version check passed: 9.2\".
3. Deploy to a test server currently on 9.1.x and verify the upgrade boot succeeds (DatabaseMigration no longer throws SemverException).
4. After boot, verify `artemis_version.latest_version` column contains the literal string \`9.2\` (not \`9.2.0\`).
5. Verify the \`Content-Version\` HTTP response header is \`9.2\`.

### Checklist

#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped project version to 9.2 and updated deployment artifact reference in docs.
  * Removed redundant top-level package version declaration; synchronized canonical version source.

* **Bug Fixes**
  * Improved version comparison and migration behavior to make upgrades and checksum handling more reliable.

* **Tools**
  * Reworked release/update script to enforce canonical versions, add patch/hotfix semantics, and provide a --check mode.

* **Tests**
  * Added tests covering version parsing, comparison, and migration scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Artemis/pull/12695)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->