### PR TITLE
`Development`: Dedupe stacked e2e runs and fix release-published build trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,11 @@ on:
     - '[0-9]+.[0-9]+'
     - '[0-9]+.[0-9]+.[0-9]+'
   release:
+    # Use `published` (not `created`) so we also fire when a draft release is
+    # promoted to published; `created` does not fire for draft → published
+    # transitions, which previously caused release 9.2 to ship without a WAR.
     types:
-    - created
+    - published
 
 
 # Concurrency control for GitHub Actions workflow
@@ -128,7 +131,7 @@ jobs:
           name: Artemis.war
           path: build/libs/Artemis-*.war
       - name: Upload Release Artifact
-        if: github.event_name == 'release' && github.event.action == 'created'
+        if: github.event_name == 'release' && github.event.action == 'published'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -6,12 +6,12 @@ on:
     workflows: ["Build"]
     types: [completed]
 
+# Single-line concurrency group to avoid YAML block-scalar quirks and keep the
+# group key reliably comparable across runs. head_branch is set on branch /
+# default-branch pushes (groups all E2E for that branch into one slot); head_sha
+# is the fallback for events with no branch.
 concurrency:
-  group: |
-    ${{
-      github.event.workflow_run.head_branch && format('e2e-{0}', github.event.workflow_run.head_branch)
-      || format('e2e-{0}', github.event.workflow_run.head_sha)
-    }}
+  group: e2e-${{ github.event.workflow_run.head_branch || github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -28,9 +28,41 @@ env:
   PLAYWRIGHT_REPORT_TRIGGERED_BY: ${{ github.event.workflow_run.event }}
 
 jobs:
+  # Guard against workflow_run queue stacking. Each Build retry fires a new
+  # workflow_run event that queues another E2E run for the same SHA; built-in
+  # concurrency cancel-in-progress does not reliably dedupe queued runs that
+  # sit waiting for the [self-hosted, e2e-test] pool. This job runs on
+  # ubuntu-latest (instant pickup) and uses styfle/cancel-workflow-action to
+  # cancel older same-SHA runs of this workflow, and self-cancels if a newer
+  # run already exists. Cross-SHA cancellation is the built-in `concurrency`
+  # block's responsibility (it works reliably when the next run starts
+  # immediately).
+  cancel-superseded:
+    name: Cancel superseded E2E runs
+    # Skip on Build failures — those workflow_run events would produce skipped
+    # E2E runs anyway, because all dependent jobs are if-gated on
+    # conclusion == 'success'. No queue stacking comes from failed Builds.
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel older E2E runs for this SHA
+        uses: styfle/cancel-workflow-action@0.13.1
+        with:
+          # all_but_latest: cancels every queued or in-progress run of this
+          # workflow except the absolute newest, including self if a newer run
+          # exists. ignore_sha defaults to false → only same-SHA runs are
+          # cancelled (we don't want to cancel a PR's E2E because of an
+          # unrelated develop push).
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
   # Job to determine which tests are relevant based on changed files (only for PRs)
   determine-tests:
     name: Determine Relevant Tests
+    needs: cancel-superseded
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
@@ -642,6 +674,7 @@ jobs:
   # Run all tests for non-PR events (push to develop, main, release branches)
   run-e2e-all-non-pr:
     name: Run All E2E Tests (Non-PR)
+    needs: cancel-superseded
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'pull_request'
     runs-on: [self-hosted, e2e-test]
     timeout-minutes: 120


### PR DESCRIPTION
### Summary
Two related GitHub Actions improvements bundled into one PR:

1. **E2E queue stacking fix** — adds a `cancel-superseded` guard job to `.github/workflows/test-e2e.yml` (using `styfle/cancel-workflow-action@0.13.1` with `all_but_latest: true`) that reliably dedupes E2E workflow runs queued by repeated `workflow_run` events. Keeps the simpler single-line `concurrency` group expression as a second defensive layer.
2. **Release `published`-trigger fix** — changes `.github/workflows/build.yml`'s `release.types` from `[created]` to `[published]` so the Build (and the `Upload Release Artifact` step) actually runs when a release is promoted from draft, instead of silently skipping. This bug caused release 9.2 to ship without an `Artemis.war` asset.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

---

## Part 1 — E2E queue stacking fix

### Motivation and Context
After PR #12692 merged on 2026‑05‑12, the post‑merge develop Build hit a transient Maven Central flake on `linux/arm64`. The Build was retried twice; each retry fired a new `workflow_run: completed` event that queued a fresh E2E Tests run for the **same SHA** (`107ef35575…`). Within ~15 minutes, **6 E2E runs were simultaneously queued** for that SHA, plus a **51‑minute‑old queued run** for an even older SHA (`5611056e4a…`) was never cancelled by newer commits.

Root cause analysis:
- The workflow already had `concurrency: { group: e2e-${head_branch || head_sha}, cancel-in-progress: true }`.
- Built‑in concurrency reliably dedupes when the next run **starts on a runner immediately** — that's why `build.yml` (same multi‑line YAML pattern, but `push`/`pull_request` triggers on GitHub‑hosted runners) works fine.
- `test-e2e.yml`'s test jobs target `[self-hosted, e2e-test]`. When that pool is saturated, new E2E workflow runs sit at `status: queued` at the orchestrator level. `cancel-in-progress: true` for `workflow_run`‑triggered runs in that state does **not** reliably dedupe — a long‑standing GitHub Actions limitation for the combination of `workflow_run` trigger + saturated self‑hosted pool.

### Description

**Commit 1 — simplify the concurrency group (`59536faf3e`)**
Replace the multi-line `|` block-scalar expression for `concurrency.group` with an equivalent single-line form. This isn't the root‑cause fix, but it removes any YAML block-scalar ambiguity and keeps the group key strictly comparable across runs.

**Commit 2 — add the `cancel-superseded` guard job (`eb1ad8cecf`)**
Add a leading job that runs on `ubuntu-latest` (instant pickup, never sits in the e2e-test queue) and uses [`styfle/cancel-workflow-action@0.13.1`](https://github.com/styfle/cancel-workflow-action) with `all_but_latest: true` to cancel older queued/in-progress same-SHA E2E runs (including self if a newer run already exists). Wire `determine-tests` and `run-e2e-all-non-pr` with `needs: cancel-superseded`; the remaining E2E jobs (`run-e2e-relevant`, `run-e2e-remaining`, `run-e2e-all-pr`, `report-results`) cascade through existing `needs:` chains.

Defense in depth — built-in `concurrency` stays in place:

| Case | Built-in concurrency | styfle guard job |
|---|:---:|:---:|
| Cross-SHA same-branch (newer commit cancels older commit's E2E) | ✅ works when next run gets a runner immediately | — (default `ignore_sha: false` only touches same-SHA) |
| Same-SHA queue stacking (Build retries fire repeat `workflow_run`) | ❌ unreliable when queued | **✅ fixed** |
| Long-stranded queued same-SHA runs (50+ min orphans) | ❌ | ✅ swept by any newer same-SHA run |

`ignore_sha` is left at its default (`false`) so the guard never cancels across branches/SHAs — that would be too aggressive (would cancel a PR's E2E because of an unrelated develop push). Cross-SHA cancellation on the same branch remains the built-in `concurrency` block's responsibility.

Why styfle's action rather than a hand-rolled `actions/github-script`:
- Canonical solution for this case; latest 0.13.1 explicitly supports cancelling `queued` (not just `in_progress`) runs and `workflow_run` triggers.
- One short marketplace step vs. ~30 lines of hand-rolled JS that would re-implement the same logic (pagination, retries, status filtering, edge cases).

---

## Part 2 — Release `published`-trigger fix

### Motivation and Context
Release [9.2](https://github.com/ls1intum/Artemis/releases/tag/9.2) shipped without an `Artemis.war` asset. Comparing with the preceding two releases:

| Release | `createdAt` | `publishedAt` | Gap | `release`-event Build run? | `Artemis.war` asset? |
|---|---|---|---|---|---|
| 8.7.5 | 12:26:51 | 12:29:49 | 3 min | ✅ run 25319044244 | ✅ |
| 9.1.2 | 07:27:55 | 07:43:36 | 16 min | ✅ run 25364089027 | ✅ |
| 9.2 | 21:30:49 | 22:11:27 | 40 min | ❌ none | ❌ |

`build.yml` had:
```yaml
release:
  types:
    - created
```

Per [GitHub's docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release): *"Workflows are not triggered for the created, edited, or deleted activity types for draft releases."* When a draft release is promoted to published, only the `published` and `released` activity types fire — **not** `created`. 9.2 was saved as a draft and published ~40 minutes later, so the Build workflow never ran on the release event and the `Upload Release Artifact` step never executed.

### Description

**Commit 3 — fire Build on `release.published` (`3490d500d8`)**
- Change `release.types: [created]` → `[published]`.
- Update the conditional on the `Upload Release Artifact` step to match: `github.event.action == 'published'`.
- `published` fires reliably for both creation flows (direct non-draft and draft-promoted), so the asset upload will always happen on a real release.

The missing `Artemis.war` for release 9.2 has already been manually attached from the tag-push Build artifact: <https://github.com/ls1intum/Artemis/releases/download/9.2/Artemis.war>.

---

### Steps for Testing

#### Part 1 — E2E queue stacking
After this PR is merged to `develop`, GitHub uses the **default branch's** workflow file for any `workflow_run`-triggered run, so the fix is only active for runs triggered after the merge.

To force the stacking scenario for verification:
1. Pick any recent develop Build that has a failed job (or trigger one): `gh run list -R ls1intum/Artemis --branch=develop --workflow=build.yml --limit 5`.
2. Re-run the Build's failed jobs **three times in close succession**: `gh run rerun <id> --failed`, repeated.
3. Each rerun completion fires a `workflow_run: completed` → queues a new E2E run for the same SHA.
4. List queued/in-progress E2E runs: `gh run list -R ls1intum/Artemis --workflow="E2E Tests" --branch=develop --limit 10 --json databaseId,status,headSha,createdAt`.
5. **Expected:** only **one** E2E run for the SHA remains `queued`/`in_progress`; the older ones show as `cancelled`. Pre-PR, all three would persist.

#### Part 2 — release-published trigger
This is harder to verify pre-merge without cutting a real release. After merge, on the next release:
1. Cut a release in the UI (either as a direct publish or via "Save draft" → "Publish release").
2. Confirm the **Build** workflow run with `event: release` is created at `publishedAt` and uploads `Artemis.war` as a release asset.
3. Confirm both flows behave identically (the previous behavior diverged on draft-promotion).

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] After merge, confirm triple-rerunning a develop Build leaves only one queued/in-progress E2E run for the SHA.
- [ ] After merge, on the next release, confirm the Build workflow runs on `release.published` and uploads `Artemis.war` to the release.
- [ ] Confirm normal develop pushes still trigger E2E exactly once and complete in their usual timeframe.