### PR TITLE
`Iris`: Fix wrong permission denied alert on AI experience page when Memiris feature is disabled

### DIFF
--- a/src/main/webapp/app/core/user/settings/ai-experience-settings/ai-experience-settings.component.spec.ts
+++ b/src/main/webapp/app/core/user/settings/ai-experience-settings/ai-experience-settings.component.spec.ts
@@ -21,6 +21,7 @@ import { LLMSelectionModalService } from 'app/logos/llm-selection-popup.service'
 import { LLMSelectionDecision, LLM_MODAL_DISMISSED } from 'app/core/user/shared/dto/updateLLMSelectionDecision.dto';
 import { ActivatedRoute } from '@angular/router';
 import { MockActivatedRoute } from 'test/helpers/mocks/activated-route/mock-activated-route';
+import { FeatureToggle, FeatureToggleService } from 'app/shared/feature-toggle/feature-toggle.service';
 
 describe('AiExperienceSettingsComponent', () => {
     setupTestBed({ zoneless: true });
@@ -33,6 +34,13 @@ describe('AiExperienceSettingsComponent', () => {
     let accountService: AccountService;
     let alertService: AlertService;
     let llmModalService: LLMSelectionModalService;
+    let featureToggleService: FeatureToggleService;
+
+    const createComponent = (memirisEnabled = true) => {
+        vi.spyOn(featureToggleService, 'getFeatureToggleActive').mockImplementation((feature: FeatureToggle) => of(feature === FeatureToggle.Memiris ? memirisEnabled : true));
+        fixture = TestBed.createComponent(AiExperienceSettingsComponent);
+        component = fixture.componentInstance;
+    };
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
@@ -44,6 +52,7 @@ describe('AiExperienceSettingsComponent', () => {
                 MockProvider(TranslateService),
                 MockProvider(AlertService),
                 MockProvider(LLMSelectionModalService),
+                MockProvider(FeatureToggleService),
                 provideHttpClient(),
                 provideHttpClientTesting(),
                 { provide: AccountService, useClass: MockAccountService },
@@ -56,14 +65,13 @@ describe('AiExperienceSettingsComponent', () => {
             })
             .compileComponents();
 
-        fixture = TestBed.createComponent(AiExperienceSettingsComponent);
-        component = fixture.componentInstance;
         irisChatHttpService = TestBed.inject(IrisChatHttpService);
         irisMemoriesHttpService = TestBed.inject(IrisMemoriesHttpService);
         irisChatService = TestBed.inject(IrisChatService);
         accountService = TestBed.inject(AccountService);
         alertService = TestBed.inject(AlertService);
         llmModalService = TestBed.inject(LLMSelectionModalService);
+        featureToggleService = TestBed.inject(FeatureToggleService);
     });
 
     afterEach(() => {
@@ -73,6 +81,7 @@ describe('AiExperienceSettingsComponent', () => {
     it('should create', () => {
         vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 0, messages: 0 }));
         vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(0));
+        createComponent();
         fixture.detectChanges();
         expect(component).toBeTruthy();
     });
@@ -80,6 +89,7 @@ describe('AiExperienceSettingsComponent', () => {
     it('should load session and message counts on init', () => {
         const countSpy = vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 5, messages: 42 }));
         vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(0));
+        createComponent();
         fixture.detectChanges();
 
         expect(countSpy).toHaveBeenCalledOnce();
@@ -90,15 +100,45 @@ describe('AiExperienceSettingsComponent', () => {
     it('should load memory count on init', () => {
         vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 0, messages: 0 }));
         const memorySpy = vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(7));
+        createComponent();
         fixture.detectChanges();
 
         expect(memorySpy).toHaveBeenCalledOnce();
         expect(component.memoryCount()).toBe(7);
     });
 
+    it('should not call memory endpoint when Memiris feature is disabled', () => {
+        vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 2, messages: 8 }));
+        const memorySpy = vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(7));
+        createComponent(false);
+        fixture.detectChanges();
+
+        expect(memorySpy).not.toHaveBeenCalled();
+        expect(component.memoryCount()).toBe(0);
+        expect(component.memirisEnabled()).toBe(false);
+    });
+
+    it('should skip memory deletion when Memiris feature is disabled', () => {
+        vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 3, messages: 10 }));
+        vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(0));
+        createComponent(false);
+        fixture.detectChanges();
+
+        const deleteChatSpy = vi.spyOn(irisChatHttpService, 'deleteAllSessions').mockReturnValue(of(new HttpResponse<void>({ status: 204 })));
+        const deleteMemorySpy = vi.spyOn(irisMemoriesHttpService, 'deleteAllUserMemories').mockReturnValue(of(undefined));
+        const alertSpy = vi.spyOn(alertService, 'success');
+
+        component.deleteAllIrisInteractions();
+
+        expect(deleteChatSpy).toHaveBeenCalledOnce();
+        expect(deleteMemorySpy).not.toHaveBeenCalled();
+        expect(alertSpy).toHaveBeenCalledWith('artemisApp.userSettings.aiExperienceSettingsPage.deleteSuccess');
+    });
+
     it('should handle zero counts', () => {
         vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 0, messages: 0 }));
         vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(0));
+        createComponent();
         fixture.detectChanges();
 
         expect(component.sessionCount()).toBe(0);
@@ -109,6 +149,7 @@ describe('AiExperienceSettingsComponent', () => {
     it('should delete all Iris interactions and memories successfully', () => {
         vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 3, messages: 10 }));
         vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(5));
+        createComponent();
         fixture.detectChanges();
 
         const deleteChatSpy = vi.spyOn(irisChatHttpService, 'deleteAllSessions').mockReturnValue(of(new HttpResponse<void>({ status: 204 })));
@@ -128,6 +169,7 @@ describe('AiExperienceSettingsComponent', () => {
     it('should handle delete failure when chat deletion fails', () => {
         vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 3, messages: 10 }));
         vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(0));
+        createComponent();
         fixture.detectChanges();
 
         vi.spyOn(irisChatHttpService, 'deleteAllSessions').mockReturnValue(throwError(() => new Error('error')));
@@ -147,6 +189,7 @@ describe('AiExperienceSettingsComponent', () => {
     it('should reset only memories when chat deletion succeeds but memory deletion fails', () => {
         vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 3, messages: 10 }));
         vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(5));
+        createComponent();
         fixture.detectChanges();
 
         vi.spyOn(irisChatHttpService, 'deleteAllSessions').mockReturnValue(of(new HttpResponse<void>({ status: 204 })));
@@ -167,6 +210,7 @@ describe('AiExperienceSettingsComponent', () => {
     it('should open selection modal and update on choice', async () => {
         vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 0, messages: 0 }));
         vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(0));
+        createComponent();
         fixture.detectChanges();
 
         const openSpy = vi.spyOn(llmModalService, 'open').mockResolvedValue(LLMSelectionDecision.CLOUD_AI);
@@ -183,6 +227,7 @@ describe('AiExperienceSettingsComponent', () => {
     it('should render delete button when sessions exist', () => {
         vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 3, messages: 10 }));
         vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(0));
+        createComponent();
         fixture.detectChanges();
 
         const deleteButton = fixture.debugElement.query(By.directive(DeleteButtonDirective));
@@ -192,6 +237,7 @@ describe('AiExperienceSettingsComponent', () => {
     it('should render delete button when memories exist', () => {
         vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 0, messages: 0 }));
         vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(3));
+        createComponent();
         fixture.detectChanges();
 
         const deleteButton = fixture.debugElement.query(By.directive(DeleteButtonDirective));
@@ -201,6 +247,7 @@ describe('AiExperienceSettingsComponent', () => {
     it('should not render delete button when no data exists', () => {
         vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 0, messages: 0 }));
         vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(0));
+        createComponent();
         fixture.detectChanges();
 
         const deleteButton = fixture.debugElement.query(By.directive(DeleteButtonDirective));
@@ -210,6 +257,7 @@ describe('AiExperienceSettingsComponent', () => {
     it('should not update when modal is dismissed', async () => {
         vi.spyOn(irisChatHttpService, 'getSessionAndMessageCount').mockReturnValue(of({ sessions: 0, messages: 0 }));
         vi.spyOn(irisMemoriesHttpService, 'getUserMemoryCount').mockReturnValue(of(0));
+        createComponent();
         fixture.detectChanges();
 
         vi.spyOn(llmModalService, 'open').mockResolvedValue(LLM_MODAL_DISMISSED);

--- a/src/main/webapp/app/core/user/settings/ai-experience-settings/ai-experience-settings.component.ts
+++ b/src/main/webapp/app/core/user/settings/ai-experience-settings/ai-experience-settings.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { Subject, forkJoin, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import dayjs from 'dayjs/esm';
@@ -14,6 +15,7 @@ import { ActionType } from 'app/shared/delete-dialog/delete-dialog.model';
 import { AlertService } from 'app/shared/service/alert.service';
 import { LLMSelectionDecision, LLM_MODAL_DISMISSED } from 'app/core/user/shared/dto/updateLLMSelectionDecision.dto';
 import { LLMSelectionModalService } from 'app/logos/llm-selection-popup.service';
+import { FeatureToggle, FeatureToggleService } from 'app/shared/feature-toggle/feature-toggle.service';
 
 @Component({
     selector: 'jhi-ai-experience-settings',
@@ -27,6 +29,7 @@ export class AiExperienceSettingsComponent implements OnInit {
     private readonly irisMemoriesHttpService = inject(IrisMemoriesHttpService);
     private readonly alertService = inject(AlertService);
     private readonly llmModalService = inject(LLMSelectionModalService);
+    private readonly featureToggleService = inject(FeatureToggleService);
 
     protected readonly ActionType = ActionType;
     protected readonly LLMSelectionDecision = LLMSelectionDecision;
@@ -36,6 +39,7 @@ export class AiExperienceSettingsComponent implements OnInit {
     sessionCount = signal(0);
     messageCount = signal(0);
     memoryCount = signal(0);
+    memirisEnabled = toSignal(this.featureToggleService.getFeatureToggleActive(FeatureToggle.Memiris), { requireSync: true });
 
     private dialogErrorSource = new Subject<string>();
     dialogError$ = this.dialogErrorSource.asObservable();
@@ -56,10 +60,8 @@ export class AiExperienceSettingsComponent implements OnInit {
     }
 
     deleteAllIrisInteractions() {
-        forkJoin([
-            this.irisChatHttpService.deleteAllSessions().pipe(catchError(() => of('error'))),
-            this.irisMemoriesHttpService.deleteAllUserMemories().pipe(catchError(() => of('error'))),
-        ]).subscribe({
+        const deleteMemories$ = this.memirisEnabled() ? this.irisMemoriesHttpService.deleteAllUserMemories().pipe(catchError(() => of('error'))) : of(undefined);
+        forkJoin([this.irisChatHttpService.deleteAllSessions().pipe(catchError(() => of('error'))), deleteMemories$]).subscribe({
             next: ([sessionsResult, memoriesResult]) => {
                 const sessionsDeleted = sessionsResult !== 'error';
                 const memoriesDeleted = memoriesResult !== 'error';
@@ -103,6 +105,10 @@ export class AiExperienceSettingsComponent implements OnInit {
             },
         });
 
+        if (!this.memirisEnabled()) {
+            this.memoryCount.set(0);
+            return;
+        }
         this.irisMemoriesHttpService.getUserMemoryCount().subscribe({
             next: (count) => this.memoryCount.set(count),
             error: () => this.memoryCount.set(0),


### PR DESCRIPTION
### Summary
When the `Memiris` feature toggle is disabled, every user got a 403 *Forbidden* toast as soon as they opened `user-settings/ai-experience`. The page now respects the feature toggle and skips the memory-data call entirely when Memiris is off.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
`IrisMemoryResource` is annotated with `@FeatureToggle(Feature.Memiris)`. When that toggle is off, `FeatureToggleAspect` throws `AccessForbiddenException`, so any call to `/api/iris/user/memory-data` returns 403. The AI experience settings page fired that request on every init, so all users (students and instructors) saw a *Forbidden* error toast on a page that is otherwise unrelated to memory features.

```
{
  title: "Forbidden",
  status: 403,
  detail: "You are not allowed to access this resource",
  path: "/api/iris/user/memory-data"
}
```

### Description
`AiExperienceSettingsComponent` now reads the `Memiris` feature toggle via the existing `FeatureToggleService` and:
- skips `getUserMemoryCount()` on init when Memiris is disabled (memory count stays at 0, no HTTP call),
- skips `deleteAllUserMemories()` from the *delete all* flow when Memiris is disabled (chat sessions are still cleaned up).

The signal is exposed as `memirisEnabled = toSignal(featureToggleService.getFeatureToggleActive(FeatureToggle.Memiris), { requireSync: true })`, mirroring the pattern already used in `LearnerProfileComponent`.

Two new Vitest cases cover the disabled-feature paths; the existing test setup was adjusted so the feature-toggle mock is in place before component construction (required for `toSignal({ requireSync: true })`).

### Steps for Testing
Prerequisites:
- 1 Admin
- 1 Student

1. As Admin, open `Administration -> Feature Toggles` and disable **Memiris**.
2. Log in as the Student and navigate to `User Settings -> AI experience`.
3. Verify that the page loads without a *Forbidden* error toast and no `GET /api/iris/user/memory-data` request is fired (check Network tab).
4. Click *Delete all* (when there are sessions). Verify the chat sessions are deleted and the success message appears without any 403.
5. Re-enable **Memiris** in the admin panel.
6. Reload `User Settings -> AI experience` and verify that the memory count is now fetched and displayed as before.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Page loads cleanly with Memiris feature toggle off (no 403 toast)
- [ ] Page loads with Memiris on and shows memory count
- [ ] *Delete all* works with Memiris off (chat-only) and with Memiris on (chat + memories)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Memory feature operations now respect a feature toggle, enabling selective control without code deployment.
  * When memory is disabled, count operations and deletion workflows are optimized by skipping unnecessary API calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Artemis/pull/12709)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->