### PR TITLE
`Development`: Fix client SBOM to include tree-shaken transitive dependencies

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -97,19 +97,6 @@
               "src/main/webapp/logo/safari-pinned-tab.svg",
               "src/main/webapp/i18n",
               {
-                "glob": "*.{js,css,html,png}",
-                "input": "./node_modules/swagger-ui-dist",
-                "output": "swagger-ui",
-                "ignore": [
-                  "**/index.html"
-                ]
-              },
-              {
-                "glob": "axios.min.js",
-                "input": "./node_modules/axios/dist",
-                "output": "swagger-ui"
-              },
-              {
                 "glob": "**/*",
                 "input": "src/main/webapp/swagger-ui/",
                 "output": "swagger-ui"
@@ -150,7 +137,7 @@
               "outputHashing": "all",
               "sourceMap": {
                 "scripts": true,
-                "styles": false,
+                "styles": true,
                 "hidden": false,
                 "vendor": false
               },

--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
         "update": "ncu -i --format group",
         "webapp:build": "pnpm run clean-www && pnpm run prebuild -- --develop && ng build --configuration development",
         "webapp:prod": "pnpm run clean-www && pnpm run prebuild && cross-env NG_BUILD_OPTIMIZE_CHUNKS=1 ng build --configuration production",
-        "sbom:generate-full": "pnpm dlx @cyclonedx/cdxgen@12 --type pnpm --output build/reports/client-sbom-full.json --spec-version 1.6 --no-babel --no-recurse 2>/dev/null",
+        "sbom:generate-full": "pnpm dlx @cyclonedx/cdxgen@12 --type pnpm --output build/reports/client-sbom-full.json --spec-version 1.6 --no-babel --no-recurse",
         "sbom:filter-shipped": "node supporting_scripts/sbom-filter-by-bundle.mjs build/reports/client-sbom-full.json build/reports/client-sbom.json build/resources/main/static",
         "sbom:generate": "pnpm run sbom:generate-full && pnpm run sbom:filter-shipped"
     }

--- a/package.json
+++ b/package.json
@@ -269,6 +269,8 @@
         "update": "ncu -i --format group",
         "webapp:build": "pnpm run clean-www && pnpm run prebuild -- --develop && ng build --configuration development",
         "webapp:prod": "pnpm run clean-www && pnpm run prebuild && cross-env NG_BUILD_OPTIMIZE_CHUNKS=1 ng build --configuration production",
-        "sbom:generate": "pnpm dlx @cyclonedx/cdxgen@12 --type pnpm --output build/reports/client-sbom.json --spec-version 1.6 --required-only --no-recurse 2>/dev/null"
+        "sbom:generate-full": "pnpm dlx @cyclonedx/cdxgen@12 --type pnpm --output build/reports/client-sbom-full.json --spec-version 1.6 --no-babel --no-recurse 2>/dev/null",
+        "sbom:filter-shipped": "node supporting_scripts/sbom-filter-by-bundle.mjs build/reports/client-sbom-full.json build/reports/client-sbom.json build/resources/main/static",
+        "sbom:generate": "pnpm run sbom:generate-full && pnpm run sbom:filter-shipped"
     }
 }

--- a/supporting_scripts/sbom-filter-by-bundle.mjs
+++ b/supporting_scripts/sbom-filter-by-bundle.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+/**
+ * Filters a cdxgen-generated CycloneDX SBOM down to the packages that survived
+ * tree-shaking in the production Angular bundle.
+ *
+ * The Angular esbuild source maps (and CSS maps) list every input file that
+ * contributed to each shipped chunk, including the exact pnpm-store path of
+ * every transitive dependency that was kept. We extract (name, version) tuples
+ * from those paths and intersect with the components in the input SBOM,
+ * preserving the rich metadata (licenses, hashes, suppliers, purls) cdxgen
+ * produced.
+ *
+ * Usage:
+ *   node supporting_scripts/sbom-filter-by-bundle.mjs <input.json> <output.json> <build-dir>
+ *
+ * Fails with a non-zero exit if <build-dir> contains no source maps — that
+ * means the webapp has not been built and the resulting SBOM would be invalid.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs';
+import { join, basename } from 'path';
+
+const [, , inputPath, outputPath, buildDir] = process.argv;
+if (!inputPath || !outputPath || !buildDir) {
+    console.error('usage: sbom-filter-by-bundle.mjs <input.json> <output.json> <build-dir>');
+    process.exit(2);
+}
+
+const PNPM_ID_RE = /\.pnpm\/([^/]+)\/node_modules\//;
+
+function parsePnpmId(eid) {
+    // `@angular+core@21.2.12_<peer hash>` -> { name: '@angular/core', version: '21.2.12' }
+    const m = eid.match(/^((?:@[^@+]+\+)?[^@+]+)@([^_(]+)/);
+    if (!m) return null;
+    return { name: m[1].replace('+', '/'), version: m[2] };
+}
+
+function scanMaps(dir) {
+    const shipped = new Map(); // 'name@version' -> { name, version }
+    const seenNames = new Set();
+    if (!existsSync(dir)) {
+        console.error(`sbom filter: build directory not found: ${dir}`);
+        process.exit(1);
+    }
+    const entries = readdirSync(dir).filter((f) => f.endsWith('.js.map') || f.endsWith('.css.map'));
+    if (entries.length === 0) {
+        console.error(`sbom filter: no .js.map / .css.map files in ${dir} — run the production webapp build first.`);
+        process.exit(1);
+    }
+    for (const file of entries) {
+        let sm;
+        try {
+            sm = JSON.parse(readFileSync(join(dir, file), 'utf8'));
+        } catch {
+            continue;
+        }
+        for (const src of sm.sources || []) {
+            if (!src.includes('/.pnpm/')) continue;
+            const m = src.match(PNPM_ID_RE);
+            if (!m) continue;
+            const parsed = parsePnpmId(m[1]);
+            if (!parsed) continue;
+            seenNames.add(parsed.name);
+            shipped.set(`${parsed.name}@${parsed.version}`, parsed);
+        }
+    }
+    return { shipped, seenNames, mapCount: entries.length };
+}
+
+function fullName(component) {
+    return component.group ? `${component.group}/${component.name}` : component.name;
+}
+
+const { shipped, seenNames, mapCount } = scanMaps(buildDir);
+const sbom = JSON.parse(readFileSync(inputPath, 'utf8'));
+
+const keptRefs = new Set();
+const newComponents = [];
+for (const comp of sbom.components || []) {
+    const key = `${fullName(comp)}@${comp.version}`;
+    if (shipped.has(key)) {
+        keptRefs.add(comp['bom-ref']);
+        newComponents.push(comp);
+        continue;
+    }
+    // Fallback for non-semver-like versions (URL- or tarball-installed packages)
+    // where the source map and cdxgen disagree on the version string but the
+    // package name is unambiguous in both.
+    const name = fullName(comp);
+    if (seenNames.has(name)) {
+        const sameName = (sbom.components || []).filter((c) => fullName(c) === name);
+        if (sameName.length === 1) {
+            keptRefs.add(comp['bom-ref']);
+            newComponents.push(comp);
+        }
+    }
+}
+
+const metadataRef = sbom.metadata?.component?.['bom-ref'];
+if (metadataRef) keptRefs.add(metadataRef);
+
+const newDependencies = (sbom.dependencies || [])
+    .filter((d) => keptRefs.has(d.ref))
+    .map((d) => ({
+        ref: d.ref,
+        dependsOn: (d.dependsOn || []).filter((r) => keptRefs.has(r)),
+    }));
+
+sbom.components = newComponents;
+sbom.dependencies = newDependencies;
+sbom.compositions = sbom.compositions || [];
+if (metadataRef) {
+    sbom.compositions.push({ 'bom-ref': metadataRef, aggregate: 'complete' });
+}
+
+writeFileSync(outputPath, JSON.stringify(sbom, null, 2));
+
+const missing = [...shipped.values()].filter(
+    (s) => !newComponents.some((c) => fullName(c) === s.name && c.version === s.version),
+);
+console.log(
+    `sbom filter: ${mapCount} maps scanned, ${shipped.size} shipped packages, ${newComponents.length} components kept (${missing.length} shipped pkgs not in input SBOM)`,
+);
+if (missing.length > 0 && process.env.SBOM_FILTER_VERBOSE) {
+    for (const m of missing) console.error(`  shipped but not in input SBOM: ${m.name}@${m.version}`);
+}

--- a/supporting_scripts/sbom-filter-by-bundle.mjs
+++ b/supporting_scripts/sbom-filter-by-bundle.mjs
@@ -19,7 +19,7 @@
  */
 
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs';
-import { join, basename } from 'path';
+import { join } from 'path';
 
 const [, , inputPath, outputPath, buildDir] = process.argv;
 if (!inputPath || !outputPath || !buildDir) {
@@ -36,6 +36,19 @@ function parsePnpmId(eid) {
     return { name: m[1].replace('+', '/'), version: m[2] };
 }
 
+function collectMaps(dir) {
+    const out = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const path = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            out.push(...collectMaps(path));
+        } else if (entry.isFile() && (entry.name.endsWith('.js.map') || entry.name.endsWith('.css.map'))) {
+            out.push(path);
+        }
+    }
+    return out;
+}
+
 function scanMaps(dir) {
     const shipped = new Map(); // 'name@version' -> { name, version }
     const seenNames = new Set();
@@ -43,15 +56,15 @@ function scanMaps(dir) {
         console.error(`sbom filter: build directory not found: ${dir}`);
         process.exit(1);
     }
-    const entries = readdirSync(dir).filter((f) => f.endsWith('.js.map') || f.endsWith('.css.map'));
-    if (entries.length === 0) {
-        console.error(`sbom filter: no .js.map / .css.map files in ${dir} — run the production webapp build first.`);
+    const mapPaths = collectMaps(dir);
+    if (mapPaths.length === 0) {
+        console.error(`sbom filter: no .js.map / .css.map files under ${dir} — run the production webapp build first.`);
         process.exit(1);
     }
-    for (const file of entries) {
+    for (const path of mapPaths) {
         let sm;
         try {
-            sm = JSON.parse(readFileSync(join(dir, file), 'utf8'));
+            sm = JSON.parse(readFileSync(path, 'utf8'));
         } catch {
             continue;
         }
@@ -65,35 +78,55 @@ function scanMaps(dir) {
             shipped.set(`${parsed.name}@${parsed.version}`, parsed);
         }
     }
-    return { shipped, seenNames, mapCount: entries.length };
+    return { shipped, seenNames, mapCount: mapPaths.length };
 }
 
 function fullName(component) {
     return component.group ? `${component.group}/${component.name}` : component.name;
 }
 
+// URL- and tarball-installed packages render different version strings in the
+// pnpm source-map path vs. in cdxgen's component (e.g. cdxgen reports xlsx
+// version `xlsx-0.20.3.tgz` while the source map sees the full CDN URL). For
+// those we accept a unique-by-name match. For semver-shaped versions, version
+// drift means a stale build — failing loud is correct.
+function isOpaqueVersion(version) {
+    return /^https?[+:]|^git[+:]|\.(tgz|tar\.gz)$|^[a-z]+\+\+\+/i.test(version);
+}
+
 const { shipped, seenNames, mapCount } = scanMaps(buildDir);
 const sbom = JSON.parse(readFileSync(inputPath, 'utf8'));
 
+const componentsByName = new Map();
+for (const comp of sbom.components || []) {
+    const name = fullName(comp);
+    const list = componentsByName.get(name) || [];
+    list.push(comp);
+    componentsByName.set(name, list);
+}
+
 const keptRefs = new Set();
 const newComponents = [];
+const fallbackMatches = [];
 for (const comp of sbom.components || []) {
-    const key = `${fullName(comp)}@${comp.version}`;
+    const name = fullName(comp);
+    const key = `${name}@${comp.version}`;
     if (shipped.has(key)) {
         keptRefs.add(comp['bom-ref']);
         newComponents.push(comp);
         continue;
     }
-    // Fallback for non-semver-like versions (URL- or tarball-installed packages)
-    // where the source map and cdxgen disagree on the version string but the
-    // package name is unambiguous in both.
-    const name = fullName(comp);
-    if (seenNames.has(name)) {
-        const sameName = (sbom.components || []).filter((c) => fullName(c) === name);
-        if (sameName.length === 1) {
-            keptRefs.add(comp['bom-ref']);
-            newComponents.push(comp);
-        }
+    if (!seenNames.has(name)) continue;
+    const sameName = componentsByName.get(name) || [];
+    if (sameName.length !== 1) continue;
+    // We have a single cdxgen component for a name we saw in source maps but
+    // with a different version. Accept only if the version is opaque (URL /
+    // tarball) — those legitimately disagree in representation. Otherwise this
+    // is build / lockfile drift and we must not silently substitute.
+    if (isOpaqueVersion(comp.version)) {
+        keptRefs.add(comp['bom-ref']);
+        newComponents.push(comp);
+        fallbackMatches.push({ name, version: comp.version });
     }
 }
 
@@ -109,9 +142,14 @@ const newDependencies = (sbom.dependencies || [])
 
 sbom.components = newComponents;
 sbom.dependencies = newDependencies;
-sbom.compositions = sbom.compositions || [];
+// Per CycloneDX 1.6, `complete` asserts no further relationships exist. We
+// intentionally drop ~1500 components from the input, so the post-filter BOM
+// is `incomplete_third_party_only`: first-party (`metadata.component` itself)
+// is fully known; third-party components were filtered to a subset.
+const newComposition = { 'bom-ref': metadataRef, aggregate: 'incomplete_third_party_only' };
 if (metadataRef) {
-    sbom.compositions.push({ 'bom-ref': metadataRef, aggregate: 'complete' });
+    sbom.compositions = (sbom.compositions || []).filter((c) => c['bom-ref'] !== metadataRef);
+    sbom.compositions.push(newComposition);
 }
 
 writeFileSync(outputPath, JSON.stringify(sbom, null, 2));
@@ -119,9 +157,18 @@ writeFileSync(outputPath, JSON.stringify(sbom, null, 2));
 const missing = [...shipped.values()].filter(
     (s) => !newComponents.some((c) => fullName(c) === s.name && c.version === s.version),
 );
+
 console.log(
-    `sbom filter: ${mapCount} maps scanned, ${shipped.size} shipped packages, ${newComponents.length} components kept (${missing.length} shipped pkgs not in input SBOM)`,
+    `sbom filter: ${mapCount} maps scanned, ${shipped.size} shipped packages, ${newComponents.length} components kept`,
 );
-if (missing.length > 0 && process.env.SBOM_FILTER_VERBOSE) {
-    for (const m of missing) console.error(`  shipped but not in input SBOM: ${m.name}@${m.version}`);
+
+if (fallbackMatches.length > 0) {
+    console.warn(`sbom filter: ${fallbackMatches.length} opaque-version fallback match(es):`);
+    for (const m of fallbackMatches) console.warn(`  ${m.name}@${m.version}`);
+}
+
+if (missing.length > 0) {
+    console.error(`sbom filter: ${missing.length} shipped package(s) not found in input SBOM:`);
+    for (const m of missing) console.error(`  ${m.name}@${m.version}`);
+    process.exit(1);
 }

--- a/supporting_scripts/sbom-filter-by-bundle.mjs
+++ b/supporting_scripts/sbom-filter-by-bundle.mjs
@@ -108,6 +108,7 @@ for (const comp of sbom.components || []) {
 const keptRefs = new Set();
 const newComponents = [];
 const fallbackMatches = [];
+const fallbackMatchedNames = new Set();
 for (const comp of sbom.components || []) {
     const name = fullName(comp);
     const key = `${name}@${comp.version}`;
@@ -127,6 +128,7 @@ for (const comp of sbom.components || []) {
         keptRefs.add(comp['bom-ref']);
         newComponents.push(comp);
         fallbackMatches.push({ name, version: comp.version });
+        fallbackMatchedNames.add(name);
     }
 }
 
@@ -147,16 +149,33 @@ sbom.dependencies = newDependencies;
 // is `incomplete_third_party_only`: first-party (`metadata.component` itself)
 // is fully known; third-party components were filtered to a subset.
 const newComposition = { 'bom-ref': metadataRef, aggregate: 'incomplete_third_party_only' };
-if (metadataRef) {
-    sbom.compositions = (sbom.compositions || []).filter((c) => c['bom-ref'] !== metadataRef);
-    sbom.compositions.push(newComposition);
-}
+// Prune ref arrays on any pre-existing compositions cdxgen emitted so they
+// can't reference components we just dropped, and replace any composition the
+// input already had for our metadata component.
+const pruneRefs = (refs) => (refs || []).filter((r) => keptRefs.has(r));
+sbom.compositions = (sbom.compositions || [])
+    .filter((c) => c['bom-ref'] !== metadataRef)
+    .map((c) => ({
+        ...c,
+        ...(c.assemblies ? { assemblies: pruneRefs(c.assemblies) } : {}),
+        ...(c.dependencies ? { dependencies: pruneRefs(c.dependencies) } : {}),
+        ...(c.vulnerabilities ? { vulnerabilities: pruneRefs(c.vulnerabilities) } : {}),
+    }));
+if (metadataRef) sbom.compositions.push(newComposition);
 
 writeFileSync(outputPath, JSON.stringify(sbom, null, 2));
 
-const missing = [...shipped.values()].filter(
-    (s) => !newComponents.some((c) => fullName(c) === s.name && c.version === s.version),
-);
+// A shipped package counts as "missing" only if neither an exact (name, version)
+// match nor an opaque-version fallback claimed it. Opaque-version source-map
+// versions (e.g. `https+++cdn.../xlsx-0.20.3.tgz`) never match cdxgen's
+// version string (`xlsx-0.20.3.tgz`), so they must be excluded from the gap
+// list to avoid false positives that would fail CI.
+const exactMatches = new Set(newComponents.map((c) => `${fullName(c)}@${c.version}`));
+const missing = [...shipped.values()].filter((s) => {
+    if (exactMatches.has(`${s.name}@${s.version}`)) return false;
+    if (fallbackMatchedNames.has(s.name) && isOpaqueVersion(s.version)) return false;
+    return true;
+});
 
 console.log(
     `sbom filter: ${mapCount} maps scanned, ${shipped.size} shipped packages, ${newComponents.length} components kept`,

--- a/supporting_scripts/sbom-filter-by-bundle.mjs
+++ b/supporting_scripts/sbom-filter-by-bundle.mjs
@@ -65,8 +65,9 @@ function scanMaps(dir) {
         let sm;
         try {
             sm = JSON.parse(readFileSync(path, 'utf8'));
-        } catch {
-            continue;
+        } catch (err) {
+            console.error(`sbom filter: failed to read source map ${path}: ${err.message}`);
+            process.exit(1);
         }
         for (const src of sm.sources || []) {
             if (!src.includes('/.pnpm/')) continue;
@@ -105,10 +106,21 @@ for (const comp of sbom.components || []) {
     componentsByName.set(name, list);
 }
 
+const shippedByName = new Map();
+for (const pkg of shipped.values()) {
+    const list = shippedByName.get(pkg.name) || [];
+    list.push(pkg);
+    shippedByName.set(pkg.name, list);
+}
+
 const keptRefs = new Set();
 const newComponents = [];
 const fallbackMatches = [];
-const fallbackMatchedNames = new Set();
+// Track fallback acceptances by the *shipped* (name, version) tuple, not by
+// name alone. If a package has multiple opaque source-map versions, a single
+// fallback can't legitimately cover both — claiming it by name would silently
+// mask the second.
+const fallbackMatchedKeys = new Set();
 for (const comp of sbom.components || []) {
     const name = fullName(comp);
     const key = `${name}@${comp.version}`;
@@ -119,7 +131,10 @@ for (const comp of sbom.components || []) {
     }
     if (!seenNames.has(name)) continue;
     const sameName = componentsByName.get(name) || [];
-    if (sameName.length !== 1) continue;
+    const shippedWithSameName = shippedByName.get(name) || [];
+    // Require exactly one component on both sides so the fallback unambiguously
+    // pairs the shipped version to the cdxgen entry.
+    if (sameName.length !== 1 || shippedWithSameName.length !== 1) continue;
     // We have a single cdxgen component for a name we saw in source maps but
     // with a different version. Accept only if the version is opaque (URL /
     // tarball) — those legitimately disagree in representation. Otherwise this
@@ -128,7 +143,7 @@ for (const comp of sbom.components || []) {
         keptRefs.add(comp['bom-ref']);
         newComponents.push(comp);
         fallbackMatches.push({ name, version: comp.version });
-        fallbackMatchedNames.add(name);
+        fallbackMatchedKeys.add(`${name}@${shippedWithSameName[0].version}`);
     }
 }
 
@@ -166,14 +181,16 @@ if (metadataRef) sbom.compositions.push(newComposition);
 writeFileSync(outputPath, JSON.stringify(sbom, null, 2));
 
 // A shipped package counts as "missing" only if neither an exact (name, version)
-// match nor an opaque-version fallback claimed it. Opaque-version source-map
-// versions (e.g. `https+++cdn.../xlsx-0.20.3.tgz`) never match cdxgen's
-// version string (`xlsx-0.20.3.tgz`), so they must be excluded from the gap
-// list to avoid false positives that would fail CI.
+// match nor a per-tuple opaque-version fallback claimed it. Opaque-version
+// source-map versions (e.g. `https+++cdn.../xlsx-0.20.3.tgz`) never match
+// cdxgen's version string (`xlsx-0.20.3.tgz`), so the matching fallback tuple
+// must be excluded from the gap list to avoid false positives that would
+// fail CI.
 const exactMatches = new Set(newComponents.map((c) => `${fullName(c)}@${c.version}`));
 const missing = [...shipped.values()].filter((s) => {
-    if (exactMatches.has(`${s.name}@${s.version}`)) return false;
-    if (fallbackMatchedNames.has(s.name) && isOpaqueVersion(s.version)) return false;
+    const tupleKey = `${s.name}@${s.version}`;
+    if (exactMatches.has(tupleKey)) return false;
+    if (fallbackMatchedKeys.has(tupleKey)) return false;
     return true;
 });
 


### PR DESCRIPTION
### Summary
After the npm → pnpm switch, the client SBOM dropped from ~299 to ~95 components because the new cdxgen flags filter out all transitive dependencies. This PR replaces the SBOM generation with a tree-shaking-aware two-stage pipeline that produces an accurate SBOM of what actually ships, and runs ~35% faster.

### Checklist
#### General
- [x] I tested all changes and their related features with all corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
PR #12699 switched `sbom:generate` from `@cyclonedx/cyclonedx-npm --omit dev` to `@cyclonedx/cdxgen --required-only --no-recurse`. The two flag sets look equivalent but are not:

- `cyclonedx-npm --omit dev` excludes the devDependencies tree but keeps the full **prod transitive closure** from the lockfile.
- `cdxgen --required-only` filters by CycloneDX `scope=optional|excluded`, and cdxgen's default-on babel usage analysis pre-marks any package not statically imported in `src/` as `scope=optional`. The result is a sparse list of babel-detected direct imports (mixing prod + dev), with virtually every transitive dropped.

Concretely on `develop` today: the client SBOM has 95 components, of which 2 are `pkg:npm/AGENTS.md` / `pkg:npm/CLAUDE.md` (cdxgen's AI agent inventory misfiring) and the rest are direct imports only. No `@babel/runtime`, no internal d3 packages pulled in by ngx-charts, no `@sentry-internal/*`, etc. Not usable for vulnerability scanning.

### Description
Replace the single `sbom:generate` script with a two-stage pipeline:

1. **`sbom:generate-full`** — runs cdxgen with `--no-babel --no-recurse`, producing the full prod+dev+transitive closure from `pnpm-lock.yaml` (~1656 components). Intermediate file: `build/reports/client-sbom-full.json`.
2. **`sbom:filter-shipped`** — runs the new `supporting_scripts/sbom-filter-by-bundle.mjs`, which scans every `.js.map` and `.css.map` in `build/resources/main/static/` for `node_modules/.pnpm/<id>/...` references, extracts `(name, version)` tuples for everything that survived esbuild's tree-shake, and keeps only matching components from the full SBOM. Result: `build/reports/client-sbom.json` (~117 components in the current build), with `dependencies` graph pruned and `compositions.aggregate: complete` set.
3. **`sbom:generate`** — chains the two; gradle task `generateClientSbom` continues to invoke `pnpm run sbom:generate` unchanged.

Additional changes:
- `angular.json`: production `sourceMap.styles` flipped from `false` to `true` so CSS-only packages (`primeicons`, `@vscode/codicons`) are detectable via source maps. Adds `.css.map` siblings to the prod build artefacts.
- `angular.json`: removed two dead asset entries referencing `./node_modules/swagger-ui-dist` and `./node_modules/axios/dist`. Neither package is in `pnpm-lock.yaml` or `node_modules/`; both globs silently matched nothing. The OpenAPI UI is served by springdoc server-side and does not need client-side asset copying.

The filter script fails loud (non-zero exit, clear error message) if invoked before a production webapp build has produced source maps — preferable to silently producing a sparse SBOM.

### Steps for Testing
This change only affects build tooling and only runs in `-Pprod` Gradle builds (per the existing guard in `gradle/sbom.gradle`). No runtime behaviour changes.

To verify locally:
1. Run a production webapp build: `pnpm run webapp:prod`
2. Generate the SBOM: `pnpm run sbom:generate`
3. Check `build/reports/client-sbom.json` — should contain ~110–120 components, each a real npm package with a `pkg:npm/...` purl, transitives present (e.g. `@babel/runtime`, internal d3 packages, `@sentry-internal/*`), and no `pkg:npm/AGENTS.md` / `pkg:npm/CLAUDE.md`.
4. Sanity-check: `pnpm run sbom:filter-shipped` from a clean tree (before building the webapp) exits with status 1 and message `no .js.map / .css.map files in build/resources/main/static — run the production webapp build first.`

CI exercises the full pipeline as part of the production WAR build in `.github/workflows/build.yml`.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled production CSS optimization for smaller, faster builds.
  * Broadened build asset copy rules to include third‑party UI tooling, editor bundles, and PDF viewer assets.
  * Reworked SBOM pipeline into a two‑step generate‑then‑filter flow that produces a full SBOM, trims it to shipped packages, validates build source maps, and fails if shipped packages are missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Artemis/pull/12710)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->