### PR TITLE
`Development`: Stabilize multi-node fast e2e runner and fix server-side concurrency races

### DIFF
--- a/run-e2e-tests-local-multinode-fast.sh
+++ b/run-e2e-tests-local-multinode-fast.sh
@@ -198,15 +198,25 @@ else
     echo -e "${YELLOW}Step 1: Skipping WAR build (--skip-build)${NC}"
 fi
 
-# Glob the WAR path AFTER the build step so a freshly produced artifact (or a renamed one after a
-# version bump) is picked up. Doing this before the build would store the literal pattern on a
-# clean checkout and the existence check below would fire even on a successful build.
-WAR_FILES=(build/libs/Artemis-*.war)
-if [ ! -e "${WAR_FILES[0]}" ]; then
-    echo -e "${RED}ERROR: No WAR found at build/libs/Artemis-*.war. Drop --skip-build to build it.${NC}"
+# Resolve the WAR for the *current* build.gradle version rather than picking the first
+# lexicographic match from build/libs. We do not `gradle clean` in the fast path (that defeats
+# fast iteration), so stale artifacts from older releases stick around — and the new
+# `major.patch` scheme makes alphabetical ordering unsafe: e.g. `Artemis-9.1.2.war` sorts before
+# `Artemis-9.2.war`. A stale WAR built from pre-PR-#12695 sources still uses the old
+# `new Semver(currentVersionString)` migration code, which then dies on startup with
+# `SemverException: Invalid version (no patch version): 9.2` when the persisted DB carries a
+# two-part version. Resolve the WAR after the build so a freshly produced artifact is picked up.
+ARTEMIS_VERSION=$(grep -E '^[[:space:]]*version[[:space:]]*=' build.gradle | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+if [ -z "$ARTEMIS_VERSION" ]; then
+    echo -e "${RED}ERROR: Could not determine Artemis version from build.gradle${NC}"
     exit 1
 fi
-WAR_FILE="${WAR_FILES[0]}"
+WAR_FILE="build/libs/Artemis-${ARTEMIS_VERSION}.war"
+if [ ! -e "$WAR_FILE" ]; then
+    echo -e "${RED}ERROR: Expected WAR not found: $WAR_FILE${NC}"
+    echo "Drop --skip-build to build it, or delete stale build/libs/Artemis-*.war from prior versions."
+    exit 1
+fi
 
 # Sanity-check the Angular bundle is in the WAR (nginx serves it from there). Without -Pprod the
 # bootWar task may produce a JSP-less, asset-less artifact.

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressService.java
@@ -117,16 +117,30 @@ public class CompetencyProgressService {
     }
 
     /**
-     * Asynchronously update the existing progress for a specific competency
+     * Asynchronously update the existing progress for a specific competency.
+     * <p>
+     * Because this runs on a different thread, the competency may have been deleted between the caller's
+     * scheduling and the async execution (common during course/competency cleanup in tests and on cascade
+     * delete in production). Touching {@code competency.getId()} can then throw
+     * {@link org.hibernate.ObjectNotFoundException} when the lazy proxy is initialized. Treat the
+     * missing entity as "nothing to do" rather than letting the async exception handler log a stack trace.
      *
      * @param competency The competency for which to update all existing student progress
      */
     @Async
     public void updateProgressByCompetencyAsync(CourseCompetency competency) {
         SecurityUtils.setAuthorizationObject(); // Required for async
-        List<CompetencyProgress> existingProgress = competencyProgressRepository.findAllByCompetencyId(competency.getId());
+        Long competencyId;
+        try {
+            competencyId = competency.getId();
+        }
+        catch (org.hibernate.ObjectNotFoundException e) {
+            log.debug("Competency was deleted before async progress update could run, skipping.");
+            return;
+        }
+        List<CompetencyProgress> existingProgress = competencyProgressRepository.findAllByCompetencyId(competencyId);
         log.debug("Updating competency progress for {} users.", existingProgress.size());
-        existingProgress.stream().map(CompetencyProgress::getUser).forEach(user -> updateCompetencyProgress(competency.getId(), user));
+        existingProgress.stream().map(CompetencyProgress::getUser).forEach(user -> updateCompetencyProgress(competencyId, user));
     }
 
     /**
@@ -253,6 +267,13 @@ public class CompetencyProgressService {
         catch (DataIntegrityViolationException e) {
             // In rare instances of initially creating a progress entity, async updates might run in parallel.
             // This fails the SQL unique constraint and throws an exception. We can safely ignore it.
+        }
+        catch (org.hibernate.ObjectNotFoundException e) {
+            // The competency was deleted between the findById above and the flush triggered by save (or
+            // by a subsequent statement in the same transaction). Bail out instead of letting the async
+            // exception handler log a stack trace.
+            log.debug("Competency was deleted while updating progress, skipping.");
+            return null;
         }
 
         log.debug("Updated progress for user {} in competency {} to {} / {}.", user.getLogin(), competency.getId(), studentProgress.getProgress(), studentProgress.getConfidence());

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressService.java
@@ -270,10 +270,11 @@ public class CompetencyProgressService {
         }
         catch (org.hibernate.ObjectNotFoundException e) {
             // The competency was deleted between the findById above and the flush triggered by save (or
-            // by a subsequent statement in the same transaction). Bail out instead of letting the async
-            // exception handler log a stack trace.
-            log.debug("Competency was deleted while updating progress, skipping.");
-            return null;
+            // by a subsequent statement in the same transaction). Skip persistence and the learning-path
+            // propagation. Return the in-memory studentProgress (rather than null) so synchronous callers
+            // that read getProgress()/getConfidence() do not NPE on the race.
+            log.debug("Competency was deleted while updating progress, skipping persistence.");
+            return studentProgress;
         }
 
         log.debug("Updated progress for user {} in competency {} to {} / {}.", user.getLogin(), competency.getId(), studentProgress.getProgress(), studentProgress.getConfidence());

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/CalendarSubscriptionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/CalendarSubscriptionService.java
@@ -81,7 +81,11 @@ public class CalendarSubscriptionService {
                 calendarSubscriptionTokenStoreRepository.saveAndFlush(store);
                 return token;
             }
-            catch (DataIntegrityViolationException violation) {
+            catch (DataIntegrityViolationException ignored) {
+                // Either a token collision (rare; retry with a fresh token) or a user-already-has-a-token
+                // collision (concurrent request inserted the row). Read back the user's token: if present,
+                // a concurrent insert won and we return the winner; otherwise it was a token collision and
+                // we keep retrying.
                 Optional<String> existing = calendarSubscriptionTokenStoreRepository.findTokenByUserLogin(userLogin);
                 if (existing.isPresent()) {
                     return existing.get();

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/CalendarSubscriptionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/CalendarSubscriptionService.java
@@ -5,6 +5,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -50,12 +51,23 @@ public class CalendarSubscriptionService {
     }
 
     /**
-     * Uses a CSPRNG that is part of SecureRandom to generate a cryptographically secure, random subscription token.
-     * Each token is a string of 32 lower-case, hexadecimal characters.
-     * Attempts to generate a unique token 10 times, then throws (should never happen in practice because of astronomical unlikeliness).
+     * Returns the user's existing token, or atomically creates one using a CSPRNG-derived 32-char hex string.
+     * <p>
+     * The store has two unique constraints — one on {@code jhi_user_id} (one row per user) and one on
+     * {@code token}. The retry loop must distinguish the two:
+     * <ul>
+     * <li>{@code jhi_user_id} collision means a concurrent request already inserted a row for this user;
+     * read it back and return it instead of retrying (retrying would keep tripping the same constraint
+     * until the loop gives up and bubbles a 500 to the client).</li>
+     * <li>{@code token} collision is the astronomically rare case the original retry was written for;
+     * retry with a fresh token.</li>
+     * </ul>
+     * Without this distinction, concurrent logins of the same user (one Playwright worker per node logging
+     * the admin user in repeatedly during E2E) reproduce {@code DataIntegrityViolationException} ten times
+     * and end with an {@code IllegalStateException}.
      *
      * @param userLogin the login of the {@link User} for whom the subscription token is requested
-     * @return the generated token
+     * @return the existing or newly-generated token
      */
     public String createSubscriptionTokenForUser(String userLogin) {
         User user = userRepository.getUserByLoginElseThrow(userLogin);
@@ -69,7 +81,11 @@ public class CalendarSubscriptionService {
                 calendarSubscriptionTokenStoreRepository.saveAndFlush(store);
                 return token;
             }
-            catch (DataIntegrityViolationException ignored) {
+            catch (DataIntegrityViolationException violation) {
+                Optional<String> existing = calendarSubscriptionTokenStoreRepository.findTokenByUserLogin(userLogin);
+                if (existing.isPresent()) {
+                    return existing.get();
+                }
             }
         }
         throw new IllegalStateException("Could not generate a unique calendar subscription token after " + MAXIMUM_ATTEMPT_NUMBER + " attempts");

--- a/src/test/playwright/e2e/atlas/LearningPathManagement.spec.ts
+++ b/src/test/playwright/e2e/atlas/LearningPathManagement.spec.ts
@@ -36,9 +36,12 @@ test.describe('Learning Path Management', { tag: '@fast' }, () => {
     test('Instructor enables learning paths via course settings', async ({ page }) => {
         // Arrange: course initially without learning paths enabled
         await page.goto(`/course-management/${course.id}`);
-        await page.waitForLoadState('domcontentloaded');
-
-        await page.getByRole('link', { name: 'Settings' }).click();
+        // domcontentloaded fires before Angular bootstraps the route component, so the Settings
+        // tab is not yet in the DOM. Wait for the course-detail tab strip to render before
+        // clicking, otherwise the click auto-wait runs the full 60s test timeout under load.
+        const settings = page.getByRole('link', { name: 'Settings' });
+        await settings.waitFor({ state: 'visible', timeout: 30_000 });
+        await settings.click();
 
         const lpCheckbox = page.locator('#field_learningPathsEnabled');
         await expect(lpCheckbox).toBeVisible({ timeout: 15000 });
@@ -58,9 +61,9 @@ test.describe('Learning Path Management', { tag: '@fast' }, () => {
 
     test('Instructor disables learning paths via course settings', async ({ page }) => {
         await page.goto(`/course-management/${course.id}`);
-        await page.waitForLoadState('domcontentloaded');
-
-        await page.getByRole('link', { name: 'Settings' }).click();
+        const settings = page.getByRole('link', { name: 'Settings' });
+        await settings.waitFor({ state: 'visible', timeout: 30_000 });
+        await settings.click();
 
         // Toggle checkbox off and save
         const lpCheckbox = page.locator('#field_learningPathsEnabled');

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseManagement.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseManagement.spec.ts
@@ -143,13 +143,14 @@ test.describe('Programming Exercise Management', { tag: '@fast' }, () => {
             await exerciseTeams.checkTeamOnList(teamShortName);
 
             await login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
-            // Wait for the exercise details container to render before asserting on its contents —
-            // login() returns at `load` but the lazy-loaded route component may not have mounted yet.
-            await expect(programmingExerciseOverview.getExerciseDetails()).toBeVisible({ timeout: 30_000 });
-            await expect(programmingExerciseOverview.getExerciseDetails().locator('.view-team')).toBeVisible({ timeout: 30_000 });
+            // The exercise-details template is wrapped in `@if (exercise)`, so the element only
+            // appears once the route component finishes its initial GET for the exercise. Under
+            // parallel CI load that round-trip occasionally creeps past 30s; allow up to 60s here.
+            await expect(programmingExerciseOverview.getExerciseDetails()).toBeVisible({ timeout: 60_000 });
+            await expect(programmingExerciseOverview.getExerciseDetails().locator('.view-team')).toBeVisible({ timeout: 60_000 });
             await login(studentFour, `/courses/${course.id}/exercises/${exercise.id}`);
-            await expect(programmingExerciseOverview.getExerciseDetails()).toBeVisible({ timeout: 30_000 });
-            await expect(programmingExerciseOverview.getExerciseDetails()).toHaveText(/No team yet/, { timeout: 30_000 });
+            await expect(programmingExerciseOverview.getExerciseDetails()).toBeVisible({ timeout: 60_000 });
+            await expect(programmingExerciseOverview.getExerciseDetails()).toHaveText(/No team yet/, { timeout: 60_000 });
         });
     });
 

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseManagement.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseManagement.spec.ts
@@ -143,9 +143,13 @@ test.describe('Programming Exercise Management', { tag: '@fast' }, () => {
             await exerciseTeams.checkTeamOnList(teamShortName);
 
             await login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
-            await expect(programmingExerciseOverview.getExerciseDetails().locator('.view-team')).toBeVisible();
+            // Wait for the exercise details container to render before asserting on its contents —
+            // login() returns at `load` but the lazy-loaded route component may not have mounted yet.
+            await expect(programmingExerciseOverview.getExerciseDetails()).toBeVisible({ timeout: 30_000 });
+            await expect(programmingExerciseOverview.getExerciseDetails().locator('.view-team')).toBeVisible({ timeout: 30_000 });
             await login(studentFour, `/courses/${course.id}/exercises/${exercise.id}`);
-            await expect(programmingExerciseOverview.getExerciseDetails()).toHaveText(/No team yet/);
+            await expect(programmingExerciseOverview.getExerciseDetails()).toBeVisible({ timeout: 30_000 });
+            await expect(programmingExerciseOverview.getExerciseDetails()).toHaveText(/No team yet/, { timeout: 30_000 });
         });
     });
 

--- a/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseLifecycle.spec.ts
+++ b/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseLifecycle.spec.ts
@@ -14,7 +14,10 @@ const course = { id: SEED_COURSES.exerciseManagement.id } as any;
  * Asserts: question title, question text, and all answer option texts.
  */
 async function assertMCQuestionInView(page: Page, title: string) {
-    await expect(page.getByText(title)).toBeVisible({ timeout: 15000 });
+    // 30s rather than 15s: the preview/solution route uses a separate lazy-loaded chunk and the
+    // first navigation after edit can run long under parallel CI load. The subsequent text checks
+    // inherit Playwright's default 10s once the first match resolves.
+    await expect(page.getByText(title)).toBeVisible({ timeout: 30000 });
     await expect(page.getByText(multipleChoiceTemplate.text)).toBeVisible();
     for (const option of multipleChoiceTemplate.answerOptions) {
         await expect(page.getByText(option.text)).toBeVisible();

--- a/src/test/playwright/support/commands.ts
+++ b/src/test/playwright/support/commands.ts
@@ -77,9 +77,17 @@ export class Commands {
         if (!showsNavbar) {
             return;
         }
+        // Use a word-boundary regex rather than `toContainText(username)`. Plain substring
+        // matching silently passes on the exact race this helper exists to catch: in the
+        // instructor→studentOne transition the navbar still showing `artemis_test_user_16`
+        // contains `artemis_test_user_1` as a prefix, so the substring assertion would pass
+        // against the stale identity. `\b` after the user index (digit/underscore are word
+        // chars) anchors the match to the full token.
+        const escaped = credentials.username.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const expectedUser = new RegExp(`\\b${escaped}\\b`);
         const containsExpectedUser = async () => {
             try {
-                await expect(accountMenu).toContainText(credentials.username, { timeout: 15000 });
+                await expect(accountMenu).toContainText(expectedUser, { timeout: 15000 });
                 return true;
             } catch {
                 return false;
@@ -92,7 +100,7 @@ export class Commands {
         // AccountService cache. Hard-reload to rebuild against the now-current cookie.
         await page.reload();
         await page.waitForLoadState('load');
-        await expect(accountMenu).toContainText(credentials.username, { timeout: 30000 });
+        await expect(accountMenu).toContainText(expectedUser, { timeout: 30000 });
     };
 
     static logout = async (page: Page): Promise<void> => {

--- a/src/test/playwright/support/commands.ts
+++ b/src/test/playwright/support/commands.ts
@@ -29,6 +29,10 @@ export class Commands {
 
         expect(response.status()).toBe(200);
 
+        // The previous user's JWT cookie has been cleared and a new one set for `username`.
+        // Verify by re-reading: the cookie jar must contain exactly one jwt that is non-empty.
+        // We do not look up the cookie by value (we only have the token after auth) — finding any
+        // jwt cookie after clearCookies + this auth POST is sufficient.
         await expect
             .poll(
                 async () =>
@@ -41,9 +45,54 @@ export class Commands {
             .toBeTruthy();
 
         if (url) {
+            // page.goto triggers a full document navigation, which re-bootstraps Angular and the
+            // APP_INITIALIZER fetches /api/core/public/account with the freshly-set JWT cookie.
+            // Even so, under heavy parallel load we have observed Angular components occasionally
+            // rendering with the previous user's cached identity (the AccountService userIdentity
+            // signal is initialized from APP_INITIALIZER but a stale Angular state from the prior
+            // route can persist briefly). Verify the navbar shows the expected user before letting
+            // the test interact with the page; if not, force a hard reload to discard any cached
+            // SPA state and re-bootstrap from scratch.
             await page.goto(url);
             await page.waitForLoadState('load');
+            await Commands.verifyAuthenticatedAs(page, credentials);
         }
+    };
+
+    /**
+     * After page.goto, the navbar must render the just-authenticated user. Wait for
+     * #account-menu to show the expected login. If a stale identity persists past the first
+     * verification window, force a full page reload to rebuild Angular from scratch — this is
+     * cheaper than retrying the whole login and reliably recovers from the rare race.
+     * <p>
+     * Skipped silently when the route does not include a navbar (exam mode, problem-statement
+     * standalone, LTI iframe) — there is nothing observable to verify against.
+     */
+    private static verifyAuthenticatedAs = async (page: Page, credentials: UserCredentials): Promise<void> => {
+        const accountMenu = page.locator('#account-menu');
+        const showsNavbar = await accountMenu
+            .waitFor({ state: 'attached', timeout: 5000 })
+            .then(() => true)
+            .catch(() => false);
+        if (!showsNavbar) {
+            return;
+        }
+        const containsExpectedUser = async () => {
+            try {
+                await expect(accountMenu).toContainText(credentials.username, { timeout: 15000 });
+                return true;
+            } catch {
+                return false;
+            }
+        };
+        if (await containsExpectedUser()) {
+            return;
+        }
+        // Mismatch — the SPA bootstrapped before the new JWT was committed to Angular's
+        // AccountService cache. Hard-reload to rebuild against the now-current cookie.
+        await page.reload();
+        await page.waitForLoadState('load');
+        await expect(accountMenu).toContainText(credentials.username, { timeout: 30000 });
     };
 
     static logout = async (page: Page): Promise<void> => {

--- a/src/test/playwright/support/pageobjects/assessment/StudentAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/StudentAssessmentPage.ts
@@ -36,7 +36,10 @@ export class StudentAssessmentPage {
     }
 
     async checkComplaintStatusText(text: string) {
-        await expect(this.getComplaintBadge().filter({ hasText: text })).toBeAttached();
+        // Default expect timeout is 10s; the student-side complaint badge appears only after the
+        // tutor's response propagates through the assessment async flow, which under parallel CI
+        // load can take longer than 10s. Wait up to 30s for the specific status text to render.
+        await expect(this.getComplaintBadge().filter({ hasText: text })).toBeAttached({ timeout: 30_000 });
     }
 
     async checkComplaintResponseText(text: string) {

--- a/src/test/playwright/support/pageobjects/course/CompetencyManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CompetencyManagementPage.ts
@@ -8,8 +8,11 @@ export class CompetencyManagementPage {
     }
 
     async goto(courseId: number) {
-        const responsePromise = this.page.waitForResponse((resp) => resp.url().includes(`/api/atlas/courses/${courseId}/course-competencies`) && resp.status() === 200, {
-            timeout: 30000,
+        // Wait for both the SPA route mount AND the initial competency fetch so subsequent steps
+        // are not racing the page load. Under parallel CI load the response can take >15s; loosen
+        // the status assertion (any 2xx/3xx, not strictly 200) and bump the timeout accordingly.
+        const responsePromise = this.page.waitForResponse((resp) => resp.url().includes(`/api/atlas/courses/${courseId}/course-competencies`) && resp.status() < 400, {
+            timeout: 45000,
         });
         await this.page.goto(`/course-management/${courseId}/competency-management`);
         await responsePromise;

--- a/src/test/playwright/support/pageobjects/course/CourseManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementPage.ts
@@ -23,9 +23,16 @@ export class CourseManagementPage {
 
     /**
      * Opens the course settings page.
+     * <p>
+     * Waits explicitly for the settings tab to render before clicking. The course detail layout is
+     * hydrated asynchronously after openCourse() navigates, so the bare .click() races the render
+     * under parallel CI load (see CourseManagement.spec.ts:260, where the deletion-summary test
+     * builds up 25+ child entities via API before reaching the UI step).
      */
     async openCourseSettings() {
-        await this.page.locator('#course-settings').click();
+        const settings = this.page.locator('#course-settings');
+        await settings.waitFor({ state: 'visible', timeout: 30_000 });
+        await settings.click();
     }
 
     /**
@@ -67,6 +74,10 @@ export class CourseManagementPage {
         const header = this.getCourse(courseID).locator('#course-card-header');
         await header.waitFor({ state: 'visible', timeout: 30_000 });
         await header.click();
+        // Wait for SPA navigation into the course detail to complete before subsequent steps
+        // (e.g. openCourseSettings) race the next render. Without this, the next click() can fire
+        // while the previous page is still mounted, then auto-wait against the wrong DOM.
+        await this.page.waitForURL(new RegExp(`/course-management/${courseID}(/|$)`));
     }
 
     private async assertCourseSummary(expectedCourseSummary: CourseSummary) {

--- a/src/test/playwright/support/pageobjects/course/CourseManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementPage.ts
@@ -172,9 +172,16 @@ export class CourseManagementPage {
 
     /**
      * Removes the first user from the registered students.
+     * <p>
+     * The students table re-renders after `addStudent()` and the bare click() can race that
+     * second render under parallel load — the row that previously had the delete button is
+     * detached and the locator points at nothing. Wait for the delete button to be attached
+     * and visible before clicking.
      */
     async removeFirstUser() {
-        await this.page.locator('#registered-students button[jhideletebutton]').first().click();
+        const deleteButton = this.page.locator('#registered-students button[jhideletebutton]').first();
+        await deleteButton.waitFor({ state: 'visible', timeout: 30_000 });
+        await deleteButton.click();
         await this.page.getByTestId('delete-dialog-confirm-button').click();
     }
 

--- a/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
@@ -70,28 +70,34 @@ export class ExerciseTeamsPage {
         }
 
         try {
-            // Retry with different input strategies — fill() can fail to trigger
-            // Angular's typeahead if change detection doesn't pick up the event.
-            for (let attempt = 0; attempt < 3; attempt++) {
+            // Ensure the input is in the DOM and interactive before typing. Under parallel CI load
+            // the tab containing the input renders late, and fill() against a not-yet-attached input
+            // silently no-ops, leaving the typeahead never triggered.
+            await inputLocator.waitFor({ state: 'visible', timeout: 30_000 });
+
+            // Retry with different input strategies — fill() can fail to trigger Angular's
+            // typeahead if signal-based change detection misses the event. Subsequent attempts
+            // use focus + pressSequentially with a longer delay, which always dispatches real
+            // keyboard events the typeahead listens for.
+            for (let attempt = 0; attempt < 4; attempt++) {
                 if (attempt > 0) {
                     await this.page.waitForTimeout(500);
                     await inputLocator.clear();
                 }
-                // First attempt: fill() (fast). Subsequent: pressSequentially (reliable).
                 if (attempt === 0) {
                     await inputLocator.fill(username);
                 } else {
-                    await inputLocator.click();
-                    await inputLocator.pressSequentially(username, { delay: 50 });
+                    await inputLocator.focus();
+                    await inputLocator.pressSequentially(username, { delay: 80 });
                 }
                 try {
-                    await listbox.waitFor({ state: 'visible', timeout: 10000 });
+                    await listbox.waitFor({ state: 'visible', timeout: 15000 });
                     const option = listbox.getByText(new RegExp(username, 'i')).first();
                     await option.waitFor({ state: 'visible', timeout: 5000 });
                     await option.click();
                     break;
                 } catch {
-                    if (attempt === 2) throw new Error(`Tutor search autocomplete did not appear after 3 attempts for '${username}'`);
+                    if (attempt === 3) throw new Error(`Tutor search autocomplete did not appear after 4 attempts for '${username}'`);
                 }
             }
         } finally {
@@ -108,7 +114,10 @@ export class ExerciseTeamsPage {
      */
     private async searchStudent(inputLocator: ReturnType<Page['locator']>, username: string) {
         const listbox = this.page.getByRole('listbox');
-        for (let attempt = 0; attempt < 3; attempt++) {
+        // Ensure the input is mounted before we start typing — under parallel CI load the dialog
+        // body can render late and pressSequentially against an absent element silently no-ops.
+        await inputLocator.waitFor({ state: 'visible', timeout: 30_000 });
+        for (let attempt = 0; attempt < 4; attempt++) {
             if (attempt > 0) {
                 await this.page.waitForTimeout(500);
             }
@@ -119,13 +128,13 @@ export class ExerciseTeamsPage {
             await inputLocator.pressSequentially(username, { delay: 100 });
 
             try {
-                await listbox.waitFor({ state: 'visible', timeout: 10000 });
+                await listbox.waitFor({ state: 'visible', timeout: 15000 });
                 const option = listbox.getByText(new RegExp(username, 'i')).first();
                 await option.waitFor({ state: 'visible', timeout: 5000 });
                 await option.click();
                 return;
             } catch {
-                if (attempt === 2) throw new Error(`Student search autocomplete did not appear after 3 attempts for '${username}'`);
+                if (attempt === 3) throw new Error(`Student search autocomplete did not appear after 4 attempts for '${username}'`);
             }
         }
     }


### PR DESCRIPTION
### Summary

Fixes three classes of failures that surfaced when running the fast multi-node E2E runner against develop: a runner script bug that picked stale WARs after the `major.patch` version-scheme switch (#12695), and two server-side concurrency races (calendar subscription token, competency progress async update) that produced 30+ stack traces per suite run and intermittently failed Playwright tests sharing seed users.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

Running `./run-e2e-tests-local-multinode-fast.sh` on a clean develop checkout fails at startup with:
```
SemverException: Invalid version (no patch version): 9.2
  at de.tum.cit.aet.artemis.core.config.migration.DatabaseMigration.checkMigrationPath
```

Root cause: the runner globs `build/libs/Artemis-*.war` and takes `[0]`. After PR #12695 switched the version scheme from `major.minor.patch` to `major.patch`, stale artifacts (e.g. `Artemis-9.1.2.war`) sort lexicographically *before* the current build (`Artemis-9.2.war`) — and the old WAR's `DatabaseMigration` still does `new Semver(previousVersionString)` directly, which strict semver4j rejects for two-part versions stored in `artemis_version`.

Once that's unblocked, the e2e suite uncovered two real server-side races introduced/exposed by recent work:
- `calendar_subscription_token_store_jhi_user_id_key` violations on concurrent same-user logins — the retry loop couldn't distinguish a token collision (rare; retry helps) from a user-already-has-a-token collision (retry guaranteed to fail), and bubbled an `IllegalStateException` to clients on every parallel test worker that hit it.
- `ObjectNotFoundException` for `CourseCompetency` in `CompetencyProgressService.updateProgressByCompetencyAsync` — `@Async` execution can lag behind competency deletion, so the lazy proxy throws when its id is first accessed (or when the save flushes).

### Description

**`run-e2e-tests-local-multinode-fast.sh`**: read the version from `build.gradle` and resolve `build/libs/Artemis-${ARTEMIS_VERSION}.war` by exact name. If missing, error with a hint to drop `--skip-build` or delete stale artifacts, rather than silently launching the wrong WAR.

**`CalendarSubscriptionService.createSubscriptionTokenForUser`**: on `DataIntegrityViolationException`, re-read the user's existing token via `findTokenByUserLogin`. If a row now exists, return it (a concurrent request already created it). Otherwise the violation came from a token collision — keep retrying with a fresh token.

**`CompetencyProgressService`**:
- Top of `updateProgressByCompetencyAsync`: wrap `competency.getId()` in a try/catch for `ObjectNotFoundException` so the lazy-proxy initialization failure becomes a debug-logged no-op when the competency was deleted before the async ran.
- `updateCompetencyProgress`: extend the existing `catch (DataIntegrityViolationException)` around `save(studentProgress)` with a sibling `catch (ObjectNotFoundException)` for the case where the competency disappears between `findById` and flush.

### Steps for Testing

Prerequisites:
- Local development environment that can run `./run-e2e-tests-local-multinode-fast.sh`
- A stale `build/libs/Artemis-9.1.x.war` (or any older version) sitting in `build/libs/` alongside the current build, to reproduce the SemverException

1. Run `./run-e2e-tests-local-multinode-fast.sh` on a develop checkout. Before this fix, node-1 dies on startup; after the fix, all three nodes boot and the suite executes.
2. Inspect server logs under `.e2e-local-multinode-fast/server-{1,2,3}.log` after a full suite run:
   - Should see **no** "calendar_subscription_token_store" duplicate-key warnings or "Could not generate a unique calendar subscription token" errors.
   - Should see **no** "Caused by: ObjectNotFoundException: ... CourseCompetency" stack traces from `updateProgressByCompetencyAsync`.
3. Run server unit/integration coverage for the touched services to confirm no regressions:
   ```
   ./gradlew test -x webapp --tests CalendarIntegrationTest
   ```

### Validation evidence

Five end-to-end runs comparing before/after:

| Run | Calendar token errors | CourseCompetency errors | Pass first try | Hard failures |
|---|---|---|---|---|
| Pre-fix (stale WAR) | ~12 | ~30 | n/a (node-1 dies) | n/a |
| Script fix only | 12 | 30 | 254 | 0 |
| + calendar fix | 0 | 16 | 256 | 2 |
| + competency fix v1 | 0 | 2 | 258 | 1 |
| + competency fix v2 | 0 | 0 | 257 | **0** |

CalendarIntegrationTest passes locally (98/98).

### Testserver States
n/a — script + server library fixes only.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Reproduce SemverException on a checkout with a stale WAR, verify fix
- [ ] Run full multi-node fast e2e suite, verify zero calendar/competency stack traces in server logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made competency progress updates resilient to concurrent deletions and persistence races
  * Stabilized calendar subscription creation to correctly return existing tokens on unique-constraint races
  * Avoided running against stale build artifacts by validating and resolving the expected WAR before tests

* **Tests**
  * Strengthened end-to-end waits for route/render timing to reduce flakiness
  * Increased timeouts and retries in page objects and typeahead searches for reliability

* **Chores**
  * Improved local test-run validation for expected artifacts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Artemis/pull/12713)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->