### PR TITLE
`Development`: Improve CI WAR build performance with Gradle build cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Build .war
         # Skip the webapp Gradle task since the Angular client was already built above.
         # Enable Gradle build cache so CI can reuse task outputs across runs.
-        run: ./gradlew -Pprod -Pwar bootWar -x webapp --build-cache
+        run: ./gradlew -Pprod -Pwar bootWar -x webapp --build-cache --info
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,9 +116,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '${{ env.java }}'
-          cache: 'gradle'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: false
       - name: Install pnpm dependencies
         run: pnpm install --frozen-lockfile
       - name: Build Angular Client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,8 @@ jobs:
         run: pnpm run clean-www && pnpm run prebuild && pnpm exec ng build --configuration production --optimization=false
       - name: Build .war
         # Skip the webapp Gradle task since the Angular client was already built above.
-        run: ./gradlew -Pprod -Pwar bootWar -x webapp
+        # Enable Gradle build cache so CI can reuse task outputs across runs.
+        run: ./gradlew -Pprod -Pwar bootWar -x webapp --build-cache
       - name: Upload Artifact
         uses: actions/upload-artifact@v7
         with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -73,3 +73,4 @@ org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 
   --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
   --add-opens java.management/sun.management=ALL-UNNAMED \
   --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+org.gradle.caching=true


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 
Enable Gradle build caching for the Build workflow WAR job to reduce repeated Java compilation work across CI runs.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
From `build.yml` workflow run analysis, we have reached the following results:
- `build-war` is the dominant job of the PR build path. This job takes ~`5m 02s` average (about 64% of the ~`7.8m` total workflow average)
- In this job, `Build .war` step takes ~`160s` average and it is the largest single step in `build-war` job

This PR targets that bottleneck by enabling Gradle **build cache** only, so repeated Java task outputs can be reused across CI runs.

### Description
<!-- Describe your changes in detail -->
1. `.github/workflows/build.yml`
   - `Build .war` step now runs:
   - `./gradlew -Pprod -Pwar bootWar -x webapp --build-cache`

2. `gradle.properties`
   - Added:
   - `org.gradle.caching=true`

No application logic or REST/UI behavior was changed.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- Java 25
- Node/pnpm installed as required by the project

1. Run a warm-up build:
   - `./gradlew clean compileJava --build-cache --info --console=plain`
2. Run the same command again (or run after cleaning outputs) and verify cache usage:
   - Look for `FROM-CACHE` entries (e.g., `:compileJava FROM-CACHE`).
3. Verify workflow command shape in CI config:
   - Confirm `build.yml` contains `bootWar ... --build-cache`.

### Testserver States
Not applicable — no server behaviour or schema changes.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-05-18 17:25:01 UTC_

