### PR TITLE
`Development`: Fix shell-quote injection in prod-like-deployment workflow

### DIFF
--- a/.github/workflows/prod-like-deployment.yml
+++ b/.github/workflows/prod-like-deployment.yml
@@ -51,9 +51,9 @@ jobs:
 
       - name: Extract workflow ID
         id: set_build_workflow_id
+        env:
+          WORKFLOW_DATA: ${{ steps.get_workflow_run.outputs.data }}
         run: |
-          WORKFLOW_DATA='${{ steps.get_workflow_run.outputs.data }}'
-
           WORKFLOW_ID=$(echo "$WORKFLOW_DATA" | jq -r '
             .workflow_runs[0].id // empty
           ')
@@ -76,8 +76,10 @@ jobs:
 
       - name: Verify artifact exists
         id: check_result
+        env:
+          ARTIFACT_DATA: ${{ steps.verify_artifact.outputs.data }}
         run: |
-          TOTAL_COUNT=$(echo '${{ steps.verify_artifact.outputs.data }}' | jq -r '.total_count')
+          TOTAL_COUNT=$(echo "$ARTIFACT_DATA" | jq -r '.total_count')
 
           if [ "$TOTAL_COUNT" -gt 0 ]; then
             echo "Found Artemis.war artifact in build for commit ${{ github.event.inputs.commit_sha }}"


### PR DESCRIPTION
### Summary
The `Extract workflow ID` and `Verify artifact exists` steps in `prod-like-deployment.yml` inline the GitHub API JSON response into single-quoted bash strings. When the head commit message contains an apostrophe (e.g. `the image's …`), the bash string terminates early and the rest of the JSON is parsed as shell — producing `syntax error near unexpected token '('` and skipping the deploy job entirely.

This pattern was also flagged by the workflow-security hook as a script-injection vector ([guide](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/)).

### Motivation and Context
Hit live on the `feat/maven-cache` PR (#12717) deploy attempt — failing run [25960574239](https://github.com/ls1intum/Artemis/actions/runs/25960574239/job/76315060471). Until this lands on `develop`, any deploy whose latest commit body contains an apostrophe fails the same way.

### Description
Pass `steps.*.outputs.data` through `env:` (the [GitHub-recommended pattern](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable)) so the JSON is never substituted into the script text. No behavioural change beyond robustness.

### Steps for Testing
1. Re-trigger the deploy workflow on a commit whose head_commit message contains an apostrophe.
2. `check-build-status / Extract workflow ID` should succeed and resolve the build workflow ID.
3. The deploy job should proceed.