### PR TITLE
`Development`: Speed up test-server deployment workflow

### DIFF
--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -36,18 +36,21 @@ env:
 #
 #  High-level flow
 #  ────────────────
-#  1. Log the incoming parameters (log-inputs)
-#  2. Decide which build artifact to use (determine-build-context)
+#  1. Decide which build artifact to use (determine-build-context)
 #     • PR exists → reuse its successful build
 #     • branch == main OR branch == develop → reuse latest push build
 #     • anything else → build the branch on-the-fly
-#  3. Deploy the resolved Docker image to the requested environment
+#  2. Deploy the resolved Docker image to the requested environment
 # ------------------------------------------------------------------------------
 jobs:
-  # Log the inputs for debugging
-  log-inputs:
-    name: Log Inputs
+  determine-build-context:
+    name: Determine Build Context
     runs-on: [self-hosted, artemis-test-deployment]
+    outputs:
+      pr_number: ${{ steps.get_pr.outputs.pr_number }}
+      head_sha: ${{ steps.get_pr.outputs.head_sha }}
+      tag: ${{ steps.get_pr.outputs.tag }}
+      is_main_or_develop: ${{ steps.get_pr.outputs.is_main_or_develop }}
     steps:
       - name: Print Inputs
         run: |
@@ -56,16 +59,6 @@ jobs:
           echo "Triggered by: ${{ github.event.inputs.triggered_by }}"
           echo "RAW_URL: ${{ env.RAW_URL }}"
 
-  determine-build-context:
-    name: Determine Build Context
-    runs-on: [self-hosted, artemis-test-deployment]
-    needs: log-inputs
-    outputs:
-      pr_number: ${{ steps.get_pr.outputs.pr_number }}
-      head_sha: ${{ steps.get_pr.outputs.head_sha }}
-      tag: ${{ steps.get_pr.outputs.tag }}
-      is_main_or_develop: ${{ steps.get_pr.outputs.is_main_or_develop }}
-    steps:
       - name: Check if a PR exists for the branch
         id: get_pr
         env:
@@ -134,17 +127,21 @@ jobs:
     runs-on: [self-hosted, artemis-test-deployment]
     steps:
       - name: Get latest successful build for branch
-        id: check_build
-        uses: octokit/request-action@v2.x
-        with:
-          route: GET /repos/${{ github.repository }}/actions/workflows/build.yml/runs?event=pull_request&status=success&head_sha=${{ needs.determine-build-context.outputs.head_sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Fail if no successful build found
-        if: ${{ steps.check_build.conclusion == 'success' && fromJSON(steps.check_build.outputs.data).total_count == 0 }}
         run: |
-          echo "::error::No successful build found for branch '${{ github.event.inputs.branch_name }}' with SHA '${{ needs.determine-build-context.outputs.head_sha }}'."
-          exit 1
+          set -euo pipefail
+
+          TOTAL_COUNT=$(gh api --method GET repos/${{ github.repository }}/actions/workflows/build.yml/runs \
+            -f event=pull_request \
+            -f status=success \
+            -f head_sha=${{ needs.determine-build-context.outputs.head_sha }} \
+            --jq '.total_count')
+
+          if [ "$TOTAL_COUNT" -eq 0 ]; then
+            echo "::error::No successful build found for branch '${{ github.event.inputs.branch_name }}' with SHA '${{ needs.determine-build-context.outputs.head_sha }}'."
+            exit 1
+          fi
 
   # Check if the build has run successfully (main or develop)
   check-existing-build-for-branch:
@@ -154,18 +151,22 @@ jobs:
     runs-on: [self-hosted, artemis-test-deployment]
     steps:
       - name: Get latest successful build for main or develop branch
-        id: check_main_build
-        uses: octokit/request-action@v2.x
-        with:
-          route: GET /repos/${{ github.repository }}/actions/workflows/build.yml/runs?event=push&status=success&branch=${{ github.event.inputs.branch_name }}&head_sha=${{ needs.determine-build-context.outputs.head_sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Fail if no successful build found
-        if: ${{ steps.check_main_build.conclusion == 'success' && fromJSON(steps.check_main_build.outputs.data).total_count == 0 }}
         run: |
-          echo "::error::No successful build found for branch '${{ github.event.inputs.branch_name }}'."
-          exit 1
+          set -euo pipefail
+
+          TOTAL_COUNT=$(gh api --method GET repos/${{ github.repository }}/actions/workflows/build.yml/runs \
+            -f event=push \
+            -f status=success \
+            -f branch=${{ github.event.inputs.branch_name }} \
+            -f head_sha=${{ needs.determine-build-context.outputs.head_sha }} \
+            --jq '.total_count')
+
+          if [ "$TOTAL_COUNT" -eq 0 ]; then
+            echo "::error::No successful build found for branch '${{ github.event.inputs.branch_name }}'."
+            exit 1
+          fi
 
   check-database-migration-approval:
     name: Check Database Migration Approval


### PR DESCRIPTION
### Summary
Speeds up the `Deploy to a test-server` workflow by removing a redundant runner spin-up and replacing the `octokit/request-action` calls with direct `gh api` invocations.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
The `testserver-deployment.yml` workflow had two avoidable sources of latency:
1. A standalone `log-inputs` job whose only purpose was to echo the workflow inputs, costing a full self-hosted-runner spin-up before `determine-build-context` could even start.
2. Two existence-check jobs (`check-existing-build-for-pull-request`, `check-existing-build-for-branch`) that used `octokit/request-action@v2.x`, which downloads a marketplace action on every run and splits the lookup into two steps (call + conditional fail).

Test-server deployments are on the critical path for reviewers validating PRs, so trimming this overhead pays off every time someone redeploys.

### Description
- Removed the `log-inputs` job. Its `Print Inputs` step is now the first step of `determine-build-context`, so the inputs are still logged but without an extra runner.
- Replaced `octokit/request-action@v2.x` with direct `gh api --method GET ... --jq '.total_count'` calls in both `check-existing-build-for-pull-request` and `check-existing-build-for-branch`. The two-step "call + conditional fail" pattern is collapsed into one step guarded by `set -euo pipefail`.
- Updated the high-level flow comment at the top of the workflow to reflect the new 2-step structure.

Semantics are preserved and slightly hardened: previously the "Fail if no successful build" step was gated on `steps.<id>.conclusion == 'success'`, which meant a transient API failure would skip the failure check and let the deploy proceed. With `set -euo pipefail`, an API failure now fails the job loudly.

`gh` is already used elsewhere in the same workflow on the same `[self-hosted, artemis-test-deployment]` runner (see `determine-build-context`), so no new tooling requirement is introduced.

### Steps for Testing
Prerequisites:
- Maintainer access to trigger `Deploy to a test-server` via the GitHub Actions UI (or Helios).

1. From this branch, trigger the `Deploy to a test-server` workflow against an arbitrary test environment for:
   a. A branch that has an open PR against `develop` → expect `check-existing-build-for-pull-request` to run and pass (or fail loudly if no build exists for the head SHA), and the deploy to proceed.
   b. The `develop` branch → expect `check-existing-build-for-branch` to run and pass, and the deploy to proceed.
   c. A branch without an open PR and not `main`/`develop` → expect `conditional-build` to build the image and the deploy to proceed.
2. In each case, confirm the `Print Inputs` step output is visible inside the `determine-build-context` job logs.
3. Confirm overall workflow wall-clock time is shorter than on `develop` (one fewer job, no marketplace-action download).

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Deploy triggered for a PR branch — `check-existing-build-for-pull-request` runs, deploy succeeds
- [ ] Deploy triggered for `develop` — `check-existing-build-for-branch` runs, deploy succeeds
- [ ] Deploy triggered for a branch without a PR — `conditional-build` runs, deploy succeeds
