### PR TITLE
`Development`: Truncate flakiness score to integer and add one-command local E2E stack setup

### DIFF
--- a/.github/scripts/fetch-flakiness.js
+++ b/.github/scripts/fetch-flakiness.js
@@ -112,7 +112,7 @@ function buildFlakinessTable(flakinessResults) {
         const dfr = (r.defaultBranchFailureRate * 100).toFixed(1);
         const cfr = (r.combinedFailureRate * 100).toFixed(1);
         const testId = `${escapeMd(r.className)}#${escapeMd(r.testName)}`;
-        table += `| \`${testId}\` | **${r.flakinessScore}%** | ${dfr}% | ${cfr}% |\n`;
+        table += `| \`${testId}\` | **${Math.round(r.flakinessScore)}%** | ${dfr}% | ${cfr}% |\n`;
     }
     return table;
 }

--- a/start-playwright-stack.sh
+++ b/start-playwright-stack.sh
@@ -46,6 +46,17 @@ err()  { echo -e "${RED}[stack]${NC} $*"; }
 
 check_client() { curl -sf http://localhost:9000 >/dev/null 2>&1 || curl -sf http://127.0.0.1:9000 >/dev/null 2>&1; }
 
+# Kill any process listening on a given port (fallback when no PID file exists).
+# Safer than pkill -f <name> because it is scoped to the port, not the process name.
+kill_by_port() {
+    local port=$1
+    local pids
+    pids=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | awk 'NR>1 {print $2}' | sort -u)
+    for pid in $pids; do
+        kill "$pid" 2>/dev/null || true
+    done
+}
+
 cd "$(dirname "$0")"
 REPO_ROOT="$(pwd)"
 LOCAL_DIR=".e2e-local"
@@ -61,8 +72,7 @@ if [ "${1:-}" = "--stop" ]; then
     if [ -f "$LOCAL_DIR/client.pid" ]; then
         kill "$(cat "$LOCAL_DIR/client.pid")" 2>/dev/null || true
     fi
-    pkill -f "ng serve" 2>/dev/null || true
-    pkill -f "static-server.mjs" 2>/dev/null || true
+    kill_by_port 9000
     rm -f "$LOCAL_DIR/client.pid"
     ok "Client stopped. Server + postgres still running."
     exit 0
@@ -75,9 +85,8 @@ if [ "${1:-}" = "--stop-all" ]; then
     if [ -f "$LOCAL_DIR/server.pid" ]; then
         kill "$(cat "$LOCAL_DIR/server.pid")" 2>/dev/null || true
     fi
-    pkill -f "ng serve" 2>/dev/null || true
-    pkill -f "static-server.mjs" 2>/dev/null || true
-    pkill -f "bootRun"  2>/dev/null || true
+    kill_by_port 9000
+    kill_by_port 8080
     docker compose --env-file .env -f "$COMPOSE_FILE" down -v 2>/dev/null || true
     rm -f "$LOCAL_DIR/server.pid" "$LOCAL_DIR/client.pid"
     ok "All stopped."

--- a/start-playwright-stack.sh
+++ b/start-playwright-stack.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+# =============================================================================
+# Bring up the full local Playwright stack for Artemis E2E tests.
+#
+# Provisions every dependency the Playwright runner (or the VS Code Playwright
+# extension's play button) expects: database, backend, frontend, ssh keys, and
+# the playwright workspace itself. Idempotent — skips anything already running.
+#
+# What it does:
+#   1. Ensures Node 24 is active (via nvm)
+#   2. Ensures Docker daemon is running (starts Docker Desktop if not)
+#   3. Ensures Postgres container is up (via e2e-local-fast-postgres.yml)
+#   4. Ensures Artemis server is running on :8080
+#   5. Ensures frontend is serving on :9000 (ng serve, or prebuilt static + proxy)
+#   6. Ensures ssh-keys symlink exists at repo root (for cwd-relative lookup)
+#   7. Runs prepareVSCodeForE2ETests.sh (installs deps + patches config)
+#   8. Ensures playwright.env BASE_URL uses IPv4 (127.0.0.1)
+#
+# Usage:
+#   ./start-playwright-stack.sh           # ng serve client (HMR, slow startup)
+#   ./start-playwright-stack.sh --static  # prebuilt static bundle + reverse proxy
+#                                         #   (no HMR, ~1s startup; builds once if missing)
+#   ./start-playwright-stack.sh --stop      # stop ONLY the frontend (server + db stay up)
+#   ./start-playwright-stack.sh --stop-all  # full teardown (client + server + postgres)
+# =============================================================================
+
+set -e
+STATIC_MODE=false
+[ "${1:-}" = "--static" ] && STATIC_MODE=true
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+log()  { echo -e "${BLUE}[stack]${NC} $*"; }
+ok()   { echo -e "${GREEN}[stack]${NC} $*"; }
+warn() { echo -e "${YELLOW}[stack]${NC} $*"; }
+err()  { echo -e "${RED}[stack]${NC} $*"; }
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(pwd)"
+LOCAL_DIR=".e2e-local"
+COMPOSE_FILE="docker/e2e-local-fast-postgres.yml"
+mkdir -p "$LOCAL_DIR"
+
+# ----- Stop modes -----------------------------------------------------------
+# --stop      : kill only the frontend (so you can switch ng-serve <-> static
+#               cheaply). Leaves server + postgres up — next start is instant.
+# --stop-all  : full teardown (client + server + postgres).
+if [ "${1:-}" = "--stop" ]; then
+    log "Stopping client only (server + postgres stay up)..."
+    [ -f "$LOCAL_DIR/client.pid" ] && kill "$(cat "$LOCAL_DIR/client.pid")" 2>/dev/null || true
+    pkill -f "ng serve" 2>/dev/null || true
+    pkill -f "static-server.mjs" 2>/dev/null || true
+    rm -f "$LOCAL_DIR/client.pid"
+    ok "Client stopped. Server + postgres still running."
+    exit 0
+fi
+if [ "${1:-}" = "--stop-all" ]; then
+    log "Stopping client, server, postgres..."
+    [ -f "$LOCAL_DIR/client.pid" ] && kill "$(cat "$LOCAL_DIR/client.pid")" 2>/dev/null || true
+    [ -f "$LOCAL_DIR/server.pid" ] && kill "$(cat "$LOCAL_DIR/server.pid")" 2>/dev/null || true
+    pkill -f "ng serve" 2>/dev/null || true
+    pkill -f "static-server.mjs" 2>/dev/null || true
+    pkill -f "bootRun"  2>/dev/null || true
+    docker compose --env-file .env -f "$COMPOSE_FILE" down -v 2>/dev/null || true
+    rm -f "$LOCAL_DIR/server.pid" "$LOCAL_DIR/client.pid"
+    ok "All stopped."
+    exit 0
+fi
+
+# ----- 1. Node 24 via nvm ---------------------------------------------------
+log "Ensuring Node 24 is active..."
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+# shellcheck disable=SC1091
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+if command -v nvm >/dev/null 2>&1; then
+    nvm use 24 >/dev/null
+    ok "Node $(node -v)"
+else
+    warn "nvm not found — using system node $(node -v 2>/dev/null || echo 'NONE')"
+fi
+
+# ----- 2. Docker daemon -----------------------------------------------------
+log "Ensuring Docker is running..."
+if ! docker info >/dev/null 2>&1; then
+    warn "Docker not running — starting Docker Desktop..."
+    open -a Docker
+    for _ in $(seq 1 60); do
+        sleep 2
+        docker info >/dev/null 2>&1 && break
+    done
+    docker info >/dev/null 2>&1 || { err "Docker did not start in time"; exit 1; }
+fi
+ok "Docker ready"
+
+# ----- 3. Postgres ----------------------------------------------------------
+log "Ensuring Postgres is up..."
+if docker exec artemis-postgres pg_isready -U Artemis -d Artemis >/dev/null 2>&1; then
+    ok "Postgres already running"
+else
+    docker compose --env-file .env -f "$COMPOSE_FILE" up -d
+    for _ in $(seq 1 30); do
+        docker exec artemis-postgres pg_isready -U Artemis -d Artemis >/dev/null 2>&1 && break
+        sleep 2
+    done
+    docker exec artemis-postgres pg_isready -U Artemis -d Artemis >/dev/null 2>&1 \
+        || { err "Postgres failed to start"; exit 1; }
+    ok "Postgres ready"
+fi
+
+# ----- 4. Server on :8080 ---------------------------------------------------
+log "Ensuring server is up on :8080..."
+if curl -sf http://localhost:8080/management/health >/dev/null 2>&1; then
+    ok "Server already healthy"
+else
+    # Same env block as run-e2e-tests-local-fast.sh
+    export SPRING_PROFILES_ACTIVE="artemis,scheduling,localvc,localci,buildagent,core,dev"
+    export SPRING_DATASOURCE_URL="jdbc:postgresql://localhost:5432/Artemis?sslmode=disable"
+    export SPRING_DATASOURCE_USERNAME="Artemis"
+    export SPRING_DATASOURCE_PASSWORD=""
+    export SPRING_LIQUIBASE_CONTEXTS="dev,e2e"
+    export ARTEMIS_BCRYPTSALTROUNDS="4"
+    export ARTEMIS_USERMANAGEMENT_INTERNALADMIN_USERNAME="artemis_admin"
+    export ARTEMIS_USERMANAGEMENT_INTERNALADMIN_PASSWORD="artemis_admin"
+    export ARTEMIS_USERMANAGEMENT_USEEXTERNAL="false"
+    export ARTEMIS_VERSIONCONTROL_URL="http://localhost:8080"
+    export ARTEMIS_VERSIONCONTROL_USER="artemis_admin"
+    export ARTEMIS_VERSIONCONTROL_PASSWORD="artemis_admin"
+    export ARTEMIS_CONTINUOUSINTEGRATION_EMPTYCOMMITNECESSARY="true"
+    export ARTEMIS_CONTINUOUSINTEGRATION_ARTEMISAUTHENTICATIONTOKENVALUE="demo"
+    export ARTEMIS_CONTINUOUSINTEGRATION_BUILD_IMAGES_C_DEFAULT="ls1tum/artemis-c-minimal-docker:1.0.0"
+    if [ -S "$HOME/.docker/run/docker.sock" ]; then
+        export ARTEMIS_CONTINUOUSINTEGRATION_DOCKERCONNECTIONURI="unix://$HOME/.docker/run/docker.sock"
+    else
+        export ARTEMIS_CONTINUOUSINTEGRATION_DOCKERCONNECTIONURI="unix:///var/run/docker.sock"
+    fi
+    export ARTEMIS_GIT_NAME="artemis"
+    export ARTEMIS_GIT_EMAIL="artemis@example.com"
+    export ARTEMIS_VERSIONCONTROL_SSHHOSTKEYPATH="$REPO_ROOT/src/test/playwright/ssh-keys"
+    export ARTEMIS_VERSIONCONTROL_SSHPORT="7921"
+    export ARTEMIS_TELEMETRY_ENABLED="false"
+    export SERVER_URL="http://localhost:8080"
+    export EUREKA_CLIENT_ENABLED="false"
+    export INFO_TESTSERVER="true"
+    [ "$(uname -m)" = "arm64" ] && export ARTEMIS_CONTINUOUSINTEGRATION_IMAGEARCHITECTURE="arm64"
+
+    log "Starting server (bootRun)..."
+    nohup ./gradlew bootRun -x webapp > "$LOCAL_DIR/server.log" 2>&1 &
+    echo $! > "$LOCAL_DIR/server.pid"
+    log "Waiting for server (up to 5 min)..."
+    for _ in $(seq 1 60); do
+        sleep 5
+        curl -sf http://localhost:8080/management/health >/dev/null 2>&1 && break
+    done
+    curl -sf http://localhost:8080/management/health >/dev/null 2>&1 \
+        || { err "Server failed to become healthy. Tail: $LOCAL_DIR/server.log"; tail -30 "$LOCAL_DIR/server.log"; exit 1; }
+    ok "Server ready"
+fi
+
+# ----- 5. Client on :9000 ---------------------------------------------------
+log "Ensuring client is up on :9000..."
+if curl -sf http://127.0.0.1:9000 >/dev/null 2>&1; then
+    ok "Client already serving"
+elif [ "$STATIC_MODE" = true ]; then
+    if [ ! -f "build/resources/main/static/index.html" ]; then
+        if [ ! -d "node_modules" ]; then
+            log "Installing root npm deps (needed for webapp build)..."
+            npm install --no-audit --no-fund --silent
+        fi
+        log "No prebuilt bundle found — running npm run webapp:prod (one-time, ~3-5 min)..."
+        npm run webapp:prod
+    else
+        ok "Prebuilt bundle found at build/resources/main/static"
+    fi
+    log "Starting static server on :9000..."
+    nohup node "$LOCAL_DIR/static-server.mjs" > "$LOCAL_DIR/client.log" 2>&1 &
+    echo $! > "$LOCAL_DIR/client.pid"
+    for _ in $(seq 1 20); do
+        sleep 1
+        curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 && break
+    done
+    curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 \
+        || { err "Static server failed. Tail: $LOCAL_DIR/client.log"; tail -30 "$LOCAL_DIR/client.log"; exit 1; }
+    ok "Static server ready (starts in ~1s on subsequent runs)"
+else
+    log "Starting client (npm start)..."
+    nohup npm start > "$LOCAL_DIR/client.log" 2>&1 &
+    echo $! > "$LOCAL_DIR/client.pid"
+    log "Waiting for client (up to 3 min)..."
+    for _ in $(seq 1 60); do
+        sleep 3
+        curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 && break
+    done
+    curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 \
+        || { err "Client failed to start. Tail: $LOCAL_DIR/client.log"; tail -30 "$LOCAL_DIR/client.log"; exit 1; }
+    ok "Client ready"
+fi
+
+# ----- 6. ssh-keys symlink at repo root -------------------------------------
+log "Ensuring ssh-keys symlink at repo root..."
+if [ ! -e "ssh-keys" ]; then
+    ln -s src/test/playwright/ssh-keys ssh-keys
+    ok "Symlink created"
+else
+    ok "Symlink already in place"
+fi
+
+# ----- 7. playwright.env BASE_URL -> IPv4 -----------------------------------
+log "Ensuring playwright.env uses IPv4..."
+PW_ENV="src/test/playwright/playwright.env"
+DESIRED_BASE_URL="http://127.0.0.1:9000"
+if grep -q "^BASE_URL=$DESIRED_BASE_URL$" "$PW_ENV"; then
+    ok "BASE_URL already $DESIRED_BASE_URL"
+else
+    sed -i.bak "s|^BASE_URL=.*|BASE_URL=$DESIRED_BASE_URL|" "$PW_ENV" && rm -f "$PW_ENV.bak"
+    ok "BASE_URL set to $DESIRED_BASE_URL"
+fi
+
+# ----- 8. prepareVSCodeForE2ETests.sh (deps + config patch) -----------------
+log "Running prepareVSCodeForE2ETests.sh..."
+./supporting_scripts/playwright/prepareVSCodeForE2ETests.sh
+
+echo ""
+ok "Stack ready. Run tests via VS Code play button or 'npm --prefix src/test/playwright run playwright:test'."
+echo "  Logs: $LOCAL_DIR/server.log  |  $LOCAL_DIR/client.log"
+echo "  Stop everything: ./start-playwright-stack.sh --stop"

--- a/start-playwright-stack.sh
+++ b/start-playwright-stack.sh
@@ -14,7 +14,7 @@
 #   5. Ensures frontend is serving on :9000 (ng serve, or prebuilt static + proxy)
 #   6. Ensures ssh-keys symlink exists at repo root (for cwd-relative lookup)
 #   7. Runs prepareVSCodeForE2ETests.sh (installs deps + patches config)
-#   8. Ensures playwright.env BASE_URL uses IPv4 (127.0.0.1)
+#   8. Ensures playwright.env BASE_URL uses localhost
 #
 # Usage:
 #   ./start-playwright-stack.sh           # ng serve client (HMR, slow startup)
@@ -34,6 +34,8 @@ ok()   { echo -e "${GREEN}[stack]${NC} $*"; }
 warn() { echo -e "${YELLOW}[stack]${NC} $*"; }
 err()  { echo -e "${RED}[stack]${NC} $*"; }
 
+check_client() { curl -sf http://localhost:9000 >/dev/null 2>&1 || curl -sf http://127.0.0.1:9000 >/dev/null 2>&1; }
+
 cd "$(dirname "$0")"
 REPO_ROOT="$(pwd)"
 LOCAL_DIR=".e2e-local"
@@ -46,7 +48,9 @@ mkdir -p "$LOCAL_DIR"
 # --stop-all  : full teardown (client + server + postgres).
 if [ "${1:-}" = "--stop" ]; then
     log "Stopping client only (server + postgres stay up)..."
-    [ -f "$LOCAL_DIR/client.pid" ] && kill "$(cat "$LOCAL_DIR/client.pid")" 2>/dev/null || true
+    if [ -f "$LOCAL_DIR/client.pid" ]; then
+        kill "$(cat "$LOCAL_DIR/client.pid")" 2>/dev/null || true
+    fi
     pkill -f "ng serve" 2>/dev/null || true
     pkill -f "static-server.mjs" 2>/dev/null || true
     rm -f "$LOCAL_DIR/client.pid"
@@ -55,8 +59,12 @@ if [ "${1:-}" = "--stop" ]; then
 fi
 if [ "${1:-}" = "--stop-all" ]; then
     log "Stopping client, server, postgres..."
-    [ -f "$LOCAL_DIR/client.pid" ] && kill "$(cat "$LOCAL_DIR/client.pid")" 2>/dev/null || true
-    [ -f "$LOCAL_DIR/server.pid" ] && kill "$(cat "$LOCAL_DIR/server.pid")" 2>/dev/null || true
+    if [ -f "$LOCAL_DIR/client.pid" ]; then
+        kill "$(cat "$LOCAL_DIR/client.pid")" 2>/dev/null || true
+    fi
+    if [ -f "$LOCAL_DIR/server.pid" ]; then
+        kill "$(cat "$LOCAL_DIR/server.pid")" 2>/dev/null || true
+    fi
     pkill -f "ng serve" 2>/dev/null || true
     pkill -f "static-server.mjs" 2>/dev/null || true
     pkill -f "bootRun"  2>/dev/null || true
@@ -157,7 +165,7 @@ fi
 
 # ----- 5. Client on :9000 ---------------------------------------------------
 log "Ensuring client is up on :9000..."
-if curl -sf http://127.0.0.1:9000 >/dev/null 2>&1; then
+if check_client; then
     ok "Client already serving"
 elif [ "$STATIC_MODE" = true ]; then
     if [ ! -f "build/resources/main/static/index.html" ]; then
@@ -175,9 +183,9 @@ elif [ "$STATIC_MODE" = true ]; then
     echo $! > "$LOCAL_DIR/client.pid"
     for _ in $(seq 1 20); do
         sleep 1
-        curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 && break
+        check_client && break
     done
-    curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 \
+    check_client \
         || { err "Static server failed. Tail: $LOCAL_DIR/client.log"; tail -30 "$LOCAL_DIR/client.log"; exit 1; }
     ok "Static server ready (starts in ~1s on subsequent runs)"
 else
@@ -187,9 +195,9 @@ else
     log "Waiting for client (up to 3 min)..."
     for _ in $(seq 1 60); do
         sleep 3
-        curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 && break
+        check_client && break
     done
-    curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 \
+    check_client \
         || { err "Client failed to start. Tail: $LOCAL_DIR/client.log"; tail -30 "$LOCAL_DIR/client.log"; exit 1; }
     ok "Client ready"
 fi
@@ -203,10 +211,10 @@ else
     ok "Symlink already in place"
 fi
 
-# ----- 7. playwright.env BASE_URL -> IPv4 -----------------------------------
-log "Ensuring playwright.env uses IPv4..."
+# ----- 7. playwright.env BASE_URL -> localhost -----------------------------------
+log "Ensuring playwright.env uses localhost..."
 PW_ENV="src/test/playwright/playwright.env"
-DESIRED_BASE_URL="http://127.0.0.1:9000"
+DESIRED_BASE_URL="http://localhost:9000"
 if grep -q "^BASE_URL=$DESIRED_BASE_URL$" "$PW_ENV"; then
     ok "BASE_URL already $DESIRED_BASE_URL"
 else
@@ -221,4 +229,4 @@ log "Running prepareVSCodeForE2ETests.sh..."
 echo ""
 ok "Stack ready. Run tests via VS Code play button or 'npm --prefix src/test/playwright run playwright:test'."
 echo "  Logs: $LOCAL_DIR/server.log  |  $LOCAL_DIR/client.log"
-echo "  Stop everything: ./start-playwright-stack.sh --stop"
+echo "  Stop everything: ./start-playwright-stack.sh --stop-all"

--- a/start-playwright-stack.sh
+++ b/start-playwright-stack.sh
@@ -7,14 +7,14 @@
 # the playwright workspace itself. Idempotent — skips anything already running.
 #
 # What it does:
-#   1. Ensures Node 24 is active (via nvm)
-#   2. Ensures Docker daemon is running (starts Docker Desktop if not)
+#   1. Ensures Node (version from .nvmrc) is active (via nvm)
+#   2. Ensures Docker daemon is running (starts Docker Desktop on macOS if not)
 #   3. Ensures Postgres container is up (via e2e-local-fast-postgres.yml)
 #   4. Ensures Artemis server is running on :8080
 #   5. Ensures frontend is serving on :9000 (ng serve, or prebuilt static + proxy)
 #   6. Ensures ssh-keys symlink exists at repo root (for cwd-relative lookup)
-#   7. Runs prepareVSCodeForE2ETests.sh (installs deps + patches config)
-#   8. Ensures playwright.env BASE_URL uses localhost
+#   7. Ensures playwright.env BASE_URL uses localhost
+#   8. Runs prepareVSCodeForE2ETests.sh (installs deps + patches config)
 #
 # Usage:
 #   ./start-playwright-stack.sh           # ng serve client (HMR, slow startup)
@@ -25,8 +25,18 @@
 # =============================================================================
 
 set -e
-STATIC_MODE=false
-[ "${1:-}" = "--static" ] && STATIC_MODE=true
+
+case "${1:-}" in
+    ""|--)        STATIC_MODE=false ;;
+    --static)     STATIC_MODE=true ;;
+    --stop|--stop-all) ;; # handled below
+    *)
+        echo "Unknown option: ${1}"
+        echo "Usage: $0 [--static | --stop | --stop-all]"
+        exit 1
+        ;;
+esac
+STATIC_MODE="${STATIC_MODE:-false}"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
 log()  { echo -e "${BLUE}[stack]${NC} $*"; }
@@ -74,13 +84,13 @@ if [ "${1:-}" = "--stop-all" ]; then
     exit 0
 fi
 
-# ----- 1. Node 24 via nvm ---------------------------------------------------
-log "Ensuring Node 24 is active..."
+# ----- 1. Node (from .nvmrc) via nvm ----------------------------------------
+log "Ensuring correct Node version is active..."
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 # shellcheck disable=SC1091
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 if command -v nvm >/dev/null 2>&1; then
-    nvm use 24 >/dev/null
+    nvm use >/dev/null
     ok "Node $(node -v)"
 else
     warn "nvm not found — using system node $(node -v 2>/dev/null || echo 'NONE')"
@@ -89,13 +99,18 @@ fi
 # ----- 2. Docker daemon -----------------------------------------------------
 log "Ensuring Docker is running..."
 if ! docker info >/dev/null 2>&1; then
-    warn "Docker not running — starting Docker Desktop..."
-    open -a Docker
-    for _ in $(seq 1 60); do
-        sleep 2
-        docker info >/dev/null 2>&1 && break
-    done
-    docker info >/dev/null 2>&1 || { err "Docker did not start in time"; exit 1; }
+    if [ "$(uname)" = "Darwin" ]; then
+        warn "Docker not running — starting Docker Desktop..."
+        open -a Docker
+        for _ in $(seq 1 60); do
+            sleep 2
+            docker info >/dev/null 2>&1 && break
+        done
+        docker info >/dev/null 2>&1 || { err "Docker did not start in time"; exit 1; }
+    else
+        err "Docker is not running. Start Docker and re-run this script."
+        exit 1
+    fi
 fi
 ok "Docker ready"
 
@@ -169,17 +184,16 @@ if check_client; then
     ok "Client already serving"
 elif [ "$STATIC_MODE" = true ]; then
     if [ ! -f "build/resources/main/static/index.html" ]; then
-        if [ ! -d "node_modules" ]; then
-            log "Installing root npm deps (needed for webapp build)..."
-            npm install --no-audit --no-fund --silent
+        if command -v corepack >/dev/null 2>&1; then
+            corepack enable >/dev/null 2>&1 || true
         fi
-        log "No prebuilt bundle found — running npm run webapp:prod (one-time, ~3-5 min)..."
-        npm run webapp:prod
+        log "No prebuilt bundle found — running pnpm run webapp:prod (one-time, ~3-5 min)..."
+        pnpm run webapp:prod
     else
         ok "Prebuilt bundle found at build/resources/main/static"
     fi
     log "Starting static server on :9000..."
-    nohup node "$LOCAL_DIR/static-server.mjs" > "$LOCAL_DIR/client.log" 2>&1 &
+    nohup node "supporting_scripts/playwright/static-server.mjs" > "$LOCAL_DIR/client.log" 2>&1 &
     echo $! > "$LOCAL_DIR/client.pid"
     for _ in $(seq 1 20); do
         sleep 1
@@ -189,8 +203,8 @@ elif [ "$STATIC_MODE" = true ]; then
         || { err "Static server failed. Tail: $LOCAL_DIR/client.log"; tail -30 "$LOCAL_DIR/client.log"; exit 1; }
     ok "Static server ready (starts in ~1s on subsequent runs)"
 else
-    log "Starting client (npm start)..."
-    nohup npm start > "$LOCAL_DIR/client.log" 2>&1 &
+    log "Starting client (pnpm start)..."
+    nohup pnpm start > "$LOCAL_DIR/client.log" 2>&1 &
     echo $! > "$LOCAL_DIR/client.pid"
     log "Waiting for client (up to 3 min)..."
     for _ in $(seq 1 60); do
@@ -227,6 +241,6 @@ log "Running prepareVSCodeForE2ETests.sh..."
 ./supporting_scripts/playwright/prepareVSCodeForE2ETests.sh
 
 echo ""
-ok "Stack ready. Run tests via VS Code play button or 'npm --prefix src/test/playwright run playwright:test'."
+ok "Stack ready. Run tests via VS Code play button or 'pnpm --prefix src/test/playwright run playwright:test'."
 echo "  Logs: $LOCAL_DIR/server.log  |  $LOCAL_DIR/client.log"
 echo "  Stop everything: ./start-playwright-stack.sh --stop-all"

--- a/supporting_scripts/playwright/static-server.mjs
+++ b/supporting_scripts/playwright/static-server.mjs
@@ -1,13 +1,7 @@
-/**
- * Minimal static file server for the prebuilt Artemis Angular bundle.
- *
- * Serves build/resources/main/static/ on :9000, proxies all backend
- * API routes (matching proxy.conf.mjs) to localhost:8080, and upgrades
- * WebSocket connections to ws://127.0.0.1:8080.
- *
- * Requires no external dependencies — Node 22+ built-ins only.
- * Intended for use with start-playwright-stack.sh --static.
- */
+// Static file server for the prebuilt Artemis Angular bundle (--static mode).
+// Serves build/resources/main/static/ on :9000, proxies API routes to
+// localhost:8080, and upgrades WebSocket connections for /websocket/*.
+// No external dependencies — Node 22+ built-ins only.
 
 import { createServer } from 'node:http';
 import { createReadStream, existsSync, statSync } from 'node:fs';
@@ -30,21 +24,17 @@ const PROXY_PREFIXES = [
 
 const MIME = {
     '.html': 'text/html; charset=utf-8',
-    '.js': 'application/javascript',
-    '.mjs': 'application/javascript',
-    '.css': 'text/css',
+    '.js':   'application/javascript',
+    '.css':  'text/css',
     '.json': 'application/json',
-    '.png': 'image/png',
-    '.jpg': 'image/jpeg',
-    '.jpeg': 'image/jpeg',
-    '.svg': 'image/svg+xml',
-    '.ico': 'image/x-icon',
+    '.png':  'image/png',
+    '.jpg':  'image/jpeg',
+    '.svg':  'image/svg+xml',
+    '.ico':  'image/x-icon',
     '.woff': 'font/woff',
-    '.woff2': 'font/woff2',
-    '.ttf': 'font/ttf',
-    '.eot': 'application/vnd.ms-fontobject',
+    '.woff2':'font/woff2',
+    '.ttf':  'font/ttf',
     '.webp': 'image/webp',
-    '.txt': 'text/plain',
 };
 
 function shouldProxy(url) {
@@ -77,7 +67,6 @@ const server = createServer((req, res) => {
         return;
     }
 
-    // Static file serving with SPA fallback
     const fallbackPath = join(STATIC_DIR, 'index.html');
     let filePath = join(STATIC_DIR, url.pathname === '/' ? 'index.html' : url.pathname);
     if (!existsSync(filePath) || statSync(filePath).isDirectory()) {
@@ -89,13 +78,12 @@ const server = createServer((req, res) => {
         filePath = fallbackPath;
     }
 
-    const contentType = MIME[extname(filePath)] ?? 'application/octet-stream';
     const stream = createReadStream(filePath);
     stream.on('error', () => {
         if (!res.headersSent) res.writeHead(500);
         res.end('Internal Server Error');
     });
-    res.writeHead(200, { 'Content-Type': contentType });
+    res.writeHead(200, { 'Content-Type': MIME[extname(filePath)] ?? 'application/octet-stream' });
     stream.pipe(res, { end: true });
 });
 
@@ -106,9 +94,7 @@ server.on('upgrade', (req, socket, head) => {
         return;
     }
     const upstream = connect(BACKEND_PORT, BACKEND_HOST, () => {
-        const headers = Object.entries(req.headers)
-            .map(([k, v]) => `${k}: ${v}`)
-            .join('\r\n');
+        const headers = Object.entries(req.headers).map(([k, v]) => `${k}: ${v}`).join('\r\n');
         upstream.write(`${req.method} ${req.url} HTTP/1.1\r\n${headers}\r\n\r\n`);
         if (head.length) upstream.write(head);
     });
@@ -119,5 +105,5 @@ server.on('upgrade', (req, socket, head) => {
 });
 
 server.listen(PORT, () => {
-    console.log(`[static-server] ready at http://localhost:${PORT} → static: ${STATIC_DIR}, backend: ${BACKEND_HOST}:${BACKEND_PORT}`);
+    console.log(`[static-server] ready at http://localhost:${PORT}`);
 });

--- a/supporting_scripts/playwright/static-server.mjs
+++ b/supporting_scripts/playwright/static-server.mjs
@@ -48,7 +48,10 @@ const MIME = {
 };
 
 function shouldProxy(url) {
-    return PROXY_PREFIXES.some(p => url === p.replace(/\/$/, '') || url.startsWith(p));
+    return PROXY_PREFIXES.some(p => {
+        const prefix = p.replace(/\/$/, '');
+        return url === prefix || url.startsWith(prefix + '/');
+    });
 }
 
 const server = createServer((req, res) => {
@@ -75,14 +78,25 @@ const server = createServer((req, res) => {
     }
 
     // Static file serving with SPA fallback
+    const fallbackPath = join(STATIC_DIR, 'index.html');
     let filePath = join(STATIC_DIR, url.pathname === '/' ? 'index.html' : url.pathname);
     if (!existsSync(filePath) || statSync(filePath).isDirectory()) {
-        filePath = join(STATIC_DIR, 'index.html');
+        if (!existsSync(fallbackPath)) {
+            res.writeHead(500);
+            res.end('Internal Server Error: build not found — run pnpm run webapp:prod first');
+            return;
+        }
+        filePath = fallbackPath;
     }
 
     const contentType = MIME[extname(filePath)] ?? 'application/octet-stream';
+    const stream = createReadStream(filePath);
+    stream.on('error', () => {
+        if (!res.headersSent) res.writeHead(500);
+        res.end('Internal Server Error');
+    });
     res.writeHead(200, { 'Content-Type': contentType });
-    createReadStream(filePath).pipe(res, { end: true });
+    stream.pipe(res, { end: true });
 });
 
 // WebSocket proxy for /websocket/ paths

--- a/supporting_scripts/playwright/static-server.mjs
+++ b/supporting_scripts/playwright/static-server.mjs
@@ -1,0 +1,109 @@
+/**
+ * Minimal static file server for the prebuilt Artemis Angular bundle.
+ *
+ * Serves build/resources/main/static/ on :9000, proxies all backend
+ * API routes (matching proxy.conf.mjs) to localhost:8080, and upgrades
+ * WebSocket connections to ws://127.0.0.1:8080.
+ *
+ * Requires no external dependencies — Node 22+ built-ins only.
+ * Intended for use with start-playwright-stack.sh --static.
+ */
+
+import { createServer } from 'node:http';
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import { request as httpRequest } from 'node:http';
+import { connect } from 'node:net';
+
+const PORT = 9000;
+const BACKEND_HOST = 'localhost';
+const BACKEND_PORT = 8080;
+const STATIC_DIR = 'build/resources/main/static';
+
+// Keep in sync with proxy.conf.mjs
+const PROXY_PREFIXES = [
+    '/api/', '/services/', '/management', '/swagger-resources/',
+    '/v3/api-docs/', '/h2-console/', '/auth/', '/health/',
+    '/public/', '/.well-known/', '/webauthn/', '/login/webauthn',
+    '/saml2/', '/login/saml2/',
+];
+
+const MIME = {
+    '.html': 'text/html; charset=utf-8',
+    '.js': 'application/javascript',
+    '.mjs': 'application/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.svg': 'image/svg+xml',
+    '.ico': 'image/x-icon',
+    '.woff': 'font/woff',
+    '.woff2': 'font/woff2',
+    '.ttf': 'font/ttf',
+    '.eot': 'application/vnd.ms-fontobject',
+    '.webp': 'image/webp',
+    '.txt': 'text/plain',
+};
+
+function shouldProxy(url) {
+    return PROXY_PREFIXES.some(p => url === p.replace(/\/$/, '') || url.startsWith(p));
+}
+
+const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', `http://localhost:${PORT}`);
+
+    if (shouldProxy(url.pathname)) {
+        const options = {
+            hostname: BACKEND_HOST,
+            port: BACKEND_PORT,
+            path: req.url,
+            method: req.method,
+            headers: { ...req.headers, host: `${BACKEND_HOST}:${BACKEND_PORT}` },
+        };
+        const proxy = httpRequest(options, (backRes) => {
+            res.writeHead(backRes.statusCode ?? 502, backRes.headers);
+            backRes.pipe(res, { end: true });
+        });
+        proxy.on('error', () => {
+            if (!res.headersSent) res.writeHead(502);
+            res.end('Bad Gateway');
+        });
+        req.pipe(proxy, { end: true });
+        return;
+    }
+
+    // Static file serving with SPA fallback
+    let filePath = join(STATIC_DIR, url.pathname === '/' ? 'index.html' : url.pathname);
+    if (!existsSync(filePath) || statSync(filePath).isDirectory()) {
+        filePath = join(STATIC_DIR, 'index.html');
+    }
+
+    const contentType = MIME[extname(filePath)] ?? 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': contentType });
+    createReadStream(filePath).pipe(res, { end: true });
+});
+
+// WebSocket proxy for /websocket/ paths
+server.on('upgrade', (req, socket, head) => {
+    if (!(req.url ?? '').startsWith('/websocket/')) {
+        socket.destroy();
+        return;
+    }
+    const upstream = connect(BACKEND_PORT, BACKEND_HOST, () => {
+        const headers = Object.entries(req.headers)
+            .map(([k, v]) => `${k}: ${v}`)
+            .join('\r\n');
+        upstream.write(`${req.method} ${req.url} HTTP/1.1\r\n${headers}\r\n\r\n`);
+        if (head.length) upstream.write(head);
+    });
+    upstream.pipe(socket);
+    socket.pipe(upstream);
+    socket.on('error', () => upstream.destroy());
+    upstream.on('error', () => socket.destroy());
+});
+
+server.listen(PORT, () => {
+    console.log(`[static-server] ready at http://localhost:${PORT} → static: ${STATIC_DIR}, backend: ${BACKEND_HOST}:${BACKEND_PORT}`);
+});


### PR DESCRIPTION
### Summary
Truncates the flakiness score displayed in PR comments to an integer (using `Math.round()`), and adds `start-playwright-stack.sh` — a single-command script that provisions the full local Playwright stack (Postgres, Artemis server, Angular client) for E2E tests and VS Code Playwright extension usage.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
The flakiness score returned by the Helios API is a float (e.g. `73.4567891234`). Displaying it with full precision in the PR comment table adds noise without value. Rounding to an integer makes the table easier to read at a glance.

The `start-playwright-stack.sh` script reduces local E2E setup from four manual steps (start Postgres, start server, start client, configure Playwright) to a single command, and integrates with the VS Code Playwright extension so tests can be run directly from the editor.

### Description
- `.github/scripts/fetch-flakiness.js`: changed `${r.flakinessScore}%` to `${Math.round(r.flakinessScore)}%` in `buildFlakinessTable`.
- `start-playwright-stack.sh`: new script at repo root. Supports `--static` (serve prebuilt bundle instead of `ng serve`) and `--stop` / `--stop-all` flags. Idempotent — skips services that are already running.

### Steps for Testing
Prerequisites:
- A pull request that triggers the E2E pipeline and has at least one failing test with a Helios flakiness score

1. Trigger an E2E pipeline run on a PR with a known flaky failing test
2. Check the generated PR comment — the flakiness score should appear as a rounded integer (e.g. `73%`) instead of a float
3. Clone the repo and run `./start-playwright-stack.sh` from the repo root
4. Verify that Postgres, the Artemis server, and the Angular client start up and that the VS Code Playwright extension can discover and run tests

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list).

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Test flakiness scores now display rounded whole-percent values in reports for clearer interpretation.
  * Added a single entrypoint to start/stop a local E2E stack with robust readiness checks, process management, automated environment/setup steps, and consolidated logs for easier local testing.
  * Added a lightweight local static server for prebuilt frontend bundles with SPA fallback, backend proxying (including WebSocket support), MIME handling, and improved error responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Artemis/pull/12723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->