### PR TITLE
`Development`: Switch the client run configuration from npm to pnpm

### DIFF
--- a/.idea/runConfigurations/Artemis__Client_.xml
+++ b/.idea/runConfigurations/Artemis__Client_.xml
@@ -3,13 +3,14 @@
     <package-json value="$PROJECT_DIR$/package.json" />
     <command value="start" />
     <node-interpreter value="project" />
-    <package-manager value="npm" />
+    <package-manager value="pnpm" />
     <envs />
     <method v="2">
       <option name="NpmBeforeRunTask" enabled="true">
         <package-json value="$PROJECT_DIR$/package.json" />
         <command value="install" />
         <node-interpreter value="project" />
+        <package-manager value="pnpm" />
         <envs />
       </option>
     </method>


### PR DESCRIPTION
### Summary

The "Artemis (Client)" IntelliJ run configuration was set to use npm, so running it
kicked off `npm install` and failed with an `ERESOLVE` error. Since Artemis is a pnpm
project, this just switches the run configuration over to pnpm.

### Checklist

#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

`package.json` pins pnpm via the `packageManager` field, but the bundled run
configuration still used npm. npm is strict about peer dependencies and can't read
pnpm's `node_modules`, so launching the client through the IDE fails before it even
starts. That's a bad first experience for anyone with a fresh checkout.

### Description

Updated `.idea/runConfigurations/Artemis__Client_.xml` to use pnpm — both for the
`start` command and for the before-run `install` task. Nothing else changed.

### Steps for Testing

Prerequisites:

1. Check out this branch and open the project in IntelliJ.
2. Run the "Artemis (Client)" run configuration.
3. Confirm the before-run step runs `pnpm install` and finishes without an `ERESOLVE` error.
4. Confirm the Angular dev server starts and the client loads.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [x] The "Artemis (Client)" run configuration starts the client without an `ERESOLVE` error.