### PR TITLE
`Communication`: Fix the form alignment and backdrop

### DIFF
--- a/src/main/webapp/app/communication/metis.component.scss
+++ b/src/main/webapp/app/communication/metis.component.scss
@@ -129,6 +129,7 @@ $delete-delay-duration: 6s;
         width: 100%;
     }
 }
+
 .modal {
     position: fixed !important;
     top: 0 !important;

--- a/src/main/webapp/app/communication/metis.component.scss
+++ b/src/main/webapp/app/communication/metis.component.scss
@@ -161,5 +161,6 @@ $delete-delay-duration: 6s;
     left: 0 !important;
     width: 100% !important;
     height: 100% !important;
-    background-color: rgba(0, 0, 0, 0.5) !important;
+    background-color: var(--bs-backdrop-bg, #000) !important;
+    opacity: var(--bs-backdrop-opacity, 0.5) !important;
 }

--- a/src/main/webapp/app/communication/metis.component.scss
+++ b/src/main/webapp/app/communication/metis.component.scss
@@ -131,19 +131,20 @@ $delete-delay-duration: 6s;
 }
 
 .modal {
-    position: fixed !important;
-    top: 0 !important;
-    left: 0 !important;
-    width: 100% !important;
-    height: 100% !important;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
     display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-    overflow: hidden !important;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    z-index: 1055;
 }
 
 .modal-dialog {
-    margin: 0 !important;
+    margin: 0;
     width: 100%;
     max-width: 800px;
     max-height: 90vh;
@@ -157,11 +158,12 @@ $delete-delay-duration: 6s;
 }
 
 .modal-backdrop {
-    position: fixed !important;
-    top: 0 !important;
-    left: 0 !important;
-    width: 100% !important;
-    height: 100% !important;
-    background-color: var(--bs-backdrop-bg, #000) !important;
-    opacity: var(--bs-backdrop-opacity, 0.5) !important;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: var(--bs-backdrop-bg, #000);
+    opacity: var(--bs-backdrop-opacity, 0.5);
+    z-index: 1055;
 }

--- a/src/main/webapp/app/communication/metis.component.scss
+++ b/src/main/webapp/app/communication/metis.component.scss
@@ -130,7 +130,7 @@ $delete-delay-duration: 6s;
     }
 }
 
-.modal {
+.post-create-edit-modal {
     position: fixed;
     top: 0;
     left: 0;
@@ -147,7 +147,6 @@ $delete-delay-duration: 6s;
     margin: 0;
     width: 100%;
     max-width: $modal-lg;
-    max-height: 90vh;
     display: flex;
     flex-direction: column;
 }
@@ -163,7 +162,6 @@ $delete-delay-duration: 6s;
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: var(--bs-backdrop-bg, #000);
     opacity: var(--bs-backdrop-opacity, 0.5);
     z-index: $zindex-modal-backdrop;
 }

--- a/src/main/webapp/app/communication/metis.component.scss
+++ b/src/main/webapp/app/communication/metis.component.scss
@@ -140,13 +140,13 @@ $delete-delay-duration: 6s;
     align-items: center;
     justify-content: center;
     overflow: hidden;
-    z-index: 1055;
+    z-index: $zindex-modal;
 }
 
 .modal-dialog {
     margin: 0;
     width: 100%;
-    max-width: 800px;
+    max-width: $modal-lg;
     max-height: 90vh;
     display: flex;
     flex-direction: column;
@@ -165,5 +165,5 @@ $delete-delay-duration: 6s;
     height: 100%;
     background-color: var(--bs-backdrop-bg, #000);
     opacity: var(--bs-backdrop-opacity, 0.5);
-    z-index: 1055;
+    z-index: $zindex-modal-backdrop;
 }

--- a/src/main/webapp/app/communication/metis.component.scss
+++ b/src/main/webapp/app/communication/metis.component.scss
@@ -130,14 +130,11 @@ $delete-delay-duration: 6s;
     }
 }
 .modal {
-    // take all available place
     position: fixed !important;
     top: 0 !important;
     left: 0 !important;
     width: 100% !important;
     height: 100% !important;
-
-    // center the form
     display: flex !important;
     align-items: center !important;
     justify-content: center !important;
@@ -154,7 +151,6 @@ $delete-delay-duration: 6s;
 }
 
 .modal-content {
-    // add scroll for big content
     max-height: 90vh;
     overflow-y: auto;
 }

--- a/src/main/webapp/app/communication/metis.component.scss
+++ b/src/main/webapp/app/communication/metis.component.scss
@@ -129,3 +129,41 @@ $delete-delay-duration: 6s;
         width: 100%;
     }
 }
+.modal {
+    // take all available place
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+
+    // center the form
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    overflow: hidden !important;
+}
+
+.modal-dialog {
+    margin: 0 !important;
+    width: 100%;
+    max-width: 800px;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.modal-content {
+    // add scroll for big content
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
+.modal-backdrop {
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    background-color: rgba(0, 0, 0, 0.5) !important;
+}

--- a/src/main/webapp/app/communication/metis.component.scss
+++ b/src/main/webapp/app/communication/metis.component.scss
@@ -155,6 +155,7 @@ $delete-delay-duration: 6s;
     max-height: 90vh;
     overflow-y: auto;
 }
+
 .post-create-edit-modal-backdrop {
     position: fixed;
     top: 0;

--- a/src/main/webapp/app/communication/metis.component.scss
+++ b/src/main/webapp/app/communication/metis.component.scss
@@ -143,7 +143,7 @@ $delete-delay-duration: 6s;
     z-index: $zindex-modal;
 }
 
-.modal-dialog {
+.post-create-edit-modal-dialog {
     margin: 0;
     width: 100%;
     max-width: $modal-lg;
@@ -151,12 +151,11 @@ $delete-delay-duration: 6s;
     flex-direction: column;
 }
 
-.modal-content {
+.post-create-edit-modal-content {
     max-height: 90vh;
     overflow-y: auto;
 }
-
-.modal-backdrop {
+.post-create-edit-modal-backdrop {
     position: fixed;
     top: 0;
     left: 0;

--- a/src/main/webapp/app/communication/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.html
+++ b/src/main/webapp/app/communication/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.html
@@ -1,8 +1,8 @@
 @if (isDialogVisible()) {
-    <div class="modal-backdrop" (click)="close()"></div>
+    <div class="modal-backdrop post-create-edit-modal-backdrop" (click)="close()"></div>
     <div class="modal d-block post-create-edit-modal" tabindex="-1" (keydown.escape)="close()">
-        <div class="modal-dialog modal-lg">
-            <div class="modal-content">
+        <div class="modal-dialog post-create-edit-modal-dialog modal-lg">
+            <div class="modal-content post-create-edit-modal-content">
                 <form [formGroup]="formGroup" (ngSubmit)="confirm()">
                     <div class="modal-header">
                         <h4 class="modal-title">{{ modalTitle | artemisTranslate }}</h4>

--- a/src/main/webapp/app/communication/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.html
+++ b/src/main/webapp/app/communication/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.html
@@ -1,6 +1,6 @@
 @if (isDialogVisible()) {
     <div class="modal-backdrop" (click)="close()"></div>
-    <div class="modal d-block" tabindex="-1" (keydown.escape)="close()">
+    <div class="modal d-block post-create-edit-modal" tabindex="-1" (keydown.escape)="close()">
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <form [formGroup]="formGroup" (ngSubmit)="confirm()">

--- a/src/main/webapp/app/core/admin/system-notification-management/parse-links.service.spec.ts
+++ b/src/main/webapp/app/core/admin/system-notification-management/parse-links.service.spec.ts
@@ -56,7 +56,8 @@ describe('ParseLinks Service', () => {
             '<https://localhost/api/communication/system-notifications' +
                 '?sort=notificationDate,desc&sort=id&page=0&size=50>; rel="last",' +
                 '<https://localhost/api/communication/system-notifications' +
-                '?sort=notificationDate,desc&sort=id&page=1&size=50>; rel="first"');
+                '?sort=notificationDate,desc&sort=id&page=1&size=50>; rel="first"',
+        );
         expect(parsedLinks).toEqual(expectedLinks);
     });
     // Precaution for cases where matrix parameters are used
@@ -66,7 +67,8 @@ describe('ParseLinks Service', () => {
             '<https://localhost/api/communication' +
                 ';a=b/system-notifications?sort=notificationDate,desc&sort=id&page=0&size=50>; rel="last",' +
                 '<https://localhost/api/communication/system-notifications' +
-                '?sort=notificationDate,desc&sort=id&page=1&size=50>; rel="first"');
+                '?sort=notificationDate,desc&sort=id&page=1&size=50>; rel="first"',
+        );
         expect(parsedLinks).toEqual(expectedLinks);
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 
This PR fixes the [issue #12738](https://github.com/ls1intum/Artemis/issues/12738)
Now when pressing the Communication > Announcements on the `New Announcement` button, there is no black background and Announcement form is centered

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [X] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [X] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [X] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [X] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [X] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [X] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes the [issue #12738](https://github.com/ls1intum/Artemis/issues/12738)

### Description
<!-- Describe your changes in detail -->
This PR fixes a rendering error which occurred by creation of new announcement in `Communication` page. Now if user clicks on `New announcement` button, the suitable backdrop is displayed instead of black screen and the `Create announcement` form is centered on screen.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course
3. Navigate to the `Communication` tab
4. Click on `General`
5. Click on `announcement`
6. Click on `New announcement` button
7. Check that backdrop and announcement form are displayed correctly

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

<img width="1280" height="800" alt="IMAGE 2026-05-19 13:36:41" src="https://github.com/user-attachments/assets/988062e8-416f-448b-9f19-b86516e5a990" />

<img width="1280" height="807" alt="IMAGE 2026-05-19 13:37:13" src="https://github.com/user-attachments/assets/49612d0e-0788-4728-9aa7-9e11396a1ba8" />


<img width="2812" height="1856" alt="fixed_announcement" src="https://github.com/user-attachments/assets/5e0e094f-f4b3-4efa-8bce-80ac9f099681" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved modal styling and behavior for a consistent, centered full-viewport presentation: dialog width capped, content constrained to viewport height and scrollable when needed, a full-screen themed backdrop honoring design tokens for background and opacity, and modals now adopt the new presentation class for these refinements.

* **Tests**
  * Adjusted unit test formatting for pagination link parsing to improve readability without changing expected behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Artemis/pull/12747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->