### PR TITLE
`Quiz exercises`: Fix missing submit button when starting practice mode

### DIFF
--- a/src/main/webapp/app/core/course/overview/exercise-details/exercise-split-panel/exercise-split-panel.component.ts
+++ b/src/main/webapp/app/core/course/overview/exercise-details/exercise-split-panel/exercise-split-panel.component.ts
@@ -65,9 +65,10 @@ export class ExerciseSplitPanelComponent {
     private readonly router = inject(Router);
     private readonly route = inject(ActivatedRoute);
     private readonly childrenOutletContexts = inject(ChildrenOutletContexts);
-    // Tracks whether a quiz batch is started from the server-provided exercise data.
+    // Tracks whether a quiz batch is started / the quiz has ended, from the server-provided exercise data.
     // Updated via effect (safe for required inputs) rather than computed (would throw NG0950 during early init).
     private readonly _quizBatchStarted = signal(false);
+    private readonly _quizEnded = signal(false);
     private readonly _quizHasStarted = signal(false);
     private readonly _quizComponent = signal<QuizParticipationComponent | undefined>(undefined);
     private quizStartedSubscription: { unsubscribe(): void } | undefined;
@@ -176,13 +177,14 @@ export class ExerciseSplitPanelComponent {
     });
 
     constructor() {
-        // Keep _quizBatchStarted in sync with the exercise input.
+        // Keep _quizBatchStarted / _quizEnded in sync with the exercise input.
         // Effects (unlike computed signals) do not throw NG0950 when reading required inputs,
         // so this is safe even during the initial evaluation before inputs are fully bound.
         effect(() => {
             const exercise = this.exercise();
-            const started = exercise.type === ExerciseType.QUIZ ? ((exercise as QuizExercise).quizBatches?.some((b) => b.started) ?? false) : false;
-            this._quizBatchStarted.set(started);
+            const isQuiz = exercise.type === ExerciseType.QUIZ;
+            this._quizBatchStarted.set(isQuiz ? ((exercise as QuizExercise).quizBatches?.some((b) => b.started) ?? false) : false);
+            this._quizEnded.set(isQuiz ? ((exercise as QuizExercise).quizEnded ?? false) : false);
         });
         effect(() => {
             const exercise = this.exercise();
@@ -226,6 +228,12 @@ export class ExerciseSplitPanelComponent {
         const quizBatchStarted = this._quizBatchStarted();
         const quizHasStarted = this._quizHasStarted();
 
+        // Practice mode on an ended quiz: submittable even before a participation exists.
+        // Checked before the guard below, which would short-circuit to false without one.
+        if (this.participationMode() === 'practice' && this._quizEnded()) {
+            return true;
+        }
+
         // Guard: prevents accessing exercise() before inputs are bound (NG0950).
         // During early init all three are falsy; the effect will update _quizBatchStarted
         // once exercise is set, causing this computed to re-evaluate.
@@ -236,7 +244,7 @@ export class ExerciseSplitPanelComponent {
         const type = this.exercise().type;
         if (type === ExerciseType.QUIZ) {
             // Quiz manages participation internally; check if a batch is started or the student triggered start
-            return quizBatchStarted || quizHasStarted || (this.participationMode() === 'practice' && ((this.exercise() as QuizExercise).quizEnded ?? false));
+            return quizBatchStarted || quizHasStarted;
         }
         if (!studentParticipation) return false;
         if (type === ExerciseType.PROGRAMMING) {


### PR DESCRIPTION
### Summary

If a student starts the practice mode of an ended quiz without having a graded participation, the submit button doesn't show up until the page is reloaded. This PR makes the button appear right away.

### Checklist

#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

The submit button only shows when `canSubmit()` in `ExerciseSplitPanelComponent` returns true. That method had an early guard that bails out with `false` when the student has no participation yet, which is exactly the case here, so the practice-mode check below it never ran. Reloading seemed to fix it only because by then a practice participation existed
on the server, which let the code get past the guard.

### Description

In `exercise-split-panel.component.ts`, the practice-mode check now runs before that guard. It uses a new `_quizEnded` signal so it can safely read whether the quiz has ended without touching the exercise input too early.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Student (must **not** have a graded participation in the quiz)
- 1 Quiz Exercise that has ended and is open for practice

1. Log in as the student who never participated in the quiz.
2. Open the quiz exercise and click **Start practice**.
3. Confirm the **Submit** button appears immediately, without reloading.
4. Repeat as a student who **does** have a graded participation and confirm nothing changed for them.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [x] Manual Test 1
- [x] Manual Test 2

### Screenshots

<!-- Add before/after screenshots: submit button missing on practice start vs. shown immediately. -->

#### Before (missing submit button):

https://github.com/user-attachments/assets/c97c1af5-0cf8-4c37-8062-0acae5d01cac

#### After:

https://github.com/user-attachments/assets/8d026892-f73f-4972-8313-4259a505b8e8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quiz submission handling by refining state tracking for quiz start and completion status.
  * Fixed practice mode quiz behavior to allow submissions immediately when a quiz ends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Artemis/pull/12748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->