### PR TITLE
`Development`: Load translations earlier to fix raw keys on first render

### DIFF
--- a/src/main/webapp/app/app.config.ts
+++ b/src/main/webapp/app/app.config.ts
@@ -113,7 +113,14 @@ export const appConfig: ApplicationConfig = {
             // AppComponent rendering on the HTTP load instead of racing against it.
             translateService.setFallbackLang('en');
             const languageKey: string = sessionStorageService.retrieve('locale') || languageHelper.determinePreferredLanguage();
-            const translationsLoaded = lastValueFrom(translateService.use(languageKey));
+            // The .catch is load-bearing: Promise.all below short-circuits on the first rejection,
+            // and a flaky i18n endpoint must degrade gracefully (missing-key placeholders, same as
+            // the previous fire-and-forget behavior) rather than block the SPA from booting at all.
+            const translationsLoaded = lastValueFrom(translateService.use(languageKey)).catch((error) => {
+                // eslint-disable-next-line no-undef
+                console.warn('Translation load failed during app initialization', error);
+                return undefined;
+            });
             // Load profile info, resolve user identity, and fetch translations in parallel to minimize startup time.
             // Profile info is required for all components; identity resolution avoids a sequential HTTP call in route guards.
             return Promise.all([profileService.loadProfileInfo(), completeSaml2.then(() => accountService.identity().catch(() => undefined)), translationsLoaded]).then(

--- a/src/main/webapp/app/app.config.ts
+++ b/src/main/webapp/app/app.config.ts
@@ -25,6 +25,9 @@ import { NotificationInterceptor } from 'app/core/interceptor/notification.inter
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { AccountService } from 'app/core/auth/account.service';
 import { AuthServerProvider } from 'app/core/auth/auth-jwt.service';
+import { TranslateService } from '@ngx-translate/core';
+import { JhiLanguageHelper } from 'app/core/language/shared/language.helper';
+import { SessionStorageService } from 'app/shared/service/session-storage.service';
 import { lastValueFrom } from 'rxjs';
 import { SentryErrorHandler } from 'app/core/sentry/sentry.error-handler';
 import { OwlNativeDateTimeModule } from '@danielmoncada/angular-datetime-picker';
@@ -74,6 +77,9 @@ export const appConfig: ApplicationConfig = {
             const profileService = inject(ProfileService);
             const accountService = inject(AccountService);
             const authServerProvider = inject(AuthServerProvider);
+            const translateService = inject(TranslateService);
+            const sessionStorageService = inject(SessionStorageService);
+            const languageHelper = inject(JhiLanguageHelper);
             inject(TraceService);
             // Ensure the service is initialized before any routing happens
             inject(ArtemisNavigationUtilService);
@@ -100,9 +106,19 @@ export const appConfig: ApplicationConfig = {
                           document.cookie = 'SAML2flow=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Lax;';
                       })
                 : Promise.resolve();
-            // Load profile info and resolve user identity in parallel to minimize startup time.
+            // Block bootstrap on translation loading so the first render never shows raw
+            // `translation-not-found[...]` keys. `artemisTranslate` and `translate` pipes
+            // resolve synchronously via `instant()`, which falls back to the missing handler
+            // until the i18n JSON is in the store. Doing this in APP_INITIALIZER gates
+            // AppComponent rendering on the HTTP load instead of racing against it.
+            translateService.setFallbackLang('en');
+            const languageKey: string = sessionStorageService.retrieve('locale') || languageHelper.determinePreferredLanguage();
+            const translationsLoaded = lastValueFrom(translateService.use(languageKey));
+            // Load profile info, resolve user identity, and fetch translations in parallel to minimize startup time.
             // Profile info is required for all components; identity resolution avoids a sequential HTTP call in route guards.
-            return Promise.all([profileService.loadProfileInfo(), completeSaml2.then(() => accountService.identity().catch(() => undefined))]).then(() => undefined);
+            return Promise.all([profileService.loadProfileInfo(), completeSaml2.then(() => accountService.identity().catch(() => undefined)), translationsLoaded]).then(
+                () => undefined,
+            );
         }),
         /**
          * @description Interceptor declarations:

--- a/src/main/webapp/app/app.main.ts
+++ b/src/main/webapp/app/app.main.ts
@@ -3,15 +3,12 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from 'app/app.config';
 import { MonacoConfig } from 'app/core/config/monaco.config';
 import { ProdConfig } from 'app/core/config/prod.config';
-import { JhiLanguageHelper } from 'app/core/language/shared/language.helper';
-import { SessionStorageService } from 'app/shared/service/session-storage.service';
 import { AppComponent } from './app.component';
 import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { registerLocaleData } from '@angular/common';
 import locale from '@angular/common/locales/en';
 import dayjs from 'dayjs/esm';
 import { NgbDatepickerConfig, NgbTooltipConfig } from '@ng-bootstrap/ng-bootstrap';
-import { TranslateService } from '@ngx-translate/core';
 import { artemisIconPack } from 'app/shared/icons/icons';
 
 ProdConfig();
@@ -24,17 +21,11 @@ bootstrapApplication(AppComponent, appConfig)
         library.addIconPacks(artemisIconPack);
         const dpConfig = app.injector.get(NgbDatepickerConfig);
         const tooltipConfig = app.injector.get(NgbTooltipConfig);
-        const translateService = app.injector.get(TranslateService);
-        const languageHelper = app.injector.get(JhiLanguageHelper);
-        const sessionStorageService = app.injector.get(SessionStorageService);
         const breakpointObserver = app.injector.get(BreakpointObserver);
 
         // Perform initialization logic
         registerLocaleData(locale);
         dpConfig.minDate = { year: dayjs().subtract(100, 'year').year(), month: 1, day: 1 };
-        translateService.setFallbackLang('en');
-        const languageKey: string = sessionStorageService.retrieve('locale') || languageHelper.determinePreferredLanguage();
-        translateService.use(languageKey);
         tooltipConfig.container = 'body';
 
         tooltipConfig.disableTooltip = breakpointObserver.isMatched(Breakpoints.Handset);


### PR DESCRIPTION
### Summary
Move language selection and `translateService.use(...)` into `provideAppInitializer` so Angular bootstrap blocks on the i18n JSON HTTP load. The first render then always sees a populated translation store, so the `artemisTranslate` pipe stops emitting `translation-not-found[...]` placeholders on hard reloads.

### Motivation and Context
Fixes #12740.

Previously, `translateService.use(languageKey)` ran inside `bootstrapApplication().then(...)` in `app.main.ts` — i.e. **after** Angular had completed bootstrap and started rendering. `ArtemisTranslatePipe` and the built-in `translate` pipe both resolve synchronously via `TranslateService.instant()`, which falls back to `MissingTranslationHandlerImpl` (returning `translation-not-found[<key>]`) until the translation store is populated. On a hard reload (empty cache) the i18n JSON download easily lost the race against the first render — especially visible on the landing page and the global search modal opened via `Ctrl/Cmd+K`.

PR #12663 tried to fix this by adding `defaultLanguage: 'en'` (later `fallbackLang: 'en'`) to `provideTranslateService(...)`. That triggered the HTTP fetch earlier during DI initialization but did not *await* it before bootstrap, so the race was narrowed but not eliminated — which matches the issue note that "the fix did not work".

### Description
- `src/main/webapp/app/app.config.ts`:
  - Inject `TranslateService`, `SessionStorageService`, and `JhiLanguageHelper` inside `provideAppInitializer`.
  - Call `translateService.setFallbackLang('en')` and `translateService.use(languageKey)` there.
  - Add the resulting `lastValueFrom(translateService.use(...))` promise to the `Promise.all` gate alongside profile/identity loading so bootstrap is blocked until the translation JSON is downloaded and stored.
- `src/main/webapp/app/app.main.ts`:
  - Remove the now-redundant `translateService.setFallbackLang` / `translateService.use` block and the related imports.

The HTTP fetch still happens in parallel with `loadProfileInfo()` and `accountService.identity()`, so the practical impact on time-to-interactive should be small — the i18n payload is one HTTP request (`i18n/<lang>.json?_=<hash>`, ~600 KB compressed by the server) and overlaps with the existing initializer work.

### Steps for Testing
Prerequisites:
- Any logged-in user on a deployment (or local `pnpm start`).

1. Open Artemis in Chrome.
2. Hard reload (`Cmd+Shift+R` / `Ctrl+Shift+R`) so the browser cache is empty.
3. Immediately after the page renders, press `Cmd+K` / `Ctrl+K` to open the global search modal.
4. Confirm every entry shows the translated string (e.g. "Ask Iris AI", "Lecture Search", "Exercises") and no `translation-not-found[...]` placeholders appear.
5. Repeat the hard reload a few times to rule out the original race.
6. Reload onto the landing page and confirm no raw keys flash on first paint.
7. Switch the UI language via the navbar and confirm runtime language switching still works.
8. Network tab: confirm `i18n/en.json?_=<hash>` (and the active language's file) loads during bootstrap and is in the store before AppComponent renders.

### Screenshots
N/A — the visible change is the *absence* of `translation-not-found[...]` flashes after a hard reload (see screenshots in #12740 for the regression this fixes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Translations now load during startup before the interface renders, ensuring your preferred language displays immediately.
  * The app sets English as a fallback and restores the last-selected locale from session storage or your preferred language.
  * Startup initializes translations in parallel with profile loading and any optional SAML2 step for faster, more reliable boot.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Artemis/pull/12753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->