### PR TITLE
`Development`: Add Docker readiness and liveness probes

### DIFF
--- a/docker/artemis.yml
+++ b/docker/artemis.yml
@@ -24,7 +24,7 @@ services:
         # as stated in the docker compose docs (at least not when this was committed)
         # https://docs.docker.com/compose/compose-file/#finding-referenced-service
         healthcheck:
-            test: wget -nv -t1 --spider http://localhost:8080/management/health || exit 1
+            test: wget -q -t1 -T5 -O - http://localhost:8080/management/health/readiness | grep -xq '{"status":"UP"}' || exit 1
             start_period: 600s
             interval: 1s
         # expose the port to make it reachable docker internally even if the external port mapping changes

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
@@ -289,7 +289,7 @@ public class SecurityConfiguration {
                     .requestMatchers("/manifest.webapp", "/robots.txt").permitAll()
                     .requestMatchers("/content/**", "/i18n/*.json", "/logo/*", "/webjars/katex/**").permitAll()
                     // Information and health endpoints do not need authentication
-                    .requestMatchers("/management/info", "/management/health").permitAll()
+                    .requestMatchers("/management/info", "/management/health", "/management/health/readiness", "/management/health/liveness").permitAll()
                     // Admin area requires specific authority.
                     .requestMatchers("/api/*/admin/**").hasAuthority(Role.ADMIN.getAuthority())
                     // Publicly accessible API endpoints (allowed for everyone, potentially with secret authentication).

--- a/src/main/resources/config/application-buildagent.yml
+++ b/src/main/resources/config/application-buildagent.yml
@@ -135,8 +135,8 @@ management:
     endpoint:
         health:
             show-details: never
-        probes:
-            enabled: false
+            probes:
+                enabled: true
         artemismetrics:
             access: none
     metrics:


### PR DESCRIPTION
### Summary
Adds proper Docker/Kubernetes readiness and liveness health probe support so that container orchestrators can reliably determine when Artemis is ready to serve traffic.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api#authorization) and checked the course groups for all new REST Calls (security).

### Motivation and Context
Docker and Kubernetes orchestrators use readiness and liveness probes to determine when a container is healthy. Previously the Docker healthcheck only tested whether the `/management/health` endpoint was reachable, not whether the response confirmed the application was actually up. Additionally, readiness/liveness endpoints were blocked by Spring Security and probes were disabled in the buildagent profile.

### Description
Three changes:
1. **`docker/artemis.yml`** – Updated the healthcheck command to parse the actual JSON response body and assert `{"status":"UP"}`, using the dedicated `/management/health/readiness` endpoint.
2. **`SecurityConfiguration.java`** – Added `/management/health/readiness` and `/management/health/liveness` to the `permitAll` list so probes can reach these endpoints without authentication.
3. **`application-buildagent.yml`** – Fixed the indentation of `probes.enabled` (it was incorrectly at the `endpoint` level instead of under `health`) and enabled it so the buildagent also exposes readiness/liveness endpoints.

### Steps for Testing
Prerequisites:
- Docker or Kubernetes environment

1. Build and start Artemis via Docker Compose using `docker/artemis.yml`.
2. Verify the healthcheck correctly reports the container as healthy once the app is up.
3. Confirm that `GET /management/health/readiness` and `GET /management/health/liveness` return HTTP 200 without authentication.
4. Confirm that `GET /management/health/readiness` returns `{"status":"UP"}` once the app is ready.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Performance Review
- [x] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Coverage table could not be generated. The `Test` workflow concluded with status `success`; coverage artifacts may be missing or incomplete. See [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/26236551003).

_Last updated: 2026-05-21 16:26:44 UTC_

