### PR TITLE
`General`: Align course management card buttons with refreshed course overview styling

### DIFF
--- a/src/main/webapp/app/core/course/manage/overview/course-management-card.component.html
+++ b/src/main/webapp/app/core/course/manage/overview/course-management-card.component.html
@@ -333,7 +333,7 @@
                 [routerLink]="['/course-management', course().id, 'course-statistics']"
                 class="btn btn-info hidden-if-mobile"
                 [ngbTooltip]="'artemisApp.courseStatistics.statistics' | artemisTranslate"
-                id="course-card-open-open-statistics"
+                id="course-card-open-statistics"
             >
                 <fa-icon [icon]="faChartBar" />
                 <span class="d-none d-xl-inline" jhiTranslate="artemisApp.courseStatistics.statistics"></span>

--- a/src/main/webapp/app/core/course/manage/overview/course-management-card.component.html
+++ b/src/main/webapp/app/core/course/manage/overview/course-management-card.component.html
@@ -304,7 +304,12 @@
             </a>
         }
         @if (isCommunicationEnabled(course()) && course().isAtLeastTutor) {
-            <a [routerLink]="['/courses', course().id, 'communication']" class="btn btn-primary" [ngbTooltip]="'artemisApp.courseOverview.menu.communication' | artemisTranslate">
+            <a
+                [routerLink]="['/courses', course().id, 'communication']"
+                class="btn btn-primary"
+                [ngbTooltip]="'artemisApp.courseOverview.menu.communication' | artemisTranslate"
+                id="course-card-open-communication"
+            >
                 <fa-icon [icon]="faComments" />
                 <span class="d-none d-xl-inline" jhiTranslate="artemisApp.metis.communication.label"></span>
             </a>

--- a/src/main/webapp/app/core/course/manage/overview/course-management-card.component.html
+++ b/src/main/webapp/app/core/course/manage/overview/course-management-card.component.html
@@ -230,26 +230,13 @@
     </div>
     <div class="card-footer">
         @if (course().isAtLeastTutor) {
-            <jhi-feature-overlay [enabled]="examEnabled" placement="right">
-                <a
-                    [routerLink]="['/course-management', course().id, 'exams']"
-                    class="btn btn-primary me-1 mb-1"
-                    [ngbTooltip]="'entity.action.exams' | artemisTranslate"
-                    id="course-card-open-exams"
-                >
-                    <fa-icon [icon]="faGraduationCap" />
-                    <span class="d-none d-xl-inline" jhiTranslate="entity.action.exams"></span>
-                </a>
-            </jhi-feature-overlay>
-        }
-        @if (course().isAtLeastTutor) {
             <a
                 [routerLink]="['/course-management', course().id, 'exercises']"
-                class="btn btn-primary me-1 mb-1"
+                class="btn course-action-btn course-action-btn--exercises"
                 [ngbTooltip]="'entity.action.exercise' | artemisTranslate"
                 id="course-card-open-exercises"
             >
-                <fa-icon [icon]="faListAlt" />
+                <fa-icon [icon]="faCode" />
                 <span class="d-none d-xl-inline" jhiTranslate="entity.action.exercise"></span>
             </a>
         }
@@ -257,46 +244,38 @@
             <jhi-feature-overlay [enabled]="lectureEnabled" placement="right">
                 <a
                     [routerLink]="['/course-management', course().id, 'lectures']"
-                    class="btn btn-primary me-1 mb-1"
+                    class="btn course-action-btn course-action-btn--lectures"
                     [ngbTooltip]="'entity.action.lecture' | artemisTranslate"
                     id="course-card-open-lectures"
                 >
-                    <fa-icon [icon]="faFilePdf" />
+                    <fa-icon [icon]="faChalkboardTeacher" />
                     <span class="d-none d-xl-inline" jhiTranslate="entity.action.lecture"></span>
                 </a>
             </jhi-feature-overlay>
-        }
-        @if (course().isAtLeastTutor) {
-            <a
-                [routerLink]="['/course-management', course().id, 'course-statistics']"
-                class="btn btn-info me-1 mb-1 hidden-if-mobile"
-                [ngbTooltip]="'artemisApp.courseStatistics.statistics' | artemisTranslate"
-                id="course-card-open-open-statistics"
-            >
-                <fa-icon [icon]="faChartBar" />
-                <span class="d-none d-xl-inline" jhiTranslate="artemisApp.courseStatistics.statistics"></span>
-            </a>
-        }
-        @if (isCommunicationEnabled(course()) && course().isAtLeastTutor) {
-            <a
-                [routerLink]="['/courses', course().id, 'communication']"
-                class="btn btn-primary me-1 mb-1"
-                [ngbTooltip]="'artemisApp.courseOverview.menu.communication' | artemisTranslate"
-            >
-                <fa-icon [icon]="faComments" />
-                <span class="d-none d-xl-inline" jhiTranslate="artemisApp.metis.communication.label"></span>
-            </a>
         }
         @if (course().timeZone || course().isAtLeastInstructor) {
             <jhi-feature-overlay [enabled]="tutorialGroupEnabled">
                 <a
                     [routerLink]="['/course-management', course().id, 'tutorial-groups']"
-                    class="btn btn-primary me-1 mb-1 hidden-if-mobile"
+                    class="btn course-action-btn course-action-btn--tutorial hidden-if-mobile"
                     [ngbTooltip]="'artemisApp.entities.tutorialGroup.plural' | artemisTranslate"
                     id="course-card-open-tutorial-groups"
                 >
-                    <fa-icon [icon]="faPersonChalkboard" />
+                    <fa-icon [icon]="faUsers" />
                     <span [innerHTML]="'artemisApp.entities.tutorialGroup.plural' | artemisTranslate" class="d-none d-xl-inline"></span>
+                </a>
+            </jhi-feature-overlay>
+        }
+        @if (course().isAtLeastTutor) {
+            <jhi-feature-overlay [enabled]="examEnabled" placement="right">
+                <a
+                    [routerLink]="['/course-management', course().id, 'exams']"
+                    class="btn course-action-btn course-action-btn--exams"
+                    [ngbTooltip]="'entity.action.exams' | artemisTranslate"
+                    id="course-card-open-exams"
+                >
+                    <fa-icon [icon]="faFileAlt" />
+                    <span class="d-none d-xl-inline" jhiTranslate="entity.action.exams"></span>
                 </a>
             </jhi-feature-overlay>
         }
@@ -304,21 +283,38 @@
             <jhi-feature-overlay [enabled]="atlasEnabled">
                 <a
                     [routerLink]="['/course-management', course().id, 'competency-management']"
-                    class="btn btn-primary me-1 mb-1 hidden-if-mobile"
+                    class="btn course-action-btn course-action-btn--competencies hidden-if-mobile"
                     [ngbTooltip]="'artemisApp.competency.competencyButton' | artemisTranslate"
                     id="course-card-open-competencies"
                 >
-                    <fa-icon [icon]="faFlag" />
+                    <fa-icon [icon]="faBullseye" />
                     <span [innerHTML]="'artemisApp.competency.competencyButton' | artemisTranslate" class="d-none d-xl-inline"></span>
                 </a>
             </jhi-feature-overlay>
+        }
+        @if (course().isAtLeastTutor) {
+            <a
+                [routerLink]="['/course-management', course().id, 'faqs']"
+                class="btn course-action-btn course-action-btn--faqs"
+                [ngbTooltip]="'entity.action.faq' | artemisTranslate"
+                id="course-card-open-faq"
+            >
+                <fa-icon [icon]="faQuestion" />
+                <span class="d-none d-xl-inline" jhiTranslate="entity.action.faq"></span>
+            </a>
+        }
+        @if (isCommunicationEnabled(course()) && course().isAtLeastTutor) {
+            <a [routerLink]="['/courses', course().id, 'communication']" class="btn btn-primary" [ngbTooltip]="'artemisApp.courseOverview.menu.communication' | artemisTranslate">
+                <fa-icon [icon]="faComments" />
+                <span class="d-none d-xl-inline" jhiTranslate="artemisApp.metis.communication.label"></span>
+            </a>
         }
         @if (course().isAtLeastInstructor) {
             <jhi-feature-overlay [enabled]="atlasEnabled">
                 <a
                     [jhiFeatureToggleHide]="FeatureToggle.LearningPaths"
                     [routerLink]="['/course-management', course().id, 'learning-path-management']"
-                    class="btn btn-primary me-1 mb-1 hidden-if-mobile"
+                    class="btn btn-primary hidden-if-mobile"
                     [ngbTooltip]="'artemisApp.learningPath.learningPathButton' | artemisTranslate"
                     id="course-card-open-learning-paths"
                 >
@@ -329,8 +325,19 @@
         }
         @if (course().isAtLeastTutor) {
             <a
+                [routerLink]="['/course-management', course().id, 'course-statistics']"
+                class="btn btn-info hidden-if-mobile"
+                [ngbTooltip]="'artemisApp.courseStatistics.statistics' | artemisTranslate"
+                id="course-card-open-open-statistics"
+            >
+                <fa-icon [icon]="faChartBar" />
+                <span class="d-none d-xl-inline" jhiTranslate="artemisApp.courseStatistics.statistics"></span>
+            </a>
+        }
+        @if (course().isAtLeastTutor) {
+            <a
                 [routerLink]="['/course-management', course().id, 'assessment-dashboard']"
-                class="btn btn-info me-1 mb-1"
+                class="btn btn-info"
                 [ngbTooltip]="'entity.action.assessmentDashboard' | artemisTranslate"
                 id="course-card-open-assessment-dashboard"
             >
@@ -341,24 +348,12 @@
         @if (course().isAtLeastInstructor) {
             <a
                 [routerLink]="['/course-management', course().id, 'scores']"
-                class="btn btn-info me-1 mb-1"
+                class="btn btn-info"
                 [ngbTooltip]="'entity.action.scores' | artemisTranslate"
                 id="course-card-open-scores"
             >
                 <fa-icon [icon]="faTable" />
                 <span class="d-none d-xl-inline" jhiTranslate="entity.action.scores"></span>
-            </a>
-        }
-
-        @if (course().isAtLeastTutor) {
-            <a
-                [routerLink]="['/course-management', course().id, 'faqs']"
-                class="btn btn-info me-1 mb-1"
-                [ngbTooltip]="'entity.action.faq' | artemisTranslate"
-                id="course-card-open-faq"
-            >
-                <fa-icon [icon]="faQuestion" />
-                <span class="d-none d-xl-inline" jhiTranslate="entity.action.faq"></span>
             </a>
         }
     </div>

--- a/src/main/webapp/app/core/course/manage/overview/course-management-card.component.ts
+++ b/src/main/webapp/app/core/course/manage/overview/course-management-card.component.ts
@@ -9,19 +9,19 @@ import { Course, isCommunicationEnabled, isMessagingEnabled } from 'app/core/cou
 import {
     faAngleDown,
     faAngleUp,
+    faBullseye,
+    faChalkboardTeacher,
     faChartBar,
     faClipboard,
+    faCode,
     faComments,
-    faFilePdf,
-    faFlag,
-    faGraduationCap,
-    faListAlt,
+    faFileAlt,
     faNetworkWired,
-    faPersonChalkboard,
     faQuestion,
     faSpinner,
     faTable,
     faUserCheck,
+    faUsers,
 } from '@fortawesome/free-solid-svg-icons';
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
@@ -98,17 +98,17 @@ export class CourseManagementCardComponent {
     // Icons
     readonly faTable = faTable;
     readonly faUserCheck = faUserCheck;
-    readonly faFlag = faFlag;
+    readonly faBullseye = faBullseye;
     readonly faNetworkWired = faNetworkWired;
-    readonly faListAlt = faListAlt;
+    readonly faCode = faCode;
     readonly faChartBar = faChartBar;
-    readonly faFilePdf = faFilePdf;
+    readonly faChalkboardTeacher = faChalkboardTeacher;
     readonly faComments = faComments;
     readonly faClipboard = faClipboard;
-    readonly faGraduationCap = faGraduationCap;
+    readonly faFileAlt = faFileAlt;
     readonly faAngleDown = faAngleDown;
     readonly faAngleUp = faAngleUp;
-    readonly faPersonChalkboard = faPersonChalkboard;
+    readonly faUsers = faUsers;
     readonly faSpinner = faSpinner;
     readonly faQuestion = faQuestion;
 

--- a/src/main/webapp/app/core/course/manage/overview/course-management-card.scss
+++ b/src/main/webapp/app/core/course/manage/overview/course-management-card.scss
@@ -1,5 +1,8 @@
 .card {
-    height: 450px;
+    height: auto;
+    min-height: 450px;
+    border-radius: 0.75rem;
+    overflow: hidden;
     transition: transform 0.2s linear;
 
     &:hover {
@@ -146,13 +149,64 @@
     }
 
     .card-footer {
-        height: 50px;
         display: flex;
+        flex-wrap: wrap;
+        row-gap: 0.4rem;
+        column-gap: 0.4rem;
         align-items: center;
-        flex-direction: row;
-        padding-left: 15px;
-        padding-bottom: 0;
-        padding-top: 5px;
+        padding: 0.5rem 0.75rem;
+        background: transparent;
+        border-top: 1px solid var(--bs-border-color);
+
+        .btn {
+            border-radius: 0.5rem;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            padding: 0.35rem 0.6rem;
+            margin: 0;
+            line-height: 1.2;
+        }
+    }
+
+    .course-action-btn {
+        color: #fff;
+        background: var(--course-action-accent, var(--bs-primary));
+        border: 1px solid transparent;
+        transition:
+            filter 0.15s ease,
+            transform 0.15s ease;
+
+        &:hover,
+        &:focus {
+            color: #fff;
+            filter: brightness(1.08);
+            transform: translateY(-1px);
+        }
+    }
+
+    .course-action-btn--exercises {
+        --course-action-accent: #6366f1;
+    }
+
+    .course-action-btn--lectures {
+        --course-action-accent: #0ea5e9;
+    }
+
+    .course-action-btn--tutorial {
+        --course-action-accent: #8b5cf6;
+    }
+
+    .course-action-btn--exams {
+        --course-action-accent: #f59e0b;
+    }
+
+    .course-action-btn--competencies {
+        --course-action-accent: #10b981;
+    }
+
+    .course-action-btn--faqs {
+        --course-action-accent: #ec4899;
     }
 
     .header-right {
@@ -269,6 +323,8 @@ HACK: Something is bogus with the scss of top-level pages
 .btn-info,
 .btn-info:hover,
 .btn-success,
-.btn-success:hover {
+.btn-success:hover,
+.course-action-btn,
+.course-action-btn:hover {
     color: #fff !important;
 }

--- a/src/main/webapp/app/core/course/manage/overview/course-management-card.scss
+++ b/src/main/webapp/app/core/course/manage/overview/course-management-card.scss
@@ -2,7 +2,6 @@
     height: auto;
     min-height: 450px;
     border-radius: 0.75rem;
-    overflow: hidden;
     transition: transform 0.2s linear;
 
     &:hover {
@@ -23,6 +22,8 @@
         display: flex;
         cursor: pointer;
         height: 100px;
+        border-top-left-radius: inherit;
+        border-top-right-radius: inherit;
 
         &:hover {
             background-color: color-mix(in srgb, var(--background-color-for-hover), transparent 15%) !important;
@@ -157,6 +158,8 @@
         padding: 0.5rem 0.75rem;
         background: transparent;
         border-top: 1px solid var(--bs-border-color);
+        border-bottom-left-radius: inherit;
+        border-bottom-right-radius: inherit;
 
         .btn {
             border-radius: 0.5rem;


### PR DESCRIPTION
### Summary
Aligns the per-course card on the Instructor Management list (`/course-management`) with the refreshed course overview styling that was recently introduced on the course detail page (`/course-management/:id`). The six content-aspect buttons (Exercises, Lectures, Tutorial Groups, Exams, Competencies, FAQs) now use the same icons, accent colors, and ordering as the course overview, and the surrounding card has matching rounded corners.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme. *(Not applicable: the six accent hexes are component-local design tokens mirroring `OnboardingExploreComponent` from #12285 — see Description.)*
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).

### Motivation and Context
The course overview page (e.g. `/course-management/564`) was recently refreshed with distinct accent colors and a modernized icon set for the six main content aspects (Exercises, Lectures, Tutorial Groups, Exams, Competencies, FAQs), see #12285. The per-course card in the Instructor Management list still used the old uniform blue buttons, the old icons (`faGraduationCap`, `faListAlt`, `faFilePdf`, `faPersonChalkboard`, `faFlag`), and a different button order. This was visually inconsistent and made it harder for instructors to map the same concept across the two views. The outer card also had a fixed 450px height, which made the new wider footer overflow visually into the next card.

### Description
- Reordered the buttons in `course-management-card.component.html` so the six content aspects come first in the same order as `OnboardingExploreComponent`: Exercises → Lectures → Tutorial Groups → Exams → Competencies → FAQs. The five remaining action buttons (Communication, Learning Paths, Statistics, Assessment Dashboard, Scores) follow in their existing neutral style.
- Swapped the icons for the six content buttons to match the overview (`faCode`, `faChalkboardTeacher`, `faUsers`, `faFileAlt`, `faBullseye`, `faQuestion`).
- Each content button now uses a new `.course-action-btn--<aspect>` class driven by a CSS custom property (`--course-action-accent`) with the same six accent colors as the explore cards (`#6366f1`, `#0ea5e9`, `#8b5cf6`, `#f59e0b`, `#10b981`, `#ec4899`).
- Replaced the per-button `me-1 mb-1` spacing with a `flex` + `gap` layout on the footer for cleaner alignment when buttons wrap, slimmed the footer padding, and gave the buttons a consistent `0.5rem` border-radius.
- The outer card now has `border-radius: 0.75rem`, `overflow: hidden`, and grows with its content (`min-height: 450px` instead of a hard `height: 450px`), so the footer no longer overflows into the next card.
- No translation key, route, guard, or REST behavior changes — only ordering, icons, and styling.

### Steps for Testing
Prerequisites:
- 1 Instructor
- At least 1 Course visible to the instructor in the course management list

1. Log in to Artemis as an instructor.
2. Navigate to `/course-management`.
3. For each course card, verify the card-footer buttons:
   - The first six buttons are Exercises, Lectures, Tutorial Groups, Exams, Competencies, FAQs in that order, each with its own accent color and the new icon.
   - The remaining buttons (Communication, Learning Paths, Statistics, Assessment, Scores) follow in a neutral style.
4. Compare side-by-side with `/course-management/:id` — icons and accent colors match.
5. Verify the card itself has visibly rounded corners and no longer overflows into the next card.
6. Resize the window down to ~1060px and ~500px:
   - Statistics / Tutorial Groups / Competencies / Learning Paths / FAQ respect their existing `hidden-if-mobile` behavior.
   - Buttons wrap cleanly without visual overlap.
7. Click each button — routing is unchanged.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1

### Test Coverage
#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| course-management-card.component.ts | 100.00% | 164 | 18 | 11.0 |

The HTML and SCSS files are not directly instrumented by Vitest; the existing 9 spec cases in `course-management-card.component.spec.ts` all pass and the underlying component logic remains at 100% line coverage.

### Screenshots
_Before/after screenshots to be attached in the PR conversation._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consolidated, role/toggle-gated action buttons for exercises, lectures, tutorial groups, exams, competencies, and FAQs in the course management card; learning-path remains hidden by feature toggle.

* **Style**
  * Redesigned card footer with consistent action-button styles, improved spacing and responsive behavior, and updated icon set and alignment; communication button visibility remains governed by existing access checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Artemis/pull/12764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
