### PR TITLE
`Development`: Migrate plagiarism case, comparison, and result endpoints to DTOs

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/domain/PlagiarismResult.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/domain/PlagiarismResult.java
@@ -99,9 +99,12 @@ public class PlagiarismResult extends AbstractAuditingEntity {
     }
 
     /**
-     * @return an unmodifiable list of the similar distribution
+     * @return an unmodifiable list of the similar distribution, or null if no distribution has been initialized yet
      */
     public List<Integer> getSimilarityDistribution() {
+        if (this.similarityDistribution == null) {
+            return null;
+        }
         return this.similarityDistribution.entrySet().stream().sorted(comparingInt(Entry::getKey)).map(Entry::getValue).toList();
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
@@ -1,0 +1,42 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.hibernate.Hibernate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCase;
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercise, PlagiarismCaseUserDTO student, PlagiarismCasePostSummaryDTO post, PlagiarismVerdict verdict,
+        ZonedDateTime verdictDate, PlagiarismCaseUserDTO verdictBy, int plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl, String verdictMessage,
+        int verdictPointDeduction, List<PlagiarismSubmissionForCaseDTO> plagiarismSubmissions) {
+
+    public static PlagiarismCaseDetailDTO ofForInstructor(PlagiarismCase plagiarismCase) {
+        return of(plagiarismCase);
+    }
+
+    public static PlagiarismCaseDetailDTO ofForStudent(PlagiarismCase plagiarismCase) {
+        return of(plagiarismCase);
+    }
+
+    private static PlagiarismCaseDetailDTO of(PlagiarismCase plagiarismCase) {
+        if (plagiarismCase == null) {
+            return null;
+        }
+
+        List<PlagiarismSubmissionForCaseDTO> plagiarismSubmissions = null;
+        if (plagiarismCase.getPlagiarismSubmissions() != null && Hibernate.isInitialized(plagiarismCase.getPlagiarismSubmissions())) {
+            plagiarismSubmissions = plagiarismCase.getPlagiarismSubmissions().stream().map(PlagiarismSubmissionForCaseDTO::fromSubmissionForCase).toList();
+        }
+        int plagiarismSubmissionCount = plagiarismSubmissions != null ? plagiarismSubmissions.size() : 0;
+
+        return new PlagiarismCaseDetailDTO(plagiarismCase.getId(), PlagiarismCaseExerciseDTO.fromExercise(plagiarismCase.getExercise()),
+                PlagiarismCaseUserDTO.fromUser(plagiarismCase.getStudent()), PlagiarismCasePostSummaryDTO.fromPost(plagiarismCase.getPost()), plagiarismCase.getVerdict(),
+                plagiarismCase.getVerdictDate(), PlagiarismCaseUserDTO.fromUser(plagiarismCase.getVerdictBy()), plagiarismSubmissionCount,
+                plagiarismCase.isCreatedByContinuousPlagiarismControl(), plagiarismCase.getVerdictMessage(), plagiarismCase.getVerdictPointDeduction(), plagiarismSubmissions);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
@@ -3,12 +3,10 @@ package de.tum.cit.aet.artemis.plagiarism.dto;
 import java.time.ZonedDateTime;
 import java.util.List;
 
-import org.hibernate.Hibernate;
 import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCase;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -47,43 +45,6 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
         this(id, exercise, userOrNull(studentId, studentLogin, fullName(studentFirstName, studentLastName), null), postOrNull(postId, postCreationDate), verdict, verdictDate,
                 userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), toBoundedInt(plagiarismSubmissionCount),
                 createdByContinuousPlagiarismControl, verdictMessage, verdictPointDeduction, null);
-    }
-
-    /**
-     * Maps a plagiarism case entity to the instructor detail DTO.
-     *
-     * @param plagiarismCase the plagiarism case entity
-     * @return the DTO representation
-     */
-    public static @Nullable PlagiarismCaseDetailDTO ofForInstructor(@Nullable PlagiarismCase plagiarismCase) {
-        return of(plagiarismCase);
-    }
-
-    /**
-     * Maps a plagiarism case entity to the student detail DTO.
-     *
-     * @param plagiarismCase the plagiarism case entity
-     * @return the DTO representation
-     */
-    public static @Nullable PlagiarismCaseDetailDTO ofForStudent(@Nullable PlagiarismCase plagiarismCase) {
-        return of(plagiarismCase);
-    }
-
-    private static @Nullable PlagiarismCaseDetailDTO of(@Nullable PlagiarismCase plagiarismCase) {
-        if (plagiarismCase == null) {
-            return null;
-        }
-
-        List<PlagiarismSubmissionForCaseDTO> plagiarismSubmissions = null;
-        if (plagiarismCase.getPlagiarismSubmissions() != null && Hibernate.isInitialized(plagiarismCase.getPlagiarismSubmissions())) {
-            plagiarismSubmissions = plagiarismCase.getPlagiarismSubmissions().stream().map(PlagiarismSubmissionForCaseDTO::fromSubmissionForCase).toList();
-        }
-        int plagiarismSubmissionCount = plagiarismSubmissions != null ? plagiarismSubmissions.size() : 0;
-
-        return new PlagiarismCaseDetailDTO(plagiarismCase.getId(), PlagiarismCaseExerciseDTO.fromExercise(plagiarismCase.getExercise()),
-                PlagiarismCaseUserDTO.fromUser(plagiarismCase.getStudent()), PlagiarismCasePostSummaryDTO.fromPost(plagiarismCase.getPost()), plagiarismCase.getVerdict(),
-                plagiarismCase.getVerdictDate(), PlagiarismCaseUserDTO.fromUser(plagiarismCase.getVerdictBy()), plagiarismSubmissionCount,
-                plagiarismCase.isCreatedByContinuousPlagiarismControl(), plagiarismCase.getVerdictMessage(), plagiarismCase.getVerdictPointDeduction(), plagiarismSubmissions);
     }
 
     private static @Nullable PlagiarismCaseUserDTO userOrNull(@Nullable Long id, @Nullable String login, @Nullable String name, @Nullable String visibleRegistrationNumber) {

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
@@ -24,7 +24,6 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
      * @param studentLogin                         the affected student login
      * @param studentFirstName                     the affected student's first name
      * @param studentLastName                      the affected student's last name
-     * @param studentVisibleRegistrationNumber     the affected student's visible registration number
      * @param postId                               the post id
      * @param postCreationDate                     the post creation date
      * @param verdict                              the plagiarism verdict
@@ -38,12 +37,11 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
      * @param verdictMessage                       the verdict message
      * @param verdictPointDeduction                the verdict point deduction
      */
-    public PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentFirstName, String studentLastName,
-            String studentVisibleRegistrationNumber, Long postId, ZonedDateTime postCreationDate, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById,
-            String verdictByLogin, String verdictByFirstName, String verdictByLastName, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl,
-            String verdictMessage, int verdictPointDeduction) {
-        this(id, exercise, userOrNull(studentId, studentLogin, fullName(studentFirstName, studentLastName), studentVisibleRegistrationNumber), postOrNull(postId, postCreationDate),
-                verdict, verdictDate, userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), Math.toIntExact(plagiarismSubmissionCount),
+    public PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentFirstName, String studentLastName, Long postId,
+            ZonedDateTime postCreationDate, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById, String verdictByLogin, String verdictByFirstName,
+            String verdictByLastName, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl, String verdictMessage, int verdictPointDeduction) {
+        this(id, exercise, userOrNull(studentId, studentLogin, fullName(studentFirstName, studentLastName), null), postOrNull(postId, postCreationDate), verdict, verdictDate,
+                userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), Math.toIntExact(plagiarismSubmissionCount),
                 createdByContinuousPlagiarismControl, verdictMessage, verdictPointDeduction, null);
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
@@ -4,6 +4,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -11,9 +12,10 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCase;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercise, PlagiarismCaseUserDTO student, PlagiarismCasePostSummaryDTO post, PlagiarismVerdict verdict,
-        ZonedDateTime verdictDate, PlagiarismCaseUserDTO verdictBy, int plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl, String verdictMessage,
-        int verdictPointDeduction, List<PlagiarismSubmissionForCaseDTO> plagiarismSubmissions) {
+public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercise, @Nullable PlagiarismCaseUserDTO student, @Nullable PlagiarismCasePostSummaryDTO post,
+        @Nullable PlagiarismVerdict verdict, @Nullable ZonedDateTime verdictDate, @Nullable PlagiarismCaseUserDTO verdictBy, int plagiarismSubmissionCount,
+        boolean createdByContinuousPlagiarismControl, @Nullable String verdictMessage, int verdictPointDeduction,
+        @Nullable List<PlagiarismSubmissionForCaseDTO> plagiarismSubmissions) {
 
     /**
      * JPQL constructor for detail projections. It keeps optional nested DTOs absent when the joined entity is absent.
@@ -37,9 +39,11 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
      * @param verdictMessage                       the verdict message
      * @param verdictPointDeduction                the verdict point deduction
      */
-    public PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentFirstName, String studentLastName, Long postId,
-            ZonedDateTime postCreationDate, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById, String verdictByLogin, String verdictByFirstName,
-            String verdictByLastName, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl, String verdictMessage, int verdictPointDeduction) {
+    public PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercise, @Nullable Long studentId, @Nullable String studentLogin, @Nullable String studentFirstName,
+            @Nullable String studentLastName, @Nullable Long postId, @Nullable ZonedDateTime postCreationDate, @Nullable PlagiarismVerdict verdict,
+            @Nullable ZonedDateTime verdictDate, @Nullable Long verdictById, @Nullable String verdictByLogin, @Nullable String verdictByFirstName,
+            @Nullable String verdictByLastName, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl, @Nullable String verdictMessage,
+            int verdictPointDeduction) {
         this(id, exercise, userOrNull(studentId, studentLogin, fullName(studentFirstName, studentLastName), null), postOrNull(postId, postCreationDate), verdict, verdictDate,
                 userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), toBoundedInt(plagiarismSubmissionCount),
                 createdByContinuousPlagiarismControl, verdictMessage, verdictPointDeduction, null);
@@ -51,7 +55,7 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
      * @param plagiarismCase the plagiarism case entity
      * @return the DTO representation
      */
-    public static PlagiarismCaseDetailDTO ofForInstructor(PlagiarismCase plagiarismCase) {
+    public static @Nullable PlagiarismCaseDetailDTO ofForInstructor(@Nullable PlagiarismCase plagiarismCase) {
         return of(plagiarismCase);
     }
 
@@ -61,11 +65,11 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
      * @param plagiarismCase the plagiarism case entity
      * @return the DTO representation
      */
-    public static PlagiarismCaseDetailDTO ofForStudent(PlagiarismCase plagiarismCase) {
+    public static @Nullable PlagiarismCaseDetailDTO ofForStudent(@Nullable PlagiarismCase plagiarismCase) {
         return of(plagiarismCase);
     }
 
-    private static PlagiarismCaseDetailDTO of(PlagiarismCase plagiarismCase) {
+    private static @Nullable PlagiarismCaseDetailDTO of(@Nullable PlagiarismCase plagiarismCase) {
         if (plagiarismCase == null) {
             return null;
         }
@@ -82,14 +86,14 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
                 plagiarismCase.isCreatedByContinuousPlagiarismControl(), plagiarismCase.getVerdictMessage(), plagiarismCase.getVerdictPointDeduction(), plagiarismSubmissions);
     }
 
-    private static PlagiarismCaseUserDTO userOrNull(Long id, String login, String name, String visibleRegistrationNumber) {
+    private static @Nullable PlagiarismCaseUserDTO userOrNull(@Nullable Long id, @Nullable String login, @Nullable String name, @Nullable String visibleRegistrationNumber) {
         if (id == null) {
             return null;
         }
         return new PlagiarismCaseUserDTO(id, login, name, visibleRegistrationNumber);
     }
 
-    private static String fullName(String firstName, String lastName) {
+    private static @Nullable String fullName(@Nullable String firstName, @Nullable String lastName) {
         boolean hasFirstName = firstName != null && !firstName.isEmpty();
         boolean hasLastName = lastName != null && !lastName.isEmpty();
         if (hasFirstName && hasLastName) {
@@ -111,7 +115,7 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
         return Math.toIntExact(value);
     }
 
-    private static PlagiarismCasePostSummaryDTO postOrNull(Long id, ZonedDateTime creationDate) {
+    private static @Nullable PlagiarismCasePostSummaryDTO postOrNull(@Nullable Long id, @Nullable ZonedDateTime creationDate) {
         if (id == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
@@ -15,10 +15,53 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
         ZonedDateTime verdictDate, PlagiarismCaseUserDTO verdictBy, int plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl, String verdictMessage,
         int verdictPointDeduction, List<PlagiarismSubmissionForCaseDTO> plagiarismSubmissions) {
 
+    /**
+     * JPQL constructor for detail projections. It keeps optional nested DTOs absent when the joined entity is absent.
+     *
+     * @param id                                   the plagiarism case id
+     * @param exercise                             the exercise DTO
+     * @param studentId                            the affected student id
+     * @param studentLogin                         the affected student login
+     * @param studentName                          the affected student name
+     * @param studentVisibleRegistrationNumber     the affected student's visible registration number
+     * @param postId                               the post id
+     * @param postCreationDate                     the post creation date
+     * @param verdict                              the plagiarism verdict
+     * @param verdictDate                          the verdict date
+     * @param verdictById                          the verdict author id
+     * @param verdictByLogin                       the verdict author login
+     * @param verdictByName                        the verdict author name
+     * @param verdictByVisibleRegistrationNumber   the verdict author's visible registration number
+     * @param plagiarismSubmissionCount            the number of submissions attached to the plagiarism case
+     * @param createdByContinuousPlagiarismControl whether the case was created by continuous plagiarism control
+     * @param verdictMessage                       the verdict message
+     * @param verdictPointDeduction                the verdict point deduction
+     */
+    public PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentName, String studentVisibleRegistrationNumber,
+            Long postId, ZonedDateTime postCreationDate, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById, String verdictByLogin, String verdictByName,
+            String verdictByVisibleRegistrationNumber, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl, String verdictMessage,
+            int verdictPointDeduction) {
+        this(id, exercise, userOrNull(studentId, studentLogin, studentName, studentVisibleRegistrationNumber), postOrNull(postId, postCreationDate), verdict, verdictDate,
+                userOrNull(verdictById, verdictByLogin, verdictByName, verdictByVisibleRegistrationNumber), Math.toIntExact(plagiarismSubmissionCount),
+                createdByContinuousPlagiarismControl, verdictMessage, verdictPointDeduction, null);
+    }
+
+    /**
+     * Maps a plagiarism case entity to the instructor detail DTO.
+     *
+     * @param plagiarismCase the plagiarism case entity
+     * @return the DTO representation
+     */
     public static PlagiarismCaseDetailDTO ofForInstructor(PlagiarismCase plagiarismCase) {
         return of(plagiarismCase);
     }
 
+    /**
+     * Maps a plagiarism case entity to the student detail DTO.
+     *
+     * @param plagiarismCase the plagiarism case entity
+     * @return the DTO representation
+     */
     public static PlagiarismCaseDetailDTO ofForStudent(PlagiarismCase plagiarismCase) {
         return of(plagiarismCase);
     }
@@ -38,5 +81,19 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
                 PlagiarismCaseUserDTO.fromUser(plagiarismCase.getStudent()), PlagiarismCasePostSummaryDTO.fromPost(plagiarismCase.getPost()), plagiarismCase.getVerdict(),
                 plagiarismCase.getVerdictDate(), PlagiarismCaseUserDTO.fromUser(plagiarismCase.getVerdictBy()), plagiarismSubmissionCount,
                 plagiarismCase.isCreatedByContinuousPlagiarismControl(), plagiarismCase.getVerdictMessage(), plagiarismCase.getVerdictPointDeduction(), plagiarismSubmissions);
+    }
+
+    private static PlagiarismCaseUserDTO userOrNull(Long id, String login, String name, String visibleRegistrationNumber) {
+        if (id == null) {
+            return null;
+        }
+        return new PlagiarismCaseUserDTO(id, login, name, visibleRegistrationNumber);
+    }
+
+    private static PlagiarismCasePostSummaryDTO postOrNull(Long id, ZonedDateTime creationDate) {
+        if (id == null) {
+            return null;
+        }
+        return new PlagiarismCasePostSummaryDTO(id, creationDate);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
@@ -41,7 +41,7 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
             ZonedDateTime postCreationDate, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById, String verdictByLogin, String verdictByFirstName,
             String verdictByLastName, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl, String verdictMessage, int verdictPointDeduction) {
         this(id, exercise, userOrNull(studentId, studentLogin, fullName(studentFirstName, studentLastName), null), postOrNull(postId, postCreationDate), verdict, verdictDate,
-                userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), Math.toIntExact(plagiarismSubmissionCount),
+                userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), toBoundedInt(plagiarismSubmissionCount),
                 createdByContinuousPlagiarismControl, verdictMessage, verdictPointDeduction, null);
     }
 
@@ -90,10 +90,25 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
     }
 
     private static String fullName(String firstName, String lastName) {
-        if (lastName != null && !lastName.isEmpty()) {
+        boolean hasFirstName = firstName != null && !firstName.isEmpty();
+        boolean hasLastName = lastName != null && !lastName.isEmpty();
+        if (hasFirstName && hasLastName) {
             return firstName + " " + lastName;
         }
-        return firstName;
+        if (hasFirstName) {
+            return firstName;
+        }
+        if (hasLastName) {
+            return lastName;
+        }
+        return null;
+    }
+
+    private static int toBoundedInt(long value) {
+        if (value > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return Math.toIntExact(value);
     }
 
     private static PlagiarismCasePostSummaryDTO postOrNull(Long id, ZonedDateTime creationDate) {

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseDetailDTO.java
@@ -22,7 +22,8 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
      * @param exercise                             the exercise DTO
      * @param studentId                            the affected student id
      * @param studentLogin                         the affected student login
-     * @param studentName                          the affected student name
+     * @param studentFirstName                     the affected student's first name
+     * @param studentLastName                      the affected student's last name
      * @param studentVisibleRegistrationNumber     the affected student's visible registration number
      * @param postId                               the post id
      * @param postCreationDate                     the post creation date
@@ -30,19 +31,19 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
      * @param verdictDate                          the verdict date
      * @param verdictById                          the verdict author id
      * @param verdictByLogin                       the verdict author login
-     * @param verdictByName                        the verdict author name
-     * @param verdictByVisibleRegistrationNumber   the verdict author's visible registration number
+     * @param verdictByFirstName                   the verdict author's first name
+     * @param verdictByLastName                    the verdict author's last name
      * @param plagiarismSubmissionCount            the number of submissions attached to the plagiarism case
      * @param createdByContinuousPlagiarismControl whether the case was created by continuous plagiarism control
      * @param verdictMessage                       the verdict message
      * @param verdictPointDeduction                the verdict point deduction
      */
-    public PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentName, String studentVisibleRegistrationNumber,
-            Long postId, ZonedDateTime postCreationDate, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById, String verdictByLogin, String verdictByName,
-            String verdictByVisibleRegistrationNumber, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl, String verdictMessage,
-            int verdictPointDeduction) {
-        this(id, exercise, userOrNull(studentId, studentLogin, studentName, studentVisibleRegistrationNumber), postOrNull(postId, postCreationDate), verdict, verdictDate,
-                userOrNull(verdictById, verdictByLogin, verdictByName, verdictByVisibleRegistrationNumber), Math.toIntExact(plagiarismSubmissionCount),
+    public PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentFirstName, String studentLastName,
+            String studentVisibleRegistrationNumber, Long postId, ZonedDateTime postCreationDate, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById,
+            String verdictByLogin, String verdictByFirstName, String verdictByLastName, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl,
+            String verdictMessage, int verdictPointDeduction) {
+        this(id, exercise, userOrNull(studentId, studentLogin, fullName(studentFirstName, studentLastName), studentVisibleRegistrationNumber), postOrNull(postId, postCreationDate),
+                verdict, verdictDate, userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), Math.toIntExact(plagiarismSubmissionCount),
                 createdByContinuousPlagiarismControl, verdictMessage, verdictPointDeduction, null);
     }
 
@@ -88,6 +89,13 @@ public record PlagiarismCaseDetailDTO(Long id, PlagiarismCaseExerciseDTO exercis
             return null;
         }
         return new PlagiarismCaseUserDTO(id, login, name, visibleRegistrationNumber);
+    }
+
+    private static String fullName(String firstName, String lastName) {
+        if (lastName != null && !lastName.isEmpty()) {
+            return firstName + " " + lastName;
+        }
+        return firstName;
     }
 
     private static PlagiarismCasePostSummaryDTO postOrNull(Long id, ZonedDateTime creationDate) {

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseExerciseDTO.java
@@ -15,6 +15,31 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismDetectionConfig;
 public record PlagiarismCaseExerciseDTO(Long id, String title, ExerciseType type, ZonedDateTime dueDate, Long courseId, String courseTitle, Long examId, String examTitle,
         Integer continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod) {
 
+    /**
+     * JPQL constructor that accepts the raw entity class produced by Hibernate's {@code TYPE(...)} function.
+     *
+     * @param id                                                             the exercise id
+     * @param title                                                          the exercise title
+     * @param type                                                           the concrete exercise entity class
+     * @param dueDate                                                        the exercise due date
+     * @param courseId                                                       the course id
+     * @param courseTitle                                                    the course title
+     * @param examId                                                         the exam id
+     * @param examTitle                                                      the exam title
+     * @param continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod the response period configured for continuous plagiarism control cases
+     */
+    public PlagiarismCaseExerciseDTO(Long id, String title, Class<? extends Exercise> type, ZonedDateTime dueDate, Long courseId, String courseTitle, Long examId, String examTitle,
+            Integer continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod) {
+        this(id, title, ExerciseType.getExerciseTypeFromClass(type), dueDate, courseId, courseTitle, examId, examTitle,
+                continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod);
+    }
+
+    /**
+     * Maps an exercise entity to the plagiarism case exercise DTO.
+     *
+     * @param exercise the exercise entity
+     * @return the DTO representation
+     */
     public static PlagiarismCaseExerciseDTO fromExercise(Exercise exercise) {
         if (exercise == null) {
             return null;

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseExerciseDTO.java
@@ -1,0 +1,31 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.core.domain.Course;
+import de.tum.cit.aet.artemis.exam.domain.Exam;
+import de.tum.cit.aet.artemis.exercise.domain.Exercise;
+import de.tum.cit.aet.artemis.exercise.domain.ExerciseType;
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismDetectionConfig;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismCaseExerciseDTO(Long id, String title, ExerciseType type, ZonedDateTime dueDate, Long courseId, String courseTitle, Long examId, String examTitle,
+        Integer continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod) {
+
+    public static PlagiarismCaseExerciseDTO fromExercise(Exercise exercise) {
+        if (exercise == null) {
+            return null;
+        }
+
+        Course course = exercise.getCourseViaExerciseGroupOrCourseMember();
+        Exam exam = exercise.getExam();
+        Integer studentResponsePeriod = Optional.ofNullable(exercise.getPlagiarismDetectionConfig())
+                .map(PlagiarismDetectionConfig::getContinuousPlagiarismControlPlagiarismCaseStudentResponsePeriod).orElse(null);
+
+        return new PlagiarismCaseExerciseDTO(exercise.getId(), exercise.getTitle(), exercise.getExerciseType(), exercise.getDueDate(), course != null ? course.getId() : null,
+                course != null ? course.getTitle() : null, exam != null ? exam.getId() : null, exam != null ? exam.getTitle() : null, studentResponsePeriod);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseExerciseDTO.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.cit.aet.artemis.core.domain.Course;
+import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.exam.domain.Exam;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.ExerciseType;

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseExerciseDTO.java
@@ -3,6 +3,8 @@ package de.tum.cit.aet.artemis.plagiarism.dto;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.course.domain.Course;
@@ -12,8 +14,8 @@ import de.tum.cit.aet.artemis.exercise.domain.ExerciseType;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismDetectionConfig;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismCaseExerciseDTO(Long id, String title, String shortName, ExerciseType type, ZonedDateTime dueDate, Long courseId, String courseTitle, Long examId,
-        String examTitle, Integer continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod) {
+public record PlagiarismCaseExerciseDTO(Long id, String title, @Nullable String shortName, ExerciseType type, @Nullable ZonedDateTime dueDate, @Nullable Long courseId,
+        @Nullable String courseTitle, @Nullable Long examId, @Nullable String examTitle, @Nullable Integer continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod) {
 
     /**
      * JPQL constructor that accepts the raw entity class produced by Hibernate's {@code TYPE(...)} function.
@@ -29,8 +31,8 @@ public record PlagiarismCaseExerciseDTO(Long id, String title, String shortName,
      * @param examTitle                                                      the exam title
      * @param continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod the response period configured for continuous plagiarism control cases
      */
-    public PlagiarismCaseExerciseDTO(Long id, String title, String shortName, Class<? extends Exercise> type, ZonedDateTime dueDate, Long courseId, String courseTitle, Long examId,
-            String examTitle, Integer continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod) {
+    public PlagiarismCaseExerciseDTO(Long id, String title, @Nullable String shortName, Class<? extends Exercise> type, @Nullable ZonedDateTime dueDate, @Nullable Long courseId,
+            @Nullable String courseTitle, @Nullable Long examId, @Nullable String examTitle, @Nullable Integer continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod) {
         this(id, title, shortName, ExerciseType.getExerciseTypeFromClass(type), dueDate, courseId, courseTitle, examId, examTitle,
                 continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod);
     }
@@ -41,7 +43,7 @@ public record PlagiarismCaseExerciseDTO(Long id, String title, String shortName,
      * @param exercise the exercise entity
      * @return the DTO representation
      */
-    public static PlagiarismCaseExerciseDTO fromExercise(Exercise exercise) {
+    public static @Nullable PlagiarismCaseExerciseDTO fromExercise(@Nullable Exercise exercise) {
         if (exercise == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseExerciseDTO.java
@@ -12,14 +12,15 @@ import de.tum.cit.aet.artemis.exercise.domain.ExerciseType;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismDetectionConfig;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismCaseExerciseDTO(Long id, String title, ExerciseType type, ZonedDateTime dueDate, Long courseId, String courseTitle, Long examId, String examTitle,
-        Integer continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod) {
+public record PlagiarismCaseExerciseDTO(Long id, String title, String shortName, ExerciseType type, ZonedDateTime dueDate, Long courseId, String courseTitle, Long examId,
+        String examTitle, Integer continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod) {
 
     /**
      * JPQL constructor that accepts the raw entity class produced by Hibernate's {@code TYPE(...)} function.
      *
      * @param id                                                             the exercise id
      * @param title                                                          the exercise title
+     * @param shortName                                                      the exercise short name
      * @param type                                                           the concrete exercise entity class
      * @param dueDate                                                        the exercise due date
      * @param courseId                                                       the course id
@@ -28,9 +29,9 @@ public record PlagiarismCaseExerciseDTO(Long id, String title, ExerciseType type
      * @param examTitle                                                      the exam title
      * @param continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod the response period configured for continuous plagiarism control cases
      */
-    public PlagiarismCaseExerciseDTO(Long id, String title, Class<? extends Exercise> type, ZonedDateTime dueDate, Long courseId, String courseTitle, Long examId, String examTitle,
-            Integer continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod) {
-        this(id, title, ExerciseType.getExerciseTypeFromClass(type), dueDate, courseId, courseTitle, examId, examTitle,
+    public PlagiarismCaseExerciseDTO(Long id, String title, String shortName, Class<? extends Exercise> type, ZonedDateTime dueDate, Long courseId, String courseTitle, Long examId,
+            String examTitle, Integer continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod) {
+        this(id, title, shortName, ExerciseType.getExerciseTypeFromClass(type), dueDate, courseId, courseTitle, examId, examTitle,
                 continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod);
     }
 
@@ -50,7 +51,8 @@ public record PlagiarismCaseExerciseDTO(Long id, String title, ExerciseType type
         Integer studentResponsePeriod = Optional.ofNullable(exercise.getPlagiarismDetectionConfig())
                 .map(PlagiarismDetectionConfig::getContinuousPlagiarismControlPlagiarismCaseStudentResponsePeriod).orElse(null);
 
-        return new PlagiarismCaseExerciseDTO(exercise.getId(), exercise.getTitle(), exercise.getExerciseType(), exercise.getDueDate(), course != null ? course.getId() : null,
-                course != null ? course.getTitle() : null, exam != null ? exam.getId() : null, exam != null ? exam.getTitle() : null, studentResponsePeriod);
+        return new PlagiarismCaseExerciseDTO(exercise.getId(), exercise.getTitle(), exercise.getShortName(), exercise.getExerciseType(), exercise.getDueDate(),
+                course != null ? course.getId() : null, course != null ? course.getTitle() : null, exam != null ? exam.getId() : null, exam != null ? exam.getTitle() : null,
+                studentResponsePeriod);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
@@ -11,7 +11,7 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, PlagiarismCaseUserDTO student, PlagiarismCasePostSummaryDTO post, PlagiarismVerdict verdict,
-        ZonedDateTime verdictDate, PlagiarismCaseUserDTO verdictBy, int plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl) {
+        ZonedDateTime verdictDate, PlagiarismCaseUserDTO verdictBy, int plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl, boolean hasStudentAnswer) {
 
     /**
      * JPQL constructor for overview projections. It keeps optional nested DTOs absent when the joined entity is absent.
@@ -24,6 +24,7 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
      * @param studentVisibleRegistrationNumber     the affected student's visible registration number
      * @param postId                               the post id
      * @param postCreationDate                     the post creation date
+     * @param hasStudentAnswer                     whether the affected student answered the notification post
      * @param verdict                              the plagiarism verdict
      * @param verdictDate                          the verdict date
      * @param verdictById                          the verdict author id
@@ -34,11 +35,11 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
      * @param createdByContinuousPlagiarismControl whether the case was created by continuous plagiarism control
      */
     public PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentName, String studentVisibleRegistrationNumber,
-            Long postId, ZonedDateTime postCreationDate, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById, String verdictByLogin, String verdictByName,
-            String verdictByVisibleRegistrationNumber, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl) {
+            Long postId, ZonedDateTime postCreationDate, boolean hasStudentAnswer, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById, String verdictByLogin,
+            String verdictByName, String verdictByVisibleRegistrationNumber, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl) {
         this(id, exercise, userOrNull(studentId, studentLogin, studentName, studentVisibleRegistrationNumber), postOrNull(postId, postCreationDate), verdict, verdictDate,
                 userOrNull(verdictById, verdictByLogin, verdictByName, verdictByVisibleRegistrationNumber), Math.toIntExact(plagiarismSubmissionCount),
-                createdByContinuousPlagiarismControl);
+                createdByContinuousPlagiarismControl, hasStudentAnswer);
     }
 
     /**
@@ -60,7 +61,7 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
         return new PlagiarismCaseOverviewDTO(plagiarismCase.getId(), PlagiarismCaseExerciseDTO.fromExercise(plagiarismCase.getExercise()),
                 PlagiarismCaseUserDTO.fromUser(plagiarismCase.getStudent()), PlagiarismCasePostSummaryDTO.fromPost(plagiarismCase.getPost()), plagiarismCase.getVerdict(),
                 plagiarismCase.getVerdictDate(), PlagiarismCaseUserDTO.fromUser(plagiarismCase.getVerdictBy()), plagiarismSubmissionCount,
-                plagiarismCase.isCreatedByContinuousPlagiarismControl());
+                plagiarismCase.isCreatedByContinuousPlagiarismControl(), false);
     }
 
     private static PlagiarismCaseUserDTO userOrNull(Long id, String login, String name, String visibleRegistrationNumber) {

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
@@ -13,6 +13,40 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
 public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, PlagiarismCaseUserDTO student, PlagiarismCasePostSummaryDTO post, PlagiarismVerdict verdict,
         ZonedDateTime verdictDate, PlagiarismCaseUserDTO verdictBy, int plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl) {
 
+    /**
+     * JPQL constructor for overview projections. It keeps optional nested DTOs absent when the joined entity is absent.
+     *
+     * @param id                                   the plagiarism case id
+     * @param exercise                             the exercise DTO
+     * @param studentId                            the affected student id
+     * @param studentLogin                         the affected student login
+     * @param studentName                          the affected student name
+     * @param studentVisibleRegistrationNumber     the affected student's visible registration number
+     * @param postId                               the post id
+     * @param postCreationDate                     the post creation date
+     * @param verdict                              the plagiarism verdict
+     * @param verdictDate                          the verdict date
+     * @param verdictById                          the verdict author id
+     * @param verdictByLogin                       the verdict author login
+     * @param verdictByName                        the verdict author name
+     * @param verdictByVisibleRegistrationNumber   the verdict author's visible registration number
+     * @param plagiarismSubmissionCount            the number of submissions attached to the plagiarism case
+     * @param createdByContinuousPlagiarismControl whether the case was created by continuous plagiarism control
+     */
+    public PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentName, String studentVisibleRegistrationNumber,
+            Long postId, ZonedDateTime postCreationDate, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById, String verdictByLogin, String verdictByName,
+            String verdictByVisibleRegistrationNumber, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl) {
+        this(id, exercise, userOrNull(studentId, studentLogin, studentName, studentVisibleRegistrationNumber), postOrNull(postId, postCreationDate), verdict, verdictDate,
+                userOrNull(verdictById, verdictByLogin, verdictByName, verdictByVisibleRegistrationNumber), Math.toIntExact(plagiarismSubmissionCount),
+                createdByContinuousPlagiarismControl);
+    }
+
+    /**
+     * Maps a plagiarism case entity to the overview DTO.
+     *
+     * @param plagiarismCase the plagiarism case entity
+     * @return the DTO representation
+     */
     public static PlagiarismCaseOverviewDTO ofOverview(PlagiarismCase plagiarismCase) {
         if (plagiarismCase == null) {
             return null;
@@ -27,5 +61,19 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
                 PlagiarismCaseUserDTO.fromUser(plagiarismCase.getStudent()), PlagiarismCasePostSummaryDTO.fromPost(plagiarismCase.getPost()), plagiarismCase.getVerdict(),
                 plagiarismCase.getVerdictDate(), PlagiarismCaseUserDTO.fromUser(plagiarismCase.getVerdictBy()), plagiarismSubmissionCount,
                 plagiarismCase.isCreatedByContinuousPlagiarismControl());
+    }
+
+    private static PlagiarismCaseUserDTO userOrNull(Long id, String login, String name, String visibleRegistrationNumber) {
+        if (id == null) {
+            return null;
+        }
+        return new PlagiarismCaseUserDTO(id, login, name, visibleRegistrationNumber);
+    }
+
+    private static PlagiarismCasePostSummaryDTO postOrNull(Long id, ZonedDateTime creationDate) {
+        if (id == null) {
+            return null;
+        }
+        return new PlagiarismCasePostSummaryDTO(id, creationDate);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
@@ -20,7 +20,8 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
      * @param exercise                             the exercise DTO
      * @param studentId                            the affected student id
      * @param studentLogin                         the affected student login
-     * @param studentName                          the affected student name
+     * @param studentFirstName                     the affected student's first name
+     * @param studentLastName                      the affected student's last name
      * @param studentVisibleRegistrationNumber     the affected student's visible registration number
      * @param postId                               the post id
      * @param postCreationDate                     the post creation date
@@ -29,16 +30,17 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
      * @param verdictDate                          the verdict date
      * @param verdictById                          the verdict author id
      * @param verdictByLogin                       the verdict author login
-     * @param verdictByName                        the verdict author name
-     * @param verdictByVisibleRegistrationNumber   the verdict author's visible registration number
+     * @param verdictByFirstName                   the verdict author's first name
+     * @param verdictByLastName                    the verdict author's last name
      * @param plagiarismSubmissionCount            the number of submissions attached to the plagiarism case
      * @param createdByContinuousPlagiarismControl whether the case was created by continuous plagiarism control
      */
-    public PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentName, String studentVisibleRegistrationNumber,
-            Long postId, ZonedDateTime postCreationDate, boolean hasStudentAnswer, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById, String verdictByLogin,
-            String verdictByName, String verdictByVisibleRegistrationNumber, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl) {
-        this(id, exercise, userOrNull(studentId, studentLogin, studentName, studentVisibleRegistrationNumber), postOrNull(postId, postCreationDate), verdict, verdictDate,
-                userOrNull(verdictById, verdictByLogin, verdictByName, verdictByVisibleRegistrationNumber), Math.toIntExact(plagiarismSubmissionCount),
+    public PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentFirstName, String studentLastName,
+            String studentVisibleRegistrationNumber, Long postId, ZonedDateTime postCreationDate, boolean hasStudentAnswer, PlagiarismVerdict verdict, ZonedDateTime verdictDate,
+            Long verdictById, String verdictByLogin, String verdictByFirstName, String verdictByLastName, long plagiarismSubmissionCount,
+            boolean createdByContinuousPlagiarismControl) {
+        this(id, exercise, userOrNull(studentId, studentLogin, fullName(studentFirstName, studentLastName), studentVisibleRegistrationNumber), postOrNull(postId, postCreationDate),
+                verdict, verdictDate, userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), Math.toIntExact(plagiarismSubmissionCount),
                 createdByContinuousPlagiarismControl, hasStudentAnswer);
     }
 
@@ -69,6 +71,13 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
             return null;
         }
         return new PlagiarismCaseUserDTO(id, login, name, visibleRegistrationNumber);
+    }
+
+    private static String fullName(String firstName, String lastName) {
+        if (lastName != null && !lastName.isEmpty()) {
+            return firstName + " " + lastName;
+        }
+        return firstName;
     }
 
     private static PlagiarismCasePostSummaryDTO postOrNull(Long id, ZonedDateTime creationDate) {

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
@@ -1,0 +1,31 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import java.time.ZonedDateTime;
+
+import org.hibernate.Hibernate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCase;
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, PlagiarismCaseUserDTO student, PlagiarismCasePostSummaryDTO post, PlagiarismVerdict verdict,
+        ZonedDateTime verdictDate, PlagiarismCaseUserDTO verdictBy, int plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl) {
+
+    public static PlagiarismCaseOverviewDTO ofOverview(PlagiarismCase plagiarismCase) {
+        if (plagiarismCase == null) {
+            return null;
+        }
+
+        int plagiarismSubmissionCount = 0;
+        if (plagiarismCase.getPlagiarismSubmissions() != null && Hibernate.isInitialized(plagiarismCase.getPlagiarismSubmissions())) {
+            plagiarismSubmissionCount = plagiarismCase.getPlagiarismSubmissions().size();
+        }
+
+        return new PlagiarismCaseOverviewDTO(plagiarismCase.getId(), PlagiarismCaseExerciseDTO.fromExercise(plagiarismCase.getExercise()),
+                PlagiarismCaseUserDTO.fromUser(plagiarismCase.getStudent()), PlagiarismCasePostSummaryDTO.fromPost(plagiarismCase.getPost()), plagiarismCase.getVerdict(),
+                plagiarismCase.getVerdictDate(), PlagiarismCaseUserDTO.fromUser(plagiarismCase.getVerdictBy()), plagiarismSubmissionCount,
+                plagiarismCase.isCreatedByContinuousPlagiarismControl());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
@@ -2,11 +2,8 @@ package de.tum.cit.aet.artemis.plagiarism.dto;
 
 import java.time.ZonedDateTime;
 
-import org.hibernate.Hibernate;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCase;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -38,30 +35,8 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
             ZonedDateTime postCreationDate, boolean hasStudentAnswer, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById, String verdictByLogin,
             String verdictByFirstName, String verdictByLastName, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl) {
         this(id, exercise, userOrNull(studentId, studentLogin, fullName(studentFirstName, studentLastName), null), postOrNull(postId, postCreationDate), verdict, verdictDate,
-                userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), Math.toIntExact(plagiarismSubmissionCount),
+                userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), toBoundedInt(plagiarismSubmissionCount),
                 createdByContinuousPlagiarismControl, hasStudentAnswer);
-    }
-
-    /**
-     * Maps a plagiarism case entity to the overview DTO.
-     *
-     * @param plagiarismCase the plagiarism case entity
-     * @return the DTO representation
-     */
-    public static PlagiarismCaseOverviewDTO ofOverview(PlagiarismCase plagiarismCase) {
-        if (plagiarismCase == null) {
-            return null;
-        }
-
-        int plagiarismSubmissionCount = 0;
-        if (plagiarismCase.getPlagiarismSubmissions() != null && Hibernate.isInitialized(plagiarismCase.getPlagiarismSubmissions())) {
-            plagiarismSubmissionCount = plagiarismCase.getPlagiarismSubmissions().size();
-        }
-
-        return new PlagiarismCaseOverviewDTO(plagiarismCase.getId(), PlagiarismCaseExerciseDTO.fromExercise(plagiarismCase.getExercise()),
-                PlagiarismCaseUserDTO.fromUser(plagiarismCase.getStudent()), PlagiarismCasePostSummaryDTO.fromPost(plagiarismCase.getPost()), plagiarismCase.getVerdict(),
-                plagiarismCase.getVerdictDate(), PlagiarismCaseUserDTO.fromUser(plagiarismCase.getVerdictBy()), plagiarismSubmissionCount,
-                plagiarismCase.isCreatedByContinuousPlagiarismControl(), false);
     }
 
     private static PlagiarismCaseUserDTO userOrNull(Long id, String login, String name, String visibleRegistrationNumber) {
@@ -72,10 +47,25 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
     }
 
     private static String fullName(String firstName, String lastName) {
-        if (lastName != null && !lastName.isEmpty()) {
+        boolean hasFirstName = firstName != null && !firstName.isEmpty();
+        boolean hasLastName = lastName != null && !lastName.isEmpty();
+        if (hasFirstName && hasLastName) {
             return firstName + " " + lastName;
         }
-        return firstName;
+        if (hasFirstName) {
+            return firstName;
+        }
+        if (hasLastName) {
+            return lastName;
+        }
+        return null;
+    }
+
+    private static int toBoundedInt(long value) {
+        if (value > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return Math.toIntExact(value);
     }
 
     private static PlagiarismCasePostSummaryDTO postOrNull(Long id, ZonedDateTime creationDate) {

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
@@ -2,13 +2,16 @@ package de.tum.cit.aet.artemis.plagiarism.dto;
 
 import java.time.ZonedDateTime;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, PlagiarismCaseUserDTO student, PlagiarismCasePostSummaryDTO post, PlagiarismVerdict verdict,
-        ZonedDateTime verdictDate, PlagiarismCaseUserDTO verdictBy, int plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl, boolean hasStudentAnswer) {
+public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, @Nullable PlagiarismCaseUserDTO student, @Nullable PlagiarismCasePostSummaryDTO post,
+        @Nullable PlagiarismVerdict verdict, @Nullable ZonedDateTime verdictDate, @Nullable PlagiarismCaseUserDTO verdictBy, int plagiarismSubmissionCount,
+        boolean createdByContinuousPlagiarismControl, boolean hasStudentAnswer) {
 
     /**
      * JPQL constructor for overview projections. It keeps optional nested DTOs absent when the joined entity is absent.
@@ -31,22 +34,23 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
      * @param plagiarismSubmissionCount            the number of submissions attached to the plagiarism case
      * @param createdByContinuousPlagiarismControl whether the case was created by continuous plagiarism control
      */
-    public PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentFirstName, String studentLastName, Long postId,
-            ZonedDateTime postCreationDate, boolean hasStudentAnswer, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById, String verdictByLogin,
-            String verdictByFirstName, String verdictByLastName, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl) {
+    public PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, @Nullable Long studentId, @Nullable String studentLogin, @Nullable String studentFirstName,
+            @Nullable String studentLastName, @Nullable Long postId, @Nullable ZonedDateTime postCreationDate, boolean hasStudentAnswer, @Nullable PlagiarismVerdict verdict,
+            @Nullable ZonedDateTime verdictDate, @Nullable Long verdictById, @Nullable String verdictByLogin, @Nullable String verdictByFirstName,
+            @Nullable String verdictByLastName, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl) {
         this(id, exercise, userOrNull(studentId, studentLogin, fullName(studentFirstName, studentLastName), null), postOrNull(postId, postCreationDate), verdict, verdictDate,
                 userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), toBoundedInt(plagiarismSubmissionCount),
                 createdByContinuousPlagiarismControl, hasStudentAnswer);
     }
 
-    private static PlagiarismCaseUserDTO userOrNull(Long id, String login, String name, String visibleRegistrationNumber) {
+    private static @Nullable PlagiarismCaseUserDTO userOrNull(@Nullable Long id, @Nullable String login, @Nullable String name, @Nullable String visibleRegistrationNumber) {
         if (id == null) {
             return null;
         }
         return new PlagiarismCaseUserDTO(id, login, name, visibleRegistrationNumber);
     }
 
-    private static String fullName(String firstName, String lastName) {
+    private static @Nullable String fullName(@Nullable String firstName, @Nullable String lastName) {
         boolean hasFirstName = firstName != null && !firstName.isEmpty();
         boolean hasLastName = lastName != null && !lastName.isEmpty();
         if (hasFirstName && hasLastName) {
@@ -68,7 +72,7 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
         return Math.toIntExact(value);
     }
 
-    private static PlagiarismCasePostSummaryDTO postOrNull(Long id, ZonedDateTime creationDate) {
+    private static @Nullable PlagiarismCasePostSummaryDTO postOrNull(@Nullable Long id, @Nullable ZonedDateTime creationDate) {
         if (id == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
@@ -22,7 +22,6 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
      * @param studentLogin                         the affected student login
      * @param studentFirstName                     the affected student's first name
      * @param studentLastName                      the affected student's last name
-     * @param studentVisibleRegistrationNumber     the affected student's visible registration number
      * @param postId                               the post id
      * @param postCreationDate                     the post creation date
      * @param hasStudentAnswer                     whether the affected student answered the notification post
@@ -35,12 +34,11 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
      * @param plagiarismSubmissionCount            the number of submissions attached to the plagiarism case
      * @param createdByContinuousPlagiarismControl whether the case was created by continuous plagiarism control
      */
-    public PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentFirstName, String studentLastName,
-            String studentVisibleRegistrationNumber, Long postId, ZonedDateTime postCreationDate, boolean hasStudentAnswer, PlagiarismVerdict verdict, ZonedDateTime verdictDate,
-            Long verdictById, String verdictByLogin, String verdictByFirstName, String verdictByLastName, long plagiarismSubmissionCount,
-            boolean createdByContinuousPlagiarismControl) {
-        this(id, exercise, userOrNull(studentId, studentLogin, fullName(studentFirstName, studentLastName), studentVisibleRegistrationNumber), postOrNull(postId, postCreationDate),
-                verdict, verdictDate, userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), Math.toIntExact(plagiarismSubmissionCount),
+    public PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exercise, Long studentId, String studentLogin, String studentFirstName, String studentLastName, Long postId,
+            ZonedDateTime postCreationDate, boolean hasStudentAnswer, PlagiarismVerdict verdict, ZonedDateTime verdictDate, Long verdictById, String verdictByLogin,
+            String verdictByFirstName, String verdictByLastName, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl) {
+        this(id, exercise, userOrNull(studentId, studentLogin, fullName(studentFirstName, studentLastName), null), postOrNull(postId, postCreationDate), verdict, verdictDate,
+                userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), Math.toIntExact(plagiarismSubmissionCount),
                 createdByContinuousPlagiarismControl, hasStudentAnswer);
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCasePostSummaryDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCasePostSummaryDTO.java
@@ -1,0 +1,27 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.hibernate.Hibernate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.communication.domain.Post;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismCasePostSummaryDTO(Long id, ZonedDateTime creationDate, List<Long> answerAuthorIds) {
+
+    public static PlagiarismCasePostSummaryDTO fromPost(Post post) {
+        if (post == null) {
+            return null;
+        }
+
+        List<Long> answerAuthorIds = null;
+        if (post.getAnswers() != null && Hibernate.isInitialized(post.getAnswers())) {
+            answerAuthorIds = post.getAnswers().stream().filter(answer -> answer.getAuthor() != null).map(answer -> answer.getAuthor().getId()).toList();
+        }
+
+        return new PlagiarismCasePostSummaryDTO(post.getId(), post.getCreationDate(), answerAuthorIds);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCasePostSummaryDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCasePostSummaryDTO.java
@@ -1,27 +1,24 @@
 package de.tum.cit.aet.artemis.plagiarism.dto;
 
 import java.time.ZonedDateTime;
-import java.util.List;
-
-import org.hibernate.Hibernate;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.communication.domain.Post;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismCasePostSummaryDTO(Long id, ZonedDateTime creationDate, List<Long> answerAuthorIds) {
+public record PlagiarismCasePostSummaryDTO(Long id, ZonedDateTime creationDate) {
 
+    /**
+     * Maps a communication post entity to the plagiarism case post summary DTO.
+     *
+     * @param post the post entity
+     * @return the DTO representation
+     */
     public static PlagiarismCasePostSummaryDTO fromPost(Post post) {
         if (post == null) {
             return null;
         }
-
-        List<Long> answerAuthorIds = null;
-        if (post.getAnswers() != null && Hibernate.isInitialized(post.getAnswers())) {
-            answerAuthorIds = post.getAnswers().stream().filter(answer -> answer.getAuthor() != null).map(answer -> answer.getAuthor().getId()).toList();
-        }
-
-        return new PlagiarismCasePostSummaryDTO(post.getId(), post.getCreationDate(), answerAuthorIds);
+        return new PlagiarismCasePostSummaryDTO(post.getId(), post.getCreationDate());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCasePostSummaryDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCasePostSummaryDTO.java
@@ -2,6 +2,8 @@ package de.tum.cit.aet.artemis.plagiarism.dto;
 
 import java.time.ZonedDateTime;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.communication.domain.Post;
@@ -15,7 +17,7 @@ public record PlagiarismCasePostSummaryDTO(Long id, ZonedDateTime creationDate) 
      * @param post the post entity
      * @return the DTO representation
      */
-    public static PlagiarismCasePostSummaryDTO fromPost(Post post) {
+    public static @Nullable PlagiarismCasePostSummaryDTO fromPost(@Nullable Post post) {
         if (post == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseUserDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseUserDTO.java
@@ -2,7 +2,7 @@ package de.tum.cit.aet.artemis.plagiarism.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.cit.aet.artemis.core.domain.User;
+import de.tum.cit.aet.artemis.account.domain.User;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PlagiarismCaseUserDTO(Long id, String login, String name, String visibleRegistrationNumber) {

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseUserDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseUserDTO.java
@@ -1,13 +1,15 @@
 package de.tum.cit.aet.artemis.plagiarism.dto;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.account.domain.User;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismCaseUserDTO(Long id, String login, String name, String visibleRegistrationNumber) {
+public record PlagiarismCaseUserDTO(Long id, @Nullable String login, @Nullable String name, @Nullable String visibleRegistrationNumber) {
 
-    public static PlagiarismCaseUserDTO fromUser(User user) {
+    public static @Nullable PlagiarismCaseUserDTO fromUser(@Nullable User user) {
         if (user == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseUserDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseUserDTO.java
@@ -1,0 +1,16 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.core.domain.User;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismCaseUserDTO(Long id, String login, String name, String visibleRegistrationNumber) {
+
+    public static PlagiarismCaseUserDTO fromUser(User user) {
+        if (user == null) {
+            return null;
+        }
+        return new PlagiarismCaseUserDTO(user.getId(), user.getLogin(), user.getName(), user.getVisibleRegistrationNumber());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseVerdictResponseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseVerdictResponseDTO.java
@@ -11,6 +11,12 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
 public record PlagiarismCaseVerdictResponseDTO(PlagiarismVerdict verdict, String verdictMessage, int verdictPointDeduction, PlagiarismCaseUserDTO verdictBy,
         ZonedDateTime verdictDate) {
 
+    /**
+     * Maps the verdict part of a plagiarism case entity to the response DTO returned after saving a verdict.
+     *
+     * @param plagiarismCase the plagiarism case entity
+     * @return the DTO representation
+     */
     public static PlagiarismCaseVerdictResponseDTO ofVerdict(PlagiarismCase plagiarismCase) {
         if (plagiarismCase == null) {
             return null;

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseVerdictResponseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseVerdictResponseDTO.java
@@ -2,13 +2,15 @@ package de.tum.cit.aet.artemis.plagiarism.dto;
 
 import java.time.ZonedDateTime;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCase;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismCaseVerdictResponseDTO(PlagiarismVerdict verdict, String verdictMessage, int verdictPointDeduction, PlagiarismCaseUserDTO verdictBy,
+public record PlagiarismCaseVerdictResponseDTO(PlagiarismVerdict verdict, @Nullable String verdictMessage, int verdictPointDeduction, PlagiarismCaseUserDTO verdictBy,
         ZonedDateTime verdictDate) {
 
     /**
@@ -17,7 +19,7 @@ public record PlagiarismCaseVerdictResponseDTO(PlagiarismVerdict verdict, String
      * @param plagiarismCase the plagiarism case entity
      * @return the DTO representation
      */
-    public static PlagiarismCaseVerdictResponseDTO ofVerdict(PlagiarismCase plagiarismCase) {
+    public static @Nullable PlagiarismCaseVerdictResponseDTO ofVerdict(@Nullable PlagiarismCase plagiarismCase) {
         if (plagiarismCase == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseVerdictResponseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseVerdictResponseDTO.java
@@ -1,0 +1,21 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import java.time.ZonedDateTime;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCase;
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismCaseVerdictResponseDTO(PlagiarismVerdict verdict, String verdictMessage, int verdictPointDeduction, PlagiarismCaseUserDTO verdictBy,
+        ZonedDateTime verdictDate) {
+
+    public static PlagiarismCaseVerdictResponseDTO ofVerdict(PlagiarismCase plagiarismCase) {
+        if (plagiarismCase == null) {
+            return null;
+        }
+        return new PlagiarismCaseVerdictResponseDTO(plagiarismCase.getVerdict(), plagiarismCase.getVerdictMessage(), plagiarismCase.getVerdictPointDeduction(),
+                PlagiarismCaseUserDTO.fromUser(plagiarismCase.getVerdictBy()), plagiarismCase.getVerdictDate());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PlagiarismComparisonDTO(Long id, PlagiarismSubmissionDTO submissionA, PlagiarismSubmissionDTO submissionB, Set<PlagiarismMatchDTO> matches, double similarity,
         PlagiarismStatus status) {
 

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
@@ -24,13 +24,28 @@ public record PlagiarismComparisonDTO(Long id, PlagiarismSubmissionDTO submissio
         if (comparison == null) {
             return null;
         }
+        return fromComparison(comparison, comparison);
+    }
 
-        Set<PlagiarismMatchDTO> matches = null;
-        if (comparison.getMatches() != null && Hibernate.isInitialized(comparison.getMatches())) {
-            matches = comparison.getMatches().stream().map(PlagiarismMatchDTO::fromMatch).collect(Collectors.toSet());
+    /**
+     * Maps a plagiarism comparison loaded in two steps to the DTO used by the split view.
+     *
+     * @param comparisonWithSubmissionA the comparison whose submission A elements are initialized
+     * @param comparisonWithSubmissionB the comparison whose submission B elements are initialized
+     * @return the DTO representation
+     */
+    public static PlagiarismComparisonDTO fromComparison(PlagiarismComparison comparisonWithSubmissionA, PlagiarismComparison comparisonWithSubmissionB) {
+        if (comparisonWithSubmissionA == null) {
+            return null;
         }
 
-        return new PlagiarismComparisonDTO(comparison.getId(), PlagiarismSubmissionDTO.fromSubmission(comparison.getSubmissionA()),
-                PlagiarismSubmissionDTO.fromSubmission(comparison.getSubmissionB()), matches, comparison.getSimilarity(), comparison.getStatus());
+        Set<PlagiarismMatchDTO> matches = null;
+        if (comparisonWithSubmissionA.getMatches() != null && Hibernate.isInitialized(comparisonWithSubmissionA.getMatches())) {
+            matches = comparisonWithSubmissionA.getMatches().stream().map(PlagiarismMatchDTO::fromMatch).collect(Collectors.toSet());
+        }
+
+        return new PlagiarismComparisonDTO(comparisonWithSubmissionA.getId(), PlagiarismSubmissionDTO.fromSubmission(comparisonWithSubmissionA.getSubmissionA()),
+                PlagiarismSubmissionDTO.fromSubmission(comparisonWithSubmissionB != null ? comparisonWithSubmissionB.getSubmissionB() : null), matches,
+                comparisonWithSubmissionA.getSimilarity(), comparisonWithSubmissionA.getStatus());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
@@ -14,6 +14,12 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus;
 public record PlagiarismComparisonDTO(Long id, PlagiarismSubmissionDTO submissionA, PlagiarismSubmissionDTO submissionB, Set<PlagiarismMatchDTO> matches, double similarity,
         PlagiarismStatus status) {
 
+    /**
+     * Maps a plagiarism comparison entity to the DTO used by the split view.
+     *
+     * @param comparison the plagiarism comparison entity
+     * @return the DTO representation
+     */
     public static PlagiarismComparisonDTO fromComparison(PlagiarismComparison comparison) {
         if (comparison == null) {
             return null;

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
@@ -3,8 +3,6 @@ package de.tum.cit.aet.artemis.plagiarism.dto;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.hibernate.Hibernate;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
@@ -39,10 +37,9 @@ public record PlagiarismComparisonDTO(Long id, PlagiarismSubmissionDTO submissio
             return null;
         }
 
-        Set<PlagiarismMatchDTO> matches = null;
-        if (comparisonWithSubmissionA.getMatches() != null && Hibernate.isInitialized(comparisonWithSubmissionA.getMatches())) {
-            matches = comparisonWithSubmissionA.getMatches().stream().map(PlagiarismMatchDTO::fromMatch).collect(Collectors.toSet());
-        }
+        Set<PlagiarismMatchDTO> matches = comparisonWithSubmissionA.getMatches() != null
+                ? comparisonWithSubmissionA.getMatches().stream().map(PlagiarismMatchDTO::fromMatch).collect(Collectors.toSet())
+                : null;
 
         return new PlagiarismComparisonDTO(comparisonWithSubmissionA.getId(), PlagiarismSubmissionDTO.fromSubmission(comparisonWithSubmissionA.getSubmissionA()),
                 PlagiarismSubmissionDTO.fromSubmission(comparisonWithSubmissionB != null ? comparisonWithSubmissionB.getSubmissionB() : null), matches,

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record PlagiarismComparisonDTO(Long id, PlagiarismSubmissionDTO submissionA, PlagiarismSubmissionDTO submissionB, Set<PlagiarismMatchDTO> matches, double similarity,
         PlagiarismStatus status) {
 

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
@@ -1,0 +1,30 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hibernate.Hibernate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismComparisonDTO(Long id, PlagiarismSubmissionDTO submissionA, PlagiarismSubmissionDTO submissionB, Set<PlagiarismMatchDTO> matches, double similarity,
+        PlagiarismStatus status) {
+
+    public static PlagiarismComparisonDTO fromComparison(PlagiarismComparison comparison) {
+        if (comparison == null) {
+            return null;
+        }
+
+        Set<PlagiarismMatchDTO> matches = null;
+        if (comparison.getMatches() != null && Hibernate.isInitialized(comparison.getMatches())) {
+            matches = comparison.getMatches().stream().map(PlagiarismMatchDTO::fromMatch).collect(Collectors.toSet());
+        }
+
+        return new PlagiarismComparisonDTO(comparison.getId(), PlagiarismSubmissionDTO.fromSubmission(comparison.getSubmissionA()),
+                PlagiarismSubmissionDTO.fromSubmission(comparison.getSubmissionB()), matches, comparison.getSimilarity(), comparison.getStatus());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonDTO.java
@@ -3,14 +3,16 @@ package de.tum.cit.aet.artemis.plagiarism.dto;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismComparisonDTO(Long id, PlagiarismSubmissionDTO submissionA, PlagiarismSubmissionDTO submissionB, Set<PlagiarismMatchDTO> matches, double similarity,
-        PlagiarismStatus status) {
+public record PlagiarismComparisonDTO(Long id, @Nullable PlagiarismSubmissionDTO submissionA, @Nullable PlagiarismSubmissionDTO submissionB,
+        @Nullable Set<PlagiarismMatchDTO> matches, double similarity, PlagiarismStatus status) {
 
     /**
      * Maps a plagiarism comparison entity to the DTO used by the split view.
@@ -18,7 +20,7 @@ public record PlagiarismComparisonDTO(Long id, PlagiarismSubmissionDTO submissio
      * @param comparison the plagiarism comparison entity
      * @return the DTO representation
      */
-    public static PlagiarismComparisonDTO fromComparison(PlagiarismComparison comparison) {
+    public static @Nullable PlagiarismComparisonDTO fromComparison(@Nullable PlagiarismComparison comparison) {
         if (comparison == null) {
             return null;
         }
@@ -32,7 +34,8 @@ public record PlagiarismComparisonDTO(Long id, PlagiarismSubmissionDTO submissio
      * @param comparisonWithSubmissionB the comparison whose submission B elements are initialized
      * @return the DTO representation
      */
-    public static PlagiarismComparisonDTO fromComparison(PlagiarismComparison comparisonWithSubmissionA, PlagiarismComparison comparisonWithSubmissionB) {
+    public static @Nullable PlagiarismComparisonDTO fromComparison(@Nullable PlagiarismComparison comparisonWithSubmissionA,
+            @Nullable PlagiarismComparison comparisonWithSubmissionB) {
         if (comparisonWithSubmissionA == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonSummaryDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonSummaryDTO.java
@@ -1,0 +1,17 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismComparisonSummaryDTO(Long id, double similarity, PlagiarismStatus status) {
+
+    public static PlagiarismComparisonSummaryDTO fromComparisonSummary(PlagiarismComparison comparison) {
+        if (comparison == null) {
+            return null;
+        }
+        return new PlagiarismComparisonSummaryDTO(comparison.getId(), comparison.getSimilarity(), comparison.getStatus());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonSummaryDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismComparisonSummaryDTO.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.plagiarism.dto;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
@@ -8,7 +10,7 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PlagiarismComparisonSummaryDTO(Long id, double similarity, PlagiarismStatus status) {
 
-    public static PlagiarismComparisonSummaryDTO fromComparisonSummary(PlagiarismComparison comparison) {
+    public static @Nullable PlagiarismComparisonSummaryDTO fromComparisonSummary(@Nullable PlagiarismComparison comparison) {
         if (comparison == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismMatchDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismMatchDTO.java
@@ -1,0 +1,16 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismMatch;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismMatchDTO(int startA, int startB, int length) {
+
+    public static PlagiarismMatchDTO fromMatch(PlagiarismMatch match) {
+        if (match == null) {
+            return null;
+        }
+        return new PlagiarismMatchDTO(match.getStartA(), match.getStartB(), match.getLength());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismMatchDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismMatchDTO.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.plagiarism.dto;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismMatch;
@@ -7,7 +9,7 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismMatch;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PlagiarismMatchDTO(int startA, int startB, int length) {
 
-    public static PlagiarismMatchDTO fromMatch(PlagiarismMatch match) {
+    public static @Nullable PlagiarismMatchDTO fromMatch(@Nullable PlagiarismMatch match) {
         if (match == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultDTO.java
@@ -2,8 +2,6 @@ package de.tum.cit.aet.artemis.plagiarism.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
-
 /**
  * Transfers information about plagiarism checks result and its statistics
  *
@@ -11,5 +9,5 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
  * @param plagiarismResultStats the statistics regarding the plagiarism result
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismResultDTO(PlagiarismResult plagiarismResult, PlagiarismResultStats plagiarismResultStats) {
+public record PlagiarismResultDTO(PlagiarismResultDetailsDTO plagiarismResult, PlagiarismResultStatsDTO plagiarismResultStats) {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultDetailsDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultDetailsDTO.java
@@ -4,13 +4,15 @@ import java.time.Instant;
 import java.util.List;
 
 import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismResultDetailsDTO(Long id, List<PlagiarismComparisonDTO> comparisons, long duration, List<Integer> similarityDistribution, Instant createdDate) {
+public record PlagiarismResultDetailsDTO(@Nullable Long id, @Nullable List<PlagiarismComparisonDTO> comparisons, long duration, @Nullable List<Integer> similarityDistribution,
+        @Nullable Instant createdDate) {
 
     /**
      * Maps a plagiarism result entity to the DTO returned by plagiarism result endpoints.
@@ -18,7 +20,7 @@ public record PlagiarismResultDetailsDTO(Long id, List<PlagiarismComparisonDTO> 
      * @param plagiarismResult the plagiarism result entity
      * @return the DTO representation
      */
-    public static PlagiarismResultDetailsDTO fromResult(PlagiarismResult plagiarismResult) {
+    public static @Nullable PlagiarismResultDetailsDTO fromResult(@Nullable PlagiarismResult plagiarismResult) {
         if (plagiarismResult == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultDetailsDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultDetailsDTO.java
@@ -1,0 +1,37 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.hibernate.Hibernate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismResultDetailsDTO(Long id, List<PlagiarismComparisonDTO> comparisons, long duration, List<Integer> similarityDistribution, Instant createdDate,
+        String createdBy) {
+
+    public static PlagiarismResultDetailsDTO fromResult(PlagiarismResult plagiarismResult) {
+        if (plagiarismResult == null) {
+            return null;
+        }
+
+        List<PlagiarismComparisonDTO> comparisons = null;
+        if (plagiarismResult.getComparisons() != null && Hibernate.isInitialized(plagiarismResult.getComparisons())) {
+            comparisons = plagiarismResult.getComparisons().stream().map(PlagiarismComparisonDTO::fromComparison).toList();
+        }
+
+        List<Integer> similarityDistribution = null;
+        try {
+            similarityDistribution = plagiarismResult.getSimilarityDistribution();
+        }
+        catch (NullPointerException ignored) {
+            // Older tests and partially initialized results may not carry a distribution yet.
+        }
+
+        return new PlagiarismResultDetailsDTO(plagiarismResult.getId(), comparisons, plagiarismResult.getDuration(), similarityDistribution, plagiarismResult.getCreatedDate(),
+                plagiarismResult.getCreatedBy());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultDetailsDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultDetailsDTO.java
@@ -10,8 +10,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismResultDetailsDTO(Long id, List<PlagiarismComparisonDTO> comparisons, long duration, List<Integer> similarityDistribution, Instant createdDate,
-        String createdBy) {
+public record PlagiarismResultDetailsDTO(Long id, List<PlagiarismComparisonDTO> comparisons, long duration, List<Integer> similarityDistribution, Instant createdDate) {
 
     /**
      * Maps a plagiarism result entity to the DTO returned by plagiarism result endpoints.
@@ -37,7 +36,6 @@ public record PlagiarismResultDetailsDTO(Long id, List<PlagiarismComparisonDTO> 
             // Older tests and partially initialized results may not carry a distribution yet.
         }
 
-        return new PlagiarismResultDetailsDTO(plagiarismResult.getId(), comparisons, plagiarismResult.getDuration(), similarityDistribution, plagiarismResult.getCreatedDate(),
-                plagiarismResult.getCreatedBy());
+        return new PlagiarismResultDetailsDTO(plagiarismResult.getId(), comparisons, plagiarismResult.getDuration(), similarityDistribution, plagiarismResult.getCreatedDate());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultDetailsDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultDetailsDTO.java
@@ -13,6 +13,12 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
 public record PlagiarismResultDetailsDTO(Long id, List<PlagiarismComparisonDTO> comparisons, long duration, List<Integer> similarityDistribution, Instant createdDate,
         String createdBy) {
 
+    /**
+     * Maps a plagiarism result entity to the DTO returned by plagiarism result endpoints.
+     *
+     * @param plagiarismResult the plagiarism result entity
+     * @return the DTO representation
+     */
     public static PlagiarismResultDetailsDTO fromResult(PlagiarismResult plagiarismResult) {
         if (plagiarismResult == null) {
             return null;

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultDetailsDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultDetailsDTO.java
@@ -28,13 +28,7 @@ public record PlagiarismResultDetailsDTO(Long id, List<PlagiarismComparisonDTO> 
             comparisons = plagiarismResult.getComparisons().stream().map(PlagiarismComparisonDTO::fromComparison).toList();
         }
 
-        List<Integer> similarityDistribution = null;
-        try {
-            similarityDistribution = plagiarismResult.getSimilarityDistribution();
-        }
-        catch (NullPointerException ignored) {
-            // Older tests and partially initialized results may not carry a distribution yet.
-        }
+        List<Integer> similarityDistribution = plagiarismResult.getSimilarityDistribution();
 
         return new PlagiarismResultDetailsDTO(plagiarismResult.getId(), comparisons, plagiarismResult.getDuration(), similarityDistribution, plagiarismResult.getCreatedDate());
     }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultStatsDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultStatsDTO.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.plagiarism.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Stores statistics about particular plagiarism checks result.
  *
@@ -8,5 +10,6 @@ package de.tum.cit.aet.artemis.plagiarism.dto;
  * @param maximalSimilarity           maximal similarity in all comparisons
  * @param createdBy                   user or entity which stated the check
  */
-public record PlagiarismResultStats(int numberOfDetectedSubmissions, double averageSimilarity, double maximalSimilarity, String createdBy) {
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismResultStatsDTO(int numberOfDetectedSubmissions, double averageSimilarity, double maximalSimilarity, String createdBy) {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultStatsDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismResultStatsDTO.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.plagiarism.dto;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
@@ -11,5 +13,5 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * @param createdBy                   user or entity which stated the check
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismResultStatsDTO(int numberOfDetectedSubmissions, double averageSimilarity, double maximalSimilarity, String createdBy) {
+public record PlagiarismResultStatsDTO(int numberOfDetectedSubmissions, double averageSimilarity, double maximalSimilarity, @Nullable String createdBy) {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionDTO.java
@@ -3,13 +3,15 @@ package de.tum.cit.aet.artemis.plagiarism.dto;
 import java.util.List;
 
 import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismSubmissionDTO(Long id, long submissionId, String studentLogin, List<PlagiarismSubmissionElementDTO> elements, int size, Double score) {
+public record PlagiarismSubmissionDTO(Long id, long submissionId, @Nullable String studentLogin, @Nullable List<PlagiarismSubmissionElementDTO> elements, int size,
+        @Nullable Double score) {
 
     /**
      * Maps a plagiarism submission entity to the DTO used by the split view.
@@ -17,7 +19,7 @@ public record PlagiarismSubmissionDTO(Long id, long submissionId, String student
      * @param submission the plagiarism submission entity
      * @return the DTO representation
      */
-    public static PlagiarismSubmissionDTO fromSubmission(PlagiarismSubmission submission) {
+    public static @Nullable PlagiarismSubmissionDTO fromSubmission(@Nullable PlagiarismSubmission submission) {
         if (submission == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionDTO.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PlagiarismSubmissionDTO(Long id, long submissionId, String studentLogin, List<PlagiarismSubmissionElementDTO> elements, int size, Double score) {
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionDTO.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record PlagiarismSubmissionDTO(Long id, long submissionId, String studentLogin, List<PlagiarismSubmissionElementDTO> elements, int size, Double score) {
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionDTO.java
@@ -11,6 +11,12 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PlagiarismSubmissionDTO(Long id, long submissionId, String studentLogin, List<PlagiarismSubmissionElementDTO> elements, int size, Double score) {
 
+    /**
+     * Maps a plagiarism submission entity to the DTO used by the split view.
+     *
+     * @param submission the plagiarism submission entity
+     * @return the DTO representation
+     */
     public static PlagiarismSubmissionDTO fromSubmission(PlagiarismSubmission submission) {
         if (submission == null) {
             return null;

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionDTO.java
@@ -1,0 +1,26 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import java.util.List;
+
+import org.hibernate.Hibernate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismSubmissionDTO(Long id, long submissionId, String studentLogin, List<PlagiarismSubmissionElementDTO> elements, int size, Double score) {
+
+    public static PlagiarismSubmissionDTO fromSubmission(PlagiarismSubmission submission) {
+        if (submission == null) {
+            return null;
+        }
+
+        List<PlagiarismSubmissionElementDTO> elements = null;
+        if (submission.getElements() != null && Hibernate.isInitialized(submission.getElements())) {
+            elements = submission.getElements().stream().map(PlagiarismSubmissionElementDTO::fromElement).toList();
+        }
+
+        return new PlagiarismSubmissionDTO(submission.getId(), submission.getSubmissionId(), submission.getStudentLogin(), elements, submission.getSize(), submission.getScore());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionElementDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionElementDTO.java
@@ -1,0 +1,16 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmissionElement;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismSubmissionElementDTO(Long id, int column, int line, String file, int length) {
+
+    public static PlagiarismSubmissionElementDTO fromElement(PlagiarismSubmissionElement element) {
+        if (element == null) {
+            return null;
+        }
+        return new PlagiarismSubmissionElementDTO(element.getId(), element.getColumn(), element.getLine(), element.getFile(), element.getLength());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionElementDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionElementDTO.java
@@ -1,13 +1,15 @@
 package de.tum.cit.aet.artemis.plagiarism.dto;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmissionElement;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismSubmissionElementDTO(Long id, int column, int line, String file, int length) {
+public record PlagiarismSubmissionElementDTO(Long id, int column, int line, @Nullable String file, int length) {
 
-    public static PlagiarismSubmissionElementDTO fromElement(PlagiarismSubmissionElement element) {
+    public static @Nullable PlagiarismSubmissionElementDTO fromElement(@Nullable PlagiarismSubmissionElement element) {
         if (element == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionForCaseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionForCaseDTO.java
@@ -1,0 +1,17 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record PlagiarismSubmissionForCaseDTO(Long id, long submissionId, String studentLogin, int size, Double score, PlagiarismComparisonSummaryDTO plagiarismComparison) {
+
+    public static PlagiarismSubmissionForCaseDTO fromSubmissionForCase(PlagiarismSubmission submission) {
+        if (submission == null) {
+            return null;
+        }
+        return new PlagiarismSubmissionForCaseDTO(submission.getId(), submission.getSubmissionId(), submission.getStudentLogin(), submission.getSize(), submission.getScore(),
+                PlagiarismComparisonSummaryDTO.fromComparisonSummary(submission.getPlagiarismComparison()));
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionForCaseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionForCaseDTO.java
@@ -1,11 +1,14 @@
 package de.tum.cit.aet.artemis.plagiarism.dto;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismSubmissionForCaseDTO(Long id, long submissionId, String studentLogin, int size, Double score, PlagiarismComparisonSummaryDTO plagiarismComparison) {
+public record PlagiarismSubmissionForCaseDTO(Long id, long submissionId, @Nullable String studentLogin, int size, @Nullable Double score,
+        @Nullable PlagiarismComparisonSummaryDTO plagiarismComparison) {
 
     /**
      * Maps a plagiarism submission entity to the compact DTO used in plagiarism case details.
@@ -13,7 +16,7 @@ public record PlagiarismSubmissionForCaseDTO(Long id, long submissionId, String 
      * @param submission the plagiarism submission entity
      * @return the DTO representation
      */
-    public static PlagiarismSubmissionForCaseDTO fromSubmissionForCase(PlagiarismSubmission submission) {
+    public static @Nullable PlagiarismSubmissionForCaseDTO fromSubmissionForCase(@Nullable PlagiarismSubmission submission) {
         if (submission == null) {
             return null;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionForCaseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionForCaseDTO.java
@@ -7,6 +7,12 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PlagiarismSubmissionForCaseDTO(Long id, long submissionId, String studentLogin, int size, Double score, PlagiarismComparisonSummaryDTO plagiarismComparison) {
 
+    /**
+     * Maps a plagiarism submission entity to the compact DTO used in plagiarism case details.
+     *
+     * @param submission the plagiarism submission entity
+     * @return the DTO representation
+     */
     public static PlagiarismSubmissionForCaseDTO fromSubmissionForCase(PlagiarismSubmission submission) {
         if (submission == null) {
             return null;

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
@@ -56,6 +56,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 student.visibleRegistrationNumber,
                 post.id,
                 post.creationDate,
+                COUNT(DISTINCT studentAnswer.id) > 0,
                 plagiarismCase.verdict,
                 plagiarismCase.verdictDate,
                 verdictBy.id,
@@ -75,6 +76,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN exerciseGroup.exam exam
                 LEFT JOIN exam.course examCourse
                 LEFT JOIN plagiarismCase.post post
+                LEFT JOIN post.answers studentAnswer ON studentAnswer.author.id = student.id
                 LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
             WHERE exercise.course.id = :courseId
             GROUP BY plagiarismCase.id, exercise.id, exercise.title, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
@@ -104,6 +106,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 student.visibleRegistrationNumber,
                 post.id,
                 post.creationDate,
+                COUNT(DISTINCT studentAnswer.id) > 0,
                 plagiarismCase.verdict,
                 plagiarismCase.verdictDate,
                 verdictBy.id,
@@ -123,6 +126,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN exerciseGroup.exam exam
                 LEFT JOIN exam.course examCourse
                 LEFT JOIN plagiarismCase.post post
+                LEFT JOIN post.answers studentAnswer ON studentAnswer.author.id = student.id
                 LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
             WHERE exam.id = :examId
             GROUP BY plagiarismCase.id, exercise.id, exercise.title, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
@@ -57,14 +57,23 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 student.lastName,
                 post.id,
                 post.creationDate,
-                COUNT(DISTINCT studentAnswer.id) > 0,
+                CASE WHEN EXISTS (
+                    SELECT 1
+                    FROM AnswerPost studentAnswer
+                    WHERE studentAnswer.post = post
+                        AND studentAnswer.author = student
+                ) THEN TRUE ELSE FALSE END,
                 plagiarismCase.verdict,
                 plagiarismCase.verdictDate,
                 verdictBy.id,
                 verdictBy.login,
                 verdictBy.firstName,
                 verdictBy.lastName,
-                COUNT(DISTINCT plagiarismSubmission.id),
+                (
+                    SELECT COUNT(plagiarismSubmission.id)
+                    FROM PlagiarismSubmission plagiarismSubmission
+                    WHERE plagiarismSubmission.plagiarismCase = plagiarismCase
+                ),
                 plagiarismCase.createdByContinuousPlagiarismControl
             )
             FROM PlagiarismCase plagiarismCase
@@ -77,13 +86,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN exerciseGroup.exam exam
                 LEFT JOIN exam.course examCourse
                 LEFT JOIN plagiarismCase.post post
-                LEFT JOIN post.answers studentAnswer ON studentAnswer.author.id = student.id
-                LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
             WHERE exercise.course.id = :courseId
-            GROUP BY plagiarismCase.id, exercise.id, exercise.title, exercise.shortName, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
-                exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.firstName, student.lastName,
-                post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login, verdictBy.firstName, verdictBy.lastName,
-                plagiarismCase.createdByContinuousPlagiarismControl
             """)
     List<PlagiarismCaseOverviewDTO> findOverviewDtosByCourseId(@Param("courseId") Long courseId);
 
@@ -108,14 +111,23 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 student.lastName,
                 post.id,
                 post.creationDate,
-                COUNT(DISTINCT studentAnswer.id) > 0,
+                CASE WHEN EXISTS (
+                    SELECT 1
+                    FROM AnswerPost studentAnswer
+                    WHERE studentAnswer.post = post
+                        AND studentAnswer.author = student
+                ) THEN TRUE ELSE FALSE END,
                 plagiarismCase.verdict,
                 plagiarismCase.verdictDate,
                 verdictBy.id,
                 verdictBy.login,
                 verdictBy.firstName,
                 verdictBy.lastName,
-                COUNT(DISTINCT plagiarismSubmission.id),
+                (
+                    SELECT COUNT(plagiarismSubmission.id)
+                    FROM PlagiarismSubmission plagiarismSubmission
+                    WHERE plagiarismSubmission.plagiarismCase = plagiarismCase
+                ),
                 plagiarismCase.createdByContinuousPlagiarismControl
             )
             FROM PlagiarismCase plagiarismCase
@@ -128,13 +140,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN exerciseGroup.exam exam
                 LEFT JOIN exam.course examCourse
                 LEFT JOIN plagiarismCase.post post
-                LEFT JOIN post.answers studentAnswer ON studentAnswer.author.id = student.id
-                LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
             WHERE exam.id = :examId
-            GROUP BY plagiarismCase.id, exercise.id, exercise.title, exercise.shortName, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
-                exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.firstName, student.lastName,
-                post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login, verdictBy.firstName, verdictBy.lastName,
-                plagiarismCase.createdByContinuousPlagiarismControl
             """)
     List<PlagiarismCaseOverviewDTO> findOverviewDtosByExamId(@Param("examId") Long examId);
 
@@ -269,7 +275,11 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 verdictBy.login,
                 verdictBy.firstName,
                 verdictBy.lastName,
-                COUNT(DISTINCT plagiarismSubmission.id),
+                (
+                    SELECT COUNT(plagiarismSubmission.id)
+                    FROM PlagiarismSubmission plagiarismSubmission
+                    WHERE plagiarismSubmission.plagiarismCase = plagiarismCase
+                ),
                 plagiarismCase.createdByContinuousPlagiarismControl,
                 plagiarismCase.verdictMessage,
                 plagiarismCase.verdictPointDeduction
@@ -284,12 +294,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN exerciseGroup.exam exam
                 LEFT JOIN exam.course examCourse
                 LEFT JOIN plagiarismCase.post post
-                LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
             WHERE plagiarismCase.id = :plagiarismCaseId
-            GROUP BY plagiarismCase.id, exercise.id, exercise.title, exercise.shortName, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
-                exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.firstName, student.lastName,
-                post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login, verdictBy.firstName, verdictBy.lastName,
-                plagiarismCase.createdByContinuousPlagiarismControl, plagiarismCase.verdictMessage, plagiarismCase.verdictPointDeduction
             """)
     Optional<PlagiarismCaseDetailDTO> findDetailDtoById(@Param("plagiarismCaseId") long plagiarismCaseId);
 

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
@@ -55,7 +55,6 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 student.login,
                 student.firstName,
                 student.lastName,
-                student.registrationNumber,
                 post.id,
                 post.creationDate,
                 COUNT(DISTINCT studentAnswer.id) > 0,
@@ -83,8 +82,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
             WHERE exercise.course.id = :courseId
             GROUP BY plagiarismCase.id, exercise.id, exercise.title, exercise.shortName, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
                 exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.firstName, student.lastName,
-                student.registrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
-                verdictBy.firstName, verdictBy.lastName, plagiarismCase.createdByContinuousPlagiarismControl
+                post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login, verdictBy.firstName, verdictBy.lastName,
+                plagiarismCase.createdByContinuousPlagiarismControl
             """)
     List<PlagiarismCaseOverviewDTO> findOverviewDtosByCourseId(@Param("courseId") Long courseId);
 
@@ -107,7 +106,6 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 student.login,
                 student.firstName,
                 student.lastName,
-                student.registrationNumber,
                 post.id,
                 post.creationDate,
                 COUNT(DISTINCT studentAnswer.id) > 0,
@@ -135,8 +133,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
             WHERE exam.id = :examId
             GROUP BY plagiarismCase.id, exercise.id, exercise.title, exercise.shortName, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
                 exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.firstName, student.lastName,
-                student.registrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
-                verdictBy.firstName, verdictBy.lastName, plagiarismCase.createdByContinuousPlagiarismControl
+                post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login, verdictBy.firstName, verdictBy.lastName,
+                plagiarismCase.createdByContinuousPlagiarismControl
             """)
     List<PlagiarismCaseOverviewDTO> findOverviewDtosByExamId(@Param("examId") Long examId);
 
@@ -251,7 +249,6 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 student.login,
                 student.firstName,
                 student.lastName,
-                student.registrationNumber,
                 post.id,
                 post.creationDate,
                 plagiarismCase.verdict,
@@ -279,9 +276,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
             WHERE plagiarismCase.id = :plagiarismCaseId
             GROUP BY plagiarismCase.id, exercise.id, exercise.title, exercise.shortName, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
                 exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.firstName, student.lastName,
-                student.registrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
-                verdictBy.firstName, verdictBy.lastName, plagiarismCase.createdByContinuousPlagiarismControl, plagiarismCase.verdictMessage,
-                plagiarismCase.verdictPointDeduction
+                post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login, verdictBy.firstName, verdictBy.lastName,
+                plagiarismCase.createdByContinuousPlagiarismControl, plagiarismCase.verdictMessage, plagiarismCase.verdictPointDeduction
             """)
     Optional<PlagiarismCaseDetailDTO> findDetailDtoById(@Param("plagiarismCaseId") long plagiarismCaseId);
 

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
@@ -14,6 +14,9 @@ import de.tum.cit.aet.artemis.core.repository.base.ArtemisJpaRepository;
 import de.tum.cit.aet.artemis.plagiarism.config.PlagiarismEnabled;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCase;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseDTO;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseDetailDTO;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseOverviewDTO;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismSubmissionForCaseDTO;
 
 /**
  * Spring Data JPA repository for the PlagiarismCase entity.
@@ -34,44 +37,100 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
     Optional<PlagiarismCase> findByStudentLoginAndExerciseIdWithPlagiarismSubmissions(@Param("studentLogin") String studentLogin, @Param("exerciseId") Long exerciseId);
 
     @Query("""
-            SELECT DISTINCT plagiarismCase
+            SELECT new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseOverviewDTO(
+                plagiarismCase.id,
+                new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseExerciseDTO(
+                    exercise.id,
+                    exercise.title,
+                    TYPE(exercise),
+                    exercise.dueDate,
+                    COALESCE(course.id, examCourse.id),
+                    COALESCE(course.title, examCourse.title),
+                    exam.id,
+                    exam.title,
+                    plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod
+                ),
+                student.id,
+                student.login,
+                student.name,
+                student.visibleRegistrationNumber,
+                post.id,
+                post.creationDate,
+                plagiarismCase.verdict,
+                plagiarismCase.verdictDate,
+                verdictBy.id,
+                verdictBy.login,
+                verdictBy.name,
+                verdictBy.visibleRegistrationNumber,
+                COUNT(DISTINCT plagiarismSubmission.id),
+                plagiarismCase.createdByContinuousPlagiarismControl
+            )
             FROM PlagiarismCase plagiarismCase
-                LEFT JOIN FETCH plagiarismCase.student
-                LEFT JOIN FETCH plagiarismCase.verdictBy
-                LEFT JOIN FETCH plagiarismCase.exercise exercise
-                LEFT JOIN FETCH exercise.plagiarismDetectionConfig
-                LEFT JOIN FETCH exercise.course
-                LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
-                LEFT JOIN FETCH exerciseGroup.exam exam
-                LEFT JOIN FETCH exam.course
-                LEFT JOIN FETCH plagiarismCase.post post
-                LEFT JOIN FETCH post.answers answers
-                LEFT JOIN FETCH answers.author
-                LEFT JOIN FETCH plagiarismCase.plagiarismSubmissions plagiarismSubmissions
-                LEFT JOIN FETCH plagiarismSubmissions.plagiarismComparison plagiarismComparison
-            WHERE plagiarismCase.exercise.course.id = :courseId
+                LEFT JOIN plagiarismCase.student student
+                LEFT JOIN plagiarismCase.verdictBy verdictBy
+                LEFT JOIN plagiarismCase.exercise exercise
+                LEFT JOIN exercise.plagiarismDetectionConfig plagiarismDetectionConfig
+                LEFT JOIN exercise.course course
+                LEFT JOIN exercise.exerciseGroup exerciseGroup
+                LEFT JOIN exerciseGroup.exam exam
+                LEFT JOIN exam.course examCourse
+                LEFT JOIN plagiarismCase.post post
+                LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
+            WHERE exercise.course.id = :courseId
+            GROUP BY plagiarismCase.id, exercise.id, exercise.title, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
+                exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.name,
+                student.visibleRegistrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
+                verdictBy.name, verdictBy.visibleRegistrationNumber, plagiarismCase.createdByContinuousPlagiarismControl
             """)
-    List<PlagiarismCase> findByCourseIdWithPlagiarismSubmissionsAndComparison(@Param("courseId") Long courseId);
+    List<PlagiarismCaseOverviewDTO> findOverviewDtosByCourseId(@Param("courseId") Long courseId);
 
     @Query("""
-            SELECT DISTINCT plagiarismCase
+            SELECT new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseOverviewDTO(
+                plagiarismCase.id,
+                new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseExerciseDTO(
+                    exercise.id,
+                    exercise.title,
+                    TYPE(exercise),
+                    exercise.dueDate,
+                    COALESCE(course.id, examCourse.id),
+                    COALESCE(course.title, examCourse.title),
+                    exam.id,
+                    exam.title,
+                    plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod
+                ),
+                student.id,
+                student.login,
+                student.name,
+                student.visibleRegistrationNumber,
+                post.id,
+                post.creationDate,
+                plagiarismCase.verdict,
+                plagiarismCase.verdictDate,
+                verdictBy.id,
+                verdictBy.login,
+                verdictBy.name,
+                verdictBy.visibleRegistrationNumber,
+                COUNT(DISTINCT plagiarismSubmission.id),
+                plagiarismCase.createdByContinuousPlagiarismControl
+            )
             FROM PlagiarismCase plagiarismCase
-                LEFT JOIN FETCH plagiarismCase.student
-                LEFT JOIN FETCH plagiarismCase.verdictBy
-                LEFT JOIN FETCH plagiarismCase.exercise exercise
-                LEFT JOIN FETCH exercise.plagiarismDetectionConfig
-                LEFT JOIN FETCH exercise.course
-                LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
-                LEFT JOIN FETCH exerciseGroup.exam exam
-                LEFT JOIN FETCH exam.course
-                LEFT JOIN FETCH plagiarismCase.post post
-                LEFT JOIN FETCH post.answers answers
-                LEFT JOIN FETCH answers.author
-                LEFT JOIN FETCH plagiarismCase.plagiarismSubmissions plagiarismSubmissions
-                LEFT JOIN FETCH plagiarismSubmissions.plagiarismComparison plagiarismComparison
-            WHERE plagiarismCase.exercise.exerciseGroup.exam.id = :examId
+                LEFT JOIN plagiarismCase.student student
+                LEFT JOIN plagiarismCase.verdictBy verdictBy
+                LEFT JOIN plagiarismCase.exercise exercise
+                LEFT JOIN exercise.plagiarismDetectionConfig plagiarismDetectionConfig
+                LEFT JOIN exercise.course course
+                LEFT JOIN exercise.exerciseGroup exerciseGroup
+                LEFT JOIN exerciseGroup.exam exam
+                LEFT JOIN exam.course examCourse
+                LEFT JOIN plagiarismCase.post post
+                LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
+            WHERE exam.id = :examId
+            GROUP BY plagiarismCase.id, exercise.id, exercise.title, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
+                exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.name,
+                student.visibleRegistrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
+                verdictBy.name, verdictBy.visibleRegistrationNumber, plagiarismCase.createdByContinuousPlagiarismControl
             """)
-    List<PlagiarismCase> findByExamIdWithPlagiarismSubmissionsAndComparison(@Param("examId") Long examId);
+    List<PlagiarismCaseOverviewDTO> findOverviewDtosByExamId(@Param("examId") Long examId);
 
     @Query("""
             SELECT plagiarismCase
@@ -166,44 +225,74 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
     Optional<PlagiarismCase> findByIdWithPlagiarismSubmissions(@Param("plagiarismCaseId") long plagiarismCaseId);
 
     @Query("""
-            SELECT plagiarismCase
+            SELECT new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseDetailDTO(
+                plagiarismCase.id,
+                new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseExerciseDTO(
+                    exercise.id,
+                    exercise.title,
+                    TYPE(exercise),
+                    exercise.dueDate,
+                    COALESCE(course.id, examCourse.id),
+                    COALESCE(course.title, examCourse.title),
+                    exam.id,
+                    exam.title,
+                    plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod
+                ),
+                student.id,
+                student.login,
+                student.name,
+                student.visibleRegistrationNumber,
+                post.id,
+                post.creationDate,
+                plagiarismCase.verdict,
+                plagiarismCase.verdictDate,
+                verdictBy.id,
+                verdictBy.login,
+                verdictBy.name,
+                verdictBy.visibleRegistrationNumber,
+                COUNT(DISTINCT plagiarismSubmission.id),
+                plagiarismCase.createdByContinuousPlagiarismControl,
+                plagiarismCase.verdictMessage,
+                plagiarismCase.verdictPointDeduction
+            )
             FROM PlagiarismCase plagiarismCase
-                LEFT JOIN FETCH plagiarismCase.student
-                LEFT JOIN FETCH plagiarismCase.verdictBy
-                LEFT JOIN FETCH plagiarismCase.post post
-                LEFT JOIN FETCH post.answers answers
-                LEFT JOIN FETCH answers.author
-                LEFT JOIN FETCH plagiarismCase.exercise exercise
-                LEFT JOIN FETCH exercise.plagiarismDetectionConfig
-                LEFT JOIN FETCH exercise.course
-                LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
-                LEFT JOIN FETCH exerciseGroup.exam exam
-                LEFT JOIN FETCH exam.course
-                LEFT JOIN FETCH plagiarismCase.plagiarismSubmissions plagiarismSubmissions
-                LEFT JOIN FETCH plagiarismSubmissions.plagiarismComparison
+                LEFT JOIN plagiarismCase.student student
+                LEFT JOIN plagiarismCase.verdictBy verdictBy
+                LEFT JOIN plagiarismCase.exercise exercise
+                LEFT JOIN exercise.plagiarismDetectionConfig plagiarismDetectionConfig
+                LEFT JOIN exercise.course course
+                LEFT JOIN exercise.exerciseGroup exerciseGroup
+                LEFT JOIN exerciseGroup.exam exam
+                LEFT JOIN exam.course examCourse
+                LEFT JOIN plagiarismCase.post post
+                LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
             WHERE plagiarismCase.id = :plagiarismCaseId
+            GROUP BY plagiarismCase.id, exercise.id, exercise.title, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
+                exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.name,
+                student.visibleRegistrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
+                verdictBy.name, verdictBy.visibleRegistrationNumber, plagiarismCase.createdByContinuousPlagiarismControl, plagiarismCase.verdictMessage,
+                plagiarismCase.verdictPointDeduction
             """)
-    Optional<PlagiarismCase> findByIdWithFullDetailsForDTO(@Param("plagiarismCaseId") long plagiarismCaseId);
+    Optional<PlagiarismCaseDetailDTO> findDetailDtoById(@Param("plagiarismCaseId") long plagiarismCaseId);
 
     @Query("""
-            SELECT plagiarismCase
-            FROM PlagiarismCase plagiarismCase
-                LEFT JOIN FETCH plagiarismCase.student
-                LEFT JOIN FETCH plagiarismCase.verdictBy
-                LEFT JOIN FETCH plagiarismCase.post post
-                LEFT JOIN FETCH post.answers answers
-                LEFT JOIN FETCH answers.author
-                LEFT JOIN FETCH plagiarismCase.plagiarismSubmissions plagiarismSubmissions
-                LEFT JOIN FETCH plagiarismCase.exercise e
-                LEFT JOIN FETCH e.plagiarismDetectionConfig
-                LEFT JOIN FETCH e.course
-                LEFT JOIN FETCH e.exerciseGroup exerciseGroup
-                LEFT JOIN FETCH exerciseGroup.exam exam
-                LEFT JOIN FETCH exam.course
-                LEFT JOIN FETCH plagiarismSubmissions.plagiarismComparison
-            WHERE plagiarismCase.id = :plagiarismCaseId
+            SELECT new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismSubmissionForCaseDTO(
+                plagiarismSubmission.id,
+                plagiarismSubmission.submissionId,
+                plagiarismSubmission.studentLogin,
+                plagiarismSubmission.size,
+                plagiarismSubmission.score,
+                new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismComparisonSummaryDTO(
+                    plagiarismComparison.id,
+                    plagiarismComparison.similarity,
+                    plagiarismComparison.status
+                )
+            )
+            FROM PlagiarismSubmission plagiarismSubmission
+                JOIN plagiarismSubmission.plagiarismComparison plagiarismComparison
+            WHERE plagiarismSubmission.plagiarismCase.id = :plagiarismCaseId
             """)
-    Optional<PlagiarismCase> findByIdWithPlagiarismSubmissionsAndPlagiarismDetectionConfig(@Param("plagiarismCaseId") long plagiarismCaseId);
+    List<PlagiarismSubmissionForCaseDTO> findSubmissionDtosByPlagiarismCaseId(@Param("plagiarismCaseId") long plagiarismCaseId);
 
     @Query("""
             SELECT plagiarismCase
@@ -218,12 +307,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
         return getValueElseThrow(findByIdWithPlagiarismSubmissions(plagiarismCaseId), plagiarismCaseId);
     }
 
-    default PlagiarismCase findByIdWithFullDetailsForDTOElseThrow(long plagiarismCaseId) {
-        return getValueElseThrow(findByIdWithFullDetailsForDTO(plagiarismCaseId), plagiarismCaseId);
-    }
-
-    default PlagiarismCase findByIdWithPlagiarismSubmissionsAndPlagiarismDetectionConfigElseThrow(long plagiarismCaseId) {
-        return getValueElseThrow(findByIdWithPlagiarismSubmissionsAndPlagiarismDetectionConfig(plagiarismCaseId), plagiarismCaseId);
+    default PlagiarismCaseDetailDTO findDetailDtoByIdElseThrow(long plagiarismCaseId) {
+        return getArbitraryValueElseThrow(findDetailDtoById(plagiarismCaseId), String.valueOf(plagiarismCaseId));
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
@@ -231,6 +231,18 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
     Optional<PlagiarismCase> findByIdWithPlagiarismSubmissions(@Param("plagiarismCaseId") long plagiarismCaseId);
 
     @Query("""
+            SELECT COALESCE(course.id, examCourse.id)
+            FROM PlagiarismCase plagiarismCase
+                LEFT JOIN plagiarismCase.exercise exercise
+                LEFT JOIN exercise.course course
+                LEFT JOIN exercise.exerciseGroup exerciseGroup
+                LEFT JOIN exerciseGroup.exam exam
+                LEFT JOIN exam.course examCourse
+            WHERE plagiarismCase.id = :plagiarismCaseId
+            """)
+    Optional<Long> findCourseIdById(@Param("plagiarismCaseId") long plagiarismCaseId);
+
+    @Query("""
             SELECT new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseDetailDTO(
                 plagiarismCase.id,
                 new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseExerciseDTO(
@@ -311,6 +323,10 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
 
     default PlagiarismCase findByIdWithPlagiarismSubmissionsElseThrow(long plagiarismCaseId) {
         return getValueElseThrow(findByIdWithPlagiarismSubmissions(plagiarismCaseId), plagiarismCaseId);
+    }
+
+    default Long findCourseIdByIdElseThrow(long plagiarismCaseId) {
+        return getArbitraryValueElseThrow(findCourseIdById(plagiarismCaseId), String.valueOf(plagiarismCaseId));
     }
 
     default PlagiarismCaseDetailDTO findDetailDtoByIdElseThrow(long plagiarismCaseId) {

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
@@ -26,18 +26,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
     @Query("""
             SELECT plagiarismCase
             FROM PlagiarismCase plagiarismCase
-                LEFT JOIN FETCH plagiarismCase.student
-                LEFT JOIN FETCH plagiarismCase.verdictBy
-                LEFT JOIN FETCH plagiarismCase.post post
-                LEFT JOIN FETCH post.answers answers
-                LEFT JOIN FETCH answers.author
-                LEFT JOIN FETCH plagiarismCase.exercise exercise
-                LEFT JOIN FETCH exercise.course
-                LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
-                LEFT JOIN FETCH exerciseGroup.exam exam
-                LEFT JOIN FETCH exam.course
+                LEFT JOIN FETCH plagiarismCase.post
                 LEFT JOIN FETCH plagiarismCase.plagiarismSubmissions plagiarismSubmission
-                LEFT JOIN FETCH plagiarismSubmission.plagiarismComparison
             WHERE plagiarismCase.student.login = :studentLogin
                 AND plagiarismCase.exercise.id = :exerciseId
             """)
@@ -49,6 +39,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN FETCH plagiarismCase.student
                 LEFT JOIN FETCH plagiarismCase.verdictBy
                 LEFT JOIN FETCH plagiarismCase.exercise exercise
+                LEFT JOIN FETCH exercise.plagiarismDetectionConfig
                 LEFT JOIN FETCH exercise.course
                 LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
                 LEFT JOIN FETCH exerciseGroup.exam exam
@@ -68,6 +59,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN FETCH plagiarismCase.student
                 LEFT JOIN FETCH plagiarismCase.verdictBy
                 LEFT JOIN FETCH plagiarismCase.exercise exercise
+                LEFT JOIN FETCH exercise.plagiarismDetectionConfig
                 LEFT JOIN FETCH exercise.course
                 LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
                 LEFT JOIN FETCH exerciseGroup.exam exam
@@ -168,12 +160,21 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
     @Query("""
             SELECT plagiarismCase
             FROM PlagiarismCase plagiarismCase
+                LEFT JOIN FETCH plagiarismCase.plagiarismSubmissions plagiarismSubmissions
+            WHERE plagiarismCase.id = :plagiarismCaseId
+            """)
+    Optional<PlagiarismCase> findByIdWithPlagiarismSubmissions(@Param("plagiarismCaseId") long plagiarismCaseId);
+
+    @Query("""
+            SELECT plagiarismCase
+            FROM PlagiarismCase plagiarismCase
                 LEFT JOIN FETCH plagiarismCase.student
                 LEFT JOIN FETCH plagiarismCase.verdictBy
                 LEFT JOIN FETCH plagiarismCase.post post
                 LEFT JOIN FETCH post.answers answers
                 LEFT JOIN FETCH answers.author
                 LEFT JOIN FETCH plagiarismCase.exercise exercise
+                LEFT JOIN FETCH exercise.plagiarismDetectionConfig
                 LEFT JOIN FETCH exercise.course
                 LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
                 LEFT JOIN FETCH exerciseGroup.exam exam
@@ -182,7 +183,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN FETCH plagiarismSubmissions.plagiarismComparison
             WHERE plagiarismCase.id = :plagiarismCaseId
             """)
-    Optional<PlagiarismCase> findByIdWithPlagiarismSubmissions(@Param("plagiarismCaseId") long plagiarismCaseId);
+    Optional<PlagiarismCase> findByIdWithFullDetailsForDTO(@Param("plagiarismCaseId") long plagiarismCaseId);
 
     @Query("""
             SELECT plagiarismCase
@@ -215,6 +216,10 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
 
     default PlagiarismCase findByIdWithPlagiarismSubmissionsElseThrow(long plagiarismCaseId) {
         return getValueElseThrow(findByIdWithPlagiarismSubmissions(plagiarismCaseId), plagiarismCaseId);
+    }
+
+    default PlagiarismCase findByIdWithFullDetailsForDTOElseThrow(long plagiarismCaseId) {
+        return getValueElseThrow(findByIdWithFullDetailsForDTO(plagiarismCaseId), plagiarismCaseId);
     }
 
     default PlagiarismCase findByIdWithPlagiarismSubmissionsAndPlagiarismDetectionConfigElseThrow(long plagiarismCaseId) {

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
@@ -52,8 +52,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 ),
                 student.id,
                 student.login,
-                student.name,
-                student.visibleRegistrationNumber,
+                CONCAT(student.firstName, ' ', student.lastName),
+                student.registrationNumber,
                 post.id,
                 post.creationDate,
                 COUNT(DISTINCT studentAnswer.id) > 0,
@@ -61,8 +61,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 plagiarismCase.verdictDate,
                 verdictBy.id,
                 verdictBy.login,
-                verdictBy.name,
-                verdictBy.visibleRegistrationNumber,
+                CONCAT(verdictBy.firstName, ' ', verdictBy.lastName),
+                verdictBy.registrationNumber,
                 COUNT(DISTINCT plagiarismSubmission.id),
                 plagiarismCase.createdByContinuousPlagiarismControl
             )
@@ -80,9 +80,9 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
             WHERE exercise.course.id = :courseId
             GROUP BY plagiarismCase.id, exercise.id, exercise.title, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
-                exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.name,
-                student.visibleRegistrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
-                verdictBy.name, verdictBy.visibleRegistrationNumber, plagiarismCase.createdByContinuousPlagiarismControl
+                exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.firstName, student.lastName,
+                student.registrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
+                verdictBy.firstName, verdictBy.lastName, verdictBy.registrationNumber, plagiarismCase.createdByContinuousPlagiarismControl
             """)
     List<PlagiarismCaseOverviewDTO> findOverviewDtosByCourseId(@Param("courseId") Long courseId);
 
@@ -102,8 +102,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 ),
                 student.id,
                 student.login,
-                student.name,
-                student.visibleRegistrationNumber,
+                CONCAT(student.firstName, ' ', student.lastName),
+                student.registrationNumber,
                 post.id,
                 post.creationDate,
                 COUNT(DISTINCT studentAnswer.id) > 0,
@@ -111,8 +111,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 plagiarismCase.verdictDate,
                 verdictBy.id,
                 verdictBy.login,
-                verdictBy.name,
-                verdictBy.visibleRegistrationNumber,
+                CONCAT(verdictBy.firstName, ' ', verdictBy.lastName),
+                verdictBy.registrationNumber,
                 COUNT(DISTINCT plagiarismSubmission.id),
                 plagiarismCase.createdByContinuousPlagiarismControl
             )
@@ -130,9 +130,9 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
             WHERE exam.id = :examId
             GROUP BY plagiarismCase.id, exercise.id, exercise.title, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
-                exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.name,
-                student.visibleRegistrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
-                verdictBy.name, verdictBy.visibleRegistrationNumber, plagiarismCase.createdByContinuousPlagiarismControl
+                exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.firstName, student.lastName,
+                student.registrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
+                verdictBy.firstName, verdictBy.lastName, verdictBy.registrationNumber, plagiarismCase.createdByContinuousPlagiarismControl
             """)
     List<PlagiarismCaseOverviewDTO> findOverviewDtosByExamId(@Param("examId") Long examId);
 
@@ -244,16 +244,16 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 ),
                 student.id,
                 student.login,
-                student.name,
-                student.visibleRegistrationNumber,
+                CONCAT(student.firstName, ' ', student.lastName),
+                student.registrationNumber,
                 post.id,
                 post.creationDate,
                 plagiarismCase.verdict,
                 plagiarismCase.verdictDate,
                 verdictBy.id,
                 verdictBy.login,
-                verdictBy.name,
-                verdictBy.visibleRegistrationNumber,
+                CONCAT(verdictBy.firstName, ' ', verdictBy.lastName),
+                verdictBy.registrationNumber,
                 COUNT(DISTINCT plagiarismSubmission.id),
                 plagiarismCase.createdByContinuousPlagiarismControl,
                 plagiarismCase.verdictMessage,
@@ -272,9 +272,9 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
             WHERE plagiarismCase.id = :plagiarismCaseId
             GROUP BY plagiarismCase.id, exercise.id, exercise.title, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
-                exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.name,
-                student.visibleRegistrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
-                verdictBy.name, verdictBy.visibleRegistrationNumber, plagiarismCase.createdByContinuousPlagiarismControl, plagiarismCase.verdictMessage,
+                exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.firstName, student.lastName,
+                student.registrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
+                verdictBy.firstName, verdictBy.lastName, verdictBy.registrationNumber, plagiarismCase.createdByContinuousPlagiarismControl, plagiarismCase.verdictMessage,
                 plagiarismCase.verdictPointDeduction
             """)
     Optional<PlagiarismCaseDetailDTO> findDetailDtoById(@Param("plagiarismCaseId") long plagiarismCaseId);

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
@@ -26,8 +26,18 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
     @Query("""
             SELECT plagiarismCase
             FROM PlagiarismCase plagiarismCase
-                LEFT JOIN FETCH plagiarismCase.post
+                LEFT JOIN FETCH plagiarismCase.student
+                LEFT JOIN FETCH plagiarismCase.verdictBy
+                LEFT JOIN FETCH plagiarismCase.post post
+                LEFT JOIN FETCH post.answers answers
+                LEFT JOIN FETCH answers.author
+                LEFT JOIN FETCH plagiarismCase.exercise exercise
+                LEFT JOIN FETCH exercise.course
+                LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
+                LEFT JOIN FETCH exerciseGroup.exam exam
+                LEFT JOIN FETCH exam.course
                 LEFT JOIN FETCH plagiarismCase.plagiarismSubmissions plagiarismSubmission
+                LEFT JOIN FETCH plagiarismSubmission.plagiarismComparison
             WHERE plagiarismCase.student.login = :studentLogin
                 AND plagiarismCase.exercise.id = :exerciseId
             """)
@@ -36,7 +46,16 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
     @Query("""
             SELECT DISTINCT plagiarismCase
             FROM PlagiarismCase plagiarismCase
-                LEFT JOIN FETCH plagiarismCase.post
+                LEFT JOIN FETCH plagiarismCase.student
+                LEFT JOIN FETCH plagiarismCase.verdictBy
+                LEFT JOIN FETCH plagiarismCase.exercise exercise
+                LEFT JOIN FETCH exercise.course
+                LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
+                LEFT JOIN FETCH exerciseGroup.exam exam
+                LEFT JOIN FETCH exam.course
+                LEFT JOIN FETCH plagiarismCase.post post
+                LEFT JOIN FETCH post.answers answers
+                LEFT JOIN FETCH answers.author
                 LEFT JOIN FETCH plagiarismCase.plagiarismSubmissions plagiarismSubmissions
                 LEFT JOIN FETCH plagiarismSubmissions.plagiarismComparison plagiarismComparison
             WHERE plagiarismCase.exercise.course.id = :courseId
@@ -46,7 +65,16 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
     @Query("""
             SELECT DISTINCT plagiarismCase
             FROM PlagiarismCase plagiarismCase
-                LEFT JOIN FETCH plagiarismCase.post
+                LEFT JOIN FETCH plagiarismCase.student
+                LEFT JOIN FETCH plagiarismCase.verdictBy
+                LEFT JOIN FETCH plagiarismCase.exercise exercise
+                LEFT JOIN FETCH exercise.course
+                LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
+                LEFT JOIN FETCH exerciseGroup.exam exam
+                LEFT JOIN FETCH exam.course
+                LEFT JOIN FETCH plagiarismCase.post post
+                LEFT JOIN FETCH post.answers answers
+                LEFT JOIN FETCH answers.author
                 LEFT JOIN FETCH plagiarismCase.plagiarismSubmissions plagiarismSubmissions
                 LEFT JOIN FETCH plagiarismSubmissions.plagiarismComparison plagiarismComparison
             WHERE plagiarismCase.exercise.exerciseGroup.exam.id = :examId
@@ -140,7 +168,18 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
     @Query("""
             SELECT plagiarismCase
             FROM PlagiarismCase plagiarismCase
+                LEFT JOIN FETCH plagiarismCase.student
+                LEFT JOIN FETCH plagiarismCase.verdictBy
+                LEFT JOIN FETCH plagiarismCase.post post
+                LEFT JOIN FETCH post.answers answers
+                LEFT JOIN FETCH answers.author
+                LEFT JOIN FETCH plagiarismCase.exercise exercise
+                LEFT JOIN FETCH exercise.course
+                LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
+                LEFT JOIN FETCH exerciseGroup.exam exam
+                LEFT JOIN FETCH exam.course
                 LEFT JOIN FETCH plagiarismCase.plagiarismSubmissions plagiarismSubmissions
+                LEFT JOIN FETCH plagiarismSubmissions.plagiarismComparison
             WHERE plagiarismCase.id = :plagiarismCaseId
             """)
     Optional<PlagiarismCase> findByIdWithPlagiarismSubmissions(@Param("plagiarismCaseId") long plagiarismCaseId);
@@ -148,9 +187,19 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
     @Query("""
             SELECT plagiarismCase
             FROM PlagiarismCase plagiarismCase
+                LEFT JOIN FETCH plagiarismCase.student
+                LEFT JOIN FETCH plagiarismCase.verdictBy
+                LEFT JOIN FETCH plagiarismCase.post post
+                LEFT JOIN FETCH post.answers answers
+                LEFT JOIN FETCH answers.author
                 LEFT JOIN FETCH plagiarismCase.plagiarismSubmissions plagiarismSubmissions
                 LEFT JOIN FETCH plagiarismCase.exercise e
                 LEFT JOIN FETCH e.plagiarismDetectionConfig
+                LEFT JOIN FETCH e.course
+                LEFT JOIN FETCH e.exerciseGroup exerciseGroup
+                LEFT JOIN FETCH exerciseGroup.exam exam
+                LEFT JOIN FETCH exam.course
+                LEFT JOIN FETCH plagiarismSubmissions.plagiarismComparison
             WHERE plagiarismCase.id = :plagiarismCaseId
             """)
     Optional<PlagiarismCase> findByIdWithPlagiarismSubmissionsAndPlagiarismDetectionConfig(@Param("plagiarismCaseId") long plagiarismCaseId);

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismCaseRepository.java
@@ -42,6 +42,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseExerciseDTO(
                     exercise.id,
                     exercise.title,
+                    exercise.shortName,
                     TYPE(exercise),
                     exercise.dueDate,
                     COALESCE(course.id, examCourse.id),
@@ -52,7 +53,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 ),
                 student.id,
                 student.login,
-                CONCAT(student.firstName, ' ', student.lastName),
+                student.firstName,
+                student.lastName,
                 student.registrationNumber,
                 post.id,
                 post.creationDate,
@@ -61,8 +63,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 plagiarismCase.verdictDate,
                 verdictBy.id,
                 verdictBy.login,
-                CONCAT(verdictBy.firstName, ' ', verdictBy.lastName),
-                verdictBy.registrationNumber,
+                verdictBy.firstName,
+                verdictBy.lastName,
                 COUNT(DISTINCT plagiarismSubmission.id),
                 plagiarismCase.createdByContinuousPlagiarismControl
             )
@@ -79,10 +81,10 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN post.answers studentAnswer ON studentAnswer.author.id = student.id
                 LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
             WHERE exercise.course.id = :courseId
-            GROUP BY plagiarismCase.id, exercise.id, exercise.title, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
+            GROUP BY plagiarismCase.id, exercise.id, exercise.title, exercise.shortName, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
                 exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.firstName, student.lastName,
                 student.registrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
-                verdictBy.firstName, verdictBy.lastName, verdictBy.registrationNumber, plagiarismCase.createdByContinuousPlagiarismControl
+                verdictBy.firstName, verdictBy.lastName, plagiarismCase.createdByContinuousPlagiarismControl
             """)
     List<PlagiarismCaseOverviewDTO> findOverviewDtosByCourseId(@Param("courseId") Long courseId);
 
@@ -92,6 +94,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseExerciseDTO(
                     exercise.id,
                     exercise.title,
+                    exercise.shortName,
                     TYPE(exercise),
                     exercise.dueDate,
                     COALESCE(course.id, examCourse.id),
@@ -102,7 +105,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 ),
                 student.id,
                 student.login,
-                CONCAT(student.firstName, ' ', student.lastName),
+                student.firstName,
+                student.lastName,
                 student.registrationNumber,
                 post.id,
                 post.creationDate,
@@ -111,8 +115,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 plagiarismCase.verdictDate,
                 verdictBy.id,
                 verdictBy.login,
-                CONCAT(verdictBy.firstName, ' ', verdictBy.lastName),
-                verdictBy.registrationNumber,
+                verdictBy.firstName,
+                verdictBy.lastName,
                 COUNT(DISTINCT plagiarismSubmission.id),
                 plagiarismCase.createdByContinuousPlagiarismControl
             )
@@ -129,10 +133,10 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN post.answers studentAnswer ON studentAnswer.author.id = student.id
                 LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
             WHERE exam.id = :examId
-            GROUP BY plagiarismCase.id, exercise.id, exercise.title, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
+            GROUP BY plagiarismCase.id, exercise.id, exercise.title, exercise.shortName, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
                 exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.firstName, student.lastName,
                 student.registrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
-                verdictBy.firstName, verdictBy.lastName, verdictBy.registrationNumber, plagiarismCase.createdByContinuousPlagiarismControl
+                verdictBy.firstName, verdictBy.lastName, plagiarismCase.createdByContinuousPlagiarismControl
             """)
     List<PlagiarismCaseOverviewDTO> findOverviewDtosByExamId(@Param("examId") Long examId);
 
@@ -234,6 +238,7 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 new de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseExerciseDTO(
                     exercise.id,
                     exercise.title,
+                    exercise.shortName,
                     TYPE(exercise),
                     exercise.dueDate,
                     COALESCE(course.id, examCourse.id),
@@ -244,7 +249,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 ),
                 student.id,
                 student.login,
-                CONCAT(student.firstName, ' ', student.lastName),
+                student.firstName,
+                student.lastName,
                 student.registrationNumber,
                 post.id,
                 post.creationDate,
@@ -252,8 +258,8 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 plagiarismCase.verdictDate,
                 verdictBy.id,
                 verdictBy.login,
-                CONCAT(verdictBy.firstName, ' ', verdictBy.lastName),
-                verdictBy.registrationNumber,
+                verdictBy.firstName,
+                verdictBy.lastName,
                 COUNT(DISTINCT plagiarismSubmission.id),
                 plagiarismCase.createdByContinuousPlagiarismControl,
                 plagiarismCase.verdictMessage,
@@ -271,10 +277,10 @@ public interface PlagiarismCaseRepository extends ArtemisJpaRepository<Plagiaris
                 LEFT JOIN plagiarismCase.post post
                 LEFT JOIN plagiarismCase.plagiarismSubmissions plagiarismSubmission
             WHERE plagiarismCase.id = :plagiarismCaseId
-            GROUP BY plagiarismCase.id, exercise.id, exercise.title, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
+            GROUP BY plagiarismCase.id, exercise.id, exercise.title, exercise.shortName, TYPE(exercise), exercise.dueDate, course.id, examCourse.id, course.title, examCourse.title, exam.id,
                 exam.title, plagiarismDetectionConfig.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod, student.id, student.login, student.firstName, student.lastName,
                 student.registrationNumber, post.id, post.creationDate, plagiarismCase.verdict, plagiarismCase.verdictDate, verdictBy.id, verdictBy.login,
-                verdictBy.firstName, verdictBy.lastName, verdictBy.registrationNumber, plagiarismCase.createdByContinuousPlagiarismControl, plagiarismCase.verdictMessage,
+                verdictBy.firstName, verdictBy.lastName, plagiarismCase.createdByContinuousPlagiarismControl, plagiarismCase.verdictMessage,
                 plagiarismCase.verdictPointDeduction
             """)
     Optional<PlagiarismCaseDetailDTO> findDetailDtoById(@Param("plagiarismCaseId") long plagiarismCaseId);

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismComparisonRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismComparisonRepository.java
@@ -34,10 +34,6 @@ public interface PlagiarismComparisonRepository extends ArtemisJpaRepository<Pla
                 LEFT JOIN FETCH comparison.submissionB submissionB
                 LEFT JOIN FETCH comparison.plagiarismResult result
                 LEFT JOIN FETCH result.exercise exercise
-                LEFT JOIN FETCH exercise.course
-                LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
-                LEFT JOIN FETCH exerciseGroup.exam exam
-                LEFT JOIN FETCH exam.course
             WHERE comparison.id = :comparisonId
             """)
     Optional<PlagiarismComparison> findByIdWithSubmissions(@Param("comparisonId") long comparisonId);
@@ -51,12 +47,6 @@ public interface PlagiarismComparisonRepository extends ArtemisJpaRepository<Pla
             FROM PlagiarismComparison comparison
                 LEFT JOIN FETCH comparison.submissionA submissionA
                 LEFT JOIN FETCH submissionA.elements elementsA
-                LEFT JOIN FETCH comparison.plagiarismResult result
-                LEFT JOIN FETCH result.exercise exercise
-                LEFT JOIN FETCH exercise.course
-                LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
-                LEFT JOIN FETCH exerciseGroup.exam exam
-                LEFT JOIN FETCH exam.course
             WHERE comparison.id = :comparisonId
             """)
     Optional<PlagiarismComparison> findByIdWithSubmissionsAndElementsA(@Param("comparisonId") long comparisonId);
@@ -76,6 +66,23 @@ public interface PlagiarismComparisonRepository extends ArtemisJpaRepository<Pla
 
     default PlagiarismComparison findByIdWithSubmissionsStudentsAndElementsBElseThrow(long comparisonId) {
         return getValueElseThrow(findByIdWithSubmissionsAndElementsB(comparisonId), comparisonId);
+    }
+
+    @Query("""
+            SELECT COALESCE(course.id, examCourse.id)
+            FROM PlagiarismComparison comparison
+                JOIN comparison.plagiarismResult result
+                JOIN result.exercise exercise
+                LEFT JOIN exercise.course course
+                LEFT JOIN exercise.exerciseGroup exerciseGroup
+                LEFT JOIN exerciseGroup.exam exam
+                LEFT JOIN exam.course examCourse
+            WHERE comparison.id = :comparisonId
+            """)
+    Optional<Long> findCourseIdById(@Param("comparisonId") long comparisonId);
+
+    default Long findCourseIdByIdElseThrow(long comparisonId) {
+        return getArbitraryValueElseThrow(findCourseIdById(comparisonId), String.valueOf(comparisonId));
     }
 
     @EntityGraph(type = LOAD, attributePaths = { "submissionA", "submissionA.plagiarismCase", "submissionB", "submissionB.plagiarismCase" })

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismComparisonRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismComparisonRepository.java
@@ -47,7 +47,6 @@ public interface PlagiarismComparisonRepository extends ArtemisJpaRepository<Pla
             FROM PlagiarismComparison comparison
                 LEFT JOIN FETCH comparison.submissionA submissionA
                 LEFT JOIN FETCH submissionA.elements elementsA
-                LEFT JOIN FETCH comparison.matches matches
             WHERE comparison.id = :comparisonId
             """)
     Optional<PlagiarismComparison> findByIdWithSubmissionsAndElementsA(@Param("comparisonId") long comparisonId);

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismComparisonRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismComparisonRepository.java
@@ -47,6 +47,7 @@ public interface PlagiarismComparisonRepository extends ArtemisJpaRepository<Pla
             FROM PlagiarismComparison comparison
                 LEFT JOIN FETCH comparison.submissionA submissionA
                 LEFT JOIN FETCH submissionA.elements elementsA
+                LEFT JOIN FETCH comparison.matches matches
             WHERE comparison.id = :comparisonId
             """)
     Optional<PlagiarismComparison> findByIdWithSubmissionsAndElementsA(@Param("comparisonId") long comparisonId);

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismComparisonRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/repository/PlagiarismComparisonRepository.java
@@ -35,6 +35,9 @@ public interface PlagiarismComparisonRepository extends ArtemisJpaRepository<Pla
                 LEFT JOIN FETCH comparison.plagiarismResult result
                 LEFT JOIN FETCH result.exercise exercise
                 LEFT JOIN FETCH exercise.course
+                LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
+                LEFT JOIN FETCH exerciseGroup.exam exam
+                LEFT JOIN FETCH exam.course
             WHERE comparison.id = :comparisonId
             """)
     Optional<PlagiarismComparison> findByIdWithSubmissions(@Param("comparisonId") long comparisonId);
@@ -51,6 +54,9 @@ public interface PlagiarismComparisonRepository extends ArtemisJpaRepository<Pla
                 LEFT JOIN FETCH comparison.plagiarismResult result
                 LEFT JOIN FETCH result.exercise exercise
                 LEFT JOIN FETCH exercise.course
+                LEFT JOIN FETCH exercise.exerciseGroup exerciseGroup
+                LEFT JOIN FETCH exerciseGroup.exam exam
+                LEFT JOIN FETCH exam.course
             WHERE comparison.id = :comparisonId
             """)
     Optional<PlagiarismComparison> findByIdWithSubmissionsAndElementsA(@Param("comparisonId") long comparisonId);

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismCaseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismCaseResource.java
@@ -97,7 +97,7 @@ public class PlagiarismCaseResource {
     @EnforceAtLeastInstructorInCourse
     public ResponseEntity<List<PlagiarismCaseOverviewDTO>> getPlagiarismCasesForCourseForInstructor(@PathVariable long courseId) {
         log.debug("REST request to get all plagiarism cases for instructor in course with id: {}", courseId);
-        var plagiarismCases = plagiarismCaseRepository.findByCourseIdWithPlagiarismSubmissionsAndComparison(courseId);
+        var plagiarismCases = plagiarismCaseRepository.findOverviewDtosByCourseId(courseId);
         return getPlagiarismCaseOverviewResponseEntity(plagiarismCases);
     }
 
@@ -115,12 +115,11 @@ public class PlagiarismCaseResource {
         Course course = courseRepository.findByIdElseThrow(courseId);
         authenticationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
 
-        var plagiarismCases = plagiarismCaseRepository.findByExamIdWithPlagiarismSubmissionsAndComparison(examId);
+        var plagiarismCases = plagiarismCaseRepository.findOverviewDtosByExamId(examId);
         if (!plagiarismCases.isEmpty()) {
-            var plagiarismCase = plagiarismCases.getFirst();
-            var exam = plagiarismCase.getExercise().getExerciseGroup().getExam();
-            if (!exam.getCourse().getId().equals(courseId)) {
-                throw new ConflictException("Exam with id " + exam.getId() + " is not related to the given course id " + courseId, ENTITY_NAME, "courseMismatch");
+            var plagiarismCaseExercise = plagiarismCases.getFirst().exercise();
+            if (plagiarismCaseExercise == null || !Long.valueOf(courseId).equals(plagiarismCaseExercise.courseId())) {
+                throw new ConflictException("Exam with id " + examId + " is not related to the given course id " + courseId, ENTITY_NAME, "courseMismatch");
             }
         }
         return getPlagiarismCaseOverviewResponseEntity(plagiarismCases);
@@ -141,8 +140,8 @@ public class PlagiarismCaseResource {
         if (!authenticationCheckService.isAtLeastInstructorInCourse(course, userRepository.getUserWithGroupsAndAuthorities())) {
             throw new AccessForbiddenException("Only instructors of this course have access to its plagiarism cases.");
         }
-        var plagiarismCase = plagiarismCaseRepository.findByIdWithFullDetailsForDTOElseThrow(plagiarismCaseId);
-        return ResponseEntity.ok(PlagiarismCaseDetailDTO.ofForInstructor(plagiarismCase));
+        var plagiarismCase = plagiarismCaseRepository.findDetailDtoByIdElseThrow(plagiarismCaseId);
+        return ResponseEntity.ok(getPlagiarismCaseDetailResponse(plagiarismCase));
     }
 
     /**
@@ -236,8 +235,15 @@ public class PlagiarismCaseResource {
         return ResponseEntity.ok(plagiarismCaseInfoDTOs);
     }
 
-    private ResponseEntity<List<PlagiarismCaseOverviewDTO>> getPlagiarismCaseOverviewResponseEntity(List<PlagiarismCase> plagiarismCases) {
-        return ResponseEntity.ok(plagiarismCases.stream().map(PlagiarismCaseOverviewDTO::ofOverview).toList());
+    private ResponseEntity<List<PlagiarismCaseOverviewDTO>> getPlagiarismCaseOverviewResponseEntity(List<PlagiarismCaseOverviewDTO> plagiarismCases) {
+        return ResponseEntity.ok(plagiarismCases);
+    }
+
+    private PlagiarismCaseDetailDTO getPlagiarismCaseDetailResponse(PlagiarismCaseDetailDTO plagiarismCase) {
+        var plagiarismSubmissions = plagiarismCaseRepository.findSubmissionDtosByPlagiarismCaseId(plagiarismCase.id());
+        return new PlagiarismCaseDetailDTO(plagiarismCase.id(), plagiarismCase.exercise(), plagiarismCase.student(), plagiarismCase.post(), plagiarismCase.verdict(),
+                plagiarismCase.verdictDate(), plagiarismCase.verdictBy(), plagiarismCase.plagiarismSubmissionCount(), plagiarismCase.createdByContinuousPlagiarismControl(),
+                plagiarismCase.verdictMessage(), plagiarismCase.verdictPointDeduction(), plagiarismSubmissions);
     }
 
     /**
@@ -255,11 +261,11 @@ public class PlagiarismCaseResource {
         User user = userRepository.getUserWithGroupsAndAuthorities();
         authenticationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.STUDENT, course, user);
 
-        var plagiarismCase = plagiarismCaseRepository.findByIdWithPlagiarismSubmissionsAndPlagiarismDetectionConfigElseThrow(plagiarismCaseId);
-        if (!plagiarismCase.getStudent().getLogin().equals(user.getLogin())) {
+        var plagiarismCase = plagiarismCaseRepository.findDetailDtoByIdElseThrow(plagiarismCaseId);
+        if (plagiarismCase.student() == null || !plagiarismCase.student().login().equals(user.getLogin())) {
             throw new AccessForbiddenException("Students only have access to plagiarism cases by which they are affected");
         }
 
-        return ResponseEntity.ok(PlagiarismCaseDetailDTO.ofForStudent(plagiarismCase));
+        return ResponseEntity.ok(getPlagiarismCaseDetailResponse(plagiarismCase));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismCaseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismCaseResource.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.plagiarism.web;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -140,6 +141,7 @@ public class PlagiarismCaseResource {
         if (!authenticationCheckService.isAtLeastInstructorInCourse(course, userRepository.getUserWithGroupsAndAuthorities())) {
             throw new AccessForbiddenException("Only instructors of this course have access to its plagiarism cases.");
         }
+        validatePlagiarismCaseCourse(plagiarismCaseId, courseId);
         var plagiarismCase = plagiarismCaseRepository.findDetailDtoByIdElseThrow(plagiarismCaseId);
         return ResponseEntity.ok(getPlagiarismCaseDetailResponse(plagiarismCase));
     }
@@ -179,6 +181,7 @@ public class PlagiarismCaseResource {
         if (!authenticationCheckService.isAtLeastInstructorInCourse(course, userRepository.getUserWithGroupsAndAuthorities())) {
             throw new AccessForbiddenException("Only instructors of this course have access to its plagiarism cases.");
         }
+        validatePlagiarismCaseCourse(plagiarismCaseId, courseId);
         var plagiarismCase = plagiarismCaseService.updatePlagiarismCaseVerdict(plagiarismCaseId, plagiarismVerdictDTO);
         return ResponseEntity.ok(PlagiarismCaseVerdictResponseDTO.ofVerdict(plagiarismCase));
     }
@@ -239,6 +242,13 @@ public class PlagiarismCaseResource {
         return ResponseEntity.ok(plagiarismCases);
     }
 
+    private void validatePlagiarismCaseCourse(long plagiarismCaseId, long courseId) {
+        Long plagiarismCaseCourseId = plagiarismCaseRepository.findCourseIdByIdElseThrow(plagiarismCaseId);
+        if (!Objects.equals(plagiarismCaseCourseId, courseId)) {
+            throw new ConflictException("Plagiarism case with id " + plagiarismCaseId + " is not related to the given course id " + courseId, ENTITY_NAME, "courseMismatch");
+        }
+    }
+
     private PlagiarismCaseDetailDTO getPlagiarismCaseDetailResponse(PlagiarismCaseDetailDTO plagiarismCase) {
         var plagiarismSubmissions = plagiarismCaseRepository.findSubmissionDtosByPlagiarismCaseId(plagiarismCase.id());
         return new PlagiarismCaseDetailDTO(plagiarismCase.id(), plagiarismCase.exercise(), plagiarismCase.student(), plagiarismCase.post(), plagiarismCase.verdict(),
@@ -262,7 +272,8 @@ public class PlagiarismCaseResource {
         authenticationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.STUDENT, course, user);
 
         var plagiarismCase = plagiarismCaseRepository.findDetailDtoByIdElseThrow(plagiarismCaseId);
-        if (plagiarismCase.student() == null || !plagiarismCase.student().login().equals(user.getLogin())) {
+        validatePlagiarismCaseCourse(plagiarismCaseId, courseId);
+        if (plagiarismCase.student() == null || !Objects.equals(plagiarismCase.student().login(), user.getLogin())) {
             throw new AccessForbiddenException("Students only have access to plagiarism cases by which they are affected");
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismCaseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismCaseResource.java
@@ -141,7 +141,7 @@ public class PlagiarismCaseResource {
         if (!authenticationCheckService.isAtLeastInstructorInCourse(course, userRepository.getUserWithGroupsAndAuthorities())) {
             throw new AccessForbiddenException("Only instructors of this course have access to its plagiarism cases.");
         }
-        var plagiarismCase = plagiarismCaseRepository.findByIdWithPlagiarismSubmissionsElseThrow(plagiarismCaseId);
+        var plagiarismCase = plagiarismCaseRepository.findByIdWithFullDetailsForDTOElseThrow(plagiarismCaseId);
         return ResponseEntity.ok(PlagiarismCaseDetailDTO.ofForInstructor(plagiarismCase));
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismCaseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismCaseResource.java
@@ -2,7 +2,6 @@ package de.tum.cit.aet.artemis.plagiarism.web;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -32,9 +31,11 @@ import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.course.repository.CourseRepository;
 import de.tum.cit.aet.artemis.plagiarism.config.PlagiarismEnabled;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCase;
-import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismDetectionConfig;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseDTO;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseDetailDTO;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseInfoDTO;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseOverviewDTO;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseVerdictResponseDTO;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismVerdictDTO;
 import de.tum.cit.aet.artemis.plagiarism.repository.PlagiarismCaseRepository;
 import de.tum.cit.aet.artemis.plagiarism.service.PlagiarismCaseService;
@@ -94,10 +95,10 @@ public class PlagiarismCaseResource {
      */
     @GetMapping("courses/{courseId}/plagiarism-cases/for-instructor")
     @EnforceAtLeastInstructorInCourse
-    public ResponseEntity<List<PlagiarismCase>> getPlagiarismCasesForCourseForInstructor(@PathVariable long courseId) {
+    public ResponseEntity<List<PlagiarismCaseOverviewDTO>> getPlagiarismCasesForCourseForInstructor(@PathVariable long courseId) {
         log.debug("REST request to get all plagiarism cases for instructor in course with id: {}", courseId);
         var plagiarismCases = plagiarismCaseRepository.findByCourseIdWithPlagiarismSubmissionsAndComparison(courseId);
-        return removeUnnecessaryData(plagiarismCases);
+        return getPlagiarismCaseOverviewResponseEntity(plagiarismCases);
     }
 
     /**
@@ -109,7 +110,7 @@ public class PlagiarismCaseResource {
      */
     @GetMapping("courses/{courseId}/exams/{examId}/plagiarism-cases/for-instructor")
     @EnforceAtLeastInstructor
-    public ResponseEntity<List<PlagiarismCase>> getPlagiarismCasesForExamForInstructor(@PathVariable long courseId, @PathVariable long examId) {
+    public ResponseEntity<List<PlagiarismCaseOverviewDTO>> getPlagiarismCasesForExamForInstructor(@PathVariable long courseId, @PathVariable long examId) {
         log.debug("REST request to get all plagiarism cases for instructor in exam with id: {}", examId);
         Course course = courseRepository.findByIdElseThrow(courseId);
         authenticationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
@@ -122,7 +123,7 @@ public class PlagiarismCaseResource {
                 throw new ConflictException("Exam with id " + exam.getId() + " is not related to the given course id " + courseId, ENTITY_NAME, "courseMismatch");
             }
         }
-        return removeUnnecessaryData(plagiarismCases);
+        return getPlagiarismCaseOverviewResponseEntity(plagiarismCases);
     }
 
     /**
@@ -134,23 +135,14 @@ public class PlagiarismCaseResource {
      */
     @GetMapping("courses/{courseId}/plagiarism-cases/{plagiarismCaseId}/for-instructor")
     @EnforceAtLeastInstructor
-    public ResponseEntity<PlagiarismCase> getPlagiarismCaseForInstructor(@PathVariable long courseId, @PathVariable long plagiarismCaseId) {
+    public ResponseEntity<PlagiarismCaseDetailDTO> getPlagiarismCaseForInstructor(@PathVariable long courseId, @PathVariable long plagiarismCaseId) {
         log.debug("REST request to get plagiarism case for instructor with id: {}", plagiarismCaseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
         if (!authenticationCheckService.isAtLeastInstructorInCourse(course, userRepository.getUserWithGroupsAndAuthorities())) {
             throw new AccessForbiddenException("Only instructors of this course have access to its plagiarism cases.");
         }
         var plagiarismCase = plagiarismCaseRepository.findByIdWithPlagiarismSubmissionsElseThrow(plagiarismCaseId);
-        return getPlagiarismCaseResponseEntity(plagiarismCase);
-    }
-
-    private ResponseEntity<PlagiarismCase> getPlagiarismCaseResponseEntity(PlagiarismCase plagiarismCase) {
-        for (var submission : plagiarismCase.getPlagiarismSubmissions()) {
-            submission.getPlagiarismComparison().getPlagiarismResult().setExercise(null);
-            submission.getPlagiarismComparison().setSubmissionA(null);
-            submission.getPlagiarismComparison().setSubmissionB(null);
-        }
-        return ResponseEntity.ok(plagiarismCase);
+        return ResponseEntity.ok(PlagiarismCaseDetailDTO.ofForInstructor(plagiarismCase));
     }
 
     /**
@@ -181,7 +173,7 @@ public class PlagiarismCaseResource {
      */
     @PutMapping("courses/{courseId}/plagiarism-cases/{plagiarismCaseId}/verdict")
     @EnforceAtLeastInstructor
-    public ResponseEntity<PlagiarismCase> savePlagiarismCaseVerdict(@PathVariable long courseId, @PathVariable long plagiarismCaseId,
+    public ResponseEntity<PlagiarismCaseVerdictResponseDTO> savePlagiarismCaseVerdict(@PathVariable long courseId, @PathVariable long plagiarismCaseId,
             @RequestBody PlagiarismVerdictDTO plagiarismVerdictDTO) {
         log.debug("REST request to save plagiarism verdict for plagiarism case with id: {}", plagiarismCaseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
@@ -189,7 +181,7 @@ public class PlagiarismCaseResource {
             throw new AccessForbiddenException("Only instructors of this course have access to its plagiarism cases.");
         }
         var plagiarismCase = plagiarismCaseService.updatePlagiarismCaseVerdict(plagiarismCaseId, plagiarismVerdictDTO);
-        return ResponseEntity.ok(plagiarismCase);
+        return ResponseEntity.ok(PlagiarismCaseVerdictResponseDTO.ofVerdict(plagiarismCase));
     }
 
     /**
@@ -244,18 +236,8 @@ public class PlagiarismCaseResource {
         return ResponseEntity.ok(plagiarismCaseInfoDTOs);
     }
 
-    private ResponseEntity<List<PlagiarismCase>> removeUnnecessaryData(List<PlagiarismCase> plagiarismCases) {
-        for (var plagiarismCase : plagiarismCases) {
-            if (plagiarismCase.getPost() != null) {
-                plagiarismCase.getPost().setPlagiarismCase(null);
-            }
-            for (var submission : plagiarismCase.getPlagiarismSubmissions()) {
-                submission.getPlagiarismComparison().getPlagiarismResult().setExercise(null);
-                submission.getPlagiarismComparison().setSubmissionA(null);
-                submission.getPlagiarismComparison().setSubmissionB(null);
-            }
-        }
-        return ResponseEntity.ok(plagiarismCases);
+    private ResponseEntity<List<PlagiarismCaseOverviewDTO>> getPlagiarismCaseOverviewResponseEntity(List<PlagiarismCase> plagiarismCases) {
+        return ResponseEntity.ok(plagiarismCases.stream().map(PlagiarismCaseOverviewDTO::ofOverview).toList());
     }
 
     /**
@@ -267,7 +249,7 @@ public class PlagiarismCaseResource {
      */
     @GetMapping("courses/{courseId}/plagiarism-cases/{plagiarismCaseId}/for-student")
     @EnforceAtLeastStudent
-    public ResponseEntity<PlagiarismCase> getPlagiarismCaseForStudent(@PathVariable long courseId, @PathVariable long plagiarismCaseId) {
+    public ResponseEntity<PlagiarismCaseDetailDTO> getPlagiarismCaseForStudent(@PathVariable long courseId, @PathVariable long plagiarismCaseId) {
         log.debug("REST request to get plagiarism case for student with id: {}", plagiarismCaseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
@@ -278,10 +260,6 @@ public class PlagiarismCaseResource {
             throw new AccessForbiddenException("Students only have access to plagiarism cases by which they are affected");
         }
 
-        // hide potentially sensitive data
-        plagiarismCase.getExercise().filterSensitiveInformation();
-        Optional.ofNullable(plagiarismCase.getExercise().getPlagiarismDetectionConfig()).ifPresent(PlagiarismDetectionConfig::filterSensitiveInformation);
-
-        return getPlagiarismCaseResponseEntity(plagiarismCase);
+        return ResponseEntity.ok(PlagiarismCaseDetailDTO.ofForStudent(plagiarismCase));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismResource.java
@@ -154,11 +154,11 @@ public class PlagiarismResource {
      * @param userLogin   of the student asking to see their plagiarism comparison.
      */
     private void checkStudentAccess(PlagiarismSubmission submissionA, PlagiarismSubmission submissionB, String userLogin) {
-        if (submissionA.getStudentLogin().equals(userLogin)) {
+        if (Objects.equals(submissionA.getStudentLogin(), userLogin)) {
             submissionA.setStudentLogin(YOUR_SUBMISSION);
             submissionB.setStudentLogin(OTHER_SUBMISSION);
         }
-        else if (submissionB.getStudentLogin().equals(userLogin)) {
+        else if (Objects.equals(submissionB.getStudentLogin(), userLogin)) {
             submissionA.setStudentLogin(OTHER_SUBMISSION);
             submissionB.setStudentLogin(YOUR_SUBMISSION);
         }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismResource.java
@@ -32,6 +32,7 @@ import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.plagiarism.config.PlagiarismEnabled;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismComparisonDTO;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismComparisonStatusDTO;
 import de.tum.cit.aet.artemis.plagiarism.repository.PlagiarismComparisonRepository;
 import de.tum.cit.aet.artemis.plagiarism.repository.PlagiarismResultRepository;
@@ -122,7 +123,7 @@ public class PlagiarismResource {
      */
     @GetMapping("courses/{courseId}/plagiarism-comparisons/{comparisonId}/for-split-view")
     @EnforceAtLeastStudent
-    public ResponseEntity<PlagiarismComparison> getPlagiarismComparisonForSplitView(@PathVariable("courseId") long courseId, @PathVariable("comparisonId") Long comparisonId) {
+    public ResponseEntity<PlagiarismComparisonDTO> getPlagiarismComparisonForSplitView(@PathVariable("courseId") long courseId, @PathVariable("comparisonId") Long comparisonId) {
         Course course = courseRepository.findByIdElseThrow(courseId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.STUDENT, course, user);
@@ -140,15 +141,7 @@ public class PlagiarismResource {
             checkStudentAccess(comparisonA, user.getLogin());
         }
 
-        // hide unnecessary details
-        comparisonA.getSubmissionA().setPlagiarismComparison(null);
-        comparisonA.getSubmissionA().setPlagiarismCase(null);
-        comparisonA.getSubmissionB().setPlagiarismComparison(null);
-        comparisonA.getSubmissionB().setPlagiarismCase(null);
-
-        // hide the chain to plagiarism result, exercise and course to avoid leaks and keep the response small
-        comparisonA.setPlagiarismResult(null);
-        return ResponseEntity.ok(comparisonA);
+        return ResponseEntity.ok(PlagiarismComparisonDTO.fromComparison(comparisonA));
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismResource.java
@@ -30,8 +30,8 @@ import de.tum.cit.aet.artemis.course.repository.CourseRepository;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.plagiarism.config.PlagiarismEnabled;
-import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus;
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismComparisonDTO;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismComparisonStatusDTO;
 import de.tum.cit.aet.artemis.plagiarism.repository.PlagiarismComparisonRepository;
@@ -136,31 +136,31 @@ public class PlagiarismResource {
             throw new BadRequestAlertException("The courseId does not belong to the given comparisonId", "PlagiarismComparison", "idMismatch");
         }
 
-        comparisonA.setSubmissionB(comparisonB.getSubmissionB());
         if (authCheckService.isOnlyStudentInCourse(course, user)) {
             // Note: this calls also checks that the student is allowed to see the complaint, and throws otherwise
-            checkStudentAccess(comparisonA, user.getLogin());
+            checkStudentAccess(comparisonA.getSubmissionA(), comparisonB.getSubmissionB(), user.getLogin());
         }
 
-        return ResponseEntity.ok(PlagiarismComparisonDTO.fromComparison(comparisonA));
+        return ResponseEntity.ok(PlagiarismComparisonDTO.fromComparison(comparisonA, comparisonB));
     }
 
     /**
-     * Check if the passed userLogin is related to the plagiarism comparison. If this is not the case, the user is now allowed to access.
+     * Check if the passed userLogin is related to the plagiarism comparison. If this is not the case, the user is not allowed to access.
      * Also anonymizes the comparison for the student view.
      * A student should not have sensitive information (e.g. the userLogin of the other student)
      *
-     * @param comparison to anonymize.
-     * @param userLogin  of the student asking to see their plagiarism comparison.
+     * @param submissionA the first submission in the comparison
+     * @param submissionB the second submission in the comparison
+     * @param userLogin   of the student asking to see their plagiarism comparison.
      */
-    private void checkStudentAccess(PlagiarismComparison comparison, String userLogin) {
-        if (comparison.getSubmissionA().getStudentLogin().equals(userLogin)) {
-            comparison.getSubmissionA().setStudentLogin(YOUR_SUBMISSION);
-            comparison.getSubmissionB().setStudentLogin(OTHER_SUBMISSION);
+    private void checkStudentAccess(PlagiarismSubmission submissionA, PlagiarismSubmission submissionB, String userLogin) {
+        if (submissionA.getStudentLogin().equals(userLogin)) {
+            submissionA.setStudentLogin(YOUR_SUBMISSION);
+            submissionB.setStudentLogin(OTHER_SUBMISSION);
         }
-        else if (comparison.getSubmissionB().getStudentLogin().equals(userLogin)) {
-            comparison.getSubmissionA().setStudentLogin(OTHER_SUBMISSION);
-            comparison.getSubmissionB().setStudentLogin(YOUR_SUBMISSION);
+        else if (submissionB.getStudentLogin().equals(userLogin)) {
+            submissionA.setStudentLogin(OTHER_SUBMISSION);
+            submissionB.setStudentLogin(YOUR_SUBMISSION);
         }
         else {
             throw new AccessForbiddenException("This plagiarism comparison is not related to the requesting user.");

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismResource.java
@@ -96,10 +96,10 @@ public class PlagiarismResource {
         Course course = courseRepository.findByIdElseThrow(courseId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, null);
 
-        // TODO: this check can take up to a few seconds in the worst case, we should do it directly in the database
         var comparison = plagiarismComparisonRepository.findByIdWithSubmissionsStudentsElseThrow(comparisonId);
         var exercise = comparison.getPlagiarismResult().getExercise();
-        if (!Objects.equals(exercise.getCourseViaExerciseGroupOrCourseMember().getId(), courseId)) {
+        var comparisonCourseId = plagiarismComparisonRepository.findCourseIdByIdElseThrow(comparisonId);
+        if (!Objects.equals(comparisonCourseId, courseId)) {
             throw new BadRequestAlertException("The courseId does not belong to the given comparisonId", "PlagiarismComparison", "idMismatch");
         }
 
@@ -131,7 +131,8 @@ public class PlagiarismResource {
         var comparisonA = plagiarismComparisonRepository.findByIdWithSubmissionsStudentsAndElementsAElseThrow(comparisonId);
         var comparisonB = plagiarismComparisonRepository.findByIdWithSubmissionsStudentsAndElementsBElseThrow(comparisonId);
 
-        if (!Objects.equals(comparisonA.getPlagiarismResult().getExercise().getCourseViaExerciseGroupOrCourseMember().getId(), courseId)) {
+        var comparisonCourseId = plagiarismComparisonRepository.findCourseIdByIdElseThrow(comparisonId);
+        if (!Objects.equals(comparisonCourseId, courseId)) {
             throw new BadRequestAlertException("The courseId does not belong to the given comparisonId", "PlagiarismComparison", "idMismatch");
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismResultResponseBuilder.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/web/PlagiarismResultResponseBuilder.java
@@ -8,7 +8,8 @@ import org.springframework.http.ResponseEntity;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismResultDTO;
-import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismResultStats;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismResultDetailsDTO;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismResultStatsDTO;
 
 /**
  * A class containing a shared logic for creating an HTTP response about plagiarism checks results
@@ -34,9 +35,9 @@ public class PlagiarismResultResponseBuilder {
                 .flatMap(comparison -> Stream.of(comparison.getSubmissionA().getSubmissionId(), comparison.getSubmissionB().getSubmissionId())).distinct().count();
         double averageSimilarity = getSimilarities(plagiarismResult).average().orElse(0.0);
         double maximalSimilarity = getSimilarities(plagiarismResult).max().orElse(0.0);
-        var stats = new PlagiarismResultStats(numberOfDetectedSubmissions, averageSimilarity, maximalSimilarity, plagiarismResult.getCreatedBy());
+        var stats = new PlagiarismResultStatsDTO(numberOfDetectedSubmissions, averageSimilarity, maximalSimilarity, plagiarismResult.getCreatedBy());
 
-        return ResponseEntity.ok(new PlagiarismResultDTO(plagiarismResult, stats));
+        return ResponseEntity.ok(new PlagiarismResultDTO(PlagiarismResultDetailsDTO.fromResult(plagiarismResult), stats));
     }
 
     private static DoubleStream getSimilarities(PlagiarismResult plagiarismResult) {

--- a/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.spec.ts
+++ b/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.spec.ts
@@ -39,7 +39,7 @@ describe('Plagiarism Cases Instructor View Component', () => {
         id: 1,
         title: 'Test Exercise',
         type: ExerciseType.TEXT,
-        courseId: 1,
+        courseId: 2,
         courseTitle: 'Test Course',
     } as PlagiarismCaseExercise;
 
@@ -78,12 +78,14 @@ describe('Plagiarism Cases Instructor View Component', () => {
     });
 
     it('should set plagiarism case and exercises on initialization', async () => {
+        const setCourseSpy = vi.spyOn(fixture.debugElement.injector.get(MetisService), 'setCourse');
         component.ngOnInit();
         await Promise.resolve();
         expect(component.courseId()).toBe(1);
         expect(component.plagiarismCaseId).toBe(1);
         expect(component.plagiarismCase()).toEqual(plagiarismCase);
         expect(component.currentAccount?.id).toBe(99);
+        expect(setCourseSpy).toHaveBeenCalledWith(expect.objectContaining({ id: 1, title: exercise.courseTitle }));
     });
 
     it('should throw when saving plagiarism case plagiarism verdict before student is notified', () => {

--- a/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.spec.ts
+++ b/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.spec.ts
@@ -175,10 +175,22 @@ describe('Plagiarism Cases Instructor View Component', () => {
         const translateServiceSpy = vi.spyOn(translateService, 'instant');
 
         const examTitle = 'Exam Title';
+        const examExercise = {
+            id: 1,
+            title: 'Test Exercise',
+            type: ExerciseType.TEXT,
+            courseId: 2,
+            courseTitle: 'Test Course',
+            examId: 3,
+            examTitle,
+        } as PlagiarismCaseExercise;
         const examPlagiarismCase = {
-            ...plagiarismCase,
-            exercise: { ...exercise, examId: 3, examTitle },
-        };
+            id: 1,
+            exercise: examExercise,
+            verdict: PlagiarismVerdict.PLAGIARISM,
+            post: { id: 1 },
+            student: { name: 'Test User' },
+        } as PlagiarismCase;
         component.plagiarismCase.set(examPlagiarismCase);
         component.currentAccount = { id: 99, name: 'user' } as User;
         component.createEmptyPost();
@@ -204,7 +216,9 @@ describe('Plagiarism Cases Instructor View Component', () => {
         const translateServiceSpy = vi.spyOn(translateService, 'instant');
 
         component.plagiarismCase.set({
-            ...plagiarismCase,
+            id: 1,
+            verdict: PlagiarismVerdict.PLAGIARISM,
+            post: { id: 1 },
             student: undefined,
             exercise: undefined,
         } as PlagiarismCase);

--- a/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.spec.ts
+++ b/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.spec.ts
@@ -6,12 +6,12 @@ import { PlagiarismCaseInstructorDetailViewComponent } from 'app/plagiarism/mana
 import { PlagiarismCasesService } from 'app/plagiarism/shared/services/plagiarism-cases.service';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { PlagiarismCase } from 'app/plagiarism/shared/entities/PlagiarismCase';
+import { PlagiarismCase, PlagiarismCaseExercise, PlagiarismCaseVerdictResponse } from 'app/plagiarism/shared/entities/PlagiarismCase';
 import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { SessionStorageService } from 'app/foundation/service/session-storage.service';
 import { WebsocketService } from 'app/foundation/service/websocket.service';
 import { Observable, ReplaySubject, of } from 'rxjs';
-import { TextExercise } from 'app/text/shared/entities/text-exercise.model';
+import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { PlagiarismVerdict } from 'app/plagiarism/shared/entities/PlagiarismVerdict';
 import { MetisService } from 'app/communication/service/metis.service';
 import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
@@ -38,8 +38,10 @@ describe('Plagiarism Cases Instructor View Component', () => {
     const exercise = {
         id: 1,
         title: 'Test Exercise',
-        course: { id: 1, title: 'Test Course' },
-    } as TextExercise;
+        type: ExerciseType.TEXT,
+        courseId: 1,
+        courseTitle: 'Test Course',
+    } as PlagiarismCaseExercise;
 
     const plagiarismCase = {
         id: 1,
@@ -95,7 +97,7 @@ describe('Plagiarism Cases Instructor View Component', () => {
     });
 
     it('should save plagiarism case plagiarism verdict', async () => {
-        saveVerdictSpy.mockReturnValue(of({ body: { verdict: PlagiarismVerdict.PLAGIARISM } }) as Observable<HttpResponse<PlagiarismCase>>);
+        saveVerdictSpy.mockReturnValue(of({ body: { verdict: PlagiarismVerdict.PLAGIARISM } }) as Observable<HttpResponse<PlagiarismCaseVerdictResponse>>);
         component.posts.set([{ id: 1, plagiarismCase: { id: 1 } }]);
         component.courseId.set(1);
         component.plagiarismCaseId = 1;
@@ -106,7 +108,7 @@ describe('Plagiarism Cases Instructor View Component', () => {
     });
 
     it('should save plagiarism case warning verdict', async () => {
-        saveVerdictSpy.mockReturnValue(of({ body: { verdict: PlagiarismVerdict.WARNING, verdictMessage: 'message' } }) as Observable<HttpResponse<PlagiarismCase>>);
+        saveVerdictSpy.mockReturnValue(of({ body: { verdict: PlagiarismVerdict.WARNING, verdictMessage: 'message' } }) as Observable<HttpResponse<PlagiarismCaseVerdictResponse>>);
         component.posts.set([{ id: 1, plagiarismCase: { id: 1 } }]);
         component.courseId.set(1);
         component.plagiarismCaseId = 1;
@@ -118,7 +120,9 @@ describe('Plagiarism Cases Instructor View Component', () => {
     });
 
     it('should save plagiarism case point deduction verdict', async () => {
-        saveVerdictSpy.mockReturnValue(of({ body: { verdict: PlagiarismVerdict.POINT_DEDUCTION, verdictPointDeduction: 80 } }) as Observable<HttpResponse<PlagiarismCase>>);
+        saveVerdictSpy.mockReturnValue(
+            of({ body: { verdict: PlagiarismVerdict.POINT_DEDUCTION, verdictPointDeduction: 80 } }) as Observable<HttpResponse<PlagiarismCaseVerdictResponse>>,
+        );
         component.posts.set([{ id: 1, plagiarismCase: { id: 1 } }]);
         component.courseId.set(1);
         component.plagiarismCaseId = 1;
@@ -130,7 +134,7 @@ describe('Plagiarism Cases Instructor View Component', () => {
     });
 
     it('should save plagiarism case no plagiarism verdict', async () => {
-        saveVerdictSpy.mockReturnValue(of({ body: { verdict: PlagiarismVerdict.NO_PLAGIARISM } }) as Observable<HttpResponse<PlagiarismCase>>);
+        saveVerdictSpy.mockReturnValue(of({ body: { verdict: PlagiarismVerdict.NO_PLAGIARISM } }) as Observable<HttpResponse<PlagiarismCaseVerdictResponse>>);
         component.posts.set([{ id: 1, plagiarismCase: { id: 1 } }]);
         component.courseId.set(1);
         component.plagiarismCaseId = 1;
@@ -159,7 +163,7 @@ describe('Plagiarism Cases Instructor View Component', () => {
                 instructor: 'user',
                 exercise: plagiarismCase.exercise!.title,
                 inCourseOrExam: 'artemisApp.plagiarism.plagiarismCases.notification.inCourse',
-                courseOrExam: exercise.course!.title,
+                courseOrExam: exercise.courseTitle,
             }),
         );
     });
@@ -171,7 +175,7 @@ describe('Plagiarism Cases Instructor View Component', () => {
         const examTitle = 'Exam Title';
         const examPlagiarismCase = {
             ...plagiarismCase,
-            exercise: { ...exercise, course: undefined, exerciseGroup: { exam: { id: 3, title: examTitle } } },
+            exercise: { ...exercise, examId: 3, examTitle },
         };
         component.plagiarismCase.set(examPlagiarismCase);
         component.currentAccount = { id: 99, name: 'user' } as User;

--- a/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.ts
@@ -44,7 +44,7 @@ import { LinkifyService } from 'app/communication/link-preview/services/linkify.
 import { PlagiarismPostService } from 'app/plagiarism/shared/services/plagiarism-post.service';
 import { PlagiarismPostCreationDtoModel } from 'app/plagiarism/shared/entities/plagiarism-post-creation-dto.model';
 import { PostCreateEditModalComponent } from 'app/communication/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component';
-import { Course } from 'app/core/course/shared/entities/course.model';
+import { Course } from 'app/course/shared/entities/course.model';
 
 @Component({
     selector: 'jhi-plagiarism-case-instructor-detail-view',

--- a/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.ts
@@ -116,7 +116,7 @@ export class PlagiarismCaseInstructorDetailViewComponent implements OnInit, OnDe
 
                 this.verdictMessage.set(plagiarismCase.verdictMessage ?? '');
                 this.verdictPointDeduction.set(plagiarismCase.verdictPointDeduction ?? 0);
-                this.metisService.setCourse({ id: plagiarismCase.exercise?.courseId, title: plagiarismCase.exercise?.courseTitle } as Course);
+                this.metisService.setCourse({ id: this.courseId(), title: plagiarismCase.exercise?.courseTitle } as Course);
                 this.metisService.setPageType(this.pageType);
                 this.metisService.getFilteredPosts({
                     plagiarismCaseId: plagiarismCase.id,

--- a/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.ts
@@ -2,12 +2,12 @@ import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
 import { Observable } from 'rxjs';
 import { PlagiarismCaseReviewComponent } from 'app/plagiarism/shared/review/plagiarism-case-review.component';
 import { PlagiarismCaseVerdictComponent } from 'app/plagiarism/shared/verdict/plagiarism-case-verdict.component';
-import { PlagiarismCase } from 'app/plagiarism/shared/entities/PlagiarismCase';
+import { PlagiarismCase, PlagiarismCaseVerdictResponse } from 'app/plagiarism/shared/entities/PlagiarismCase';
 import { PlagiarismCasesService } from 'app/plagiarism/shared/services/plagiarism-cases.service';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { HttpResponse } from '@angular/common/http';
-import { getCourseFromExercise, getExerciseUrlSegment, getIcon } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { getExerciseUrlSegment, getIcon } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { PlagiarismVerdict } from 'app/plagiarism/shared/entities/PlagiarismVerdict';
 import { MetisService } from 'app/communication/service/metis.service';
 import { PageType } from 'app/communication/metis.util';
@@ -44,6 +44,7 @@ import { LinkifyService } from 'app/communication/link-preview/services/linkify.
 import { PlagiarismPostService } from 'app/plagiarism/shared/services/plagiarism-post.service';
 import { PlagiarismPostCreationDtoModel } from 'app/plagiarism/shared/entities/plagiarism-post-creation-dto.model';
 import { PostCreateEditModalComponent } from 'app/communication/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component';
+import { Course } from 'app/core/course/shared/entities/course.model';
 
 @Component({
     selector: 'jhi-plagiarism-case-instructor-detail-view',
@@ -115,7 +116,7 @@ export class PlagiarismCaseInstructorDetailViewComponent implements OnInit, OnDe
 
                 this.verdictMessage.set(plagiarismCase.verdictMessage ?? '');
                 this.verdictPointDeduction.set(plagiarismCase.verdictPointDeduction ?? 0);
-                this.metisService.setCourse(getCourseFromExercise(plagiarismCase.exercise!)!);
+                this.metisService.setCourse({ id: plagiarismCase.exercise?.courseId, title: plagiarismCase.exercise?.courseTitle } as Course);
                 this.metisService.setPageType(this.pageType);
                 this.metisService.getFilteredPosts({
                     plagiarismCaseId: plagiarismCase.id,
@@ -156,7 +157,7 @@ export class PlagiarismCaseInstructorDetailViewComponent implements OnInit, OnDe
                 verdictPointDeduction: this.verdictPointDeduction(),
             })
             .subscribe({
-                next: (res: HttpResponse<PlagiarismCase>) => {
+                next: (res: HttpResponse<PlagiarismCaseVerdictResponse>) => {
                     this.plagiarismCase.update((plagiarismCase) => ({
                         ...plagiarismCase,
                         verdict: res.body!.verdict,
@@ -182,7 +183,7 @@ export class PlagiarismCaseInstructorDetailViewComponent implements OnInit, OnDe
                 verdictMessage: this.verdictMessage(),
             })
             .subscribe({
-                next: (res: HttpResponse<PlagiarismCase>) => {
+                next: (res: HttpResponse<PlagiarismCaseVerdictResponse>) => {
                     this.plagiarismCase.update((plagiarismCase) => ({
                         ...plagiarismCase,
                         verdict: res.body!.verdict,
@@ -202,7 +203,7 @@ export class PlagiarismCaseInstructorDetailViewComponent implements OnInit, OnDe
             throw new Error('Cannot call saveVerdict before student is notified');
         }
         this.plagiarismCasesService.saveVerdict(this.courseId(), this.plagiarismCaseId, { verdict: PlagiarismVerdict.PLAGIARISM }).subscribe({
-            next: (res: HttpResponse<PlagiarismCase>) => {
+            next: (res: HttpResponse<PlagiarismCaseVerdictResponse>) => {
                 this.plagiarismCase.update((plagiarismCase) => ({
                     ...plagiarismCase,
                     verdict: res.body!.verdict,
@@ -221,7 +222,7 @@ export class PlagiarismCaseInstructorDetailViewComponent implements OnInit, OnDe
             throw new Error('Cannot call saveNoPlagiarismVerdict before student is notified');
         }
         this.plagiarismCasesService.saveVerdict(this.courseId(), this.plagiarismCaseId, { verdict: PlagiarismVerdict.NO_PLAGIARISM }).subscribe({
-            next: (res: HttpResponse<PlagiarismCase>) => {
+            next: (res: HttpResponse<PlagiarismCaseVerdictResponse>) => {
                 this.plagiarismCase.update((plagiarismCase) => ({
                     ...plagiarismCase,
                     verdict: res.body!.verdict,
@@ -262,8 +263,8 @@ export class PlagiarismCaseInstructorDetailViewComponent implements OnInit, OnDe
         const studentName = abbreviateString(plagiarismCase.student?.name ?? '', 70);
         const instructorName = abbreviateString(this.currentAccount?.name ?? '', 70);
         const exerciseTitle = abbreviateString(plagiarismCase.exercise?.title ?? '', 70);
-        const belongsToExam = !!plagiarismCase.exercise?.exerciseGroup;
-        const courseOrExamTitle = abbreviateString((belongsToExam ? plagiarismCase.exercise?.exerciseGroup?.exam?.title : plagiarismCase.exercise?.course?.title) ?? '', 70);
+        const belongsToExam = !!plagiarismCase.exercise?.examId;
+        const courseOrExamTitle = abbreviateString((belongsToExam ? plagiarismCase.exercise?.examTitle : plagiarismCase.exercise?.courseTitle) ?? '', 70);
 
         const createdPost = this.metisService.createEmptyPostForContext(undefined, plagiarismCase); // Note the limit of 1.000 characters for the post's content
         createdPost.title = this.translateService.instant('artemisApp.plagiarism.plagiarismCases.notification.title', {

--- a/src/main/webapp/app/plagiarism/manage/instructor-view/plagiarism-cases-instructor-view.component.html
+++ b/src/main/webapp/app/plagiarism/manage/instructor-view/plagiarism-cases-instructor-view.component.html
@@ -66,12 +66,10 @@
                                     </a>
                                 </div>
                             }
-                            @if (plagiarismCase.plagiarismSubmissions) {
+                            @if (plagiarismCase.plagiarismSubmissionCount !== undefined) {
                                 <div class="col-2 text-center">
                                     <span>
-                                        {{
-                                            'artemisApp.plagiarism.plagiarismCases.appearsInComparisons' | artemisTranslate: { count: plagiarismCase.plagiarismSubmissions?.length }
-                                        }}
+                                        {{ 'artemisApp.plagiarism.plagiarismCases.appearsInComparisons' | artemisTranslate: { count: plagiarismCase.plagiarismSubmissionCount } }}
                                     </span>
                                 </div>
                             }

--- a/src/main/webapp/app/plagiarism/manage/instructor-view/plagiarism-cases-instructor-view.component.spec.ts
+++ b/src/main/webapp/app/plagiarism/manage/instructor-view/plagiarism-cases-instructor-view.component.spec.ts
@@ -15,7 +15,6 @@ import dayjs from 'dayjs/esm';
 import { DocumentationButtonComponent } from 'app/shared-ui/components/buttons/documentation-button/documentation-button.component';
 import { MockComponent } from 'ng-mocks';
 import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
-import { PlagiarismSubmission } from 'app/plagiarism/shared/entities/PlagiarismSubmission';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { ArtemisDatePipe } from 'app/foundation/pipes/artemis-date.pipe';
 import { ProgressBarComponent } from 'app/exercise/dashboards/tutor-participation-graph/progress-bar/progress-bar.component';
@@ -54,12 +53,6 @@ describe('Plagiarism Cases Instructor View Component', () => {
         type: ExerciseType.TEXT,
     } as TextExercise;
 
-    const studentLoginA = 'studentA';
-    const plagiarismSubmission1 = {
-        id: 1,
-        studentLogin: studentLoginA,
-    } as PlagiarismSubmission;
-
     const plagiarismCase1 = {
         id: 1,
         exercise: exercise1,
@@ -72,13 +65,9 @@ describe('Plagiarism Cases Instructor View Component', () => {
         verdictDate: date,
         post: {
             id: 1,
-            answers: [
-                {
-                    author: { id: 1 },
-                },
-            ],
+            answerAuthorIds: [1],
         },
-        plagiarismSubmissions: [plagiarismSubmission1],
+        plagiarismSubmissionCount: 1,
     } as PlagiarismCase;
     const plagiarismCase2 = {
         id: 2,

--- a/src/main/webapp/app/plagiarism/manage/instructor-view/plagiarism-cases-instructor-view.component.spec.ts
+++ b/src/main/webapp/app/plagiarism/manage/instructor-view/plagiarism-cases-instructor-view.component.spec.ts
@@ -65,9 +65,9 @@ describe('Plagiarism Cases Instructor View Component', () => {
         verdictDate: date,
         post: {
             id: 1,
-            answerAuthorIds: [1],
         },
         plagiarismSubmissionCount: 1,
+        hasStudentAnswer: true,
     } as PlagiarismCase;
     const plagiarismCase2 = {
         id: 2,

--- a/src/main/webapp/app/plagiarism/manage/instructor-view/plagiarism-cases-instructor-view.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/instructor-view/plagiarism-cases-instructor-view.component.ts
@@ -161,7 +161,7 @@ export class PlagiarismCasesInstructorViewComponent implements OnInit {
      * @return whether the student has responded or not
      */
     hasStudentAnswer(plagiarismCase: PlagiarismCase): boolean {
-        return !!plagiarismCase.post?.answerAuthorIds?.some((authorId) => authorId === plagiarismCase.student?.id);
+        return !!plagiarismCase.hasStudentAnswer;
     }
 
     /**

--- a/src/main/webapp/app/plagiarism/manage/instructor-view/plagiarism-cases-instructor-view.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/instructor-view/plagiarism-cases-instructor-view.component.ts
@@ -2,8 +2,8 @@ import { HttpResponse } from '@angular/common/http';
 import { Component, ElementRef, OnInit, effect, inject, signal, viewChildren } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { PlagiarismCasesService } from 'app/plagiarism/shared/services/plagiarism-cases.service';
-import { PlagiarismCase } from 'app/plagiarism/shared/entities/PlagiarismCase';
-import { Exercise, getExerciseUrlSegment, getIcon } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { PlagiarismCase, PlagiarismCaseExercise } from 'app/plagiarism/shared/entities/PlagiarismCase';
+import { getExerciseUrlSegment, getIcon } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { downloadFile } from 'app/foundation/util/download.util';
 import { DocumentationType } from 'app/shared-ui/components/buttons/documentation-button/documentation-button.component';
 import { GroupedPlagiarismCases } from 'app/plagiarism/shared/entities/GroupedPlagiarismCase';
@@ -40,7 +40,7 @@ export class PlagiarismCasesInstructorViewComponent implements OnInit {
     examId?: number;
     readonly plagiarismCases = signal<PlagiarismCase[]>([]);
     readonly groupedPlagiarismCases = signal<GroupedPlagiarismCases>({});
-    readonly exercisesWithPlagiarismCases = signal<Exercise[]>([]);
+    readonly exercisesWithPlagiarismCases = signal<PlagiarismCaseExercise[]>([]);
 
     exerciseWithPlagCasesElements = viewChildren<ElementRef>('plagExerciseElement');
 
@@ -161,7 +161,7 @@ export class PlagiarismCasesInstructorViewComponent implements OnInit {
      * @return whether the student has responded or not
      */
     hasStudentAnswer(plagiarismCase: PlagiarismCase): boolean {
-        return !!plagiarismCase.post && !!plagiarismCase.post.answers && plagiarismCase.post.answers.some((answer) => answer.author?.id === plagiarismCase.student?.id);
+        return !!plagiarismCase.post?.answerAuthorIds?.some((authorId) => authorId === plagiarismCase.student?.id);
     }
 
     /**
@@ -216,7 +216,7 @@ export class PlagiarismCasesInstructorViewComponent implements OnInit {
      * @private return object containing grouped cases
      */
     private getGroupedPlagiarismCasesByExercise(cases: PlagiarismCase[]): GroupedPlagiarismCases {
-        const exercisesWithPlagiarismCases: Exercise[] = [];
+        const exercisesWithPlagiarismCases: PlagiarismCaseExercise[] = [];
         const grouped = cases.reduce((acc: { [exerciseId: number]: PlagiarismCase[] }, plagiarismCase: PlagiarismCase) => {
             const caseExerciseId = plagiarismCase.exercise?.id;
             if (caseExerciseId === undefined) {

--- a/src/main/webapp/app/plagiarism/manage/plagiarism-inspector/plagiarism-inspector.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/plagiarism-inspector/plagiarism-inspector.component.ts
@@ -20,7 +20,7 @@ import { NgbDropdown, NgbDropdownButtonItem, NgbDropdownItem, NgbDropdownMenu, N
 import { DialogModule } from 'primeng/dialog';
 import { AlertService, AlertType } from 'app/foundation/service/alert.service';
 import { Subscription } from 'rxjs';
-import { PlagiarismResultDTO, PlagiarismResultStats } from 'app/plagiarism/shared/entities/PlagiarismResultDTO';
+import { PlagiarismResultDTO, PlagiarismResultStatsDTO } from 'app/plagiarism/shared/entities/PlagiarismResultDTO';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { FeatureToggleDirective } from 'app/foundation/feature-toggle/feature-toggle.directive';
@@ -81,7 +81,7 @@ export class PlagiarismInspectorComponent implements OnInit, OnDestroy {
     /**
      * Statistics for the automated plagiarism detection result
      */
-    readonly plagiarismResultStats = signal<PlagiarismResultStats | undefined>(undefined);
+    readonly plagiarismResultStats = signal<PlagiarismResultStatsDTO | undefined>(undefined);
 
     /**
      * True, if an automated plagiarism detection is running; false otherwise.

--- a/src/main/webapp/app/plagiarism/manage/plagiarism-run-details/plagiarism-run-details.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/plagiarism-run-details/plagiarism-run-details.component.ts
@@ -3,7 +3,7 @@ import { GraphColors } from 'app/exercise/shared/entities/statistics.model';
 import { Range, round } from 'app/foundation/util/utils';
 import { PlagiarismComparison } from 'app/plagiarism/shared/entities/PlagiarismComparison';
 import { PlagiarismStatus } from 'app/plagiarism/shared/entities/PlagiarismStatus';
-import { PlagiarismResultStats } from 'app/plagiarism/shared/entities/PlagiarismResultDTO';
+import { PlagiarismResultStatsDTO } from 'app/plagiarism/shared/entities/PlagiarismResultDTO';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { TranslateService } from '@ngx-translate/core';
 import { HelpIconComponent } from 'app/shared-ui/components/help-icon/help-icon.component';
@@ -43,7 +43,7 @@ export class PlagiarismRunDetailsComponent extends PlagiarismAndTutorEffortDirec
     /**
      * Statistics for the automated plagiarism detection result
      */
-    readonly plagiarismResultStats = input<PlagiarismResultStats>();
+    readonly plagiarismResultStats = input<PlagiarismResultStatsDTO>();
     readonly similaritySelected = output<Range>();
 
     yScaleMax = 5;

--- a/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/plagiarism-split-view.component.spec.ts
+++ b/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/plagiarism-split-view.component.spec.ts
@@ -90,6 +90,22 @@ describe('Plagiarism Split View Component', () => {
         expect(comp.parseTextMatches).toHaveBeenCalledOnce();
     });
 
+    it('should not fetch comparison until course id and comparison id are available', () => {
+        const getComparisonSpy = vi
+            .spyOn(plagiarismCasesService, 'getPlagiarismComparisonForSplitView')
+            .mockReturnValue(of({ body: comparison } as HttpResponse<PlagiarismComparison>));
+
+        comp.ngOnChanges({
+            comparison: { currentValue: { id: 1 } } as SimpleChange,
+        });
+        comp.ngOnChanges({
+            exercise: { currentValue: textExercise } as SimpleChange,
+            comparison: { currentValue: {} } as SimpleChange,
+        });
+
+        expect(getComparisonSpy).not.toHaveBeenCalled();
+    });
+
     it('should subscribe to the split control subject', () => {
         fixture.componentRef.setInput('exercise', textExercise as Exercise);
         const subscribeSpy = vi.spyOn(splitControlSubject, 'subscribe');

--- a/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/plagiarism-split-view.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/plagiarism-split-view.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, OnChanges, OnDestroy, OnInit, SimpleChanges, afterNextRender, inject, input, signal } from '@angular/core';
-import { PlagiarismComparison } from 'app/plagiarism/shared/entities/PlagiarismComparison';
+import { PlagiarismComparison, PlagiarismComparisonSummary } from 'app/plagiarism/shared/entities/PlagiarismComparison';
 import { FromToElement } from 'app/plagiarism/shared/entities/PlagiarismSubmissionElement';
 import { Subject } from 'rxjs';
 import { Exercise, ExerciseType, getCourseId } from 'app/exercise/shared/entities/exercise/exercise.model';
@@ -15,6 +15,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { SplitterModule } from 'primeng/splitter';
 import { TooltipModule } from 'primeng/tooltip';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
+import { PlagiarismCaseExercise } from 'app/plagiarism/shared/entities/PlagiarismCase';
 
 @Component({
     selector: 'jhi-plagiarism-split-view',
@@ -26,8 +27,8 @@ export class PlagiarismSplitViewComponent implements OnChanges, OnInit, OnDestro
     private plagiarismCasesService = inject(PlagiarismCasesService);
     private readonly hostElement = inject<ElementRef<HTMLElement>>(ElementRef);
 
-    readonly comparison = input<PlagiarismComparison | undefined>(undefined!);
-    readonly exercise = input<Exercise>();
+    readonly comparison = input<PlagiarismComparison | PlagiarismComparisonSummary | undefined>(undefined!);
+    readonly exercise = input<Exercise | PlagiarismCaseExercise>();
     readonly splitControlSubject = input<Subject<string>>();
     readonly sortByStudentLogin = input<string>();
     readonly forStudent = input<boolean>();
@@ -112,7 +113,7 @@ export class PlagiarismSplitViewComponent implements OnChanges, OnInit, OnDestro
 
         if (changes.comparison) {
             this.plagiarismCasesService
-                .getPlagiarismComparisonForSplitView(getCourseId(this.exercise())!, changes.comparison.currentValue.id)
+                .getPlagiarismComparisonForSplitView(this.getCourseIdForExercise()!, changes.comparison.currentValue.id)
                 .subscribe((resp: HttpResponse<PlagiarismComparison>) => {
                     const plagiarismComparison = resp.body!;
                     const sortByStudentLogin = this.sortByStudentLogin();
@@ -125,6 +126,17 @@ export class PlagiarismSplitViewComponent implements OnChanges, OnInit, OnDestro
                     }
                 });
         }
+    }
+
+    private getCourseIdForExercise(): number | undefined {
+        const exercise = this.exercise();
+        if (!exercise) {
+            return undefined;
+        }
+        if ('courseId' in exercise && exercise.courseId !== undefined) {
+            return exercise.courseId;
+        }
+        return getCourseId(exercise as Exercise);
     }
 
     ngOnDestroy() {

--- a/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/plagiarism-split-view.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/plagiarism-split-view.component.ts
@@ -106,30 +106,38 @@ export class PlagiarismSplitViewComponent implements OnChanges, OnInit, OnDestro
 
     ngOnChanges(changes: SimpleChanges) {
         if (changes.exercise) {
-            const exercise = changes.exercise.currentValue;
+            const exercise = changes.exercise.currentValue as Exercise | PlagiarismCaseExercise | undefined;
 
-            this.isProgrammingOrTextExercise.set(exercise.type === ExerciseType.PROGRAMMING || exercise.type === ExerciseType.TEXT);
+            this.isProgrammingOrTextExercise.set(exercise?.type === ExerciseType.PROGRAMMING || exercise?.type === ExerciseType.TEXT);
         }
 
-        if (changes.comparison) {
-            this.plagiarismCasesService
-                .getPlagiarismComparisonForSplitView(this.getCourseIdForExercise()!, changes.comparison.currentValue.id)
-                .subscribe((resp: HttpResponse<PlagiarismComparison>) => {
-                    const plagiarismComparison = resp.body!;
-                    const sortByStudentLogin = this.sortByStudentLogin();
-                    if (sortByStudentLogin && sortByStudentLogin === plagiarismComparison.submissionB.studentLogin) {
-                        this.swapSubmissions(plagiarismComparison);
-                    }
-                    this.plagiarismComparison.set(plagiarismComparison);
-                    if (this.isProgrammingOrTextExercise()) {
-                        this.parseTextMatches(plagiarismComparison);
-                    }
-                });
+        if (changes.comparison || changes.exercise) {
+            this.fetchComparisonIfReady(changes.comparison?.currentValue, changes.exercise?.currentValue);
         }
     }
 
-    private getCourseIdForExercise(): number | undefined {
-        const exercise = this.exercise();
+    private fetchComparisonIfReady(changedComparison?: PlagiarismComparison | PlagiarismComparisonSummary, changedExercise?: Exercise | PlagiarismCaseExercise): void {
+        const comparison = changedComparison ?? this.comparison();
+        const courseId = this.getCourseIdForExercise(changedExercise);
+        if (courseId === undefined || comparison?.id === undefined) {
+            return;
+        }
+
+        this.plagiarismCasesService.getPlagiarismComparisonForSplitView(courseId, comparison.id).subscribe((resp: HttpResponse<PlagiarismComparison>) => {
+            const plagiarismComparison = resp.body!;
+            const sortByStudentLogin = this.sortByStudentLogin();
+            if (sortByStudentLogin && sortByStudentLogin === plagiarismComparison.submissionB.studentLogin) {
+                this.swapSubmissions(plagiarismComparison);
+            }
+            this.plagiarismComparison.set(plagiarismComparison);
+            if (this.isProgrammingOrTextExercise()) {
+                this.parseTextMatches(plagiarismComparison);
+            }
+        });
+    }
+
+    private getCourseIdForExercise(changedExercise?: Exercise | PlagiarismCaseExercise): number | undefined {
+        const exercise = changedExercise ?? this.exercise();
         if (!exercise) {
             return undefined;
         }

--- a/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.spec.ts
+++ b/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.spec.ts
@@ -160,6 +160,17 @@ describe('Text Submission Viewer Component', () => {
         expect(filtered).not.toContain('src/');
     });
 
+    it('falls back to the exercise id when downloading a file without an exercise short name', () => {
+        const downloadFileSpy = vi.spyOn(repositoryService, 'downloadFile');
+        fixture.componentRef.setInput('exercise', { id: 234, type: ExerciseType.PROGRAMMING } as Exercise);
+        fixture.componentRef.setInput('plagiarismSubmission', { submissionId: 1, studentLogin: 'student' } as PlagiarismSubmission);
+        comp.currentFile.set('Main.java');
+
+        comp.downloadCurrentFile();
+
+        expect(downloadFileSpy).toHaveBeenCalledWith('Main.java', '234_student_Main.java');
+    });
+
     it('handles file selection', async () => {
         const submissionId = 1;
 

--- a/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
@@ -211,7 +211,7 @@ export class TextSubmissionViewerComponent implements OnChanges {
     downloadCurrentFile() {
         const currentFile = this.currentFile();
         const exercise = this.exercise();
-        const exerciseName = exercise && 'shortName' in exercise ? exercise.shortName : exercise?.id;
+        const exerciseName = exercise && 'shortName' in exercise ? exercise.shortName : (exercise?.id ?? 'exercise');
         this.repositoryService.downloadFile(currentFile!, exerciseName + '_' + this.plagiarismSubmission()?.studentLogin + '_' + currentFile);
     }
 

--- a/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
@@ -18,6 +18,7 @@ import { TranslateDirective } from 'app/foundation/language/translate.directive'
 import { NgClass } from '@angular/common';
 import { CodeEditorRepositoryFileService } from 'app/programming/shared/code-editor/services/code-editor-repository.service';
 import { DomainChange, DomainType, FileType } from 'app/programming/shared/code-editor/model/code-editor.model';
+import { PlagiarismCaseExercise } from 'app/plagiarism/shared/entities/PlagiarismCase';
 
 type FilesWithType = { [p: string]: FileType };
 
@@ -32,7 +33,7 @@ export class TextSubmissionViewerComponent implements OnChanges {
     private repositoryService = inject(CodeEditorRepositoryFileService);
     private textSubmissionService = inject(TextSubmissionService);
 
-    exercise = input<ProgrammingExercise | TextExercise>();
+    exercise = input<ProgrammingExercise | TextExercise | PlagiarismCaseExercise>();
     matches = input<Map<string, FromToElement[]>>();
     plagiarismSubmission = input<PlagiarismSubmission>();
     hideContent = input<boolean>();
@@ -209,7 +210,9 @@ export class TextSubmissionViewerComponent implements OnChanges {
      */
     downloadCurrentFile() {
         const currentFile = this.currentFile();
-        this.repositoryService.downloadFile(currentFile!, this.exercise()?.shortName + '_' + this.plagiarismSubmission()?.studentLogin + '_' + currentFile);
+        const exercise = this.exercise();
+        const exerciseName = exercise && 'shortName' in exercise ? exercise.shortName : exercise?.id;
+        this.repositoryService.downloadFile(currentFile!, exerciseName + '_' + this.plagiarismSubmission()?.studentLogin + '_' + currentFile);
     }
 
     getMatchesForCurrentFile() {

--- a/src/main/webapp/app/plagiarism/overview/detail-view/plagiarism-case-student-detail-view.component.html
+++ b/src/main/webapp/app/plagiarism/overview/detail-view/plagiarism-case-student-detail-view.component.html
@@ -75,8 +75,7 @@
                                                             : {
                                                                   dueDate: (plagiarismCase.createdByContinuousPlagiarismControl
                                                                       ? dayjs(plagiarismCase.exercise!.dueDate!).add(
-                                                                            plagiarismCase.exercise!.plagiarismDetectionConfig!
-                                                                                .continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod!,
+                                                                            plagiarismCase.exercise!.continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod!,
                                                                             'day'
                                                                         )
                                                                       : posts[0].creationDate.add(7, 'day')

--- a/src/main/webapp/app/plagiarism/overview/detail-view/plagiarism-case-student-detail-view.component.spec.ts
+++ b/src/main/webapp/app/plagiarism/overview/detail-view/plagiarism-case-student-detail-view.component.spec.ts
@@ -18,6 +18,7 @@ import { MetisConversationService } from 'app/communication/service/metis-conver
 import { MockMetisConversationService } from 'test/helpers/mocks/service/mock-metis-conversation.service';
 import { MockWebsocketService } from 'test/helpers/mocks/service/mock-websocket.service';
 import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { MetisService } from 'app/communication/service/metis.service';
 
 describe('Plagiarism Cases Student View Component', () => {
     setupTestBed({ zoneless: true });
@@ -39,7 +40,7 @@ describe('Plagiarism Cases Student View Component', () => {
         id: 1,
         title: 'Test Exercise',
         type: ExerciseType.TEXT,
-        courseId: 1,
+        courseId: 2,
         courseTitle: 'Test Course',
     } as PlagiarismCaseExercise;
 
@@ -84,12 +85,14 @@ describe('Plagiarism Cases Student View Component', () => {
     });
 
     it('should set plagiarism case on initialization', async () => {
+        const setCourseSpy = vi.spyOn(fixture.debugElement.injector.get(MetisService), 'setCourse');
         component.ngOnInit();
         await Promise.resolve();
         expect(component.courseId).toBe(1);
         expect(component.plagiarismCaseId).toBe(1);
         await Promise.resolve();
         expect(component.plagiarismCase()).toEqual(plagiarismCase);
+        expect(setCourseSpy).toHaveBeenCalledWith(expect.objectContaining({ id: 1, title: exercise.courseTitle }));
     });
 
     it('should set isAfterDueDate', async () => {

--- a/src/main/webapp/app/plagiarism/overview/detail-view/plagiarism-case-student-detail-view.component.spec.ts
+++ b/src/main/webapp/app/plagiarism/overview/detail-view/plagiarism-case-student-detail-view.component.spec.ts
@@ -8,8 +8,7 @@ import { SessionStorageService } from 'app/foundation/service/session-storage.se
 import { WebsocketService } from 'app/foundation/service/websocket.service';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { HttpResponse, provideHttpClient } from '@angular/common/http';
-import { PlagiarismCase } from 'app/plagiarism/shared/entities/PlagiarismCase';
-import { TextExercise } from 'app/text/shared/entities/text-exercise.model';
+import { PlagiarismCase, PlagiarismCaseExercise } from 'app/plagiarism/shared/entities/PlagiarismCase';
 import { PlagiarismVerdict } from 'app/plagiarism/shared/entities/PlagiarismVerdict';
 import dayjs from 'dayjs/esm';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
@@ -18,6 +17,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { MetisConversationService } from 'app/communication/service/metis-conversation.service';
 import { MockMetisConversationService } from 'test/helpers/mocks/service/mock-metis-conversation.service';
 import { MockWebsocketService } from 'test/helpers/mocks/service/mock-websocket.service';
+import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 
 describe('Plagiarism Cases Student View Component', () => {
     setupTestBed({ zoneless: true });
@@ -38,8 +38,10 @@ describe('Plagiarism Cases Student View Component', () => {
     const exercise = {
         id: 1,
         title: 'Test Exercise',
-        course: { id: 1, title: 'Test Course' },
-    } as TextExercise;
+        type: ExerciseType.TEXT,
+        courseId: 1,
+        courseTitle: 'Test Course',
+    } as PlagiarismCaseExercise;
 
     const plagiarismCase = {
         id: 1,

--- a/src/main/webapp/app/plagiarism/overview/detail-view/plagiarism-case-student-detail-view.component.ts
+++ b/src/main/webapp/app/plagiarism/overview/detail-view/plagiarism-case-student-detail-view.component.ts
@@ -19,7 +19,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ButtonComponent } from 'app/shared-ui/components/buttons/button/button.component';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
 import { PostComponent } from 'app/communication/post/post.component';
-import { Course } from 'app/core/course/shared/entities/course.model';
+import { Course } from 'app/course/shared/entities/course.model';
 
 @Component({
     selector: 'jhi-plagiarism-case-student-detail-view',

--- a/src/main/webapp/app/plagiarism/overview/detail-view/plagiarism-case-student-detail-view.component.ts
+++ b/src/main/webapp/app/plagiarism/overview/detail-view/plagiarism-case-student-detail-view.component.ts
@@ -5,7 +5,7 @@ import { PlagiarismCase } from 'app/plagiarism/shared/entities/PlagiarismCase';
 import { PlagiarismCasesService } from 'app/plagiarism/shared/services/plagiarism-cases.service';
 import { ActivatedRoute, Params, RouterLink } from '@angular/router';
 import { HttpResponse } from '@angular/common/http';
-import { getCourseFromExercise, getIcon } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { getIcon } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { Subscription, combineLatest } from 'rxjs';
 import { MetisService } from 'app/communication/service/metis.service';
 import { Post } from 'app/communication/shared/entities/post.model';
@@ -19,6 +19,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ButtonComponent } from 'app/shared-ui/components/buttons/button/button.component';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
 import { PostComponent } from 'app/communication/post/post.component';
+import { Course } from 'app/core/course/shared/entities/course.model';
 
 @Component({
     selector: 'jhi-plagiarism-case-student-detail-view',
@@ -70,7 +71,7 @@ export class PlagiarismCaseStudentDetailViewComponent implements OnInit, OnDestr
                     const plagiarismCase = res.body!;
                     this.plagiarismCase.set(plagiarismCase);
 
-                    const examId = plagiarismCase?.exercise?.exerciseGroup?.exam?.id;
+                    const examId = plagiarismCase.exercise?.examId;
                     if (examId) {
                         // Navigate to the exam result since individual exam exercises are not addressable.
                         this.affectedExerciseRouterLink.set(['/courses', this.courseId, 'exams', examId]);
@@ -78,7 +79,7 @@ export class PlagiarismCaseStudentDetailViewComponent implements OnInit, OnDestr
                         this.affectedExerciseRouterLink.set(['/courses', this.courseId, 'exercises', plagiarismCase.exercise!.id!]);
                     }
 
-                    this.metisService.setCourse(getCourseFromExercise(plagiarismCase.exercise!)!);
+                    this.metisService.setCourse({ id: plagiarismCase.exercise?.courseId, title: plagiarismCase.exercise?.courseTitle } as Course);
 
                     this.metisService.setPageType(this.pageType);
                     this.metisService.getFilteredPosts({

--- a/src/main/webapp/app/plagiarism/overview/detail-view/plagiarism-case-student-detail-view.component.ts
+++ b/src/main/webapp/app/plagiarism/overview/detail-view/plagiarism-case-student-detail-view.component.ts
@@ -79,7 +79,7 @@ export class PlagiarismCaseStudentDetailViewComponent implements OnInit, OnDestr
                         this.affectedExerciseRouterLink.set(['/courses', this.courseId, 'exercises', plagiarismCase.exercise!.id!]);
                     }
 
-                    this.metisService.setCourse({ id: plagiarismCase.exercise?.courseId, title: plagiarismCase.exercise?.courseTitle } as Course);
+                    this.metisService.setCourse({ id: this.courseId, title: plagiarismCase.exercise?.courseTitle } as Course);
 
                     this.metisService.setPageType(this.pageType);
                     this.metisService.getFilteredPosts({

--- a/src/main/webapp/app/plagiarism/shared/entities/PlagiarismCase.ts
+++ b/src/main/webapp/app/plagiarism/shared/entities/PlagiarismCase.ts
@@ -1,20 +1,19 @@
-import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
-import { User } from 'app/account/user/user.model';
 import dayjs from 'dayjs/esm';
 import { PlagiarismSubmission } from 'app/plagiarism/shared/entities/PlagiarismSubmission';
-import { Post } from 'app/communication/shared/entities/post.model';
 import { PlagiarismVerdict } from 'app/plagiarism/shared/entities/PlagiarismVerdict';
+import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 
 export class PlagiarismCase {
     public id: number;
-    public exercise?: Exercise;
-    public post?: Post;
+    public exercise?: PlagiarismCaseExercise;
+    public post?: PlagiarismCasePostSummary;
     public plagiarismSubmissions?: PlagiarismSubmission[];
-    public student?: User;
+    public plagiarismSubmissionCount?: number;
+    public student?: PlagiarismCaseUser;
     public verdict?: PlagiarismVerdict;
     public verdictDate?: dayjs.Dayjs;
     public verdictMessage?: string;
-    public verdictBy?: User;
+    public verdictBy?: PlagiarismCaseUser;
     public verdictPointDeduction?: number;
     public createdByContinuousPlagiarismControl?: boolean;
 }
@@ -23,4 +22,37 @@ export class PlagiarismCaseDTO {
     public id: number;
     public verdict?: PlagiarismVerdict;
     public studentId?: number;
+}
+
+export class PlagiarismCaseUser {
+    public id?: number;
+    public login?: string;
+    public name?: string;
+    public visibleRegistrationNumber?: string;
+}
+
+export class PlagiarismCaseExercise {
+    public id?: number;
+    public title?: string;
+    public type?: ExerciseType;
+    public dueDate?: dayjs.Dayjs;
+    public courseId?: number;
+    public courseTitle?: string;
+    public examId?: number;
+    public examTitle?: string;
+    public continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod?: number;
+}
+
+export class PlagiarismCasePostSummary {
+    public id?: number;
+    public creationDate?: dayjs.Dayjs;
+    public answerAuthorIds?: number[];
+}
+
+export class PlagiarismCaseVerdictResponse {
+    public verdict?: PlagiarismVerdict;
+    public verdictDate?: dayjs.Dayjs;
+    public verdictMessage?: string;
+    public verdictBy?: PlagiarismCaseUser;
+    public verdictPointDeduction?: number;
 }

--- a/src/main/webapp/app/plagiarism/shared/entities/PlagiarismCase.ts
+++ b/src/main/webapp/app/plagiarism/shared/entities/PlagiarismCase.ts
@@ -16,6 +16,7 @@ export class PlagiarismCase {
     public verdictBy?: PlagiarismCaseUser;
     public verdictPointDeduction?: number;
     public createdByContinuousPlagiarismControl?: boolean;
+    public hasStudentAnswer?: boolean;
 }
 
 export class PlagiarismCaseDTO {
@@ -46,7 +47,6 @@ export class PlagiarismCaseExercise {
 export class PlagiarismCasePostSummary {
     public id?: number;
     public creationDate?: dayjs.Dayjs;
-    public answerAuthorIds?: number[];
 }
 
 export class PlagiarismCaseVerdictResponse {

--- a/src/main/webapp/app/plagiarism/shared/entities/PlagiarismCase.ts
+++ b/src/main/webapp/app/plagiarism/shared/entities/PlagiarismCase.ts
@@ -35,6 +35,7 @@ export class PlagiarismCaseUser {
 export class PlagiarismCaseExercise {
     public id?: number;
     public title?: string;
+    public shortName?: string;
     public type?: ExerciseType;
     public dueDate?: dayjs.Dayjs;
     public courseId?: number;

--- a/src/main/webapp/app/plagiarism/shared/entities/PlagiarismComparison.spec.ts
+++ b/src/main/webapp/app/plagiarism/shared/entities/PlagiarismComparison.spec.ts
@@ -3,7 +3,6 @@ import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { PlagiarismComparison } from './PlagiarismComparison';
 import { PlagiarismStatus } from './PlagiarismStatus';
 import { PlagiarismSubmission } from './PlagiarismSubmission';
-import { PlagiarismResult } from './PlagiarismResult';
 import { PlagiarismMatch } from './PlagiarismMatch';
 
 describe('PlagiarismComparison', () => {
@@ -12,7 +11,6 @@ describe('PlagiarismComparison', () => {
     let plagiarismComparison: PlagiarismComparison;
     let mockSubmissionA: PlagiarismSubmission;
     let mockSubmissionB: PlagiarismSubmission;
-    let mockPlagiarismResult: PlagiarismResult;
     let mockMatches: PlagiarismMatch[];
 
     beforeEach(() => {
@@ -31,15 +29,6 @@ describe('PlagiarismComparison', () => {
             size: 200,
             score: 90,
         } as PlagiarismSubmission;
-
-        mockPlagiarismResult = {
-            id: 100,
-            comparisons: [],
-            duration: 1000,
-            exercise: {} as any,
-            similarityDistribution: new Array(10).fill(0) as [number, 10],
-            createdDate: {} as any,
-        } as PlagiarismResult;
 
         mockMatches = [
             {
@@ -65,7 +54,6 @@ describe('PlagiarismComparison', () => {
             plagiarismComparison.similarity = 95.7;
             plagiarismComparison.status = PlagiarismStatus.CONFIRMED;
             plagiarismComparison.matches = mockMatches;
-            plagiarismComparison.plagiarismResult = mockPlagiarismResult;
 
             expect(plagiarismComparison.similarity).toBeGreaterThan(90);
             expect(plagiarismComparison.status).toBe(PlagiarismStatus.CONFIRMED);

--- a/src/main/webapp/app/plagiarism/shared/entities/PlagiarismComparison.ts
+++ b/src/main/webapp/app/plagiarism/shared/entities/PlagiarismComparison.ts
@@ -1,7 +1,6 @@
 import { PlagiarismStatus } from './PlagiarismStatus';
 import { PlagiarismSubmission } from './PlagiarismSubmission';
 import { PlagiarismMatch } from './PlagiarismMatch';
-import { PlagiarismResult } from 'app/plagiarism/shared/entities/PlagiarismResult';
 
 /**
  * Pair of compared student submissions whose similarity is above a certain threshold.
@@ -11,11 +10,6 @@ export class PlagiarismComparison {
      * Unique identifier of the comparison.
      */
     id: number;
-
-    /**
-     * The plagiarism result
-     */
-    plagiarismResult?: PlagiarismResult;
 
     /**
      * First submission involved in this comparison.
@@ -40,5 +34,11 @@ export class PlagiarismComparison {
     /**
      * Status of this submission comparison.
      */
+    status: PlagiarismStatus;
+}
+
+export class PlagiarismComparisonSummary {
+    id: number;
+    similarity: number;
     status: PlagiarismStatus;
 }

--- a/src/main/webapp/app/plagiarism/shared/entities/PlagiarismResult.ts
+++ b/src/main/webapp/app/plagiarism/shared/entities/PlagiarismResult.ts
@@ -32,9 +32,4 @@ export class PlagiarismResult {
      * Time when the plagiarism checks started.
      */
     createdDate: dayjs.Dayjs;
-
-    /**
-     * User or entity which started the plagiarism check.
-     */
-    createdBy?: string;
 }

--- a/src/main/webapp/app/plagiarism/shared/entities/PlagiarismResult.ts
+++ b/src/main/webapp/app/plagiarism/shared/entities/PlagiarismResult.ts
@@ -1,5 +1,4 @@
 import { PlagiarismComparison } from './PlagiarismComparison';
-import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 import dayjs from 'dayjs/esm';
 
 /**
@@ -19,11 +18,6 @@ export class PlagiarismResult {
     duration: number;
 
     /**
-     * Exercise for which plagiarism was detected.
-     */
-    exercise: Exercise;
-
-    /**
      * 10-element array representing the similarity distribution of the detected comparisons.
      *
      * Each entry represents the absolute frequency of comparisons whose similarity lies within the
@@ -32,10 +26,15 @@ export class PlagiarismResult {
      * Intervals:
      * 0: [0% - 10%), 1: [10% - 20%), 2: [20% - 30%), ..., 9: [90% - 100%]
      */
-    similarityDistribution: [number, 10];
+    similarityDistribution: number[];
 
     /**
      * Time when the plagiarism checks started.
      */
     createdDate: dayjs.Dayjs;
+
+    /**
+     * User or entity which started the plagiarism check.
+     */
+    createdBy?: string;
 }

--- a/src/main/webapp/app/plagiarism/shared/entities/PlagiarismResultDTO.ts
+++ b/src/main/webapp/app/plagiarism/shared/entities/PlagiarismResultDTO.ts
@@ -5,10 +5,10 @@ import { PlagiarismResult } from 'app/plagiarism/shared/entities/PlagiarismResul
  */
 export class PlagiarismResultDTO {
     plagiarismResult: PlagiarismResult;
-    plagiarismResultStats: PlagiarismResultStats;
+    plagiarismResultStats: PlagiarismResultStatsDTO;
 }
 
-export class PlagiarismResultStats {
+export class PlagiarismResultStatsDTO {
     numberOfDetectedSubmissions: number;
     averageSimilarity: number;
     maximalSimilarity: number;

--- a/src/main/webapp/app/plagiarism/shared/entities/PlagiarismSubmission.ts
+++ b/src/main/webapp/app/plagiarism/shared/entities/PlagiarismSubmission.ts
@@ -1,5 +1,5 @@
 import { PlagiarismSubmissionElement } from './PlagiarismSubmissionElement';
-import { PlagiarismComparison } from './PlagiarismComparison';
+import { PlagiarismComparisonSummary } from './PlagiarismComparison';
 
 /**
  * Each `PlagiarismSubmission` refers to a submission that has been compared during plagiarism detection.
@@ -36,10 +36,10 @@ export class PlagiarismSubmission {
     /**
      * Result score of the related submission.
      */
-    score: number;
+    score?: number;
 
     /**
      * Comparison of the submission.
      */
-    plagiarismComparison: PlagiarismComparison;
+    plagiarismComparison?: PlagiarismComparisonSummary;
 }

--- a/src/main/webapp/app/plagiarism/shared/review/plagiarism-case-review.component.html
+++ b/src/main/webapp/app/plagiarism/shared/review/plagiarism-case-review.component.html
@@ -4,7 +4,7 @@
             <a ngbNavLink class="btn-sm text-center">{{ 'artemisApp.plagiarism.plagiarismCases.comparison' | artemisTranslate }} {{ i + 1 }}</a>
             <div class="my-2 text-center fs-5">
                 {{ 'artemisApp.plagiarism.plagiarismCases.overallSimilarity' | artemisTranslate }}:
-                <strong>{{ submission.plagiarismComparison.similarity?.toFixed(1) }}%</strong>
+                <strong>{{ submission.plagiarismComparison?.similarity?.toFixed(1) }}%</strong>
             </div>
             <ng-template ngbNavContent>
                 <jhi-plagiarism-split-view

--- a/src/main/webapp/app/plagiarism/shared/review/plagiarism-case-review.component.html
+++ b/src/main/webapp/app/plagiarism/shared/review/plagiarism-case-review.component.html
@@ -7,13 +7,15 @@
                 <strong>{{ submission.plagiarismComparison?.similarity?.toFixed(1) }}%</strong>
             </div>
             <ng-template ngbNavContent>
-                <jhi-plagiarism-split-view
-                    [comparison]="submission.plagiarismComparison!"
-                    [exercise]="plagiarismCase()?.exercise!"
-                    [sortByStudentLogin]="forStudent() ? 'Your submission' : (plagiarismCase()?.student)!.login!"
-                    [splitControlSubject]="splitControlSubject"
-                    [forStudent]="forStudent()"
-                />
+                @if (submission.plagiarismComparison) {
+                    <jhi-plagiarism-split-view
+                        [comparison]="submission.plagiarismComparison"
+                        [exercise]="plagiarismCase()?.exercise!"
+                        [sortByStudentLogin]="forStudent() ? 'Your submission' : (plagiarismCase()?.student)!.login!"
+                        [splitControlSubject]="splitControlSubject"
+                        [forStudent]="forStudent()"
+                    />
+                }
             </ng-template>
         </li>
     }

--- a/src/main/webapp/app/plagiarism/shared/review/plagiarism-case-review.component.spec.ts
+++ b/src/main/webapp/app/plagiarism/shared/review/plagiarism-case-review.component.spec.ts
@@ -9,6 +9,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslateModule } from '@ngx-translate/core';
 import { PlagiarismSplitViewComponent } from 'app/plagiarism/manage/plagiarism-split-view/plagiarism-split-view.component';
 import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { PlagiarismSubmission } from 'app/plagiarism/shared/entities/PlagiarismSubmission';
 
 describe('PlagiarismCaseReviewComponent', () => {
     setupTestBed({ zoneless: true });
@@ -24,7 +25,7 @@ describe('PlagiarismCaseReviewComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [PlagiarismCaseReviewComponent, MockModule(NgbModule), MockModule(TranslateModule), MockComponent(PlagiarismSplitViewComponent)],
+            imports: [PlagiarismCaseReviewComponent, MockModule(NgbModule), TranslateModule.forRoot(), MockComponent(PlagiarismSplitViewComponent)],
         }).compileComponents();
 
         fixture = TestBed.createComponent(PlagiarismCaseReviewComponent);
@@ -43,6 +44,20 @@ describe('PlagiarismCaseReviewComponent', () => {
     it('should set plagiarismCase input', () => {
         fixture.componentRef.setInput('plagiarismCase', mockPlagiarismCase);
         expect(component.plagiarismCase()).toEqual(mockPlagiarismCase);
+    });
+
+    it('should not render split view for submissions without comparison data', () => {
+        const plagiarismCaseWithoutComparison = {
+            id: 1,
+            exercise: { id: 1 } as Exercise,
+            student: { login: 'student' },
+            plagiarismSubmissions: [{ id: 1 } as PlagiarismSubmission],
+        } as PlagiarismCase;
+
+        fixture.componentRef.setInput('plagiarismCase', plagiarismCaseWithoutComparison);
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelectorAll('jhi-plagiarism-split-view')).toHaveLength(0);
     });
 
     it('should set forStudent input to false', () => {

--- a/src/main/webapp/app/plagiarism/shared/services/plagiarism-cases.service.ts
+++ b/src/main/webapp/app/plagiarism/shared/services/plagiarism-cases.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { PlagiarismCase, PlagiarismCaseDTO } from 'app/plagiarism/shared/entities/PlagiarismCase';
+import { PlagiarismCase, PlagiarismCaseDTO, PlagiarismCaseVerdictResponse } from 'app/plagiarism/shared/entities/PlagiarismCase';
 import { PlagiarismStatus } from 'app/plagiarism/shared/entities/PlagiarismStatus';
 import { PlagiarismComparison } from 'app/plagiarism/shared/entities/PlagiarismComparison';
 import { PlagiarismVerdict } from 'app/plagiarism/shared/entities/PlagiarismVerdict';
@@ -10,6 +10,7 @@ import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 
 export type EntityResponseType = HttpResponse<PlagiarismCase>;
 export type EntityArrayResponseType = HttpResponse<PlagiarismCase[]>;
+export type VerdictResponseType = HttpResponse<PlagiarismCaseVerdictResponse>;
 export type Comparison = PlagiarismComparison;
 
 @Injectable({ providedIn: 'root' })
@@ -64,8 +65,10 @@ export class PlagiarismCasesService {
         courseId: number,
         plagiarismCaseId: number,
         plagiarismVerdict: { verdict: PlagiarismVerdict; verdictMessage?: string; verdictPointDeduction?: number },
-    ): Observable<EntityResponseType> {
-        return this.http.put<PlagiarismCase>(`${this.resourceUrl}/${courseId}/plagiarism-cases/${plagiarismCaseId}/verdict`, plagiarismVerdict, { observe: 'response' });
+    ): Observable<VerdictResponseType> {
+        return this.http.put<PlagiarismCaseVerdictResponse>(`${this.resourceUrl}/${courseId}/plagiarism-cases/${plagiarismCaseId}/verdict`, plagiarismVerdict, {
+            observe: 'response',
+        });
     }
 
     /* Student */

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
@@ -151,6 +151,7 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
                 .containsExactlyInAnyOrderElementsOf(coursePlagiarismCases.stream().map(PlagiarismCase::getId).toList());
         assertThat(plagiarismCasesResponse.getFirst().plagiarismSubmissionCount()).as("should include the number of submissions").isEqualTo(2);
         assertThat(plagiarismCasesResponse.getFirst().exercise().id()).as("should include exercise summary").isEqualTo(textExercise.getId());
+        assertThat(plagiarismCasesResponse.getFirst().student().visibleRegistrationNumber()).as("should not expose hidden registration numbers").isNull();
     }
 
     @Test
@@ -179,6 +180,7 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
         assertThat(plagiarismCase.id()).as("should get plagiarism case for instructor").isEqualTo(plagiarismCase1.getId());
         assertThat(plagiarismCase.plagiarismSubmissions()).as("should include plagiarism submissions").hasSize(2);
         assertThat(plagiarismCase.plagiarismSubmissions().getFirst().plagiarismComparison()).as("should include comparison summaries").isNotNull();
+        assertThat(plagiarismCase.student().visibleRegistrationNumber()).as("should not expose hidden registration numbers").isNull();
     }
 
     @Test
@@ -210,6 +212,7 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
         assertThat(plagiarismCasesResponse).as("should get exam plagiarism cases for instructor").extracting(PlagiarismCaseOverviewDTO::id)
                 .containsExactlyInAnyOrderElementsOf(examPlagiarismCases.stream().map(PlagiarismCase::getId).toList());
         assertThat(plagiarismCasesResponse.getFirst().exercise().examId()).as("should include exam summary").isEqualTo(exam.getId());
+        assertThat(plagiarismCasesResponse.getFirst().student().visibleRegistrationNumber()).as("should not expose hidden registration numbers").isNull();
     }
 
     @Test
@@ -363,6 +366,7 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
         assertThat(plagiarismCase.id()).as("should get plagiarism case for student").isEqualTo(plagiarismCase1.getId());
         assertThat(plagiarismCase.plagiarismSubmissions()).as("should include plagiarism submissions").hasSize(2);
         assertThat(plagiarismCase.plagiarismSubmissions().getFirst().plagiarismComparison()).as("should include comparison summaries").isNotNull();
+        assertThat(plagiarismCase.student().visibleRegistrationNumber()).as("should not expose hidden registration numbers").isNull();
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
@@ -29,7 +29,10 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseDetailDTO;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseInfoDTO;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseOverviewDTO;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseVerdictResponseDTO;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismVerdictDTO;
 import de.tum.cit.aet.artemis.plagiarism.repository.PlagiarismCaseRepository;
 import de.tum.cit.aet.artemis.plagiarism.repository.PlagiarismComparisonRepository;
@@ -142,13 +145,12 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testGetPlagiarismCasesForCourseForInstructor() throws Exception {
-        var plagiarismCasesResponse = request.getList("/api/plagiarism/courses/" + course.getId() + "/plagiarism-cases/for-instructor", HttpStatus.OK, PlagiarismCase.class);
-        assertThat(plagiarismCasesResponse).as("should get course plagiarism cases for instructor").containsExactlyInAnyOrderElementsOf(coursePlagiarismCases);
-        for (var submission : plagiarismCasesResponse.getFirst().getPlagiarismSubmissions()) {
-            assertThat(submission.getPlagiarismComparison().getPlagiarismResult().getExercise()).as("should prepare plagiarism case response entity").isNull();
-            assertThat(submission.getPlagiarismComparison().getSubmissionA()).as("should prepare plagiarism case response entity").isNull();
-            assertThat(submission.getPlagiarismComparison().getSubmissionB()).as("should prepare plagiarism case response entity").isNull();
-        }
+        var plagiarismCasesResponse = request.getList("/api/plagiarism/courses/" + course.getId() + "/plagiarism-cases/for-instructor", HttpStatus.OK,
+                PlagiarismCaseOverviewDTO.class);
+        assertThat(plagiarismCasesResponse).as("should get course plagiarism cases for instructor").extracting(PlagiarismCaseOverviewDTO::id)
+                .containsExactlyInAnyOrderElementsOf(coursePlagiarismCases.stream().map(PlagiarismCase::getId).toList());
+        assertThat(plagiarismCasesResponse.getFirst().plagiarismSubmissionCount()).as("should include the number of submissions").isEqualTo(2);
+        assertThat(plagiarismCasesResponse.getFirst().exercise().id()).as("should include exercise summary").isEqualTo(textExercise.getId());
     }
 
     @Test
@@ -173,8 +175,10 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testGetPlagiarismCaseForInstructor() throws Exception {
         var plagiarismCase = request.get("/api/plagiarism/courses/" + course.getId() + "/plagiarism-cases/" + plagiarismCase1.getId() + "/for-instructor", HttpStatus.OK,
-                PlagiarismCase.class);
-        assertThat(plagiarismCase).as("should get plagiarism case for instructor").isEqualTo(plagiarismCase1);
+                PlagiarismCaseDetailDTO.class);
+        assertThat(plagiarismCase.id()).as("should get plagiarism case for instructor").isEqualTo(plagiarismCase1.getId());
+        assertThat(plagiarismCase.plagiarismSubmissions()).as("should include plagiarism submissions").hasSize(2);
+        assertThat(plagiarismCase.plagiarismSubmissions().getFirst().plagiarismComparison()).as("should include comparison summaries").isNotNull();
     }
 
     @Test
@@ -202,13 +206,10 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
         Course examCourse = examTextExercise.getCourseViaExerciseGroupOrCourseMember();
         Exam exam = examTextExercise.getExerciseGroup().getExam();
         var plagiarismCasesResponse = request.getList("/api/plagiarism/courses/" + examCourse.getId() + "/exams/" + exam.getId() + "/plagiarism-cases/for-instructor",
-                HttpStatus.OK, PlagiarismCase.class);
-        assertThat(plagiarismCasesResponse).as("should get exam plagiarism cases for instructor").containsExactlyInAnyOrderElementsOf(examPlagiarismCases);
-        for (var submission : plagiarismCasesResponse.getFirst().getPlagiarismSubmissions()) {
-            assertThat(submission.getPlagiarismComparison().getPlagiarismResult().getExercise()).as("should remove unneeded elements from the response").isNull();
-            assertThat(submission.getPlagiarismComparison().getSubmissionA()).as("should filter out submission A").isNull();
-            assertThat(submission.getPlagiarismComparison().getSubmissionB()).as("should filter out submission B").isNull();
-        }
+                HttpStatus.OK, PlagiarismCaseOverviewDTO.class);
+        assertThat(plagiarismCasesResponse).as("should get exam plagiarism cases for instructor").extracting(PlagiarismCaseOverviewDTO::id)
+                .containsExactlyInAnyOrderElementsOf(examPlagiarismCases.stream().map(PlagiarismCase::getId).toList());
+        assertThat(plagiarismCasesResponse.getFirst().exercise().examId()).as("should include exam summary").isEqualTo(exam.getId());
     }
 
     @Test
@@ -244,7 +245,10 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testSavePlagiarismCaseVerdict_warning() throws Exception {
         var plagiarismVerdictDTO = new PlagiarismVerdictDTO(WARNING, "This is a warning!", 0);
-        request.put("/api/plagiarism/courses/" + course.getId() + "/plagiarism-cases/" + plagiarismCase1.getId() + "/verdict", plagiarismVerdictDTO, HttpStatus.OK);
+        var response = request.putWithResponseBody("/api/plagiarism/courses/" + course.getId() + "/plagiarism-cases/" + plagiarismCase1.getId() + "/verdict", plagiarismVerdictDTO,
+                PlagiarismCaseVerdictResponseDTO.class, HttpStatus.OK);
+        assertThat(response.verdict()).as("should return updated plagiarism case verdict warning").isEqualTo(PlagiarismVerdict.WARNING);
+        assertThat(response.verdictMessage()).as("should return updated plagiarism case verdict message").isEqualTo("This is a warning!");
         var updatedPlagiarismCase = plagiarismCaseRepository.findByIdWithPlagiarismSubmissionsElseThrow(plagiarismCase1.getId());
         assertThat(updatedPlagiarismCase.getVerdict()).as("should update plagiarism case verdict warning").isEqualTo(PlagiarismVerdict.WARNING);
         assertThat(updatedPlagiarismCase.getVerdictMessage()).as("should update plagiarism case verdict message").isEqualTo("This is a warning!");
@@ -254,7 +258,10 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testSavePlagiarismCaseVerdict_pointDeduction() throws Exception {
         var plagiarismVerdictDTO = new PlagiarismVerdictDTO(POINT_DEDUCTION, "", 90);
-        request.put("/api/plagiarism/courses/" + course.getId() + "/plagiarism-cases/" + plagiarismCase1.getId() + "/verdict", plagiarismVerdictDTO, HttpStatus.OK);
+        var response = request.putWithResponseBody("/api/plagiarism/courses/" + course.getId() + "/plagiarism-cases/" + plagiarismCase1.getId() + "/verdict", plagiarismVerdictDTO,
+                PlagiarismCaseVerdictResponseDTO.class, HttpStatus.OK);
+        assertThat(response.verdict()).as("should return updated plagiarism case verdict point deduction").isEqualTo(PlagiarismVerdict.POINT_DEDUCTION);
+        assertThat(response.verdictPointDeduction()).as("should return updated plagiarism case verdict point deduction").isEqualTo(90);
         var updatedPlagiarismCase = plagiarismCaseRepository.findByIdWithPlagiarismSubmissionsElseThrow(plagiarismCase1.getId());
         assertThat(updatedPlagiarismCase.getVerdict()).as("should update plagiarism case verdict point deduction").isEqualTo(PlagiarismVerdict.POINT_DEDUCTION);
         assertThat(updatedPlagiarismCase.getVerdictPointDeduction()).as("should update plagiarism case verdict point deduction").isEqualTo(90);
@@ -352,13 +359,10 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetPlagiarismCaseForStudent() throws Exception {
         var plagiarismCase = request.get("/api/plagiarism/courses/" + course.getId() + "/plagiarism-cases/" + plagiarismCase1.getId() + "/for-student", HttpStatus.OK,
-                PlagiarismCase.class);
-        assertThat(plagiarismCase).as("should get plagiarism case for student").isEqualTo(plagiarismCase1);
-        for (var submission : plagiarismCase.getPlagiarismSubmissions()) {
-            assertThat(submission.getPlagiarismComparison().getPlagiarismResult().getExercise()).as("should prepare plagiarism case response entity").isNull();
-            assertThat(submission.getPlagiarismComparison().getSubmissionA()).as("should prepare plagiarism case response entity").isNull();
-            assertThat(submission.getPlagiarismComparison().getSubmissionB()).as("should prepare plagiarism case response entity").isNull();
-        }
+                PlagiarismCaseDetailDTO.class);
+        assertThat(plagiarismCase.id()).as("should get plagiarism case for student").isEqualTo(plagiarismCase1.getId());
+        assertThat(plagiarismCase.plagiarismSubmissions()).as("should include plagiarism submissions").hasSize(2);
+        assertThat(plagiarismCase.plagiarismSubmissions().getFirst().plagiarismComparison()).as("should include comparison summaries").isNotNull();
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismCaseIntegrationTest.java
@@ -149,9 +149,11 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
                 PlagiarismCaseOverviewDTO.class);
         assertThat(plagiarismCasesResponse).as("should get course plagiarism cases for instructor").extracting(PlagiarismCaseOverviewDTO::id)
                 .containsExactlyInAnyOrderElementsOf(coursePlagiarismCases.stream().map(PlagiarismCase::getId).toList());
-        assertThat(plagiarismCasesResponse.getFirst().plagiarismSubmissionCount()).as("should include the number of submissions").isEqualTo(2);
-        assertThat(plagiarismCasesResponse.getFirst().exercise().id()).as("should include exercise summary").isEqualTo(textExercise.getId());
-        assertThat(plagiarismCasesResponse.getFirst().student().visibleRegistrationNumber()).as("should not expose hidden registration numbers").isNull();
+        assertThat(plagiarismCasesResponse).allSatisfy(plagiarismCase -> {
+            assertThat(plagiarismCase.plagiarismSubmissionCount()).as("should include the number of submissions").isEqualTo(2);
+            assertThat(plagiarismCase.exercise().id()).as("should include exercise summary").isEqualTo(textExercise.getId());
+            assertThat(plagiarismCase.student().visibleRegistrationNumber()).as("should not expose hidden registration numbers").isNull();
+        });
     }
 
     @Test
@@ -184,6 +186,16 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
     }
 
     @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testGetPlagiarismCaseForInstructor_wrongCourse() throws Exception {
+        var examPlagiarismCase = examPlagiarismCases.getFirst();
+        assertThat(examTextExercise.getCourseViaExerciseGroupOrCourseMember().getId()).isNotEqualTo(course.getId());
+
+        request.get("/api/plagiarism/courses/" + course.getId() + "/plagiarism-cases/" + examPlagiarismCase.getId() + "/for-instructor", HttpStatus.CONFLICT,
+                PlagiarismCaseDetailDTO.class);
+    }
+
+    @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetPlagiarismCasesForExamForInstructor_forbidden_student() throws Exception {
         request.getList("/api/plagiarism/courses/1/exams/1/plagiarism-cases/for-instructor", HttpStatus.FORBIDDEN, PlagiarismCase.class);
@@ -211,8 +223,10 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
                 HttpStatus.OK, PlagiarismCaseOverviewDTO.class);
         assertThat(plagiarismCasesResponse).as("should get exam plagiarism cases for instructor").extracting(PlagiarismCaseOverviewDTO::id)
                 .containsExactlyInAnyOrderElementsOf(examPlagiarismCases.stream().map(PlagiarismCase::getId).toList());
-        assertThat(plagiarismCasesResponse.getFirst().exercise().examId()).as("should include exam summary").isEqualTo(exam.getId());
-        assertThat(plagiarismCasesResponse.getFirst().student().visibleRegistrationNumber()).as("should not expose hidden registration numbers").isNull();
+        assertThat(plagiarismCasesResponse).allSatisfy(plagiarismCase -> {
+            assertThat(plagiarismCase.exercise().examId()).as("should include exam summary").isEqualTo(exam.getId());
+            assertThat(plagiarismCase.student().visibleRegistrationNumber()).as("should not expose hidden registration numbers").isNull();
+        });
     }
 
     @Test
@@ -255,6 +269,20 @@ class PlagiarismCaseIntegrationTest extends AbstractSpringIntegrationIndependent
         var updatedPlagiarismCase = plagiarismCaseRepository.findByIdWithPlagiarismSubmissionsElseThrow(plagiarismCase1.getId());
         assertThat(updatedPlagiarismCase.getVerdict()).as("should update plagiarism case verdict warning").isEqualTo(PlagiarismVerdict.WARNING);
         assertThat(updatedPlagiarismCase.getVerdictMessage()).as("should update plagiarism case verdict message").isEqualTo("This is a warning!");
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testSavePlagiarismCaseVerdict_wrongCourse() throws Exception {
+        var examPlagiarismCase = examPlagiarismCases.getFirst();
+        var plagiarismVerdictDTO = new PlagiarismVerdictDTO(WARNING, "This is a warning!", 0);
+        assertThat(examTextExercise.getCourseViaExerciseGroupOrCourseMember().getId()).isNotEqualTo(course.getId());
+
+        request.put("/api/plagiarism/courses/" + course.getId() + "/plagiarism-cases/" + examPlagiarismCase.getId() + "/verdict", plagiarismVerdictDTO, HttpStatus.CONFLICT);
+
+        var unchangedPlagiarismCase = plagiarismCaseRepository.findByIdWithPlagiarismSubmissionsElseThrow(examPlagiarismCase.getId());
+        assertThat(unchangedPlagiarismCase.getVerdict()).as("should not update plagiarism case verdict for a different course").isNull();
+        assertThat(unchangedPlagiarismCase.getVerdictMessage()).as("should not update plagiarism case verdict message for a different course").isNull();
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismCheckIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismCheckIntegrationTest.java
@@ -61,15 +61,12 @@ class PlagiarismCheckIntegrationTest extends AbstractSpringIntegrationIndependen
 
     private static void verifyPlagiarismResult(PlagiarismResultDTO result) {
         // verify comparisons
-        for (var comparison : result.plagiarismResult().getComparisons()) {
-            var submissionA = comparison.getSubmissionA();
-            var submissionB = comparison.getSubmissionB();
+        for (var comparison : result.plagiarismResult().comparisons()) {
+            var submissionA = comparison.submissionA();
+            var submissionB = comparison.submissionB();
 
             assertThat(submissionA).as("should have a submission A").isNotNull();
             assertThat(submissionB).as("should have a submission B").isNotNull();
-
-            assertThat(submissionA.getPlagiarismComparison()).as("should have a bidirectional connection").isEqualTo(comparison);
-            assertThat(submissionB.getPlagiarismComparison()).as("should have a bidirectional connection").isEqualTo(comparison);
         }
 
         // verify plagiarism result stats

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismDtoTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismDtoTest.java
@@ -1,10 +1,13 @@
-package de.tum.cit.aet.artemis.plagiarism.dto;
+package de.tum.cit.aet.artemis.plagiarism;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseDetailDTO;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismCaseOverviewDTO;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismResultDetailsDTO;
 
 class PlagiarismDtoTest {
 

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismIntegrationTest.java
@@ -25,6 +25,7 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismMatch;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmissionElement;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismComparisonDTO;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismComparisonStatusDTO;
 import de.tum.cit.aet.artemis.plagiarism.repository.PlagiarismCaseRepository;
@@ -218,6 +219,39 @@ class PlagiarismIntegrationTest extends AbstractSpringIntegrationIndependentTest
             assertThat(match.startB()).isEqualTo(2);
             assertThat(match.length()).isEqualTo(3);
         });
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "editor1", roles = "EDITOR")
+    void testGetPlagiarismComparisonsForSplitView_multipleMatchesDoesNotDuplicateElements() throws Exception {
+        var submissionA = plagiarismComparison2.getSubmissionA();
+        submissionA.setElements(List.of(createSubmissionElement(submissionA, 1), createSubmissionElement(submissionA, 2)));
+        var submissionB = plagiarismComparison2.getSubmissionB();
+        submissionB.setElements(List.of(createSubmissionElement(submissionB, 1), createSubmissionElement(submissionB, 2), createSubmissionElement(submissionB, 3)));
+
+        var secondMatch = new PlagiarismMatch();
+        secondMatch.setStartA(4);
+        secondMatch.setStartB(5);
+        secondMatch.setLength(6);
+        plagiarismComparison2.setMatches(Set.of(plagiarismComparison2.getMatches().iterator().next(), secondMatch));
+        plagiarismComparisonRepository.saveAndFlush(plagiarismComparison2);
+
+        PlagiarismComparisonDTO comparison = request.get(
+                "/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + plagiarismComparison2.getId() + "/for-split-view", HttpStatus.OK,
+                PlagiarismComparisonDTO.class);
+
+        assertThat(comparison.submissionA().elements()).hasSize(2);
+        assertThat(comparison.submissionB().elements()).hasSize(3);
+        assertThat(comparison.matches()).hasSize(2);
+    }
+
+    private PlagiarismSubmissionElement createSubmissionElement(PlagiarismSubmission submission, int column) {
+        var element = new PlagiarismSubmissionElement();
+        element.setPlagiarismSubmission(submission);
+        element.setColumn(column);
+        element.setLine(1);
+        element.setLength(1);
+        return element;
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismIntegrationTest.java
@@ -5,6 +5,7 @@ import static de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus.DENIED;
 import static de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus.NONE;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -174,8 +175,18 @@ class PlagiarismIntegrationTest extends AbstractSpringIntegrationIndependentTest
     void testGetPlagiarismComparisonsForSplitView_student() throws Exception {
         var comparison = request.get("/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + plagiarismComparison1.getId() + "/for-split-view", HttpStatus.OK,
                 PlagiarismComparisonDTO.class);
-        assertThat(comparison.submissionA().studentLogin()).as("should anonymize plagiarism comparison").isIn("Your submission", "Other submission");
-        assertThat(comparison.submissionB().studentLogin()).as("should anonymize plagiarism comparison").isIn("Your submission", "Other submission");
+        assertThat(List.of(comparison.submissionA().studentLogin(), comparison.submissionB().studentLogin())).as("should anonymize plagiarism comparison")
+                .containsExactlyInAnyOrder("Your submission", "Other submission");
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetPlagiarismComparisonsForSplitView_studentWithNullSubmissionLogin_forbidden() throws Exception {
+        plagiarismComparison1.getSubmissionA().setStudentLogin(null);
+        plagiarismComparison1 = plagiarismComparisonRepository.save(plagiarismComparison1);
+
+        request.get("/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + plagiarismComparison1.getId() + "/for-split-view", HttpStatus.FORBIDDEN,
+                plagiarismComparison1.getClass());
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismIntegrationTest.java
@@ -6,6 +6,7 @@ import static de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus.NONE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCase;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismMatch;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismComparisonDTO;
@@ -99,6 +101,11 @@ class PlagiarismIntegrationTest extends AbstractSpringIntegrationIndependentTest
         plagiarismSubmissionB2.setSubmissionId(submission3.getId());
         plagiarismComparison2.setSubmissionA(plagiarismSubmissionA2);
         plagiarismComparison2.setSubmissionB(plagiarismSubmissionB2);
+        var plagiarismMatch = new PlagiarismMatch();
+        plagiarismMatch.setStartA(1);
+        plagiarismMatch.setStartB(2);
+        plagiarismMatch.setLength(3);
+        plagiarismComparison2.setMatches(Set.of(plagiarismMatch));
         plagiarismComparison2 = plagiarismComparisonRepository.save(plagiarismComparison2);
     }
 
@@ -190,7 +197,16 @@ class PlagiarismIntegrationTest extends AbstractSpringIntegrationIndependentTest
         assertThat(comparison.submissionB().id()).isEqualTo(plagiarismComparison1.getSubmissionB().getId());
         assertThat(comparison.similarity()).isEqualTo(plagiarismComparison1.getSimilarity());
         assertThat(comparison.status()).isEqualTo(plagiarismComparison1.getStatus());
-        assertThat(comparison.matches()).hasSameSizeAs(plagiarismComparison1.getMatches());
+        assertThat(comparison.matches()).as("should omit empty plagiarism matches").isNull();
+
+        PlagiarismComparisonDTO comparisonWithMatches = request.get(
+                "/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + plagiarismComparison2.getId() + "/for-split-view", HttpStatus.OK,
+                PlagiarismComparisonDTO.class);
+        assertThat(comparisonWithMatches.matches()).as("should include plagiarism matches").singleElement().satisfies(match -> {
+            assertThat(match.startA()).isEqualTo(1);
+            assertThat(match.startB()).isEqualTo(2);
+            assertThat(match.length()).isEqualTo(3);
+        });
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismIntegrationTest.java
@@ -22,6 +22,7 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismCase;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmission;
+import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismComparisonDTO;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismComparisonStatusDTO;
 import de.tum.cit.aet.artemis.plagiarism.repository.PlagiarismCaseRepository;
 import de.tum.cit.aet.artemis.plagiarism.repository.PlagiarismComparisonRepository;
@@ -165,9 +166,9 @@ class PlagiarismIntegrationTest extends AbstractSpringIntegrationIndependentTest
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetPlagiarismComparisonsForSplitView_student() throws Exception {
         var comparison = request.get("/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + plagiarismComparison1.getId() + "/for-split-view", HttpStatus.OK,
-                plagiarismComparison1.getClass());
-        assertThat(comparison.getSubmissionA().getStudentLogin()).as("should anonymize plagiarism comparison").isIn("Your submission", "Other submission");
-        assertThat(comparison.getSubmissionB().getStudentLogin()).as("should anonymize plagiarism comparison").isIn("Your submission", "Other submission");
+                PlagiarismComparisonDTO.class);
+        assertThat(comparison.submissionA().studentLogin()).as("should anonymize plagiarism comparison").isIn("Your submission", "Other submission");
+        assertThat(comparison.submissionB().studentLogin()).as("should anonymize plagiarism comparison").isIn("Your submission", "Other submission");
     }
 
     @Test
@@ -181,19 +182,15 @@ class PlagiarismIntegrationTest extends AbstractSpringIntegrationIndependentTest
     @Test
     @WithMockUser(username = TEST_PREFIX + "editor1", roles = "EDITOR")
     void testGetPlagiarismComparisonsForSplitView_editor() throws Exception {
-        PlagiarismComparison comparison = request.get("/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + plagiarismComparison1.getId() + "/for-split-view",
-                HttpStatus.OK, plagiarismComparison1.getClass());
-        assertThat(comparison).isEqualTo(plagiarismComparison1);
-        assertThat(comparison.getPlagiarismResult()).isNull();
-        assertThat(comparison.getSubmissionA()).isEqualTo(plagiarismComparison1.getSubmissionA());
-        assertThat(comparison.getSubmissionB()).isEqualTo(plagiarismComparison1.getSubmissionB());
-        assertThat(comparison.getSimilarity()).isEqualTo(plagiarismComparison1.getSimilarity());
-        assertThat(comparison.getStatus()).isEqualTo(plagiarismComparison1.getStatus());
-        assertThat(comparison.getMatches()).isEqualTo(plagiarismComparison1.getMatches());
-
-        // Important: make sure those additional information is hidden
-        assertThat(comparison.getSubmissionA().getPlagiarismCase()).isNull();
-        assertThat(comparison.getSubmissionB().getPlagiarismCase()).isNull();
+        PlagiarismComparisonDTO comparison = request.get(
+                "/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + plagiarismComparison1.getId() + "/for-split-view", HttpStatus.OK,
+                PlagiarismComparisonDTO.class);
+        assertThat(comparison.id()).isEqualTo(plagiarismComparison1.getId());
+        assertThat(comparison.submissionA().id()).isEqualTo(plagiarismComparison1.getSubmissionA().getId());
+        assertThat(comparison.submissionB().id()).isEqualTo(plagiarismComparison1.getSubmissionB().getId());
+        assertThat(comparison.similarity()).isEqualTo(plagiarismComparison1.getSimilarity());
+        assertThat(comparison.status()).isEqualTo(plagiarismComparison1.getStatus());
+        assertThat(comparison.matches()).hasSameSizeAs(plagiarismComparison1.getMatches());
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismResultResponseBuilderTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismResultResponseBuilderTest.java
@@ -37,7 +37,7 @@ class PlagiarismResultResponseBuilderTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().plagiarismResult()).isSameAs(plagiarismResult);
+        assertThat(response.getBody().plagiarismResult().comparisons()).hasSize(plagiarismResult.getComparisons().size());
         assertThat(response.getBody().plagiarismResultStats().numberOfDetectedSubmissions()).isEqualTo(3);
         assertThat(response.getBody().plagiarismResultStats().averageSimilarity()).isEqualTo(0.78);
         assertThat(response.getBody().plagiarismResultStats().maximalSimilarity()).isEqualTo(0.78);
@@ -55,7 +55,7 @@ class PlagiarismResultResponseBuilderTest {
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().plagiarismResult()).isSameAs(plagiarismResult);
+        assertThat(response.getBody().plagiarismResult().comparisons()).hasSize(plagiarismResult.getComparisons().size());
         assertThat(response.getBody().plagiarismResultStats().numberOfDetectedSubmissions()).isEqualTo(3);
         assertThat(response.getBody().plagiarismResultStats().averageSimilarity()).isEqualTo(0.78);
         assertThat(response.getBody().plagiarismResultStats().maximalSimilarity()).isEqualTo(0.78);

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/architecture/PlagiarismCodeStyleArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/architecture/PlagiarismCodeStyleArchitectureTest.java
@@ -11,6 +11,6 @@ class PlagiarismCodeStyleArchitectureTest extends AbstractModuleCodeStyleTest {
 
     @Override
     protected int dtoNameEndingThreshold() {
-        return 1;
+        return 0;
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/architecture/PlagiarismEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/architecture/PlagiarismEntityUsageArchitectureTest.java
@@ -27,7 +27,6 @@ class PlagiarismEntityUsageArchitectureTest extends AbstractModuleEntityUsageArc
         return 0;
     }
 
-    // TODO: Reduce this to 0 by removing entity references from DTOs
     @Override
     protected int getExpectedDtoEntityFieldViolations() {
         return 0;

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/architecture/PlagiarismEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/architecture/PlagiarismEntityUsageArchitectureTest.java
@@ -18,7 +18,7 @@ class PlagiarismEntityUsageArchitectureTest extends AbstractModuleEntityUsageArc
     // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getExpectedEntityReturnViolations() {
-        return 6;
+        return 0;
     }
 
     // Plagiarism request bodies are fully DTO-based; do not let any new entity @RequestBody slip back in.
@@ -30,6 +30,6 @@ class PlagiarismEntityUsageArchitectureTest extends AbstractModuleEntityUsageArc
     // TODO: Reduce this to 0 by removing entity references from DTOs
     @Override
     protected int getExpectedDtoEntityFieldViolations() {
-        return 1;
+        return 0;
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/architecture/PlagiarismEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/architecture/PlagiarismEntityUsageArchitectureTest.java
@@ -5,8 +5,6 @@ import de.tum.cit.aet.artemis.shared.architecture.module.AbstractModuleEntityUsa
 /**
  * Architecture test to verify that REST controllers in the Plagiarism module
  * do not use @Entity types directly. Controllers should use DTOs instead.
- * <p>
- * TODO: Reduce violation counts to 0 by introducing DTOs for all endpoints.
  */
 class PlagiarismEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitectureTest {
 
@@ -15,7 +13,6 @@ class PlagiarismEntityUsageArchitectureTest extends AbstractModuleEntityUsageArc
         return ARTEMIS_PACKAGE + ".plagiarism";
     }
 
-    // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getExpectedEntityReturnViolations() {
         return 0;

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismDtoTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismDtoTest.java
@@ -1,0 +1,37 @@
+package de.tum.cit.aet.artemis.plagiarism.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
+
+class PlagiarismDtoTest {
+
+    @Test
+    void detailConstructorHandlesPartialNamesAndLargeSubmissionCounts() {
+        var dto = new PlagiarismCaseDetailDTO(1L, null, 2L, "student", null, "Student", null, null, null, null, 3L, "instructor", "Instructor", null, Long.MAX_VALUE, false, null,
+                0);
+
+        assertThat(dto.student().name()).isEqualTo("Student");
+        assertThat(dto.verdictBy().name()).isEqualTo("Instructor");
+        assertThat(dto.plagiarismSubmissionCount()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    void overviewConstructorHandlesPartialNamesAndLargeSubmissionCounts() {
+        var dto = new PlagiarismCaseOverviewDTO(1L, null, 2L, "student", "Student", null, null, null, false, null, null, 3L, "instructor", null, "Instructor", Long.MAX_VALUE,
+                false);
+
+        assertThat(dto.student().name()).isEqualTo("Student");
+        assertThat(dto.verdictBy().name()).isEqualTo("Instructor");
+        assertThat(dto.plagiarismSubmissionCount()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    void resultDetailsKeepsMissingSimilarityDistributionNull() {
+        var dto = PlagiarismResultDetailsDTO.fromResult(new PlagiarismResult());
+
+        assertThat(dto.similarityDistribution()).isNull();
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
@@ -87,7 +87,6 @@ import de.tum.cit.aet.artemis.localci.service.ci.ContinuousIntegrationService;
 import de.tum.cit.aet.artemis.localvc.service.GitService;
 import de.tum.cit.aet.artemis.localvc.service.vcs.VersionControlService;
 import de.tum.cit.aet.artemis.plagiarism.PlagiarismUtilService;
-import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus;
 import de.tum.cit.aet.artemis.plagiarism.dto.PlagiarismResultDTO;
@@ -1731,13 +1730,12 @@ public class ProgrammingExerciseIntegrationTestService {
 
     private void assertPlagiarismResult(ProgrammingExercise programmingExercise, PlagiarismResultDTO result, double expectedSimilarity) {
         // verify plagiarism result
-        assertThat(result.plagiarismResult().getComparisons()).hasSize(1);
-        assertThat(result.plagiarismResult().getExercise().getId()).isEqualTo(programmingExercise.getId());
+        assertThat(result.plagiarismResult().comparisons()).hasSize(1);
 
-        PlagiarismComparison comparison = result.plagiarismResult().getComparisons().iterator().next();
-        assertThat(comparison.getSimilarity()).isEqualTo(expectedSimilarity, Offset.offset(0.0001));
-        assertThat(comparison.getStatus()).isEqualTo(PlagiarismStatus.NONE);
-        assertThat(comparison.getMatches()).hasSize(1);
+        var comparison = result.plagiarismResult().comparisons().getFirst();
+        assertThat(comparison.similarity()).isEqualTo(expectedSimilarity, Offset.offset(0.0001));
+        assertThat(comparison.status()).isEqualTo(PlagiarismStatus.NONE);
+        assertThat(comparison.matches()).hasSize(1);
 
         // verify plagiarism result stats
         var stats = result.plagiarismResultStats();
@@ -1891,7 +1889,7 @@ public class ProgrammingExerciseIntegrationTestService {
         PlagiarismResult expectedResult = textExerciseUtilService.createPlagiarismResultForExercise(programmingExercise);
 
         var result = request.get("/api/programming/programming-exercises/" + programmingExercise.getId() + "/plagiarism-result", HttpStatus.OK, PlagiarismResultDTO.class);
-        assertThat(result.plagiarismResult().getId()).isEqualTo(expectedResult.getId());
+        assertThat(result.plagiarismResult().id()).isEqualTo(expectedResult.getId());
     }
 
     void testGetPlagiarismResultWithoutResult() throws Exception {

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
@@ -81,7 +81,6 @@ import de.tum.cit.aet.artemis.exercise.util.ExerciseIntegrationTestService;
 import de.tum.cit.aet.artemis.globalsearch.service.WeaviateService;
 import de.tum.cit.aet.artemis.lecture.dto.CompetencyLinkDTO;
 import de.tum.cit.aet.artemis.plagiarism.PlagiarismUtilService;
-import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismComparison;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismDetectionConfig;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismResult;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus;
@@ -1270,19 +1269,18 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
         var path = "/api/text/text-exercises/" + textExercise.getId() + "/check-plagiarism";
         var result = request.get(path, HttpStatus.OK, PlagiarismResultDTO.class, plagiarismUtilService.getDefaultPlagiarismOptions());
-        assertThat(result.plagiarismResult().getComparisons()).hasSize(1);
-        assertThat(result.plagiarismResult().getExercise().getId()).isEqualTo(textExercise.getId());
+        assertThat(result.plagiarismResult().comparisons()).hasSize(1);
         var plagiarismResult = result.plagiarismResult();
 
-        PlagiarismComparison comparison = plagiarismResult.getComparisons().iterator().next();
+        var comparison = plagiarismResult.comparisons().getFirst();
         // Both submissions compared consist of 4 words (= 4 tokens). JPlag seems to be off by 1
         // when counting the length of a match. This is why it calculates a similarity of 3/4 = 75%
         // instead of 4/4 = 100% (5 words ==> 80%, 100 words ==> 99%, etc.). Therefore, we use a rather
         // high offset here to compensate this issue.
         // TODO: Reduce the offset once this issue is fixed in JPlag
-        assertThat(comparison.getSimilarity()).isEqualTo(100.0, Offset.offset(1.0));
-        assertThat(comparison.getStatus()).isEqualTo(PlagiarismStatus.NONE);
-        assertThat(comparison.getMatches()).hasSize(1);
+        assertThat(comparison.similarity()).isEqualTo(100.0, Offset.offset(1.0));
+        assertThat(comparison.status()).isEqualTo(PlagiarismStatus.NONE);
+        assertThat(comparison.matches()).hasSize(1);
 
         // verify plagiarism result stats
         var stats = result.plagiarismResultStats();
@@ -1291,16 +1289,16 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         assertThat(stats.maximalSimilarity()).isEqualTo(100.0, Offset.offset(1.0));
 
         var plagiarismStatusDto = new PlagiarismComparisonStatusDTO(CONFIRMED);
-        request.put("/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + comparison.getId() + "/status", plagiarismStatusDto, HttpStatus.OK);
-        assertThat(plagiarismComparisonRepository.findByIdWithSubmissionsStudentsElseThrow(comparison.getId()).getStatus()).isEqualTo(PlagiarismStatus.CONFIRMED);
+        request.put("/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + comparison.id() + "/status", plagiarismStatusDto, HttpStatus.OK);
+        assertThat(plagiarismComparisonRepository.findByIdWithSubmissionsStudentsElseThrow(comparison.id()).getStatus()).isEqualTo(PlagiarismStatus.CONFIRMED);
 
         plagiarismStatusDto = new PlagiarismComparisonStatusDTO(DENIED);
-        request.put("/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + comparison.getId() + "/status", plagiarismStatusDto, HttpStatus.OK);
-        assertThat(plagiarismComparisonRepository.findByIdWithSubmissionsStudentsElseThrow(comparison.getId()).getStatus()).isEqualTo(DENIED);
+        request.put("/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + comparison.id() + "/status", plagiarismStatusDto, HttpStatus.OK);
+        assertThat(plagiarismComparisonRepository.findByIdWithSubmissionsStudentsElseThrow(comparison.id()).getStatus()).isEqualTo(DENIED);
 
         plagiarismStatusDto = new PlagiarismComparisonStatusDTO(NONE);
-        request.put("/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + comparison.getId() + "/status", plagiarismStatusDto, HttpStatus.OK);
-        assertThat(plagiarismComparisonRepository.findByIdWithSubmissionsStudentsElseThrow(comparison.getId()).getStatus()).isEqualTo(PlagiarismStatus.NONE);
+        request.put("/api/plagiarism/courses/" + course.getId() + "/plagiarism-comparisons/" + comparison.id() + "/status", plagiarismStatusDto, HttpStatus.OK);
+        assertThat(plagiarismComparisonRepository.findByIdWithSubmissionsStudentsElseThrow(comparison.id()).getStatus()).isEqualTo(PlagiarismStatus.NONE);
     }
 
     @Test
@@ -1336,7 +1334,7 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         PlagiarismResult expectedResult = textExerciseUtilService.createPlagiarismResultForExercise(textExercise);
 
         var result = request.get("/api/text/text-exercises/" + textExercise.getId() + "/plagiarism-result", HttpStatus.OK, PlagiarismResultDTO.class);
-        assertThat(result.plagiarismResult().getId()).isEqualTo(expectedResult.getId());
+        assertThat(result.plagiarismResult().id()).isEqualTo(expectedResult.getId());
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 

This PR migrates the plagiarism case, comparison split-view, and plagiarism result REST responses from JPA entity graphs to DTO-safe response models. It introduces dedicated DTOs for plagiarism case overviews/details, verdict responses, comparisons, submissions, matches, and result details. Case overview and detail endpoints now use bounded JPQL constructor-expression projections, avoiding lazy-loading risks and unnecessary entity loading. All endpoint URLs, frontend workflows, and student anonymization semantics are preserved. The Angular plagiarism views and manual TypeScript models are adapted to the new response shapes.


### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The plagiarism module exposed JPA entities directly through several REST responses, contributing 6 entity-return violations, 1 DTO-entity-field violation, and 1 DTO-naming violation in the architecture tests.

This PR is scoped to the cases, comparison, and result submodules and maps their REST responses to DTO records. Repositories now provide DTO projections directly, while services remain entity-based where appropriate. After this change, the remaining plagiarism architecture-test thresholds are 0.


### Description
<!-- Describe your changes in detail -->

Server — New DTOs
* Added DTO records for plagiarism case overviews, case details, case users, case exercises, case post summaries, verdict responses, comparison summaries, full comparisons, submissions, submission elements, matches, and result details.
* Changed `PlagiarismResultDTO` to wrap `PlagiarismResultDetailsDTO` instead of the `PlagiarismResult` entity.
* Renamed `PlagiarismResultStats` to `PlagiarismResultStatsDTO`.

Server — Controllers
* Changed `PlagiarismCaseResource` to return `PlagiarismCaseOverviewDTO` / `PlagiarismCaseDetailDTO` for instructor and student case endpoints.
* Changed verdict save to return `PlagiarismCaseVerdictResponseDTO` instead of a full `PlagiarismCase` entity.
* Changed split-view comparison endpoint to return `PlagiarismComparisonDTO` while preserving student anonymization.
* Refactored comparison course-ID validation to use a dedicated `findCourseIdByIdElseThrow` query instead of traversing the entity graph.

Server — Repositories
* Added JPQL constructor-expression projections in `PlagiarismCaseRepository` for overview, detail, and submission DTOs, avoiding lazy-loading risks and unnecessary entity loading.
* Added `findCourseIdById` query in `PlagiarismComparisonRepository` for efficient course-membership checks.

Server — Architecture tests
* Lowered `PlagiarismEntityUsageArchitectureTest` thresholds to 0 for entity-return and DTO-entity-field violations. The entity-input threshold remains at 0.
* Lowered `PlagiarismCodeStyleArchitectureTest` DTO-naming threshold to 0.

Client
* Updated manual TypeScript models (`PlagiarismCase`, `PlagiarismComparison`, `PlagiarismSubmission`, `PlagiarismResult`, `PlagiarismResultDTO`) to match new server DTO shapes.
* Added `PlagiarismCaseExercise`, `PlagiarismCaseUser`, `PlagiarismCasePostSummary`, `PlagiarismCaseVerdictResponse`, and `PlagiarismComparisonSummary` TypeScript models.
* Updated `PlagiarismCasesService` verdict method to return `PlagiarismCaseVerdictResponse`.
* Adapted instructor overview, instructor detail, student detail, split-view, inspector, and run-details components to consume the new DTO-safe response shapes.
* Updated corresponding component specs.

#### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

Prerequisites
- 1 Instructor
- 2 Students, where at least 1 student is affected by a plagiarism case and has responded to the notification post
- 1 Course with Text or Programming plagiarism cases
- 1 Text Exercise and 1 Programming Exercise with existing plagiarism results

You can use the existing (in **TS4**);
{courseId}=153
{plagiarismCaseId}=13
{comparisonId}=20
{exerciseId}=587 -> _for Text Exercise_
{exerciseId}=590 -> _for Programming Exercise_ (be aware to set the Similarity Threshold to 50 to see)
{examId}=79

#### Instructor — Case Management
1. Log in as instructor.
2. Navigate to `/course-management/{courseId}/plagiarism-cases`.
3. Verify that plagiarism cases load, are grouped by exercise, show verdict/post/student-answer statistics, and CSV export works.
4. Verify that the student-answer column correctly reflects whether students have responded (not always 0%).
5. Open one plagiarism case detail page.
6. Verify that exercise/student/verdict information is shown, the notification post/thread works, and comparison tabs are visible.
7. Save a verdict (e.g. warning or point deduction).
8. Verify that verdict, verdict author, verdict date, and message/point deduction update without reloading the page.
9. Log in as the affected student and verify that the verdict notification appears only for that student.
10. Open a comparison tab.
11. Verify that the split view loads both submissions, highlights matches, and supports switching comparison tabs.

#### Instructor — Plagiarism Inspector
1. Open the plagiarism result view of a Text exercise and a Programming exercise.
2. Verify that fetching the latest plagiarism result works for both.
3. Run a plagiarism check for at least one exercise type and verify statistics, comparison sidebar, split-view details, JSON export, and CSV export.

#### Network Tab — DTO Shape Verification ->
In the browser network tab or console, verify that the following endpoints return DTO-safe JSON without entity back-references (e.g. no `plagiarismResult` inside comparisons, no `plagiarismCase` inside submissions, no full `exercise` database entity inside results). 

* **GET `/api/plagiarism/courses/{courseId}/plagiarism-cases/for-instructor`**
  * **Console Query**:
    ```javascript
    fetch(`/api/plagiarism/courses/${courseId}/plagiarism-cases/for-instructor`).then(res => res.json()).then(console.log);
    ```
  * **Expected Result**: An array of `PlagiarismCaseOverviewDTO` objects. The nested `exercise` attribute must be a lightweight `PlagiarismCaseExerciseDTO` (containing only simple fields like `id`, `title`, `shortName`, `type`, `dueDate`, `courseId`, `courseTitle`, `examId`, `examTitle`, `continuousPlagiarismControlPlagiarismCaseStudentResponsePeriod`) rather than a full `Exercise` database entity.
* **GET `/api/plagiarism/courses/{courseId}/plagiarism-cases/{plagiarismCaseId}/for-instructor`**
  * **Console Query**:
    ```javascript
    fetch(`/api/plagiarism/courses/${courseId}/plagiarism-cases/${plagiarismCaseId}/for-instructor`).then(res => res.json()).then(console.log);
    ```
  * **Expected Result**: A single `PlagiarismCaseDetailDTO` object containing `exercise`, `student`, `post`, `verdictBy`, and `plagiarismSubmissions` as clean DTOs (without entity back-references or nested database models).
* **PUT `/api/plagiarism/courses/{courseId}/plagiarism-cases/{plagiarismCaseId}/verdict`**
  * **Console Query**:
    ```javascript
    fetch(`/api/plagiarism/courses/${courseId}/plagiarism-cases/${plagiarismCaseId}/verdict`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ verdict: 'WARNING', verdictMessage: 'Verbal warning' }) }).then(res => res.json()).then(console.log);
    ```
  * **Expected Result**: A `PlagiarismCaseVerdictResponse` object containing the updated verdict fields (without nested database entity associations like full User objects or parent PlagiarismCase references).
* **GET `/api/plagiarism/courses/{courseId}/plagiarism-comparisons/{comparisonId}/for-split-view`**
  * **Console Query**:
    ```javascript
    fetch(`/api/plagiarism/courses/${courseId}/plagiarism-comparisons/${comparisonId}/for-split-view`).then(res => res.json()).then(console.log);
    ```
  * **Expected Result**: A `PlagiarismComparisonDTO` object. The `submissionA` and `submissionB` fields should be DTOs and there must be no nested `plagiarismResult` back-reference.
* **PUT `/api/plagiarism/courses/{courseId}/plagiarism-comparisons/{comparisonId}/status`**
  * **Console Query**:
    ```javascript
    fetch(`/api/plagiarism/courses/${courseId}/plagiarism-comparisons/${comparisonId}/status`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ status: 'CONFIRMED' }) }).then(res => console.log('HTTP Status:', res.status));
    ```
  * **Expected Result**: Returns HTTP status `200 OK` with no response body.
* **GET `/api/text/text-exercises/{exerciseId}/plagiarism-result`**
  * **Console Query**:
    ```javascript
    fetch(`/api/text/text-exercises/${exerciseId}/plagiarism-result`).then(res => res.status === 204 ? 'No Content (204)' : res.json()).then(console.log);
    ```
  * **Expected Result**: Returns a `PlagiarismResultDetailsDTO` containing `comparisons` and `similarityDistribution` (or `204 No Content` if no checks have run). No database entities (like full `exercise` or back-referenced `plagiarismResult` inside the comparisons) should be present.
* **GET `/api/programming/programming-exercises/{exerciseId}/plagiarism-result`**
  * **Console Query**:
    ```javascript
    fetch(`/api/programming/programming-exercises/${exerciseId}/plagiarism-result`).then(res => res.status === 204 ? 'No Content (204)' : res.json()).then(console.log);
    ```
  * **Expected Result**: Returns a `PlagiarismResultDetailsDTO` containing `comparisons` and `similarityDistribution` (or `204 No Content` if no checks have run). No database entities (like full `exercise` or back-referenced `plagiarismResult` inside the comparisons) should be present.

#### Student View
1. Log in as the affected student.
2. Open `/courses/{courseId}/plagiarism-cases/{plagiarismCaseId}`.
3. Verify that the student can see the case, post, verdict, and comparison.
4. Verify that the split view anonymizes submissions as **Your submission** / **Other submission** and does not expose the other student's login.
5. Log in as another student and verify that accessing the same plagiarism case or comparison is forbidden.

#### Course Scores
1. Log in as instructor and navigate to `/course-management/{courseId}/scores`.
2. Verify that the table loads successfully and a student with a verdict of `PLAGIARISM` shows the plagiarism grade step (e.g., **`U`**) in the **Grades** column.


#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites
- 1 Instructor, 1 Student affected by an exam plagiarism case
- 1 Exam with a Text or Programming Exercise and plagiarism cases

### Instructor Steps
1. Log in as instructor.
2. Open `/course-management/{courseId}/exams/{examId}/plagiarism-cases`.
3. Verify that exam plagiarism cases load and are grouped by exercise.
4. Open one exam case detail page, verify exercise/student/verdict/notification/comparison tabs render correctly.
5. Save a verdict and verify it updates without reloading.
6. Open a comparison tab and verify split view loads both submissions and highlights matches.

### Student Steps
1. Log in as the affected student.
2. Open the student plagiarism case page:
   * Verify the exam context is handled correctly (e.g. the exercise link correctly points to `/courses/{courseId}/exams/{examId}`).
   * Verify that the verdict and notification post/discussion thread render correctly.
   * Verify that the comparisons list and split view are hidden (as expected for exam mode).

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Exam Mode Test
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/28134915731) did not pass (`failure`). Coverage below may be partial.

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| plagiarism-case-instructor-detail-view.component.ts | 96.15% | 252 | 41 | 16.3 |
| plagiarism-cases-instructor-view.component.ts | 95.08% | 152 | 36 | 23.7 |
| plagiarism-inspector.component.ts | 92.14% | 327 | 57 | 17.4 |
| plagiarism-run-details.component.ts | 82.35% | 118 | 15 | 12.7 |
| plagiarism-split-view.component.ts | 93.87% | 177 | 26 | 14.7 |
| text-submission-viewer.component.ts | 93.75% | 233 | 29 | 12.4 |
| plagiarism-case-student-detail-view.component.ts | 94.44% | 87 | 19 | 21.8 |
| PlagiarismCase.ts | not found (modified) | 53 | ? | ? |
| PlagiarismComparison.ts | not found (modified) | 16 | 15 | 93.8 |
| PlagiarismResult.ts | not found (modified) | 9 | ? | ? |
| PlagiarismResultDTO.ts | not found (modified) | 11 | ? | ? |
| PlagiarismSubmission.ts | not found (modified) | 11 | ? | ? |
| plagiarism-cases.service.ts | 100.00% | 78 | 4 | 5.1 |

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| PlagiarismResult.java | not found (modified) | 97 |
| PlagiarismCaseDetailDTO.java | not found (modified) | 53 |
| PlagiarismCaseExerciseDTO.java | not found (modified) | 31 |
| PlagiarismCaseOverviewDTO.java | not found (modified) | 50 |
| PlagiarismCasePostSummaryDTO.java | not found (modified) | 14 |
| PlagiarismCaseUserDTO.java | not found (modified) | 13 |
| PlagiarismCaseVerdictResponseDTO.java | not found (modified) | 17 |
| PlagiarismComparisonDTO.java | not found (modified) | 29 |
| PlagiarismComparisonSummaryDTO.java | not found (modified) | 14 |
| PlagiarismMatchDTO.java | not found (modified) | 13 |
| PlagiarismResultDTO.java | not found (modified) | 5 |
| PlagiarismResultDetailsDTO.java | not found (modified) | 22 |
| PlagiarismResultStatsDTO.java | not found (modified) | 6 |
| PlagiarismSubmissionDTO.java | not found (modified) | 20 |
| PlagiarismSubmissionElementDTO.java | not found (modified) | 13 |
| PlagiarismSubmissionForCaseDTO.java | not found (modified) | 15 |
| PlagiarismCaseRepository.java | not found (modified) | 318 |
| PlagiarismComparisonRepository.java | not found (modified) | 85 |
| PlagiarismCaseResource.java | not found (modified) | 185 |
| PlagiarismResource.java | not found (modified) | 135 |
| PlagiarismResultResponseBuilder.java | not found (modified) | 27 |

_Last updated: 2026-06-24 23:25:11 UTC_

