### PR TITLE
Restrict Python pytest collection

### DIFF
--- a/src/main/resources/templates/jenkins/python/regularRuns/pipeline.groovy
+++ b/src/main/resources/templates/jenkins/python/regularRuns/pipeline.groovy
@@ -33,7 +33,7 @@ private void test() {
         python3 -m compileall . -q || error=true
         if [ ! $error ]
         then
-            pytest --junitxml=test-reports/results.xml
+            pytest --ignore=assignment --junitxml=test-reports/results.xml
         else
             exit 1
         fi

--- a/src/main/resources/templates/phases/python/default.yaml
+++ b/src/main/resources/templates/phases/python/default.yaml
@@ -3,7 +3,7 @@
     python3 -m compileall . -q || error=true
     if [ ! $error ]
     then
-        pytest --junitxml=test-reports/results.xml
+        pytest --ignore=assignment --junitxml=test-reports/results.xml
     fi
   resultPaths:
     - 'test-reports/*results.xml'

--- a/src/main/resources/templates/phases/python/default_static.yaml
+++ b/src/main/resources/templates/phases/python/default_static.yaml
@@ -7,7 +7,7 @@
     python3 -m compileall . -q || error=true
     if [ ! $error ]
     then
-        pytest --junitxml=test-reports/results.xml
+        pytest --ignore=assignment --junitxml=test-reports/results.xml
     fi
   resultPaths:
     - 'test-reports/*results.xml'

--- a/supporting_scripts/course-scripts/setup-course/lib/exercises.mjs
+++ b/supporting_scripts/course-scripts/setup-course/lib/exercises.mjs
@@ -170,7 +170,7 @@ main "\${@}"
 `,
         PYTHON: `#!/usr/bin/env bash
 set -e
-python3 -m pytest --junitxml=test-reports/results.xml
+python3 -m pytest --ignore=assignment --junitxml=test-reports/results.xml
 `,
         C: `#!/usr/bin/env bash
 set -e


### PR DESCRIPTION
## Summary

Restrict default Python pytest collection so pytest ignores the student submission checkout directory `assignment/`.

This prevents pytest from automatically collecting student-controlled files such as `*_test.py`, `test_*.py`, or `conftest.py` while preserving existing test repository layouts. Grader tests can still explicitly import student code from `assignment` when needed.

Fixes #12782.

## Changes

- Add `--ignore=assignment` to the default Python build phase template.
- Add `--ignore=assignment` to the static-analysis Python build phase template.
- Add `--ignore=assignment` to the legacy Jenkins Python build template.
- Add the same flag to the course setup script Python build command.

## Validation

Ran a local pytest smoke test with a failing `assignment/bad_test.py` and official tests under `behavior/` and `structural/`:

```text
pytest --ignore=assignment --junitxml=test-reports/results.xml -q
2 passed
```
