### PR TITLE
`Programming exercises`: Persist assessment type by update of exercise

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/dto/UpdateProgrammingExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/dto/UpdateProgrammingExerciseDTO.java
@@ -11,6 +11,7 @@ import org.jspecify.annotations.Nullable;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
 import de.tum.cit.aet.artemis.assessment.dto.GradingCriterionDTO;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
@@ -52,7 +53,7 @@ public record UpdateProgrammingExerciseDTO(
         String testRepositoryUri, String solutionRepositoryUri, List<AuxiliaryRepositoryDTO> auxiliaryRepositories, Boolean allowOnlineEditor, Boolean allowOfflineIde,
         boolean allowOnlineIde, Boolean staticCodeAnalysisEnabled, Integer maxStaticCodeAnalysisPenalty, ProgrammingLanguage programmingLanguage, String packageName,
         boolean showTestNamesToStudents, @Nullable ZonedDateTime buildAndTestStudentSubmissionsAfterDueDate, Boolean testCasesChanged, String projectKey,
-        @Nullable SubmissionPolicy submissionPolicy, @Nullable ProjectType projectType, boolean releaseTestsWithExampleSolution,
+        @Nullable SubmissionPolicy submissionPolicy, @Nullable ProjectType projectType, boolean releaseTestsWithExampleSolution, @Nullable AssessmentType assessmentType,
 
         // Build config
         UpdateProgrammingExerciseBuildConfigDTO buildConfig) implements CompetencyLinksHolderDTO {
@@ -102,6 +103,7 @@ public record UpdateProgrammingExerciseDTO(
                 exercise.isAllowOnlineEditor(), exercise.isAllowOfflineIde(), exercise.isAllowOnlineIde(), exercise.isStaticCodeAnalysisEnabled(),
                 exercise.getMaxStaticCodeAnalysisPenalty(), exercise.getProgrammingLanguage(), exercise.getPackageName(), exercise.getShowTestNamesToStudents(),
                 exercise.getBuildAndTestStudentSubmissionsAfterDueDate(), exercise.getTestCasesChanged(), exercise.getProjectKey(), exercise.getSubmissionPolicy(),
-                exercise.getProjectType(), exercise.isReleaseTestsWithExampleSolution(), UpdateProgrammingExerciseBuildConfigDTO.of(exercise.getBuildConfig()));
+                exercise.getProjectType(), exercise.isReleaseTestsWithExampleSolution(), exercise.getAssessmentType(),
+                UpdateProgrammingExerciseBuildConfigDTO.of(exercise.getBuildConfig()));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseUpdateResource.java
@@ -343,6 +343,7 @@ public class ProgrammingExerciseUpdateResource {
         exercise.setStartDate(dto.startDate());
         exercise.setDueDate(dto.dueDate());
         exercise.setAssessmentDueDate(dto.assessmentDueDate());
+        exercise.setAssessmentType(dto.assessmentType());
         exercise.setExampleSolutionPublicationDate(dto.exampleSolutionPublicationDate());
 
         // Only set boolean values if they are explicitly provided (not null)

--- a/src/main/webapp/app/core/admin/system-notification-management/parse-links.service.spec.ts
+++ b/src/main/webapp/app/core/admin/system-notification-management/parse-links.service.spec.ts
@@ -56,7 +56,8 @@ describe('ParseLinks Service', () => {
             '<https://localhost/api/communication/system-notifications' +
                 '?sort=notificationDate,desc&sort=id&page=0&size=50>; rel="last",' +
                 '<https://localhost/api/communication/system-notifications' +
-                '?sort=notificationDate,desc&sort=id&page=1&size=50>; rel="first"');
+                '?sort=notificationDate,desc&sort=id&page=1&size=50>; rel="first"',
+        );
         expect(parsedLinks).toEqual(expectedLinks);
     });
     // Precaution for cases where matrix parameters are used
@@ -66,7 +67,8 @@ describe('ParseLinks Service', () => {
             '<https://localhost/api/communication' +
                 ';a=b/system-notifications?sort=notificationDate,desc&sort=id&page=0&size=50>; rel="last",' +
                 '<https://localhost/api/communication/system-notifications' +
-                '?sort=notificationDate,desc&sort=id&page=1&size=50>; rel="first"');
+                '?sort=notificationDate,desc&sort=id&page=1&size=50>; rel="first"',
+        );
         expect(parsedLinks).toEqual(expectedLinks);
     });
 });

--- a/src/main/webapp/app/programming/manage/services/update-programming-exercise-dto.model.ts
+++ b/src/main/webapp/app/programming/manage/services/update-programming-exercise-dto.model.ts
@@ -5,7 +5,7 @@ import { DifficultyLevel, IncludedInOverallScore } from 'app/exercise/shared/ent
 import { ProgrammingLanguage, ProjectType } from 'app/programming/shared/entities/programming-exercise.model';
 import { SubmissionPolicy } from 'app/exercise/shared/entities/submission/submission-policy.model';
 import { CompetencyLinkDTO, GradingCriterionDTO } from 'app/exercise/shared/exercise-update-shared-dto.model';
-
+import { AssessmentType } from 'app/assessment/shared/entities/assessment-type.model';
 /**
  * DTO for auxiliary repository
  */
@@ -67,6 +67,7 @@ export interface UpdateProgrammingExerciseDTO {
     startDate?: string;
     dueDate?: string;
     assessmentDueDate?: string;
+    assessmentType?: AssessmentType;
     exampleSolutionPublicationDate?: string;
 
     // Course/ExerciseGroup references (by ID)
@@ -187,6 +188,7 @@ export function toUpdateProgrammingExerciseDTO(exercise: ProgrammingExercise): U
         startDate: convertDateFromClient(exercise.startDate),
         dueDate: convertDateFromClient(exercise.dueDate),
         assessmentDueDate: convertDateFromClient(exercise.assessmentDueDate),
+        assessmentType: exercise.assessmentType,
         exampleSolutionPublicationDate: convertDateFromClient(exercise.exampleSolutionPublicationDate),
         courseId,
         exerciseGroupId,


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
This PR solves a bug where after a programming exercise was edited, its changes were not applied for `assessment Type`. 

The issue was caused by the `assessmentType` field missing from the `UpdateProgrammingExerciseDTO` on the both client and server sides, causing it to be ignored during the update request. This PR synchronizes the DTO definitions and ensures the `assessmentType` is correctly mapped and persisted in the database.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.


#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **LocalVC** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 
Closes the issue [12767](https://github.com/ls1intum/Artemis/issues/12767)

### Description
<!-- Describe your changes in detail -->
This PR addresses an issue where updates of the `assessmentType` of a programming exercise were not persisting. The root cause was that the `assessmentType` field was missing from the `UpdateProgrammingExerciseDTO` on both the client and server sides, causing the value to be ignored during the update process.

This PR adds the `assessmentType` field to the `UpdateProgrammingExerciseDTO `in both the client and server sides. Additionally, it ensures that the `assessmentType` is correctly mapped from the DTO to the `exercise` object on the server side during the update operation.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 created Programming Exercise

1. Log in to Artemis
2. Navigate to Course Administration (go to /course-management)
3. Pick any course and go to exercises
4. Create a sample programming exercise if have not done it yet
5. Click on `Edit` the exercise
6. Change the Assessment Type of your exercise (click on the icon under the `Assessment Type`)
7. Set `Assessment Due Date` if needed
8. Save the exercise
9. Check if assessment type of exercise was changed


### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

<!--### Test Coverage-->
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->
<!--
| Class/File | Line Coverage | Confirmation (assert/expect) |
|------------|--------------:|-----------------------------:|
| ExerciseService.java | 85% | ✅                           |
| programming-exercise.component.ts | 95% | ✅              |
-->

### Screenshots

<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->

<img width="803" height="480" alt="video" src="https://github.com/user-attachments/assets/e0119c4a-f8fe-4ea9-837f-a6f755266560" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Instructors can now update the assessment type for programming exercises during the exercise modification process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Artemis/pull/12785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->