### PR TITLE
`Development`: Use DTOs for text, online, and exercise units

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/lecture/dto/ExerciseUnitDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/dto/ExerciseUnitDTO.java
@@ -1,0 +1,41 @@
+package de.tum.cit.aet.artemis.lecture.dto;
+
+import java.time.ZonedDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import de.tum.cit.aet.artemis.exercise.domain.Exercise;
+import de.tum.cit.aet.artemis.exercise.domain.ExerciseType;
+import de.tum.cit.aet.artemis.lecture.domain.ExerciseUnit;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ExerciseUnitDTO(Long id, String name, ZonedDateTime releaseDate, boolean completed, boolean visibleToStudents, Set<CompetencyLinkDTO> competencyLinks,
+        ExerciseReferenceDTO exercise, @JsonProperty("type") String type) implements LectureUnitDTO {
+
+    public ExerciseUnitDTO {
+        type = "exercise";
+    }
+
+    public static ExerciseUnitDTO of(ExerciseUnit exerciseUnit) {
+        return new ExerciseUnitDTO(exerciseUnit.getId(), exerciseUnit.getName(), exerciseUnit.getReleaseDate(), exerciseUnit.isCompleted(), exerciseUnit.isVisibleToStudents(),
+                exerciseUnit.getCompetencyLinks().stream().map(CompetencyLinkDTO::of).collect(Collectors.toSet()), ExerciseReferenceDTO.of(exerciseUnit.getExercise()),
+                exerciseUnit.getType());
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public record ExerciseReferenceDTO(Long id, String title, ZonedDateTime releaseDate, ExerciseType type) {
+
+        public static ExerciseReferenceDTO of(Exercise exercise) {
+            if (exercise == null) {
+                return null;
+            }
+            return new ExerciseReferenceDTO(exercise.getId(), exercise.getTitle(), exercise.getReleaseDate(), exercise.getExerciseType());
+        }
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/dto/OnlineUnitDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/dto/OnlineUnitDTO.java
@@ -2,11 +2,25 @@ package de.tum.cit.aet.artemis.lecture.dto;
 
 import java.time.ZonedDateTime;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import de.tum.cit.aet.artemis.lecture.domain.OnlineUnit;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record OnlineUnitDTO(Long id, String name, ZonedDateTime releaseDate, String description, String source, Set<CompetencyLinkDTO> competencyLinks) implements LectureUnitDTO {
+public record OnlineUnitDTO(Long id, String name, ZonedDateTime releaseDate, String description, String source, Set<CompetencyLinkDTO> competencyLinks,
+        @JsonProperty("type") String type) implements LectureUnitDTO {
+
+    public OnlineUnitDTO {
+        type = "online";
+    }
+
+    public static OnlineUnitDTO of(OnlineUnit onlineUnit) {
+        return new OnlineUnitDTO(onlineUnit.getId(), onlineUnit.getName(), onlineUnit.getReleaseDate(), onlineUnit.getDescription(), onlineUnit.getSource(),
+                onlineUnit.getCompetencyLinks().stream().map(CompetencyLinkDTO::of).collect(Collectors.toSet()), onlineUnit.getType());
+    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/dto/TextUnitDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/dto/TextUnitDTO.java
@@ -2,11 +2,25 @@ package de.tum.cit.aet.artemis.lecture.dto;
 
 import java.time.ZonedDateTime;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import de.tum.cit.aet.artemis.lecture.domain.TextUnit;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record TextUnitDTO(Long id, String name, ZonedDateTime releaseDate, String content, Set<CompetencyLinkDTO> competencyLinks) implements LectureUnitDTO {
+public record TextUnitDTO(Long id, String name, ZonedDateTime releaseDate, String content, Set<CompetencyLinkDTO> competencyLinks, @JsonProperty("type") String type)
+        implements LectureUnitDTO {
+
+    public TextUnitDTO {
+        type = "text";
+    }
+
+    public static TextUnitDTO of(TextUnit textUnit) {
+        return new TextUnitDTO(textUnit.getId(), textUnit.getName(), textUnit.getReleaseDate(), textUnit.getContent(),
+                textUnit.getCompetencyLinks().stream().map(CompetencyLinkDTO::of).collect(Collectors.toSet()), textUnit.getType());
+    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/ExerciseUnitResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/ExerciseUnitResource.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.lecture.web;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,8 +71,11 @@ public class ExerciseUnitResource {
 
         Lecture lecture = lectureRepository.findByIdWithLectureUnitsElseThrow(lectureId);
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseUnitDto.exercise().id());
-        if (lecture.getCourse() == null) {
+        if (lecture.getCourse() == null || exercise.getCourseViaExerciseGroupOrCourseMember() == null) {
             throw new BadRequestAlertException("Input data not valid", ENTITY_NAME, "inputInvalid");
+        }
+        if (!Objects.equals(lecture.getCourse().getId(), exercise.getCourseViaExerciseGroupOrCourseMember().getId())) {
+            throw new BadRequestAlertException("The exercise must belong to the same course as the lecture", ENTITY_NAME, "courseMismatch");
         }
 
         ExerciseUnit exerciseUnit = new ExerciseUnit();

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/ExerciseUnitResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/ExerciseUnitResource.java
@@ -18,9 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.security.annotations.enforceRoleInLecture.EnforceAtLeastEditorInLecture;
+import de.tum.cit.aet.artemis.exercise.domain.Exercise;
+import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.lecture.config.LectureEnabled;
 import de.tum.cit.aet.artemis.lecture.domain.ExerciseUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
+import de.tum.cit.aet.artemis.lecture.dto.ExerciseUnitDTO;
 import de.tum.cit.aet.artemis.lecture.repository.ExerciseUnitRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
 
@@ -38,37 +41,46 @@ public class ExerciseUnitResource {
 
     private final LectureRepository lectureRepository;
 
-    public ExerciseUnitResource(LectureRepository lectureRepository, ExerciseUnitRepository exerciseUnitRepository) {
+    private final ExerciseRepository exerciseRepository;
+
+    public ExerciseUnitResource(LectureRepository lectureRepository, ExerciseUnitRepository exerciseUnitRepository, ExerciseRepository exerciseRepository) {
         this.exerciseUnitRepository = exerciseUnitRepository;
         this.lectureRepository = lectureRepository;
+        this.exerciseRepository = exerciseRepository;
     }
 
     /**
      * POST /lectures/:lectureId/exercise-units : creates a new exercise unit.
      *
-     * @param lectureId    the id of the lecture to which the attachment video unit should be added
-     * @param exerciseUnit the exercise unit that should be created
+     * @param lectureId       the id of the lecture to which the attachment video unit should be added
+     * @param exerciseUnitDto the exercise unit that should be created
      * @return the ResponseEntity with status 201 (Created) and with body the new exercise unit
      * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PostMapping("lectures/{lectureId}/exercise-units")
     @EnforceAtLeastEditorInLecture
-    public ResponseEntity<ExerciseUnit> createExerciseUnit(@PathVariable Long lectureId, @RequestBody ExerciseUnit exerciseUnit) throws URISyntaxException {
-        log.debug("REST request to create ExerciseUnit : {}", exerciseUnit);
-        if (exerciseUnit.getId() != null) {
+    public ResponseEntity<ExerciseUnitDTO> createExerciseUnit(@PathVariable Long lectureId, @RequestBody ExerciseUnitDTO exerciseUnitDto) throws URISyntaxException {
+        log.debug("REST request to create ExerciseUnit : {}", exerciseUnitDto);
+        if (exerciseUnitDto.id() != null) {
             throw new BadRequestAlertException("A new exercise unit cannot have an id", ENTITY_NAME, "idExists");
         }
-        Lecture lecture = lectureRepository.findByIdWithLectureUnitsElseThrow(lectureId);
-        if (lecture.getCourse() == null || (exerciseUnit.getLecture() != null && !lecture.getId().equals(exerciseUnit.getLecture().getId()))) {
+        if (exerciseUnitDto.exercise() == null || exerciseUnitDto.exercise().id() == null) {
             throw new BadRequestAlertException("Input data not valid", ENTITY_NAME, "inputInvalid");
         }
 
-        lecture.addLectureUnit(exerciseUnit);
-        Lecture updatedLecture = lectureRepository.saveAndFlush(lecture);
-        ExerciseUnit persistedUnit = (ExerciseUnit) updatedLecture.getLectureUnits().getLast();
-        persistedUnit = exerciseUnitRepository.saveAndFlush(persistedUnit);
+        Lecture lecture = lectureRepository.findByIdWithLectureUnitsElseThrow(lectureId);
+        Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseUnitDto.exercise().id());
+        if (lecture.getCourse() == null) {
+            throw new BadRequestAlertException("Input data not valid", ENTITY_NAME, "inputInvalid");
+        }
 
-        return ResponseEntity.created(new URI("/api/exercise-units/" + persistedUnit.getId())).body(persistedUnit);
+        ExerciseUnit exerciseUnit = new ExerciseUnit();
+        exerciseUnit.setExercise(exercise);
+        lecture.addLectureUnit(exerciseUnit);
+        lectureRepository.saveAndFlush(lecture);
+        ExerciseUnit persistedUnit = exerciseUnitRepository.saveAndFlush(exerciseUnit);
+
+        return ResponseEntity.created(new URI("/api/exercise-units/" + persistedUnit.getId())).body(ExerciseUnitDTO.of(persistedUnit));
     }
 
     /**
@@ -79,13 +91,13 @@ public class ExerciseUnitResource {
      */
     @GetMapping("lectures/{lectureId}/exercise-units")
     @EnforceAtLeastEditorInLecture
-    public ResponseEntity<List<ExerciseUnit>> getAllExerciseUnitsOfLecture(@PathVariable Long lectureId) {
+    public ResponseEntity<List<ExerciseUnitDTO>> getAllExerciseUnitsOfLecture(@PathVariable Long lectureId) {
         log.debug("REST request to get all exercise units for lecture : {}", lectureId);
         Lecture lecture = lectureRepository.findByIdWithLectureUnitsAndCompetenciesElseThrow(lectureId);
         if (lecture.getCourse() == null) {
             throw new BadRequestAlertException("Specified lecture is not part of a course", ENTITY_NAME, "courseMissing");
         }
-        List<ExerciseUnit> exerciseUnitsOfLecture = exerciseUnitRepository.findByLectureId(lectureId);
+        List<ExerciseUnitDTO> exerciseUnitsOfLecture = exerciseUnitRepository.findByLectureId(lectureId).stream().map(ExerciseUnitDTO::of).toList();
         return ResponseEntity.ok().body(exerciseUnitsOfLecture);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/ExerciseUnitResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/ExerciseUnitResource.java
@@ -80,8 +80,10 @@ public class ExerciseUnitResource {
 
         ExerciseUnit exerciseUnit = new ExerciseUnit();
         exerciseUnit.setExercise(exercise);
+        // addLectureUnit sets the lecture back-reference and the lecture unit order on the new unit.
         lecture.addLectureUnit(exerciseUnit);
-        lectureRepository.saveAndFlush(lecture);
+        // Persist the new unit directly. Saving via the lecture would trigger a JPA merge that returns a managed copy while
+        // leaving this transient reference id-less, so the subsequent save below would insert a second, duplicate unit.
         ExerciseUnit persistedUnit = exerciseUnitRepository.saveAndFlush(exerciseUnit);
 
         return ResponseEntity.created(new URI("/api/exercise-units/" + persistedUnit.getId())).body(ExerciseUnitDTO.of(persistedUnit));

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/OnlineUnitResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/OnlineUnitResource.java
@@ -114,7 +114,7 @@ public class OnlineUnitResource {
 
         // Validation
         checkOnlineUnitCourseAndLecture(existingOnlineUnit, lectureId);
-        validateUrlStringAndReturnUrl(onlineUnitDto.source());
+        validateOnlineUnitSource(onlineUnitDto.source());
 
         // Precompute original competency IDs for progress update below
         Set<Long> originalCompetencyIds = existingOnlineUnit.getCompetencyLinks().stream().map(CompetencyLearningObjectLink::getCompetency).map(CourseCompetency::getId)
@@ -166,7 +166,7 @@ public class OnlineUnitResource {
             throw new BadRequestAlertException("A new online unit cannot have an id", ENTITY_NAME, "idExists");
         }
 
-        validateUrlStringAndReturnUrl(onlineUnitDto.source());
+        validateOnlineUnitSource(onlineUnitDto.source());
 
         Lecture lecture = lectureRepository.findByIdWithLectureUnitsElseThrow(lectureId);
         if (lecture.getCourse() == null) {
@@ -294,7 +294,17 @@ public class OnlineUnitResource {
      * @return The URL object
      * @throws BadRequestException If the URL string is invalid
      */
+    private static void validateOnlineUnitSource(String source) {
+        if (source == null || source.isBlank()) {
+            throw new BadRequestAlertException("Input data not valid", ENTITY_NAME, "inputInvalid");
+        }
+        validateUrlStringAndReturnUrl(source);
+    }
+
     private static URL validateUrlStringAndReturnUrl(String urlString) {
+        if (urlString == null || urlString.isBlank()) {
+            throw new BadRequestException("The specified link must not be empty");
+        }
         try {
             return new URI(urlString).toURL();
         }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/OnlineUnitResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/OnlineUnitResource.java
@@ -45,11 +45,8 @@ import de.tum.cit.aet.artemis.globalsearch.service.SearchableEntityWeaviateServi
 import de.tum.cit.aet.artemis.lecture.config.LectureEnabled;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.OnlineUnit;
-import de.tum.cit.aet.artemis.lecture.dto.CompetencyDTO;
-import de.tum.cit.aet.artemis.lecture.dto.CompetencyLinkDTO;
 import de.tum.cit.aet.artemis.lecture.dto.OnlineUnitDTO;
 import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
-import de.tum.cit.aet.artemis.lecture.repository.LectureUnitRepository;
 import de.tum.cit.aet.artemis.lecture.repository.OnlineUnitRepository;
 import de.tum.cit.aet.artemis.lecture.service.LectureUnitService;
 
@@ -71,17 +68,14 @@ public class OnlineUnitResource {
 
     private final LectureUnitService lectureUnitService;
 
-    private final LectureUnitRepository lectureUnitRepository;
-
     private final Optional<SearchableEntityWeaviateService> searchableEntityWeaviateService;
 
     public OnlineUnitResource(LectureRepository lectureRepository, OnlineUnitRepository onlineUnitRepository, Optional<CompetencyProgressApi> competencyProgressApi,
-            LectureUnitService lectureUnitService, LectureUnitRepository lectureUnitRepository, Optional<SearchableEntityWeaviateService> searchableEntityWeaviateServiceOptional) {
+            LectureUnitService lectureUnitService, Optional<SearchableEntityWeaviateService> searchableEntityWeaviateServiceOptional) {
         this.lectureRepository = lectureRepository;
         this.onlineUnitRepository = onlineUnitRepository;
         this.competencyProgressApi = competencyProgressApi;
         this.lectureUnitService = lectureUnitService;
-        this.lectureUnitRepository = lectureUnitRepository;
         this.searchableEntityWeaviateService = searchableEntityWeaviateServiceOptional;
     }
 
@@ -94,11 +88,11 @@ public class OnlineUnitResource {
      */
     @GetMapping("lectures/{lectureId}/online-units/{onlineUnitId}")
     @EnforceAtLeastEditorInLectureUnit(resourceIdFieldName = "onlineUnitId")
-    public ResponseEntity<OnlineUnit> getOnlineUnit(@PathVariable Long onlineUnitId, @PathVariable Long lectureId) {
+    public ResponseEntity<OnlineUnitDTO> getOnlineUnit(@PathVariable Long onlineUnitId, @PathVariable Long lectureId) {
         log.debug("REST request to get onlineUnit : {}", onlineUnitId);
         var onlineUnit = onlineUnitRepository.findByIdWithCompetenciesElseThrow(onlineUnitId);
         checkOnlineUnitCourseAndLecture(onlineUnit, lectureId);
-        return ResponseEntity.ok().body(onlineUnit);
+        return ResponseEntity.ok(OnlineUnitDTO.of(onlineUnit));
     }
 
     /**
@@ -153,38 +147,38 @@ public class OnlineUnitResource {
             }
         });
 
-        // convert into DTO
-        var result = new OnlineUnitDTO(existingOnlineUnit.getId(), existingOnlineUnit.getName(), existingOnlineUnit.getReleaseDate(), existingOnlineUnit.getDescription(),
-                existingOnlineUnit.getSource(), existingOnlineUnit.getCompetencyLinks().stream()
-                        .map(link -> new CompetencyLinkDTO(new CompetencyDTO(link.getCompetency().getId()), link.getWeight())).collect(Collectors.toSet()));
-
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(OnlineUnitDTO.of(existingOnlineUnit));
     }
 
     /**
      * POST /lectures/:lectureId/online-units : creates a new online unit.
      *
-     * @param lectureId  the id of the lecture to which the online unit should be added
-     * @param onlineUnit the online unit that should be created
+     * @param lectureId     the id of the lecture to which the online unit should be added
+     * @param onlineUnitDto the online unit that should be created
      * @return the ResponseEntity with status 201 (Created) and with body the new online unit
      * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PostMapping("lectures/{lectureId}/online-units")
     @EnforceAtLeastEditorInLecture
-    public ResponseEntity<OnlineUnit> createOnlineUnit(@PathVariable Long lectureId, @RequestBody final OnlineUnit onlineUnit) throws URISyntaxException {
-        log.debug("REST request to create onlineUnit : {}", onlineUnit);
-        if (onlineUnit.getId() != null) {
+    public ResponseEntity<OnlineUnitDTO> createOnlineUnit(@PathVariable Long lectureId, @RequestBody final OnlineUnitDTO onlineUnitDto) throws URISyntaxException {
+        log.debug("REST request to create onlineUnit : {}", onlineUnitDto);
+        if (onlineUnitDto.id() != null) {
             throw new BadRequestAlertException("A new online unit cannot have an id", ENTITY_NAME, "idExists");
         }
 
-        validateUrlStringAndReturnUrl(onlineUnit.getSource());
+        validateUrlStringAndReturnUrl(onlineUnitDto.source());
 
         Lecture lecture = lectureRepository.findByIdWithLectureUnitsElseThrow(lectureId);
-        if (lecture.getCourse() == null || (onlineUnit.getLecture() != null && !lecture.getId().equals(onlineUnit.getLecture().getId()))) {
+        if (lecture.getCourse() == null) {
             throw new BadRequestAlertException("Input data not valid", ENTITY_NAME, "inputInvalid");
         }
 
-        lectureUnitRepository.reconnectCompetencyLinks(onlineUnit);
+        OnlineUnit onlineUnit = new OnlineUnit();
+        onlineUnit.setDescription(onlineUnitDto.description());
+        onlineUnit.setSource(onlineUnitDto.source());
+        onlineUnit.setName(onlineUnitDto.name());
+        onlineUnit.setReleaseDate(onlineUnitDto.releaseDate());
+        lectureUnitService.updateCompetencyLinks(onlineUnitDto, onlineUnit);
 
         lecture.addLectureUnit(onlineUnit);
         Lecture updatedLecture = lectureRepository.saveAndFlush(lecture);
@@ -194,9 +188,6 @@ public class OnlineUnitResource {
         onlineUnitRepository.save(persistedUnit);
         competencyProgressApi.ifPresent(api -> api.updateProgressByLearningObjectAsync(persistedUnit));
 
-        // TODO: return a DTO instead to avoid manipulation of the entity before sending it to the client
-        lectureUnitService.disconnectCompetencyLectureUnitLinks(persistedUnit);
-
         searchableEntityWeaviateService.ifPresent(service -> {
             if (LectureUnitSearchableEntityDTO.isIndexable(persistedUnit)) {
                 service.upsertLectureUnitAsync(LectureUnitSearchableEntityDTO.fromLectureUnit(persistedUnit));
@@ -205,7 +196,7 @@ public class OnlineUnitResource {
                 service.deleteEntityAsync(SearchableEntitySchema.TypeValues.LECTURE_UNIT, persistedUnit.getId());
             }
         });
-        return ResponseEntity.created(new URI("/api/online-units/" + persistedUnit.getId())).body(persistedUnit);
+        return ResponseEntity.created(new URI("/api/online-units/" + persistedUnit.getId())).body(OnlineUnitDTO.of(persistedUnit));
     }
 
     private static final Pattern DOMAIN_PATTERN = Pattern.compile("^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*\\.[A-Za-z]{2,}$");

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/TextUnitResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/TextUnitResource.java
@@ -32,11 +32,8 @@ import de.tum.cit.aet.artemis.globalsearch.service.SearchableEntityWeaviateServi
 import de.tum.cit.aet.artemis.lecture.config.LectureEnabled;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.TextUnit;
-import de.tum.cit.aet.artemis.lecture.dto.CompetencyDTO;
-import de.tum.cit.aet.artemis.lecture.dto.CompetencyLinkDTO;
 import de.tum.cit.aet.artemis.lecture.dto.TextUnitDTO;
 import de.tum.cit.aet.artemis.lecture.repository.LectureRepository;
-import de.tum.cit.aet.artemis.lecture.repository.LectureUnitRepository;
 import de.tum.cit.aet.artemis.lecture.repository.TextUnitRepository;
 import de.tum.cit.aet.artemis.lecture.service.LectureUnitService;
 
@@ -58,17 +55,14 @@ public class TextUnitResource {
 
     private final TextUnitRepository textUnitRepository;
 
-    private final LectureUnitRepository lectureUnitRepository;
-
     private final Optional<SearchableEntityWeaviateService> searchableEntityWeaviateService;
 
     public TextUnitResource(LectureRepository lectureRepository, TextUnitRepository textUnitRepository, Optional<CompetencyProgressApi> competencyProgressApi,
-            LectureUnitService lectureUnitService, LectureUnitRepository lectureUnitRepository, Optional<SearchableEntityWeaviateService> searchableEntityWeaviateServiceOptional) {
+            LectureUnitService lectureUnitService, Optional<SearchableEntityWeaviateService> searchableEntityWeaviateServiceOptional) {
         this.lectureRepository = lectureRepository;
         this.textUnitRepository = textUnitRepository;
         this.competencyProgressApi = competencyProgressApi;
         this.lectureUnitService = lectureUnitService;
-        this.lectureUnitRepository = lectureUnitRepository;
         this.searchableEntityWeaviateService = searchableEntityWeaviateServiceOptional;
     }
 
@@ -81,7 +75,7 @@ public class TextUnitResource {
      */
     @GetMapping("lectures/{lectureId}/text-units/{textUnitId}")
     @EnforceAtLeastEditorInLectureUnit(resourceIdFieldName = "textUnitId")
-    public ResponseEntity<TextUnit> getTextUnit(@PathVariable Long textUnitId, @PathVariable Long lectureId) {
+    public ResponseEntity<TextUnitDTO> getTextUnit(@PathVariable Long textUnitId, @PathVariable Long lectureId) {
         log.debug("REST request to get TextUnit : {}", textUnitId);
         Optional<TextUnit> optionalTextUnit = textUnitRepository.findByIdWithCompetencies(textUnitId);
         if (optionalTextUnit.isEmpty()) {
@@ -91,7 +85,7 @@ public class TextUnitResource {
         if (textUnit.getLecture() == null || textUnit.getLecture().getCourse() == null || !textUnit.getLecture().getId().equals(lectureId)) {
             throw new BadRequestAlertException("Input data not valid", ENTITY_NAME, "inputInvalid");
         }
-        return ResponseEntity.ok().body(textUnit);
+        return ResponseEntity.ok(TextUnitDTO.of(textUnit));
     }
 
     /**
@@ -145,34 +139,35 @@ public class TextUnitResource {
             }
         });
 
-        // convert into DTO
-        var result = new TextUnitDTO(existingTextUnit.getId(), existingTextUnit.getName(), existingTextUnit.getReleaseDate(), existingTextUnit.getContent(), existingTextUnit
-                .getCompetencyLinks().stream().map(link -> new CompetencyLinkDTO(new CompetencyDTO(link.getCompetency().getId()), link.getWeight())).collect(Collectors.toSet()));
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(TextUnitDTO.of(existingTextUnit));
     }
 
     /**
      * POST /lectures/:lectureId/text-units : creates a new text unit.
      *
-     * @param lectureId the id of the lecture to which the text unit should be added
-     * @param textUnit  the text unit that should be created
+     * @param lectureId   the id of the lecture to which the text unit should be added
+     * @param textUnitDto the text unit that should be created
      * @return the ResponseEntity with status 201 (Created) and with body the new text unit
      * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PostMapping("lectures/{lectureId}/text-units")
     @EnforceAtLeastEditorInLecture
-    public ResponseEntity<TextUnit> createTextUnit(@PathVariable Long lectureId, @RequestBody TextUnit textUnit) throws URISyntaxException {
-        log.debug("REST request to create TextUnit : {}", textUnit);
-        if (textUnit.getId() != null) {
+    public ResponseEntity<TextUnitDTO> createTextUnit(@PathVariable Long lectureId, @RequestBody TextUnitDTO textUnitDto) throws URISyntaxException {
+        log.debug("REST request to create TextUnit : {}", textUnitDto);
+        if (textUnitDto.id() != null) {
             throw new BadRequestAlertException("A new text unit cannot have an id", ENTITY_NAME, "idExists");
         }
 
         Lecture lecture = lectureRepository.findByIdWithLectureUnitsElseThrow(lectureId);
-        if (lecture.getCourse() == null || (textUnit.getLecture() != null && !lecture.getId().equals(textUnit.getLecture().getId()))) {
+        if (lecture.getCourse() == null) {
             throw new BadRequestAlertException("Input data not valid", ENTITY_NAME, "inputInvalid");
         }
 
-        lectureUnitRepository.reconnectCompetencyLinks(textUnit);
+        TextUnit textUnit = new TextUnit();
+        textUnit.setName(textUnitDto.name());
+        textUnit.setReleaseDate(textUnitDto.releaseDate());
+        textUnit.setContent(textUnitDto.content());
+        lectureUnitService.updateCompetencyLinks(textUnitDto, textUnit);
 
         lecture.addLectureUnit(textUnit);
         Lecture updatedLecture = lectureRepository.saveAndFlush(lecture);
@@ -190,8 +185,6 @@ public class TextUnitResource {
             }
         });
 
-        // TODO: return a DTO instead to avoid manipulation of the entity before sending it to the client
-        lectureUnitService.disconnectCompetencyLectureUnitLinks(persistedUnit);
-        return ResponseEntity.created(new URI("/api/text-units/" + persistedUnit.getId())).body(persistedUnit);
+        return ResponseEntity.created(new URI("/api/text-units/" + persistedUnit.getId())).body(TextUnitDTO.of(persistedUnit));
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/ExerciseUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/ExerciseUnitIntegrationTest.java
@@ -141,7 +141,8 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
         }
 
         List<ExerciseUnitDTO> exerciseUnitsOfLecture = request.getList("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", HttpStatus.OK, ExerciseUnitDTO.class);
-        assertThat(exerciseUnitsOfLecture).containsAll(persistedExerciseUnits);
+        // Each exercise must yield exactly one unit; a superset check (containsAll) would not catch duplicate persistence.
+        assertThat(exerciseUnitsOfLecture).containsExactlyInAnyOrderElementsOf(persistedExerciseUnits);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/ExerciseUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/ExerciseUnitIntegrationTest.java
@@ -8,7 +8,9 @@ import static org.mockito.Mockito.verify;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,8 +22,8 @@ import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.fileupload.domain.FileUploadExercise;
 import de.tum.cit.aet.artemis.fileupload.repository.FileUploadExerciseRepository;
-import de.tum.cit.aet.artemis.lecture.domain.ExerciseUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
+import de.tum.cit.aet.artemis.lecture.dto.ExerciseUnitDTO;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
 import de.tum.cit.aet.artemis.modeling.test_repository.ModelingExerciseTestRepository;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
@@ -85,9 +87,8 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
     }
 
     private void testAllPreAuthorize() throws Exception {
-        ExerciseUnit exerciseUnit = new ExerciseUnit();
-        request.post("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnit, HttpStatus.FORBIDDEN);
-        request.getList("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", HttpStatus.FORBIDDEN, ExerciseUnit.class);
+        request.post("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnitDtoFor(textExercise), HttpStatus.FORBIDDEN);
+        request.getList("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", HttpStatus.FORBIDDEN, ExerciseUnitDTO.class);
     }
 
     @Test
@@ -106,24 +107,28 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void createExerciseUnit_asInstructor_shouldCreateExerciseUnit() throws Exception {
         Set<Exercise> exercisesOfCourse = course1.getExercises();
-        Set<ExerciseUnit> persistedExerciseUnits = new HashSet<>();
+        Set<ExerciseUnitDTO> persistedExerciseUnits = new HashSet<>();
 
         for (Exercise exerciseOfCourse : exercisesOfCourse) {
-            ExerciseUnit exerciseUnit = new ExerciseUnit();
-            exerciseUnit.setExercise(exerciseOfCourse);
-            ExerciseUnit persistedExerciseUnit = request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnit, ExerciseUnit.class,
-                    HttpStatus.CREATED);
+            ExerciseUnitDTO persistedExerciseUnit = request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units",
+                    exerciseUnitDtoFor(exerciseOfCourse), ExerciseUnitDTO.class, HttpStatus.CREATED);
             persistedExerciseUnits.add(persistedExerciseUnit);
         }
         assertThat(persistedExerciseUnits).hasSameSizeAs(exercisesOfCourse);
+        Map<Long, Exercise> exerciseById = exercisesOfCourse.stream().collect(Collectors.toMap(Exercise::getId, exercise -> exercise));
 
-        for (ExerciseUnit exerciseUnit : persistedExerciseUnits) {
-            assertThat(exerciseUnit.getId()).isNotNull();
-            assertThat(exerciseUnit.getExercise()).isNotNull();
-            assertThat(exercisesOfCourse).contains(exerciseUnit.getExercise());
+        for (ExerciseUnitDTO exerciseUnit : persistedExerciseUnits) {
+            assertThat(exerciseUnit.id()).isNotNull();
+            assertThat(exerciseUnit.type()).isEqualTo("exercise");
+            assertThat(exerciseUnit.exercise()).isNotNull();
+            Exercise exercise = exerciseById.get(exerciseUnit.exercise().id());
+            assertThat(exercise).isNotNull();
+            assertThat(exerciseUnit.name()).isEqualTo(exercise.getTitle());
+            assertThat(exerciseUnit.releaseDate()).isEqualTo(exercise.getReleaseDate());
+            assertThat(exerciseUnit.exercise().type()).isEqualTo(exercise.getExerciseType());
         }
 
-        List<ExerciseUnit> exerciseUnitsOfLecture = request.getList("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", HttpStatus.OK, ExerciseUnit.class);
+        List<ExerciseUnitDTO> exerciseUnitsOfLecture = request.getList("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", HttpStatus.OK, ExerciseUnitDTO.class);
         assertThat(exerciseUnitsOfLecture).containsAll(persistedExerciseUnits);
     }
 
@@ -131,51 +136,55 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void createExerciseUnit_withId_shouldReturnBadRequest() throws Exception {
         Exercise exercise = course1.getExercises().stream().findFirst().orElseThrow();
-        ExerciseUnit exerciseUnit = new ExerciseUnit();
-        exerciseUnit.setExercise(exercise);
-        exerciseUnit.setId(1L);
-        request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnit, ExerciseUnit.class, HttpStatus.BAD_REQUEST);
+        request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnitDtoWithIdFor(1L, exercise), ExerciseUnitDTO.class,
+                HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void createExerciseUnit_missingExercise_shouldReturnBadRequest() throws Exception {
+        ExerciseUnitDTO exerciseUnitDTO = new ExerciseUnitDTO(null, null, null, false, false, null, null, null);
+        request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnitDTO, ExerciseUnitDTO.class, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void createExerciseUnit_missingExerciseId_shouldReturnBadRequest() throws Exception {
+        ExerciseUnitDTO exerciseUnitDTO = new ExerciseUnitDTO(null, null, null, false, false, null, new ExerciseUnitDTO.ExerciseReferenceDTO(null, null, null, null), null);
+        request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnitDTO, ExerciseUnitDTO.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "INSTRUCTOR")
     void createExerciseUnit_asStudent_shouldForbidden() throws Exception {
         Exercise exercise = course1.getExercises().stream().findFirst().orElseThrow();
-        ExerciseUnit exerciseUnit = new ExerciseUnit();
-        exerciseUnit.setExercise(exercise);
-        exerciseUnit.setId(1L);
-        request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnit, ExerciseUnit.class, HttpStatus.FORBIDDEN);
+        request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnitDtoWithIdFor(1L, exercise), ExerciseUnitDTO.class,
+                HttpStatus.FORBIDDEN);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void createExerciseUnit_notExistingLectureId_shouldReturnForbidden() throws Exception {
         Exercise exercise = course1.getExercises().stream().findFirst().orElseThrow();
-        ExerciseUnit exerciseUnit = new ExerciseUnit();
-        exerciseUnit.setExercise(exercise);
-        request.postWithResponseBody("/api/lecture/lectures/" + 0 + "/exercise-units", exerciseUnit, ExerciseUnit.class, HttpStatus.FORBIDDEN);
+        request.postWithResponseBody("/api/lecture/lectures/" + 0 + "/exercise-units", exerciseUnitDtoFor(exercise), ExerciseUnitDTO.class, HttpStatus.FORBIDDEN);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor42", roles = "INSTRUCTOR")
     void createExerciseUnit_notInstructorInCourse_shouldReturnForbidden() throws Exception {
         Exercise exercise = course1.getExercises().stream().findFirst().orElseThrow();
-        ExerciseUnit exerciseUnit = new ExerciseUnit();
-        exerciseUnit.setExercise(exercise);
-        request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnit, ExerciseUnit.class, HttpStatus.FORBIDDEN);
+        request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnitDtoFor(exercise), ExerciseUnitDTO.class, HttpStatus.FORBIDDEN);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void deleteExercise_exerciseConnectedWithExerciseUnit_shouldDeleteExerciseUnit() throws Exception {
         Set<Exercise> exercisesOfCourse = course1.getExercises();
-        Set<ExerciseUnit> persistedExerciseUnits = new HashSet<>();
+        Set<ExerciseUnitDTO> persistedExerciseUnits = new HashSet<>();
 
         for (Exercise exerciseOfCourse : exercisesOfCourse) {
-            ExerciseUnit exerciseUnit = new ExerciseUnit();
-            exerciseUnit.setExercise(exerciseOfCourse);
-            ExerciseUnit persistedExerciseUnit = request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnit, ExerciseUnit.class,
-                    HttpStatus.CREATED);
+            ExerciseUnitDTO persistedExerciseUnit = request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units",
+                    exerciseUnitDtoFor(exerciseOfCourse), ExerciseUnitDTO.class, HttpStatus.CREATED);
             persistedExerciseUnits.add(persistedExerciseUnit);
         }
         assertThat(persistedExerciseUnits).hasSameSizeAs(exercisesOfCourse);
@@ -186,7 +195,7 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
         request.delete("/api/fileupload/file-upload-exercises/" + fileUploadExercise.getId(), HttpStatus.OK);
         request.delete("/api/programming/programming-exercises/" + programmingExercise.getId(), HttpStatus.OK, deleteProgrammingExerciseParamsFalse());
 
-        List<ExerciseUnit> exerciseUnitsOfLecture = request.getList("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", HttpStatus.OK, ExerciseUnit.class);
+        List<ExerciseUnitDTO> exerciseUnitsOfLecture = request.getList("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", HttpStatus.OK, ExerciseUnitDTO.class);
         assertThat(exerciseUnitsOfLecture).isEmpty();
 
     }
@@ -195,19 +204,17 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void deleteExerciseUnit_exerciseConnectedWithExerciseUnit_shouldNOTDeleteExercise() throws Exception {
         Set<Exercise> exercisesOfCourse = course1.getExercises();
-        Set<ExerciseUnit> persistedExerciseUnits = new HashSet<>();
+        Set<ExerciseUnitDTO> persistedExerciseUnits = new HashSet<>();
 
         for (Exercise exerciseOfCourse : exercisesOfCourse) {
-            ExerciseUnit exerciseUnit = new ExerciseUnit();
-            exerciseUnit.setExercise(exerciseOfCourse);
-            ExerciseUnit persistedExerciseUnit = request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnit, ExerciseUnit.class,
-                    HttpStatus.CREATED);
+            ExerciseUnitDTO persistedExerciseUnit = request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units",
+                    exerciseUnitDtoFor(exerciseOfCourse), ExerciseUnitDTO.class, HttpStatus.CREATED);
             persistedExerciseUnits.add(persistedExerciseUnit);
         }
         assertThat(persistedExerciseUnits).hasSameSizeAs(exercisesOfCourse);
 
-        for (ExerciseUnit exerciseUnit : persistedExerciseUnits) {
-            request.delete("/api/lecture/lectures/" + lecture1.getId() + "/lecture-units/" + exerciseUnit.getId(), HttpStatus.OK);
+        for (ExerciseUnitDTO exerciseUnit : persistedExerciseUnits) {
+            request.delete("/api/lecture/lectures/" + lecture1.getId() + "/lecture-units/" + exerciseUnit.id(), HttpStatus.OK);
         }
 
         for (Exercise exercise : exercisesOfCourse) {
@@ -215,6 +222,14 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
         }
 
         verify(competencyProgressApi, never()).updateProgressForUpdatedLearningObjectAsync(any(), any());
+    }
+
+    private static ExerciseUnitDTO exerciseUnitDtoFor(Exercise exercise) {
+        return exerciseUnitDtoWithIdFor(null, exercise);
+    }
+
+    private static ExerciseUnitDTO exerciseUnitDtoWithIdFor(Long id, Exercise exercise) {
+        return new ExerciseUnitDTO(id, null, null, false, false, null, new ExerciseUnitDTO.ExerciseReferenceDTO(exercise.getId(), null, null, null), null);
     }
 
 }

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/ExerciseUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/ExerciseUnitIntegrationTest.java
@@ -33,6 +33,7 @@ import de.tum.cit.aet.artemis.quiz.test_repository.QuizExerciseTestRepository;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.repository.TextExerciseRepository;
+import de.tum.cit.aet.artemis.text.util.TextExerciseUtilService;
 
 class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
@@ -40,6 +41,9 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Autowired
     private TextExerciseRepository textExerciseRepository;
+
+    @Autowired
+    private TextExerciseUtilService textExerciseUtilService;
 
     @Autowired
     private ModelingExerciseTestRepository modelingExerciseRepository;
@@ -54,6 +58,8 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
     private FileUploadExerciseRepository fileUploadExerciseRepository;
 
     private Course course1;
+
+    private Course course2;
 
     private Lecture lecture1;
 
@@ -72,6 +78,7 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
         userUtilService.addUsers(TEST_PREFIX, 2, 2, 0, 1);
         List<Course> courses = courseUtilService.createCoursesWithExercisesAndLectures(TEST_PREFIX, true, 2);
         this.course1 = this.courseRepository.findByIdWithExercisesAndExerciseDetailsAndLecturesElseThrow(courses.getFirst().getId());
+        this.course2 = this.courseRepository.findByIdWithExercisesAndExerciseDetailsAndLecturesElseThrow(courses.get(1).getId());
         this.lecture1 = this.course1.getLectures().stream().findFirst().orElseThrow();
 
         this.textExercise = textExerciseRepository.findByCourseIdWithCategories(course1.getId()).stream().findFirst().orElseThrow();
@@ -124,7 +131,12 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
             Exercise exercise = exerciseById.get(exerciseUnit.exercise().id());
             assertThat(exercise).isNotNull();
             assertThat(exerciseUnit.name()).isEqualTo(exercise.getTitle());
-            assertThat(exerciseUnit.releaseDate()).isEqualTo(exercise.getReleaseDate());
+            if (exercise.getReleaseDate() == null) {
+                assertThat(exerciseUnit.releaseDate()).isNull();
+            }
+            else {
+                assertThat(exerciseUnit.releaseDate().toInstant()).isEqualTo(exercise.getReleaseDate().toInstant());
+            }
             assertThat(exerciseUnit.exercise().type()).isEqualTo(exercise.getExerciseType());
         }
 
@@ -138,6 +150,13 @@ class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationIndependentTe
         Exercise exercise = course1.getExercises().stream().findFirst().orElseThrow();
         request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnitDtoWithIdFor(1L, exercise), ExerciseUnitDTO.class,
                 HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void createExerciseUnit_exerciseFromDifferentCourse_shouldReturnBadRequest() throws Exception {
+        TextExercise exercise = textExerciseUtilService.createSampleTextExercise(course2);
+        request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnitDtoFor(exercise), ExerciseUnitDTO.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/OnlineUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/OnlineUnitIntegrationTest.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.lecture;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
@@ -86,9 +87,9 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
     }
 
     private void testAllPreAuthorize() throws Exception {
-        request.put("/api/lecture/lectures/" + lecture1.getId() + "/online-units", onlineUnit, HttpStatus.FORBIDDEN);
-        request.post("/api/lecture/lectures/" + lecture1.getId() + "/online-units", onlineUnit, HttpStatus.FORBIDDEN);
-        request.get("/api/lecture/lectures/" + lecture1.getId() + "/online-units/0", HttpStatus.FORBIDDEN, OnlineUnit.class);
+        request.put("/api/lecture/lectures/" + lecture1.getId() + "/online-units", OnlineUnitDTO.of(onlineUnit), HttpStatus.FORBIDDEN);
+        request.post("/api/lecture/lectures/" + lecture1.getId() + "/online-units", OnlineUnitDTO.of(onlineUnit), HttpStatus.FORBIDDEN);
+        request.get("/api/lecture/lectures/" + lecture1.getId() + "/online-units/0", HttpStatus.FORBIDDEN, OnlineUnitDTO.class);
     }
 
     @AfterEach
@@ -113,31 +114,40 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
     void createOnlineUnit_asInstructor_shouldCreateOnlineUnit() throws Exception {
         onlineUnit.setCompetencyLinks(Set.of(new CompetencyLectureUnitLink(competency, onlineUnit, 1)));
         onlineUnit.setSource("https://www.youtube.com/embed/8iU8LPEa4o0");
-        var persistedOnlineUnit = request.postWithResponseBody("/api/lecture/lectures/" + this.lecture1.getId() + "/online-units", onlineUnit, OnlineUnit.class,
-                HttpStatus.CREATED);
-        assertThat(persistedOnlineUnit.getId()).isNotNull();
-        verify(competencyProgressApi).updateProgressByLearningObjectAsync(eq(persistedOnlineUnit));
+        var persistedOnlineUnit = request.postWithResponseBody("/api/lecture/lectures/" + this.lecture1.getId() + "/online-units", OnlineUnitDTO.of(onlineUnit),
+                OnlineUnitDTO.class, HttpStatus.CREATED);
+        assertThat(persistedOnlineUnit.id()).isNotNull();
+        assertThat(persistedOnlineUnit.type()).isEqualTo("online");
+        assertThat(persistedOnlineUnit.name()).isEqualTo(onlineUnit.getName());
+        assertThat(persistedOnlineUnit.description()).isEqualTo(onlineUnit.getDescription());
+        assertThat(persistedOnlineUnit.source()).isEqualTo(onlineUnit.getSource());
+        assertThat(persistedOnlineUnit.competencyLinks()).hasSize(1);
+        var competencyLink = persistedOnlineUnit.competencyLinks().stream().findFirst().orElseThrow();
+        assertThat(competencyLink.competency().id()).isEqualTo(competency.getId());
+        assertThat(competencyLink.weight()).isEqualTo(1);
+        verify(competencyProgressApi)
+                .updateProgressByLearningObjectAsync(argThat(unit -> unit instanceof OnlineUnit onlineUnit && onlineUnit.getId().equals(persistedOnlineUnit.id())));
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void createOnlineUnit_invalidUrl_shouldReturnBadRequest() throws Exception {
         onlineUnit.setSource("abc123");
-        request.postWithResponseBody("/api/lecture/lectures/" + this.lecture1.getId() + "/online-units", onlineUnit, OnlineUnit.class, HttpStatus.BAD_REQUEST);
+        request.postWithResponseBody("/api/lecture/lectures/" + this.lecture1.getId() + "/online-units", OnlineUnitDTO.of(onlineUnit), OnlineUnitDTO.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor42", roles = "INSTRUCTOR")
     void createOnlineUnit_InstructorNotInCourse_shouldReturnForbidden() throws Exception {
         onlineUnit.setSource("https://www.youtube.com/embed/8iU8LPEa4o0");
-        request.postWithResponseBody("/api/lecture/lectures/" + this.lecture1.getId() + "/online-units", onlineUnit, OnlineUnit.class, HttpStatus.FORBIDDEN);
+        request.postWithResponseBody("/api/lecture/lectures/" + this.lecture1.getId() + "/online-units", OnlineUnitDTO.of(onlineUnit), OnlineUnitDTO.class, HttpStatus.FORBIDDEN);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void createOnlineUnit_withId_shouldReturnBadRequest() throws Exception {
         onlineUnit.setId(999L);
-        request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/online-units", this.onlineUnit, OnlineUnit.class, HttpStatus.BAD_REQUEST);
+        request.postWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/online-units", OnlineUnitDTO.of(this.onlineUnit), OnlineUnitDTO.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -149,7 +159,11 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
         this.onlineUnit = (OnlineUnit) lectureRepository.findByIdWithLectureUnitsAndAttachmentsElseThrow(lecture1.getId()).getLectureUnits().stream().findFirst().orElseThrow();
         this.onlineUnit.setSource("https://www.youtube.com/embed/8iU8LPEa4o0");
         this.onlineUnit.setDescription("Changed");
-        var updatedOnlineUnit = request.putWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/online-units", this.onlineUnit, OnlineUnitDTO.class, HttpStatus.OK);
+        var updatedOnlineUnit = request.putWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/online-units", onlineUnitDtoForRequest(this.onlineUnit),
+                OnlineUnitDTO.class, HttpStatus.OK);
+        assertThat(updatedOnlineUnit.type()).isEqualTo("online");
+        assertThat(updatedOnlineUnit.name()).isEqualTo(this.onlineUnit.getName());
+        assertThat(updatedOnlineUnit.source()).isEqualTo(this.onlineUnit.getSource());
         assertThat(updatedOnlineUnit.description()).isEqualTo("Changed");
         verify(competencyProgressApi, timeout(1000).times(1)).updateProgressForUpdatedLearningObjectAsyncWithOriginalCompetencyIds(eq(Set.of(competency.getId())), eq(onlineUnit));
     }
@@ -167,10 +181,14 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
         List<LectureUnit> orderedUnits = lecture1.getLectureUnits();
 
         // Updating the lecture unit should not change order attribute
-        request.putWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/online-units", onlineUnit, OnlineUnitDTO.class, HttpStatus.OK);
+        request.putWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/online-units", onlineUnitDtoForRequest(onlineUnit), OnlineUnitDTO.class, HttpStatus.OK);
 
         List<LectureUnit> updatedOrderedUnits = lectureRepository.findByIdWithLectureUnitsAndAttachments(lecture1.getId()).orElseThrow().getLectureUnits();
         assertThat(updatedOrderedUnits).containsExactlyElementsOf(orderedUnits);
+    }
+
+    private static OnlineUnitDTO onlineUnitDtoForRequest(OnlineUnit onlineUnit) {
+        return new OnlineUnitDTO(onlineUnit.getId(), onlineUnit.getName(), onlineUnit.getReleaseDate(), onlineUnit.getDescription(), onlineUnit.getSource(), null, null);
     }
 
     private void persistOnlineUnitWithLecture() {
@@ -192,7 +210,8 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
         this.onlineUnit = (OnlineUnit) lectureRepository.findByIdWithLectureUnitsAndAttachmentsElseThrow(lecture1.getId()).getLectureUnits().stream().findFirst().orElseThrow();
         this.onlineUnit.setDescription("Changed");
         this.onlineUnit.setSource("https://www.youtube.com/embed/8iU8LPEa4o0");
-        this.onlineUnit = request.putWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/online-units", this.onlineUnit, OnlineUnit.class, HttpStatus.FORBIDDEN);
+        request.putWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/online-units", onlineUnitDtoForRequest(this.onlineUnit), OnlineUnitDTO.class,
+                HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -201,18 +220,20 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
         persistOnlineUnitWithLecture();
 
         this.onlineUnit = (OnlineUnit) lectureRepository.findByIdWithLectureUnitsAndAttachmentsElseThrow(lecture1.getId()).getLectureUnits().stream().findFirst().orElseThrow();
-        this.onlineUnit.setId(null);
-        this.onlineUnit = request.putWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/online-units", this.onlineUnit, OnlineUnit.class, HttpStatus.BAD_REQUEST);
+        OnlineUnitDTO onlineUnitWithoutId = new OnlineUnitDTO(null, this.onlineUnit.getName(), this.onlineUnit.getReleaseDate(), this.onlineUnit.getDescription(),
+                this.onlineUnit.getSource(), null, null);
+        request.putWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/online-units", onlineUnitWithoutId, OnlineUnitDTO.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void updateOnlineUnit_noLecture_shouldReturnBadRequest() throws Exception {
+    void updateOnlineUnit_incorrectLectureId_shouldReturnBadRequest() throws Exception {
         persistOnlineUnitWithLecture();
 
         this.onlineUnit = (OnlineUnit) lectureRepository.findByIdWithLectureUnitsAndAttachmentsElseThrow(lecture1.getId()).getLectureUnits().stream().findFirst().orElseThrow();
-        this.onlineUnit.setLecture(null);
-        this.onlineUnit = request.putWithResponseBody("/api/lecture/lectures/" + lecture1.getId() + "/online-units", this.onlineUnit, OnlineUnit.class, HttpStatus.BAD_REQUEST);
+        Lecture otherLecture = lectureUtilService.createLecture(lecture1.getCourse());
+        request.putWithResponseBody("/api/lecture/lectures/" + otherLecture.getId() + "/online-units", onlineUnitDtoForRequest(this.onlineUnit), OnlineUnitDTO.class,
+                HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -221,8 +242,13 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
         persistOnlineUnitWithLecture();
 
         this.onlineUnit = (OnlineUnit) lectureRepository.findByIdWithLectureUnitsAndAttachmentsElseThrow(lecture1.getId()).getLectureUnits().stream().findFirst().orElseThrow();
-        OnlineUnit onlineUnitFromRequest = request.get("/api/lecture/lectures/" + lecture1.getId() + "/online-units/" + this.onlineUnit.getId(), HttpStatus.OK, OnlineUnit.class);
-        assertThat(this.onlineUnit.getId()).isEqualTo(onlineUnitFromRequest.getId());
+        OnlineUnitDTO onlineUnitFromRequest = request.get("/api/lecture/lectures/" + lecture1.getId() + "/online-units/" + this.onlineUnit.getId(), HttpStatus.OK,
+                OnlineUnitDTO.class);
+        assertThat(onlineUnitFromRequest.id()).isEqualTo(this.onlineUnit.getId());
+        assertThat(onlineUnitFromRequest.type()).isEqualTo("online");
+        assertThat(onlineUnitFromRequest.name()).isEqualTo(this.onlineUnit.getName());
+        assertThat(onlineUnitFromRequest.description()).isEqualTo(this.onlineUnit.getDescription());
+        assertThat(onlineUnitFromRequest.source()).isEqualTo(this.onlineUnit.getSource());
     }
 
     @Test
@@ -231,7 +257,7 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
         persistOnlineUnitWithLecture();
 
         this.onlineUnit = (OnlineUnit) lectureRepository.findByIdWithLectureUnitsAndAttachmentsElseThrow(lecture1.getId()).getLectureUnits().stream().findFirst().orElseThrow();
-        request.get("/api/lecture/lectures/999/online-units/" + this.onlineUnit.getId(), HttpStatus.BAD_REQUEST, OnlineUnit.class);
+        request.get("/api/lecture/lectures/999/online-units/" + this.onlineUnit.getId(), HttpStatus.BAD_REQUEST, OnlineUnitDTO.class);
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
@@ -271,7 +297,7 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
         this.onlineUnit = (OnlineUnit) lectureRepository.findByIdWithLectureUnitsAndAttachmentsElseThrow(lecture1.getId()).getLectureUnits().stream().findFirst().orElseThrow();
         assertThat(this.onlineUnit.getId()).isNotNull();
         request.delete("/api/lecture/lectures/" + lecture1.getId() + "/lecture-units/" + this.onlineUnit.getId(), HttpStatus.OK);
-        request.get("/api/lecture/lectures/" + lecture1.getId() + "/online-units/" + this.onlineUnit.getId(), HttpStatus.FORBIDDEN, OnlineUnit.class);
+        request.get("/api/lecture/lectures/" + lecture1.getId() + "/online-units/" + this.onlineUnit.getId(), HttpStatus.FORBIDDEN, OnlineUnitDTO.class);
         verify(competencyProgressApi, timeout(1000).times(1)).updateProgressForUpdatedLearningObjectAsync(eq(onlineUnit), eq(Optional.empty()));
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/OnlineUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/OnlineUnitIntegrationTest.java
@@ -137,6 +137,13 @@ class OnlineUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest
     }
 
     @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void createOnlineUnit_missingSource_shouldReturnBadRequest() throws Exception {
+        OnlineUnitDTO onlineUnitWithoutSource = new OnlineUnitDTO(null, onlineUnit.getName(), onlineUnit.getReleaseDate(), onlineUnit.getDescription(), null, null, null);
+        request.postWithResponseBody("/api/lecture/lectures/" + this.lecture1.getId() + "/online-units", onlineUnitWithoutSource, OnlineUnitDTO.class, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
     @WithMockUser(username = TEST_PREFIX + "instructor42", roles = "INSTRUCTOR")
     void createOnlineUnit_InstructorNotInCourse_shouldReturnForbidden() throws Exception {
         onlineUnit.setSource("https://www.youtube.com/embed/8iU8LPEa4o0");

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/TextUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/TextUnitIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -95,7 +96,8 @@ class TextUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         var competencyLink = persistedTextUnit.competencyLinks().stream().findFirst().orElseThrow();
         assertThat(competencyLink.competency().id()).isEqualTo(competency.getId());
         assertThat(competencyLink.weight()).isEqualTo(1);
-        verify(competencyProgressApi).updateProgressByLearningObjectAsync(argThat(unit -> unit instanceof TextUnit textUnit && textUnit.getId().equals(persistedTextUnit.id())));
+        verify(competencyProgressApi)
+                .updateProgressByLearningObjectAsync(argThat(unit -> unit instanceof TextUnit textUnit && Objects.equals(textUnit.getId(), persistedTextUnit.id())));
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/TextUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/TextUnitIntegrationTest.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.lecture;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -63,9 +64,9 @@ class TextUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     }
 
     private void testAllPreAuthorize() throws Exception {
-        request.put("/api/lecture/lectures/" + lecture.getId() + "/text-units", textUnit, HttpStatus.FORBIDDEN);
-        request.post("/api/lecture/lectures/" + lecture.getId() + "/text-units", textUnit, HttpStatus.FORBIDDEN);
-        request.get("/api/lecture/lectures/" + lecture.getId() + "/text-units/0", HttpStatus.FORBIDDEN, TextUnit.class);
+        request.put("/api/lecture/lectures/" + lecture.getId() + "/text-units", TextUnitDTO.of(textUnit), HttpStatus.FORBIDDEN);
+        request.post("/api/lecture/lectures/" + lecture.getId() + "/text-units", TextUnitDTO.of(textUnit), HttpStatus.FORBIDDEN);
+        request.get("/api/lecture/lectures/" + lecture.getId() + "/text-units/0", HttpStatus.FORBIDDEN, TextUnitDTO.class);
     }
 
     @Test
@@ -84,21 +85,25 @@ class TextUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @WithMockUser(username = TEST_PREFIX + "editor1", roles = "EDITOR")
     void createTextUnit_asEditor_shouldCreateTextUnitUnit() throws Exception {
         textUnit.setCompetencyLinks(Set.of(new CompetencyLectureUnitLink(competency, textUnit, 1)));
-        var persistedTextUnit = request.postWithResponseBody("/api/lecture/lectures/" + this.lecture.getId() + "/text-units", textUnit, TextUnit.class, HttpStatus.CREATED);
-        assertThat(persistedTextUnit.getId()).isNotNull();
-        assertThat(persistedTextUnit.getName()).isEqualTo("LoremIpsum");
-        verify(competencyProgressApi).updateProgressByLearningObjectAsync(eq(persistedTextUnit));
+        var persistedTextUnit = request.postWithResponseBody("/api/lecture/lectures/" + this.lecture.getId() + "/text-units", TextUnitDTO.of(textUnit), TextUnitDTO.class,
+                HttpStatus.CREATED);
+        assertThat(persistedTextUnit.id()).isNotNull();
+        assertThat(persistedTextUnit.type()).isEqualTo("text");
+        assertThat(persistedTextUnit.name()).isEqualTo("LoremIpsum");
+        assertThat(persistedTextUnit.content()).isEqualTo(textUnit.getContent());
+        assertThat(persistedTextUnit.competencyLinks()).hasSize(1);
+        var competencyLink = persistedTextUnit.competencyLinks().stream().findFirst().orElseThrow();
+        assertThat(competencyLink.competency().id()).isEqualTo(competency.getId());
+        assertThat(competencyLink.weight()).isEqualTo(1);
+        verify(competencyProgressApi).updateProgressByLearningObjectAsync(argThat(unit -> unit instanceof TextUnit textUnit && textUnit.getId().equals(persistedTextUnit.id())));
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "editor42", roles = "EDITOR")
     void createTextUnit_EditorNotInCourse_shouldReturnForbidden() throws Exception {
-        request.postWithResponseBody("/api/lecture/lectures/" + this.lecture.getId() + "/text-units", textUnit, TextUnit.class, HttpStatus.FORBIDDEN);
-        request.postWithResponseBody("/api/lecture/lectures/" + "2379812738912" + "/text-units", textUnit, TextUnit.class, HttpStatus.FORBIDDEN);
-        textUnit.setLecture(new Lecture());
-        request.postWithResponseBody("/api/lecture/lectures/" + this.lecture.getId() + "/text-units", textUnit, TextUnit.class, HttpStatus.FORBIDDEN);
-        textUnit.setId(21312321L);
-        request.postWithResponseBody("/api/lecture/lectures/" + this.lecture.getId() + "/text-units", textUnit, TextUnit.class, HttpStatus.FORBIDDEN);
+        request.postWithResponseBody("/api/lecture/lectures/" + this.lecture.getId() + "/text-units", TextUnitDTO.of(textUnit), TextUnitDTO.class, HttpStatus.FORBIDDEN);
+        request.postWithResponseBody("/api/lecture/lectures/" + "2379812738912" + "/text-units", TextUnitDTO.of(textUnit), TextUnitDTO.class, HttpStatus.FORBIDDEN);
+        request.postWithResponseBody("/api/lecture/lectures/" + this.lecture.getId() + "/text-units", textUnitDtoWithId(21312321L), TextUnitDTO.class, HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -107,7 +112,10 @@ class TextUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         textUnit.setCompetencyLinks(Set.of(new CompetencyLectureUnitLink(competency, textUnit, 1)));
         persistTextUnitWithLecture();
         textUnit.setContent("Changed");
-        TextUnitDTO updatedTextUnit = request.putWithResponseBody("/api/lecture/lectures/" + lecture.getId() + "/text-units", textUnit, TextUnitDTO.class, HttpStatus.OK);
+        TextUnitDTO updatedTextUnit = request.putWithResponseBody("/api/lecture/lectures/" + lecture.getId() + "/text-units", TextUnitDTO.of(textUnit), TextUnitDTO.class,
+                HttpStatus.OK);
+        assertThat(updatedTextUnit.type()).isEqualTo("text");
+        assertThat(updatedTextUnit.name()).isEqualTo(textUnit.getName());
         assertThat(updatedTextUnit.content()).isEqualTo("Changed");
         verify(competencyProgressApi, timeout(1000).times(1)).updateProgressForUpdatedLearningObjectAsyncWithOriginalCompetencyIds(eq(Set.of(competency.getId())), eq(textUnit));
     }
@@ -131,7 +139,7 @@ class TextUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         List<LectureUnit> orderedUnits = lecture.getLectureUnits();
 
         // Updating the lecture unit should not change order attribute
-        request.putWithResponseBody("/api/lecture/lectures/" + lecture.getId() + "/text-units", secondTextUnit, TextUnitDTO.class, HttpStatus.OK);
+        request.putWithResponseBody("/api/lecture/lectures/" + lecture.getId() + "/text-units", TextUnitDTO.of(secondTextUnit), TextUnitDTO.class, HttpStatus.OK);
         databaseLecture = lectureRepository.findByIdWithLectureUnitsAndAttachments(lecture.getId()).orElseThrow();
         assertThat(lecture.getLectureUnits()).hasSize(2);
 
@@ -143,19 +151,23 @@ class TextUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
     @WithMockUser(username = TEST_PREFIX + "editor1", roles = "EDITOR")
     void updateTextUnit_noId_shouldReturnBadRequest() throws Exception {
         persistTextUnitWithLecture();
-        TextUnit textUnitFromRequest = request.get("/api/lecture/lectures/" + lecture.getId() + "/text-units/" + this.textUnit.getId(), HttpStatus.OK, TextUnit.class);
-        textUnitFromRequest.setId(null);
-        request.putWithResponseBody("/api/lecture/lectures/" + lecture.getId() + "/text-units", textUnitFromRequest, TextUnitDTO.class, HttpStatus.BAD_REQUEST);
+        TextUnitDTO textUnitFromRequest = request.get("/api/lecture/lectures/" + lecture.getId() + "/text-units/" + this.textUnit.getId(), HttpStatus.OK, TextUnitDTO.class);
+        TextUnitDTO textUnitWithoutId = new TextUnitDTO(null, textUnitFromRequest.name(), textUnitFromRequest.releaseDate(), textUnitFromRequest.content(),
+                textUnitFromRequest.competencyLinks(), null);
+        request.putWithResponseBody("/api/lecture/lectures/" + lecture.getId() + "/text-units", textUnitWithoutId, TextUnitDTO.class, HttpStatus.BAD_REQUEST);
 
-        request.get("/api/lecture/lectures/" + "2379812738912" + "/text-units/" + this.textUnit.getId(), HttpStatus.BAD_REQUEST, TextUnit.class);
+        request.get("/api/lecture/lectures/" + "2379812738912" + "/text-units/" + this.textUnit.getId(), HttpStatus.BAD_REQUEST, TextUnitDTO.class);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "editor1", roles = "EDITOR")
     void getTextUnit_correctId_shouldReturnTextUnit() throws Exception {
         persistTextUnitWithLecture();
-        TextUnit textUnitFromRequest = request.get("/api/lecture/lectures/" + lecture.getId() + "/text-units/" + this.textUnit.getId(), HttpStatus.OK, TextUnit.class);
-        assertThat(this.textUnit.getId()).isEqualTo(textUnitFromRequest.getId());
+        TextUnitDTO textUnitFromRequest = request.get("/api/lecture/lectures/" + lecture.getId() + "/text-units/" + this.textUnit.getId(), HttpStatus.OK, TextUnitDTO.class);
+        assertThat(textUnitFromRequest.id()).isEqualTo(this.textUnit.getId());
+        assertThat(textUnitFromRequest.type()).isEqualTo("text");
+        assertThat(textUnitFromRequest.name()).isEqualTo(this.textUnit.getName());
+        assertThat(textUnitFromRequest.content()).isEqualTo(this.textUnit.getContent());
     }
 
     @Test
@@ -165,8 +177,12 @@ class TextUnitIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         persistTextUnitWithLecture();
         assertThat(this.textUnit.getId()).isNotNull();
         request.delete("/api/lecture/lectures/" + lecture.getId() + "/lecture-units/" + this.textUnit.getId(), HttpStatus.OK);
-        request.get("/api/lecture/lectures/" + lecture.getId() + "/text-units/" + this.textUnit.getId(), HttpStatus.FORBIDDEN, TextUnit.class);
+        request.get("/api/lecture/lectures/" + lecture.getId() + "/text-units/" + this.textUnit.getId(), HttpStatus.FORBIDDEN, TextUnitDTO.class);
         verify(competencyProgressApi, timeout(1000).times(1)).updateProgressForUpdatedLearningObjectAsync(eq(textUnit), eq(Optional.empty()));
+    }
+
+    private TextUnitDTO textUnitDtoWithId(Long id) {
+        return new TextUnitDTO(id, textUnit.getName(), textUnit.getReleaseDate(), textUnit.getContent(), TextUnitDTO.of(textUnit).competencyLinks(), null);
     }
 
     private void persistTextUnitWithLecture() {

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/architecture/LectureEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/architecture/LectureEntityUsageArchitectureTest.java
@@ -18,13 +18,13 @@ class LectureEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchit
     // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getExpectedEntityReturnViolations() {
-        return 17;
+        return 11;
     }
 
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getExpectedEntityInputViolations() {
-        return 7;
+        return 4;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs

--- a/src/test/playwright/e2e/lecture/LectureManagement.spec.ts
+++ b/src/test/playwright/e2e/lecture/LectureManagement.spec.ts
@@ -95,7 +95,7 @@ test.describe('Lecture management', { tag: '@fast' }, () => {
             const exercise = await exerciseAPIRequests.createModelingExercise({ course });
             await lectureManagement.openUnitsPage(lecture.id!);
             await lectureManagement.addExerciseUnit(exercise.id!);
-            await expect(page.locator('.exercise-title', { hasText: new RegExp(`^${exercise.title!}$`) })).toBeVisible();
+            await expect(page.locator('.exercise-title:visible', { hasText: new RegExp(`^${exercise.title!}$`) })).toBeVisible();
         });
 
         test('Can open page to add attachment unit to the lecture', async ({ lectureManagement, page }) => {

--- a/src/test/playwright/e2e/lecture/LectureManagement.spec.ts
+++ b/src/test/playwright/e2e/lecture/LectureManagement.spec.ts
@@ -95,7 +95,7 @@ test.describe('Lecture management', { tag: '@fast' }, () => {
             const exercise = await exerciseAPIRequests.createModelingExercise({ course });
             await lectureManagement.openUnitsPage(lecture.id!);
             await lectureManagement.addExerciseUnit(exercise.id!);
-            await expect(page.locator('.exercise-title:visible', { hasText: new RegExp(`^${exercise.title!}$`) })).toBeVisible();
+            await expect(page.locator('.exercise-title', { hasText: new RegExp(`^${exercise.title!}$`) }).first()).toBeVisible();
         });
 
         test('Can open page to add attachment unit to the lecture', async ({ lectureManagement, page }) => {

--- a/src/test/playwright/e2e/lecture/LectureManagement.spec.ts
+++ b/src/test/playwright/e2e/lecture/LectureManagement.spec.ts
@@ -95,7 +95,7 @@ test.describe('Lecture management', { tag: '@fast' }, () => {
             const exercise = await exerciseAPIRequests.createModelingExercise({ course });
             await lectureManagement.openUnitsPage(lecture.id!);
             await lectureManagement.addExerciseUnit(exercise.id!);
-            await expect(page.locator('.exercise-title', { hasText: new RegExp(`^${exercise.title!}$`) }).first()).toBeVisible();
+            await expect(page.locator('.exercise-title', { hasText: new RegExp(`^${exercise.title!}$`) })).toBeVisible();
         });
 
         test('Can open page to add attachment unit to the lecture', async ({ lectureManagement, page }) => {


### PR DESCRIPTION
### Summary

This PR migrates selected Lecture unit REST endpoints from entity request/response bodies to DTOs.

The affected endpoints are the management endpoints for text units, online units, and exercise units. They now use Java record DTOs at the REST boundary while preserving the existing routes, authorization annotations, and behavior.

### Checklist

#### General

- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server

- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context

Some Lecture unit REST endpoints still accepted or returned JPA entities directly. This couples the REST API contract to persistence entities and contributes to the Lecture module's REST entity-usage architecture-test violations.

This PR is a focused DTO migration slice for Lecture unit management. It only changes the REST boundary for text units, online units, and exercise units.

### Description

This PR changes the following Lecture unit endpoints to use DTOs at the REST boundary:

- `POST /api/lecture/lectures/{lectureId}/text-units`
- `GET /api/lecture/lectures/{lectureId}/text-units/{textUnitId}`
- `PUT /api/lecture/lectures/{lectureId}/text-units`
- `POST /api/lecture/lectures/{lectureId}/online-units`
- `GET /api/lecture/lectures/{lectureId}/online-units/{onlineUnitId}`
- `PUT /api/lecture/lectures/{lectureId}/online-units`
- `POST /api/lecture/lectures/{lectureId}/exercise-units`
- `GET /api/lecture/lectures/{lectureId}/exercise-units`

The changed DTOs are:

- `TextUnitDTO`
- `OnlineUnitDTO`
- `ExerciseUnitDTO`

The DTOs expose the lecture unit discriminator through fixed `type` values:

- `text`
- `online`
- `exercise`

For write requests, the resources now construct or update managed entities explicitly instead of deserializing Lecture unit entities from the request body. Exercise unit creation resolves the referenced exercise via the exercise id in the DTO.

The integration tests were updated to use DTOs at the migrated REST boundary and to assert relevant DTO response fields, including discriminator type values, nested exercise references, missing exercise references, and competency links.

The Lecture entity-usage architecture-test thresholds were tightened for this partial migration slice:

- entity return violations: `18 -> 12`
- entity input violations: `7 -> 4`
- DTO entity field violations: unchanged at `1`

### Steps for Testing

Prerequisites:

- A course exists with:
  - at least one lecture
  - at least one exercise that is not yet linked as an exercise unit to the selected lecture

If no suitable course, lecture, or exercise exists on the selected test server, create them through Course Management before starting the test.

Testing steps:

1. Log in as an instructor or administrator.
2. Open Course Management.
3. Open a course that contains a lecture.
4. Open the lecture management page.
5. Open the lecture content / lecture units view.
6. Create a new text unit and set a future release date.
7. Verify that the text unit appears in the lecture content list with the expected release date.
8. Edit the text unit, including changing the release date.
9. Verify that the changed text unit content and changed release date are shown after saving.
10. Delete the text unit.
11. Verify that the text unit is removed from the lecture content list.
12. Create a new online unit with a valid URL and set a future release date.
13. Verify that the online unit appears in the lecture content list with the expected release date.
14. Edit the online unit, including changing the release date.
15. Verify that the changed online unit data and changed release date are shown after saving.
16. Delete the online unit.
17. Verify that the online unit is removed from the lecture content list.
18. Create a new exercise unit by selecting an existing exercise.
19. Verify that the exercise appears as a lecture unit in the lecture content list.
20. Delete or unlink the exercise unit.
21. Verify that the exercise unit is removed from the lecture content list and that the original exercise still exists in the course.

Expected result:

- Text units can be created, edited, displayed, and deleted through the UI, including release date create/update display.
- Online units can be created, edited, displayed, and deleted through the UI, including release date create/update display.
- Exercise units can be created, displayed, and deleted/unlinked through the UI.
- The lecture content list updates correctly after each action.
- No unexpected error notification is shown.

#### Exam Mode Testing

Not applicable. This PR changes Lecture unit management REST DTO boundaries and does not affect exam mode.

### Testserver States

Earlier deployed to `artemis-test3` via Helios from branch `chore/lecture/online-text-exercise-unit-dtos` at commit `9413458` .

### Review Progress

#### Code Review

- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests

- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Coverage table could not be generated. The `Test` workflow concluded with status `success`; coverage artifacts may be missing or incomplete. See [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/26719511250).

_Last updated: 2026-05-31 17:59:29 UTC_

