### PR TITLE
`Adaptive learning`: Fix JSON serialization cycle for exercises with competency links

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/atlas/domain/competency/CompetencyExerciseLink.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/domain/competency/CompetencyExerciseLink.java
@@ -12,6 +12,7 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 
@@ -23,6 +24,7 @@ public class CompetencyExerciseLink extends CompetencyLearningObjectLink {
     @JsonIgnore
     protected CompetencyExerciseId id = new CompetencyExerciseId();
 
+    @JsonIgnoreProperties("competencyLinks")
     @ManyToOne(optional = false)
     @MapsId("exerciseId")
     private Exercise exercise;


### PR DESCRIPTION
### Summary

Fix infinite JSON serialization recursion when submitting/overriding assessments for exercises with linked competencies. The server returned `HttpMessageNotWritableException: Document nesting depth (1001) exceeds the maximum allowed (1000)`, which surfaced on the client as `Http failure during parsing`.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).

### Motivation and Context

Closes #12790

Submitting or overriding a text assessment (and potentially other exercise types) fails when the exercise has competency links. The returned `Result` object graph contains a serialization cycle: `Result → submission → participation → exercise → competencyLinks → CompetencyExerciseLink → competency → exerciseLinks → CompetencyExerciseLink → exercise → ...` which recurses until Jackson's 1000-depth limit is hit.

### Description

Added `@JsonIgnoreProperties("competencyLinks")` to `CompetencyExerciseLink.exercise`, mirroring the identical annotation already present on `CompetencyLectureUnitLink.lectureUnit` (added in PR #11648). This breaks the serialization cycle by preventing Jackson from re-serializing `exercise.competencyLinks` when traversing through a competency's exercise links.

**Root cause history:**
- PR #9517 (Oct 2024) created both `CompetencyExerciseLink` and `CompetencyLectureUnitLink` — neither had the annotation.
- PR #11648 (Nov 2025) added the annotation to `CompetencyLectureUnitLink.lectureUnit` but missed `CompetencyExerciseLink.exercise`.
- The bug became reproducible after the Hibernate L2 cache removal (PR #12594), which caused lazy collections to be session-bound and initializable during Jackson serialization.

**One file changed:** `CompetencyExerciseLink.java` — one annotation + one import added.

### Steps for Testing
Prerequisites:
- 1 Instructor/Tutor
- 1 Student
- 1 Text Exercise with at least one competency linked

1. Log in as a student and submit a text exercise that has a competency link.
2. Set the submission due date to the past.
3. Log in as a tutor, open the assessment dashboard, and assess the submission.
4. Open the same submission again and click **Override Assessment**.
5. Verify the override succeeds without errors.
6. Check the server logs — no `HttpMessageNotWritableException` or nesting depth errors.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Coverage table could not be generated. The `Test` workflow concluded with status `failure`; coverage artifacts may be missing or incomplete. See [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/26457122881).

_Last updated: 2026-05-26 15:48:38 UTC_

