### PR TITLE
`Tutorial groups`: Move management actions into the title bar and remove duplicated page titles

### DIFF
--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/tutorial-free-periods-management/tutorial-group-free-periods-management.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/tutorial-free-periods-management/tutorial-group-free-periods-management.component.html
@@ -1,17 +1,10 @@
 <jhi-loading-indicator-container [isLoading]="isLoading">
     @if (tutorialGroupsConfiguration && tutorialGroupFreePeriods) {
         <div class="row">
-            <div class="col-12">
-                <div class="d-flex justify-content-between">
-                    <h4 jhiTranslate="artemisApp.pages.tutorialFreePeriodsManagement.title"></h4>
-                    <div>
-                        <button type="button" class="btn btn-primary" id="create-tutorial-free-day" (click)="openCreateFreePeriodDialog($event)">
-                            <fa-icon [icon]="faPlus" />
-                            <span jhiTranslate="artemisApp.pages.tutorialFreePeriodsManagement.createFreePeriodButton"></span>
-                        </button>
-                    </div>
-                </div>
-            </div>
+            <button *titleBarActions type="button" class="btn btn-primary btn-sm" id="create-tutorial-free-day" (click)="openCreateFreePeriodDialog($event)">
+                <fa-icon [icon]="faPlus" />
+                <span jhiTranslate="artemisApp.pages.tutorialFreePeriodsManagement.createFreePeriodButton"></span>
+            </button>
             <div class="col-12 mb-2">
                 <div
                     class="alert alert-info"

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/tutorial-free-periods-management/tutorial-group-free-periods-management.component.spec.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/tutorial-free-periods-management/tutorial-group-free-periods-management.component.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, input } from '@angular/core';
+import { Component, EmbeddedViewRef, input } from '@angular/core';
 import { MockProvider } from 'ng-mocks';
 import { AlertService } from 'app/shared/service/alert.service';
 import { MockRouter } from 'test/helpers/mocks/mock-router';
@@ -27,6 +27,7 @@ import { MockDialogService } from 'test/helpers/mocks/service/mock-dialog.servic
 import { TutorialGroupFreePeriodsTableComponent } from './tutorial-group-free-periods-table/tutorial-group-free-periods-table.component';
 import { OwlNativeDateTimeModule } from '@danielmoncada/angular-datetime-picker';
 import { tutorialGroupConfigurationDtoFromEntity } from 'app/tutorialgroup/shared/entities/tutorial-groups-configuration-dto.model';
+import { CourseTitleBarService } from 'app/course/shared/services/course-title-bar.service';
 
 @Component({
     selector: 'jhi-tutorial-group-free-periods-table',
@@ -59,6 +60,25 @@ describe('TutorialGroupFreePeriodsManagementComponent', () => {
     let thirdOfJanuaryPeriod: TutorialGroupFreePeriod;
 
     const router = new MockRouter();
+
+    // Embedded views created by renderTitleBarActions() are tracked so they can be destroyed after each test.
+    let titleBarActionViews: EmbeddedViewRef<unknown>[] = [];
+
+    /**
+     * The "Add New Free Period" button is projected into the shared course title bar via the `*titleBarActions`
+     * directive, so it is not part of the component's own DOM. This renders the registered actions template the
+     * same way `jhi-course-title-bar` would and returns the projected button element.
+     */
+    function renderTitleBarActions(): HTMLElement {
+        const actionsTemplate = TestBed.inject(CourseTitleBarService).actionsTemplate();
+        expect(actionsTemplate).toBeDefined();
+        const view = actionsTemplate!.createEmbeddedView({});
+        titleBarActionViews.push(view);
+        view.detectChanges();
+        // The `*titleBarActions` directive sits directly on the button, so the embedded view's first root node is it.
+        return view.rootNodes[0] as HTMLElement;
+    }
+
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             imports: [TutorialGroupFreePeriodsManagementComponent, OwlNativeDateTimeModule],
@@ -113,6 +133,8 @@ describe('TutorialGroupFreePeriodsManagementComponent', () => {
     });
 
     afterEach(() => {
+        titleBarActionViews.forEach((view) => view.destroy());
+        titleBarActionViews = [];
         vi.restoreAllMocks();
     });
 
@@ -125,7 +147,7 @@ describe('TutorialGroupFreePeriodsManagementComponent', () => {
         vi.spyOn(component, 'createFreePeriodDialog').mockReturnValue(mockCreateDialog);
         const openDialogSpy = vi.spyOn(component, 'openCreateFreePeriodDialog');
 
-        const button = fixture.debugElement.nativeElement.querySelector('#create-tutorial-free-day');
+        const button = renderTitleBarActions();
         button.click();
 
         await fixture.whenStable();

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/tutorial-free-periods-management/tutorial-group-free-periods-management.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/tutorial-free-periods-management/tutorial-group-free-periods-management.component.ts
@@ -18,13 +18,21 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TutorialGroupFreePeriodsTableComponent } from './tutorial-group-free-periods-table/tutorial-group-free-periods-table.component';
 import { TutorialGroupsConfigurationService } from 'app/tutorialgroup/manage/service/tutorial-groups-configuration.service';
 import { tutorialGroupsConfigurationEntityFromDto } from 'app/tutorialgroup/shared/entities/tutorial-groups-configuration-dto.model';
+import { CourseTitleBarActionsDirective } from 'app/course/shared/directives/course-title-bar-actions.directive';
 
 @Component({
     selector: 'jhi-tutorial-free-periods',
     templateUrl: './tutorial-group-free-periods-management.component.html',
     styleUrls: ['./tutorial-group-free-periods-management.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [LoadingIndicatorContainerComponent, TranslateDirective, FaIconComponent, TutorialGroupFreePeriodsTableComponent, CreateTutorialGroupFreePeriodComponent],
+    imports: [
+        LoadingIndicatorContainerComponent,
+        TranslateDirective,
+        FaIconComponent,
+        TutorialGroupFreePeriodsTableComponent,
+        CreateTutorialGroupFreePeriodComponent,
+        CourseTitleBarActionsDirective,
+    ],
 })
 export class TutorialGroupFreePeriodsManagementComponent implements OnInit, OnDestroy {
     private activatedRoute = inject(ActivatedRoute);

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/create-tutorial-groups-configuration/create-tutorial-groups-configuration.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/create-tutorial-groups-configuration/create-tutorial-groups-configuration.component.html
@@ -1,5 +1,4 @@
 <jhi-loading-indicator-container [isLoading]="isLoading">
-    <h3 jhiTranslate="artemisApp.pages.createTutorialGroupsConfiguration.title"></h3>
     <div class="alert alert-info" role="alert" jhiTranslate="artemisApp.pages.createTutorialGroupsConfiguration.explanation"></div>
     <jhi-tutorial-groups-configuration-form [isEditMode]="false" (formSubmitted)="createTutorialsGroupConfiguration($event)" [course]="course" />
 </jhi-loading-indicator-container>

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/edit-tutorial-groups-configuration/edit-tutorial-groups-configuration.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/edit-tutorial-groups-configuration/edit-tutorial-groups-configuration.component.html
@@ -1,4 +1,3 @@
 <jhi-loading-indicator-container [isLoading]="isLoading">
-    <h3 jhiTranslate="artemisApp.pages.editTutorialGroupsConfiguration.title"></h3>
     <jhi-tutorial-groups-configuration-form [formData]="formData" [isEditMode]="true" (formSubmitted)="updateTutorialGroupsConfiguration($event)" [course]="course" />
 </jhi-loading-indicator-container>

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/edit-tutorial-groups-configuration/edit-tutorial-groups-configuration.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/edit-tutorial-groups-configuration/edit-tutorial-groups-configuration.component.ts
@@ -9,7 +9,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Course } from 'app/course/shared/entities/course.model';
 import { CourseStorageService } from 'app/course/manage/services/course-storage.service';
 import { LoadingIndicatorContainerComponent } from 'app/shared/loading-indicator-container/loading-indicator-container.component';
-import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { TutorialGroupsConfigurationFormComponent } from '../tutorial-groups-configuration-form/tutorial-groups-configuration-form.component';
 import { TutorialGroupsConfigurationService } from 'app/tutorialgroup/manage/service/tutorial-groups-configuration.service';
 import { TutorialGroupConfigurationDTO, tutorialGroupsConfigurationEntityFromDto } from 'app/tutorialgroup/shared/entities/tutorial-groups-configuration-dto.model';
@@ -19,7 +18,7 @@ import dayjs from 'dayjs/esm';
     selector: 'jhi-edit-tutorial-groups-configuration',
     templateUrl: './edit-tutorial-groups-configuration.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [LoadingIndicatorContainerComponent, TranslateDirective, TutorialGroupsConfigurationFormComponent],
+    imports: [LoadingIndicatorContainerComponent, TutorialGroupsConfigurationFormComponent],
 })
 export class EditTutorialGroupsConfigurationComponent implements OnInit, OnDestroy {
     private activatedRoute = inject(ActivatedRoute);

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/tutorial-groups-configuration-form/tutorial-groups-configuration-form.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/tutorial-groups-configuration-form/tutorial-groups-configuration-form.component.html
@@ -38,7 +38,7 @@
                         </div>
                     }
                     <!-- Do not show options if the course has communication disabled -->
-                    <div [hidden]="!isMessagingEnabled(course())">
+                    <div class="mt-3" [hidden]="!isMessagingEnabled(course())">
                         <div class="form-check">
                             <input class="form-check-input" type="checkbox" formControlName="useTutorialGroupChannels" id="useTutorialGroupChannels" />
                             <label
@@ -61,7 +61,7 @@
                             }
                         </div>
                         <!--Public Channel / Private Channel -->
-                        <div class="form-group" [hidden]="!useTutorialGroupChannelsControl?.value">
+                        <div class="form-group mt-3" [hidden]="!useTutorialGroupChannelsControl?.value">
                             <label class="d-block" jhiTranslate="artemisApp.dialogs.createChannel.channelForm.isPublicInput.label"></label>
                             <div class="btn-group" role="group">
                                 <input formControlName="usePublicTutorialGroupChannels" type="radio" class="btn-check" id="public" autocomplete="off" checked [value]="true" />
@@ -77,7 +77,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="row mt-2">
+                <div class="row mt-3">
                     <div class="col-12 d-flex justify-content-end">
                         <button id="submitButton" class="btn btn-primary" type="submit" [disabled]="!isSubmitPossible">
                             <span jhiTranslate="{{ isEditMode() ? 'entity.action.save' : 'global.generic.create' }}"></span>

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/tutorial-groups-configuration-form/tutorial-groups-configuration-form.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/tutorial-groups-configuration-form/tutorial-groups-configuration-form.component.html
@@ -10,6 +10,7 @@
                             name="period"
                             id="period"
                             required
+                            [attr.aria-label]="'artemisApp.forms.configurationForm.periodInput.label' | artemisTranslate"
                             [class.is-invalid]="isPeriodInvalid"
                             (focus)="markPeriodAsTouched()"
                             [value]="periodControl?.value | artemisDateRange: 'long-date' : undefined : true"

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/tutorial-groups-configuration-form/tutorial-groups-configuration-form.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/tutorial-groups-configuration-form/tutorial-groups-configuration-form.component.html
@@ -78,9 +78,9 @@
                     </div>
                 </div>
                 <div class="row mt-2">
-                    <div class="col-12">
+                    <div class="col-12 d-flex justify-content-end">
                         <button id="submitButton" class="btn btn-primary" type="submit" [disabled]="!isSubmitPossible">
-                            <span jhiTranslate="{{ isEditMode() ? 'global.generic.edit' : 'global.generic.create' }}"></span>
+                            <span jhiTranslate="{{ isEditMode() ? 'entity.action.save' : 'global.generic.create' }}"></span>
                         </button>
                     </div>
                 </div>

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/tutorial-groups-configuration-form/tutorial-groups-configuration-form.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/tutorial-groups-configuration-form/tutorial-groups-configuration-form.component.html
@@ -4,7 +4,7 @@
             <form class="row" [formGroup]="form" (ngSubmit)="submitForm()">
                 <!-- Period -->
                 <div class="col-auto">
-                    <label class="form-label" for="period" jhiTranslate="artemisApp.forms.configurationForm.periodInput.label"></label>
+                    <h5 jhiTranslate="artemisApp.forms.configurationForm.periodInput.label"></h5>
                     <div class="input-group">
                         <input
                             name="period"
@@ -62,7 +62,7 @@
                         </div>
                         <!--Public Channel / Private Channel -->
                         <div class="form-group mt-3" [hidden]="!useTutorialGroupChannelsControl?.value">
-                            <label class="d-block" jhiTranslate="artemisApp.dialogs.createChannel.channelForm.isPublicInput.label"></label>
+                            <h5 jhiTranslate="artemisApp.dialogs.createChannel.channelForm.isPublicInput.label"></h5>
                             <div class="btn-group" role="group">
                                 <input formControlName="usePublicTutorialGroupChannels" type="radio" class="btn-check" id="public" autocomplete="off" checked [value]="true" />
                                 <label class="btn btn-outline-secondary" for="public" jhiTranslate="artemisApp.dialogs.createChannel.channelForm.isPublicInput.public"></label>
@@ -77,12 +77,10 @@
                         </div>
                     </div>
                 </div>
-                <div class="row mt-3">
-                    <div class="col-12 d-flex justify-content-end">
-                        <button id="submitButton" class="btn btn-primary" type="submit" [disabled]="!isSubmitPossible">
-                            <span jhiTranslate="{{ isEditMode() ? 'entity.action.save' : 'global.generic.create' }}"></span>
-                        </button>
-                    </div>
+                <div class="col-12 mt-3 d-flex justify-content-end">
+                    <button id="submitButton" class="btn btn-primary" type="submit" [disabled]="!isSubmitPossible">
+                        <span jhiTranslate="{{ isEditMode() ? 'entity.action.save' : 'global.generic.create' }}"></span>
+                    </button>
                 </div>
             </form>
         }

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/tutorial-groups-configuration-form/tutorial-groups-configuration-form.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/tutorial-groups-configuration-form/tutorial-groups-configuration-form.component.ts
@@ -7,6 +7,7 @@ import { OwlDateTimeModule } from '@danielmoncada/angular-datetime-picker';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ArtemisDateRangePipe } from 'app/shared/pipes/artemis-date-range.pipe';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 
 export interface TutorialGroupsConfigurationFormData {
     period?: Date[];
@@ -19,7 +20,7 @@ export interface TutorialGroupsConfigurationFormData {
     templateUrl: './tutorial-groups-configuration-form.component.html',
     styleUrls: ['./tutorial-groups-configuration-form.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [FormsModule, ReactiveFormsModule, TranslateDirective, OwlDateTimeModule, FaIconComponent, ArtemisDateRangePipe],
+    imports: [FormsModule, ReactiveFormsModule, TranslateDirective, OwlDateTimeModule, FaIconComponent, ArtemisDateRangePipe, ArtemisTranslatePipe],
     providers: [ArtemisDatePipe],
 })
 export class TutorialGroupsConfigurationFormComponent implements OnInit {

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.html
@@ -6,20 +6,20 @@
                     @if (course?.tutorialGroupsConfiguration && isAtLeastInstructor) {
                         <a
                             ngbTooltip="{{ 'artemisApp.pages.tutorialFreePeriodsManagement.explanation' | artemisTranslate }}"
-                            class="btn btn-primary"
+                            class="btn btn-primary btn-sm"
                             [routerLink]="['/course-management', courseId, 'tutorial-groups', 'configuration', course!.tutorialGroupsConfiguration!.id, 'tutorial-free-days']"
                         >
                             <fa-icon [icon]="faUmbrellaBeach" />
                             <span class="d-none d-md-inline" jhiTranslate="artemisApp.pages.tutorialGroupsManagement.freePeriodsButtons"></span>
                         </a>
                     }
-                    <a class="btn btn-primary" [routerLink]="['/course-management', courseId, 'tutorial-groups', 'create']">
+                    <a class="btn btn-primary btn-sm" [routerLink]="['/course-management', courseId, 'tutorial-groups', 'create']">
                         <fa-icon [icon]="faPlus" />
                         <span class="d-none d-md-inline" jhiTranslate="artemisApp.pages.tutorialGroupsManagement.creatTutorialGroupButton"></span>
                     </a>
                     @if (isAtLeastInstructor) {
                         <div ngbDropdown class="d-inline-block">
-                            <button type="button" class="btn btn-primary" id="dropdownBasic1" ngbDropdownToggle jhiTranslate="artemisApp.generic.more"></button>
+                            <button type="button" class="btn btn-primary btn-sm" id="dropdownBasic1" ngbDropdownToggle jhiTranslate="artemisApp.generic.more"></button>
                             <div ngbDropdownMenu>
                                 @if (course?.tutorialGroupsConfiguration) {
                                     <a

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.html
@@ -72,7 +72,6 @@
                 <div>
                     <div class="alert alert-success" role="alert">
                         <div>
-                            <span class="badge rounded-pill text-bg-warning ms-1" ngbTooltip="{{ 'artemisApp.generic.betaWarning' | artemisTranslate }}">BETA</span>
                             {{ 'artemisApp.pages.tutorialGroupsManagement.intro' | artemisTranslate }}
                         </div>
                         <div class="text-center">

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.html
@@ -1,10 +1,6 @@
 <jhi-loading-indicator-container [isLoading]="isLoading">
     <div class="row">
         <div class="col-12 col-xl-10">
-            <div *titleBarTitle class="d-flex align-items-center">
-                <jhi-course-title-bar-title title="artemisApp.pages.tutorialGroupsManagement.title" />
-                <span class="badge rounded-pill text-bg-warning ms-2" ngbTooltip="{{ 'artemisApp.generic.betaWarning' | artemisTranslate }}">BETA</span>
-            </div>
             @if (isAtLeastEditor) {
                 <div *titleBarActions class="d-flex gap-2">
                     @if (course?.tutorialGroupsConfiguration && isAtLeastInstructor) {

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.html
@@ -1,56 +1,54 @@
 <jhi-loading-indicator-container [isLoading]="isLoading">
     <div class="row">
         <div class="col-12 col-xl-10">
-            <div class="d-flex justify-content-between">
-                <h4>
-                    {{ 'artemisApp.pages.tutorialGroupsManagement.title' | artemisTranslate }}
-                    <span class="badge rounded-pill text-bg-warning ms-1" ngbTooltip="{{ 'artemisApp.generic.betaWarning' | artemisTranslate }}">BETA</span>
-                </h4>
-                @if (isAtLeastEditor) {
-                    <div>
-                        @if (course?.tutorialGroupsConfiguration && isAtLeastInstructor) {
-                            <a
-                                ngbTooltip="{{ 'artemisApp.pages.tutorialFreePeriodsManagement.explanation' | artemisTranslate }}"
-                                class="btn btn-primary"
-                                [routerLink]="['/course-management', courseId, 'tutorial-groups', 'configuration', course!.tutorialGroupsConfiguration!.id, 'tutorial-free-days']"
-                            >
-                                <fa-icon [icon]="faUmbrellaBeach" />
-                                <span class="d-none d-md-inline" jhiTranslate="artemisApp.pages.tutorialGroupsManagement.freePeriodsButtons"></span>
-                            </a>
-                        }
-                        <a class="btn btn-primary" [routerLink]="['/course-management', courseId, 'tutorial-groups', 'create']">
-                            <fa-icon [icon]="faPlus" />
-                            <span class="d-none d-md-inline" jhiTranslate="artemisApp.pages.tutorialGroupsManagement.creatTutorialGroupButton"></span>
-                        </a>
-                        @if (isAtLeastInstructor) {
-                            <div ngbDropdown class="d-inline-block">
-                                <button type="button" class="btn btn-primary" id="dropdownBasic1" ngbDropdownToggle jhiTranslate="artemisApp.generic.more"></button>
-                                <div ngbDropdownMenu>
-                                    @if (course?.tutorialGroupsConfiguration) {
-                                        <a
-                                            ngbDropdownItem
-                                            class="btn"
-                                            [routerLink]="['/course-management', courseId, 'tutorial-groups', 'configuration', course!.tutorialGroupsConfiguration!.id, 'edit']"
-                                        >
-                                            <span jhiTranslate="artemisApp.pages.tutorialGroupsManagement.editConfigurationButton"></span>
-                                        </a>
-                                    }
-                                    <jhi-tutorial-groups-import-button
-                                        ngbTooltip="{{ 'artemisApp.tutorialGroupImportDialog.explanations.description' | artemisTranslate }}"
-                                        [courseId]="courseId"
-                                        (importFinished)="loadTutorialGroups()"
-                                    />
-                                    <jhi-tutorial-groups-export-button
-                                        ngbTooltip="{{ 'artemisApp.tutorialGroupExportDialog.toolTip' | artemisTranslate }}"
-                                        [courseId]="courseId"
-                                        (exportFinished)="loadTutorialGroups()"
-                                    />
-                                </div>
-                            </div>
-                        }
-                    </div>
-                }
+            <div *titleBarTitle class="d-flex align-items-center">
+                <jhi-course-title-bar-title title="artemisApp.pages.tutorialGroupsManagement.title" />
+                <span class="badge rounded-pill text-bg-warning ms-2" ngbTooltip="{{ 'artemisApp.generic.betaWarning' | artemisTranslate }}">BETA</span>
             </div>
+            @if (isAtLeastEditor) {
+                <div *titleBarActions class="d-flex gap-2">
+                    @if (course?.tutorialGroupsConfiguration && isAtLeastInstructor) {
+                        <a
+                            ngbTooltip="{{ 'artemisApp.pages.tutorialFreePeriodsManagement.explanation' | artemisTranslate }}"
+                            class="btn btn-primary"
+                            [routerLink]="['/course-management', courseId, 'tutorial-groups', 'configuration', course!.tutorialGroupsConfiguration!.id, 'tutorial-free-days']"
+                        >
+                            <fa-icon [icon]="faUmbrellaBeach" />
+                            <span class="d-none d-md-inline" jhiTranslate="artemisApp.pages.tutorialGroupsManagement.freePeriodsButtons"></span>
+                        </a>
+                    }
+                    <a class="btn btn-primary" [routerLink]="['/course-management', courseId, 'tutorial-groups', 'create']">
+                        <fa-icon [icon]="faPlus" />
+                        <span class="d-none d-md-inline" jhiTranslate="artemisApp.pages.tutorialGroupsManagement.creatTutorialGroupButton"></span>
+                    </a>
+                    @if (isAtLeastInstructor) {
+                        <div ngbDropdown class="d-inline-block">
+                            <button type="button" class="btn btn-primary" id="dropdownBasic1" ngbDropdownToggle jhiTranslate="artemisApp.generic.more"></button>
+                            <div ngbDropdownMenu>
+                                @if (course?.tutorialGroupsConfiguration) {
+                                    <a
+                                        ngbDropdownItem
+                                        class="btn"
+                                        [routerLink]="['/course-management', courseId, 'tutorial-groups', 'configuration', course!.tutorialGroupsConfiguration!.id, 'edit']"
+                                    >
+                                        <span jhiTranslate="artemisApp.pages.tutorialGroupsManagement.editConfigurationButton"></span>
+                                    </a>
+                                }
+                                <jhi-tutorial-groups-import-button
+                                    ngbTooltip="{{ 'artemisApp.tutorialGroupImportDialog.explanations.description' | artemisTranslate }}"
+                                    [courseId]="courseId"
+                                    (importFinished)="loadTutorialGroups()"
+                                />
+                                <jhi-tutorial-groups-export-button
+                                    ngbTooltip="{{ 'artemisApp.tutorialGroupExportDialog.toolTip' | artemisTranslate }}"
+                                    [courseId]="courseId"
+                                    (exportFinished)="loadTutorialGroups()"
+                                />
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
             @if (tutorialGroups?.length) {
                 <jhi-tutorial-groups-table
                     [tutorialGroups]="tutorialGroups"

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.spec.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DebugElement, getDebugNode } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { MockProvider } from 'ng-mocks';
@@ -26,6 +27,7 @@ import { OwlNativeDateTimeModule } from '@danielmoncada/angular-datetime-picker'
 import '@angular/localize/init';
 import { tutorialGroupConfigurationDtoFromEntity } from 'app/tutorialgroup/shared/entities/tutorial-groups-configuration-dto.model';
 import { TutorialGroupApiService } from 'app/openapi/api/tutorialGroupApi.service';
+import { CourseTitleBarService } from 'app/course/shared/services/course-title-bar.service';
 
 interface TutorialGroupApiServiceMock {
     getTutorialGroupsForCourse: ReturnType<typeof vi.fn>;
@@ -47,6 +49,19 @@ describe('TutorialGroupsManagementComponent', () => {
     let getOneOfCourseSpy: ReturnType<typeof vi.spyOn>;
 
     const router = new MockRouter();
+
+    /**
+     * The Holidays / Create / More actions (including the import and export buttons) are projected into the
+     * shared course title bar via the `*titleBarActions` directive, so they are not part of the component's own
+     * DOM. This renders the registered actions template the same way `jhi-course-title-bar` would, allowing the
+     * projected buttons to be queried.
+     */
+    function renderTitleBarActions(): DebugElement {
+        const actionsTemplate = TestBed.inject(CourseTitleBarService).actionsTemplate();
+        const view = actionsTemplate!.createEmbeddedView({});
+        view.detectChanges();
+        return getDebugNode(view.rootNodes[0]) as DebugElement;
+    }
 
     beforeEach(async () => {
         tutorialGroupApiServiceMock = {
@@ -120,7 +135,7 @@ describe('TutorialGroupsManagementComponent', () => {
         getOneOfCourseSpy.mockClear();
         expect(getOneOfCourseSpy).not.toHaveBeenCalled();
         expect(tutorialGroupApiServiceMock.getTutorialGroupsForCourse).not.toHaveBeenCalled();
-        const tutorialGroupImportButtonComponent = fixture.debugElement.query(By.directive(TutorialGroupsImportButtonComponent)).componentInstance;
+        const tutorialGroupImportButtonComponent = renderTitleBarActions().query(By.directive(TutorialGroupsImportButtonComponent)).componentInstance;
         tutorialGroupImportButtonComponent.importFinished.emit();
         expect(tutorialGroupApiServiceMock.getTutorialGroupsForCourse).toHaveBeenCalledOnce();
         expect(tutorialGroupApiServiceMock.getTutorialGroupsForCourse).toHaveBeenCalledWith(1, 'response');
@@ -132,7 +147,7 @@ describe('TutorialGroupsManagementComponent', () => {
         getOneOfCourseSpy.mockClear();
         expect(getOneOfCourseSpy).not.toHaveBeenCalled();
         expect(tutorialGroupApiServiceMock.getTutorialGroupsForCourse).not.toHaveBeenCalled();
-        const tutorialGroupExportButtonComponent = fixture.debugElement.query(By.directive(TutorialGroupsExportButtonComponent)).componentInstance;
+        const tutorialGroupExportButtonComponent = renderTitleBarActions().query(By.directive(TutorialGroupsExportButtonComponent)).componentInstance;
         tutorialGroupExportButtonComponent.exportFinished.emit();
         expect(tutorialGroupApiServiceMock.getTutorialGroupsForCourse).toHaveBeenCalledOnce();
         expect(tutorialGroupApiServiceMock.getTutorialGroupsForCourse).toHaveBeenCalledWith(1, 'response');

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.spec.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.spec.ts
@@ -62,9 +62,14 @@ describe('TutorialGroupsManagementComponent', () => {
      */
     function renderTitleBarActions(): DebugElement {
         const actionsTemplate = TestBed.inject(CourseTitleBarService).actionsTemplate();
+        // The directive only registers a template when the `@if (isAtLeastEditor)` block renders; assert it
+        // explicitly so a missing template fails with a clear message instead of a cryptic null dereference.
+        expect(actionsTemplate).toBeDefined();
         const view = actionsTemplate!.createEmbeddedView({});
         titleBarActionViews.push(view);
         view.detectChanges();
+        // The `*titleBarActions` directive sits directly on the actions wrapper `<div>`, so the embedded view's
+        // first root node is that element; its DebugElement.query traverses into the nested action buttons.
         return getDebugNode(view.rootNodes[0]) as DebugElement;
     }
 

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.spec.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { DebugElement, getDebugNode } from '@angular/core';
+import { DebugElement, EmbeddedViewRef, getDebugNode } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { MockProvider } from 'ng-mocks';
@@ -50,6 +50,10 @@ describe('TutorialGroupsManagementComponent', () => {
 
     const router = new MockRouter();
 
+    // Embedded views created by renderTitleBarActions() are tracked so they can be destroyed after each test,
+    // preventing leaked component instances and subscriptions across tests.
+    let titleBarActionViews: EmbeddedViewRef<unknown>[] = [];
+
     /**
      * The Holidays / Create / More actions (including the import and export buttons) are projected into the
      * shared course title bar via the `*titleBarActions` directive, so they are not part of the component's own
@@ -59,6 +63,7 @@ describe('TutorialGroupsManagementComponent', () => {
     function renderTitleBarActions(): DebugElement {
         const actionsTemplate = TestBed.inject(CourseTitleBarService).actionsTemplate();
         const view = actionsTemplate!.createEmbeddedView({});
+        titleBarActionViews.push(view);
         view.detectChanges();
         return getDebugNode(view.rootNodes[0]) as DebugElement;
     }
@@ -110,6 +115,8 @@ describe('TutorialGroupsManagementComponent', () => {
     });
 
     afterEach(() => {
+        titleBarActionViews.forEach((view) => view.destroy());
+        titleBarActionViews = [];
         fixture.destroy();
         vi.restoreAllMocks();
     });

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.ts
@@ -23,8 +23,6 @@ import { TutorialGroupsTableComponent } from 'app/tutorialgroup/manage/tutorial-
 import { TutorialGroupFreeDaysOverviewComponent } from 'app/tutorialgroup/shared/tutorial-group-free-days-overview/tutorial-group-free-days-overview.component';
 import { TutorialGroupsConfigurationService } from 'app/tutorialgroup/manage/service/tutorial-groups-configuration.service';
 import { CourseTitleBarActionsDirective } from 'app/course/shared/directives/course-title-bar-actions.directive';
-import { CourseTitleBarTitleDirective } from 'app/course/shared/directives/course-title-bar-title.directive';
-import { CourseTitleBarTitleComponent } from 'app/course/shared/course-title-bar-title/course-title-bar-title.component';
 import { tutorialGroupsConfigurationEntityFromDto } from 'app/tutorialgroup/shared/entities/tutorial-groups-configuration-dto.model';
 import { TutorialGroupApiService } from 'app/openapi/api/tutorialGroupApi.service';
 import { HttpResponse } from '@angular/common/http';
@@ -53,8 +51,6 @@ import { convertTutorialGroupResponseArrayDatesFromServer } from 'app/tutorialgr
         TutorialGroupFreeDaysOverviewComponent,
         ArtemisTranslatePipe,
         CourseTitleBarActionsDirective,
-        CourseTitleBarTitleDirective,
-        CourseTitleBarTitleComponent,
     ],
 })
 export class TutorialGroupsManagementComponent implements OnInit, OnDestroy {

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-management/tutorial-groups-management.component.ts
@@ -22,6 +22,9 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { TutorialGroupsTableComponent } from 'app/tutorialgroup/manage/tutorial-groups-table/tutorial-groups-table.component';
 import { TutorialGroupFreeDaysOverviewComponent } from 'app/tutorialgroup/shared/tutorial-group-free-days-overview/tutorial-group-free-days-overview.component';
 import { TutorialGroupsConfigurationService } from 'app/tutorialgroup/manage/service/tutorial-groups-configuration.service';
+import { CourseTitleBarActionsDirective } from 'app/course/shared/directives/course-title-bar-actions.directive';
+import { CourseTitleBarTitleDirective } from 'app/course/shared/directives/course-title-bar-title.directive';
+import { CourseTitleBarTitleComponent } from 'app/course/shared/course-title-bar-title/course-title-bar-title.component';
 import { tutorialGroupsConfigurationEntityFromDto } from 'app/tutorialgroup/shared/entities/tutorial-groups-configuration-dto.model';
 import { TutorialGroupApiService } from 'app/openapi/api/tutorialGroupApi.service';
 import { HttpResponse } from '@angular/common/http';
@@ -49,6 +52,9 @@ import { convertTutorialGroupResponseArrayDatesFromServer } from 'app/tutorialgr
         TutorialGroupsCourseInformationComponent,
         TutorialGroupFreeDaysOverviewComponent,
         ArtemisTranslatePipe,
+        CourseTitleBarActionsDirective,
+        CourseTitleBarTitleDirective,
+        CourseTitleBarTitleComponent,
     ],
 })
 export class TutorialGroupsManagementComponent implements OnInit, OnDestroy {

--- a/src/main/webapp/i18n/de/tutorialGroups.json
+++ b/src/main/webapp/i18n/de/tutorialGroups.json
@@ -81,7 +81,7 @@
         },
         "pages": {
             "tutorialGroupsManagement": {
-                "intro": "Willkommen auf der Seite zur Verwaltung der Übungsgruppen! Eine Beta-Funktion von Artemis, die es ermöglicht, wöchentliche Online- und Offline-Übungsgruppen zu verwalten. Du kannst damit beginnen, Übungsgruppen aus einer CSV-Datei zu importieren oder manuell eine neue Übungsgruppe zu erstellen.",
+                "intro": "Willkommen auf der Seite zur Verwaltung der Übungsgruppen! Sie ermöglicht es, wöchentliche Online- und Offline-Übungsgruppen zu verwalten. Du kannst damit beginnen, Übungsgruppen aus einer CSV-Datei zu importieren oder manuell eine neue Übungsgruppe zu erstellen.",
                 "title": "Übungsgruppen-Verwaltung",
                 "freePeriodsButtons": "Freie Tage",
                 "creatTutorialGroupButton": "Neue Übungsgruppe",

--- a/src/main/webapp/i18n/de/tutorialGroups.json
+++ b/src/main/webapp/i18n/de/tutorialGroups.json
@@ -12,8 +12,7 @@
                 "everyWeek": "Jede Woche",
                 "everyNWeeks": "Alle {{ n }} Wochen"
             },
-            "timeZone": "Zeitzone: {{ timeZone }}",
-            "betaWarning": "Diese Funktion befindet sich derzeit im Beta-Stadium. Es können Bugs und Änderungen auftreten. Bitte melde Fehler unter: https://github.com/ls1intum/Artemis/issues "
+            "timeZone": "Zeitzone: {{ timeZone }}"
         },
         "entities": {
             "tutorialGroup": {

--- a/src/main/webapp/i18n/en/tutorialGroups.json
+++ b/src/main/webapp/i18n/en/tutorialGroups.json
@@ -81,7 +81,7 @@
         },
         "pages": {
             "tutorialGroupsManagement": {
-                "intro": "Welcome to the tutorial group management page! A beta feature of Artemis that allows you to manage online and offline weekly tutorial groups. Start by either importing tutorial groups from a CSV file or by creating a new tutorial group manually.",
+                "intro": "Welcome to the tutorial group management page! It allows you to manage online and offline weekly tutorial groups. Start by either importing tutorial groups from a CSV file or by creating a new tutorial group manually.",
                 "title": "Tutorial Groups Management",
                 "freePeriodsButtons": "Holidays",
                 "creatTutorialGroupButton": "Create New Tutorial Group",

--- a/src/main/webapp/i18n/en/tutorialGroups.json
+++ b/src/main/webapp/i18n/en/tutorialGroups.json
@@ -12,8 +12,7 @@
                 "everyWeek": "Every week",
                 "everyNWeeks": "Every {{ n }} weeks"
             },
-            "timeZone": "Time Zone: {{ timeZone }}",
-            "betaWarning": "This feature is currently in beta. Bugs and breaking changes may occur. Please report any issues on: https://github.com/ls1intum/Artemis/issues"
+            "timeZone": "Time Zone: {{ timeZone }}"
         },
         "entities": {
             "tutorialGroup": {


### PR DESCRIPTION
### Summary

The Tutorial Groups Management page rendered its title **twice**: the shared course title bar (the sticky bar at the top) already shows the page title, but the page also printed the same "Tutorial Groups Management" heading plus a BETA badge in the content area right below it. The Holidays / Create New Tutorial Group / More… action buttons were stranded in that content area instead of sitting in the title bar like the other course management pages. This PR removes the duplicate, drops the BETA badge (the feature is no longer in beta), and moves the actions into the top bar.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

The duplicated heading looked broken and inconsistent with the rest of the course management area (e.g. Lectures, FAQs), where the page title and its actions live in the shared title bar. Artemis already provides the `*titleBarTitle` and `*titleBarActions` directives for exactly this purpose, but the Tutorial Groups Management page predated/ignored that pattern.

### Description

- Removed the duplicated `<h4>` title from the content area; the title now appears only once, in the shared title bar (rendered from the route's page title).
- Removed the BETA badge entirely (from both the title and the empty-state alert) since the feature is no longer in beta.
- Moved the **Holidays**, **Create New Tutorial Group**, and **More…** actions into the title bar using the `*titleBarActions` directive — the same pattern used by the lecture and FAQ management pages.
- Updated the component spec: the import/export buttons now live in the projected actions template, so the two affected tests render that registered template (the way `jhi-course-title-bar` does) to keep verifying that finishing an import/export reloads the tutorial groups.

No server changes, no REST calls changed, no routing/authority changes — the title and actions remain gated by the existing `isAtLeastEditor` / `isAtLeastInstructor` checks.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Course with the Tutorial Groups feature enabled

1. Log in to Artemis as the instructor.
2. Navigate to Course Management → the course → **Tutorials**.
3. Verify the title "Tutorial Groups Management" appears **once**, in the top title bar, with no BETA badge anywhere on the page.
4. Verify the **Holidays**, **Create New Tutorial Group**, and **More…** buttons are in the top title bar and all work (navigation, dropdown, import, export).
5. Confirm this holds both when the course already has tutorial groups and when it has none (empty state).
6. Log in as a tutor (non-editor) and confirm the title still shows but the action buttons are hidden.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Coverage table could not be generated. The `Test` workflow concluded with status `failure`; coverage artifacts may be missing or incomplete. See [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/26501000736).

_Last updated: 2026-05-27 09:30:56 UTC_




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned the tutorial groups management header into a title-bar layout; actions (create, free-period config, import/export, instructor menu) were moved into the title-bar and the beta badge removed from the intro/empty state. Updated English and German intro texts to remove the beta sentence.
* **Tests**
  * Updated tests to render and query projected title-bar actions and clean up embedded views after each test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ls1intum/Artemis/pull/12797?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->