### PR TITLE
`Development`: Fix flaky `MessageIntegrationTest` order-dependent Jackson deserialization

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -32,6 +32,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.communication.domain.AnswerPost;
 import de.tum.cit.aet.artemis.communication.domain.ConversationParticipant;
@@ -385,8 +387,12 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         var params = new LinkedMultiValueMap<String, String>();
         params.add("conversationIds", channel.getId().toString());
 
-        List<Post> returnedPosts = request.getList("/api/communication/courses/" + courseId + "/messages", HttpStatus.OK, Post.class, params);
-        // get amount of posts with that certain
+        // Deserialize into a JSON tree instead of the Post entity graph. That graph forms a Jackson cycle
+        // (Post -> reactions -> Reaction -> post -> Post) and Reaction.user carries @JsonIncludeProperties; resolving
+        // the filtered deserializer mid-cycle is order-dependent and can leave User.id without a value deserializer
+        // ("No _valueDeserializer assigned") when this test runs before another has warmed the shared ObjectMapper's
+        // cache, which makes it flaky in CI. This assertion only needs the number of returned posts. See #12798.
+        List<JsonNode> returnedPosts = request.getList("/api/communication/courses/" + courseId + "/messages", HttpStatus.OK, JsonNode.class, params);
         assertThat(returnedPosts).hasSize(1);
     }
 


### PR DESCRIPTION
### Summary
`MessageIntegrationTest.testGetConversationPosts_IfNoParticipant` is an order-dependent flaky test. It deserialized the REST response into the `Post` JPA entity graph, which forms a Jackson cycle (`Post → reactions → Reaction → post → Post`) where `Reaction.user` carries `@JsonIncludeProperties({ "id", "name" })`. Resolving that property-filtered deserializer mid-cycle is order-dependent: when this test runs before any other has warmed the shared (Spring-bean) `ObjectMapper`'s deserializer cache, `User.id` is left without a value deserializer and Jackson throws `No _valueDeserializer assigned`. This made `server-tests` flaky depending on CI shard composition. Fixes #12798.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
Closes #12798. The failure reproduces deterministically in isolation on a clean `develop`:

```
./gradlew test --tests "de.tum.cit.aet.artemis.communication.MessageIntegrationTest.testGetConversationPosts_IfNoParticipant" -x webapp
```

Because `gh run rerun --failed` preserves the same shard composition, the test failed repeatedly on PRs whose shard distribution was unfavorable (e.g. it failed 4/4 attempts on the client-only PR #12667, whose server code is byte-identical to `develop`), forcing repeated CI re-runs. Note: this deserialization happens only on the test side — production serializes these entities and never deserializes the cyclic graph — so there is no production impact, only CI flakiness.

### Description
Deserialize the response into a JSON tree (`List<JsonNode>`) instead of the `Post` entity graph. The assertion only needs the number of returned posts, so no cyclic bean deserialization is required, which removes the order dependency entirely. A comment documents the root cause inline.

This is a targeted fix for the one test that actually flakes in CI. The broader pattern (any test deserializing `Post`/`Reaction` with a populated `user` before the cache is warm) is described in #12798; a more general fix (e.g. deserializing via DTOs/projections, or addressing the Jackson cyclic `@JsonIncludeProperties` resolution centrally) can be evaluated separately.

### Steps for Testing
This is a server test-only change; no functional/UI behavior changes.

1. Check out this branch.
2. Run the previously-flaky test in isolation (it failed on `develop`, passes here):
   ```
   ./gradlew test --tests "de.tum.cit.aet.artemis.communication.MessageIntegrationTest.testGetConversationPosts_IfNoParticipant" -x webapp
   ```
3. Run the full class to confirm no regressions:
   ```
   ./gradlew test --tests "de.tum.cit.aet.artemis.communication.MessageIntegrationTest" -x webapp
   ```

### Testserver States
Not applicable — server test-only change, no deployment needed.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1