### PR TITLE
`Quiz exercises`: Use DTOs for live and exam quiz submission endpoints

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizSubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/web/QuizSubmissionResource.java
@@ -43,6 +43,7 @@ import de.tum.cit.aet.artemis.quiz.domain.QuizExercise;
 import de.tum.cit.aet.artemis.quiz.domain.QuizSubmission;
 import de.tum.cit.aet.artemis.quiz.domain.SubmittedAnswer;
 import de.tum.cit.aet.artemis.quiz.dto.result.ResultAfterEvaluationWithSubmissionDTO;
+import de.tum.cit.aet.artemis.quiz.dto.submission.QuizSubmissionBeforeEvaluationDTO;
 import de.tum.cit.aet.artemis.quiz.dto.submission.QuizSubmissionFromLiveClientDTO;
 import de.tum.cit.aet.artemis.quiz.dto.submission.QuizSubmissionFromStudentDTO;
 import de.tum.cit.aet.artemis.quiz.repository.QuizExerciseRepository;
@@ -107,13 +108,13 @@ public class QuizSubmissionResource {
      */
     @PostMapping("exercises/{exerciseId}/submissions/live")
     @EnforceAtLeastStudentInExercise
-    public ResponseEntity<QuizSubmission> saveOrSubmitForLiveMode(@PathVariable Long exerciseId, @Valid @RequestBody QuizSubmissionFromLiveClientDTO submissionDTO,
-            @RequestParam(name = "submit", defaultValue = "false") boolean submit) {
+    public ResponseEntity<QuizSubmissionBeforeEvaluationDTO> saveOrSubmitForLiveMode(@PathVariable Long exerciseId,
+            @Valid @RequestBody QuizSubmissionFromLiveClientDTO submissionDTO, @RequestParam(name = "submit", defaultValue = "false") boolean submit) {
         log.debug("REST request to save or submit QuizSubmission for live mode for exercise {}", exerciseId);
         String userLogin = SecurityUtils.getCurrentUserLogin().orElseThrow();
         try {
             QuizSubmission updatedQuizSubmission = quizSubmissionService.saveSubmissionForLiveMode(exerciseId, submissionDTO, userLogin, submit);
-            return ResponseEntity.ok(updatedQuizSubmission);
+            return ResponseEntity.ok(QuizSubmissionBeforeEvaluationDTO.of(updatedQuizSubmission));
         }
         catch (QuizSubmissionException e) {
             log.warn("QuizSubmissionException: {} for user {} in quiz {}", e.getMessage(), userLogin, exerciseId);
@@ -228,7 +229,7 @@ public class QuizSubmissionResource {
      */
     @PutMapping("exercises/{exerciseId}/submissions/exam")
     @EnforceAtLeastStudentInExercise
-    public ResponseEntity<QuizSubmission> submitQuizForExam(@PathVariable Long exerciseId, @Valid @RequestBody QuizSubmissionFromLiveClientDTO submissionDTO) {
+    public ResponseEntity<QuizSubmissionBeforeEvaluationDTO> submitQuizForExam(@PathVariable Long exerciseId, @Valid @RequestBody QuizSubmissionFromLiveClientDTO submissionDTO) {
         long start = System.currentTimeMillis();
         log.debug("REST request to submit QuizSubmission for exam for exercise {}", exerciseId);
 
@@ -258,6 +259,6 @@ public class QuizSubmissionResource {
         QuizSubmission updatedQuizSubmission = quizSubmissionService.saveSubmissionForExamMode(quizExercise, quizSubmission, user);
         long end = System.currentTimeMillis();
         log.info("submitQuizForExam took {}ms for exercise {} and user {}", end - start, exerciseId, user.getLogin());
-        return ResponseEntity.ok(updatedQuizSubmission);
+        return ResponseEntity.ok(QuizSubmissionBeforeEvaluationDTO.of(updatedQuizSubmission));
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/quiz/architecture/QuizEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/quiz/architecture/QuizEntityUsageArchitectureTest.java
@@ -18,7 +18,8 @@ class QuizEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitect
     // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getExpectedEntityReturnViolations() {
-        return 3;
+        // remaining: QuizExerciseRetrievalResource#getAllExercisesOnPage returns SearchResultPageDTO<QuizExercise> (outside this slice)
+        return 1;
     }
 
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
@@ -30,6 +31,7 @@ class QuizEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitect
     // TODO: Reduce this to 0 by removing entity references from DTOs
     @Override
     protected int getExpectedDtoEntityFieldViolations() {
+        // remaining: QuizExerciseFromEditorDTO.quizBatches and .quizQuestions expose entity fields (2, outside this slice)
         return 2;
     }
 }


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process/#naming-conventions-for-github-pull-requests).
#### Server
- [x] Important: I implemented the changes with a strong focus on performance and maintainability, following the [server coding guidelines](https://docs.artemis.tum.de/developer/guidelines/server/).
- [x] I strictly followed the principle of data economy for all database calls.
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.tum.de/developer/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.

## Motivation and Context

Continues the quiz module's move away from exposing JPA entities at the REST boundary (API-driven development / reduced entity exposure). The quiz submission endpoints already return DTOs for practice and preview; the two remaining endpoints still returned the raw `QuizSubmission` entity.

## Description

Replaces the raw `QuizSubmission` entity in the **response** of the two remaining quiz submission endpoints with the existing `QuizSubmissionBeforeEvaluationDTO`:

- `POST exercises/{exerciseId}/submissions/live` — `saveOrSubmitForLiveMode`
- `PUT exercises/{exerciseId}/submissions/exam` — `submitQuizForExam`

Both now wrap the saved submission via `QuizSubmissionBeforeEvaluationDTO.of(...)` at the controller boundary. This is a narrow, behavior-preserving change:

- Routes, status codes, the `QuizSubmissionException` → 400 path, and all exam-specific checks (`examSubmissionApi` allowance, test-exam ownership guard, `preventMultipleSubmissions`) are unchanged.
- The service layer stays entity-based; only the response is mapped to a DTO at the boundary (mirroring how practice/preview already work).
- Request bodies were already DTOs (`QuizSubmissionFromLiveClientDTO`) and are untouched.
- The `QuizSubmissionBeforeEvaluationDTO` contains no entity fields and is narrower than the entity (it carries `id`, `submissionExerciseType`, `submitted`, `type`, `submissionDate`, and the submitted answers — no scores or results), which also satisfies data economy for these endpoints. The Angular client reads only these fields, so the change is transparent to it.

The quiz entity-usage architecture-test return-violation threshold is lowered from `3` to `1`. The remaining violation is `QuizExerciseRetrievalResource#getAllExercisesOnPage` (returns `SearchResultPageDTO<QuizExercise>`), which is outside this slice; the two remaining DTO-entity-field violations (`QuizExerciseFromEditorDTO.quizBatches` / `.quizQuestions`) are likewise out of scope and left documented in the test.

This is an intentional **partial** module slice (submission endpoints only). OpenAPI/client regeneration is deferred to a follow-up.

## Steps for Testing

Prerequisites:
- 1 Student, 1 Instructor
- A course with a quiz exercise, and a course with an exam containing a quiz exercise

Live quiz:
1. As Instructor, create and start a quiz exercise in a course.
2. As Student, open the quiz, select answer option(s), and submit.
3. Verify the UI shows the submission as saved/submitted (answers retained, submission time shown) without errors.

Exam quiz:
1. As Instructor, create an exam with a quiz exercise, register the Student, and generate the student exams.
2. As Student, start the exam, answer the quiz question, and let it save / hand in.
3. Verify the answer is saved and the exam can be submitted without errors.

In both cases the submission save/submit must behave exactly as before; only the internal response representation changed.

## Testserver States

Deployment and test-server verification pending (draft).

## Test Coverage

Existing quiz/exam integration tests cover these endpoints and were updated/kept green (`QuizSubmissionIntegrationTest`, `StudentExamIntegrationTest`, `LtiQuizIntegrationTest`, `QuizExerciseIntegrationTest`, `QuizEntityUsageArchitectureTest`). Coverage numbers are left to CI.
