### PR TITLE
`Development`: Migrate foundation module to Angular 21 signals and Vitest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -150,6 +150,7 @@ module.exports = {
         '!<rootDir>/src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.ts', // legacy converter uses Vitest (see vitest.config.ts)
         '!<rootDir>/src/main/webapp/app/programming/shared/entities/build-plan-phases.model.ts', // build-plan-phases model uses Vitest (see vitest.config.ts)
         '!<rootDir>/src/main/webapp/app/programming/shared/programming-exercise-update-timeline/**', // programming exercise update timeline uses Vitest (see vitest.config.ts)
+        '!<rootDir>/src/main/webapp/app/foundation/**', // foundation module uses Vitest (see vitest.config.ts; supersedes the feature-toggle/sort entries above)
         '<rootDir>/src/main/webapp/**/*.ts',
     ],
     // Each entry below excludes a module that has been migrated to Vitest.
@@ -214,6 +215,7 @@ module.exports = {
         '<rootDir>/src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.ts',
         '<rootDir>/src/main/webapp/app/programming/shared/entities/build-plan-phases.model.ts',
         '<rootDir>/src/main/webapp/app/programming/shared/programming-exercise-update-timeline/',
+        '<rootDir>/src/main/webapp/app/foundation/', // foundation module uses Vitest (supersedes the sort entry above)
     ],
     // Global coverage thresholds for Jest. Modules using Vitest (e.g., fileupload) have their own
     // coverage thresholds in vitest.config.ts. Per-module thresholds are enforced by check-client-module-coverage.mjs
@@ -224,7 +226,7 @@ module.exports = {
         global: {
             statements: 83,
             branches: 72.9,
-            functions: 72.5,
+            functions: 71.7, // lowered 72.5 -> 71.7: foundation Jest->Vitest migration moved 41 specs out of Jest scope; measured actual 72.22%, ~0.5pp below per convention
             lines: 84,
         },
     },
@@ -317,6 +319,7 @@ module.exports = {
         '<rootDir>/src/main/webapp/app/programming/shared/services/build-phases-template.service.spec.ts', // migrated to Vitest
         '<rootDir>/src/main/webapp/app/programming/shared/entities/build-plan-phases.model.spec.ts', // migrated to Vitest
         '<rootDir>/src/main/webapp/app/programming/shared/programming-exercise-update-timeline/', // migrated to Vitest
+        '<rootDir>/src/main/webapp/app/foundation/', // foundation module migrated to Vitest (supersedes the feature-toggle/sort entries above)
     ],
     testTimeout: 3000,
     testMatch: ['<rootDir>/src/main/webapp/app/**/*.spec.ts', '<rootDir>/src/test/javascript/spec/**/*.integration.spec.ts'],

--- a/src/main/webapp/app/course/shared/course-title-bar/course-title-bar.component.spec.ts
+++ b/src/main/webapp/app/course/shared/course-title-bar/course-title-bar.component.spec.ts
@@ -118,7 +118,7 @@ describe('CourseTitleBarComponent', () => {
         const titleElement = fixture.debugElement.query(By.css('h5'));
         const translateDirective = titleElement.injector.get(TranslateDirective);
 
-        expect(translateDirective.jhiTranslate).toBe('custom.translation.key');
+        expect(translateDirective.jhiTranslate()).toBe('custom.translation.key');
     });
 
     it('should render content through ng-content', () => {

--- a/src/main/webapp/app/course/sidebar/sidebar.component.spec.ts
+++ b/src/main/webapp/app/course/sidebar/sidebar.component.spec.ts
@@ -107,7 +107,7 @@ describe('SidebarComponent', () => {
         const noDataMessageElement = fixture.debugElement.query(By.css('.scrollable-item-content'));
         expect(noDataMessageElement).toBeTruthy();
         const directiveInstance = noDataMessageElement.injector.get(TranslateDirective);
-        expect(directiveInstance.jhiTranslate).toBe('artemisApp.courseOverview.general.noDataFound');
+        expect(directiveInstance.jhiTranslate()).toBe('artemisApp.courseOverview.general.noDataFound');
     });
 
     it('should give the correct size for exercises', () => {

--- a/src/main/webapp/app/exam/overview/exercises/file-upload/file-upload-exam-submission.component.spec.ts
+++ b/src/main/webapp/app/exam/overview/exercises/file-upload/file-upload-exam-submission.component.spec.ts
@@ -107,8 +107,8 @@ describe('FileUploadExamSubmissionComponent', () => {
             expect(el).not.toBeNull();
 
             const directiveInstance = el.injector.get(TranslateDirective);
-            expect(directiveInstance.jhiTranslate).toBe('artemisApp.examParticipation.points');
-            expect(directiveInstance.translateValues).toEqual({ points: maxScore, bonusPoints: 0 });
+            expect(directiveInstance.jhiTranslate()).toBe('artemisApp.examParticipation.points');
+            expect(directiveInstance.translateValues()).toEqual({ points: maxScore, bonusPoints: 0 });
         });
 
         it('should show exercise bonus score if any', () => {
@@ -121,8 +121,8 @@ describe('FileUploadExamSubmissionComponent', () => {
             expect(el).not.toBeNull();
 
             const directiveInstance = el.injector.get(TranslateDirective);
-            expect(directiveInstance.jhiTranslate).toBe('artemisApp.examParticipation.bonus');
-            expect(directiveInstance.translateValues).toEqual({ points: maxScore, bonusPoints: bonusPoints });
+            expect(directiveInstance.jhiTranslate()).toBe('artemisApp.examParticipation.bonus');
+            expect(directiveInstance.translateValues()).toEqual({ points: maxScore, bonusPoints: bonusPoints });
         });
 
         it('should show problem statement if there is any', () => {

--- a/src/main/webapp/app/exam/overview/exercises/modeling/modeling-exam-submission.component.spec.ts
+++ b/src/main/webapp/app/exam/overview/exercises/modeling/modeling-exam-submission.component.spec.ts
@@ -130,8 +130,8 @@ describe('ModelingExamSubmissionComponent', () => {
             expect(el).not.toBeNull();
 
             const directiveInstance = el.injector.get(TranslateDirective);
-            expect(directiveInstance.jhiTranslate).toBe('artemisApp.examParticipation.points');
-            expect(directiveInstance.translateValues).toEqual({ points: maxScore, bonusPoints: 0 });
+            expect(directiveInstance.jhiTranslate()).toBe('artemisApp.examParticipation.points');
+            expect(directiveInstance.translateValues()).toEqual({ points: maxScore, bonusPoints: 0 });
         });
 
         it('should show exercise bonus score if any', () => {
@@ -144,8 +144,8 @@ describe('ModelingExamSubmissionComponent', () => {
             expect(el).not.toBeNull();
 
             const directiveInstance = el.injector.get(TranslateDirective);
-            expect(directiveInstance.jhiTranslate).toBe('artemisApp.examParticipation.bonus');
-            expect(directiveInstance.translateValues).toEqual({ points: maxScore, bonusPoints: bonusPoints });
+            expect(directiveInstance.jhiTranslate()).toBe('artemisApp.examParticipation.bonus');
+            expect(directiveInstance.translateValues()).toEqual({ points: maxScore, bonusPoints: bonusPoints });
         });
 
         it('should call triggerSave if save exercise button is clicked', () => {

--- a/src/main/webapp/app/foundation/auth/has-any-authority.directive.spec.ts
+++ b/src/main/webapp/app/foundation/auth/has-any-authority.directive.spec.ts
@@ -1,0 +1,121 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { AccountService } from 'app/core/auth/account.service';
+import { User } from 'app/account/user/user.model';
+import { Authority } from 'app/foundation/constants/authority.constants';
+import { HasAnyAuthorityDirective } from 'app/foundation/auth/has-any-authority.directive';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+@Component({
+    template: `<div *jhiHasAnyAuthority="[Authority.ADMIN]" id="guarded">secret</div>`,
+    imports: [HasAnyAuthorityDirective],
+})
+class HostComponent {
+    protected readonly Authority = Authority;
+}
+
+/**
+ * Minimal AccountService stand-in that faithfully reproduces the runtime behaviour relevant to the directive:
+ *  - `getAuthenticationState()` returns a `BehaviorSubject` that synchronously replays its current value on subscribe.
+ *  - `hasAnyAuthorityDirect()` mirrors the real implementation, including the `authorities.length` dereference that
+ *    throws a `TypeError` when `authorities` is `undefined` for an already-authenticated user.
+ */
+class MockAccountService {
+    readonly authenticationState: BehaviorSubject<User | undefined>;
+
+    constructor(user: User | undefined) {
+        this.authenticationState = new BehaviorSubject<User | undefined>(user);
+    }
+
+    getAuthenticationState(): Observable<User | undefined> {
+        return this.authenticationState.asObservable();
+    }
+
+    private currentUser(): User | undefined {
+        return this.authenticationState.getValue();
+    }
+
+    authenticated(): boolean {
+        return !!this.currentUser();
+    }
+
+    userIdentity(): User | undefined {
+        return this.currentUser();
+    }
+
+    hasAnyAuthority(authorities: readonly Authority[]): Promise<boolean> {
+        return Promise.resolve(this.hasAnyAuthorityDirect(authorities));
+    }
+
+    // Faithful copy of AccountService.hasAnyAuthorityDirect so the spec exercises the exact code path that crashed.
+    hasAnyAuthorityDirect(authorities: readonly Authority[]): boolean {
+        const user = this.currentUser();
+        if (!user || !user.authorities) {
+            return false;
+        }
+        for (let i = 0; i < authorities.length; i++) {
+            if (user.authorities.includes(authorities[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+function userWithAuthorities(authorities: string[]): User {
+    return { id: 99, login: 'admin', authorities } as User;
+}
+
+describe('HasAnyAuthorityDirective', () => {
+    setupTestBed({ zoneless: true });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    async function configure(user: User | undefined): Promise<MockAccountService> {
+        const mock = new MockAccountService(user);
+        await TestBed.configureTestingModule({
+            imports: [HostComponent],
+            providers: [{ provide: AccountService, useValue: mock }],
+        }).compileComponents();
+        return mock;
+    }
+
+    it('does not throw when created while already authenticated', async () => {
+        // Authentication state already holds a user BEFORE the host (and thus the directive) is created.
+        // The directive's constructor subscription replays this value synchronously, calling updateView() before
+        // the input effect has populated `authorities`. With `authorities` initialised to [] this is harmless;
+        // without that initialisation, hasAnyAuthorityDirect(undefined) dereferences `undefined.length` and throws.
+        await configure(userWithAuthorities([Authority.ADMIN]));
+
+        expect(() => {
+            const fixture = TestBed.createComponent(HostComponent);
+            fixture.detectChanges();
+        }).not.toThrow();
+    });
+
+    it('renders the element when the user has the authority', async () => {
+        await configure(userWithAuthorities([Authority.ADMIN]));
+
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('#guarded')).toBeTruthy();
+    });
+
+    it('hides the element when the user lacks the authority', async () => {
+        await configure(userWithAuthorities([Authority.STUDENT]));
+
+        const fixture = TestBed.createComponent(HostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('#guarded')).toBeNull();
+    });
+});

--- a/src/main/webapp/app/foundation/auth/has-any-authority.directive.ts
+++ b/src/main/webapp/app/foundation/auth/has-any-authority.directive.ts
@@ -1,4 +1,5 @@
-import { Directive, TemplateRef, ViewContainerRef, effect, inject, input } from '@angular/core';
+import { DestroyRef, Directive, TemplateRef, ViewContainerRef, effect, inject, input } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AccountService } from 'app/core/auth/account.service';
 import { Authority } from 'app/foundation/constants/authority.constants';
 
@@ -18,19 +19,25 @@ export class HasAnyAuthorityDirective {
     private accountService = inject(AccountService);
     private templateRef = inject<TemplateRef<any>>(TemplateRef);
     private viewContainerRef = inject(ViewContainerRef);
+    private readonly destroyRef = inject(DestroyRef);
 
     readonly jhiHasAnyAuthority = input.required<string | string[] | readonly Authority[]>();
 
     private authorities: readonly Authority[];
 
     constructor() {
+        // Re-derive the authorities and re-render whenever the input changes.
         effect(() => {
             const value = this.jhiHasAnyAuthority();
             this.authorities = typeof value === 'string' ? [value as Authority] : (value as readonly Authority[]);
             this.updateView();
-            // Get notified each time authentication state changes.
-            this.accountService.getAuthenticationState().subscribe(() => this.updateView());
         });
+        // Get notified each time authentication state changes. Subscribe exactly once so the subscription is not
+        // re-created on every input change (the authentication state observable never completes).
+        this.accountService
+            .getAuthenticationState()
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe(() => this.updateView());
     }
 
     private updateView(): void {

--- a/src/main/webapp/app/foundation/auth/has-any-authority.directive.ts
+++ b/src/main/webapp/app/foundation/auth/has-any-authority.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, TemplateRef, ViewContainerRef, inject } from '@angular/core';
+import { Directive, TemplateRef, ViewContainerRef, effect, inject, input } from '@angular/core';
 import { AccountService } from 'app/core/auth/account.service';
 import { Authority } from 'app/foundation/constants/authority.constants';
 
@@ -19,14 +19,18 @@ export class HasAnyAuthorityDirective {
     private templateRef = inject<TemplateRef<any>>(TemplateRef);
     private viewContainerRef = inject(ViewContainerRef);
 
+    readonly jhiHasAnyAuthority = input.required<string | string[] | readonly Authority[]>();
+
     private authorities: readonly Authority[];
 
-    @Input()
-    set jhiHasAnyAuthority(value: string | string[] | readonly Authority[]) {
-        this.authorities = typeof value === 'string' ? [value as Authority] : (value as readonly Authority[]);
-        this.updateView();
-        // Get notified each time authentication state changes.
-        this.accountService.getAuthenticationState().subscribe(() => this.updateView());
+    constructor() {
+        effect(() => {
+            const value = this.jhiHasAnyAuthority();
+            this.authorities = typeof value === 'string' ? [value as Authority] : (value as readonly Authority[]);
+            this.updateView();
+            // Get notified each time authentication state changes.
+            this.accountService.getAuthenticationState().subscribe(() => this.updateView());
+        });
     }
 
     private updateView(): void {

--- a/src/main/webapp/app/foundation/auth/has-any-authority.directive.ts
+++ b/src/main/webapp/app/foundation/auth/has-any-authority.directive.ts
@@ -23,7 +23,7 @@ export class HasAnyAuthorityDirective {
 
     readonly jhiHasAnyAuthority = input.required<string | string[] | readonly Authority[]>();
 
-    private authorities: readonly Authority[];
+    private authorities: readonly Authority[] = [];
 
     constructor() {
         // Re-derive the authorities and re-render whenever the input changes.

--- a/src/main/webapp/app/foundation/extension-point/extension-point.directive.ts
+++ b/src/main/webapp/app/foundation/extension-point/extension-point.directive.ts
@@ -60,7 +60,9 @@ export class ExtensionPointDirective {
                     }
 
                     this.viewRef = extensionPoint ? viewContainerRef.createEmbeddedView(extensionPoint, context) : viewContainerRef.createEmbeddedView(this.templateRef, context);
-                } else if (this.viewRef && context) {
+                } else if (this.viewRef) {
+                    // Propagate the new context even when it is falsy, so resetting jhiExtensionPointContext clears
+                    // the previously rendered context instead of leaving the stale one attached.
                     this.viewRef.context = context;
                 }
             });

--- a/src/main/webapp/app/foundation/extension-point/extension-point.directive.ts
+++ b/src/main/webapp/app/foundation/extension-point/extension-point.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, EmbeddedViewRef, Input, OnChanges, SimpleChanges, TemplateRef, ViewContainerRef, inject } from '@angular/core';
+import { Directive, EmbeddedViewRef, TemplateRef, ViewContainerRef, effect, inject, input, untracked } from '@angular/core';
 
 /**
  * @whatItDoes marks parts of a (parent) template as extendable to allow other (child) components to override them.
@@ -14,7 +14,7 @@ import { Directive, EmbeddedViewRef, Input, OnChanges, SimpleChanges, TemplateRe
  * </div>
  *
  * parent typescript:
- * @ContentChild('overrideId') overrideAttribute: TemplateRef<any>;
+ * \@ContentChild('overrideId') overrideAttribute: TemplateRef<any>;
  *
  * child template:
  * <parent-selector>
@@ -26,28 +26,44 @@ import { Directive, EmbeddedViewRef, Input, OnChanges, SimpleChanges, TemplateRe
  * produces a child component looking exactly like the parent component but with the marked element overridden
  */
 @Directive({ selector: '[jhiExtensionPoint]' })
-export class ExtensionPointDirective implements OnChanges {
+export class ExtensionPointDirective {
     private viewContainerRef = inject(ViewContainerRef);
     private templateRef = inject<TemplateRef<any>>(TemplateRef);
 
     private viewRef: EmbeddedViewRef<any> | undefined = undefined;
 
-    @Input() public jhiExtensionPoint: TemplateRef<any> | undefined = undefined;
-    @Input() public jhiExtensionPointContext?: any = undefined;
+    readonly jhiExtensionPoint = input<TemplateRef<any> | undefined>(undefined);
+    readonly jhiExtensionPointContext = input<any>(undefined);
 
-    ngOnChanges(changes: SimpleChanges) {
-        if (changes['jhiExtensionPoint']) {
-            const viewContainerRef = this.viewContainerRef;
+    // Tracks whether jhiExtensionPoint has ever been processed, so the effect can distinguish a genuine change
+    // of the override template (which recreates the view) from a context-only change (which only updates the
+    // existing view's context) — reproducing the change-discrimination the previous ngOnChanges performed.
+    private extensionPointInitialized = false;
+    private lastExtensionPoint: TemplateRef<any> | undefined = undefined;
 
-            if (this.viewRef) {
-                viewContainerRef.remove(viewContainerRef.indexOf(this.viewRef));
-            }
+    constructor() {
+        effect(() => {
+            const extensionPoint = this.jhiExtensionPoint();
+            const context = this.jhiExtensionPointContext();
 
-            this.viewRef = this.jhiExtensionPoint
-                ? viewContainerRef.createEmbeddedView(this.jhiExtensionPoint, this.jhiExtensionPointContext)
-                : viewContainerRef.createEmbeddedView(this.templateRef, this.jhiExtensionPointContext);
-        } else if (this.viewRef && changes['jhiExtensionPointContext'] && this.jhiExtensionPointContext) {
-            this.viewRef.context = this.jhiExtensionPointContext;
-        }
+            untracked(() => {
+                const extensionPointChanged = !this.extensionPointInitialized || extensionPoint !== this.lastExtensionPoint;
+
+                if (extensionPointChanged) {
+                    this.extensionPointInitialized = true;
+                    this.lastExtensionPoint = extensionPoint;
+
+                    const viewContainerRef = this.viewContainerRef;
+
+                    if (this.viewRef) {
+                        viewContainerRef.remove(viewContainerRef.indexOf(this.viewRef));
+                    }
+
+                    this.viewRef = extensionPoint ? viewContainerRef.createEmbeddedView(extensionPoint, context) : viewContainerRef.createEmbeddedView(this.templateRef, context);
+                } else if (this.viewRef && context) {
+                    this.viewRef.context = context;
+                }
+            });
+        });
     }
 }

--- a/src/main/webapp/app/foundation/language/translate.directive.spec.ts
+++ b/src/main/webapp/app/foundation/language/translate.directive.spec.ts
@@ -1,8 +1,10 @@
-import { Component } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 @Component({
     template: '<div jhiTranslate="test"></div>',
@@ -11,17 +13,18 @@ import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.
 class TestTranslateDirectiveComponent {}
 
 @Component({
-    template: '<div [jhiTranslate]="key"></div>',
+    template: '<div [jhiTranslate]="key()"></div>',
     imports: [TranslateDirective],
 })
 class TestDynamicKeyTranslateDirectiveComponent {
-    key?: string;
+    key = signal<string | undefined>(undefined);
 }
 
 describe('TranslateDirective', () => {
-    let fixture: ComponentFixture<TestTranslateDirectiveComponent>;
+    setupTestBed({ zoneless: true });
+
     let translateService: TranslateService;
-    let spy: jest.SpyInstance;
+    let spy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
@@ -30,11 +33,16 @@ describe('TranslateDirective', () => {
         }).compileComponents();
 
         translateService = TestBed.inject(TranslateService);
-        spy = jest.spyOn(translateService, 'get');
-        fixture = TestBed.createComponent(TestTranslateDirectiveComponent);
+        spy = vi.spyOn(translateService, 'get');
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it('should change HTML', () => {
+        // Created inside the test so its directive effect is not flushed by other tests' change detection (zoneless ApplicationRef.tick is global).
+        const fixture = TestBed.createComponent(TestTranslateDirectiveComponent);
         fixture.detectChanges();
 
         expect(spy).toHaveBeenCalledWith('test', undefined);
@@ -42,7 +50,7 @@ describe('TranslateDirective', () => {
 
     it.each([undefined, ''])('should not call translateService.get for an empty key (%p) and should clear the element', (key) => {
         const dynamicFixture = TestBed.createComponent(TestDynamicKeyTranslateDirectiveComponent);
-        dynamicFixture.componentInstance.key = key;
+        dynamicFixture.componentInstance.key.set(key);
         const element: HTMLElement = dynamicFixture.nativeElement.querySelector('div');
         element.textContent = 'stale';
 
@@ -54,11 +62,11 @@ describe('TranslateDirective', () => {
 
     it('should translate once a previously empty key becomes non-empty', () => {
         const dynamicFixture = TestBed.createComponent(TestDynamicKeyTranslateDirectiveComponent);
-        dynamicFixture.componentInstance.key = undefined;
+        dynamicFixture.componentInstance.key.set(undefined);
         dynamicFixture.detectChanges();
         expect(spy).not.toHaveBeenCalled();
 
-        dynamicFixture.componentInstance.key = 'test';
+        dynamicFixture.componentInstance.key.set('test');
         dynamicFixture.detectChanges();
         expect(spy).toHaveBeenCalledWith('test', undefined);
     });

--- a/src/main/webapp/app/foundation/language/translate.directive.ts
+++ b/src/main/webapp/app/foundation/language/translate.directive.ts
@@ -62,7 +62,9 @@ export class TranslateDirective implements OnInit, OnDestroy {
                 next: (value) => {
                     this.el.nativeElement.innerHTML = value;
                 },
-                error: () => `${translationNotFoundMessage}[${key}]`,
+                error: () => {
+                    this.el.nativeElement.textContent = `${translationNotFoundMessage}[${key}]`;
+                },
             });
     }
 }

--- a/src/main/webapp/app/foundation/language/translate.directive.ts
+++ b/src/main/webapp/app/foundation/language/translate.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Input, OnChanges, OnDestroy, OnInit, inject } from '@angular/core';
+import { Directive, ElementRef, OnDestroy, OnInit, effect, inject, input } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { translationNotFoundMessage } from 'app/core/config/translation.config';
 import { Subject } from 'rxjs';
@@ -10,14 +10,24 @@ import { takeUntil } from 'rxjs/operators';
 @Directive({
     selector: '[jhiTranslate]',
 })
-export class TranslateDirective implements OnChanges, OnInit, OnDestroy {
+export class TranslateDirective implements OnInit, OnDestroy {
     private el = inject(ElementRef);
     private translateService = inject(TranslateService);
 
-    @Input() jhiTranslate!: string;
-    @Input() translateValues?: { [key: string]: unknown };
+    readonly jhiTranslate = input<string>();
+    readonly translateValues = input<{ [key: string]: unknown }>();
 
     private readonly directiveDestroyed = new Subject<void>();
+
+    constructor() {
+        // Re-translate whenever the key or the interpolation values change (replaces ngOnChanges).
+        effect(() => {
+            // Track both inputs so the effect re-runs on either change.
+            this.jhiTranslate();
+            this.translateValues();
+            this.getTranslation();
+        });
+    }
 
     ngOnInit(): void {
         this.translateService.onLangChange.pipe(takeUntil(this.directiveDestroyed)).subscribe(() => {
@@ -28,34 +38,31 @@ export class TranslateDirective implements OnChanges, OnInit, OnDestroy {
         });
     }
 
-    ngOnChanges() {
-        this.getTranslation();
-    }
-
     ngOnDestroy(): void {
         this.directiveDestroyed.next();
         this.directiveDestroyed.complete();
     }
 
     private getTranslation(): void {
+        const key = this.jhiTranslate();
         // ngx-translate's get() throws synchronously ('Parameter "key" is required and cannot be empty') when the
         // key is empty or undefined. Because it throws before returning the Observable, the error handler below
         // never sees it — the exception escapes ngOnChanges/ngOnInit during change detection. A binding such as
         // [jhiTranslate]="someValue" can legitimately evaluate to undefined for a tick before its backing value
         // is assigned (or to '' via a `?? ''` fallback), so treat an empty key as "nothing to translate" and
         // clear the element instead of letting the throw spam the console and abort the surrounding view's render.
-        if (!this.jhiTranslate) {
+        if (!key) {
             this.el.nativeElement.textContent = '';
             return;
         }
         this.translateService
-            .get(this.jhiTranslate, this.translateValues)
+            .get(key, this.translateValues())
             .pipe(takeUntil(this.directiveDestroyed))
             .subscribe({
                 next: (value) => {
                     this.el.nativeElement.innerHTML = value;
                 },
-                error: () => `${translationNotFoundMessage}[${this.jhiTranslate}]`,
+                error: () => `${translationNotFoundMessage}[${key}]`,
             });
     }
 }

--- a/src/main/webapp/app/foundation/pagination/item-count.component.spec.ts
+++ b/src/main/webapp/app/foundation/pagination/item-count.component.spec.ts
@@ -2,65 +2,66 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { ItemCountComponent } from 'app/foundation/pagination/item-count.component';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('ItemCountComponent test', () => {
+    setupTestBed({ zoneless: true });
+
     let comp: ItemCountComponent;
     let fixture: ComponentFixture<ItemCountComponent>;
 
-    beforeEach(() => {
-        TestBed.configureTestingModule({
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
             imports: [TranslateModule.forRoot(), TranslateDirective],
-        })
-            .compileComponents()
-            .then(() => {
-                fixture = TestBed.createComponent(ItemCountComponent);
-                comp = fixture.componentInstance;
-            });
+        }).compileComponents();
+        fixture = TestBed.createComponent(ItemCountComponent);
+        comp = fixture.componentInstance;
     });
 
     describe('UI logic tests', () => {
         it('should initialize with zero', () => {
-            expect(comp.itemRangeBegin).toBe(0);
-            expect(comp.itemRangeEnd).toBe(0);
-            expect(comp.itemTotal).toBe(0);
+            expect(comp.itemRangeBegin()).toBe(0);
+            expect(comp.itemRangeEnd()).toBe(0);
+            expect(comp.itemTotal()).toBe(0);
         });
 
         it('should set range from 0 to 0, total 0 if there are no elements', () => {
             // GIVEN
-            comp.params = { page: 1, totalItems: 0, itemsPerPage: 10 };
+            fixture.componentRef.setInput('params', { page: 1, totalItems: 0, itemsPerPage: 10 });
 
             // THEN
-            expect(comp.itemRangeBegin).toBe(0);
-            expect(comp.itemRangeEnd).toBe(0);
-            expect(comp.itemTotal).toBe(0);
+            expect(comp.itemRangeBegin()).toBe(0);
+            expect(comp.itemRangeEnd()).toBe(0);
+            expect(comp.itemTotal()).toBe(0);
         });
 
         it('should change the content on page change', () => {
             // GIVEN
-            comp.params = { page: 1, totalItems: 100, itemsPerPage: 10 };
+            fixture.componentRef.setInput('params', { page: 1, totalItems: 100, itemsPerPage: 10 });
 
             // THEN
-            expect(comp.itemRangeBegin).toBe(1);
-            expect(comp.itemRangeEnd).toBe(10);
-            expect(comp.itemTotal).toBe(100);
+            expect(comp.itemRangeBegin()).toBe(1);
+            expect(comp.itemRangeEnd()).toBe(10);
+            expect(comp.itemTotal()).toBe(100);
 
             // GIVEN
-            comp.params = { page: 2, totalItems: 100, itemsPerPage: 10 };
+            fixture.componentRef.setInput('params', { page: 2, totalItems: 100, itemsPerPage: 10 });
 
             // THEN
-            expect(comp.itemRangeBegin).toBe(11);
-            expect(comp.itemRangeEnd).toBe(20);
-            expect(comp.itemTotal).toBe(100);
+            expect(comp.itemRangeBegin()).toBe(11);
+            expect(comp.itemRangeEnd()).toBe(20);
+            expect(comp.itemTotal()).toBe(100);
         });
 
         it('should set the second number to totalItems if this is the last page which contains less than itemsPerPage items', () => {
             // GIVEN
-            comp.params = { page: 2, totalItems: 16, itemsPerPage: 10 };
+            fixture.componentRef.setInput('params', { page: 2, totalItems: 16, itemsPerPage: 10 });
 
             // THEN
-            expect(comp.itemRangeBegin).toBe(11);
-            expect(comp.itemRangeEnd).toBe(16);
-            expect(comp.itemTotal).toBe(16);
+            expect(comp.itemRangeBegin()).toBe(11);
+            expect(comp.itemRangeEnd()).toBe(16);
+            expect(comp.itemTotal()).toBe(16);
         });
     });
 });

--- a/src/main/webapp/app/foundation/pagination/item-count.component.ts
+++ b/src/main/webapp/app/foundation/pagination/item-count.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 
 /**
@@ -6,23 +6,33 @@ import { TranslateDirective } from 'app/foundation/language/translate.directive'
  */
 @Component({
     selector: 'jhi-item-count',
-    template: ` <div jhiTranslate="global.item-count" [translateValues]="{ first: itemRangeBegin, second: itemRangeEnd, total: itemTotal }"></div> `,
+    template: ` <div jhiTranslate="global.item-count" [translateValues]="{ first: itemRangeBegin(), second: itemRangeEnd(), total: itemTotal() }"></div> `,
     imports: [TranslateDirective],
 })
 export class ItemCountComponent {
     /**
-     * @param params  Contains parameters for component:
-     *                    page          Current page number
-     *                    totalItems    Total number of items
-     *                    itemsPerPage  Number of items per page
+     * Contains parameters for component:
+     *   page          Current page number
+     *   totalItems    Total number of items
+     *   itemsPerPage  Number of items per page
      */
-    @Input() set params(params: { page: number; totalItems: number; itemsPerPage: number }) {
-        this.itemRangeBegin = params.totalItems === 0 ? 0 : (params.page - 1) * params.itemsPerPage + 1;
-        this.itemRangeEnd = Math.min(params.page * params.itemsPerPage, params.totalItems);
-        this.itemTotal = params.totalItems;
-    }
+    readonly params = input<{ page: number; totalItems: number; itemsPerPage: number }>();
 
-    itemRangeBegin = 0;
-    itemRangeEnd = 0;
-    itemTotal = 0;
+    readonly itemRangeBegin = computed(() => {
+        const params = this.params();
+        if (!params) {
+            return 0;
+        }
+        return params.totalItems === 0 ? 0 : (params.page - 1) * params.itemsPerPage + 1;
+    });
+
+    readonly itemRangeEnd = computed(() => {
+        const params = this.params();
+        if (!params) {
+            return 0;
+        }
+        return Math.min(params.page * params.itemsPerPage, params.totalItems);
+    });
+
+    readonly itemTotal = computed(() => this.params()?.totalItems ?? 0);
 }

--- a/src/main/webapp/app/foundation/pipes/artemis-date.pipe.spec.ts
+++ b/src/main/webapp/app/foundation/pipes/artemis-date.pipe.spec.ts
@@ -7,7 +7,7 @@ import 'dayjs/esm/locale/en';
 import 'dayjs/esm/locale/de';
 import { ArtemisDatePipe } from 'app/foundation/pipes/artemis-date.pipe';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
-import { beforeEach, describe, expect, it, test } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 const GERMAN_SHORT_DATE_FORMAT = 'DD. MMM. YYYY';

--- a/src/main/webapp/app/foundation/pipes/artemis-date.pipe.spec.ts
+++ b/src/main/webapp/app/foundation/pipes/artemis-date.pipe.spec.ts
@@ -1,12 +1,19 @@
 import { TestBed } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import dayjs from 'dayjs/esm';
+// Register the locales used in this spec. Under Jest these were loaded transitively via the global
+// setup importing 'app/core/config/dayjs'; the Vitest setup does not, so import them explicitly here.
+import 'dayjs/esm/locale/en';
+import 'dayjs/esm/locale/de';
 import { ArtemisDatePipe } from 'app/foundation/pipes/artemis-date.pipe';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
+import { beforeEach, describe, expect, it, test } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 const GERMAN_SHORT_DATE_FORMAT = 'DD. MMM. YYYY';
 
 describe('ArtemisDatePipe', () => {
+    setupTestBed({ zoneless: true });
     let pipe: ArtemisDatePipe;
     let translateService: TranslateService;
     const dateTime = dayjs().year(2020).month(3).date(14).hour(9).minute(27).second(3); // 2020-03-14 09:27:03

--- a/src/main/webapp/app/foundation/pipes/artemis-duration-from-seconds.pipe.spec.ts
+++ b/src/main/webapp/app/foundation/pipes/artemis-duration-from-seconds.pipe.spec.ts
@@ -1,6 +1,9 @@
 import { ArtemisDurationFromSecondsPipe } from 'app/foundation/pipes/artemis-duration-from-seconds.pipe';
+import { describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('ArtemisDurationFromSecondsPipe', () => {
+    setupTestBed({ zoneless: true });
     const pipe: ArtemisDurationFromSecondsPipe = new ArtemisDurationFromSecondsPipe();
 
     describe('long format', () => {

--- a/src/main/webapp/app/foundation/pipes/artemis-time-ago.pipe.spec.ts
+++ b/src/main/webapp/app/foundation/pipes/artemis-time-ago.pipe.spec.ts
@@ -1,15 +1,23 @@
 import { ArtemisTimeAgoPipe } from 'app/foundation/pipes/artemis-time-ago.pipe';
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { ChangeDetectorRef } from '@angular/core';
 import dayjs from 'dayjs/esm';
+// Register the locales used in this spec. Under Jest these were loaded transitively via the global
+// setup importing 'app/core/config/dayjs'; the Vitest setup does not, so import them explicitly here.
+import 'dayjs/esm/locale/en';
+import 'dayjs/esm/locale/de';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { provideHttpClient } from '@angular/common/http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('ArtemisTimeAgoPipe', () => {
+    setupTestBed({ zoneless: true });
+
     let pipe: ArtemisTimeAgoPipe;
     let translateService: TranslateService;
-    const cdRef = { markForCheck: jest.fn() } as any as ChangeDetectorRef;
+    const cdRef = { markForCheck: vi.fn() } as any as ChangeDetectorRef;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -18,6 +26,10 @@ describe('ArtemisTimeAgoPipe', () => {
         translateService = TestBed.inject(TranslateService);
         translateService.use('en');
         pipe = TestBed.inject(ArtemisTimeAgoPipe);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it.each([
@@ -34,16 +46,21 @@ describe('ArtemisTimeAgoPipe', () => {
         });
     });
 
-    it('updates the output automatically as time passes, but removes the timer after destroy', fakeAsync(() => {
-        const time = dayjs().subtract(60, 'seconds');
-        expect(pipe.transform(time)).toBe('a minute ago');
-        expect(cdRef.markForCheck).not.toHaveBeenCalled();
-        tick(30000);
-        expect(cdRef.markForCheck).toHaveBeenCalledOnce();
-        expect(pipe.transform(time)).toBe('2 minutes ago');
+    it('updates the output automatically as time passes, but removes the timer after destroy', async () => {
+        vi.useFakeTimers();
+        try {
+            const time = dayjs().subtract(60, 'seconds');
+            expect(pipe.transform(time)).toBe('a minute ago');
+            expect(cdRef.markForCheck).not.toHaveBeenCalled();
+            await vi.advanceTimersByTimeAsync(30000);
+            expect(cdRef.markForCheck).toHaveBeenCalledOnce();
+            expect(pipe.transform(time)).toBe('2 minutes ago');
 
-        pipe.ngOnDestroy();
-        tick(30000);
-        expect(cdRef.markForCheck).toHaveBeenCalledOnce(); // not a second time
-    }));
+            pipe.ngOnDestroy();
+            await vi.advanceTimersByTimeAsync(30000);
+            expect(cdRef.markForCheck).toHaveBeenCalledOnce(); // not a second time
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 });

--- a/src/main/webapp/app/foundation/pipes/feedback-content.pipe.spec.ts
+++ b/src/main/webapp/app/foundation/pipes/feedback-content.pipe.spec.ts
@@ -2,8 +2,11 @@ import { TestBed } from '@angular/core/testing';
 import { FeedbackContentPipe } from 'app/foundation/pipes/feedback-content.pipe';
 import { Feedback } from 'app/assessment/shared/entities/feedback.model';
 import { GradingInstruction } from 'app/exercise/structured-grading-criterion/grading-instruction.model';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('FeedbackContentPipe', () => {
+    setupTestBed({ zoneless: true });
     let pipe: FeedbackContentPipe;
 
     beforeEach(() => {

--- a/src/main/webapp/app/foundation/pipes/grade-step-bounds.pipe.spec.ts
+++ b/src/main/webapp/app/foundation/pipes/grade-step-bounds.pipe.spec.ts
@@ -1,8 +1,11 @@
 import { GradeStep } from 'app/assessment/shared/entities/grade-step.model';
 import { GradeStepBoundsPipe } from 'app/foundation/pipes/grade-step-bounds.pipe';
 import { GradeEditMode } from 'app/assessment/manage/grading/grading.component';
+import { describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('GradeStepBoundsPipe', () => {
+    setupTestBed({ zoneless: true });
     const pipe = new GradeStepBoundsPipe();
 
     it('should format non-last step percentage', () => {

--- a/src/main/webapp/app/foundation/pipes/quote.pipe.spec.ts
+++ b/src/main/webapp/app/foundation/pipes/quote.pipe.spec.ts
@@ -1,7 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { QuotePipe } from 'app/foundation/pipes/quote.pipe';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('QuotePipe', () => {
+    setupTestBed({ zoneless: true });
     let pipe: QuotePipe;
 
     beforeEach(() => {

--- a/src/main/webapp/app/foundation/pipes/reacting-users-on-posting.pipe.spec.ts
+++ b/src/main/webapp/app/foundation/pipes/reacting-users-on-posting.pipe.spec.ts
@@ -1,86 +1,87 @@
 import { HtmlForPostingMarkdownPipe } from 'app/foundation/pipes/html-for-posting-markdown.pipe';
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { PLACEHOLDER_USER_REACTED, ReactingUsersOnPostingPipe } from 'app/foundation/pipes/reacting-users-on-posting.pipe';
 import { TranslateService } from '@ngx-translate/core';
 import { metisTutor, metisUser1, metisUser2 } from 'test/helpers/sample/metis-sample-data';
 import { MockPipe } from 'ng-mocks';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('ReactingUsersOnPostingsPipe', () => {
+    setupTestBed({ zoneless: true });
+
     let reactingUsersPipe: ReactingUsersOnPostingPipe;
     let translateService: TranslateService;
-    let updateReactingUsersStringSpy: jest.SpyInstance;
+    let updateReactingUsersStringSpy: ReturnType<typeof vi.spyOn>;
     let transformedStringWithReactingUsers: string;
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             imports: [MockPipe(HtmlForPostingMarkdownPipe)],
             providers: [ReactingUsersOnPostingPipe, { provide: TranslateService, useClass: MockTranslateService }],
-        })
-            .compileComponents()
-            .then(() => {
-                translateService = TestBed.inject(TranslateService);
-                reactingUsersPipe = TestBed.inject(ReactingUsersOnPostingPipe);
-                updateReactingUsersStringSpy = jest.spyOn(reactingUsersPipe as any, 'updateReactingUsersString');
-            });
+        }).compileComponents();
+        translateService = TestBed.inject(TranslateService);
+        reactingUsersPipe = TestBed.inject(ReactingUsersOnPostingPipe);
+        updateReactingUsersStringSpy = vi.spyOn(reactingUsersPipe as any, 'updateReactingUsersString');
     });
 
     afterEach(() => {
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
     });
 
-    it('should return string for one user that is not "you"', fakeAsync(() => {
+    it('should return string for one user that is not "you"', async () => {
         const reactingUsers = [metisUser1.name!];
         reactingUsersPipe.transform(reactingUsers).subscribe((transformedReactingUsers: string) => {
             transformedStringWithReactingUsers = transformedReactingUsers;
         });
-        tick();
+        await Promise.resolve();
         expect(transformedStringWithReactingUsers).toBe(metisUser1.name + 'artemisApp.metis.reactedTooltip');
         expect(updateReactingUsersStringSpy).toHaveBeenCalledOnce();
-    }));
+    });
 
-    it('should return string for one user that is "you"', fakeAsync(() => {
+    it('should return string for one user that is "you"', async () => {
         reactingUsersPipe.transform([PLACEHOLDER_USER_REACTED]).subscribe((transformedReactingUsers: string) => {
             transformedStringWithReactingUsers = transformedReactingUsers;
         });
-        tick();
+        await Promise.resolve();
         expect(transformedStringWithReactingUsers).toBe('artemisApp.metis.you');
         expect(updateReactingUsersStringSpy).toHaveBeenCalledOnce();
-    }));
+    });
 
-    it('should return string for two users that do not include "you"', fakeAsync(() => {
+    it('should return string for two users that do not include "you"', async () => {
         const reactingUsers = [metisUser1.name!, metisUser2.name!];
         reactingUsersPipe.transform(reactingUsers).subscribe((transformedReactingUsers: string) => {
             transformedStringWithReactingUsers = transformedReactingUsers;
         });
-        tick();
+        await Promise.resolve();
         expect(transformedStringWithReactingUsers).toBe(metisUser1.name! + 'artemisApp.metis.and' + metisUser2.name! + 'artemisApp.metis.reactedTooltip');
         expect(updateReactingUsersStringSpy).toHaveBeenCalledOnce();
-    }));
+    });
 
-    it('should return string for two users that do include "you"', fakeAsync(() => {
+    it('should return string for two users that do include "you"', async () => {
         const reactingUsers = [metisUser1.name!, PLACEHOLDER_USER_REACTED];
         reactingUsersPipe.transform(reactingUsers).subscribe((transformedReactingUsers: string) => {
             transformedStringWithReactingUsers = transformedReactingUsers;
         });
-        tick();
+        await Promise.resolve();
         expect(transformedStringWithReactingUsers).toBe('artemisApp.metis.you' + 'artemisApp.metis.and' + metisUser1.name! + 'artemisApp.metis.reactedTooltip');
         expect(updateReactingUsersStringSpy).toHaveBeenCalledOnce();
-    }));
+    });
 
-    it('should return string for three users that do include "you" and separate the first two users with comma', fakeAsync(() => {
+    it('should return string for three users that do include "you" and separate the first two users with comma', async () => {
         const reactingUsers = [metisUser1.name!, PLACEHOLDER_USER_REACTED, metisTutor.name!];
         reactingUsersPipe.transform(reactingUsers).subscribe((transformedReactingUsers: string) => {
             transformedStringWithReactingUsers = transformedReactingUsers;
         });
-        tick();
+        await Promise.resolve();
         expect(transformedStringWithReactingUsers).toBe(
             'artemisApp.metis.you' + ', ' + metisUser1.name! + 'artemisApp.metis.and' + metisTutor.name! + 'artemisApp.metis.reactedTooltip',
         );
         expect(updateReactingUsersStringSpy).toHaveBeenCalledOnce();
-    }));
+    });
 
-    it('should trim list of reacting users but always include "you', fakeAsync(() => {
+    it('should trim list of reacting users but always include "you', async () => {
         const reactingUsers = [
             metisUser1.name!,
             metisUser2.name!,
@@ -98,7 +99,7 @@ describe('ReactingUsersOnPostingsPipe', () => {
         reactingUsersPipe.transform(reactingUsers).subscribe((transformedReactingUsers: string) => {
             transformedStringWithReactingUsers = transformedReactingUsers;
         });
-        tick();
+        await Promise.resolve();
         expect(transformedStringWithReactingUsers).toBe(
             'artemisApp.metis.you' +
                 ', ' +
@@ -122,16 +123,16 @@ describe('ReactingUsersOnPostingsPipe', () => {
                 'artemisApp.metis.reactedTooltipTrimmed',
         );
         expect(updateReactingUsersStringSpy).toHaveBeenCalledOnce();
-    }));
+    });
 
-    it('should trigger update of reacting users on language change', fakeAsync(() => {
+    it('should trigger update of reacting users on language change', async () => {
         const reactingUsers = [metisUser1.name!, PLACEHOLDER_USER_REACTED, metisTutor.name!];
         reactingUsersPipe.transform(reactingUsers).subscribe((transformedReactingUsers: string) => {
             transformedStringWithReactingUsers = transformedReactingUsers;
         });
-        tick();
+        await Promise.resolve();
         translateService.use('de');
-        tick();
+        await Promise.resolve();
         expect(updateReactingUsersStringSpy).toHaveBeenCalledTimes(2);
-    }));
+    });
 });

--- a/src/main/webapp/app/foundation/pipes/search-filter.pipe.spec.ts
+++ b/src/main/webapp/app/foundation/pipes/search-filter.pipe.spec.ts
@@ -1,6 +1,9 @@
 import { SearchFilterPipe } from 'app/foundation/pipes/search-filter.pipe';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('SearchFilterPipe', () => {
+    setupTestBed({ zoneless: true });
     let pipe: SearchFilterPipe;
 
     beforeEach(() => {

--- a/src/main/webapp/app/foundation/route/getPathVariable.spec.ts
+++ b/src/main/webapp/app/foundation/route/getPathVariable.spec.ts
@@ -3,6 +3,8 @@ import { ActivatedRoute, ParamMap, convertToParamMap } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 
 import { getNumericPathVariableSignal } from 'app/foundation/route/getPathVariable';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 interface TestActivatedRoute extends ActivatedRoute {
     paramMapSubject: BehaviorSubject<ParamMap>;
@@ -22,6 +24,7 @@ function createActivatedRoute(params: Record<string, string>, parent?: Activated
 }
 
 describe('getNumericPathVariableSignal', () => {
+    setupTestBed({ zoneless: true });
     beforeEach(() => {
         TestBed.configureTestingModule({});
     });

--- a/src/main/webapp/app/foundation/route/getRouteData.spec.ts
+++ b/src/main/webapp/app/foundation/route/getRouteData.spec.ts
@@ -1,6 +1,8 @@
 import { ActivatedRoute, ActivatedRouteSnapshot, Data } from '@angular/router';
 
 import { getRouteData } from 'app/foundation/route/getRouteData';
+import { describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 function createSnapshot(data: Data, parentPathFromRoot: ActivatedRouteSnapshot[] = []): ActivatedRouteSnapshot {
     const snapshot = { data } as ActivatedRouteSnapshot;
@@ -16,6 +18,7 @@ function createRouteSnapshot(data: Data, parentPathFromRoot: ActivatedRouteSnaps
 }
 
 describe('getRouteData', () => {
+    setupTestBed({ zoneless: true });
     it('should return data from the current route', () => {
         const route = createRouteSnapshot({ courseId: 42 });
 

--- a/src/main/webapp/app/foundation/science/science.service.spec.ts
+++ b/src/main/webapp/app/foundation/science/science.service.spec.ts
@@ -10,12 +10,15 @@ import { FeatureToggleService } from 'app/foundation/feature-toggle/feature-togg
 import { MockFeatureToggleService } from 'test/helpers/mocks/service/mock-feature-toggle.service';
 import { of } from 'rxjs';
 import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('ScienceService', () => {
+    setupTestBed({ zoneless: true });
     let scienceService: ScienceService;
     let httpService: HttpClient;
     let featureToggleService: FeatureToggleService;
-    let putStub: jest.SpyInstance;
+    let putStub: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -30,14 +33,14 @@ describe('ScienceService', () => {
             .then(() => {
                 httpService = TestBed.inject(HttpClient);
                 featureToggleService = TestBed.inject(FeatureToggleService);
-                jest.spyOn(featureToggleService, 'getFeatureToggleActive').mockReturnValue(of(true));
+                vi.spyOn(featureToggleService, 'getFeatureToggleActive').mockReturnValue(of(true));
                 scienceService = TestBed.inject(ScienceService);
-                putStub = jest.spyOn(httpService, 'put');
+                putStub = vi.spyOn(httpService, 'put');
             });
     });
 
     afterEach(() => {
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
     });
 
     it('should send a request to the server to log event', () => {

--- a/src/main/webapp/app/foundation/science/science.service.spec.ts
+++ b/src/main/webapp/app/foundation/science/science.service.spec.ts
@@ -10,7 +10,7 @@ import { FeatureToggleService } from 'app/foundation/feature-toggle/feature-togg
 import { MockFeatureToggleService } from 'test/helpers/mocks/service/mock-feature-toggle.service';
 import { of } from 'rxjs';
 import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
-import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('ScienceService', () => {

--- a/src/main/webapp/app/foundation/service/alert.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/alert.service.spec.ts
@@ -1,11 +1,15 @@
 import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
-import { TestBed, fakeAsync, flush, inject, tick } from '@angular/core/testing';
+import { TestBed, inject } from '@angular/core/testing';
 import { MissingTranslationHandler, TranslateModule, TranslateService } from '@ngx-translate/core';
 import { missingTranslationHandler } from 'app/core/config/translation.config';
 import { Alert, AlertCreationProperties, AlertService, AlertType } from 'app/foundation/service/alert.service';
 import { EventManager } from 'app/foundation/service/event-manager.service';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('Alert Service Test', () => {
+    setupTestBed({ zoneless: true });
+
     const alertSample = {
         type: AlertType.SUCCESS,
         message: 'Hello Jhipster',
@@ -45,6 +49,10 @@ describe('Alert Service Test', () => {
         eventManager = TestBed.inject(EventManager);
     });
 
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('should produce a proper alert object and fetch it', () => {
         expect(service.addAlert(alertSample)).toEqual(expect.objectContaining(alertSampleWithId as Alert));
         expect(service.get()).toHaveLength(1);
@@ -52,9 +60,9 @@ describe('Alert Service Test', () => {
     });
 
     it('should close an alert correctly', () => {
-        const alert0 = service.addAlert({ type: AlertType.INFO, message: 'Hello Jhipster info', onClose: jest.fn() });
-        const alert1 = service.addAlert({ type: AlertType.INFO, message: 'Hello Jhipster info 2', onClose: jest.fn() });
-        const alert2 = service.addAlert({ type: AlertType.SUCCESS, message: 'Hello Jhipster success', onClose: jest.fn() });
+        const alert0 = service.addAlert({ type: AlertType.INFO, message: 'Hello Jhipster info', onClose: vi.fn() });
+        const alert1 = service.addAlert({ type: AlertType.INFO, message: 'Hello Jhipster info 2', onClose: vi.fn() });
+        const alert2 = service.addAlert({ type: AlertType.SUCCESS, message: 'Hello Jhipster success', onClose: vi.fn() });
         expect(alert2).toEqual(
             expect.objectContaining({
                 type: AlertType.SUCCESS,
@@ -87,25 +95,28 @@ describe('Alert Service Test', () => {
         expect(alert0.onClose).toHaveBeenCalledOnce();
     });
 
-    it('should close an alert on timeout correctly', () => {
-        jest.useFakeTimers();
+    it('should close an alert on timeout correctly', async () => {
+        vi.useFakeTimers();
+        try {
+            const alert = { type: AlertType.INFO, message: 'Hello Jhipster info', onClose: vi.fn() } as AlertCreationProperties;
+            service.addAlert(alert);
 
-        const alert = { type: AlertType.INFO, message: 'Hello Jhipster info', onClose: jest.fn() } as AlertCreationProperties;
-        service.addAlert(alert);
+            expect(service.get()).toHaveLength(1);
 
-        expect(service.get()).toHaveLength(1);
+            await vi.advanceTimersByTimeAsync(16000);
 
-        jest.advanceTimersByTime(16000);
-
-        expect(service.get()).toHaveLength(0);
-        expect(alert.onClose).toHaveBeenCalledOnce();
+            expect(service.get()).toHaveLength(0);
+            expect(alert.onClose).toHaveBeenCalledOnce();
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('should clear alerts', () => {
         const alerts = [
-            { type: AlertType.INFO, message: 'Hello Jhipster info1', onClose: jest.fn() },
-            { type: AlertType.DANGER, message: 'Hello Jhipster info2', onClose: jest.fn() },
-            { type: AlertType.SUCCESS, message: 'Hello Jhipster info3', onClose: jest.fn() },
+            { type: AlertType.INFO, message: 'Hello Jhipster info1', onClose: vi.fn() },
+            { type: AlertType.DANGER, message: 'Hello Jhipster info2', onClose: vi.fn() },
+            { type: AlertType.SUCCESS, message: 'Hello Jhipster info3', onClose: vi.fn() },
         ] as AlertCreationProperties[];
         alerts.forEach((alert) => service.addAlert(alert));
         expect(service.get()).toHaveLength(3);
@@ -269,37 +280,40 @@ describe('Alert Service Test', () => {
         expect(service.get()[0].message).toBe('Error Message');
     });
 
-    it('should not show two alerts with the same content if spawned within 50ms', fakeAsync(() => {
-        const initialAlert = service.addAlert({
-            type: AlertType.DANGER,
-            message: 'Test123',
-        });
-        expect(service.get()).toEqual([initialAlert]);
+    it('should not show two alerts with the same content if spawned within 50ms', async () => {
+        vi.useFakeTimers();
+        try {
+            const initialAlert = service.addAlert({
+                type: AlertType.DANGER,
+                message: 'Test123',
+            });
+            expect(service.get()).toEqual([initialAlert]);
 
-        tick(25);
+            await vi.advanceTimersByTimeAsync(25);
 
-        const secondAlert = service.addAlert({
-            type: AlertType.DANGER,
-            message: 'Test123',
-        });
+            const secondAlert = service.addAlert({
+                type: AlertType.DANGER,
+                message: 'Test123',
+            });
 
-        // Check that it is actually the same object by reference
-        expect(secondAlert).toBe(initialAlert);
-        expect(service.get()).toEqual([initialAlert]);
+            // Check that it is actually the same object by reference
+            expect(secondAlert).toBe(initialAlert);
+            expect(service.get()).toEqual([initialAlert]);
 
-        // After at least 50ms, the new alert should actually be added again
-        tick(30);
+            // After at least 50ms, the new alert should actually be added again
+            await vi.advanceTimersByTimeAsync(30);
 
-        const thirdAlert = service.addAlert({
-            type: AlertType.DANGER,
-            message: 'Test123',
-        });
+            const thirdAlert = service.addAlert({
+                type: AlertType.DANGER,
+                message: 'Test123',
+            });
 
-        expect(thirdAlert).not.toBe(initialAlert);
-        expect(service.get()).toEqual([thirdAlert, initialAlert]);
-
-        flush();
-    }));
+            expect(thirdAlert).not.toBe(initialAlert);
+            expect(service.get()).toEqual([thirdAlert, initialAlert]);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
 
     it.each([400, 403, 405, 412])('should not show alerts with skipAlert=true', (statusCode) => {
         // GIVEN
@@ -316,6 +330,6 @@ describe('Alert Service Test', () => {
         });
         eventManager.broadcast({ name: 'artemisApp.httpError', content: response });
         // THEN
-        expect(service.get()).toBeEmpty();
+        expect(service.get()).toHaveLength(0);
     });
 });

--- a/src/main/webapp/app/foundation/service/base-api-http.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/base-api-http.service.spec.ts
@@ -1,52 +1,63 @@
 import { BaseApiHttpService } from 'app/foundation/service/base-api-http.service';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('debounce', () => {
-    jest.useFakeTimers();
+    setupTestBed({ zoneless: true });
 
-    it('calls the callback after the specified delay', () => {
-        const callback = jest.fn();
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('calls the callback after the specified delay', async () => {
+        const callback = vi.fn();
         const debouncedFunction = BaseApiHttpService.debounce(callback, 1000);
 
         debouncedFunction();
         expect(callback).not.toHaveBeenCalled();
 
-        jest.advanceTimersByTime(1000);
+        await vi.advanceTimersByTimeAsync(1000);
         expect(callback).toHaveBeenCalledOnce();
     });
 
-    it('resets the delay if called again within the delay period', () => {
-        const callback = jest.fn();
+    it('resets the delay if called again within the delay period', async () => {
+        const callback = vi.fn();
         const debouncedFunction = BaseApiHttpService.debounce(callback, 1000);
 
         debouncedFunction();
-        jest.advanceTimersByTime(500);
+        await vi.advanceTimersByTimeAsync(500);
         debouncedFunction();
-        jest.advanceTimersByTime(500);
+        await vi.advanceTimersByTimeAsync(500);
         expect(callback).not.toHaveBeenCalled();
 
-        jest.advanceTimersByTime(500);
+        await vi.advanceTimersByTimeAsync(500);
         expect(callback).toHaveBeenCalledOnce();
     });
 
-    it('calls the callback with the correct arguments', () => {
-        const callback = jest.fn();
+    it('calls the callback with the correct arguments', async () => {
+        const callback = vi.fn();
         const debouncedFunction = BaseApiHttpService.debounce(callback, 1000);
 
         debouncedFunction('arg1', 'arg2');
-        jest.advanceTimersByTime(1000);
+        await vi.advanceTimersByTimeAsync(1000);
         expect(callback).toHaveBeenCalledWith('arg1', 'arg2');
     });
 
-    it('handles multiple calls correctly', () => {
-        const callback = jest.fn();
+    it('handles multiple calls correctly', async () => {
+        const callback = vi.fn();
         const debouncedFunction = BaseApiHttpService.debounce(callback, 1000);
 
         debouncedFunction();
-        jest.advanceTimersByTime(1000);
+        await vi.advanceTimersByTimeAsync(1000);
         expect(callback).toHaveBeenCalledOnce();
 
         debouncedFunction();
-        jest.advanceTimersByTime(1000);
+        await vi.advanceTimersByTimeAsync(1000);
         expect(callback).toHaveBeenCalledTimes(2);
     });
 });

--- a/src/main/webapp/app/foundation/service/event-manager.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/event-manager.service.spec.ts
@@ -1,7 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import { EventManager, EventWithContent } from 'app/foundation/service/event-manager.service';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('Event Manager tests', () => {
+    setupTestBed({ zoneless: true });
     describe('EventWithContent', () => {
         it('should create correctly EventWithContent', () => {
             // WHEN

--- a/src/main/webapp/app/foundation/service/file-uploader.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/file-uploader.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { MAX_FILE_SIZE, MAX_FILE_SIZE_COMMUNICATION } from '../constants/input.constants';
 import { FileUploaderService } from 'app/foundation/service/file-uploader.service';
-import { beforeEach, describe, expect, it, test } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('FileUploaderService', () => {

--- a/src/main/webapp/app/foundation/service/file-uploader.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/file-uploader.service.spec.ts
@@ -3,8 +3,11 @@ import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { MAX_FILE_SIZE, MAX_FILE_SIZE_COMMUNICATION } from '../constants/input.constants';
 import { FileUploaderService } from 'app/foundation/service/file-uploader.service';
+import { beforeEach, describe, expect, it, test } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('FileUploaderService', () => {
+    setupTestBed({ zoneless: true });
     let service: FileUploaderService;
     let httpMock: HttpTestingController;
 

--- a/src/main/webapp/app/foundation/service/file.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/file.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { ProgrammingLanguage, ProjectType } from 'app/programming/shared/entities/programming-exercise.model';
 import { FileService } from 'app/foundation/service/file.service';
-import { beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('FileService', () => {

--- a/src/main/webapp/app/foundation/service/file.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/file.service.spec.ts
@@ -3,14 +3,17 @@ import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { ProgrammingLanguage, ProjectType } from 'app/programming/shared/entities/programming-exercise.model';
 import { FileService } from 'app/foundation/service/file.service';
+import { beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('FileService', () => {
+    setupTestBed({ zoneless: true });
     const firstUniqueFileName = 'someOtherUniqueFileName';
     const secondUniqueFileName = 'someUniqueFileName';
 
     let fileService: FileService;
     let httpMock: HttpTestingController;
-    let getUniqueFileNameSpy: jest.SpyInstance;
+    let getUniqueFileNameSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -18,7 +21,7 @@ describe('FileService', () => {
         });
         fileService = TestBed.inject(FileService);
         httpMock = TestBed.inject(HttpTestingController);
-        getUniqueFileNameSpy = jest.spyOn(fileService, 'getUniqueFileName');
+        getUniqueFileNameSpy = vi.spyOn(fileService, 'getUniqueFileName');
     });
 
     describe('getFile', () => {
@@ -160,7 +163,7 @@ describe('FileService', () => {
             const encodedUrl = 'http://example.com/files/some%20file%20name.txt';
             const newWindowMock = { location: { href: '' } } as Window;
 
-            jest.spyOn(window, 'open').mockReturnValue(newWindowMock);
+            vi.spyOn(window, 'open').mockReturnValue(newWindowMock);
 
             const newWindow = fileService.downloadFile(downloadUrl);
             expect(newWindow).not.toBeNull();
@@ -175,7 +178,7 @@ describe('FileService', () => {
             const encodedUrl = 'http://example.com/files/newAttachment.txt';
             const newWindowMock = { location: { href: '' } } as Window;
 
-            jest.spyOn(window, 'open').mockReturnValue(newWindowMock);
+            vi.spyOn(window, 'open').mockReturnValue(newWindowMock);
 
             const newWindow = fileService.downloadFileByAttachmentName(downloadUrl, downloadName);
             expect(newWindow).not.toBeNull();

--- a/src/main/webapp/app/foundation/service/local-storage.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/local-storage.service.spec.ts
@@ -1,5 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { LocalStorageService } from './local-storage.service';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 enum TestStringEnum {
     Category1 = 'category1',
@@ -8,6 +10,7 @@ enum TestStringEnum {
 }
 
 describe('LocalStorageService', () => {
+    setupTestBed({ zoneless: true });
     let service: LocalStorageService;
     const testKey = 'testKey';
 

--- a/src/main/webapp/app/foundation/service/markdown.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/markdown.service.spec.ts
@@ -2,8 +2,11 @@ import { MultipleChoiceQuestion } from 'app/quiz/shared/entities/multiple-choice
 import { ShortAnswerQuestion } from 'app/quiz/shared/entities/short-answer-question.model';
 import { parseExerciseHintExplanation } from 'app/foundation/util/markdown.util';
 import { htmlForMarkdown } from 'app/foundation/util/markdown.conversion.util';
+import { describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('Markdown Service', () => {
+    setupTestBed({ zoneless: true });
     const hintText = 'Add an explanation here (only visible in feedback after quiz has ended)';
     const markdownHint = '[hint] ' + hintText;
     const explanationText = 'Add an explanation here (only visible in feedback after quiz has ended)';

--- a/src/main/webapp/app/foundation/service/server-date.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/server-date.service.spec.ts
@@ -4,14 +4,17 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import dayjs from 'dayjs/esm';
 import { ArtemisServerDateService } from 'app/foundation/service/server-date.service';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('ArtemisServerDateService', () => {
+    setupTestBed({ zoneless: true });
     let service: ArtemisServerDateService;
     let httpMock: HttpTestingController;
 
     beforeEach(() => {
-        jest.useFakeTimers();
-        jest.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
 
         TestBed.configureTestingModule({
             providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
@@ -23,7 +26,7 @@ describe('ArtemisServerDateService', () => {
 
     afterEach(() => {
         httpMock.verify();
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it('should request server time when sync is needed', () => {
@@ -70,7 +73,7 @@ describe('ArtemisServerDateService', () => {
 
     it('should return client date when no offsets are available', () => {
         const now = service.now();
-        expect(now.isSame(dayjs())).toBeTrue();
+        expect(now.isSame(dayjs())).toBe(true);
     });
 
     it('should average offsets when five values exist', () => {

--- a/src/main/webapp/app/foundation/service/session-storage.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/session-storage.service.spec.ts
@@ -1,5 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { SessionStorageService } from './session-storage.service';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 enum TestStringEnum {
     Category1 = 'category1',
@@ -8,6 +10,7 @@ enum TestStringEnum {
 }
 
 describe('SessionStorageService', () => {
+    setupTestBed({ zoneless: true });
     let service: SessionStorageService;
     const testKey = 'testKey';
 

--- a/src/main/webapp/app/foundation/service/sort.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/sort.service.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import dayjs from 'dayjs/esm';
 import { SortService } from 'app/foundation/service/sort.service';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 type TestObject = {
     a: number;
@@ -15,6 +17,7 @@ type TestObject = {
 };
 
 describe('Sort Service', () => {
+    setupTestBed({ zoneless: true });
     let service: SortService;
     const e1: TestObject = {
         a: 10,
@@ -119,9 +122,13 @@ describe('Sort Service', () => {
                 service.sortByProperty(shuffled, key, ascending);
                 if (ascending) {
                     expect(shuffled.slice(0, expectedDefinedOrder.length)).toEqual(expectedDefinedOrder);
-                    expect(shuffled.slice(expectedDefinedOrder.length, shuffled.length)).toIncludeSameMembers(undefinedObjects);
+                    const tail = shuffled.slice(expectedDefinedOrder.length, shuffled.length);
+                    expect(tail).toHaveLength(undefinedObjects.length);
+                    expect(tail).toEqual(expect.arrayContaining(undefinedObjects));
                 } else {
-                    expect(shuffled.slice(0, undefinedObjects.length)).toIncludeSameMembers(undefinedObjects);
+                    const head = shuffled.slice(0, undefinedObjects.length);
+                    expect(head).toHaveLength(undefinedObjects.length);
+                    expect(head).toEqual(expect.arrayContaining(undefinedObjects));
                     expect(shuffled.slice(undefinedObjects.length, shuffled.length)).toEqual(expectedDefinedOrder);
                 }
             }

--- a/src/main/webapp/app/foundation/service/websocket.service.spec.ts
+++ b/src/main/webapp/app/foundation/service/websocket.service.spec.ts
@@ -7,27 +7,34 @@ import { MockAccountService } from 'test/helpers/mocks/service/mock-account.serv
 import { RxStompState } from '@stomp/rx-stomp';
 import { BehaviorSubject, EMPTY, filter, firstValueFrom, of } from 'rxjs';
 import { IMessage } from '@stomp/stompjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
-const constructedRxStompClients: any[] = [];
-const watchMock = jest.fn();
+// vi.mock factories are hoisted above all imports, so shared state they reference must be created via
+// vi.hoisted() (which is hoisted alongside the mocks). This replaces the plain top-level consts used under Jest.
+const { constructedRxStompClients, watchMock, captureExceptionMock } = vi.hoisted(() => ({
+    constructedRxStompClients: [] as any[],
+    watchMock: vi.fn(),
+    captureExceptionMock: vi.fn(),
+}));
 
-jest.mock('@stomp/rx-stomp', () => {
-    const { RxStompState: ActualRxStompState, ReconnectionTimeMode: ActualReconnectionTimeMode } = jest.requireActual('@stomp/rx-stomp');
+vi.mock('@stomp/rx-stomp', async () => {
+    const { RxStompState: ActualRxStompState, ReconnectionTimeMode: ActualReconnectionTimeMode } = await vi.importActual<typeof import('@stomp/rx-stomp')>('@stomp/rx-stomp');
     return {
         TickerStrategy: { Worker: 'worker-ticker' },
         RxStompState: ActualRxStompState,
         ReconnectionTimeMode: ActualReconnectionTimeMode,
-        RxStomp: jest.fn().mockImplementation(() => {
+        RxStomp: vi.fn().mockImplementation(function () {
             const client = {
-                configure: jest.fn(),
-                activate: jest.fn(),
-                deactivate: jest.fn(),
-                publish: jest.fn(),
+                configure: vi.fn(),
+                activate: vi.fn(),
+                deactivate: vi.fn(),
+                publish: vi.fn(),
                 watch: watchMock,
-                connected: jest.fn().mockReturnValue(true),
+                connected: vi.fn().mockReturnValue(true),
                 connectionState$: new BehaviorSubject<RxStompState>(ActualRxStompState.CLOSED),
                 stompClient: {
-                    unsubscribe: jest.fn(),
+                    unsubscribe: vi.fn(),
                     onConnect: undefined as (() => void) | undefined,
                     onStompError: undefined,
                     onWebSocketClose: undefined,
@@ -40,22 +47,23 @@ jest.mock('@stomp/rx-stomp', () => {
     };
 });
 
-const captureExceptionMock = jest.fn();
-jest.mock('@sentry/angular', () => ({
+vi.mock('@sentry/angular', () => ({
     captureException: (...args: any[]) => captureExceptionMock(...args),
 }));
 
 const baseMessage: IMessage = {
     body: '',
     headers: {},
-    ack: jest.fn(),
-    nack: jest.fn(),
+    ack: vi.fn(),
+    nack: vi.fn(),
     command: '',
     binaryBody: new Uint8Array(),
     isBinaryBody: false,
 };
 
 describe('WebsocketService', () => {
+    setupTestBed({ zoneless: true });
+
     let websocketService: WebsocketService;
 
     beforeEach(() => {
@@ -70,7 +78,7 @@ describe('WebsocketService', () => {
 
     afterEach(() => {
         websocketService.ngOnDestroy();
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
     });
 
     it('connects, configures, activates, and emits connection state on successful connect', async () => {
@@ -89,7 +97,7 @@ describe('WebsocketService', () => {
     it('disconnects gracefully and updates connection state', () => {
         websocketService.connect();
         const rxStomp = constructedRxStompClients[0];
-        rxStomp.connected = jest.fn().mockReturnValue(true);
+        rxStomp.connected = vi.fn().mockReturnValue(true);
 
         let latestState: ConnectionState | undefined;
         websocketService.connectionState.subscribe((state) => (latestState = state));
@@ -102,13 +110,13 @@ describe('WebsocketService', () => {
     });
 
     it('reports connection status via isConnected', () => {
-        expect(websocketService.isConnected()).toBeFalse();
+        expect(websocketService.isConnected()).toBe(false);
         websocketService.connect();
         const rxStomp = constructedRxStompClients[0];
-        rxStomp.connected = jest.fn().mockReturnValue(true);
-        expect(websocketService.isConnected()).toBeTrue();
-        rxStomp.connected = jest.fn().mockReturnValue(false);
-        expect(websocketService.isConnected()).toBeFalse();
+        rxStomp.connected = vi.fn().mockReturnValue(true);
+        expect(websocketService.isConnected()).toBe(true);
+        rxStomp.connected = vi.fn().mockReturnValue(false);
+        expect(websocketService.isConnected()).toBe(false);
     });
 
     it('returns EMPTY observable when subscribing without a channel', async () => {
@@ -117,12 +125,12 @@ describe('WebsocketService', () => {
         await new Promise<void>((resolve) => {
             obs.subscribe({ complete: () => (completed = true) }).add(() => resolve());
         });
-        expect(completed).toBeTrue();
+        expect(completed).toBe(true);
         expect(watchMock).not.toHaveBeenCalled();
     });
 
     it('returns EMPTY when no client is available after connect attempt', () => {
-        jest.spyOn(websocketService, 'connect').mockImplementation(() => {
+        vi.spyOn(websocketService, 'connect').mockImplementation(() => {
             (websocketService as any).rxStomp = undefined;
         });
         const result = websocketService.subscribe('/topic/test');
@@ -157,7 +165,7 @@ describe('WebsocketService', () => {
     });
 
     it('reports decompression errors and propagates them', async () => {
-        const decodeSpy = jest.spyOn(WebsocketService as any, 'decodeAndDecompress').mockImplementation(() => {
+        const decodeSpy = vi.spyOn(WebsocketService as any, 'decodeAndDecompress').mockImplementation(() => {
             throw new Error('boom');
         });
         const message: IMessage = { ...baseMessage, body: '"raw"', headers: { [COMPRESSION_HEADER_KEY]: 'true' } };
@@ -174,7 +182,7 @@ describe('WebsocketService', () => {
     it('send does nothing when disconnected', () => {
         websocketService.connect();
         const rxStomp = constructedRxStompClients[0];
-        rxStomp.connected = jest.fn().mockReturnValue(false);
+        rxStomp.connected = vi.fn().mockReturnValue(false);
         websocketService.send('/test', { data: 'test' });
         expect(rxStomp.publish).not.toHaveBeenCalled();
     });
@@ -182,7 +190,7 @@ describe('WebsocketService', () => {
     it('sends uncompressed payloads when below threshold', () => {
         websocketService.connect();
         const rxStomp = constructedRxStompClients[0];
-        rxStomp.connected = jest.fn().mockReturnValue(true);
+        rxStomp.connected = vi.fn().mockReturnValue(true);
 
         websocketService.send('/test', { data: 'abc' });
 
@@ -196,9 +204,9 @@ describe('WebsocketService', () => {
     it('sends compressed payloads and falls back if compression fails', () => {
         websocketService.connect();
         const rxStomp = constructedRxStompClients[0];
-        rxStomp.connected = jest.fn().mockReturnValue(true);
+        rxStomp.connected = vi.fn().mockReturnValue(true);
 
-        const compressSpy = jest.spyOn(WebsocketService as any, 'compressAndEncode').mockReturnValue('compressed');
+        const compressSpy = vi.spyOn(WebsocketService as any, 'compressAndEncode').mockReturnValue('compressed');
         websocketService.send('/test', { data: 'x'.repeat(2000) });
         expect(compressSpy).toHaveBeenCalled();
         expect(rxStomp.publish).toHaveBeenCalledWith({
@@ -207,7 +215,7 @@ describe('WebsocketService', () => {
             headers: COMPRESSION_HEADER,
         });
 
-        const errorSpy = jest.spyOn(WebsocketService as any, 'compressAndEncode').mockImplementation(() => {
+        const errorSpy = vi.spyOn(WebsocketService as any, 'compressAndEncode').mockImplementation(() => {
             throw new Error('compress fail');
         });
         websocketService.send('/test', { data: 'x'.repeat(2000) });
@@ -236,73 +244,77 @@ describe('WebsocketService', () => {
     });
 
     it('delegates ngOnDestroy to disconnect', () => {
-        const disconnectSpy = jest.spyOn(websocketService, 'disconnect');
+        const disconnectSpy = vi.spyOn(websocketService, 'disconnect');
         websocketService.ngOnDestroy();
         expect(disconnectSpy).toHaveBeenCalled();
     });
 
     it('delays non-OPEN connection states by 5 seconds', () => {
-        jest.useFakeTimers();
-        websocketService.connect();
-        const rxStomp = constructedRxStompClients[0];
+        vi.useFakeTimers();
+        try {
+            websocketService.connect();
+            const rxStomp = constructedRxStompClients[0];
 
-        // First connect
-        rxStomp.connectionState$.next(RxStompState.OPEN);
+            // First connect
+            rxStomp.connectionState$.next(RxStompState.OPEN);
 
-        const stateChanges: ConnectionState[] = [];
-        websocketService.connectionState.subscribe((state) => stateChanges.push(state));
+            const stateChanges: ConnectionState[] = [];
+            websocketService.connectionState.subscribe((state) => stateChanges.push(state));
 
-        // Simulate connection loss
-        stateChanges.length = 0;
-        rxStomp.connectionState$.next(RxStompState.CLOSED);
+            // Simulate connection loss
+            stateChanges.length = 0;
+            rxStomp.connectionState$.next(RxStompState.CLOSED);
 
-        // No state change should be emitted immediately for non-OPEN states
-        expect(stateChanges).toHaveLength(0);
+            // No state change should be emitted immediately for non-OPEN states
+            expect(stateChanges).toHaveLength(0);
 
-        // After 4 seconds, still no change
-        jest.advanceTimersByTime(4000);
-        expect(stateChanges).toHaveLength(0);
+            // After 4 seconds, still no change
+            vi.advanceTimersByTime(4000);
+            expect(stateChanges).toHaveLength(0);
 
-        // After 5 seconds total, the CLOSED state should be emitted
-        jest.advanceTimersByTime(1000);
-        expect(stateChanges).toHaveLength(1);
-        expect(stateChanges[0]).toEqual(new ConnectionState(false, true));
-
-        jest.useRealTimers();
+            // After 5 seconds total, the CLOSED state should be emitted
+            vi.advanceTimersByTime(1000);
+            expect(stateChanges).toHaveLength(1);
+            expect(stateChanges[0]).toEqual(new ConnectionState(false, true));
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('cancels delayed non-OPEN state if connection recovers within 5 seconds', () => {
-        jest.useFakeTimers();
-        websocketService.connect();
-        const rxStomp = constructedRxStompClients[0];
+        vi.useFakeTimers();
+        try {
+            websocketService.connect();
+            const rxStomp = constructedRxStompClients[0];
 
-        // First connect
-        rxStomp.connectionState$.next(RxStompState.OPEN);
+            // First connect
+            rxStomp.connectionState$.next(RxStompState.OPEN);
 
-        const stateChanges: ConnectionState[] = [];
-        websocketService.connectionState.subscribe((state) => stateChanges.push(state));
+            const stateChanges: ConnectionState[] = [];
+            websocketService.connectionState.subscribe((state) => stateChanges.push(state));
 
-        // Simulate connection loss
-        stateChanges.length = 0;
-        rxStomp.connectionState$.next(RxStompState.CLOSED);
+            // Simulate connection loss
+            stateChanges.length = 0;
+            rxStomp.connectionState$.next(RxStompState.CLOSED);
 
-        // No state change should be emitted immediately
-        expect(stateChanges).toHaveLength(0);
+            // No state change should be emitted immediately
+            expect(stateChanges).toHaveLength(0);
 
-        // After 3 seconds, connection recovers
-        jest.advanceTimersByTime(3000);
-        expect(stateChanges).toHaveLength(0);
+            // After 3 seconds, connection recovers
+            vi.advanceTimersByTime(3000);
+            expect(stateChanges).toHaveLength(0);
 
-        rxStomp.connectionState$.next(RxStompState.OPEN);
+            rxStomp.connectionState$.next(RxStompState.OPEN);
 
-        // OPEN state should be emitted immediately
-        expect(stateChanges).toHaveLength(1);
-        expect(stateChanges[0]).toEqual(new ConnectionState(true, true));
+            // OPEN state should be emitted immediately
+            expect(stateChanges).toHaveLength(1);
+            expect(stateChanges[0]).toEqual(new ConnectionState(true, true));
 
-        // Even after 5 more seconds, no CLOSED state should have been emitted
-        jest.advanceTimersByTime(5000);
-        expect(stateChanges).toHaveLength(1);
-
-        jest.useRealTimers();
+            // Even after 5 more seconds, no CLOSED state should have been emitted
+            vi.advanceTimersByTime(5000);
+            expect(stateChanges).toHaveLength(1);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/src/main/webapp/app/foundation/sort/icon/sort-icon.component.spec.ts
+++ b/src/main/webapp/app/foundation/sort/icon/sort-icon.component.spec.ts
@@ -2,8 +2,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { SortIconComponent } from 'app/foundation/sort/icon/sort-icon.component';
 import { SortingOrder } from 'app/foundation/pagination/pageable-table';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('SortIconComponent', () => {
+    setupTestBed({ zoneless: true });
     let component: SortIconComponent;
     let fixture: ComponentFixture<SortIconComponent>;
 
@@ -19,21 +22,21 @@ describe('SortIconComponent', () => {
     it('should set isAscending to true when direction is Ascending', () => {
         fixture.componentRef.setInput('direction', SortingOrder.ASCENDING);
         fixture.detectChanges();
-        expect(component.isAscending()).toBeTrue();
-        expect(component.isDescending()).toBeFalse();
+        expect(component.isAscending()).toBe(true);
+        expect(component.isDescending()).toBe(false);
     });
 
     it('should set isDescending to true when direction is Descending', () => {
         fixture.componentRef.setInput('direction', SortingOrder.DESCENDING);
         fixture.detectChanges();
-        expect(component.isDescending()).toBeTrue();
-        expect(component.isAscending()).toBeFalse();
+        expect(component.isDescending()).toBe(true);
+        expect(component.isAscending()).toBe(false);
     });
 
     it('should set both isAscending and isDescending to false when direction is "none"', () => {
         fixture.componentRef.setInput('direction', 'none');
         fixture.detectChanges();
-        expect(component.isAscending()).toBeFalse();
-        expect(component.isDescending()).toBeFalse();
+        expect(component.isAscending()).toBe(false);
+        expect(component.isDescending()).toBe(false);
     });
 });

--- a/src/main/webapp/app/foundation/util/base64.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/base64.util.spec.ts
@@ -1,6 +1,10 @@
 import { decodeBase64url, encodeAsBase64Url } from 'app/foundation/util/base64.util';
+import { describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('Base64 Utility Functions', () => {
+    setupTestBed({ zoneless: true });
+
     describe('decodeBase64url', () => {
         const textDecoder = new TextDecoder();
 

--- a/src/main/webapp/app/foundation/util/blob-util.spec.ts
+++ b/src/main/webapp/app/foundation/util/blob-util.spec.ts
@@ -7,8 +7,11 @@ import {
     createBlob,
     objectToJsonBlob,
 } from 'app/foundation/util/blob-util';
+import { describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('BlobUtil', () => {
+    setupTestBed({ zoneless: true });
     describe('createBlob', () => {
         it('should create blob from no parts', () => {
             const blob = createBlob([]);
@@ -120,7 +123,7 @@ describe('BlobUtil', () => {
             const binary = '';
             const arrayBuffer = binaryStringToArrayBuffer(binary);
             const bytes = new Uint8Array(arrayBuffer);
-            expect(bytes).toBeEmpty();
+            expect(bytes).toHaveLength(0);
         });
 
         it('should return an array buffer with the correct contents', () => {

--- a/src/main/webapp/app/foundation/util/color.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/color.util.spec.ts
@@ -1,16 +1,19 @@
 import { getBackgroundColorHue, getColorBrightness, getContrastingTextColor, isColorDark } from 'app/foundation/util/color.utils';
 import { deterministicRandomValueFromString } from 'app/foundation/util/text.utils';
+import { Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
-jest.mock('app/foundation/util/text.utils', () => ({
-    deterministicRandomValueFromString: jest.fn(),
+vi.mock('app/foundation/util/text.utils', () => ({
+    deterministicRandomValueFromString: vi.fn(),
 }));
 
 describe('color utils', () => {
+    setupTestBed({ zoneless: true });
     describe('getBackgroundColorHue', () => {
-        const mockDeterministic = deterministicRandomValueFromString as jest.Mock;
+        const mockDeterministic = deterministicRandomValueFromString as Mock;
 
         beforeEach(() => {
-            jest.clearAllMocks();
+            vi.clearAllMocks();
         });
 
         it('returns correct HSL using deterministicRandomValueFromString', () => {
@@ -24,7 +27,7 @@ describe('color utils', () => {
         it('uses Math.random when seed undefined', () => {
             mockDeterministic.mockReturnValue(0.25);
             const randomValue = 0.123456;
-            const mathRandomSpy = jest.spyOn(Math, 'random').mockReturnValue(randomValue);
+            const mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(randomValue);
 
             const result = getBackgroundColorHue(undefined);
             expect(mathRandomSpy).toHaveBeenCalled();
@@ -52,15 +55,15 @@ describe('color utils', () => {
 
     describe('isColorDark', () => {
         it('returns true for dark colors', () => {
-            expect(isColorDark('#000000')).toBeTrue();
+            expect(isColorDark('#000000')).toBe(true);
         });
 
         it('returns false for light colors', () => {
-            expect(isColorDark('#FFFFFF')).toBeFalse();
+            expect(isColorDark('#FFFFFF')).toBe(false);
         });
 
         it('threshold at 128 returns false', () => {
-            expect(isColorDark('#808080')).toBeFalse();
+            expect(isColorDark('#808080')).toBe(false);
         });
     });
 
@@ -76,11 +79,11 @@ describe('color utils', () => {
 
     describe('edge cases for invalid color formats', () => {
         it('getColorBrightness returns NaN for invalid hex', () => {
-            expect(isNaN(getColorBrightness('GGGGGG'))).toBeTrue();
+            expect(isNaN(getColorBrightness('GGGGGG'))).toBe(true);
         });
 
         it('isColorDark returns false for NaN brightness', () => {
-            expect(isColorDark('GGGGGG')).toBeFalse();
+            expect(isColorDark('GGGGGG')).toBe(false);
         });
 
         it('getContrastingTextColor returns black for NaN brightness', () => {

--- a/src/main/webapp/app/foundation/util/crypto.utils.spec.ts
+++ b/src/main/webapp/app/foundation/util/crypto.utils.spec.ts
@@ -1,5 +1,5 @@
 import { sha1Hex } from 'app/foundation/util/crypto.utils';
-import { describe, expect, it, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('CryptoUtils', () => {

--- a/src/main/webapp/app/foundation/util/crypto.utils.spec.ts
+++ b/src/main/webapp/app/foundation/util/crypto.utils.spec.ts
@@ -1,6 +1,9 @@
 import { sha1Hex } from 'app/foundation/util/crypto.utils';
+import { describe, expect, it, test } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('CryptoUtils', () => {
+    setupTestBed({ zoneless: true });
     describe('sha1Hex', () => {
         it('should compute Hash for "foo"', () => {
             expect(sha1Hex('foo')).toBe('0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33');

--- a/src/main/webapp/app/foundation/util/date.utils.spec.ts
+++ b/src/main/webapp/app/foundation/util/date.utils.spec.ts
@@ -7,8 +7,11 @@ import {
     toISO8601DateTimeString,
 } from 'app/foundation/util/date.utils';
 import dayjs from 'dayjs/esm';
+import { describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('DateUtils', () => {
+    setupTestBed({ zoneless: true });
     // month of js date is 0-based
     const exampleDate = new Date(2019, 8, 10, 12, 30, 20);
     const exampleISO8601DateString = '2019-09-10';
@@ -80,17 +83,17 @@ describe('DateUtils', () => {
     describe('isDateLessThanAWeekInTheFuture', () => {
         it('should return true if date is less than a week away', () => {
             const date = dayjs().add(6, 'days');
-            expect(isDateLessThanAWeekInTheFuture(date)).toBeTrue();
+            expect(isDateLessThanAWeekInTheFuture(date)).toBe(true);
         });
 
         it('should return false if date is more than a week away', () => {
             const date = dayjs().add(8, 'days');
-            expect(isDateLessThanAWeekInTheFuture(date)).toBeFalse();
+            expect(isDateLessThanAWeekInTheFuture(date)).toBe(false);
         });
 
         it('should return false if date is more than a week ago', () => {
             const date = dayjs().subtract(8, 'days');
-            expect(isDateLessThanAWeekInTheFuture(date)).toBeFalse();
+            expect(isDateLessThanAWeekInTheFuture(date)).toBe(false);
         });
     });
 });

--- a/src/main/webapp/app/foundation/util/deep-clone.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/deep-clone.util.spec.ts
@@ -1,6 +1,6 @@
 import { deepClone } from 'app/foundation/util/deep-clone.util';
 import dayjs from 'dayjs/esm';
-import { describe, expect, it, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('deepClone', () => {

--- a/src/main/webapp/app/foundation/util/deep-clone.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/deep-clone.util.spec.ts
@@ -1,7 +1,10 @@
 import { deepClone } from 'app/foundation/util/deep-clone.util';
 import dayjs from 'dayjs/esm';
+import { describe, expect, it, test } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('deepClone', () => {
+    setupTestBed({ zoneless: true });
     it('should return null for null input', () => {
         expect(deepClone(null)).toBeNull();
     });
@@ -13,7 +16,7 @@ describe('deepClone', () => {
     it('should clone primitive values', () => {
         expect(deepClone('test')).toBe('test');
         expect(deepClone(42)).toBe(42);
-        expect(deepClone(true)).toBeTrue();
+        expect(deepClone(true)).toBe(true);
     });
 
     it('should create a new object reference for plain objects', () => {
@@ -52,8 +55,8 @@ describe('deepClone', () => {
         const originalDate = dayjs('2024-01-15T10:30:00');
         const cloned = deepClone(originalDate);
 
-        expect(dayjs.isDayjs(cloned)).toBeTrue();
-        expect(cloned.isSame(originalDate)).toBeTrue();
+        expect(dayjs.isDayjs(cloned)).toBe(true);
+        expect(cloned.isSame(originalDate)).toBe(true);
         expect(cloned).not.toBe(originalDate);
     });
 
@@ -66,10 +69,10 @@ describe('deepClone', () => {
         const cloned = deepClone(original);
 
         expect(cloned.title).toBe(original.title);
-        expect(dayjs.isDayjs(cloned.startDate)).toBeTrue();
-        expect(dayjs.isDayjs(cloned.endDate)).toBeTrue();
-        expect(cloned.startDate.isSame(original.startDate)).toBeTrue();
-        expect(cloned.endDate.isSame(original.endDate)).toBeTrue();
+        expect(dayjs.isDayjs(cloned.startDate)).toBe(true);
+        expect(dayjs.isDayjs(cloned.endDate)).toBe(true);
+        expect(cloned.startDate.isSame(original.startDate)).toBe(true);
+        expect(cloned.endDate.isSame(original.endDate)).toBe(true);
         expect(cloned.startDate).not.toBe(original.startDate);
         expect(cloned.endDate).not.toBe(original.endDate);
     });
@@ -79,8 +82,8 @@ describe('deepClone', () => {
         const cloned = deepClone(original);
 
         expect(cloned).toHaveLength(2);
-        expect(dayjs.isDayjs(cloned[0])).toBeTrue();
-        expect(dayjs.isDayjs(cloned[1])).toBeTrue();
+        expect(dayjs.isDayjs(cloned[0])).toBe(true);
+        expect(dayjs.isDayjs(cloned[1])).toBe(true);
         expect(cloned[0]).not.toBe(original[0]);
     });
 
@@ -154,8 +157,8 @@ describe('deepClone', () => {
         const cloned = deepClone(original);
 
         expect(cloned).toBeInstanceOf(Map);
-        expect(dayjs.isDayjs(cloned.get('date1'))).toBeTrue();
-        expect(cloned.get('date1')!.isSame(original.get('date1'))).toBeTrue();
+        expect(dayjs.isDayjs(cloned.get('date1'))).toBe(true);
+        expect(cloned.get('date1')!.isSame(original.get('date1'))).toBe(true);
         expect(cloned.get('date1')).not.toBe(original.get('date1'));
     });
 
@@ -185,8 +188,8 @@ describe('deepClone', () => {
         expect(cloned).toBeInstanceOf(Set);
         expect(cloned.size).toBe(2);
         const clonedArray = Array.from(cloned);
-        expect(dayjs.isDayjs(clonedArray[0])).toBeTrue();
-        expect(dayjs.isDayjs(clonedArray[1])).toBeTrue();
+        expect(dayjs.isDayjs(clonedArray[0])).toBe(true);
+        expect(dayjs.isDayjs(clonedArray[1])).toBe(true);
     });
 
     it('should clone native Date objects', () => {
@@ -243,7 +246,7 @@ describe('deepClone', () => {
         const cloned = deepClone(original);
 
         expect(cloned).toBeInstanceOf(Set);
-        expect(cloned.has(cloned)).toBeTrue();
+        expect(cloned.has(cloned)).toBe(true);
         expect(cloned).not.toBe(original);
     });
 });

--- a/src/main/webapp/app/foundation/util/global.utils.spec.ts
+++ b/src/main/webapp/app/foundation/util/global.utils.spec.ts
@@ -4,16 +4,19 @@ import { TranslateService } from '@ngx-translate/core';
 import { Subject } from 'rxjs';
 import { AlertService, AlertType } from 'app/foundation/service/alert.service';
 import { getCurrentLocaleSignal, isErrorAlert, onError } from 'app/foundation/util/global.utils';
+import { Mocked, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('GlobalUtils', () => {
+    setupTestBed({ zoneless: true });
     describe('onError', () => {
-        let mockAlertService: jest.Mocked<AlertService>;
+        let mockAlertService: Mocked<AlertService>;
 
         beforeEach(() => {
             mockAlertService = {
-                error: jest.fn(),
-                addAlert: jest.fn(),
-            } as unknown as jest.Mocked<AlertService>;
+                error: vi.fn(),
+                addAlert: vi.fn(),
+            } as unknown as Mocked<AlertService>;
         });
 
         it('should show error.http.400 for status 400', () => {
@@ -109,7 +112,7 @@ describe('GlobalUtils', () => {
 
             const result = isErrorAlert(error);
 
-            expect(result).toBeTrue();
+            expect(result).toBe(true);
         });
 
         it('should return false when error does not have errorKey', () => {
@@ -121,13 +124,13 @@ describe('GlobalUtils', () => {
 
             const result = isErrorAlert(error);
 
-            expect(result).toBeFalse();
+            expect(result).toBe(false);
         });
 
         it('should return false when error is null', () => {
             const result = isErrorAlert(null);
 
-            expect(result).toBeFalse();
+            expect(result).toBe(false);
         });
 
         it('should return false when error.error is undefined', () => {
@@ -135,7 +138,7 @@ describe('GlobalUtils', () => {
 
             const result = isErrorAlert(error);
 
-            expect(result).toBeFalse();
+            expect(result).toBe(false);
         });
 
         it('should return false when errorKey is empty string', () => {
@@ -147,7 +150,7 @@ describe('GlobalUtils', () => {
 
             const result = isErrorAlert(error);
 
-            expect(result).toBeFalse();
+            expect(result).toBe(false);
         });
 
         it('should return false when errorKey is null', () => {
@@ -159,7 +162,7 @@ describe('GlobalUtils', () => {
 
             const result = isErrorAlert(error);
 
-            expect(result).toBeFalse();
+            expect(result).toBe(false);
         });
     });
 
@@ -176,7 +179,7 @@ describe('GlobalUtils', () => {
                         provide: TranslateService,
                         useValue: {
                             onLangChange: langChangeSubject.asObservable(),
-                            getCurrentLang: jest.fn().mockReturnValue('en'),
+                            getCurrentLang: vi.fn().mockReturnValue('en'),
                         },
                     },
                 ],

--- a/src/main/webapp/app/foundation/util/markdown.conversion.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/markdown.conversion.util.spec.ts
@@ -1,7 +1,7 @@
 import { MarkdownitTagClass, htmlForMarkdown, markdownForHtml } from './markdown.conversion.util';
 import type { PluginSimple } from 'markdown-it';
 import MarkdownIt from 'markdown-it';
-import { beforeEach, describe, expect, it, test } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('markdown.conversion.util', () => {

--- a/src/main/webapp/app/foundation/util/markdown.conversion.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/markdown.conversion.util.spec.ts
@@ -1,8 +1,11 @@
 import { MarkdownitTagClass, htmlForMarkdown, markdownForHtml } from './markdown.conversion.util';
 import type { PluginSimple } from 'markdown-it';
 import MarkdownIt from 'markdown-it';
+import { beforeEach, describe, expect, it, test } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('markdown.conversion.util', () => {
+    setupTestBed({ zoneless: true });
     describe('htmlForMarkdown', () => {
         describe('empty and undefined input', () => {
             it('should return empty string for undefined input', () => {
@@ -83,7 +86,7 @@ describe('markdown.conversion.util', () => {
 
             it('should strip trailing newline for legacy compatibility', () => {
                 const result = htmlForMarkdown('text');
-                expect(result.endsWith('\n')).toBeFalse();
+                expect(result.endsWith('\n')).toBe(false);
             });
         });
 
@@ -256,7 +259,7 @@ describe('markdown.conversion.util', () => {
                 };
 
                 htmlForMarkdown('test', [customExtension]);
-                expect(extensionCalled).toBeTrue();
+                expect(extensionCalled).toBe(true);
             });
 
             it('should apply multiple custom extensions', () => {

--- a/src/main/webapp/app/foundation/util/markdown.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/markdown.util.spec.ts
@@ -1,6 +1,6 @@
 import { generateExerciseHintExplanation, parseExerciseHintExplanation, sanitizeStringForMarkdownEditor } from './markdown.util';
 import { ExerciseHintExplanationInterface } from 'app/quiz/shared/entities/quiz-question.model';
-import { beforeEach, describe, expect, it, test } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('markdown.util', () => {

--- a/src/main/webapp/app/foundation/util/markdown.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/markdown.util.spec.ts
@@ -1,7 +1,10 @@
 import { generateExerciseHintExplanation, parseExerciseHintExplanation, sanitizeStringForMarkdownEditor } from './markdown.util';
 import { ExerciseHintExplanationInterface } from 'app/quiz/shared/entities/quiz-question.model';
+import { beforeEach, describe, expect, it, test } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('markdown.util', () => {
+    setupTestBed({ zoneless: true });
     describe('sanitizeStringForMarkdownEditor', () => {
         it('should return undefined for undefined input', () => {
             expect(sanitizeStringForMarkdownEditor(undefined)).toBeUndefined();

--- a/src/main/webapp/app/foundation/util/navigation.utils.spec.ts
+++ b/src/main/webapp/app/foundation/util/navigation.utils.spec.ts
@@ -3,7 +3,7 @@ import { Router, UrlTree } from '@angular/router';
 import { Location } from '@angular/common';
 import { ArtemisNavigationUtilService } from 'app/foundation/util/navigation.utils';
 import { MockRouter } from 'test/helpers/mocks/mock-router';
-import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('Navigation Util Service', () => {
@@ -73,7 +73,7 @@ describe('Navigation Util Service', () => {
         creationMock.mockReturnValue(urlTreeMock);
         const serializationMock = vi.spyOn(router, 'serializeUrl');
         serializationMock.mockReturnValue('serializationMockTestValue');
-        const windowStub = vi.spyOn(window, 'open').mockImplementation();
+        const windowStub = vi.spyOn(window, 'open').mockImplementation(() => null);
 
         service.routeInNewTab(['course-management', 17], queryParam);
 

--- a/src/main/webapp/app/foundation/util/navigation.utils.spec.ts
+++ b/src/main/webapp/app/foundation/util/navigation.utils.spec.ts
@@ -3,8 +3,11 @@ import { Router, UrlTree } from '@angular/router';
 import { Location } from '@angular/common';
 import { ArtemisNavigationUtilService } from 'app/foundation/util/navigation.utils';
 import { MockRouter } from 'test/helpers/mocks/mock-router';
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('Navigation Util Service', () => {
+    setupTestBed({ zoneless: true });
     let service: ArtemisNavigationUtilService;
 
     const router = new MockRouter();
@@ -26,12 +29,12 @@ describe('Navigation Util Service', () => {
     });
 
     afterEach(() => {
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
         router.navigate.mockRestore();
     });
 
     it('should go back', () => {
-        const backSpy = jest.spyOn(TestBed.inject(Location), 'back');
+        const backSpy = vi.spyOn(TestBed.inject(Location), 'back');
         // @ts-ignore
         service.onFirstPage = false;
 
@@ -66,11 +69,11 @@ describe('Navigation Util Service', () => {
         const route = ['course-management', 17];
         const queryParam = { filterOption: 30 };
         const urlTreeMock = { path: 'urlTreeMockTestValue' } as unknown as UrlTree;
-        const creationMock = jest.spyOn(router, 'createUrlTree');
+        const creationMock = vi.spyOn(router, 'createUrlTree');
         creationMock.mockReturnValue(urlTreeMock);
-        const serializationMock = jest.spyOn(router, 'serializeUrl');
+        const serializationMock = vi.spyOn(router, 'serializeUrl');
         serializationMock.mockReturnValue('serializationMockTestValue');
-        const windowStub = jest.spyOn(window, 'open').mockImplementation();
+        const windowStub = vi.spyOn(window, 'open').mockImplementation();
 
         service.routeInNewTab(['course-management', 17], queryParam);
 

--- a/src/main/webapp/app/foundation/util/regex.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/regex.util.spec.ts
@@ -1,34 +1,37 @@
 import { matchesRegexFully } from 'app/foundation/util/regex.util';
+import { describe, expect, it, test } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('matchesRegexFully', () => {
+    setupTestBed({ zoneless: true });
     it('should return true if regex is undefined', () => {
-        expect(matchesRegexFully('test', undefined)).toBeTrue();
+        expect(matchesRegexFully('test', undefined)).toBe(true);
     });
 
     it('should return false if input is undefined', () => {
-        expect(matchesRegexFully(undefined, 'test')).toBeFalse();
+        expect(matchesRegexFully(undefined, 'test')).toBe(false);
     });
 
     it('should return true for a full match', () => {
-        expect(matchesRegexFully('test', 'test')).toBeTrue();
+        expect(matchesRegexFully('test', 'test')).toBe(true);
     });
 
     it('should return false for a partial match', () => {
-        expect(matchesRegexFully('testing', 'test')).toBeFalse();
+        expect(matchesRegexFully('testing', 'test')).toBe(false);
     });
 
     it('should return true for a match with regex special characters', () => {
-        expect(matchesRegexFully('test123', 'test\\d+')).toBeTrue();
+        expect(matchesRegexFully('test123', 'test\\d+')).toBe(true);
     });
 
     it('should return false for no match', () => {
-        expect(matchesRegexFully('test', 'no-match')).toBeFalse();
+        expect(matchesRegexFully('test', 'no-match')).toBe(false);
     });
 
     it('should handle regex without ^ and $', () => {
-        expect(matchesRegexFully('test', 'test')).toBeTrue();
-        expect(matchesRegexFully('test', '^test')).toBeTrue();
-        expect(matchesRegexFully('test', 'test$')).toBeTrue();
-        expect(matchesRegexFully('test', '^test$')).toBeTrue();
+        expect(matchesRegexFully('test', 'test')).toBe(true);
+        expect(matchesRegexFully('test', '^test')).toBe(true);
+        expect(matchesRegexFully('test', 'test$')).toBe(true);
+        expect(matchesRegexFully('test', '^test$')).toBe(true);
     });
 });

--- a/src/main/webapp/app/foundation/util/regex.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/regex.util.spec.ts
@@ -1,5 +1,5 @@
 import { matchesRegexFully } from 'app/foundation/util/regex.util';
-import { describe, expect, it, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('matchesRegexFully', () => {

--- a/src/main/webapp/app/foundation/util/request.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/request.util.spec.ts
@@ -1,7 +1,10 @@
 import { createNestedRequestOption } from 'app/foundation/util/request.util';
 import { HttpParams } from '@angular/common/http';
+import { describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('createNestedRequestOption', () => {
+    setupTestBed({ zoneless: true });
     it('should create HttpParams with nested keys', () => {
         const req = { key1: 'value1', key2: 'value2' };
         const parentKey = 'parent';

--- a/src/main/webapp/app/foundation/util/semester-utils.spec.ts
+++ b/src/main/webapp/app/foundation/util/semester-utils.spec.ts
@@ -7,11 +7,14 @@ import {
     getSemesterProgress,
     getSemesters,
 } from 'app/foundation/util/semester-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('SemesterUtils', () => {
+    setupTestBed({ zoneless: true });
     describe('getSemesters', () => {
         it('should get semesters around current year', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2019-01-10'));
+            vi.useFakeTimers().setSystemTime(new Date('2019-01-10'));
             const expectedSemesters = ['WS20/21', 'SS20', 'WS19/20', 'SS19', 'WS18/19', 'SS18', ''];
 
             const semesters = getSemesters();
@@ -24,79 +27,79 @@ describe('SemesterUtils', () => {
 
     describe('getCurrentSemester', () => {
         afterEach(() => {
-            jest.useRealTimers();
+            vi.useRealTimers();
         });
 
         it('should return winter semester for October-December', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2025-10-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2025-10-15'));
             expect(getCurrentSemester()).toBe('WS25/26');
 
-            jest.useFakeTimers().setSystemTime(new Date('2025-11-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2025-11-15'));
             expect(getCurrentSemester()).toBe('WS25/26');
 
-            jest.useFakeTimers().setSystemTime(new Date('2025-12-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2025-12-15'));
             expect(getCurrentSemester()).toBe('WS25/26');
         });
 
         it('should return winter semester for January-March (continuation)', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2026-01-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2026-01-15'));
             expect(getCurrentSemester()).toBe('WS25/26');
 
-            jest.useFakeTimers().setSystemTime(new Date('2026-02-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2026-02-15'));
             expect(getCurrentSemester()).toBe('WS25/26');
 
-            jest.useFakeTimers().setSystemTime(new Date('2026-03-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2026-03-15'));
             expect(getCurrentSemester()).toBe('WS25/26');
         });
 
         it('should return summer semester for April-September', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2025-04-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2025-04-15'));
             expect(getCurrentSemester()).toBe('SS25');
 
-            jest.useFakeTimers().setSystemTime(new Date('2025-07-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2025-07-15'));
             expect(getCurrentSemester()).toBe('SS25');
 
-            jest.useFakeTimers().setSystemTime(new Date('2025-09-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2025-09-15'));
             expect(getCurrentSemester()).toBe('SS25');
         });
     });
 
     describe('getNextSemester', () => {
         afterEach(() => {
-            jest.useRealTimers();
+            vi.useRealTimers();
         });
 
         it('should return summer semester when in winter semester (Oct-Dec)', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2025-10-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2025-10-15'));
             expect(getNextSemester()).toBe('SS26');
         });
 
         it('should return summer semester when in winter semester (Jan-Mar)', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2026-02-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2026-02-15'));
             expect(getNextSemester()).toBe('SS26');
         });
 
         it('should return winter semester when in summer semester', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2025-06-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2025-06-15'));
             expect(getNextSemester()).toBe('WS25/26');
         });
     });
 
     describe('getSemesterProgress', () => {
         afterEach(() => {
-            jest.useRealTimers();
+            vi.useRealTimers();
         });
 
         it('should return 0 at start of semester', () => {
             // Start of winter semester
-            jest.useFakeTimers().setSystemTime(new Date(2025, 9, 1, 12));
+            vi.useFakeTimers().setSystemTime(new Date(2025, 9, 1, 12));
             const progress = getSemesterProgress();
             expect(progress).toBeCloseTo(0, 0);
         });
 
         it('should return approximately 50 at mid-semester', () => {
             // Mid-winter semester (around mid-December)
-            jest.useFakeTimers().setSystemTime(new Date(2025, 11, 15, 12));
+            vi.useFakeTimers().setSystemTime(new Date(2025, 11, 15, 12));
             const progress = getSemesterProgress();
             expect(progress).toBeGreaterThan(40);
             expect(progress).toBeLessThan(60);
@@ -104,7 +107,7 @@ describe('SemesterUtils', () => {
 
         it('should return close to 100 at end of semester', () => {
             // End of winter semester
-            jest.useFakeTimers().setSystemTime(new Date(2026, 2, 30, 12));
+            vi.useFakeTimers().setSystemTime(new Date(2026, 2, 30, 12));
             const progress = getSemesterProgress();
             expect(progress).toBeGreaterThan(95);
         });
@@ -112,29 +115,29 @@ describe('SemesterUtils', () => {
 
     describe('getDefaultSemester', () => {
         afterEach(() => {
-            jest.useRealTimers();
+            vi.useRealTimers();
         });
 
         it('should return current semester when progress < 50%', () => {
             // Early in winter semester
-            jest.useFakeTimers().setSystemTime(new Date('2025-10-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2025-10-15'));
             expect(getDefaultSemester()).toBe('WS25/26');
         });
 
         it('should return next semester when progress >= 50%', () => {
             // Late in winter semester (February)
-            jest.useFakeTimers().setSystemTime(new Date('2026-02-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2026-02-15'));
             expect(getDefaultSemester()).toBe('SS26');
         });
     });
 
     describe('getCurrentAndFutureSemesters', () => {
         afterEach(() => {
-            jest.useRealTimers();
+            vi.useRealTimers();
         });
 
         it('should return current and future semesters only', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2025-10-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2025-10-15'));
             const semesters = getCurrentAndFutureSemesters();
 
             expect(semesters).toContain('WS25/26');
@@ -145,14 +148,14 @@ describe('SemesterUtils', () => {
         });
 
         it('should start with current semester', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2025-06-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2025-06-15'));
             const semesters = getCurrentAndFutureSemesters();
 
             expect(semesters[0]).toBe('SS25');
         });
 
         it('should include winter semester spanning previous/current year in Jan-Mar', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2025-02-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2025-02-15'));
             const semesters = getCurrentAndFutureSemesters();
 
             // Current semester should be WS24/25 (winter semester spanning 2024/2025)
@@ -163,7 +166,7 @@ describe('SemesterUtils', () => {
         });
 
         it('should have SS26 as default while WS25/26 is still selectable in Jan-Mar 2026', () => {
-            jest.useFakeTimers().setSystemTime(new Date('2026-02-15'));
+            vi.useFakeTimers().setSystemTime(new Date('2026-02-15'));
             const semesters = getCurrentAndFutureSemesters();
 
             // Default semester should be SS26 (next semester, since we're > 50% through WS)

--- a/src/main/webapp/app/foundation/util/string-pure.utils.spec.ts
+++ b/src/main/webapp/app/foundation/util/string-pure.utils.spec.ts
@@ -1,6 +1,9 @@
 import { matchRegexWithLineNumbers } from 'app/foundation/util/string-pure.utils';
+import { describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('StringPureUtils', () => {
+    setupTestBed({ zoneless: true });
     describe('matchRegexWithLineNumbers', () => {
         const globalRegex = /.*(def).*/g;
         const nonGlobalRegex = /.*(def).*/;

--- a/src/main/webapp/app/foundation/util/utils.spec.ts
+++ b/src/main/webapp/app/foundation/util/utils.spec.ts
@@ -13,8 +13,12 @@ import {
 import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { Course } from 'app/course/shared/entities/course.model';
 import { Range } from 'app/foundation/util/utils';
+import { describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('Round', () => {
+    setupTestBed({ zoneless: true });
+
     it('Decimal length', () => {
         expect(round(14.821354, 4)).toBe(14.8214);
         expect(round(14.821354, 3)).toBe(14.821);
@@ -49,6 +53,7 @@ describe('Round', () => {
 });
 
 describe('Rounding of scores', () => {
+    setupTestBed({ zoneless: true });
     it('RoundScore', () => {
         expect(roundValueSpecifiedByCourseSettings(13.821354, { accuracyOfScores: 4 })).toBe(13.8214);
         expect(roundValueSpecifiedByCourseSettings(54.821354, { accuracyOfScores: 3 })).toBe(54.821);
@@ -67,6 +72,7 @@ describe('Rounding of scores', () => {
 });
 
 describe('stringifyIgnoringFields', () => {
+    setupTestBed({ zoneless: true });
     it('should ignore nothing', () => {
         expect(stringifyIgnoringFields({})).toBe(JSON.stringify({}));
         expect(stringifyIgnoringFields({}, 'a', 'b')).toBe(JSON.stringify({}));
@@ -82,6 +88,7 @@ describe('stringifyIgnoringFields', () => {
 });
 
 describe('average', () => {
+    setupTestBed({ zoneless: true });
     it('should return an average of 0 for an empty array', () => {
         expect(average([])).toBe(0);
     });
@@ -94,6 +101,7 @@ describe('average', () => {
 });
 
 describe('Range', () => {
+    setupTestBed({ zoneless: true });
     it('should return the correct string representation', () => {
         const range = new Range(10, 50);
         expect(range.toString()).toBe('[10%, 50%)');
@@ -104,6 +112,7 @@ describe('Range', () => {
 });
 
 describe('getAsMutableObject', () => {
+    setupTestBed({ zoneless: true });
     it('should return immutable object as mutable object', () => {
         const immutableObject = Object.freeze({
             name: 'Jane',
@@ -119,22 +128,24 @@ describe('getAsMutableObject', () => {
 });
 
 describe('isExamExercise', () => {
+    setupTestBed({ zoneless: true });
     it('should return true if course is not set', () => {
         const examExercise = { course: undefined } as Exercise;
 
         const isExamExerciseResult = isExamExercise(examExercise);
-        expect(isExamExerciseResult).toBeTrue();
+        expect(isExamExerciseResult).toBe(true);
     });
 
     it('should return false if course is set', () => {
         const courseExercise = { course: new Course() } as Exercise;
 
         const isExamExerciseResult = isExamExercise(courseExercise);
-        expect(isExamExerciseResult).toBeFalse();
+        expect(isExamExerciseResult).toBe(false);
     });
 });
 
 describe('roundUpToNextMultiple', () => {
+    setupTestBed({ zoneless: true });
     it('should round up to multiple of 5 if value is closer to lower multiple', () => {
         expect(roundToNextMultiple(21, 5, true)).toBe(25);
     });
@@ -157,6 +168,7 @@ describe('roundUpToNextMultiple', () => {
 });
 
 describe('removeSpecialCharacters', () => {
+    setupTestBed({ zoneless: true });
     it('should remove special characters', () => {
         expect(removeSpecialCharacters('Hello, World!')).toBe('HelloWorld');
         expect(removeSpecialCharacters('Hello, World! 123')).toBe('HelloWorld123');
@@ -165,6 +177,7 @@ describe('removeSpecialCharacters', () => {
 });
 
 describe('secondsInMilliseconds', () => {
+    setupTestBed({ zoneless: true });
     it('should convert seconds to milliseconds', () => {
         expect(secondsToMilliseconds(1)).toBe(1000);
         expect(secondsToMilliseconds(1.5)).toBe(1500);

--- a/src/main/webapp/app/foundation/util/week-grouping.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/week-grouping.util.spec.ts
@@ -1,8 +1,11 @@
 import { WeekGroupingUtil } from './week-grouping.util';
 import { SidebarCardElement } from '../types/sidebar';
 import dayjs from 'dayjs/esm';
+import { describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 describe('WeekGroupingUtil', () => {
+    setupTestBed({ zoneless: true });
     it('returns a single group for noDate', () => {
         const items: SidebarCardElement[] = [
             { title: 'Item 1', id: 'i1', size: 'M' },

--- a/src/main/webapp/app/foundation/validators/custom-max-length-validator/custom-max-length-validator.directive.spec.ts
+++ b/src/main/webapp/app/foundation/validators/custom-max-length-validator/custom-max-length-validator.directive.spec.ts
@@ -4,6 +4,8 @@ import { FormControl, FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { CustomMaxLengthDirective } from './custom-max-length-validator.directive';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 @Component({
     template: `<input [customMaxLength]="maxLength" ngModel />`,
@@ -15,6 +17,7 @@ class TestHostComponent {
 }
 
 describe('CustomMaxLengthDirective', () => {
+    setupTestBed({ zoneless: true });
     let fixture: ComponentFixture<TestHostComponent>;
     let host: TestHostComponent;
 

--- a/src/main/webapp/app/foundation/validators/custom-pattern-validator.directive.spec.ts
+++ b/src/main/webapp/app/foundation/validators/custom-pattern-validator.directive.spec.ts
@@ -1,9 +1,11 @@
-import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { CustomPatternValidatorDirective } from './custom-pattern-validator.directive';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
 @Component({
     standalone: true,
@@ -15,6 +17,8 @@ class CustomPatternComponent {
 }
 
 describe('CustomPatternValidatorDirective', () => {
+    setupTestBed({ zoneless: true });
+
     let fixture: ComponentFixture<CustomPatternComponent>;
     let component = new CustomPatternComponent();
 
@@ -26,31 +30,27 @@ describe('CustomPatternValidatorDirective', () => {
         component = fixture.componentInstance;
     });
 
-    it('should accept correct patterns', fakeAsync(() => {
+    it('should accept correct patterns', async () => {
         component.pattern = '^.*@example.com$';
 
         fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
 
-        fixture.whenStable().then(() => {
-            fixture.detectChanges();
+        const patternEl = fixture.debugElement.query(By.css('input[name=pattern]')).references['patternModel'];
 
-            const patternEl = fixture.debugElement.query(By.css('input[name=pattern]')).references['patternModel'];
+        expect(patternEl.errors).toBeNull();
+    });
 
-            expect(patternEl.errors).toBeNull();
-        });
-    }));
-
-    it('should set error on incorrect patterns', fakeAsync(() => {
+    it('should set error on incorrect patterns', async () => {
         component.pattern = '*@example.com$';
 
         fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
 
-        fixture.whenStable().then(() => {
-            fixture.detectChanges();
+        const patternEl = fixture.debugElement.query(By.css('input[name=pattern]')).references['patternModel'];
 
-            const patternEl = fixture.debugElement.query(By.css('input[name=pattern]')).references['patternModel'];
-
-            expect(patternEl.errors.validPattern).toBeTrue();
-        });
-    }));
+        expect(patternEl.errors.validPattern).toBe(true);
+    });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -96,6 +96,7 @@ export default defineConfig({
             'src/main/webapp/app/programming/shared/entities/build-plan-phases.model.spec.ts', // include build plan phases model tests
             'src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.spec.ts', // include legacy build plan converter service tests
             'src/main/webapp/app/programming/shared/programming-exercise-update-timeline/**/*.spec.ts', // include programming exercise update timeline tests
+            'src/main/webapp/app/foundation/**/*.spec.ts', // include all foundation tests (migrated Jest->Vitest; supersedes the feature-toggle/sort entries above)
         ],
         exclude: ['**/node_modules/**', '**/build/**'],
         testTimeout: 10000,
@@ -171,6 +172,7 @@ export default defineConfig({
                 'src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.ts', // include legacy build plan converter service for code coverage
                 'src/main/webapp/app/programming/shared/entities/build-plan-phases.model.ts', // include build plan phases model for code coverage
                 'src/main/webapp/app/programming/shared/programming-exercise-update-timeline/**/*.ts', // include programming exercise update timeline for code coverage
+                'src/main/webapp/app/foundation/**/*.ts', // include all foundation for code coverage (migrated Jest->Vitest; supersedes the feature-toggle/sort entries above)
             ],
             exclude: [
                 '**/node_modules/**', // exclude node_modules with third-party code


### PR DESCRIPTION
### Summary

This PR migrates the `foundation` module to Angular 21 conventions as part of the ongoing Angular 21 migration campaign. It contains two mechanical, behavior-preserving changes plus the corresponding test-runner config sync:

1. **Jest → Vitest**: 41 foundation Jest specs were migrated to Vitest (zoneless `setupTestBed`, `vi.*` APIs, `fakeAsync`/`tick`/`flush` → top-level `async`/`await`). 3 foundation specs that were already on Vitest (`feature-toggle`, `sort-by`, `sort` directives) were left untouched. After migration, the full foundation Vitest suite is **46 spec files / 564 tests, all green**.
2. **Legacy decorators → signal APIs** in 4 files:
   - `pagination/item-count.component.ts` — `@Input set` → `input()` + `computed()` guards
   - `auth/has-any-authority.directive.ts` — `input.required()` + constructor `effect()`
   - `language/translate.directive.ts` — `jhiTranslate` → `input()` + `effect()`
   - `extension-point/extension-point.directive.ts` — `ngOnChanges` → `effect()` + `untracked()` state machine (reproducing the old truthy-only context-update behavior)

No production runtime behavior changes; this is an infrastructure-only refactor with no intended visual change.

### Config sync (append-only)

To wire the migrated specs to the correct runner, the shared test config was updated **append-only** (no existing entries reordered or removed), per the campaign's config-edit rule:

- `vitest.config.ts`: appended `src/main/webapp/app/foundation/**/*.spec.ts` to `test.include` and `src/main/webapp/app/foundation/**/*.ts` to `coverage.include` (broad globs supersede the pre-existing individual `feature-toggle`/`sort` entries; harmless overlap, noted inline).
- `jest.config.js` (3 sites): added matching foundation excludes to `collectCoverageFrom` (negation before the catch-all), `coveragePathIgnorePatterns`, and `testPathIgnorePatterns`.
- `jest.config.js` coverage threshold: `coverageThreshold.global.functions` lowered `72.5` → `71.7`. Foundation is the largest single mover this campaign (41 specs leaving Jest), measured Jest `functions` actual after removal ≈ 72.22%, set ~0.5pp below per campaign convention. The other three metrics (statements 83, branches 72.9, lines 84) are unchanged and continue to pass. This value is intentionally the minimum among in-flight migration PRs.

### Develop merge

`origin/develop` (`12cfcc94269e`, which now includes #12817 logos/sharing/app-shell → Vitest) was merged into this branch. The only conflicts were in `vitest.config.ts` and `jest.config.js`, both resolved append-only:
- Glob conflicts: kept **both** develop's (logos/sharing/app.component) and foundation's added entries.
- `functions` threshold conflict (foundation 71.7 vs develop's 72.2): took the **minimum** = 71.7, since the threshold is a floor that only drops as specs leave Jest.

All other develop changes (lecture youtube-player, iris/logos/sharing specs) auto-merged cleanly.

### Testing

All gates run locally on Node 24.7.0:
- `tsc -p tsconfig.app.json --noEmit` — clean (exit 0)
- `ngc -p tsconfig.app.json --noEmit` — clean (exit 0)
- Foundation Vitest suite — **46 files / 564 tests pass** (exit 0)
- `prettier --check` on config + foundation files — clean

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

Part of the Angular 21 migration campaign. The `foundation` module holds core utilities, pipes, directives, services, and validators used app-wide. Migrating its specs to Vitest and its remaining legacy decorators to signal APIs brings it in line with the mandated Angular 21 conventions and removes 41 specs from the deprecated Jest runner.

### Description

See Summary above. The changes are purely a test-runner migration plus decorator → signal conversions, with no production behavior change. Reviewer cross-check during integration confirmed all 4 decorator conversions are behavior-faithful, and that the `custom-pattern-validator.directive` spec migration made previously-dead `fakeAsync whenStable().then()` assertions (which never ran without `tick()`/`flush()`) **live** (proven via mutation testing) — i.e. stronger than before, not weaker.

### Steps for Testing

This is a client infrastructure refactor with no visual or behavioral change. To verify:

1. Check out the branch and run `pnpm run vitest run src/main/webapp/app/foundation` — all 564 foundation tests pass.
2. Run `npx tsc -p tsconfig.app.json --noEmit` and `npx ngc -p tsconfig.app.json --noEmit` — both clean.
3. CI validates the full Jest coverage run with the adjusted threshold.

### Screenshots

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated the foundation module to Vitest, updated test runner configs, and excluded foundation from Jest runs; adjusted global coverage thresholds.
  * Refactored several foundation internals to use Angular Signals (no intended behavioral changes).

* **Tests**
  * Updated many unit tests to Vitest-style setup, modernized assertions and timer handling, and added/adjusted specs to align with the migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->