### PR TITLE
`Development`: Migrate shared-ui delete and user-import dialogs to signal APIs

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -150,6 +150,10 @@ module.exports = {
         '!<rootDir>/src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.ts', // legacy converter uses Vitest (see vitest.config.ts)
         '!<rootDir>/src/main/webapp/app/programming/shared/entities/build-plan-phases.model.ts', // build-plan-phases model uses Vitest (see vitest.config.ts)
         '!<rootDir>/src/main/webapp/app/programming/shared/programming-exercise-update-timeline/**', // programming exercise update timeline uses Vitest (see vitest.config.ts)
+        '!<rootDir>/src/main/webapp/app/shared-ui/delete-dialog/**', // delete-dialog uses Vitest (see vitest.config.ts)
+        '!<rootDir>/src/main/webapp/app/shared-ui/confirm-entity-name/**', // confirm-entity-name uses Vitest (see vitest.config.ts)
+        '!<rootDir>/src/main/webapp/app/shared-ui/user-import/button/**', // user import button uses Vitest (see vitest.config.ts)
+        '!<rootDir>/src/main/webapp/app/shared-ui/user-import/dialog/**', // user import dialog uses Vitest (see vitest.config.ts)
         '<rootDir>/src/main/webapp/**/*.ts',
     ],
     // Each entry below excludes a module that has been migrated to Vitest.
@@ -214,6 +218,10 @@ module.exports = {
         '<rootDir>/src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.ts',
         '<rootDir>/src/main/webapp/app/programming/shared/entities/build-plan-phases.model.ts',
         '<rootDir>/src/main/webapp/app/programming/shared/programming-exercise-update-timeline/',
+        '<rootDir>/src/main/webapp/app/shared-ui/delete-dialog/', // delete-dialog uses Vitest
+        '<rootDir>/src/main/webapp/app/shared-ui/confirm-entity-name/', // confirm-entity-name uses Vitest
+        '<rootDir>/src/main/webapp/app/shared-ui/user-import/button/', // user import button uses Vitest
+        '<rootDir>/src/main/webapp/app/shared-ui/user-import/dialog/', // user import dialog uses Vitest
     ],
     // Global coverage thresholds for Jest. Modules using Vitest (e.g., fileupload) have their own
     // coverage thresholds in vitest.config.ts. Per-module thresholds are enforced by check-client-module-coverage.mjs
@@ -224,7 +232,7 @@ module.exports = {
         global: {
             statements: 83,
             branches: 72.9,
-            functions: 72.5,
+            functions: 71.2,
             lines: 84,
         },
     },
@@ -317,6 +325,10 @@ module.exports = {
         '<rootDir>/src/main/webapp/app/programming/shared/services/build-phases-template.service.spec.ts', // migrated to Vitest
         '<rootDir>/src/main/webapp/app/programming/shared/entities/build-plan-phases.model.spec.ts', // migrated to Vitest
         '<rootDir>/src/main/webapp/app/programming/shared/programming-exercise-update-timeline/', // migrated to Vitest
+        '<rootDir>/src/main/webapp/app/shared-ui/delete-dialog/', // delete-dialog (Vitest)
+        '<rootDir>/src/main/webapp/app/shared-ui/confirm-entity-name/', // confirm-entity-name (Vitest)
+        '<rootDir>/src/main/webapp/app/shared-ui/user-import/button/', // user import button (Vitest)
+        '<rootDir>/src/main/webapp/app/shared-ui/user-import/dialog/', // user import dialog (Vitest)
     ],
     testTimeout: 3000,
     testMatch: ['<rootDir>/src/main/webapp/app/**/*.spec.ts', '<rootDir>/src/test/javascript/spec/**/*.integration.spec.ts'],

--- a/src/main/webapp/app/shared-ui/confirm-entity-name/confirm-entity-name.component.html
+++ b/src/main/webapp/app/shared-ui/confirm-entity-name/confirm-entity-name.component.html
@@ -1,6 +1,6 @@
 <div class="form-group d-flex flex-column gap-1">
     <div class="d-flex flex-md-row flex-column align-items-md-center">
-        <label for="confirm-entity-name" [ngClass]="warningTextColor" [jhiTranslate]="confirmationText"></label>
+        <label for="confirm-entity-name" [ngClass]="warningTextColor()" [jhiTranslate]="confirmationText()"></label>
         <code class="display-spaces background-grey rounded-2 d-inline-block ms-md-2 px-2">{{ entityNameSignal() }}</code>
         <jhi-copy-to-clipboard-button [copyText]="entityNameSignal()" />
     </div>

--- a/src/main/webapp/app/shared-ui/confirm-entity-name/confirm-entity-name.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/confirm-entity-name/confirm-entity-name.component.spec.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ConfirmEntityNameComponent } from 'app/shared-ui/confirm-entity-name/confirm-entity-name.component';
@@ -10,7 +12,7 @@ import { By } from '@angular/platform-browser';
 const expectedEntityName = 'TestEntityName';
 
 @Component({
-    template: '<jhi-confirm-entity-name [entityName]="expectedEntityName" />',
+    template: '<jhi-confirm-entity-name [entityName]="expectedEntityName" confirmationText="artemisApp.confirm" />',
     imports: [ConfirmEntityNameComponent],
 })
 class ConfirmEntityNameHostComponent {
@@ -20,7 +22,13 @@ class ConfirmEntityNameHostComponent {
 }
 
 describe('ConfirmEntityNameComponent', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     describe('NgModel', () => {
+        setupTestBed({ zoneless: true });
+
         let component: ConfirmEntityNameHostComponent;
         let fixture: ComponentFixture<ConfirmEntityNameHostComponent>;
         let confirmEntityNameComponent: ConfirmEntityNameComponent;
@@ -39,39 +47,47 @@ describe('ConfirmEntityNameComponent', () => {
         });
 
         it('control should be valid with valid input', async () => {
-            confirmEntityNameComponent.entityName = expectedEntityName;
-            fixture.changeDetectorRef.detectChanges();
+            fixture.detectChanges();
+            await fixture.whenStable();
             confirmEntityNameComponent.control.setValue(expectedEntityName);
-            fixture.changeDetectorRef.detectChanges();
-            expect(confirmEntityNameComponent.control.valid).toBeTrue();
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(confirmEntityNameComponent.control.valid).toBe(true);
         });
 
         it('control should be invalid with invalid input', async () => {
-            confirmEntityNameComponent.entityName = expectedEntityName;
-            fixture.changeDetectorRef.detectChanges();
+            fixture.detectChanges();
+            await fixture.whenStable();
             confirmEntityNameComponent.control.setValue('');
-            fixture.changeDetectorRef.detectChanges();
-            expect(confirmEntityNameComponent.control.invalid).toBeTrue();
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(confirmEntityNameComponent.control.invalid).toBe(true);
         });
 
         it('control should be valid for dynamic entity name', async () => {
             component.expectedEntityName = 'OtherTestEntityName';
-            fixture.changeDetectorRef.detectChanges();
+            fixture.detectChanges();
+            await fixture.whenStable();
             confirmEntityNameComponent.control.setValue('OtherTestEntityName');
-            fixture.changeDetectorRef.detectChanges();
-            expect(confirmEntityNameComponent.control.valid).toBeTrue();
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(confirmEntityNameComponent.control.valid).toBe(true);
         });
 
         it('control should be invalid for dynamic entity name with previous entity name', async () => {
             component.expectedEntityName = 'OtherTestEntityName';
-            fixture.changeDetectorRef.detectChanges();
+            fixture.detectChanges();
+            await fixture.whenStable();
             confirmEntityNameComponent.control.setValue('TestEntityName');
-            fixture.changeDetectorRef.detectChanges();
-            expect(confirmEntityNameComponent.control.invalid).toBeTrue();
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expect(confirmEntityNameComponent.control.invalid).toBe(true);
         });
     });
 
     describe('Component', () => {
+        setupTestBed({ zoneless: true });
+
         let component: ConfirmEntityNameComponent;
         let fixture: ComponentFixture<ConfirmEntityNameComponent>;
 
@@ -89,14 +105,15 @@ describe('ConfirmEntityNameComponent', () => {
         });
 
         it('should change warning text color', () => {
-            component.warningTextColor = 'text-danger';
-            fixture.changeDetectorRef.detectChanges();
+            fixture.componentRef.setInput('confirmationText', 'artemisApp.confirm');
+            fixture.componentRef.setInput('warningTextColor', 'text-danger');
+            fixture.detectChanges();
             expect(fixture.nativeElement.querySelector('label[for="confirm-entity-name"]').classList.contains('text-danger')).toBeTruthy();
         });
 
         it('should display confirmation text', () => {
-            component.confirmationText = 'foobar';
-            fixture.changeDetectorRef.detectChanges();
+            fixture.componentRef.setInput('confirmationText', 'foobar');
+            fixture.detectChanges();
             expect(fixture.nativeElement.querySelector('label[for="confirm-entity-name"]').textContent).toBe('foobar');
         });
     });

--- a/src/main/webapp/app/shared-ui/confirm-entity-name/confirm-entity-name.component.ts
+++ b/src/main/webapp/app/shared-ui/confirm-entity-name/confirm-entity-name.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, effect, inject, input, signal, untracked } from '@angular/core';
 import {
     ControlValueAccessor,
     FormBuilder,
@@ -37,29 +37,30 @@ import { CopyToClipboardButtonComponent } from 'app/shared-ui/components/buttons
 export class ConfirmEntityNameComponent implements OnInit, OnDestroy, ControlValueAccessor, Validator {
     private fb = inject(FormBuilder);
 
-    @Input() warningTextColor: string;
-    @Input() confirmationText: string;
-
-    @Input()
-    set entityName(entityName: string) {
-        this.currentEntityName = entityName;
-        this.entityNameSignal.set(entityName);
-        this.onValidatorChange?.();
-    }
+    readonly warningTextColor = input<string>();
+    readonly confirmationText = input.required<string>();
+    readonly entityName = input<string>('');
 
     entityNameSignal = signal<string>('');
-
-    get entityName(): string {
-        return this.currentEntityName;
-    }
 
     control: FormControl<string>;
 
     onTouched = () => {};
 
-    private currentEntityName: string;
     private onChangeSubs: Subscription[] = [];
     private onValidatorChange?: () => void;
+
+    constructor() {
+        // Mirror the entityName input into the display signal and notify the validator whenever it changes,
+        // reproducing the original @Input setter side effects.
+        effect(() => {
+            const entityName = this.entityName();
+            untracked(() => {
+                this.entityNameSignal.set(entityName);
+                this.onValidatorChange?.();
+            });
+        });
+    }
 
     ngOnInit() {
         this.control = this.fb.control('', {
@@ -109,7 +110,7 @@ export class ConfirmEntityNameComponent implements OnInit, OnDestroy, ControlVal
     }
 
     private compareWithEntityName(control: FormControl): ValidationErrors | null {
-        if (control.value !== this.entityName) {
+        if (control.value !== this.entityName()) {
             return { invalidName: true };
         }
         return null;

--- a/src/main/webapp/app/shared-ui/delete-dialog/component/delete-dialog.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/delete-dialog/component/delete-dialog.component.spec.ts
@@ -1,4 +1,6 @@
-import { ComponentFixture, TestBed, fakeAsync, flush } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { EventEmitter } from '@angular/core';
 import { DeleteDialogComponent } from 'app/shared-ui/delete-dialog/component/delete-dialog.component';
@@ -14,6 +16,8 @@ import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { ActionType } from 'app/shared-ui/delete-dialog/delete-dialog.model';
 
 describe('DeleteDialogComponent', () => {
+    setupTestBed({ zoneless: true });
+
     let comp: DeleteDialogComponent;
     let fixture: ComponentFixture<DeleteDialogComponent>;
     let dialogRef: DynamicDialogRef;
@@ -43,77 +47,84 @@ describe('DeleteDialogComponent', () => {
 
     beforeEach(async () => {
         const mockDialogRef = {
-            close: jest.fn(),
+            close: vi.fn(),
         };
 
         await TestBed.configureTestingModule({
             imports: [TranslateModule.forRoot(), ReactiveFormsModule, FormsModule, DeleteDialogComponent],
-            declarations: [MockPipe(ArtemisTranslatePipe), MockDirective(TranslateDirective)],
             providers: [
                 JhiLanguageHelper,
                 AlertService,
                 { provide: DynamicDialogRef, useValue: mockDialogRef },
                 { provide: DynamicDialogConfig, useValue: createMockDialogConfig() },
             ],
-        }).compileComponents();
+        })
+            .overrideComponent(DeleteDialogComponent, {
+                remove: { imports: [ArtemisTranslatePipe, TranslateDirective] },
+                add: { imports: [MockPipe(ArtemisTranslatePipe), MockDirective(TranslateDirective)] },
+            })
+            .compileComponents();
         fixture = TestBed.createComponent(DeleteDialogComponent);
         comp = fixture.componentInstance;
         dialogRef = TestBed.inject(DynamicDialogRef);
     });
 
-    it('Dialog is correctly initialized', fakeAsync(() => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('Dialog is correctly initialized', async () => {
         fixture.detectChanges();
-        const closeSpy = jest.spyOn(dialogRef, 'close');
+        await fixture.whenStable();
+        const closeSpy = vi.spyOn(dialogRef, 'close');
 
         expect(comp.entityTitle()).toBe('title');
         expect(comp.deleteQuestion).toBe('artemisApp.exercise.delete.question');
         expect(comp.warningTextColor).toBe('text-danger');
-        expect(comp.useFaCheckIcon).toBeFalse();
+        expect(comp.useFaCheckIcon).toBe(false);
 
         // Check that clear method calls dialogRef.close
         comp.clear();
         expect(closeSpy).toHaveBeenCalledOnce();
-
-        flush();
-    }));
+    });
 
     it('Form properly checked before submission', async () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
         // Initially the form should be invalid (empty value doesn't match 'title')
-        expect(comp.deleteForm.invalid).toBeTrue();
+        expect(comp.deleteForm().invalid).toBe(true);
 
         // User entered some title (wrong title)
         comp.confirmEntityName = 'some title';
         fixture.detectChanges();
         await fixture.whenStable();
-        expect(comp.deleteForm.invalid).toBeTrue();
+        expect(comp.deleteForm().invalid).toBe(true);
 
         // User entered correct title
         comp.confirmEntityName = 'title';
         fixture.detectChanges();
         await fixture.whenStable();
-        expect(comp.deleteForm.invalid).toBeFalse();
+        expect(comp.deleteForm().invalid).toBe(false);
     });
 
-    it('Dialog closes immediately when confirmDelete is called', fakeAsync(() => {
+    it('Dialog closes immediately when confirmDelete is called', async () => {
         fixture.detectChanges();
-        const closeSpy = jest.spyOn(dialogRef, 'close');
+        await fixture.whenStable();
+        const closeSpy = vi.spyOn(dialogRef, 'close');
 
         // external component delete method was executed
         comp.confirmDelete();
 
         // submit should be disabled and dialog should close immediately
-        expect(comp.submitDisabled()).toBeTrue();
+        expect(comp.submitDisabled()).toBe(true);
         expect(closeSpy).toHaveBeenCalledOnce();
 
         // Note: Error handling is now done in DeleteDialogService, not in the component.
         // The dialog closes immediately so the progress bar can be shown during deletion.
 
         fixture.destroy();
-        flush();
-    }));
+    });
 
     it('getItemPairs should correctly group items', () => {
         fixture.detectChanges();

--- a/src/main/webapp/app/shared-ui/delete-dialog/component/delete-dialog.component.ts
+++ b/src/main/webapp/app/shared-ui/delete-dialog/component/delete-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, EventEmitter, OnInit, ViewChild, inject, signal } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, OnInit, inject, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { mapValues } from 'lodash-es';
@@ -53,9 +53,8 @@ export class DeleteDialogComponent implements OnInit {
     confirmEntityName = '';
     additionalChecksValues: { [key: string]: boolean } = {};
 
-    // Note: Using @ViewChild here because the template has #deleteForm="ngForm" which creates a template
-    // reference variable that shadows any component property. The viewChild signal cannot be used in this case.
-    @ViewChild('deleteForm', { static: true }) deleteForm: NgForm;
+    // The template has #deleteForm="ngForm"; viewChild resolves the exported NgForm directive instance.
+    readonly deleteForm = viewChild.required<NgForm>('deleteForm');
 
     deleteQuestion: string;
     entitySummaryTitle?: string;

--- a/src/main/webapp/app/shared-ui/delete-dialog/directive/delete-button.directive.spec.ts
+++ b/src/main/webapp/app/shared-ui/delete-dialog/directive/delete-button.directive.spec.ts
@@ -1,4 +1,6 @@
-import { ComponentFixture, TestBed, discardPeriodicTasks, fakeAsync } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { Component, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
@@ -19,20 +21,22 @@ class TestComponent {
 }
 
 describe('DeleteDialogDirective', () => {
+    setupTestBed({ zoneless: true });
+
     let comp: TestComponent;
     let fixture: ComponentFixture<TestComponent>;
     let debugElement: DebugElement;
     let deleteDialogService: DeleteDialogService;
     let translateService: TranslateService;
-    let translateSpy: jest.SpyInstance;
+    let translateSpy: ReturnType<typeof vi.spyOn>;
 
     const mockDialogRef = {
         onClose: new Subject<void>(),
-        close: jest.fn(),
+        close: vi.fn(),
     } as unknown as DynamicDialogRef;
 
     const mockDialogService = {
-        open: jest.fn().mockReturnValue(mockDialogRef),
+        open: vi.fn().mockReturnValue(mockDialogRef),
     };
 
     beforeEach(() =>
@@ -50,12 +54,12 @@ describe('DeleteDialogDirective', () => {
                 debugElement = fixture.debugElement;
                 deleteDialogService = TestBed.inject(DeleteDialogService);
                 translateService = TestBed.inject(TranslateService);
-                translateSpy = jest.spyOn(translateService, 'instant');
+                translateSpy = vi.spyOn(translateService, 'instant');
             }),
     );
 
     afterEach(() => {
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
     });
 
     it('directive should be correctly initialized', () => {
@@ -82,17 +86,18 @@ describe('DeleteDialogDirective', () => {
         expect(directiveInstance.deleteConfirmationText()).toBe('text');
     });
 
-    it('on click should call delete dialog service', fakeAsync(() => {
+    it('on click should call delete dialog service', async () => {
         // Ignore console errors
-        console.error = jest.fn();
+        console.error = vi.fn();
         fixture.detectChanges();
-        const deleteDialogSpy = jest.spyOn(deleteDialogService, 'openDeleteDialog');
+        await fixture.whenStable();
+        const deleteDialogSpy = vi.spyOn(deleteDialogService, 'openDeleteDialog');
         const directiveEl = debugElement.query(By.directive(DeleteButtonDirective));
         directiveEl.nativeElement.click();
         fixture.detectChanges();
+        await fixture.whenStable();
         expect(deleteDialogSpy).toHaveBeenCalledOnce();
-        discardPeriodicTasks();
-    }));
+    });
 
     it('action type cleanup should change button title', () => {
         comp.actionType = ActionType.Cleanup;

--- a/src/main/webapp/app/shared-ui/delete-dialog/directive/delete-button.directive.spec.ts
+++ b/src/main/webapp/app/shared-ui/delete-dialog/directive/delete-button.directive.spec.ts
@@ -88,7 +88,7 @@ describe('DeleteDialogDirective', () => {
 
     it('on click should call delete dialog service', async () => {
         // Ignore console errors
-        console.error = vi.fn();
+        vi.spyOn(console, 'error').mockImplementation(() => undefined);
         fixture.detectChanges();
         await fixture.whenStable();
         const deleteDialogSpy = vi.spyOn(deleteDialogService, 'openDeleteDialog');

--- a/src/main/webapp/app/shared-ui/delete-dialog/directive/delete-button.directive.ts
+++ b/src/main/webapp/app/shared-ui/delete-dialog/directive/delete-button.directive.ts
@@ -29,8 +29,9 @@ export class DeleteButtonDirective implements OnInit {
     renderButtonText = input<boolean>(true);
     requireConfirmationOnlyForAdditionalChecks = input<boolean>(false);
     dialogError = input<Observable<string>>();
-    // Note: Using @Output here because the EventEmitter is passed through the service to DeleteDialogComponent
-    // which calls .emit() on it. Signal outputs (OutputEmitterRef) don't support this pattern.
+    // Kept as @Output()/EventEmitter (not migrated to output()): the EventEmitter instance is passed by
+    // reference through DeleteDialogData into DeleteDialogService and DeleteDialogComponent, which call
+    // .emit() on it externally. OutputEmitterRef from output() cannot be handed to another component to emit.
     @Output() delete = new EventEmitter<{ [key: string]: boolean }>();
     animation = input<boolean>(true);
 

--- a/src/main/webapp/app/shared-ui/delete-dialog/service/delete-dialog.service.spec.ts
+++ b/src/main/webapp/app/shared-ui/delete-dialog/service/delete-dialog.service.spec.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { TestBed } from '@angular/core/testing';
 import { DeleteDialogService } from 'app/shared-ui/delete-dialog/service/delete-dialog.service';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -11,13 +13,15 @@ import { ButtonType } from 'app/shared-ui/components/buttons/button/button.compo
 import { AlertService } from 'app/foundation/service/alert.service';
 
 describe('Delete Dialog Service', () => {
+    setupTestBed({ zoneless: true });
+
     let service: DeleteDialogService;
     let dialogService: DialogService;
     let alertService: AlertService;
 
     const mockDialogRef = {
         onClose: new Subject<void>(),
-        close: jest.fn(),
+        close: vi.fn(),
     } as unknown as DynamicDialogRef;
 
     beforeEach(() => {
@@ -28,14 +32,14 @@ describe('Delete Dialog Service', () => {
                 {
                     provide: DialogService,
                     useValue: {
-                        open: jest.fn().mockReturnValue(mockDialogRef),
+                        open: vi.fn().mockReturnValue(mockDialogRef),
                     },
                 },
                 {
                     provide: AlertService,
                     useValue: {
-                        closeAll: jest.fn(),
-                        error: jest.fn(),
+                        closeAll: vi.fn(),
+                        error: vi.fn(),
                     },
                 },
             ],
@@ -46,7 +50,7 @@ describe('Delete Dialog Service', () => {
     });
 
     afterEach(() => {
-        jest.resetAllMocks();
+        vi.resetAllMocks();
     });
 
     it('should open delete dialog', () => {
@@ -62,7 +66,7 @@ describe('Delete Dialog Service', () => {
             delete: new EventEmitter<any>(),
             requireConfirmationOnlyForAdditionalChecks: false,
         };
-        const openDialogSpy = jest.spyOn(dialogService, 'open');
+        const openDialogSpy = vi.spyOn(dialogService, 'open');
         service.openDeleteDialog(data);
         expect(openDialogSpy).toHaveBeenCalledOnce();
         expect(openDialogSpy).toHaveBeenCalledWith(

--- a/src/main/webapp/app/shared-ui/user-import/button/user-import-button.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/user-import/button/user-import-button.component.spec.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent, MockProvider } from 'ng-mocks';
 import { AlertService } from 'app/foundation/service/alert.service';
@@ -8,6 +10,8 @@ import { UsersImportButtonComponent } from 'app/shared-ui/user-import/button/use
 import { UsersImportDialogComponent } from 'app/shared-ui/user-import/dialog/users-import-dialog.component';
 
 describe('UsersImportButtonComponent', () => {
+    setupTestBed({ zoneless: true });
+
     let fixture: ComponentFixture<UsersImportButtonComponent>;
     let comp: UsersImportButtonComponent;
 
@@ -29,7 +33,7 @@ describe('UsersImportButtonComponent', () => {
     });
 
     afterEach(() => {
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
     });
 
     it('should initialize', () => {
@@ -40,8 +44,8 @@ describe('UsersImportButtonComponent', () => {
 
     it('should call open on dialog when openUsersImportDialog is called', () => {
         fixture.detectChanges();
-        const mockDialog = { open: jest.fn() };
-        jest.spyOn(comp, 'importDialog').mockReturnValue(mockDialog as any);
+        const mockDialog = { open: vi.fn() };
+        vi.spyOn(comp, 'importDialog').mockReturnValue(mockDialog as any);
 
         comp.openUsersImportDialog(new MouseEvent('click'));
 
@@ -49,7 +53,7 @@ describe('UsersImportButtonComponent', () => {
     });
 
     it('should emit importDone when onImportCompleted is called', () => {
-        const emitSpy = jest.spyOn(comp.importDone, 'emit');
+        const emitSpy = vi.spyOn(comp.importDone, 'emit');
 
         comp.onImportCompleted();
 

--- a/src/main/webapp/app/shared-ui/user-import/dialog/user-import-dialog.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/user-import/dialog/user-import-dialog.component.spec.ts
@@ -1,3 +1,5 @@
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
@@ -28,6 +30,8 @@ import { User } from 'app/account/user/user.model';
 import { TutorialGroupApiService } from 'app/openapi/api/tutorialGroupApi.service';
 
 describe('UsersImportDialogComponent', () => {
+    setupTestBed({ zoneless: true });
+
     let fixture: ComponentFixture<UsersImportDialogComponent>;
     let component: UsersImportDialogComponent;
     let examManagementService: ExamManagementService;
@@ -74,26 +78,26 @@ describe('UsersImportDialogComponent', () => {
     });
 
     afterEach(() => {
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
     });
 
     it('should open and close dialog', () => {
-        expect(component.dialogVisible()).toBeFalse();
+        expect(component.dialogVisible()).toBe(false);
 
         component.open();
-        expect(component.dialogVisible()).toBeTrue();
+        expect(component.dialogVisible()).toBe(true);
 
         component.close();
-        expect(component.dialogVisible()).toBeFalse();
+        expect(component.dialogVisible()).toBe(false);
     });
 
     it('should emit importCompleted on finish', () => {
-        const emitSpy = jest.spyOn(component.importCompleted, 'emit');
+        const emitSpy = vi.spyOn(component.importCompleted, 'emit');
 
         component.onFinish();
 
         expect(emitSpy).toHaveBeenCalledOnce();
-        expect(component.dialogVisible()).toBeFalse();
+        expect(component.dialogVisible()).toBe(false);
     });
 
     it('should reset dialog when selecting csv file', async () => {
@@ -114,7 +118,7 @@ describe('UsersImportDialogComponent', () => {
 
         expect(component.usersToImport).toHaveLength(0);
         expect(component.notFoundUsers).toHaveLength(0);
-        expect(component.noUsersFoundError).toBeTrue();
+        expect(component.noUsersFoundError).toBe(true);
     });
 
     it('should read students from csv file', async () => {
@@ -138,15 +142,15 @@ describe('UsersImportDialogComponent', () => {
     });
 
     it('should stop parsing and show a generic error when csv parsing fails unexpectedly', async () => {
-        jest.spyOn(readUsersFromCsv, 'readStudentDTOsFromCSVFile').mockRejectedValue(new Error('parse failed'));
+        vi.spyOn(readUsersFromCsv, 'readStudentDTOsFromCSVFile').mockRejectedValue(new Error('parse failed'));
         const alertService = TestBed.inject(AlertService);
-        const alertSpy = jest.spyOn(alertService, 'error');
+        const alertSpy = vi.spyOn(alertService, 'error');
         const event = { target: { files: [studentCsvColumns], value: 'students.csv' } };
 
         await component.onCSVFileSelect(event);
 
         expect(alertSpy).toHaveBeenCalledWith('artemisApp.importUsers.genericErrorMessage');
-        expect(component.isParsing).toBeFalse();
+        expect(component.isParsing).toBe(false);
         expect(event.target.value).toBe('');
     });
 
@@ -159,14 +163,14 @@ describe('UsersImportDialogComponent', () => {
         const studentsNotFound: ExamUserDTO[] = [{ registrationNumber: '2', firstName: 'Bob', lastName: 'Ross', login: 'login2', email: 'test@mail' }];
 
         const fakeResponse = { body: studentsNotFound } as HttpResponse<ExamUserDTO[]>;
-        jest.spyOn(examManagementService, 'addStudentsToExam').mockReturnValue(of(fakeResponse));
+        vi.spyOn(examManagementService, 'addStudentsToExam').mockReturnValue(of(fakeResponse));
 
         component.usersToImport = studentsToImport;
         component.importUsers();
 
         expect(examManagementService.addStudentsToExam).toHaveBeenCalledOnce();
-        expect(component.isImporting).toBeFalse();
-        expect(component.hasImported).toBeTrue();
+        expect(component.isImporting).toBe(false);
+        expect(component.hasImported).toBe(true);
         expect(component.notFoundUsers).toHaveLength(studentsNotFound.length);
     });
 
@@ -296,13 +300,13 @@ describe('UsersImportDialogComponent', () => {
         const notImportedStudents: ExamUserDTO[] = [{ registrationNumber: '3', firstName: 'Some', lastName: 'Dude', login: 'login3', email: '' }];
 
         const fakeResponse = { body: notImportedStudents } as HttpResponse<ExamUserDTO[]>;
-        jest.spyOn(examManagementService, 'addStudentsToExam').mockReturnValue(of(fakeResponse));
+        vi.spyOn(examManagementService, 'addStudentsToExam').mockReturnValue(of(fakeResponse));
 
         component.usersToImport = importedStudents.concat(notImportedStudents);
         component.importUsers();
 
-        importedStudents.forEach((student) => expect(component.wasImported(student)).toBeTrue());
-        notImportedStudents.forEach((student) => expect(component.wasImported(student)).toBeFalse());
+        importedStudents.forEach((student) => expect(component.wasImported(student)).toBe(true));
+        notImportedStudents.forEach((student) => expect(component.wasImported(student)).toBe(false));
         expect(component.numberOfUsersImported).toBe(importedStudents.length);
         expect(component.numberOfUsersNotImported).toBe(notImportedStudents.length);
     });
@@ -316,7 +320,7 @@ describe('UsersImportDialogComponent', () => {
         const studentsNotFound: ExamUserDTO[] = [{ registrationNumber: '3', firstName: 'Some', lastName: 'Dude', login: 'login3', email: '' }];
 
         const fakeResponse = { body: studentsNotFound } as HttpResponse<ExamUserDTO[]>;
-        jest.spyOn(examManagementService, 'addStudentsToExam').mockReturnValue(of(fakeResponse));
+        vi.spyOn(examManagementService, 'addStudentsToExam').mockReturnValue(of(fakeResponse));
 
         component.open();
         // Set usersToImport after open() since open() calls resetDialog() which clears the array
@@ -324,8 +328,8 @@ describe('UsersImportDialogComponent', () => {
 
         fixture.detectChanges();
 
-        expect(component.hasImported).toBeFalse();
-        expect(component.isSubmitDisabled).toBeFalse();
+        expect(component.hasImported).toBe(false);
+        expect(component.isSubmitDisabled).toBe(false);
         const importButton = fixture.debugElement.query(By.css('#import'));
 
         expect(importButton).not.toBeNull();
@@ -333,11 +337,11 @@ describe('UsersImportDialogComponent', () => {
         importButton.nativeElement.click();
 
         expect(examManagementService.addStudentsToExam).toHaveBeenCalledOnce();
-        expect(component.isImporting).toBeFalse();
-        expect(component.hasImported).toBeTrue();
+        expect(component.isImporting).toBe(false);
+        expect(component.hasImported).toBe(true);
         expect(component.notFoundUsers).toHaveLength(studentsNotFound.length);
 
-        jest.spyOn(examManagementService, 'addStudentsToExam').mockReturnValue(of(fakeResponse));
+        vi.spyOn(examManagementService, 'addStudentsToExam').mockReturnValue(of(fakeResponse));
 
         component.hasImported = true;
         fixture.detectChanges();
@@ -351,7 +355,7 @@ describe('UsersImportDialogComponent', () => {
 
     it('should expose validationError for invalid exam user csv rows', async () => {
         fixture.componentRef.setInput('examUserMode', true);
-        jest.spyOn(readUsersFromCsv, 'readExamUserDTOsFromCSVFile').mockResolvedValue({
+        vi.spyOn(readUsersFromCsv, 'readExamUserDTOsFromCSVFile').mockResolvedValue({
             ok: false,
             invalidRowIndices: [2, 4],
         });
@@ -362,13 +366,13 @@ describe('UsersImportDialogComponent', () => {
         expect(component.validationError).toBe('2, 4');
         expect(component.noUsersFoundError).toBeUndefined();
         expect(component.examUsersToImport).toHaveLength(0);
-        expect(component.isParsing).toBeFalse();
+        expect(component.isParsing).toBe(false);
         expect(event.target.value).toBe('');
     });
 
     it('should set noUsersFoundError when exam user csv contains no entries', async () => {
         fixture.componentRef.setInput('examUserMode', true);
-        jest.spyOn(readUsersFromCsv, 'readExamUserDTOsFromCSVFile').mockResolvedValue({
+        vi.spyOn(readUsersFromCsv, 'readExamUserDTOsFromCSVFile').mockResolvedValue({
             ok: true,
             examUsers: [],
         });
@@ -376,22 +380,22 @@ describe('UsersImportDialogComponent', () => {
 
         await component.onCSVFileSelect(event);
 
-        expect(component.noUsersFoundError).toBeTrue();
+        expect(component.noUsersFoundError).toBe(true);
         expect(component.validationError).toBeUndefined();
         expect(component.examUsersToImport).toHaveLength(0);
-        expect(component.isParsing).toBeFalse();
+        expect(component.isParsing).toBe(false);
         expect(event.target.value).toBe('');
     });
 
     it('should show a generic error and stop importing on save error', () => {
         const alertService = TestBed.inject(AlertService);
-        const alertSpy = jest.spyOn(alertService, 'error');
+        const alertSpy = vi.spyOn(alertService, 'error');
         component.isImporting = true;
 
         component.onSaveError();
 
         expect(alertSpy).toHaveBeenCalledWith('artemisApp.importUsers.genericErrorMessage');
-        expect(component.isImporting).toBeFalse();
+        expect(component.isImporting).toBe(false);
     });
 
     it('should import tutorial group students and convert generated student dto response', () => {
@@ -409,14 +413,14 @@ describe('UsersImportDialogComponent', () => {
         ];
 
         const fakeResponse = { body: generatedStudents } as HttpResponse<any[]>;
-        jest.spyOn(tutorialGroupApiService, 'importRegistrations').mockReturnValue(of(fakeResponse));
+        vi.spyOn(tutorialGroupApiService, 'importRegistrations').mockReturnValue(of(fakeResponse));
 
         component.usersToImport = studentsToImport;
         component.importUsers();
 
         expect(tutorialGroupApiService.importRegistrations).toHaveBeenCalledWith(course.id, 5, studentsToImport, 'response');
-        expect(component.isImporting).toBeFalse();
-        expect(component.hasImported).toBeTrue();
+        expect(component.isImporting).toBe(false);
+        expect(component.hasImported).toBe(true);
         expect(component.notFoundUsers).toEqual([
             {
                 registrationNumber: '2',
@@ -445,7 +449,7 @@ describe('UsersImportDialogComponent', () => {
 
         const importedUsers: User[] = [firstImportedUser, secondImportedUser];
 
-        jest.spyOn(adminUserService, 'importAll').mockReturnValue(of(new HttpResponse<User[]>({ body: importedUsers })));
+        vi.spyOn(adminUserService, 'importAll').mockReturnValue(of(new HttpResponse<User[]>({ body: importedUsers })));
 
         component.usersToImport = usersToImport;
         component.importUsers();
@@ -454,8 +458,8 @@ describe('UsersImportDialogComponent', () => {
             { registrationNumber: '1', firstName: 'Max', lastName: 'Mustermann', login: 'login1', email: 'test@mail', visibleRegistrationNumber: '1' },
             { registrationNumber: '2', firstName: 'Ada', lastName: 'Lovelace', login: 'ada', email: 'ada@example.com', visibleRegistrationNumber: '2' },
         ]);
-        expect(component.isImporting).toBeFalse();
-        expect(component.hasImported).toBeTrue();
+        expect(component.isImporting).toBe(false);
+        expect(component.hasImported).toBe(true);
         expect(component.notFoundUsers).toMatchObject([
             { registrationNumber: '3', firstName: 'Alan', lastName: 'Turing', login: 'alan', email: 'alan@example.com', visibleRegistrationNumber: '3' },
             { registrationNumber: '4', firstName: 'Grace', lastName: 'Hopper', login: 'grace', email: 'grace@example.com', visibleRegistrationNumber: '4' },
@@ -468,12 +472,12 @@ describe('UsersImportDialogComponent', () => {
         fixture.componentRef.setInput('tutorialGroup', undefined);
         fixture.componentRef.setInput('adminUserMode', false);
         const alertService = TestBed.inject(AlertService);
-        const alertSpy = jest.spyOn(alertService, 'error');
+        const alertSpy = vi.spyOn(alertService, 'error');
 
         component.importUsers();
 
         expect(alertSpy).toHaveBeenCalledWith('artemisApp.importUsers.genericErrorMessage');
-        expect(component.isImporting).toBeFalse();
-        expect(component.hasImported).toBeFalse();
+        expect(component.isImporting).toBe(false);
+        expect(component.hasImported).toBe(false);
     });
 });

--- a/src/main/webapp/app/shared-ui/user-import/dialog/users-import-dialog.component.ts
+++ b/src/main/webapp/app/shared-ui/user-import/dialog/users-import-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, ViewChild, ViewEncapsulation, inject, input, output, signal } from '@angular/core';
+import { Component, OnDestroy, ViewEncapsulation, inject, input, output, signal, viewChild } from '@angular/core';
 import { FormsModule, NgForm } from '@angular/forms';
 import { AlertService } from 'app/foundation/service/alert.service';
 import { DialogModule } from 'primeng/dialog';
@@ -40,7 +40,7 @@ export class UsersImportDialogComponent implements OnDestroy {
     readonly dialogVisible = signal<boolean>(false);
     readonly importCompleted = output<void>();
 
-    @ViewChild('importForm', { static: false }) importForm: NgForm;
+    readonly importForm = viewChild<NgForm>('importForm');
 
     courseId = input<number>();
     courseGroup = input<string>();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -96,6 +96,10 @@ export default defineConfig({
             'src/main/webapp/app/programming/shared/entities/build-plan-phases.model.spec.ts', // include build plan phases model tests
             'src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.spec.ts', // include legacy build plan converter service tests
             'src/main/webapp/app/programming/shared/programming-exercise-update-timeline/**/*.spec.ts', // include programming exercise update timeline tests
+            'src/main/webapp/app/shared-ui/delete-dialog/**/*.spec.ts', // include delete-dialog tests
+            'src/main/webapp/app/shared-ui/confirm-entity-name/**/*.spec.ts', // include confirm-entity-name tests
+            'src/main/webapp/app/shared-ui/user-import/button/**/*.spec.ts', // include user import button tests
+            'src/main/webapp/app/shared-ui/user-import/dialog/**/*.spec.ts', // include user import dialog tests
         ],
         exclude: ['**/node_modules/**', '**/build/**'],
         testTimeout: 10000,
@@ -171,6 +175,10 @@ export default defineConfig({
                 'src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.ts', // include legacy build plan converter service for code coverage
                 'src/main/webapp/app/programming/shared/entities/build-plan-phases.model.ts', // include build plan phases model for code coverage
                 'src/main/webapp/app/programming/shared/programming-exercise-update-timeline/**/*.ts', // include programming exercise update timeline for code coverage
+                'src/main/webapp/app/shared-ui/delete-dialog/**/*.ts', // include delete-dialog for code coverage
+                'src/main/webapp/app/shared-ui/confirm-entity-name/**/*.ts', // include confirm-entity-name for code coverage
+                'src/main/webapp/app/shared-ui/user-import/button/**/*.ts', // include user import button for code coverage
+                'src/main/webapp/app/shared-ui/user-import/dialog/**/*.ts', // include user import dialog for code coverage
             ],
             exclude: [
                 '**/node_modules/**', // exclude node_modules with third-party code


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).

### Motivation and Context
Part of the ongoing Angular 21 migration campaign. The shared-ui delete-dialog and user-import dialogs (plus the shared `ConfirmEntityNameComponent` they rely on) still used legacy `@Input` / `@ViewChild` decorators and their tests ran on Jest. This PR migrates these components to the mandatory Angular 21 signal-based APIs and moves their specs to Vitest, keeping the shared-ui module consistent with the rest of the migration.

### Description
Signal-API migration of the shared delete and user-import dialog components; no functional or visual changes.

- **`confirm-entity-name.component.ts`**: `@Input() warningTextColor` → `input<string>()`; `@Input() confirmationText` → `input.required<string>()`; the `@Input() set entityName` setter (which had side effects: updating the display signal and notifying the validator) → `input<string>('')` plus an `effect()` that faithfully reproduces those side effects (`entityNameSignal.set(...)` and `onValidatorChange?.()`, wrapped in `untracked()` to avoid re-running on unrelated signal writes). The validator comparison now reads `this.entityName()`.
- **`delete-dialog.component.ts`**: `@ViewChild('deleteForm') deleteForm: NgForm` → `viewChild.required<NgForm>('deleteForm')`. The `#deleteForm="ngForm"` template reference resolves to the exported `NgForm` directive instance as before.
- **`users-import-dialog.component.ts`**: `@ViewChild('importForm') importForm: NgForm` → `viewChild<NgForm>('importForm')`.
- **`delete-button.directive.ts`**: the `@Output() delete = new EventEmitter<...>()` is **intentionally kept** (not migrated to `output()`), with an explanatory comment. The `EventEmitter` instance is passed by reference through `DeleteDialogData` into `DeleteDialogService`/`DeleteDialogComponent`, which call `.emit()` on it externally — a pattern `OutputEmitterRef` from `output()` does not support.
- Both dialogs were already on PrimeNG (`DialogModule` / `DynamicDialog`), so there is **no `NgbModal` change** in this PR.
- Specs for these components migrated from Jest to Vitest (`vi.*` mocks); Jest/Vitest config include/ignore lists updated append-only, and the Jest global `functions` coverage threshold was reconciled to the minimum across develop and this branch during the develop merge.

### Steps for Testing
Prerequisites:
- 1 Instructor

1. Log in to Artemis.
2. Open any entity-deletion dialog (e.g. delete a course, exercise, or lecture). Confirm the name-confirmation field still validates: the confirm/delete button stays disabled until the typed name exactly matches, and the warning text and confirmation text render as before.
3. Open the user-import dialog (e.g. import users into a course/exam) and confirm the form behavior (CSV upload / manual entry, validation, import) is unchanged.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Screenshots
No intended visual change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted test/configuration to exclude migrated shared UI pieces from Jest coverage and lowered global function coverage threshold.

* **Tests**
  * Migrated multiple unit tests from Jest to Vitest and updated test setup/teardown and mocks accordingly.
  * Updated test discovery and coverage inclusion for migrated shared UI areas.

* **Refactor**
  * Updated several shared UI components and templates to use Angular signal-based APIs for inputs and view queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->