### PR TITLE
`Development`: Migrate shared-ui export and archive button dialogs to PrimeNG

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -236,7 +236,7 @@ module.exports = {
         global: {
             statements: 83,
             branches: 72.9,
-            functions: 72.2,
+            functions: 71.2,
             lines: 84,
         },
     },

--- a/jest.config.js
+++ b/jest.config.js
@@ -150,6 +150,9 @@ module.exports = {
         '!<rootDir>/src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.ts', // legacy converter uses Vitest (see vitest.config.ts)
         '!<rootDir>/src/main/webapp/app/programming/shared/entities/build-plan-phases.model.ts', // build-plan-phases model uses Vitest (see vitest.config.ts)
         '!<rootDir>/src/main/webapp/app/programming/shared/programming-exercise-update-timeline/**', // programming exercise update timeline uses Vitest (see vitest.config.ts)
+        '!<rootDir>/src/main/webapp/app/shared-ui/components/slice-navigator/**', // slice-navigator uses Vitest (see vitest.config.ts)
+        '!<rootDir>/src/main/webapp/app/shared-ui/components/feature-overlay/**', // feature-overlay uses Vitest (see vitest.config.ts)
+        '!<rootDir>/src/main/webapp/app/shared-ui/export/**', // export module uses Vitest (see vitest.config.ts)
         '<rootDir>/src/main/webapp/**/*.ts',
     ],
     // Each entry below excludes a module that has been migrated to Vitest.
@@ -214,6 +217,9 @@ module.exports = {
         '<rootDir>/src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.ts',
         '<rootDir>/src/main/webapp/app/programming/shared/entities/build-plan-phases.model.ts',
         '<rootDir>/src/main/webapp/app/programming/shared/programming-exercise-update-timeline/',
+        '<rootDir>/src/main/webapp/app/shared-ui/components/slice-navigator/', // slice-navigator uses Vitest
+        '<rootDir>/src/main/webapp/app/shared-ui/components/feature-overlay/', // feature-overlay uses Vitest
+        '<rootDir>/src/main/webapp/app/shared-ui/export/', // export module uses Vitest
     ],
     // Global coverage thresholds for Jest. Modules using Vitest (e.g., fileupload) have their own
     // coverage thresholds in vitest.config.ts. Per-module thresholds are enforced by check-client-module-coverage.mjs
@@ -224,7 +230,10 @@ module.exports = {
         global: {
             statements: 83,
             branches: 72.9,
-            functions: 72.5,
+            // Lowered 72.5 -> 72.3 after moving shared-ui/export + slice-navigator + feature-overlay
+            // specs to Vitest (actual Jest function coverage dropped to 72.36%). Minimal reduction,
+            // small headroom below actual. Re-tune when migration completes.
+            functions: 72.3,
             lines: 84,
         },
     },
@@ -317,6 +326,9 @@ module.exports = {
         '<rootDir>/src/main/webapp/app/programming/shared/services/build-phases-template.service.spec.ts', // migrated to Vitest
         '<rootDir>/src/main/webapp/app/programming/shared/entities/build-plan-phases.model.spec.ts', // migrated to Vitest
         '<rootDir>/src/main/webapp/app/programming/shared/programming-exercise-update-timeline/', // migrated to Vitest
+        '<rootDir>/src/main/webapp/app/shared-ui/components/slice-navigator/', // slice-navigator (Vitest)
+        '<rootDir>/src/main/webapp/app/shared-ui/components/feature-overlay/', // feature-overlay (Vitest)
+        '<rootDir>/src/main/webapp/app/shared-ui/export/', // export module (Vitest)
     ],
     testTimeout: 3000,
     testMatch: ['<rootDir>/src/main/webapp/app/**/*.spec.ts', '<rootDir>/src/test/javascript/spec/**/*.integration.spec.ts'],

--- a/src/main/webapp/app/exam/manage/exam-scores/exam-scores.component.spec.ts
+++ b/src/main/webapp/app/exam/manage/exam-scores/exam-scores.component.spec.ts
@@ -11,6 +11,7 @@ import {
     StudentResult,
 } from 'app/exam/manage/exam-scores/exam-score-dtos.model';
 import { MockProvider } from 'ng-mocks';
+import { DialogService } from 'primeng/dynamicdialog';
 import { ExamScoresComponent, MedianType } from 'app/exam/manage/exam-scores/exam-scores.component';
 import { ExamManagementService } from 'app/exam/manage/services/exam-management.service';
 import { ParticipantScoresService, ScoresDTO } from 'app/course/participant-scores/participant-scores.service';
@@ -296,6 +297,7 @@ describe('ExamScoresComponent', () => {
                 { provide: AccountService, useClass: MockAccountService },
                 MockProvider(AlertService),
                 { provide: TranslateService, useClass: MockTranslateService },
+                MockProvider(DialogService),
                 provideNoopAnimationsForTests(),
             ],
         }).compileComponents();

--- a/src/main/webapp/app/shared-ui/components/buttons/confirm-autofocus-button/confirm-autofocus-button.component.ts
+++ b/src/main/webapp/app/shared-ui/components/buttons/confirm-autofocus-button/confirm-autofocus-button.component.ts
@@ -11,6 +11,13 @@ import { ButtonComponent, ButtonType } from 'app/shared-ui/components/buttons/bu
     imports: [ButtonComponent],
 })
 export class ConfirmAutofocusButtonComponent {
+    // NOTE: This button intentionally still uses NgbModal to open ConfirmAutofocusModalComponent.
+    // ConfirmAutofocusModalComponent is a shared dialog opened by several callers, two of which live
+    // in the deferred programming/** carve-out (and others in separate migration groups: atlas, quiz,
+    // plagiarism). All of them rely on the `modalRef.componentInstance.* = ...` write contract, which
+    // would silently break if the dialog's @Inputs became signal inputs or it switched to PrimeNG's
+    // DynamicDialog. Migrating it here would require editing carve-out files, so it is DEFERRED until
+    // the carve-out lifts and all callers can be migrated together.
     private modalService = inject(NgbModal);
 
     icon = input<IconProp | undefined>(undefined);

--- a/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.html
+++ b/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.html
@@ -24,13 +24,13 @@
             <p [jhiTranslate]="'artemisApp.courseExamArchive.archiveSuccessWithWarnings'">The archival process has completed with the following warnings:</p>
             <br />
             <ul style="height: 200px; overflow: auto">
-                @for (item of archiveWarnings(); track item) {
+                @for (item of archiveWarnings(); track $index) {
                     <li>{{ item }}</li>
                 }
             </ul>
         </ng-container>
         <ng-template #footer>
-            <button type="button" class="btn btn-warning" (click)="archiveCompleteWithWarningsModalVisible.set(false)">Close</button>
+            <button type="button" class="btn btn-warning" (click)="archiveCompleteWithWarningsModalVisible.set(false)" jhiTranslate="entity.action.close">Close</button>
         </ng-template>
     </p-dialog>
     <p-dialog

--- a/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.html
+++ b/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.html
@@ -6,6 +6,7 @@
         [closeOnEscape]="true"
         [dismissableMask]="true"
         [draggable]="false"
+        [resizable]="false"
         [appendTo]="'body'"
         [style]="{ width: '40rem' }"
     >
@@ -39,6 +40,7 @@
         [closeOnEscape]="true"
         [dismissableMask]="true"
         [draggable]="false"
+        [resizable]="false"
         [appendTo]="'body'"
         [style]="{ width: '40rem' }"
     >
@@ -86,10 +88,11 @@
     <p-dialog
         [(visible)]="archiveConfirmModalVisible"
         [modal]="true"
-        [closable]="true"
+        [closable]="false"
         [closeOnEscape]="true"
         [dismissableMask]="true"
         [draggable]="false"
+        [resizable]="false"
         [appendTo]="'body'"
         [style]="{ width: '40rem' }"
     >

--- a/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.html
+++ b/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.html
@@ -1,6 +1,15 @@
 <ng-container>
-    <ng-template #archiveCompleteWithWarningsModal let-modal>
-        <div class="modal-header">
+    <p-dialog
+        [(visible)]="archiveCompleteWithWarningsModalVisible"
+        [modal]="true"
+        [closable]="true"
+        [closeOnEscape]="true"
+        [dismissableMask]="true"
+        [draggable]="false"
+        [appendTo]="'body'"
+        [style]="{ width: '40rem' }"
+    >
+        <ng-template #header>
             <h4 class="modal-title">
                 @if (archiveMode() === 'Course') {
                     <span [jhiTranslate]="'artemisApp.courseExamArchive.archiveCourseSuccess'">The course has been archived!</span>
@@ -9,25 +18,31 @@
                     <span [jhiTranslate]="'artemisApp.courseExamArchive.archiveExamSuccess'">The exam has been archived!</span>
                 }
             </h4>
-            <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss()"></button>
-        </div>
-        <div class="modal-body">
-            <ng-container>
-                <p [jhiTranslate]="'artemisApp.courseExamArchive.archiveSuccessWithWarnings'">The archival process has completed with the following warnings:</p>
-                <br />
-                <ul style="height: 200px; overflow: auto">
-                    @for (item of archiveWarnings(); track item) {
-                        <li>{{ item }}</li>
-                    }
-                </ul>
-            </ng-container>
-        </div>
-        <div class="modal-footer">
-            <button type="button" class="btn btn-warning" (click)="modal.close()">Close</button>
-        </div>
-    </ng-template>
-    <ng-template #archiveWarningPopup let-modal>
-        <div class="modal-header">
+        </ng-template>
+        <ng-container>
+            <p [jhiTranslate]="'artemisApp.courseExamArchive.archiveSuccessWithWarnings'">The archival process has completed with the following warnings:</p>
+            <br />
+            <ul style="height: 200px; overflow: auto">
+                @for (item of archiveWarnings(); track item) {
+                    <li>{{ item }}</li>
+                }
+            </ul>
+        </ng-container>
+        <ng-template #footer>
+            <button type="button" class="btn btn-warning" (click)="archiveCompleteWithWarningsModalVisible.set(false)">Close</button>
+        </ng-template>
+    </p-dialog>
+    <p-dialog
+        [(visible)]="archiveWarningPopupVisible"
+        [modal]="true"
+        [closable]="true"
+        [closeOnEscape]="true"
+        [dismissableMask]="true"
+        [draggable]="false"
+        [appendTo]="'body'"
+        [style]="{ width: '40rem' }"
+    >
+        <ng-template #header>
             <h4 class="modal-title">
                 @if (archiveMode() === 'Course') {
                     <span [jhiTranslate]="'artemisApp.courseExamArchive.popup.course.title'">Confirm Archive Course Operation</span>
@@ -36,61 +51,61 @@
                     <span [jhiTranslate]="'artemisApp.courseExamArchive.popup.exam.title'">Confirm Archive Exam Operation</span>
                 }
             </h4>
-            <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss()"></button>
-        </div>
-        <div class="modal-body">
-            @if (archiveMode() === 'Course') {
-                <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.course.question'" [translateValues]="{ title: currentCourse()?.title }">
-                    Are you sure you want to archive??
-                </p>
-                <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.course.statement1'">
-                    The process will compress all student code repositories, file upload exercises, modeling exercises, and text exercises for exercises and exams.
-                </p>
-                <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.course.statement1b'">Additionally, the archive will include comprehensive student data.</p>
-            }
-            @if (archiveMode() === 'Exam') {
-                <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.exam.question'" [translateValues]="{ title: currentExam()?.title || '' }">
-                    Are you sure you want to archive??
-                </p>
-                <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.exam.statement1'">
-                    The process will compress all student code repositories, file upload exercises, modeling exercises, and text exercises in the exam.
-                </p>
-            }
-            <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.statement2'">
-                This process can take several hours depending on the number of students and programming exercises and will take up many server resources. Please start this process
-                only once when the server load is low (e.g. early in the morning)
+        </ng-template>
+        @if (archiveMode() === 'Course') {
+            <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.course.question'" [translateValues]="{ title: currentCourse()?.title }">Are you sure you want to archive??</p>
+            <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.course.statement1'">
+                The process will compress all student code repositories, file upload exercises, modeling exercises, and text exercises for exercises and exams.
             </p>
-            <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.footerStatement'">
-                You will receive a notification when the process is finished. Then you can download the archive as zip file on this page.
+            <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.course.statement1b'">Additionally, the archive will include comprehensive student data.</p>
+        }
+        @if (archiveMode() === 'Exam') {
+            <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.exam.question'" [translateValues]="{ title: currentExam()?.title || '' }">Are you sure you want to archive??</p>
+            <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.exam.statement1'">
+                The process will compress all student code repositories, file upload exercises, modeling exercises, and text exercises in the exam.
             </p>
-        </div>
-        <div class="modal-footer">
+        }
+        <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.statement2'">
+            This process can take several hours depending on the number of students and programming exercises and will take up many server resources. Please start this process only
+            once when the server load is low (e.g. early in the morning)
+        </p>
+        <p [jhiTranslate]="'artemisApp.courseExamArchive.popup.footerStatement'">
+            You will receive a notification when the process is finished. Then you can download the archive as zip file on this page.
+        </p>
+        <ng-template #footer>
             <button
                 type="button"
                 class="btn btn-warning"
-                (click)="modal.close('archive-confirm')"
+                (click)="onArchiveWarningConfirm()"
                 [jhiTranslate]="archiveMode() === 'Course' ? 'artemisApp.courseExamArchive.archiveCourse' : 'artemisApp.courseExamArchive.archiveExam'"
             >
                 Archive
             </button>
-        </div>
-    </ng-template>
-    <ng-template #archiveConfirmModal let-modal>
-        <div class="modal-header">
+        </ng-template>
+    </p-dialog>
+    <p-dialog
+        [(visible)]="archiveConfirmModalVisible"
+        [modal]="true"
+        [closable]="true"
+        [closeOnEscape]="true"
+        [dismissableMask]="true"
+        [draggable]="false"
+        [appendTo]="'body'"
+        [style]="{ width: '40rem' }"
+    >
+        <ng-template #header>
             <h4 class="modal-title">
                 <span [jhiTranslate]="'artemisApp.courseExamArchive.confirmArchive.title'">Warning: an archive already exists!</span>
             </h4>
-        </div>
-        <div class="modal-body">
-            <p [jhiTranslate]="'artemisApp.courseExamArchive.confirmArchive.message'">
-                Warning! The course has already been archived. If you continue, the archive will be overwritten! Are you sure you want to continue?
-            </p>
-        </div>
-        <div class="modal-footer">
-            <button type="button" class="btn btn-warning" (click)="modal.close('archive')" [jhiTranslate]="'global.generic.yes'">Yes</button>
-            <button type="button" class="btn btn-success" [jhiTranslate]="'global.generic.no'" (click)="modal.dismiss()">No</button>
-        </div>
-    </ng-template>
+        </ng-template>
+        <p [jhiTranslate]="'artemisApp.courseExamArchive.confirmArchive.message'">
+            Warning! The course has already been archived. If you continue, the archive will be overwritten! Are you sure you want to continue?
+        </p>
+        <ng-template #footer>
+            <button type="button" class="btn btn-warning" (click)="onArchiveConfirm()" [jhiTranslate]="'global.generic.yes'">Yes</button>
+            <button type="button" class="btn btn-success" [jhiTranslate]="'global.generic.no'" (click)="archiveConfirmModalVisible.set(false)">No</button>
+        </ng-template>
+    </p-dialog>
     @if (canArchive()) {
         <button
             [jhiFeatureToggle]="FeatureToggle.Exports"
@@ -99,7 +114,7 @@
             [attr.data-mode]="archiveMode()"
             id="archiveButton"
             class="btn btn-sm btn-warning"
-            (click)="openModal(archiveWarningPopup)"
+            (click)="openArchiveWarningPopup()"
         >
             <fa-icon [hidden]="!isBeingArchived()" animation="spin" [icon]="faCircleNotch" />
             <fa-icon [hidden]="isBeingArchived()" [icon]="faArchive" />&nbsp;

--- a/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.spec.ts
@@ -17,7 +17,6 @@ import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { MockRouterLinkDirective } from 'test/helpers/mocks/directive/mock-router-link.directive';
 import { DeleteButtonDirective } from 'app/shared-ui/delete-dialog/directive/delete-button.directive';
 import { ArtemisDatePipe } from 'app/foundation/pipes/artemis-date.pipe';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { CourseExamArchiveButtonComponent, CourseExamArchiveState } from 'app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component';
 import { Exam } from 'app/exam/shared/entities/exam.model';
 import { ExamManagementService } from 'app/exam/manage/services/exam-management.service';
@@ -56,9 +55,10 @@ describe('Course Exam Archive Button Component', () => {
                 LocalStorageService,
                 SessionStorageService,
                 { provide: TranslateService, useClass: MockTranslateService },
-                { provide: DialogService, useValue: { open: vi.fn(), close: vi.fn() } },
+                // DialogService is required transitively by DeleteButtonDirective -> DeleteDialogService,
+                // not by this component itself (its dialogs are inline <p-dialog> bound to visibility signals).
+                MockProvider(DialogService),
                 MockProvider(AlertService),
-                MockProvider(NgbModal),
                 provideHttpClient(),
                 provideHttpClientTesting(),
                 { provide: AccountService, useClass: MockAccountService },
@@ -207,6 +207,45 @@ describe('Course Exam Archive Button Component', () => {
             expect(downloadStub).toHaveBeenCalledOnce();
         });
 
+        it('openArchiveWarningPopup shows the archive warning dialog', () => {
+            comp.openArchiveWarningPopup();
+            expect(comp.archiveWarningPopupVisible()).toBe(true);
+        });
+
+        it('onArchiveWarningConfirm archives directly when no existing archive can be downloaded', () => {
+            comp.archiveWarningPopupVisible.set(true);
+            vi.spyOn(comp, 'canDownloadArchive').mockReturnValue(false);
+            const archiveSpy = vi.spyOn(comp, 'archive').mockImplementation(() => {});
+
+            comp.onArchiveWarningConfirm();
+
+            expect(comp.archiveWarningPopupVisible()).toBe(false);
+            expect(comp.archiveConfirmModalVisible()).toBe(false);
+            expect(archiveSpy).toHaveBeenCalledOnce();
+        });
+
+        it('onArchiveWarningConfirm opens the overwrite confirmation when an archive already exists', () => {
+            comp.archiveWarningPopupVisible.set(true);
+            vi.spyOn(comp, 'canDownloadArchive').mockReturnValue(true);
+            const archiveSpy = vi.spyOn(comp, 'archive').mockImplementation(() => {});
+
+            comp.onArchiveWarningConfirm();
+
+            expect(comp.archiveWarningPopupVisible()).toBe(false);
+            expect(comp.archiveConfirmModalVisible()).toBe(true);
+            expect(archiveSpy).not.toHaveBeenCalled();
+        });
+
+        it('onArchiveConfirm closes the overwrite dialog and archives', () => {
+            comp.archiveConfirmModalVisible.set(true);
+            const archiveSpy = vi.spyOn(comp, 'archive').mockImplementation(() => {});
+
+            comp.onArchiveConfirm();
+
+            expect(comp.archiveConfirmModalVisible()).toBe(false);
+            expect(archiveSpy).toHaveBeenCalledOnce();
+        });
+
         it('should reload course on archive complete', () => {
             const alertService = TestBed.inject(AlertService);
             const alertServiceSpy = vi.spyOn(alertService, 'success');
@@ -222,15 +261,12 @@ describe('Course Exam Archive Button Component', () => {
         });
 
         it('should display warning and reload course on archive complete with warnings', () => {
-            const modalService = TestBed.inject(NgbModal);
-
             vi.spyOn(courseManagementService, 'find').mockReturnValue(of(new HttpResponse({ status: 200, body: course })));
-            const ngModalRef: NgbModalRef = { result: Promise.resolve('') } as any;
-            vi.spyOn(modalService, 'open').mockReturnValue(ngModalRef);
 
             const archiveState: CourseExamArchiveState = { exportState: 'COMPLETED_WITH_WARNINGS', message: 'warning 1\nwarning 2' };
             comp.handleArchiveStateChanges(archiveState);
 
+            expect(comp.archiveCompleteWithWarningsModalVisible()).toBe(true);
             expect(comp.isBeingArchived()).toBe(false);
             expect(comp.archiveWarnings()).toEqual(archiveState.message.split('\n'));
             expect(comp.course()).toBeDefined();

--- a/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.ts
+++ b/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.ts
@@ -1,9 +1,9 @@
-import { Component, OnDestroy, OnInit, TemplateRef, computed, effect, inject, input, signal, untracked, viewChild } from '@angular/core';
+import { Component, OnDestroy, OnInit, computed, effect, inject, input, signal, untracked } from '@angular/core';
 import { AlertService } from 'app/foundation/service/alert.service';
 import { CourseManagementService } from 'app/course/manage/services/course-management.service';
 import { WebsocketService } from 'app/foundation/service/websocket.service';
 import { TranslateService } from '@ngx-translate/core';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { DialogModule } from 'primeng/dialog';
 import { tap } from 'rxjs/operators';
 import { ExamManagementService } from 'app/exam/manage/services/exam-management.service';
 import { Course } from 'app/course/shared/entities/course.model';
@@ -31,7 +31,7 @@ export type CourseExamArchiveState = {
     templateUrl: './course-exam-archive-button.component.html',
     styleUrls: ['./course-exam-archive-button.component.scss'],
     styles: [':host {display: contents}'],
-    imports: [TranslateDirective, FeatureToggleDirective, FaIconComponent, DeleteButtonDirective],
+    imports: [TranslateDirective, FeatureToggleDirective, FaIconComponent, DeleteButtonDirective, DialogModule],
 })
 export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
     private courseService = inject(CourseManagementService);
@@ -39,7 +39,6 @@ export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
     private alertService = inject(AlertService);
     private websocketService = inject(WebsocketService);
     private translateService = inject(TranslateService);
-    private modalService = inject(NgbModal);
     private accountService = inject(AccountService);
     private websocketRegistered = false;
 
@@ -117,9 +116,10 @@ export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
         return this.accountService.isAtLeastInstructorInCourse(course) && hasBeenArchived;
     });
 
-    archiveCompleteWithWarningsModal = viewChild.required<TemplateRef<any>>('archiveCompleteWithWarningsModal');
-
-    archiveConfirmModal = viewChild.required<TemplateRef<any>>('archiveConfirmModal');
+    // Dialog visibility signals (replaces the NgbModal-opened ng-templates)
+    archiveCompleteWithWarningsModalVisible = signal(false);
+    archiveWarningPopupVisible = signal(false);
+    archiveConfirmModalVisible = signal(false);
 
     // Subscriptions
     private dialogErrorSource = new Subject<string>();
@@ -216,7 +216,7 @@ export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
             this.alertService.success(this.getArchiveSuccessText());
             this.reloadCourseOrExam();
         } else if (exportState === 'COMPLETED_WITH_WARNINGS') {
-            this.openModal(this.archiveCompleteWithWarningsModal());
+            this.archiveCompleteWithWarningsModalVisible.set(true);
             this.reloadCourseOrExam();
         } else if (exportState === 'COMPLETED_WITH_ERRORS') {
             this.alertService.error(this.getArchiveErrorText(subMessage!));
@@ -265,18 +265,33 @@ export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
         } else return null;
     }
 
-    openModal(modalRef: TemplateRef<any>) {
-        this.modalService.open(modalRef).result.then(
-            (result: string) => {
-                if (result === 'archive-confirm' && this.canDownloadArchive()) {
-                    this.openModal(this.archiveConfirmModal());
-                }
-                if (result === 'archive' || !this.canDownloadArchive()) {
-                    this.archive();
-                }
-            },
-            () => {},
-        );
+    /**
+     * Opens the initial archive-warning confirmation dialog.
+     */
+    openArchiveWarningPopup() {
+        this.archiveWarningPopupVisible.set(true);
+    }
+
+    /**
+     * Handles the user confirming the archive-warning dialog (the "Archive" button).
+     * If an archive already exists (canDownloadArchive), an overwrite confirmation is shown first;
+     * otherwise the archive is started immediately. Mirrors the original NgbModal result chaining.
+     */
+    onArchiveWarningConfirm() {
+        this.archiveWarningPopupVisible.set(false);
+        if (this.canDownloadArchive()) {
+            this.archiveConfirmModalVisible.set(true);
+        } else {
+            this.archive();
+        }
+    }
+
+    /**
+     * Handles the user confirming the overwrite-archive dialog (the "Yes" button).
+     */
+    onArchiveConfirm() {
+        this.archiveConfirmModalVisible.set(false);
+        this.archive();
     }
 
     archive() {

--- a/src/main/webapp/app/shared-ui/components/confirm-autofocus-modal/confirm-autofocus-modal.component.ts
+++ b/src/main/webapp/app/shared-ui/components/confirm-autofocus-modal/confirm-autofocus-modal.component.ts
@@ -9,6 +9,13 @@ import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pip
     templateUrl: './confirm-autofocus-modal.component.html',
     imports: [NgTemplateOutlet, TranslateDirective, ArtemisTranslatePipe],
 })
+// NOTE: This shared dialog intentionally still uses NgbActiveModal and @Input decorators. It is opened
+// via `NgbModal.open(ConfirmAutofocusModalComponent)` + `modalRef.componentInstance.* = ...` by several
+// callers, two of which live in the deferred programming/** carve-out (and others in separate migration
+// groups: atlas, quiz, plagiarism). Converting it to PrimeNG DynamicDialog or signal inputs would
+// silently break the `componentInstance` write contract for all callers, including carve-out files we are
+// not allowed to touch. Therefore both the modal mechanism and the decorators are DEFERRED until the
+// carve-out lifts and every caller can be migrated together.
 export class ConfirmAutofocusModalComponent {
     modal = inject(NgbActiveModal);
 

--- a/src/main/webapp/app/shared-ui/components/feature-overlay/feature-overlay.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/components/feature-overlay/feature-overlay.component.spec.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FeatureOverlayComponent } from 'app/shared-ui/components/feature-overlay/feature-overlay.component';
 import { NgbTooltip, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
@@ -6,6 +8,8 @@ import { By } from '@angular/platform-browser';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 
 describe('Feature Overlay Component Tests', () => {
+    setupTestBed({ zoneless: true });
+
     let fixture: ComponentFixture<FeatureOverlayComponent>;
 
     beforeEach(() => {

--- a/src/main/webapp/app/shared-ui/components/slice-navigator/slice-navigator.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/components/slice-navigator/slice-navigator.component.spec.ts
@@ -1,9 +1,15 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
 import { PageChangeEvent, PaginationConfig, SliceNavigatorComponent } from './slice-navigator.component';
 import { ButtonComponent } from 'app/shared-ui/components/buttons/button/button.component';
 import { MockComponent } from 'ng-mocks';
+import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 
 describe('SliceNavigatorComponent', () => {
+    setupTestBed({ zoneless: true });
+
     let component: SliceNavigatorComponent;
     let fixture: ComponentFixture<SliceNavigatorComponent>;
 
@@ -15,6 +21,7 @@ describe('SliceNavigatorComponent', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             imports: [SliceNavigatorComponent, MockComponent(ButtonComponent)],
+            providers: [{ provide: TranslateService, useClass: MockTranslateService }],
         }).compileComponents();
 
         fixture = TestBed.createComponent(SliceNavigatorComponent);
@@ -67,25 +74,25 @@ describe('SliceNavigatorComponent', () => {
     });
 
     it('should disable the previous button when on the first page', () => {
-        expect(component.previousDisabled()).toBeTrue();
+        expect(component.previousDisabled()).toBe(true);
     });
 
     it('should enable the previous button when not on the first page', () => {
         component.nextPage();
         fixture.detectChanges();
-        expect(component.previousDisabled()).toBeFalse();
+        expect(component.previousDisabled()).toBe(false);
     });
 
     it('should disable the next button when hasMoreItems is false', () => {
         fixture.componentRef.setInput('hasMoreItems', false);
         fixture.detectChanges();
-        expect(component.nextDisabled()).toBeTrue();
+        expect(component.nextDisabled()).toBe(true);
     });
 
     it('should disable the next button when isLoading is true', () => {
         fixture.componentRef.setInput('isLoading', true);
         fixture.detectChanges();
-        expect(component.nextDisabled()).toBeTrue();
+        expect(component.nextDisabled()).toBe(true);
     });
 
     it('should not emit a page change event when nextPage is called and hasMoreItems is false', () => {

--- a/src/main/webapp/app/shared-ui/export/button/export-button.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/export/button/export-button.component.spec.ts
@@ -37,7 +37,7 @@ describe('ExportButtonComponent', () => {
 
     it('should initialize and open the export dialog', () => {
         const onClose = new Subject<ExportModalResult | undefined>();
-        const dialogServiceOpenStub = vi.spyOn(dialogService, 'open').mockReturnValue({ onClose } as DynamicDialogRef);
+        const dialogServiceOpenStub = vi.spyOn(dialogService, 'open').mockReturnValue({ onClose } as unknown as DynamicDialogRef);
 
         comp.openExportModal(new MouseEvent('click'));
 
@@ -59,7 +59,7 @@ describe('ExportButtonComponent', () => {
 
     it('should emit chosen csv options when the dialog returns a csv result', () => {
         const onClose = new Subject<ExportModalResult | undefined>();
-        vi.spyOn(dialogService, 'open').mockReturnValue({ onClose } as DynamicDialogRef);
+        vi.spyOn(dialogService, 'open').mockReturnValue({ onClose } as unknown as DynamicDialogRef);
         const emitSpy = vi.spyOn(comp.onExport, 'emit');
         const options: CsvExportOptions = {
             fieldSeparator: CsvFieldSeparator.COMMA,
@@ -76,7 +76,7 @@ describe('ExportButtonComponent', () => {
 
     it('should emit undefined when the dialog returns an excel result', () => {
         const onClose = new Subject<ExportModalResult | undefined>();
-        vi.spyOn(dialogService, 'open').mockReturnValue({ onClose } as DynamicDialogRef);
+        vi.spyOn(dialogService, 'open').mockReturnValue({ onClose } as unknown as DynamicDialogRef);
         const emitSpy = vi.spyOn(comp.onExport, 'emit');
 
         comp.openExportModal(new MouseEvent('click'));
@@ -87,7 +87,7 @@ describe('ExportButtonComponent', () => {
 
     it('should not emit when the dialog is dismissed', () => {
         const onClose = new Subject<ExportModalResult | undefined>();
-        vi.spyOn(dialogService, 'open').mockReturnValue({ onClose } as DynamicDialogRef);
+        vi.spyOn(dialogService, 'open').mockReturnValue({ onClose } as unknown as DynamicDialogRef);
         const emitSpy = vi.spyOn(comp.onExport, 'emit');
 
         comp.openExportModal(new MouseEvent('click'));

--- a/src/main/webapp/app/shared-ui/export/button/export-button.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/export/button/export-button.component.spec.ts
@@ -1,39 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MockComponent, MockModule } from 'ng-mocks';
+import { MockComponent } from 'ng-mocks';
 import { By } from '@angular/platform-browser';
-import { NgbModal, NgbModalRef, NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { TranslateService } from '@ngx-translate/core';
+import { Subject } from 'rxjs';
+import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { ButtonComponent } from 'app/shared-ui/components/buttons/button/button.component';
 import { ExportButtonComponent } from 'app/shared-ui/export/button/export-button.component';
+import { CsvDecimalSeparator, CsvExportOptions, CsvFieldSeparator, CsvQuoteStrings, ExportModalResult } from 'app/shared-ui/export/modal/export-modal.component';
 
 describe('ExportButtonComponent', () => {
+    setupTestBed({ zoneless: true });
+
     let fixture: ComponentFixture<ExportButtonComponent>;
     let comp: ExportButtonComponent;
-    let modalService: NgbModal;
+    let dialogService: DialogService;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [MockModule(NgbModule)],
-            declarations: [ExportButtonComponent, MockComponent(ButtonComponent)],
+            imports: [ExportButtonComponent, MockComponent(ButtonComponent)],
+            providers: [DialogService, { provide: TranslateService, useClass: MockTranslateService }],
         })
             .compileComponents()
             .then(() => {
                 fixture = TestBed.createComponent(ExportButtonComponent);
                 comp = fixture.componentInstance;
-                modalService = TestBed.inject(NgbModal);
+                dialogService = TestBed.inject(DialogService);
             });
     });
 
     afterEach(() => {
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
     });
 
-    it('should initialize', () => {
-        const result = new Promise((resolve) => resolve(true));
-        const modalServiceOpenStub = jest.spyOn(modalService, 'open').mockReturnValue(<NgbModalRef>{ result });
+    it('should initialize and open the export dialog', () => {
+        const onClose = new Subject<ExportModalResult | undefined>();
+        const dialogServiceOpenStub = vi.spyOn(dialogService, 'open').mockReturnValue({ onClose } as DynamicDialogRef);
 
         comp.openExportModal(new MouseEvent('click'));
+
         const csvExportButton = fixture.debugElement.query(By.css('jhi-button'));
         expect(csvExportButton).not.toBeNull();
-        expect(modalServiceOpenStub).toHaveBeenCalledOnce();
+        expect(dialogServiceOpenStub).toHaveBeenCalledOnce();
+    });
+
+    it('should emit chosen csv options when the dialog returns a csv result', () => {
+        const onClose = new Subject<ExportModalResult | undefined>();
+        vi.spyOn(dialogService, 'open').mockReturnValue({ onClose } as DynamicDialogRef);
+        const emitSpy = vi.spyOn(comp.onExport, 'emit');
+        const options: CsvExportOptions = {
+            fieldSeparator: CsvFieldSeparator.COMMA,
+            quoteStrings: true,
+            quoteCharacter: CsvQuoteStrings.QUOTES_DOUBLE,
+            decimalSeparator: CsvDecimalSeparator.PERIOD,
+        };
+
+        comp.openExportModal(new MouseEvent('click'));
+        onClose.next({ type: 'csv', options });
+
+        expect(emitSpy).toHaveBeenCalledWith(options);
+    });
+
+    it('should emit undefined when the dialog returns an excel result', () => {
+        const onClose = new Subject<ExportModalResult | undefined>();
+        vi.spyOn(dialogService, 'open').mockReturnValue({ onClose } as DynamicDialogRef);
+        const emitSpy = vi.spyOn(comp.onExport, 'emit');
+
+        comp.openExportModal(new MouseEvent('click'));
+        onClose.next({ type: 'excel' });
+
+        expect(emitSpy).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should not emit when the dialog is dismissed', () => {
+        const onClose = new Subject<ExportModalResult | undefined>();
+        vi.spyOn(dialogService, 'open').mockReturnValue({ onClose } as DynamicDialogRef);
+        const emitSpy = vi.spyOn(comp.onExport, 'emit');
+
+        comp.openExportModal(new MouseEvent('click'));
+        onClose.next(undefined);
+
+        expect(emitSpy).not.toHaveBeenCalled();
     });
 });

--- a/src/main/webapp/app/shared-ui/export/button/export-button.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/export/button/export-button.component.spec.ts
@@ -44,6 +44,17 @@ describe('ExportButtonComponent', () => {
         const csvExportButton = fixture.debugElement.query(By.css('jhi-button'));
         expect(csvExportButton).not.toBeNull();
         expect(dialogServiceOpenStub).toHaveBeenCalledOnce();
+        // Assert the dialog config reproduces the original NgbModal contract: closable (X button), Esc dismissal,
+        // static backdrop (dismissableMask false), and a non-draggable/non-resizable dialog.
+        const config = dialogServiceOpenStub.mock.calls[0][1];
+        expect(config).toMatchObject({
+            modal: true,
+            closable: true,
+            closeOnEscape: true,
+            dismissableMask: false,
+            draggable: false,
+            resizable: false,
+        });
     });
 
     it('should emit chosen csv options when the dialog returns a csv result', () => {

--- a/src/main/webapp/app/shared-ui/export/button/export-button.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/export/button/export-button.component.spec.ts
@@ -28,6 +28,7 @@ describe('ExportButtonComponent', () => {
                 fixture = TestBed.createComponent(ExportButtonComponent);
                 comp = fixture.componentInstance;
                 dialogService = TestBed.inject(DialogService);
+                fixture.detectChanges();
             });
     });
 

--- a/src/main/webapp/app/shared-ui/export/button/export-button.component.ts
+++ b/src/main/webapp/app/shared-ui/export/button/export-button.component.ts
@@ -44,7 +44,11 @@ export class ExportButtonComponent {
             modal: true,
             closable: true,
             closeOnEscape: true,
+            // dismissableMask false reproduces the original NgbModal `backdrop: 'static'` (backdrop click does not dismiss).
             dismissableMask: false,
+            // The original NgbModal dialog was neither draggable nor resizable; make that explicit.
+            draggable: false,
+            resizable: false,
         });
         dialogRef?.onClose.subscribe((result: ExportModalResult | undefined) => {
             if (!result) {

--- a/src/main/webapp/app/shared-ui/export/button/export-button.component.ts
+++ b/src/main/webapp/app/shared-ui/export/button/export-button.component.ts
@@ -1,27 +1,36 @@
-import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
-import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { Component, inject, input, output } from '@angular/core';
+import { DialogService } from 'primeng/dynamicdialog';
+import { TranslateService } from '@ngx-translate/core';
 import { ButtonSize, ButtonType } from 'app/shared-ui/components/buttons/button/button.component';
-import { CsvExportOptions, ExportModalComponent } from 'app/shared-ui/export/modal/export-modal.component';
+import { CsvExportOptions, ExportModalComponent, ExportModalResult } from 'app/shared-ui/export/modal/export-modal.component';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { ButtonComponent } from 'app/shared-ui/components/buttons/button/button.component';
 
 @Component({
     selector: 'jhi-csv-export-button',
-    template: ` <jhi-button [btnType]="ButtonType.PRIMARY" [btnSize]="buttonSize" [icon]="icon" [disabled]="disabled" [title]="title" (onClick)="openExportModal($event)" /> `,
+    template: `
+        <jhi-button [btnType]="ButtonType.PRIMARY" [btnSize]="buttonSize()" [icon]="icon()" [disabled]="disabled()" [title]="title()" (onClick)="openExportModal($event)" />
+    `,
     imports: [ButtonComponent],
 })
 export class ExportButtonComponent {
-    private modalService = inject(NgbModal);
+    private dialogService = inject(DialogService);
+    private translateService = inject(TranslateService);
 
     ButtonType = ButtonType;
     ButtonSize = ButtonSize;
 
-    @Input() title: string;
-    @Input() disabled: boolean;
-    @Input() buttonSize: ButtonSize = ButtonSize.MEDIUM;
-    @Input() icon: IconProp;
+    // Defaults match the child <jhi-button> input types (string / boolean) and the original behavior
+    // where an unbound title rendered empty and an unbound disabled was falsy.
+    title = input<string>('');
+    disabled = input<boolean>(false);
+    buttonSize = input<ButtonSize>(ButtonSize.MEDIUM);
+    icon = input<IconProp>();
 
-    @Output() onExport: EventEmitter<CsvExportOptions> = new EventEmitter();
+    // Emits the chosen CSV options for a CSV export, or `undefined` for an Excel export.
+    // A dismissed/cancelled dialog does not emit. This preserves the original NgbModal contract
+    // where confirming Excel resolved with `undefined` and dismissing rejected (no emit).
+    onExport = output<CsvExportOptions | undefined>();
 
     /**
      * Open up export option modal
@@ -29,10 +38,25 @@ export class ExportButtonComponent {
      */
     openExportModal(event: MouseEvent) {
         event.stopPropagation();
-        const modalRef: NgbModalRef = this.modalService.open(ExportModalComponent, { size: 'lg', backdrop: 'static' });
-        modalRef.result.then(
-            (customCsvOptions) => this.onExport.emit(customCsvOptions),
-            () => {},
-        );
+        const dialogRef = this.dialogService.open(ExportModalComponent, {
+            header: this.translateService.instant('export.dialogTitle'),
+            width: '50rem',
+            modal: true,
+            closable: true,
+            closeOnEscape: true,
+            dismissableMask: false,
+        });
+        dialogRef?.onClose.subscribe((result: ExportModalResult | undefined) => {
+            if (!result) {
+                // dialog dismissed/cancelled
+                return;
+            }
+            if (result.type === 'csv') {
+                this.onExport.emit(result.options);
+            } else {
+                // Excel export: preserve original contract of emitting `undefined`
+                this.onExport.emit(undefined);
+            }
+        });
     }
 }

--- a/src/main/webapp/app/shared-ui/export/modal/export-modal.component.html
+++ b/src/main/webapp/app/shared-ui/export/modal/export-modal.component.html
@@ -1,10 +1,4 @@
 <form id="csvExportOptionsForm" name="exportOptionForm" role="form" novalidate>
-    <div class="modal-header">
-        <h4 class="modal-title">
-            <span [jhiTranslate]="'export.dialogTitle'"> Export Options </span>
-        </h4>
-        <button type="button" class="btn-close" data-dismiss="modal" aria-hidden="true" (click)="cancel()"></button>
-    </div>
     <nav ngbNav #nav="ngbNav" [(activeId)]="activeTab" class="nav-tabs">
         <ng-container ngbNavItem [ngbNavItem]="1">
             <a ngbNavLink>Excel</a>
@@ -76,7 +70,7 @@
     </div>
     <div class="modal-footer justify-content-between">
         <div class="flex-grow-1 d-flex justify-content-end">
-            <button type="button" class="btn btn-secondary cancel me-1" data-dismiss="modal" (click)="cancel()">
+            <button type="button" class="btn btn-secondary cancel me-1" (click)="cancel()">
                 <fa-icon [icon]="faBan" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
             </button>
             <button class="btn btn-success" id="finish-button" (click)="onFinish()">

--- a/src/main/webapp/app/shared-ui/export/modal/export-modal.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/export/modal/export-modal.component.spec.ts
@@ -1,54 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NgbActiveModal, NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TranslateService } from '@ngx-translate/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
 import { MockDirective, MockPipe, MockProvider } from 'ng-mocks';
 import { CsvDecimalSeparator, CsvExportOptions, CsvFieldSeparator, CsvQuoteStrings, ExportModalComponent } from 'app/shared-ui/export/modal/export-modal.component';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
+import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { By } from '@angular/platform-browser';
 
 describe('ExportModalComponent', () => {
+    setupTestBed({ zoneless: true });
+
     let component: ExportModalComponent;
     let fixture: ComponentFixture<ExportModalComponent>;
-    let ngbActiveModal: NgbActiveModal;
+    let dialogRef: DynamicDialogRef;
     let translateService: TranslateService;
 
     beforeEach(() => {
         return TestBed.configureTestingModule({
-            imports: [NgbNavModule, FaIconComponent],
-            declarations: [ExportModalComponent, MockPipe(ArtemisTranslatePipe), MockDirective(TranslateDirective)],
-            providers: [MockProvider(NgbActiveModal), MockProvider(TranslateService)],
+            imports: [NgbNavModule, FaIconComponent, ExportModalComponent, MockPipe(ArtemisTranslatePipe)],
+            providers: [MockProvider(DynamicDialogRef), { provide: TranslateService, useClass: MockTranslateService }],
         })
+            .overrideComponent(ExportModalComponent, { remove: { imports: [TranslateDirective] }, add: { imports: [MockDirective(TranslateDirective)] } })
             .compileComponents()
             .then(() => {
                 fixture = TestBed.createComponent(ExportModalComponent);
                 component = fixture.componentInstance;
-                ngbActiveModal = TestBed.inject(NgbActiveModal);
+                dialogRef = TestBed.inject(DynamicDialogRef);
                 translateService = TestBed.inject(TranslateService);
                 fixture.detectChanges();
             });
     });
 
     afterEach(() => {
-        jest.restoreAllMocks();
+        vi.restoreAllMocks();
     });
 
     it('should init with default options', () => {
-        jest.spyOn(translateService, 'getCurrentLang').mockReturnValue('en');
+        vi.spyOn(translateService, 'getCurrentLang').mockReturnValue('en');
         component.ngOnInit();
         expect(component.options.fieldSeparator).toBe(CsvFieldSeparator.COMMA);
         expect(component.options.quoteCharacter).toBe(CsvQuoteStrings.QUOTES_DOUBLE);
-        expect(component.options.quoteStrings).toBeTrue();
+        expect(component.options.quoteStrings).toBe(true);
         expect(component.options.decimalSeparator).toBe(CsvDecimalSeparator.PERIOD);
     });
 
     it('should init with german default options', () => {
-        jest.spyOn(translateService, 'getCurrentLang').mockReturnValue('de');
+        vi.spyOn(translateService, 'getCurrentLang').mockReturnValue('de');
         component.ngOnInit();
         expect(component.options.fieldSeparator).toBe(CsvFieldSeparator.SEMICOLON);
         expect(component.options.quoteCharacter).toBe(CsvQuoteStrings.QUOTES_DOUBLE);
-        expect(component.options.quoteStrings).toBeTrue();
+        expect(component.options.quoteStrings).toBe(true);
         expect(component.options.decimalSeparator).toBe(CsvDecimalSeparator.COMMA);
     });
 
@@ -58,28 +64,23 @@ describe('ExportModalComponent', () => {
         component.setCsvDecimalSeparator(CsvDecimalSeparator.PERIOD);
         expect(component.options.fieldSeparator).toBe(CsvFieldSeparator.SPACE);
         expect(component.options.quoteCharacter).toBe(CsvQuoteStrings.NONE);
-        expect(component.options.quoteStrings).toBeFalse();
+        expect(component.options.quoteStrings).toBe(false);
         expect(component.options.decimalSeparator).toBe(CsvDecimalSeparator.PERIOD);
     });
 
-    it('should dismiss modal if close or cancel button are clicked', () => {
-        const dismissSpy = jest.spyOn(ngbActiveModal, 'dismiss');
-        const closeButton = fixture.debugElement.query(By.css('button.btn-close'));
-        expect(closeButton).not.toBeNull();
-        closeButton.nativeElement.click();
-        expect(dismissSpy).toHaveBeenCalledOnce();
-
+    it('should close (dismiss) the modal if close or cancel button are clicked', () => {
+        const closeSpy = vi.spyOn(dialogRef, 'close');
         const cancelButton = fixture.debugElement.query(By.css('button.cancel'));
         expect(cancelButton).not.toBeNull();
         cancelButton.nativeElement.click();
-        expect(dismissSpy).toHaveBeenCalledTimes(2);
+        expect(closeSpy).toHaveBeenCalledWith();
     });
 
-    it('should return empty on finish when excel export is active', () => {
+    it('should return an excel result on finish when excel export is active', () => {
         component.activeTab = 1;
-        const activeModalStub = jest.spyOn(ngbActiveModal, 'close');
+        const closeSpy = vi.spyOn(dialogRef, 'close');
         component.onFinish();
-        expect(activeModalStub).toHaveBeenCalledWith();
+        expect(closeSpy).toHaveBeenCalledWith({ type: 'excel' });
     });
 
     it('should return the csv export options on finish when csv export is active', () => {
@@ -91,8 +92,8 @@ describe('ExportModalComponent', () => {
         };
         component.options = testOptions;
         component.activeTab = 2;
-        const activeModalStub = jest.spyOn(ngbActiveModal, 'close');
+        const closeSpy = vi.spyOn(dialogRef, 'close');
         component.onFinish();
-        expect(activeModalStub).toHaveBeenCalledWith(testOptions);
+        expect(closeSpy).toHaveBeenCalledWith({ type: 'csv', options: testOptions });
     });
 });

--- a/src/main/webapp/app/shared-ui/export/modal/export-modal.component.ts
+++ b/src/main/webapp/app/shared-ui/export/modal/export-modal.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, inject } from '@angular/core';
-import { NgbActiveModal, NgbNav, NgbNavContent, NgbNavItem, NgbNavLink, NgbNavLinkBase, NgbNavOutlet } from '@ng-bootstrap/ng-bootstrap';
+import { NgbNav, NgbNavContent, NgbNavItem, NgbNavLink, NgbNavLinkBase, NgbNavOutlet } from '@ng-bootstrap/ng-bootstrap';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TranslateService } from '@ngx-translate/core';
 import { faBan, faDownload } from '@fortawesome/free-solid-svg-icons';
 import { FormsModule } from '@angular/forms';
@@ -34,6 +35,12 @@ export interface CsvExportOptions {
     decimalSeparator: CsvDecimalSeparator;
 }
 
+/**
+ * Discriminated result of the export modal so the caller can distinguish a confirmed Excel export
+ * (no custom CSV options) from a confirmed CSV export, while a dismiss/cancel resolves to `undefined`.
+ */
+export type ExportModalResult = { type: 'excel' } | { type: 'csv'; options: CsvExportOptions };
+
 @Component({
     selector: 'jhi-csv-export-modal',
     templateUrl: './export-modal.component.html',
@@ -54,7 +61,7 @@ export interface CsvExportOptions {
     ],
 })
 export class ExportModalComponent implements OnInit {
-    private activeModal = inject(NgbActiveModal);
+    private dialogRef = inject(DynamicDialogRef);
     private translateService = inject(TranslateService);
 
     readonly CsvFieldSeparator = CsvFieldSeparator;
@@ -118,7 +125,7 @@ export class ExportModalComponent implements OnInit {
      * Dismisses the csv export options modal
      */
     cancel() {
-        this.activeModal.dismiss();
+        this.dialogRef.close();
     }
 
     /**
@@ -126,11 +133,11 @@ export class ExportModalComponent implements OnInit {
      */
     onFinish() {
         if (this.activeTab === 1) {
-            // Excel export
-            this.activeModal.close();
+            // Excel export: confirmed, but no custom CSV options to return
+            this.dialogRef.close({ type: 'excel' } satisfies ExportModalResult);
         } else {
             // CSV export
-            this.activeModal.close(this.options);
+            this.dialogRef.close({ type: 'csv', options: this.options } satisfies ExportModalResult);
         }
     }
 }

--- a/src/main/webapp/app/shared-ui/export/row-builder/csv-export-row-builder.spec.ts
+++ b/src/main/webapp/app/shared-ui/export/row-builder/csv-export-row-builder.spec.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from 'vitest';
 import { CourseScoresStudentStatistics } from 'app/course/manage/course-scores/course-scores-student-statistics';
 import { EMAIL_KEY, NAME_KEY, POINTS_KEY, REGISTRATION_NUMBER_KEY, SCORE_KEY, USERNAME_KEY } from 'app/shared-ui/export/export-constants';
 import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';

--- a/src/main/webapp/app/shared-ui/export/row-builder/excel-export-row-builder.spec.ts
+++ b/src/main/webapp/app/shared-ui/export/row-builder/excel-export-row-builder.spec.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from 'vitest';
 import { POINTS_KEY, SCORE_KEY } from 'app/shared-ui/export/export-constants';
 import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { ExportRowBuilder } from 'app/shared-ui/export/row-builder/export-row-builder';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -96,6 +96,9 @@ export default defineConfig({
             'src/main/webapp/app/programming/shared/entities/build-plan-phases.model.spec.ts', // include build plan phases model tests
             'src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.spec.ts', // include legacy build plan converter service tests
             'src/main/webapp/app/programming/shared/programming-exercise-update-timeline/**/*.spec.ts', // include programming exercise update timeline tests
+            'src/main/webapp/app/shared-ui/components/slice-navigator/**/*.spec.ts', // include slice-navigator tests
+            'src/main/webapp/app/shared-ui/components/feature-overlay/**/*.spec.ts', // include feature-overlay tests
+            'src/main/webapp/app/shared-ui/export/**/*.spec.ts', // include export (button/modal/row-builder) tests
         ],
         exclude: ['**/node_modules/**', '**/build/**'],
         testTimeout: 10000,
@@ -171,6 +174,9 @@ export default defineConfig({
                 'src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.ts', // include legacy build plan converter service for code coverage
                 'src/main/webapp/app/programming/shared/entities/build-plan-phases.model.ts', // include build plan phases model for code coverage
                 'src/main/webapp/app/programming/shared/programming-exercise-update-timeline/**/*.ts', // include programming exercise update timeline for code coverage
+                'src/main/webapp/app/shared-ui/components/slice-navigator/**/*.ts', // include slice-navigator for code coverage
+                'src/main/webapp/app/shared-ui/components/feature-overlay/**/*.ts', // include feature-overlay for code coverage
+                'src/main/webapp/app/shared-ui/export/**/*.ts', // include export (button/modal/row-builder) for code coverage
             ],
             exclude: [
                 '**/node_modules/**', // exclude node_modules with third-party code


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).

### Motivation and Context
Part of the Angular 21 migration campaign. The shared-ui export and course/exam archive buttons still used the deprecated `@ng-bootstrap/ng-bootstrap` `NgbModal` for their dialogs and were still covered by Jest. ng-bootstrap is deprecated (and incompatible with Angular signal inputs), and Jest is being migrated to Vitest. This PR migrates these shared-ui button dialogs to PrimeNG and moves their specs to Vitest, while faithfully preserving the original dialog dismissal behavior.

### Description
- **`course-exam-archive-button`**: its three inline confirmation modals (`archiveCompleteWithWarningsModal`, `archiveWarningPopup`, `archiveConfirmModal`) were opened via `NgbModal.open(templateRef)` with the default backdrop. They are migrated to PrimeNG `<p-dialog>` elements driven by visibility signals (`archiveCompleteWithWarningsModalVisible`, `archiveWarningPopupVisible`, `archiveConfirmModalVisible`). Each dialog sets `[closeOnEscape]="true"` and `[dismissableMask]="true"` to preserve the original NgbModal default-backdrop dismiss (clicking the backdrop closes the dialog). The original `NgbModal` result-chaining (`archive-confirm` → overwrite-confirm dialog → `archive()`) is reproduced faithfully through the `onArchiveWarningConfirm()` / `onArchiveConfirm()` handlers.
- **`export-button`**: its `ExportModalComponent` was opened via `NgbModal.open(ExportModalComponent, { size: 'lg', backdrop: 'static' })`. It now opens through PrimeNG's `DialogService` (`primeng/dynamicdialog`) with `dismissableMask: false`, preserving the original `backdrop: 'static'` (backdrop click does not dismiss). `@Input()`/`@Output()` are migrated to `input()`/`output()`. `ExportModalComponent` now closes via `DynamicDialogRef` and returns a typed `ExportModalResult` discriminated union so the caller can distinguish a confirmed CSV export, a confirmed Excel export (emits `undefined`), and a dismiss (no emit) — matching the original NgbModal contract.
- **`ConfirmAutofocusButtonComponent` / `ConfirmAutofocusModalComponent`**: intentionally **NOT** migrated (deferred, documented with code comments). This shared dialog is opened by several callers via `NgbModal.open(...)` + `modalRef.componentInstance.* = ...` writes, some of which live in deferred carve-out modules (programming, atlas, quiz, plagiarism). Switching it to PrimeNG DynamicDialog or signal inputs would silently break the `componentInstance` write contract for those callers, so it stays on NgbModal until the carve-out lifts and all callers can be migrated together.
- **Tests**: the affected specs are migrated from Jest to Vitest. `jest.config.js` and `vitest.config.ts` include/ignore lists are updated append-only to route these paths to Vitest, and the Jest global coverage floors are reconciled with `develop` (the `develop` value is the lower of the two, so it is kept).

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Course with completed exercises (and optionally 1 Exam)

1. Log in to Artemis as an instructor.
2. Open a course (or exam) and trigger **Archive**. Confirm the archive-warning dialog appears; verify Esc dismisses it and clicking the backdrop dismisses it (default-backdrop behavior, matching `develop`).
3. If an archive already exists, confirm the overwrite-confirmation dialog chains correctly and starts the archive on "Yes".
4. On a page with the CSV export button (e.g. exercise/exam scores), click **Export**, confirm the export dialog opens, and verify that clicking the backdrop does **not** dismiss it (static backdrop), while Esc and the X button do. Confirm that a CSV export emits the chosen options and an Excel export completes.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Screenshots
No intended visual change. The dialogs are re-implemented with PrimeNG while preserving the existing layout, content, and dismissal behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Archive and export dialogs migrated to PrimeNG dynamic dialogs and signal-driven visibility; archive flows now use explicit confirmation/warning dialogs while preserving prior user-facing behavior.

* **Tests**
  * Test suites migrated to Vitest with zoneless testbed; updated to use new dialog APIs, mocks, and assertions; added/adjusted tests for archive and export dialog flows.

* **Chores**
  * Test tooling updated to adjust Jest coverage collection/discovery and Vitest coverage inclusion; global Jest coverage threshold for functions reduced.

* **Documentation**
  * Notes added documenting intentional deferred modal migrations for shared dialog contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->