### PR TITLE
`Development`: Migrate signal stragglers (localvc, logos) and refresh the ESLint signal allowlist

### DIFF
--- a/rules/enforce-signal-apis-in-migrated-modules.mjs
+++ b/rules/enforce-signal-apis-in-migrated-modules.mjs
@@ -8,21 +8,31 @@ const createRule = ESLintUtils.RuleCreator(() => '');
  * must not be reintroduced in these modules.
  */
 // TODO: Add other modules here once they have been fully migrated to Angular signal-based APIs.
+// Still pending (legacy decorators remain): course, editor, exercise, programming.
 const MIGRATED_MODULES = [
+    'account',
+    'admin',
     'assessment',
     'atlas',
-    'buildagent',
+    'calendar',
     'communication',
     'core',
+    'exam',
     'fileupload',
     'foundation',
+    'hyperion',
     'iris',
     'lecture',
+    'localci',
+    'localvc',
+    'logos',
     'lti',
     'modeling',
+    'notification',
     'plagiarism',
     'quiz',
     'shared-ui',
+    'sharing',
     'text',
     'tutorialgroup',
 ];

--- a/src/main/webapp/app/localvc/repository-view/repository-view.component.ts
+++ b/src/main/webapp/app/localvc/repository-view/repository-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, viewChild } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ExerciseType, getCourseFromExercise } from 'app/exercise/shared/entities/exercise/exercise.model';
@@ -48,7 +48,7 @@ export class RepositoryViewComponent implements OnInit, OnDestroy {
     private programmingExerciseService = inject(ProgrammingExerciseService);
     private router = inject(Router);
 
-    @ViewChild(CodeEditorContainerComponent, { static: false }) codeEditorContainer: CodeEditorContainerComponent;
+    readonly codeEditorContainer = viewChild(CodeEditorContainerComponent);
 
     PROGRAMMING = ExerciseType.PROGRAMMING;
     protected readonly FeatureToggle = FeatureToggle;

--- a/src/main/webapp/app/logos/llm-selection-popup.component.ts
+++ b/src/main/webapp/app/logos/llm-selection-popup.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, EventEmitter, OnDestroy, OnInit, Output, inject } from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit, inject, output } from '@angular/core';
 import { LLMSelectionModalService } from 'app/logos/llm-selection-popup.service';
 import { Theme, ThemeService } from 'app/core/theme/shared/theme.service';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
@@ -24,7 +24,7 @@ export class LLMSelectionModalComponent implements OnInit, OnDestroy {
     private accountService = inject(AccountService);
     private router = inject(Router);
 
-    @Output() choice = new EventEmitter<LLMModalResult>();
+    readonly choice = output<LLMModalResult>();
 
     isVisible = false;
     currentSelection?: LLMSelectionDecision;


### PR DESCRIPTION
### Summary
Closes the last two standalone Angular signal "stragglers" (localvc, logos) and refreshes the ESLint signal-migration allowlist so every already-decoratorless client module is locked against regressions. No behavioral change.

### Checklist
#### General
- [x] I chose a title conforming to the naming conventions for pull requests.
#### Client
- [x] I strictly followed the client coding guidelines.
- [x] Existing Vitest suites for the affected modules pass (localvc + logos: 69 tests).
- [x] I documented the TypeScript code using JSDoc style (no public API changes).

### Motivation and Context
As part of the ongoing Angular 21 signal migration, `localvc` and `logos` were the only top-level modules left with a single residual legacy decorator each, and the `enforce-signal-apis-in-migrated-modules` ESLint allowlist had drifted behind reality (10 fully-migrated modules were not yet locked, and the removed `buildagent` module was still listed).

### Description
- **localvc** `repository-view.component.ts`: `@ViewChild(CodeEditorContainerComponent)` → `viewChild()` (the field was unused outside its declaration, so the change is purely mechanical).
- **logos** `llm-selection-popup.component.ts`: `@Output() choice` → `output<LLMModalResult>()` (the host `<jhi-llm-selection-modal />` has no `(choice)` binding; the real channel is the popup service, so this is safe).
- **`rules/enforce-signal-apis-in-migrated-modules.mjs`**: added `account, admin, calendar, exam, hyperion, localci, localvc, logos, notification, sharing`; removed the dead `buildagent` entry (absorbed into `localci`).

### Steps for Testing
Prerequisites:
- 1 Instructor, 1 Programming Exercise

1. `pnpm run vitest:run -- src/main/webapp/app/localvc src/main/webapp/app/logos` → all pass.
2. `pnpm run lint` → no `enforce-signal-apis-in-migrated-modules` violations.
3. As a student/instructor, open a programming exercise repository view → renders and behaves as before.
4. Trigger the LLM selection popup (e.g. AI feedback) → selecting Cloud/Local/None still works and the choice is applied.

### Testserver States
You can manage test servers using Helios. This is a client-only, no-behavior-change PR; local testing is sufficient.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Repository view renders/behaves unchanged
- [x] LLM selection popup choices apply correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized Angular component implementations to use signal-based APIs, improving code patterns with no functional changes to user experience.
  * Updated internal module migration tracking system for enhanced code standards enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->