### PR TITLE
`Development`: Lock course and editor into the signal-migration ESLint allowlist

### DIFF
--- a/rules/enforce-signal-apis-in-migrated-modules.mjs
+++ b/rules/enforce-signal-apis-in-migrated-modules.mjs
@@ -8,7 +8,7 @@ const createRule = ESLintUtils.RuleCreator(() => '');
  * must not be reintroduced in these modules.
  */
 // TODO: Add other modules here once they have been fully migrated to Angular signal-based APIs.
-// Still pending (legacy decorators remain): course, editor, exercise, programming.
+// Still pending (legacy decorators remain): exercise, programming.
 const MIGRATED_MODULES = [
     'account',
     'admin',
@@ -17,6 +17,8 @@ const MIGRATED_MODULES = [
     'calendar',
     'communication',
     'core',
+    'course',
+    'editor',
     'exam',
     'fileupload',
     'foundation',


### PR DESCRIPTION
### Summary
Adds `course` and `editor` to `MIGRATED_MODULES` in the `enforce-signal-apis-in-migrated-modules` ESLint rule. Both modules are already fully decoratorless on develop, so locking them prevents legacy Angular decorators from being reintroduced. Rule-only change, no runtime impact.

### Checklist
#### General
- [x] I chose a title conforming to the naming conventions for pull requests.
#### Client
- [x] I strictly followed the client coding guidelines.
- [x] `eslint` passes on `src/main/webapp/app/course` and `src/main/webapp/app/editor` with the rule active (0 forbidden-decorator violations).

### Motivation and Context
The signal migration removed all legacy decorators from `course` (the sidebar migration) and `editor` (merged via #12843), but neither module was added to the `MIGRATED_MODULES` allowlist, so the `enforce-signal-apis-in-migrated-modules` rule wasn't guarding them. This locks them in so `@Input`/`@Output`/`@ViewChild`/`@ViewChildren`/`@ContentChild`/`@ContentChildren` cannot reappear.

### Description
- `rules/enforce-signal-apis-in-migrated-modules.mjs`: add `course` and `editor` to `MIGRATED_MODULES` (kept alphabetical); update the "still pending" comment to `exercise, programming`.

### Steps for Testing
1. `pnpm run lint` (or `npx eslint src/main/webapp/app/course src/main/webapp/app/editor`) → passes, no `enforce-signal-apis-in-migrated-modules` violations.
2. Add a `@ViewChild(...)` to any non-spec file in `course` or `editor` → lint now errors (rule active). Revert.

### Testserver States
Lint/config-only change; no server or runtime behavior affected. Local lint is sufficient.

### Review Progress
#### Code Review
- [ ] Code Review 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended legacy decorator enforcement rules to the `course` and `editor` modules, strengthening code standards across additional parts of the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->