### PR TITLE
`Infrastructure`: Test ARC BuildKit Docker workflow

### DIFF
--- a/.github/workflows/append_feature_proposal.yml
+++ b/.github/workflows/append_feature_proposal.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-labels:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     outputs:
       status: ${{ steps.feature-proposal-tag-check.outputs.status }}
     steps:
@@ -37,7 +37,7 @@ jobs:
   manage-feature-proposal:
     needs: check-labels
     if: needs.check-labels.outputs.status == 'success'
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - name: Check if feature proposal tag added
         uses: actions/github-script@v9

--- a/.github/workflows/append_feature_proposal.yml
+++ b/.github/workflows/append_feature_proposal.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-labels:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     outputs:
       status: ${{ steps.feature-proposal-tag-check.outputs.status }}
     steps:
@@ -37,7 +37,7 @@ jobs:
   manage-feature-proposal:
     needs: check-labels
     if: needs.check-labels.outputs.status == 'success'
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - name: Check if feature proposal tag added
         uses: actions/github-script@v9

--- a/.github/workflows/bean-instantiations.yml
+++ b/.github/workflows/bean-instantiations.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   bean-instantiation-check:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
 
     env:
       MAX_STARTUP_DEPENDENCY_CHAIN_LENGTH: 10

--- a/.github/workflows/bean-instantiations.yml
+++ b/.github/workflows/bean-instantiations.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   bean-instantiation-check:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
 
     env:
       MAX_STARTUP_DEPENDENCY_CHAIN_LENGTH: 10

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
 
   build-war:
     name: Build .war artifact
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - uses: actions/checkout@v6
         with:
@@ -179,9 +179,9 @@ jobs:
       ref: ${{ github.event.pull_request.head.sha || github.sha }}
       image-name: ls1intum/artemis
       docker-file: ./docker/artemis/Dockerfile
-      runner-amd64: arc-buildkit-ls1intum-stud-amd64
+      runner-amd64: arc-buildkit-ls1intum-theiaprod-amd64
       runner-arm64: arc-buildkit-ls1intum-parma-arm64
-      runner-merge: arc-buildkit-ls1intum-stud-amd64
+      runner-merge: arc-buildkit-ls1intum-theiaprod-amd64
       build-amd64: true
       build-arm64: false
       tags: |
@@ -200,9 +200,9 @@ jobs:
       ref: ${{ github.ref_name }}
       image-name: ls1intum/artemis
       docker-file: ./docker/artemis/Dockerfile
-      runner-amd64: arc-buildkit-ls1intum-stud-amd64
+      runner-amd64: arc-buildkit-ls1intum-theiaprod-amd64
       runner-arm64: arc-buildkit-ls1intum-parma-arm64
-      runner-merge: arc-buildkit-ls1intum-stud-amd64
+      runner-merge: arc-buildkit-ls1intum-theiaprod-amd64
       tags: |
         type=ref,event=tag
 
@@ -213,7 +213,7 @@ jobs:
     name: Save Docker Image Tag
     needs: [docker-pr, docker-release]
     if: ${{ always() && (needs.docker-pr.result == 'success' || needs.docker-release.result == 'success') }}
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - name: Save Docker tag to file
         env:
@@ -231,7 +231,7 @@ jobs:
     name: ARC E2E Test
     needs: save-docker-tag
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 120
     environment: playwright-e2e-tests
     env:
@@ -279,7 +279,7 @@ jobs:
     name: Block default workflow_run E2E
     needs: arc-e2e-test
     if: ${{ always() && github.event_name == 'pull_request' }}
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - name: Fail intentionally after ARC E2E test
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
 
   build-war:
     name: Build .war artifact
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - uses: actions/checkout@v6
         with:
@@ -164,68 +164,28 @@ jobs:
           asset_name: Artemis.war
           asset_content_type: application/x-webarchive
 
-  # Fast PR path: single-arch (linux/amd64) image that reuses the .war produced by
-  # `build-war` via the Dockerfile's `external_builder` stage. Skips the duplicate
-  # Angular + Gradle build that the reusable multi-arch workflow would otherwise
-  # run inside the image.
+  # PR path: single-arch (linux/amd64) image built through the shared ARC BuildKit
+  # reusable workflow. This intentionally exercises the same stateful BuildKit
+  # infrastructure used by release image builds.
   docker-pr:
     name: Build and Push Docker Image (PR, amd64)
     needs: build-war
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'ls1intum/Artemis' }}
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Download .war artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: Artemis.war
-          path: build/libs
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/ls1intum/artemis
-          tags: |
-            type=ref,event=pr
-      - name: Build and push (linux/amd64)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./docker/artemis/Dockerfile
-          platforms: linux/amd64
-          # Skip the in-image .war build; COPY the artifact produced by `build-war` instead.
-          build-args: WAR_FILE_STAGE=external_builder
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      # Consumed by .github/actions/e2e-setup, which downloads the `docker-tag`
-      # artifact from the triggering Build run and pulls ghcr.io/ls1intum/artemis:<tag>.
-      - name: Save Docker tag to file
-        env:
-          DOCKER_TAG: ${{ steps.meta.outputs.version }}
-        run: |
-          printf '%s' "$DOCKER_TAG" > docker-tag.txt
-          echo "Using Docker tag: $DOCKER_TAG"
-      - name: Upload Docker tag as artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: docker-tag
-          path: docker-tag.txt
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image-self-hosted-buildkit.yml@feature/split-build-workflow-modes
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      image-name: ls1intum/artemis
+      docker-file: ./docker/artemis/Dockerfile
+      runner-amd64: arc-buildkit-ls1intum-stud-amd64
+      runner-arm64: arc-buildkit-ls1intum-parma-arm64
+      runner-merge: arc-buildkit-ls1intum-stud-amd64
+      build-amd64: true
+      build-arm64: false
+      tags: |
+        type=ref,event=pr
 
   # Release / default-branch path: multi-arch publish via the shared reusable workflow.
   # Kept as-is because the reusable workflow runs its own checkout and cannot see the
@@ -246,18 +206,18 @@ jobs:
       tags: |
         type=ref,event=tag
 
-  # Mirrors the `docker-tag` artifact upload from `docker-pr` for the release path,
-  # so .github/actions/e2e-setup can consume it uniformly regardless of which docker
+  # Uploads the docker-tag artifact for both PR and release paths, so
+  # .github/actions/e2e-setup can consume it uniformly regardless of which Docker
   # job produced the image.
   save-docker-tag:
     name: Save Docker Image Tag
-    needs: docker-release
-    if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
-    runs-on: ubuntu-latest
+    needs: [docker-pr, docker-release]
+    if: ${{ always() && (needs.docker-pr.result == 'success' || needs.docker-release.result == 'success') }}
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - name: Save Docker tag to file
         env:
-          DOCKER_TAG: ${{ needs.docker-release.outputs.image_tag }}
+          DOCKER_TAG: ${{ needs.docker-pr.outputs.image_tag || needs.docker-release.outputs.image_tag }}
         run: |
           printf '%s' "$DOCKER_TAG" > docker-tag.txt
           echo "Using Docker tag: $DOCKER_TAG"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,7 +230,7 @@ jobs:
   arc-e2e-test:
     name: ARC E2E Test
     needs: save-docker-tag
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ always() && github.event_name == 'pull_request' && needs.save-docker-tag.result == 'success' }}
     runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 120
     environment: playwright-e2e-tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,3 +226,62 @@ jobs:
         with:
           name: docker-tag
           path: docker-tag.txt
+
+  arc-e2e-test:
+    name: ARC E2E Test
+    needs: save-docker-tag
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: arc-buildkit-ls1intum-stud-amd64
+    timeout-minutes: 120
+    environment: playwright-e2e-tests
+    env:
+      ARTEMIS_ADMIN_PASSWORD: ${{ secrets.ARTEMIS_ADMIN_PASSWORD }}
+      ARTEMIS_ADMIN_USERNAME: ${{ secrets.ARTEMIS_ADMIN_USERNAME }}
+      PLAYWRIGHT_CREATE_USERS: ${{ vars.PLAYWRIGHT_CREATE_USERS }}
+      PLAYWRIGHT_PASSWORD_TEMPLATE: ${{ vars.PLAYWRIGHT_PASSWORD_TEMPLATE }}
+      PLAYWRIGHT_USERNAME_TEMPLATE: ${{ vars.PLAYWRIGHT_USERNAME_TEMPLATE }}
+      SLOW_TEST_TIMEOUT_SECONDS: ${{ vars.SLOW_TEST_TIMEOUT_SECONDS }}
+      TEST_RETRIES: ${{ vars.TEST_RETRIES }}
+      TEST_TIMEOUT_SECONDS: ${{ vars.TEST_TIMEOUT_SECONDS }}
+      TEST_WORKER_PROCESSES: ${{ vars.TEST_WORKER_PROCESSES }}
+      PLAYWRIGHT_REPORT_SERVER_URL: ${{ vars.PLAYWRIGHT_REPORT_SERVER_URL }}
+      PLAYWRIGHT_REPORT_TOKEN: ${{ secrets.PLAYWRIGHT_REPORT_TOKEN }}
+      PLAYWRIGHT_REPORT_BRANCH: ${{ github.event.pull_request.head.ref }}
+      PLAYWRIGHT_REPORT_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+      PLAYWRIGHT_REPORT_PR_NUMBER: ${{ github.event.pull_request.number }}
+      PLAYWRIGHT_REPORT_PHASE: arc
+      PLAYWRIGHT_REPORT_TRIGGERED_BY: pull_request
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+      - name: Download Docker tag
+        uses: actions/download-artifact@v8
+        with:
+          name: docker-tag
+      - name: Set Docker tag environment variable
+        run: |
+          ARTEMIS_DOCKER_TAG="$(cat docker-tag.txt)"
+          echo "ARTEMIS_DOCKER_TAG=${ARTEMIS_DOCKER_TAG}" >> "$GITHUB_ENV"
+          echo "Using Docker tag: ${ARTEMIS_DOCKER_TAG}"
+      - name: Make E2E scripts executable
+        run: chmod +x .ci/E2E-tests/cleanup.sh .ci/E2E-tests/execute.sh
+      - name: Run cleanup script before E2E
+        run: .ci/E2E-tests/cleanup.sh
+      - name: Run ARC E2E tests
+        run: .ci/E2E-tests/execute.sh postgres-localci playwright
+        env:
+          FAST_TEST_TIMEOUT_SECONDS: 60
+
+  block-default-e2e-workflow-run:
+    name: Block default workflow_run E2E
+    needs: arc-e2e-test
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: arc-buildkit-ls1intum-stud-amd64
+    steps:
+      - name: Fail intentionally after ARC E2E test
+        run: |
+          echo "Intentional temporary failure: keep the Build workflow conclusion non-successful so the default-branch workflow_run E2E path does not start on the old runners."
+          exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,11 +235,14 @@ jobs:
   docker-release:
     name: Build and Push Docker Image
     if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.1
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image-self-hosted-buildkit.yml@feature/split-build-workflow-modes
     with:
       ref: ${{ github.ref_name }}
       image-name: ls1intum/artemis
       docker-file: ./docker/artemis/Dockerfile
+      runner-amd64: arc-buildkit-ls1intum-stud-amd64
+      runner-arm64: arc-buildkit-ls1intum-parma-arm64
+      runner-merge: arc-buildkit-ls1intum-stud-amd64
       tags: |
         type=ref,event=tag
 

--- a/.github/workflows/check-translation-keys.yml
+++ b/.github/workflows/check-translation-keys.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build:
     name: Check if translation keys are consistent
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/check-translation-keys.yml
+++ b/.github/workflows/check-translation-keys.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build:
     name: Check if translation keys are consistent
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   analyse:
     name: Analyse
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   analyse:
     name: Analyse
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - uses: actions/checkout@v6
 
@@ -48,7 +48,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - uses: actions/checkout@v6
 
@@ -48,7 +48,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     validation:
         name: "Gradle Wrapper Validation"
-        runs-on: arc-buildkit-ls1intum-stud-amd64
+        runs-on: arc-buildkit-ls1intum-theiaprod-amd64
         steps:
             - uses: actions/checkout@v6
             - uses: gradle/actions/wrapper-validation@v6

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
     validation:
         name: "Gradle Wrapper Validation"
-        runs-on: ubuntu-latest
+        runs-on: arc-buildkit-ls1intum-stud-amd64
         steps:
             - uses: actions/checkout@v6
             - uses: gradle/actions/wrapper-validation@v6

--- a/.github/workflows/issue-labler.yml
+++ b/.github/workflows/issue-labler.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - uses: MaximilianAnzinger/issue-labeler@1.0.2
         with:

--- a/.github/workflows/issue-labler.yml
+++ b/.github/workflows/issue-labler.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - uses: MaximilianAnzinger/issue-labeler@1.0.2
         with:

--- a/.github/workflows/nightly-lti-interop.yml
+++ b/.github/workflows/nightly-lti-interop.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   moodle-interop:
     name: nightly-lti / moodle
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/nightly-lti-interop.yml
+++ b/.github/workflows/nightly-lti-interop.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   moodle-interop:
     name: nightly-lti / moodle
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/prod-like-deployment.yml
+++ b/.github/workflows/prod-like-deployment.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   check-build-status:
-    runs-on: [self-hosted, artemis-prod-deployment]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     outputs:
       build_workflow_run_id: ${{ steps.set_build_workflow_id.outputs.workflow_id }}
     steps:
@@ -90,7 +90,7 @@ jobs:
 
   deploy:
     needs: check-build-status
-    runs-on: [self-hosted, artemis-prod-deployment]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     environment:
       name: ${{ github.event.inputs.environment_name }}
       url: ${{ vars.DEPLOYMENT_URL }}

--- a/.github/workflows/prod-like-deployment.yml
+++ b/.github/workflows/prod-like-deployment.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   check-build-status:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     outputs:
       build_workflow_run_id: ${{ steps.set_build_workflow_id.outputs.workflow_id }}
     steps:
@@ -90,7 +90,7 @@ jobs:
 
   deploy:
     needs: check-build-status
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     environment:
       name: ${{ github.event.inputs.environment_name }}
       url: ${{ vars.DEPLOYMENT_URL }}

--- a/.github/workflows/pullrequest-closed.yml
+++ b/.github/workflows/pullrequest-closed.yml
@@ -8,7 +8,7 @@ jobs:
   # If a PR is closed the docker image should be deleted to save space
   purge-image:
     name: Delete image from ghcr.io
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - name: Delete image
         uses: bots-house/ghcr-delete-image-action@v1.1.0

--- a/.github/workflows/pullrequest-closed.yml
+++ b/.github/workflows/pullrequest-closed.yml
@@ -8,7 +8,7 @@ jobs:
   # If a PR is closed the docker image should be deleted to save space
   purge-image:
     name: Delete image from ghcr.io
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - name: Delete image
         uses: bots-house/ghcr-delete-image-action@v1.1.0

--- a/.github/workflows/pullrequest-coverage-reporter.yml
+++ b/.github/workflows/pullrequest-coverage-reporter.yml
@@ -24,7 +24,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion != 'cancelled' &&
       github.event.workflow_run.conclusion != 'skipped'
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 15
     permissions:
       pull-requests: write

--- a/.github/workflows/pullrequest-coverage-reporter.yml
+++ b/.github/workflows/pullrequest-coverage-reporter.yml
@@ -24,7 +24,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion != 'cancelled' &&
       github.event.workflow_run.conclusion != 'skipped'
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 15
     permissions:
       pull-requests: write

--- a/.github/workflows/pullrequest-labeler.yml
+++ b/.github/workflows/pullrequest-labeler.yml
@@ -3,7 +3,7 @@ on: [pull_request_target]
 
 jobs:
   label:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - uses: actions/labeler@v6
         with:

--- a/.github/workflows/pullrequest-labeler.yml
+++ b/.github/workflows/pullrequest-labeler.yml
@@ -3,7 +3,7 @@ on: [pull_request_target]
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - uses: actions/labeler@v6
         with:

--- a/.github/workflows/pullrequest-opened.yml
+++ b/.github/workflows/pullrequest-opened.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   assign:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - name: Assign Pull Request to its Author
         uses: technote-space/assign-author@v1

--- a/.github/workflows/pullrequest-opened.yml
+++ b/.github/workflows/pullrequest-opened.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   assign:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - name: Assign Pull Request to its Author
         uses: technote-space/assign-author@v1

--- a/.github/workflows/pullrequest-ready-to-merge-validator.yml
+++ b/.github/workflows/pullrequest-ready-to-merge-validator.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   validate-ready-to-merge:
     if: github.event.label.name == 'ready to merge'
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 5
     permissions:
       pull-requests: write

--- a/.github/workflows/pullrequest-ready-to-merge-validator.yml
+++ b/.github/workflows/pullrequest-ready-to-merge-validator.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   validate-ready-to-merge:
     if: github.event.label.name == 'ready to merge'
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 5
     permissions:
       pull-requests: write

--- a/.github/workflows/pullrequest-readyforreview.yml
+++ b/.github/workflows/pullrequest-readyforreview.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pullequestReadyForReview:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - name: Label "ready for review"
         uses: actions/github-script@v9

--- a/.github/workflows/pullrequest-readyforreview.yml
+++ b/.github/workflows/pullrequest-readyforreview.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pullequestReadyForReview:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - name: Label "ready for review"
         uses: actions/github-script@v9

--- a/.github/workflows/pullrequest-stale.yml
+++ b/.github/workflows/pullrequest-stale.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   stale:
     if: github.repository_owner == 'ls1intum'
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - name: Check for stale PRs
         uses: actions/stale@v10

--- a/.github/workflows/pullrequest-stale.yml
+++ b/.github/workflows/pullrequest-stale.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   stale:
     if: github.repository_owner == 'ls1intum'
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - name: Check for stale PRs
         uses: actions/stale@v10

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   code-quality-analysis:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
 
     steps:
       - name: Checkout code

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   code-quality-analysis:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
 
     steps:
       - name: Checkout code

--- a/.github/workflows/query-quality.yml
+++ b/.github/workflows/query-quality.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   query-quality-check:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
 
     steps:
       - name: Checkout code

--- a/.github/workflows/query-quality.yml
+++ b/.github/workflows/query-quality.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   query-quality-check:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   e2e-tests:
     name: Android E2E Tests
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   e2e-tests:
     name: Android E2E Tests
-    runs-on: [self-hosted, ase-large-android-sdk-34]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -31,8 +31,8 @@ jobs:
   # Guard against workflow_run queue stacking. Each Build retry fires a new
   # workflow_run event that queues another E2E run for the same SHA; built-in
   # concurrency cancel-in-progress does not reliably dedupe queued runs that
-  # sit waiting for the [self-hosted, e2e-test] pool. This job runs on
-  # ubuntu-latest (instant pickup) and uses styfle/cancel-workflow-action to
+  # sit waiting for the runner pool. This test branch routes the guard job to
+  # the ARC BuildKit runner and uses styfle/cancel-workflow-action to
   # cancel older same-SHA runs of this workflow, and self-cancels if a newer
   # run already exists. Cross-SHA cancellation is the built-in `concurrency`
   # block's responsibility (it works reliably when the next run starts
@@ -43,7 +43,7 @@ jobs:
     # E2E runs anyway, because all dependent jobs are if-gated on
     # conclusion == 'success'. No queue stacking comes from failed Builds.
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 2
     permissions:
       actions: write
@@ -64,7 +64,7 @@ jobs:
     name: Determine Relevant Tests
     needs: cancel-superseded
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     outputs:
       run_all_tests: ${{ steps.determine.outputs.RUN_ALL_TESTS }}
       relevant_tests: ${{ steps.determine.outputs.RELEVANT_TESTS }}
@@ -103,7 +103,7 @@ jobs:
       needs.determine-tests.result == 'success' &&
       needs.determine-tests.outputs.run_all_tests != 'true' &&
       needs.determine-tests.outputs.relevant_tests != ''
-    runs-on: [self-hosted, e2e-test]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 120
     environment: playwright-e2e-tests
     env:
@@ -295,7 +295,7 @@ jobs:
       needs.determine-tests.outputs.run_all_tests != 'true' &&
       needs.determine-tests.outputs.remaining_tests != '' &&
       (needs.run-e2e-relevant.result == 'success' || needs.run-e2e-relevant.result == 'skipped')
-    runs-on: [self-hosted, e2e-test]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 120
     environment: playwright-e2e-tests
     outputs:
@@ -496,7 +496,7 @@ jobs:
       needs.determine-tests.result == 'success' &&
       (needs.determine-tests.outputs.run_all_tests == 'true' ||
        (needs.determine-tests.outputs.relevant_tests == '' && needs.determine-tests.outputs.remaining_tests == ''))
-    runs-on: [self-hosted, e2e-test]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 120
     environment: playwright-e2e-tests
     outputs:
@@ -676,7 +676,7 @@ jobs:
     name: Run All E2E Tests (Non-PR)
     needs: cancel-superseded
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'pull_request'
-    runs-on: [self-hosted, e2e-test]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 120
     environment: playwright-e2e-tests
     env:
@@ -752,7 +752,7 @@ jobs:
     name: Report E2E Overall Status
     needs: [determine-tests, run-e2e-relevant, run-e2e-remaining, run-e2e-all-pr, run-e2e-all-non-pr]
     if: always() && github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
 
       - name: Determine overall status

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -43,7 +43,7 @@ jobs:
     # E2E runs anyway, because all dependent jobs are if-gated on
     # conclusion == 'success'. No queue stacking comes from failed Builds.
     if: github.event.workflow_run.conclusion == 'success'
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 2
     permissions:
       actions: write
@@ -64,7 +64,7 @@ jobs:
     name: Determine Relevant Tests
     needs: cancel-superseded
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     outputs:
       run_all_tests: ${{ steps.determine.outputs.RUN_ALL_TESTS }}
       relevant_tests: ${{ steps.determine.outputs.RELEVANT_TESTS }}
@@ -103,7 +103,7 @@ jobs:
       needs.determine-tests.result == 'success' &&
       needs.determine-tests.outputs.run_all_tests != 'true' &&
       needs.determine-tests.outputs.relevant_tests != ''
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 120
     environment: playwright-e2e-tests
     env:
@@ -295,7 +295,7 @@ jobs:
       needs.determine-tests.outputs.run_all_tests != 'true' &&
       needs.determine-tests.outputs.remaining_tests != '' &&
       (needs.run-e2e-relevant.result == 'success' || needs.run-e2e-relevant.result == 'skipped')
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 120
     environment: playwright-e2e-tests
     outputs:
@@ -496,7 +496,7 @@ jobs:
       needs.determine-tests.result == 'success' &&
       (needs.determine-tests.outputs.run_all_tests == 'true' ||
        (needs.determine-tests.outputs.relevant_tests == '' && needs.determine-tests.outputs.remaining_tests == ''))
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 120
     environment: playwright-e2e-tests
     outputs:
@@ -676,7 +676,7 @@ jobs:
     name: Run All E2E Tests (Non-PR)
     needs: cancel-superseded
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'pull_request'
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 120
     environment: playwright-e2e-tests
     env:
@@ -752,7 +752,7 @@ jobs:
     name: Report E2E Overall Status
     needs: [determine-tests, run-e2e-relevant, run-e2e-remaining, run-e2e-all-pr, run-e2e-all-non-pr]
     if: always() && github.event.workflow_run.conclusion == 'success'
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
 
       - name: Determine overall status

--- a/.github/workflows/test-mysql.yml
+++ b/.github/workflows/test-mysql.yml
@@ -19,7 +19,7 @@ env:
 jobs:
 
   server-tests-mysql:
-    runs-on: aet-large-ubuntu
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 80
 
     steps:

--- a/.github/workflows/test-mysql.yml
+++ b/.github/workflows/test-mysql.yml
@@ -19,7 +19,7 @@ env:
 jobs:
 
   server-tests-mysql:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 80
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
   # This matches the production database engine and catches SQL dialect issues that
   # in-memory databases like H2 would miss.
   server-tests:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 80
 
     steps:
@@ -219,7 +219,7 @@ jobs:
         cat $AGGREGATED_REPORT_FILE > $GITHUB_STEP_SUMMARY
 
   server-style:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v6
@@ -246,7 +246,7 @@ jobs:
         reporter: java-junit
 
   client-tests:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 45
     steps:
         - uses: actions/checkout@v6
@@ -306,7 +306,7 @@ jobs:
             path: build/test-results/vitest/junit.xml
 
   client-style:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v6
@@ -336,7 +336,7 @@ jobs:
       if: success() || failure()
 
   client-compilation:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 5
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
   # This matches the production database engine and catches SQL dialect issues that
   # in-memory databases like H2 would miss.
   server-tests:
-    runs-on: aet-large-ubuntu
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 80
 
     steps:
@@ -219,7 +219,7 @@ jobs:
         cat $AGGREGATED_REPORT_FILE > $GITHUB_STEP_SUMMARY
 
   server-style:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v6
@@ -246,7 +246,7 @@ jobs:
         reporter: java-junit
 
   client-tests:
-    runs-on: aet-large-ubuntu
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 45
     steps:
         - uses: actions/checkout@v6
@@ -306,7 +306,7 @@ jobs:
             path: build/test-results/vitest/junit.xml
 
   client-style:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v6
@@ -336,7 +336,7 @@ jobs:
       if: success() || failure()
 
   client-compilation:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 5
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -47,7 +47,7 @@ jobs:
   # Log the inputs for debugging
   log-inputs:
     name: Log Inputs
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - name: Print Inputs
         run: |
@@ -58,7 +58,7 @@ jobs:
 
   determine-build-context:
     name: Determine Build Context
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     needs: log-inputs
     outputs:
       pr_number: ${{ steps.get_pr.outputs.pr_number }}
@@ -124,9 +124,9 @@ jobs:
       ref: ${{ github.event.inputs.branch_name }}
       image-name: ls1intum/artemis
       docker-file: ./docker/artemis/Dockerfile
-      runner-amd64: arc-buildkit-ls1intum-stud-amd64
+      runner-amd64: arc-buildkit-ls1intum-theiaprod-amd64
       runner-arm64: arc-buildkit-ls1intum-parma-arm64
-      runner-merge: arc-buildkit-ls1intum-stud-amd64
+      runner-merge: arc-buildkit-ls1intum-theiaprod-amd64
       tags: ${{ needs.determine-build-context.outputs.tag }}
 
   # Check if the build has run successfully (PR)
@@ -134,7 +134,7 @@ jobs:
     name: Check Existing Build of Pull Request
     if: ${{ needs.determine-build-context.outputs.pr_number != '' }}
     needs: determine-build-context
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - name: Get latest successful build for branch
         id: check_build
@@ -154,7 +154,7 @@ jobs:
     name: Check Existing Build of main or develop branch
     if: ${{ needs.determine-build-context.outputs.is_main_or_develop == 'true' }}
     needs: determine-build-context
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
       - name: Get latest successful build for main or develop branch
         id: check_main_build
@@ -172,7 +172,7 @@ jobs:
 
   check-database-migration-approval:
     name: Check Database Migration Approval
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     needs: [determine-build-context]
     if: ${{ needs.determine-build-context.outputs.pr_number != '' }}
     steps:
@@ -206,7 +206,7 @@ jobs:
     # Use always() since one of the jobs will always skip
     if: always() && (needs.conditional-build.result == 'success' || needs.check-existing-build-for-pull-request.result == 'success' || needs.check-existing-build-for-branch.result == 'success') && (needs.check-database-migration-approval.result == 'success' || needs.check-database-migration-approval.result == 'skipped')
     name: Deploy to Test-Server
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     environment:
       name: ${{ github.event.inputs.environment_name }}
       url: ${{ vars.DEPLOYMENT_URL }}

--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -119,11 +119,14 @@ jobs:
   conditional-build:
     if: ${{ needs.determine-build-context.outputs.pr_number == '' && needs.determine-build-context.outputs.is_main_or_develop == 'false' }}
     needs: determine-build-context
-    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.1.1
+    uses: ls1intum/.github/.github/workflows/build-and-push-docker-image-self-hosted-buildkit.yml@feature/split-build-workflow-modes
     with:
       ref: ${{ github.event.inputs.branch_name }}
       image-name: ls1intum/artemis
       docker-file: ./docker/artemis/Dockerfile
+      runner-amd64: arc-buildkit-ls1intum-stud-amd64
+      runner-arm64: arc-buildkit-ls1intum-parma-arm64
+      runner-merge: arc-buildkit-ls1intum-stud-amd64
       tags: ${{ needs.determine-build-context.outputs.tag }}
 
   # Check if the build has run successfully (PR)

--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -47,7 +47,7 @@ jobs:
   # Log the inputs for debugging
   log-inputs:
     name: Log Inputs
-    runs-on: [self-hosted, artemis-test-deployment]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - name: Print Inputs
         run: |
@@ -58,7 +58,7 @@ jobs:
 
   determine-build-context:
     name: Determine Build Context
-    runs-on: [self-hosted, artemis-test-deployment]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     needs: log-inputs
     outputs:
       pr_number: ${{ steps.get_pr.outputs.pr_number }}
@@ -134,7 +134,7 @@ jobs:
     name: Check Existing Build of Pull Request
     if: ${{ needs.determine-build-context.outputs.pr_number != '' }}
     needs: determine-build-context
-    runs-on: [self-hosted, artemis-test-deployment]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - name: Get latest successful build for branch
         id: check_build
@@ -154,7 +154,7 @@ jobs:
     name: Check Existing Build of main or develop branch
     if: ${{ needs.determine-build-context.outputs.is_main_or_develop == 'true' }}
     needs: determine-build-context
-    runs-on: [self-hosted, artemis-test-deployment]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
       - name: Get latest successful build for main or develop branch
         id: check_main_build
@@ -172,7 +172,7 @@ jobs:
 
   check-database-migration-approval:
     name: Check Database Migration Approval
-    runs-on: [self-hosted, artemis-test-deployment]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     needs: [determine-build-context]
     if: ${{ needs.determine-build-context.outputs.pr_number != '' }}
     steps:
@@ -206,7 +206,7 @@ jobs:
     # Use always() since one of the jobs will always skip
     if: always() && (needs.conditional-build.result == 'success' || needs.check-existing-build-for-pull-request.result == 'success' || needs.check-existing-build-for-branch.result == 'success') && (needs.check-database-migration-approval.result == 'success' || needs.check-database-migration-approval.result == 'skipped')
     name: Deploy to Test-Server
-    runs-on: [self-hosted, artemis-test-deployment]
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     environment:
       name: ${{ github.event.inputs.environment_name }}
       url: ${{ vars.DEPLOYMENT_URL }}

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -13,7 +13,7 @@ jobs:
             github.event.pull_request.base.ref == 'develop' &&
             github.event.pull_request.head.repo != null &&
             github.event.pull_request.head.repo.fork == false
-        runs-on: arc-buildkit-ls1intum-stud-amd64
+        runs-on: arc-buildkit-ls1intum-theiaprod-amd64
         timeout-minutes: 2
         permissions:
             pull-requests: write

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -13,7 +13,7 @@ jobs:
             github.event.pull_request.base.ref == 'develop' &&
             github.event.pull_request.head.repo != null &&
             github.event.pull_request.head.repo.fork == false
-        runs-on: ubuntu-latest
+        runs-on: arc-buildkit-ls1intum-stud-amd64
         timeout-minutes: 2
         permissions:
             pull-requests: write

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   validate-pr-title:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     timeout-minutes: 1
     steps:
       - uses: Slashgear/action-check-pr-title@v5.0.1

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   validate-pr-title:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     timeout-minutes: 1
     steps:
       - uses: Slashgear/action-check-pr-title@v5.0.1

--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   check:
-    runs-on: arc-buildkit-ls1intum-stud-amd64
+    runs-on: arc-buildkit-ls1intum-theiaprod-amd64
     steps:
     - uses: actions/checkout@v6
     - name: Verify version is consistent across build.gradle, openapi.yaml and README.md

--- a/.github/workflows/version-consistency.yml
+++ b/.github/workflows/version-consistency.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: arc-buildkit-ls1intum-stud-amd64
     steps:
     - uses: actions/checkout@v6
     - name: Verify version is consistent across build.gradle, openapi.yaml and README.md


### PR DESCRIPTION
### Motivation and Context
This is a small test PR to route Artemis Docker image builds through the ARC BuildKit runners.

### Description
- Point the release Docker image workflow to `build-and-push-docker-image-self-hosted-buildkit.yml@feature/split-build-workflow-modes`.
- Point the test-server conditional Docker build to the same reusable workflow.
- Route the PR Docker image build through the self-hosted BuildKit reusable workflow on the ls1intum ARC runners.
- Run the `.war` build and docker-tag artifact job on the ls1intum AMD64 ARC runner for this test PR.
- Route every workflow job in this test branch to `arc-buildkit-ls1intum-stud-amd64` to validate broad ARC scheduling.

### Steps for Testing
1. Open this PR and let the Build workflow run.
2. Verify `Build .war artifact` runs on `arc-buildkit-ls1intum-stud-amd64`.
3. Verify `Build and Push Docker Image (PR, amd64)` calls the self-hosted BuildKit reusable workflow and builds on `arc-buildkit-ls1intum-stud-amd64`.
4. Verify the other PR workflows pick up jobs on `arc-buildkit-ls1intum-stud-amd64`.
5. Verify the `docker-tag` artifact is uploaded for downstream E2E setup.

### Checklist
- [x] This PR only changes CI workflow routing for ARC BuildKit validation.
- [ ] Revert or replace this temporary test wiring before merging production workflow changes.

### Review Progress
- [ ] Code Review 1
- [ ] Code Review 2
