### PR TITLE
docs: Add Javadoc to AbstractApi interface

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/api/AbstractApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/api/AbstractApi.java
@@ -1,4 +1,11 @@
 package de.tum.cit.aet.artemis.core.api;
 
+/**
+ * Abstract interface for API definitions in the Artemis platform.
+ * <p>
+ * This interface provides a common base for all API implementations,
+ * ensuring consistency and enabling polymorphism in API handling.
+ * </p>
+ */
 public interface AbstractApi {
 }


### PR DESCRIPTION
## Problem
The public interface `AbstractApi` lacks Javadoc documentation. This reduces the readability of the code and makes it harder for new contributors to understand the purpose and contract of this base interface, potentially hindering maintainability.

## Solution
This PR adds a concise and descriptive Javadoc comment to the `AbstractApi` interface. The documentation explains that it serves as a common base for all API definitions in the Artemis platform, promoting consistency and enabling polymorphism.

## Changes
- Added Javadoc documentation to the `AbstractApi` interface.

## Verification
- The change is purely additive documentation and does not alter any code logic, API, or behavior.
- The project should build and all existing tests should continue to pass.