### PR TITLE
`Development`: Resolve template and solution participations in Hades result callback

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseParticipationService.java
@@ -375,6 +375,36 @@ public class ProgrammingExerciseParticipationService {
      */
     public ProgrammingExerciseStudentParticipation findStudentParticipationWithLatestSubmissionResultAndFeedbacksElseThrow(long participationId) throws EntityNotFoundException {
         ProgrammingExerciseStudentParticipation participation = studentParticipationRepository.findByIdElseThrow(participationId);
+        return attachLatestSubmissionWithResult(participation, participationId);
+    }
+
+    /**
+     * Retrieves the {@link ProgrammingExerciseParticipation} (template, solution, or student) for the given ID,
+     * enriched with its latest {@link Submission} and the most recent {@link Result} with feedback (if available).
+     *
+     * <p>
+     * The lookup checks the template repository, then the solution repository, then the student repository,
+     * in that order. This is needed for CI callbacks (e.g., Hades) that send back only the participation ID
+     * without indicating the participation type.
+     * </p>
+     *
+     * @param participationId the ID of the participation to retrieve
+     * @return the participation enriched with its latest submission and corresponding result (if available)
+     * @throws EntityNotFoundException if no participation with the given ID exists in any of the three repositories
+     */
+    public ProgrammingExerciseParticipation findProgrammingExerciseParticipationWithLatestSubmissionResultAndFeedbacksElseThrow(long participationId) throws EntityNotFoundException {
+        Optional<TemplateProgrammingExerciseParticipation> template = templateParticipationRepository.findById(participationId);
+        if (template.isPresent()) {
+            return attachLatestSubmissionWithResult(template.get(), participationId);
+        }
+        Optional<SolutionProgrammingExerciseParticipation> solution = solutionParticipationRepository.findById(participationId);
+        if (solution.isPresent()) {
+            return attachLatestSubmissionWithResult(solution.get(), participationId);
+        }
+        return findStudentParticipationWithLatestSubmissionResultAndFeedbacksElseThrow(participationId);
+    }
+
+    private <T extends Participation & ProgrammingExerciseParticipation> T attachLatestSubmissionWithResult(T participation, long participationId) {
         Optional<Submission> latestSubmissionOptional = submissionRepository.findLatestSubmissionByParticipationId(participationId);
         if (latestSubmissionOptional.isEmpty()) {
             participation.setSubmissions(Set.of());

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseParticipationService.java
@@ -392,7 +392,8 @@ public class ProgrammingExerciseParticipationService {
      * @return the participation enriched with its latest submission and corresponding result (if available)
      * @throws EntityNotFoundException if no participation with the given ID exists in any of the three repositories
      */
-    public ProgrammingExerciseParticipation findProgrammingExerciseParticipationWithLatestSubmissionResultAndFeedbacksElseThrow(long participationId) throws EntityNotFoundException {
+    public ProgrammingExerciseParticipation findProgrammingExerciseParticipationWithLatestSubmissionResultAndFeedbacksElseThrow(long participationId)
+            throws EntityNotFoundException {
         Optional<TemplateProgrammingExerciseParticipation> template = templateParticipationRepository.findById(participationId);
         if (template.isPresent()) {
             return attachLatestSubmissionWithResult(template.get(), participationId);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/open/PublicProgrammingExerciseResultResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/open/PublicProgrammingExerciseResultResource.java
@@ -92,7 +92,7 @@ public class PublicProgrammingExerciseResultResource {
 
         if (participationId != null) {
             try {
-                participation = programmingExerciseParticipationService.findStudentParticipationWithLatestSubmissionResultAndFeedbacksElseThrow(participationId);
+                participation = programmingExerciseParticipationService.findProgrammingExerciseParticipationWithLatestSubmissionResultAndFeedbacksElseThrow(participationId);
                 log.info("Successfully retrieved participation via ID: {}", participationId);
             }
             catch (ContinuousIntegrationException cISException) {


### PR DESCRIPTION
### Summary
Resolve template and solution participations in the public Hades result callback so that builds for the template and sample solution repositories no longer fail with a 404 from the connector.

### Checklist
#### General
- [x] This is a small issue that I tested on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
With the Hades CI integration enabled, student submissions produced results successfully, but builds for the template and sample-solution repositories failed: the Hades connector reported a `404` when it posted the build result back to Artemis.

Root cause: `POST /api/programming/public/programming-exercises/new-result/{participationId}` resolved the participation via `findStudentParticipationWithLatestSubmissionResultAndFeedbacksElseThrow`, which only queries `ProgrammingExerciseStudentParticipationRepository`. Template and solution participations live in their own repositories (`TemplateProgrammingExerciseParticipationRepository`, `SolutionProgrammingExerciseParticipationRepository`), so the student-only lookup threw `EntityNotFoundException`, which Spring mapped to the 404 observed by the connector. The Hades job payload only carries the participation ID, so the endpoint must resolve all three participation types on its own.

### Description
- Added `ProgrammingExerciseParticipationService#findProgrammingExerciseParticipationWithLatestSubmissionResultAndFeedbacksElseThrow(long)`: looks up the participation in the template repository, then the solution repository, then falls back to the existing student lookup. Returns the shared `ProgrammingExerciseParticipation` interface.
- Extracted the "attach latest submission and its latest result with feedback" logic into a private generic helper (`attachLatestSubmissionWithResult`) used by both the new method and the existing student-only method (which is still required by `LocalCIIntegrationTest` and `ProgrammingExerciseParticipationResource`).
- Switched `PublicProgrammingExerciseResultResource#processNewProgrammingExerciseResultWithParticipationID` to the new multi-type lookup.

No changes to the Hades trigger path, the build job payload, or the connector contract — the fix is purely in how the result callback resolves the participation ID.

### Steps for Testing
Prerequisites:
- 1 Instructor
- A Hades-backed Artemis instance (e.g. `artemis-test6`)
- 1 Programming Exercise (any language; Java/Maven is sufficient)

1. Log in to Artemis as the instructor.
2. Create or open a programming exercise in a course that uses Hades for CI.
3. Trigger a build of the **template** participation (e.g. push a commit to the template repository, or use the "Trigger build" action on the template participation).
4. Wait for the Hades job to complete and verify that:
   - The build result is visible on the template participation in Artemis.
   - The Hades connector logs show `200 OK` for `POST /api/programming/public/programming-exercises/new-result/{participationId}` (no more `404`).
5. Repeat step 3–4 for the **solution** participation.
6. Submit as a student and confirm that student builds continue to produce results (regression check).

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Template participation build returns a result via the Hades callback (no 404)
- [x] Solution participation build returns a result via the Hades callback (no 404)
- [x] Student submissions still produce results (regression check)

<img width="591" height="126" alt="image" src="https://github.com/user-attachments/assets/0fc474f4-ce46-4086-ab13-21b29bc7d76b" />


### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Coverage table could not be generated. The `Test` workflow concluded with status `failure`; coverage artifacts may be missing or incomplete. See [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/27072791608).

_Last updated: 2026-06-06 20:43:13 UTC_

