### PR TITLE
`Programming exercises`: Fix customize build config uses right build template for non java

### DIFF
--- a/src/main/webapp/app/programming/manage/update/update-components/custom-build-plans/programming-exercise-custom-build-plan.component.spec.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/custom-build-plans/programming-exercise-custom-build-plan.component.spec.ts
@@ -117,6 +117,46 @@ describe('ProgrammingExerciseCustomBuildPlanComponent', () => {
         expect(comp.programmingExercise().buildConfig?.timeoutSeconds).toBe(0);
     });
 
+    it('should reload template when programming language changes on the same exercise instance', () => {
+        comp.programmingLanguage = programmingExercise.programmingLanguage;
+        comp.projectType = programmingExercise.projectType;
+        comp.staticCodeAnalysisEnabled = programmingExercise.staticCodeAnalysisEnabled;
+        comp.sequentialTestRuns = programmingExercise.buildConfig?.sequentialTestRuns;
+        buildPhasesTemplateServiceMock.getTemplate.mockClear();
+
+        programmingExercise.programmingLanguage = ProgrammingLanguage.KOTLIN;
+
+        fixture.detectChanges();
+
+        expect(buildPhasesTemplateServiceMock.getTemplate).toHaveBeenCalledOnce();
+        expect(buildPhasesTemplateServiceMock.getTemplate).toHaveBeenCalledWith(
+            ProgrammingLanguage.KOTLIN,
+            programmingExercise.projectType,
+            programmingExercise.staticCodeAnalysisEnabled,
+            programmingExercise.buildConfig?.sequentialTestRuns,
+        );
+    });
+
+    it('should reload template when project type changes on the same exercise instance', () => {
+        comp.programmingLanguage = programmingExercise.programmingLanguage;
+        comp.projectType = programmingExercise.projectType;
+        comp.staticCodeAnalysisEnabled = programmingExercise.staticCodeAnalysisEnabled;
+        comp.sequentialTestRuns = programmingExercise.buildConfig?.sequentialTestRuns;
+        buildPhasesTemplateServiceMock.getTemplate.mockClear();
+
+        programmingExercise.projectType = ProjectType.PLAIN_MAVEN;
+
+        fixture.detectChanges();
+
+        expect(buildPhasesTemplateServiceMock.getTemplate).toHaveBeenCalledOnce();
+        expect(buildPhasesTemplateServiceMock.getTemplate).toHaveBeenCalledWith(
+            programmingExercise.programmingLanguage,
+            ProjectType.PLAIN_MAVEN,
+            programmingExercise.staticCodeAnalysisEnabled,
+            programmingExercise.buildConfig?.sequentialTestRuns,
+        );
+    });
+
     it('should reset custom build plan when template loading fails', () => {
         programmingExercise.buildConfig!.buildPlanConfiguration = 'x';
         programmingExercise.buildConfig!.buildScript = 'y';

--- a/src/main/webapp/app/programming/manage/update/update-components/custom-build-plans/programming-exercise-custom-build-plan.component.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/custom-build-plans/programming-exercise-custom-build-plan.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, effect, inject, input, untracked, viewChild } from '@angular/core';
+import { Component, DoCheck, OnInit, inject, input, viewChild } from '@angular/core';
 import { ProgrammingExercise, ProgrammingLanguage, ProjectType } from 'app/programming/shared/entities/programming-exercise.model';
 import { ProgrammingExerciseCreationConfig } from 'app/programming/manage/update/programming-exercise-creation-config';
 import { BuildPhasesTemplateService } from 'app/programming/shared/services/build-phases-template.service';
@@ -16,7 +16,7 @@ import { LegacyBuildPlanConverterService } from 'app/programming/shared/services
     styleUrls: ['../../../../shared/programming-exercise-form.scss'],
     imports: [FormsModule, TranslateDirective, HelpIconComponent, ProgrammingExerciseBuildConfigurationComponent, BuildPhasesEditorComponent],
 })
-export class ProgrammingExerciseCustomBuildPlanComponent implements OnInit {
+export class ProgrammingExerciseCustomBuildPlanComponent implements DoCheck, OnInit {
     private buildPhasesTemplateService = inject(BuildPhasesTemplateService);
     private legacyBuildPlanConverterService = inject(LegacyBuildPlanConverterService);
 
@@ -43,36 +43,6 @@ export class ProgrammingExerciseCustomBuildPlanComponent implements OnInit {
         ],
     } as BuildPlanPhases;
 
-    // Snapshot of the previously seen input references, used to reproduce the reference-change semantics
-    // of the former ngOnChanges (which only fired when one of the two inputs changed by reference).
-    private previousInputs: { programmingExercise?: ProgrammingExercise; programmingExerciseCreationConfig?: ProgrammingExerciseCreationConfig } = {};
-
-    constructor() {
-        // Replaces the former ngOnChanges: react when either input reference changes and, if a reload is
-        // warranted, load the matching build-phases template. isImportFromFile is only derived from the
-        // creation config when that input itself changed (matching the old changes.programmingExerciseCreationConfig
-        // ?.currentValue?.isImportFromFile ?? false logic; a programmingExercise-only change yields false).
-        effect(() => {
-            const currentProgrammingExercise = this.programmingExercise();
-            const currentCreationConfig = this.programmingExerciseCreationConfig();
-
-            const programmingExerciseChanged = currentProgrammingExercise !== this.previousInputs.programmingExercise;
-            const creationConfigChanged = currentCreationConfig !== this.previousInputs.programmingExerciseCreationConfig;
-            this.previousInputs = { programmingExercise: currentProgrammingExercise, programmingExerciseCreationConfig: currentCreationConfig };
-
-            if (!programmingExerciseChanged && !creationConfigChanged) {
-                return;
-            }
-
-            untracked(() => {
-                if (this.shouldReloadTemplate()) {
-                    const isImportFromFile = creationConfigChanged ? (currentCreationConfig?.isImportFromFile ?? false) : false;
-                    this.loadBuildPhasesTemplate(isImportFromFile);
-                }
-            });
-        });
-    }
-
     ngOnInit() {
         const buildConfig = this.programmingExercise().buildConfig;
         const configJson = buildConfig?.buildPlanConfiguration;
@@ -98,6 +68,13 @@ export class ProgrammingExerciseCustomBuildPlanComponent implements OnInit {
         }
 
         this.resetCustomBuildPlan();
+    }
+
+    ngDoCheck() {
+        // the parent form mutates the exercise object in-place
+        if (this.shouldReloadTemplate()) {
+            this.loadBuildPhasesTemplate(this.programmingExerciseCreationConfig().isImportFromFile);
+        }
     }
 
     shouldReloadTemplate(): boolean {


### PR DESCRIPTION
### Summary 
When creating a programming exercise and changing a language the build plan is not refetched, so it stays at the default java one. This PR fixes that.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
Fixes an bug introduced by the recent migrations.

### Description
The change detection was not working properly. Since the programming exercise object is mutated in place, the changes were not getting picked up by the relevant component and the refetch never happened.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Start to create a programming exercise
2. Tick "Customize build configuration"
4. Scroll down a bit until you get to the build phases.
5. Note the build phases mentally.
3. Change the language from Java to another one
4. Check "Customize build configuration" again
6. Scroll down a bit until you get to the build phases.
7. Check that the build phases changed compared to the previous one.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

- [ ] Code Review / Manual Test

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Coverage table could not be generated. The `Test` workflow concluded with status `failure`; coverage artifacts may be missing or incomplete. See [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/27073667249).

_Last updated: 2026-06-06 21:24:33 UTC_


### Screenshots
No visual changes, client bugfix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom build plans now reliably reload when the programming language or project type changes, ensuring build-phase templates stay in sync.

* **Tests**
  * Added unit tests that verify build-phase templates reload correctly on language and project-type changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->