### PR TITLE
`Development`: Instrument server test buckets with timing and CPU usage

### DIFF
--- a/documentation/docs/developer/guidelines/server-tests.mdx
+++ b/documentation/docs/developer/guidelines/server-tests.mdx
@@ -166,6 +166,14 @@ After a server test run, Artemis prints a `Test Bucket Timing Summary` for the i
 Use the `Wall time` column to find the bucket that dominates the parallel run, `Class time` to see the accumulated time spent in test classes,
 and `Gap` to estimate waiting time where no class in the bucket was active.
 The slowest-class list below the table identifies candidates for local setup optimizations or for rebalancing into a compatible bucket.
+A `Test CPU Usage Summary` follows it, showing average/peak system- and JVM-wide CPU utilization and a parallelization headroom hint.
+If many cores stay idle, the run is bound by the per-bucket `@ResourceLock` (one active class per bucket) rather than by CPU.
+
+Experimental: to bound the peak number of concurrently cached Spring contexts (server starts) on machines with fewer cores, run with
+`-Dartemis.test.wave-ordering.enabled=true -Dspring.test.context.cache.maxSize=<waveSize>`.
+This groups buckets into waves of `artemis.test.wave-size` (default: available cores) via `BucketWaveClassOrderer`, so finished
+waves' contexts can be evicted before the next wave loads. Validate per target machine — JUnit has no cross-class barrier, so a
+wave boundary can occasionally reload a context.
 
 
 ## Spring Boot Server Starts and Context Configuration

--- a/documentation/docs/developer/guidelines/server-tests.mdx
+++ b/documentation/docs/developer/guidelines/server-tests.mdx
@@ -162,6 +162,11 @@ Follow these tips to write performant tests:
 * Use the [Awaitility](https://github.com/awaitility) library for asserting async code.
 * Limit object creation in tests and the test setup.
 
+After a server test run, Artemis prints a `Test Bucket Timing Summary` for the integration-test buckets.
+Use the `Wall time` column to find the bucket that dominates the parallel run, `Class time` to see the accumulated time spent in test classes,
+and `Gap` to estimate waiting time where no class in the bucket was active.
+The slowest-class list below the table identifies candidates for local setup optimizations or for rebalancing into a compatible bucket.
+
 
 ## Spring Boot Server Starts and Context Configuration
 

--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/InternalAuthenticationIntegrationTest.java
@@ -42,8 +42,6 @@ import de.tum.cit.aet.artemis.core.security.jwt.JWTCookieService;
 import de.tum.cit.aet.artemis.core.security.jwt.TokenProvider;
 import de.tum.cit.aet.artemis.core.util.CourseFactory;
 import de.tum.cit.aet.artemis.core.util.JsonObjectMapper;
-import de.tum.cit.aet.artemis.course.domain.Course;
-import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseUtilService;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationJenkinsLocalVCTest;
 
 class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCTest {
@@ -63,9 +61,6 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
     private AuthorityRepository authorityRepository;
 
     @Autowired
-    private ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
     private ArtemisInternalAuthenticationProvider artemisInternalAuthenticationProvider;
 
     private User student;
@@ -77,8 +72,6 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
         jenkinsRequestMockProvider.enableMockingOfRequests();
 
         userUtilService.addUsers(TEST_PREFIX, 1, 0, 0, 0);
-        Course course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
-        courseUtilService.addOnlineCourseConfigurationToCourse(course);
 
         final var userAuthority = new Authority(Role.STUDENT.getAuthority());
         final var instructorAuthority = new Authority(Role.INSTRUCTOR.getAuthority());

--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/LdapAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/LdapAuthenticationIntegrationTest.java
@@ -29,12 +29,6 @@ import de.tum.cit.aet.artemis.account.test_repository.UserTestRepository;
 import de.tum.cit.aet.artemis.core.dto.StudentDTO;
 import de.tum.cit.aet.artemis.core.dto.vm.LoginVM;
 import de.tum.cit.aet.artemis.core.security.Role;
-import de.tum.cit.aet.artemis.core.util.CourseUtilService;
-import de.tum.cit.aet.artemis.course.domain.Course;
-import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
-import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
-import de.tum.cit.aet.artemis.programming.test_repository.ProgrammingExerciseTestRepository;
-import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseUtilService;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationLocalCILocalVCTest;
 
 class LdapAuthenticationIntegrationTest extends AbstractSpringIntegrationLocalCILocalVCTest {
@@ -44,19 +38,10 @@ class LdapAuthenticationIntegrationTest extends AbstractSpringIntegrationLocalCI
     private static final String INCORRECT_PASSWORD = "incorrectPassword123";
 
     @Autowired
-    protected ProgrammingExerciseTestRepository programmingExerciseRepository;
-
-    @Autowired
     protected UserTestRepository userRepository;
 
     @Autowired
     protected AuthorityRepository authorityRepository;
-
-    @Autowired
-    protected ProgrammingExerciseUtilService programmingExerciseUtilService;
-
-    @Autowired
-    protected CourseUtilService courseUtilService;
 
     @Autowired
     protected LdapAuthenticationProvider ldapAuthenticationProvider;
@@ -69,17 +54,8 @@ class LdapAuthenticationIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     private static final String NONEXISTENT_LOGIN = TEST_PREFIX + "student2";
 
-    protected ProgrammingExercise programmingExercise;
-
-    protected Course course;
-
     @BeforeEach
     void setUp() throws InvalidNameException {
-        course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise();
-        courseUtilService.addOnlineCourseConfigurationToCourse(course);
-        programmingExercise = ExerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
-        programmingExercise = programmingExerciseRepository.findWithEagerStudentParticipationsById(programmingExercise.getId()).orElseThrow();
-
         final var userAuthority = new Authority(Role.STUDENT.getAuthority());
         final var instructorAuthority = new Authority(Role.INSTRUCTOR.getAuthority());
         final var adminAuthority = new Authority(Role.ADMIN.getAuthority());

--- a/src/test/java/de/tum/cit/aet/artemis/account/service/ConductAgreementServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/service/ConductAgreementServiceTest.java
@@ -11,9 +11,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tum.cit.aet.artemis.account.util.UserUtilService;
 import de.tum.cit.aet.artemis.core.util.CourseFactory;
-import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentBatchTest;
 
-class ConductAgreementServiceTest extends AbstractSpringIntegrationIndependentTest {
+class ConductAgreementServiceTest extends AbstractSpringIntegrationIndependentBatchTest {
 
     private static final String TEST_PREFIX = "conductagreementservice";
 

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/BucketWaveClassOrderer.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/BucketWaveClassOrderer.java
@@ -1,0 +1,59 @@
+package de.tum.cit.aet.artemis.core.util.junit_extensions;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.ClassDescriptor;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.ClassOrdererContext;
+
+/**
+ * Orders integration-test classes into "waves" of buckets so that, together with a bounded
+ * {@code spring.test.context.cache.maxSize}, the Spring contexts of finished buckets can be evicted before the next
+ * wave starts. This caps the peak number of concurrently cached contexts ("server starts") to roughly the wave size,
+ * which keeps memory bounded on smaller CI machines while still running a full wave of buckets in parallel on larger
+ * machines.
+ * <p>
+ * The wave size defaults to the number of available processors, so:
+ * <ul>
+ * <li>on a machine with at least as many cores as buckets, all buckets land in a single wave (today's behaviour), and</li>
+ * <li>on a 4-core runner the buckets are processed in waves of four, so at most ~4 contexts are cached at once.</li>
+ * </ul>
+ * <p>
+ * <b>Prototype.</b> Enabled via {@code -Dartemis.test.wave-ordering.enabled=true} (pair it with
+ * {@code -Dspring.test.context.cache.maxSize=<waveSize>} to actually evict finished waves). When disabled it falls back
+ * to deterministic class-name ordering, preserving the previous behaviour. Caveat: JUnit has no cross-class barrier, so
+ * a wave boundary can still occasionally reload a context — validate on the target machines before enabling by default.
+ */
+public class BucketWaveClassOrderer implements ClassOrderer {
+
+    private static final boolean ENABLED = Boolean.getBoolean("artemis.test.wave-ordering.enabled");
+
+    private static final int WAVE_SIZE = Math.max(1, Integer.getInteger("artemis.test.wave-size", Runtime.getRuntime().availableProcessors()));
+
+    // Sorts after all real bucket names so non-bucketed classes (plain unit/architecture tests) run last.
+    private static final String NO_BUCKET = "~~no-bucket";
+
+    @Override
+    public void orderClasses(ClassOrdererContext context) {
+        List<? extends ClassDescriptor> classDescriptors = context.getClassDescriptors();
+        if (!ENABLED) {
+            classDescriptors.sort(Comparator.comparing(classDescriptor -> classDescriptor.getTestClass().getName()));
+            return;
+        }
+
+        // Assign each distinct bucket (sorted for stability) to a wave of WAVE_SIZE buckets.
+        List<String> orderedBuckets = classDescriptors.stream().map(BucketWaveClassOrderer::bucketOf).distinct().sorted().toList();
+        Map<String, Integer> waveByBucket = IntStream.range(0, orderedBuckets.size()).boxed().collect(Collectors.toMap(orderedBuckets::get, index -> index / WAVE_SIZE));
+
+        classDescriptors.sort(Comparator.comparingInt((ClassDescriptor classDescriptor) -> waveByBucket.getOrDefault(bucketOf(classDescriptor), Integer.MAX_VALUE))
+                .thenComparing(BucketWaveClassOrderer::bucketOf).thenComparing(classDescriptor -> classDescriptor.getTestClass().getName()));
+    }
+
+    private static String bucketOf(ClassDescriptor classDescriptor) {
+        return TestBucketTiming.bucketForClass(classDescriptor.getTestClass()).orElse(NO_BUCKET);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/CpuUsageMonitor.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/CpuUsageMonitor.java
@@ -44,9 +44,13 @@ final class CpuUsageMonitor {
 
     private static double maxSystemLoad;
 
+    private static int systemLoadSamples;
+
     private static double sumProcessLoad;
 
     private static double maxProcessLoad;
+
+    private static int processLoadSamples;
 
     private static double sumLoadAverage;
 
@@ -72,13 +76,17 @@ final class CpuUsageMonitor {
 
         synchronized (LOCK) {
             samples++;
+            // getCpuLoad()/getProcessCpuLoad() can return -1 (e.g. for the first call or on unsupported platforms); only valid readings
+            // may contribute to the sums, so each metric needs its own sample count for a correct average
             if (isValidLoad(systemLoad)) {
                 sumSystemLoad += systemLoad;
                 maxSystemLoad = Math.max(maxSystemLoad, systemLoad);
+                systemLoadSamples++;
             }
             if (isValidLoad(processLoad)) {
                 sumProcessLoad += processLoad;
                 maxProcessLoad = Math.max(maxProcessLoad, processLoad);
+                processLoadSamples++;
             }
             if (loadAverage >= 0) {
                 sumLoadAverage += loadAverage;
@@ -97,24 +105,25 @@ final class CpuUsageMonitor {
         }
 
         synchronized (LOCK) {
-            if (samples == 0) {
+            // without any valid system-load reading there is nothing meaningful to report (the headroom hint would be wrong)
+            if (systemLoadSamples == 0) {
                 return Optional.empty();
             }
 
-            double avgSystem = sumSystemLoad / samples;
-            double avgProcess = sumProcessLoad / samples;
+            double avgSystem = sumSystemLoad / systemLoadSamples;
             double avgIdlePercent = Math.max(0, (1.0 - avgSystem) * 100.0);
+            String avgJvm = processLoadSamples > 0 ? String.format(Locale.ROOT, "%.1f%%", sumProcessLoad / processLoadSamples * 100) : "n/a";
+            String peakJvm = processLoadSamples > 0 ? String.format(Locale.ROOT, "%.1f%%", maxProcessLoad * 100) : "n/a";
 
             StringBuilder summary = new StringBuilder();
             summary.append('\n');
             summary.append(String.format(Locale.ROOT, "=== Test CPU Usage Summary (%d cores) ===%n", CORES));
-            summary.append(String.format(Locale.ROOT, "Avg CPU used:    %.1f%% system (~%.1f of %d cores), %.1f%% this JVM%n", avgSystem * 100, avgSystem * CORES, CORES,
-                    avgProcess * 100));
-            summary.append(String.format(Locale.ROOT, "Peak CPU used:   %.1f%% system, %.1f%% this JVM%n", maxSystemLoad * 100, maxProcessLoad * 100));
+            summary.append(String.format(Locale.ROOT, "Avg CPU used:    %.1f%% system (~%.1f of %d cores), %s this JVM%n", avgSystem * 100, avgSystem * CORES, CORES, avgJvm));
+            summary.append(String.format(Locale.ROOT, "Peak CPU used:   %.1f%% system, %s this JVM%n", maxSystemLoad * 100, peakJvm));
             if (loadAverageSamples > 0) {
                 summary.append(String.format(Locale.ROOT, "Avg system load: %.2f (1m, %d cores)%n", sumLoadAverage / loadAverageSamples, CORES));
             }
-            summary.append(String.format(Locale.ROOT, "Samples:         %d (every %ds)%n", samples, SAMPLE_INTERVAL_MS / 1000));
+            summary.append(String.format(Locale.ROOT, "Samples:         %d valid of %d (every %ds)%n", systemLoadSamples, samples, SAMPLE_INTERVAL_MS / 1000));
             summary.append("Parallelization: ").append(headroomHint(avgIdlePercent)).append('\n');
 
             return Optional.of(summary.toString());

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/CpuUsageMonitor.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/CpuUsageMonitor.java
@@ -1,0 +1,145 @@
+package de.tum.cit.aet.artemis.core.util.junit_extensions;
+
+import java.lang.management.ManagementFactory;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.sun.management.OperatingSystemMXBean;
+
+/**
+ * Samples system- and JVM-wide CPU utilization while the server integration tests run and renders a summary.
+ * <p>
+ * Server integration tests run in a single JVM using JUnit's parallel execution, so the headroom reported here
+ * (how many of the available cores stayed idle on average) indicates whether increasing the test parallelism could
+ * shorten the wall time. The summary mirrors the CPU-usage section printed by the local Playwright E2E runner.
+ * <p>
+ * Sampling is started by {@link GlobalCleanupListener#testPlanExecutionStarted} and the summary is rendered (and
+ * sampling stopped) by {@link TestBucketTiming#printSummary()}.
+ */
+final class CpuUsageMonitor {
+
+    private static final long SAMPLE_INTERVAL_MS = 2_000;
+
+    private static final int CORES = Runtime.getRuntime().availableProcessors();
+
+    private static final OperatingSystemMXBean OS_BEAN = resolveOperatingSystemBean();
+
+    private static final ScheduledExecutorService SCHEDULER = Executors.newSingleThreadScheduledExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "cpu-usage-monitor");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private static final Object LOCK = new Object();
+
+    private static ScheduledFuture<?> samplingTask;
+
+    private static int samples;
+
+    private static double sumSystemLoad;
+
+    private static double maxSystemLoad;
+
+    private static double sumProcessLoad;
+
+    private static double maxProcessLoad;
+
+    private static double sumLoadAverage;
+
+    private static int loadAverageSamples;
+
+    private CpuUsageMonitor() {
+    }
+
+    /**
+     * Starts periodic CPU sampling. No-op if the JVM does not expose CPU metrics or sampling is already running.
+     */
+    static synchronized void start() {
+        if (OS_BEAN == null || samplingTask != null) {
+            return;
+        }
+        samplingTask = SCHEDULER.scheduleAtFixedRate(CpuUsageMonitor::sample, SAMPLE_INTERVAL_MS, SAMPLE_INTERVAL_MS, TimeUnit.MILLISECONDS);
+    }
+
+    private static void sample() {
+        double systemLoad = OS_BEAN.getCpuLoad();
+        double processLoad = OS_BEAN.getProcessCpuLoad();
+        double loadAverage = OS_BEAN.getSystemLoadAverage();
+
+        synchronized (LOCK) {
+            samples++;
+            if (isValidLoad(systemLoad)) {
+                sumSystemLoad += systemLoad;
+                maxSystemLoad = Math.max(maxSystemLoad, systemLoad);
+            }
+            if (isValidLoad(processLoad)) {
+                sumProcessLoad += processLoad;
+                maxProcessLoad = Math.max(maxProcessLoad, processLoad);
+            }
+            if (loadAverage >= 0) {
+                sumLoadAverage += loadAverage;
+                loadAverageSamples++;
+            }
+        }
+    }
+
+    /**
+     * Stops sampling and returns the rendered CPU usage summary, or {@link Optional#empty()} if no samples were collected.
+     */
+    static synchronized Optional<String> summaryAndStop() {
+        if (samplingTask != null) {
+            samplingTask.cancel(false);
+            samplingTask = null;
+        }
+
+        synchronized (LOCK) {
+            if (samples == 0) {
+                return Optional.empty();
+            }
+
+            double avgSystem = sumSystemLoad / samples;
+            double avgProcess = sumProcessLoad / samples;
+            double avgIdlePercent = Math.max(0, (1.0 - avgSystem) * 100.0);
+
+            StringBuilder summary = new StringBuilder();
+            summary.append('\n');
+            summary.append(String.format(Locale.ROOT, "=== Test CPU Usage Summary (%d cores) ===%n", CORES));
+            summary.append(String.format(Locale.ROOT, "Avg CPU used:    %.1f%% system (~%.1f of %d cores), %.1f%% this JVM%n", avgSystem * 100, avgSystem * CORES, CORES,
+                    avgProcess * 100));
+            summary.append(String.format(Locale.ROOT, "Peak CPU used:   %.1f%% system, %.1f%% this JVM%n", maxSystemLoad * 100, maxProcessLoad * 100));
+            if (loadAverageSamples > 0) {
+                summary.append(String.format(Locale.ROOT, "Avg system load: %.2f (1m, %d cores)%n", sumLoadAverage / loadAverageSamples, CORES));
+            }
+            summary.append(String.format(Locale.ROOT, "Samples:         %d (every %ds)%n", samples, SAMPLE_INTERVAL_MS / 1000));
+            summary.append("Parallelization: ").append(headroomHint(avgIdlePercent)).append('\n');
+
+            return Optional.of(summary.toString());
+        }
+    }
+
+    private static String headroomHint(double avgIdlePercent) {
+        if (avgIdlePercent > 40) {
+            return String.format(Locale.ROOT, "✓ Significant headroom (%.0f%% idle on average) — try more parallel test threads", avgIdlePercent);
+        }
+        if (avgIdlePercent > 20) {
+            return String.format(Locale.ROOT, "~ Moderate headroom (%.0f%% idle on average) — a few more parallel test threads may help", avgIdlePercent);
+        }
+        return String.format(Locale.ROOT, "✗ CPU mostly saturated (%.0f%% idle on average) — more parallelism is unlikely to help", avgIdlePercent);
+    }
+
+    private static boolean isValidLoad(double load) {
+        return load >= 0 && load <= 1 && Double.isFinite(load);
+    }
+
+    private static OperatingSystemMXBean resolveOperatingSystemBean() {
+        // com.sun.management.OperatingSystemMXBean exposes getCpuLoad()/getProcessCpuLoad(); fall back to null on non-HotSpot JVMs.
+        if (ManagementFactory.getOperatingSystemMXBean() instanceof OperatingSystemMXBean operatingSystemBean) {
+            return operatingSystemBean;
+        }
+        return null;
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/GlobalCleanupListener.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/GlobalCleanupListener.java
@@ -2,7 +2,9 @@ package de.tum.cit.aet.artemis.core.util.junit_extensions;
 
 import java.nio.file.Path;
 
+import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
 import org.junit.platform.launcher.TestPlan;
 
 import de.tum.cit.aet.artemis.programming.util.RepositoryExportTestUtil;
@@ -26,7 +28,28 @@ import de.tum.cit.aet.artemis.programming.util.RepositoryExportTestUtil;
 public class GlobalCleanupListener implements TestExecutionListener {
 
     @Override
+    public void testPlanExecutionStarted(TestPlan testPlan) {
+        CpuUsageMonitor.start();
+    }
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        TestBucketTiming.recordExecutionStarted(testIdentifier);
+    }
+
+    @Override
+    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+        TestBucketTiming.recordExecutionFinished(testIdentifier);
+    }
+
+    @Override
+    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+        TestBucketTiming.recordExecutionSkipped(testIdentifier);
+    }
+
+    @Override
     public void testPlanExecutionFinished(TestPlan testPlan) {
+        TestBucketTiming.printSummary();
         RepositoryExportTestUtil.safeDeleteDirectory(Path.of("local", "server-integration-test"));
         RepositoryExportTestUtil.safeDeleteDirectory(Path.of("local", "server-integration-test-independent-batch"));
     }

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/TestBucketTiming.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/TestBucketTiming.java
@@ -160,6 +160,17 @@ public final class TestBucketTiming {
         return Optional.empty();
     }
 
+    /**
+     * Resolves the bucket a test class belongs to (by its integration-test base class). Used by
+     * {@link BucketWaveClassOrderer} to group classes into bucket waves.
+     *
+     * @param testClass the test class to resolve
+     * @return the bucket name, or empty if the class does not belong to a known bucket
+     */
+    static Optional<String> bucketForClass(Class<?> testClass) {
+        return findBucketName(testClass);
+    }
+
     private static Optional<Class<?>> getJavaClass(TestIdentifier testIdentifier) {
         return testIdentifier.getSource().flatMap(TestBucketTiming::getJavaClass);
     }

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/TestBucketTiming.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/TestBucketTiming.java
@@ -1,0 +1,298 @@
+package de.tum.cit.aet.artemis.core.util.junit_extensions;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.TestTag;
+import org.junit.platform.engine.support.descriptor.ClassSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
+import org.junit.platform.launcher.TestIdentifier;
+
+import de.tum.cit.aet.artemis.core.util.junit_parallel_logging.ParallelConsoleAppender;
+import de.tum.cit.aet.artemis.shared.base.AbstractArtemisBuildAgentTest;
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentBatchTest;
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationJenkinsLocalVCBatchTest;
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationJenkinsLocalVCTemplateTest;
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationJenkinsLocalVCTest;
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationLocalCILocalVCTest;
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationLocalVCSamlTest;
+
+/**
+ * Aggregates wall-clock timing for the server integration-test buckets.
+ * <p>
+ * The summary is printed by {@link GlobalCleanupListener} after the complete JUnit test plan has finished.
+ */
+public final class TestBucketTiming {
+
+    private static final int SLOW_CLASS_COUNT = 5;
+
+    private static final List<BucketDefinition> BUCKET_DEFINITIONS = List.of(new BucketDefinition("BucketIndependent", List.of(AbstractSpringIntegrationIndependentTest.class)),
+            new BucketDefinition("BucketLocalCILocalVC", List.of(AbstractSpringIntegrationLocalCILocalVCTest.class)),
+            new BucketDefinition("BucketJenkinsLocalVC", List.of(AbstractSpringIntegrationJenkinsLocalVCTest.class)),
+            new BucketDefinition("BucketJenkinsLocalVCBatch", List.of(AbstractSpringIntegrationJenkinsLocalVCBatchTest.class)),
+            new BucketDefinition("BucketIndependentBatch", List.of(AbstractSpringIntegrationIndependentBatchTest.class)),
+            new BucketDefinition("BucketSmall", List.of(AbstractSpringIntegrationLocalVCSamlTest.class, AbstractArtemisBuildAgentTest.class)),
+            new BucketDefinition("BucketJenkinsLocalVCTemplate", List.of(AbstractSpringIntegrationJenkinsLocalVCTemplateTest.class)));
+
+    private static final Set<String> BUCKET_NAMES = BUCKET_DEFINITIONS.stream().map(BucketDefinition::name).collect(Collectors.toUnmodifiableSet());
+
+    private static final ConcurrentMap<String, BucketTiming> BUCKET_TIMINGS = new ConcurrentHashMap<>();
+
+    private static final ConcurrentMap<String, ClassStart> ACTIVE_CLASSES = new ConcurrentHashMap<>();
+
+    private static final Set<String> COUNTED_TESTS = ConcurrentHashMap.newKeySet();
+
+    private TestBucketTiming() {
+    }
+
+    static void recordExecutionStarted(TestIdentifier testIdentifier) {
+        if (!isClassContainer(testIdentifier)) {
+            return;
+        }
+
+        Optional<Class<?>> testClass = getJavaClass(testIdentifier);
+        Optional<String> bucketName = findBucketName(testIdentifier, testClass);
+        if (testClass.isEmpty() || bucketName.isEmpty()) {
+            return;
+        }
+
+        long startNanos = System.nanoTime();
+        BUCKET_TIMINGS.computeIfAbsent(bucketName.get(), ignored -> new BucketTiming()).recordClassStart(startNanos);
+        ACTIVE_CLASSES.put(testIdentifier.getUniqueId(), new ClassStart(bucketName.get(), testClass.get().getSimpleName(), startNanos));
+    }
+
+    static void recordExecutionFinished(TestIdentifier testIdentifier) {
+        if (testIdentifier.isTest()) {
+            recordTest(testIdentifier);
+            return;
+        }
+
+        ClassStart classStart = ACTIVE_CLASSES.remove(testIdentifier.getUniqueId());
+        if (classStart == null) {
+            return;
+        }
+
+        BUCKET_TIMINGS.computeIfAbsent(classStart.bucketName(), ignored -> new BucketTiming()).recordClassFinish(classStart.className(), classStart.startNanos(),
+                System.nanoTime());
+    }
+
+    static void recordExecutionSkipped(TestIdentifier testIdentifier) {
+        if (testIdentifier.isTest()) {
+            recordTest(testIdentifier);
+        }
+    }
+
+    static void printSummary() {
+        List<BucketTimingSnapshot> snapshots = BUCKET_DEFINITIONS.stream().map(definition -> new BucketTimingSnapshot(definition.name(), BUCKET_TIMINGS.get(definition.name())))
+                .filter(BucketTimingSnapshot::hasTiming).sorted(Comparator.comparingLong(BucketTimingSnapshot::wallNanos).reversed()).toList();
+
+        StringBuilder summary = new StringBuilder();
+        appendBucketSummary(summary, snapshots);
+        CpuUsageMonitor.summaryAndStop().ifPresent(summary::append);
+
+        if (!summary.isEmpty()) {
+            ParallelConsoleAppender.printToConsole(summary.toString());
+        }
+    }
+
+    private static void appendBucketSummary(StringBuilder summary, List<BucketTimingSnapshot> snapshots) {
+        if (snapshots.isEmpty()) {
+            return;
+        }
+
+        summary.append('\n');
+        summary.append("=== Test Bucket Timing Summary ===\n");
+        summary.append(String.format(Locale.ROOT, "%-34s %7s %8s %12s %12s %10s  %s%n", "Bucket", "Classes", "Tests", "Wall time", "Class time", "Gap", "Slowest class"));
+
+        for (BucketTimingSnapshot snapshot : snapshots) {
+            summary.append(String.format(Locale.ROOT, "%-34s %7d %8d %12s %12s %10s  %s%n", snapshot.bucketName(), snapshot.classes(), snapshot.tests(),
+                    formatDuration(snapshot.wallNanos()), formatDuration(snapshot.classNanos()), formatDuration(snapshot.gapNanos()), snapshot.slowestClassDescription()));
+        }
+
+        summary.append('\n');
+        summary.append("Slowest classes per bucket:\n");
+        for (BucketTimingSnapshot snapshot : snapshots) {
+            summary.append(snapshot.bucketName()).append(":\n");
+            for (ClassTiming classTiming : snapshot.slowestClasses()) {
+                summary.append(String.format(Locale.ROOT, "  %12s  %s%n", formatDuration(classTiming.durationNanos()), classTiming.className()));
+            }
+        }
+    }
+
+    private static boolean isClassContainer(TestIdentifier testIdentifier) {
+        return testIdentifier.isContainer() && testIdentifier.getSource().filter(ClassSource.class::isInstance).isPresent();
+    }
+
+    private static void recordTest(TestIdentifier testIdentifier) {
+        if (!COUNTED_TESTS.add(testIdentifier.getUniqueId())) {
+            return;
+        }
+
+        Optional<String> bucketName = findBucketName(testIdentifier, getJavaClass(testIdentifier));
+        bucketName.ifPresent(bucket -> BUCKET_TIMINGS.computeIfAbsent(bucket, ignored -> new BucketTiming()).recordTest());
+    }
+
+    private static Optional<String> findBucketName(TestIdentifier testIdentifier, Optional<Class<?>> testClass) {
+        Optional<String> bucketFromTags = testIdentifier.getTags().stream().map(TestTag::getName).filter(BUCKET_NAMES::contains).findFirst();
+        if (bucketFromTags.isPresent()) {
+            return bucketFromTags;
+        }
+
+        return testClass.flatMap(TestBucketTiming::findBucketName);
+    }
+
+    private static Optional<String> findBucketName(Class<?> testClass) {
+        for (BucketDefinition bucketDefinition : BUCKET_DEFINITIONS) {
+            if (bucketDefinition.matches(testClass)) {
+                return Optional.of(bucketDefinition.name());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Class<?>> getJavaClass(TestIdentifier testIdentifier) {
+        return testIdentifier.getSource().flatMap(TestBucketTiming::getJavaClass);
+    }
+
+    private static Optional<Class<?>> getJavaClass(TestSource testSource) {
+        if (testSource instanceof ClassSource classSource) {
+            return Optional.of(classSource.getJavaClass());
+        }
+        if (testSource instanceof MethodSource methodSource) {
+            return Optional.of(methodSource.getJavaClass());
+        }
+        return Optional.empty();
+    }
+
+    private static String formatDuration(long durationNanos) {
+        long totalMillis = TimeUnit.NANOSECONDS.toMillis(durationNanos);
+        long minutes = totalMillis / 60_000;
+        long seconds = totalMillis % 60_000 / 1_000;
+        long millis = totalMillis % 1_000;
+
+        if (minutes > 0) {
+            return String.format(Locale.ROOT, "%dm %02d.%03ds", minutes, seconds, millis);
+        }
+        return String.format(Locale.ROOT, "%d.%03ds", seconds, millis);
+    }
+
+    private record BucketDefinition(String name, List<Class<?>> bucketClasses) {
+
+        private boolean matches(Class<?> testClass) {
+            return bucketClasses.stream().anyMatch(bucketClass -> bucketClass.isAssignableFrom(testClass));
+        }
+    }
+
+    private record ClassStart(String bucketName, String className, long startNanos) {
+    }
+
+    private record ClassTiming(String className, long durationNanos) {
+    }
+
+    private static final class BucketTiming {
+
+        private long wallStartNanos = Long.MAX_VALUE;
+
+        private long wallEndNanos;
+
+        private long classNanos;
+
+        private int classes;
+
+        private int tests;
+
+        private ClassTiming slowestClass;
+
+        private final List<ClassTiming> classTimings = new ArrayList<>();
+
+        private synchronized void recordClassStart(long startNanos) {
+            wallStartNanos = Math.min(wallStartNanos, startNanos);
+        }
+
+        private synchronized void recordClassFinish(String className, long startNanos, long endNanos) {
+            long durationNanos = Math.max(0, endNanos - startNanos);
+            ClassTiming classTiming = new ClassTiming(className, durationNanos);
+
+            classes++;
+            classNanos += durationNanos;
+            wallStartNanos = Math.min(wallStartNanos, startNanos);
+            wallEndNanos = Math.max(wallEndNanos, endNanos);
+            classTimings.add(classTiming);
+
+            if (slowestClass == null || durationNanos > slowestClass.durationNanos()) {
+                slowestClass = classTiming;
+            }
+        }
+
+        private synchronized void recordTest() {
+            tests++;
+        }
+
+        private synchronized BucketTimingValues snapshot() {
+            List<ClassTiming> slowestClasses = classTimings.stream().sorted(Comparator.comparingLong(ClassTiming::durationNanos).reversed()).limit(SLOW_CLASS_COUNT).toList();
+            return new BucketTimingValues(classes, tests, wallNanos(), classNanos, slowestClass, slowestClasses);
+        }
+
+        private long wallNanos() {
+            if (wallStartNanos == Long.MAX_VALUE || wallEndNanos == 0) {
+                return 0;
+            }
+            return Math.max(0, wallEndNanos - wallStartNanos);
+        }
+    }
+
+    private record BucketTimingValues(int classes, int tests, long wallNanos, long classNanos, ClassTiming slowestClass, List<ClassTiming> slowestClasses) {
+    }
+
+    private record BucketTimingSnapshot(String bucketName, BucketTimingValues values) {
+
+        private BucketTimingSnapshot(String bucketName, BucketTiming bucketTiming) {
+            this(bucketName, bucketTiming == null ? null : bucketTiming.snapshot());
+        }
+
+        private boolean hasTiming() {
+            return values != null && (values.classes() > 0 || values.tests() > 0);
+        }
+
+        private int classes() {
+            return values.classes();
+        }
+
+        private int tests() {
+            return values.tests();
+        }
+
+        private long wallNanos() {
+            return values.wallNanos();
+        }
+
+        private long classNanos() {
+            return values.classNanos();
+        }
+
+        private long gapNanos() {
+            return Math.max(0, wallNanos() - classNanos());
+        }
+
+        private String slowestClassDescription() {
+            if (values.slowestClass() == null) {
+                return "-";
+            }
+            return values.slowestClass().className() + " (" + formatDuration(values.slowestClass().durationNanos()) + ")";
+        }
+
+        private List<ClassTiming> slowestClasses() {
+            return values.slowestClasses();
+        }
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_parallel_logging/ParallelConsoleAppender.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_parallel_logging/ParallelConsoleAppender.java
@@ -80,6 +80,16 @@ public class ParallelConsoleAppender extends AppenderBase<ILoggingEvent> {
     }
 
     /**
+     * Prints test infrastructure output directly to the console after all test logs have been flushed.
+     *
+     * @param output the output to print
+     */
+    public static synchronized void printToConsole(String output) {
+        System.out.print(output);
+        System.out.flush();
+    }
+
+    /**
      * Adds the given string to the logs for the current test group.
      *
      * @param string the string to add to the logs

--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExamRoomDistributionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExamRoomDistributionIntegrationTest.java
@@ -36,9 +36,9 @@ import de.tum.cit.aet.artemis.exam.test_repository.ExamRoomTestRepository;
 import de.tum.cit.aet.artemis.exam.test_repository.ExamTestRepository;
 import de.tum.cit.aet.artemis.exam.util.ExamRoomZipFiles;
 import de.tum.cit.aet.artemis.exam.util.ExamUtilService;
-import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentBatchTest;
 
-class ExamRoomDistributionIntegrationTest extends AbstractSpringIntegrationIndependentTest {
+class ExamRoomDistributionIntegrationTest extends AbstractSpringIntegrationIndependentBatchTest {
 
     private static final String TEST_PREFIX = "roomdistributionintegration";
 

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,8 +1,10 @@
 # Enables junit5 parallel test execution. Tests are run on one JVM instance.
 junit.jupiter.execution.parallel.enabled = true
 
-# Enables ordering test-classes with JUnit5 by class name.
-junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$ClassName
+# Orders test classes by class name (default), or, when -Dartemis.test.wave-ordering.enabled=true is set, into bucket
+# waves so finished buckets' Spring contexts can be evicted (pair with -Dspring.test.context.cache.maxSize=<waveSize>)
+# to bound the peak number of cached server contexts on smaller machines. Falls back to class-name ordering when disabled.
+junit.jupiter.testclass.order.default = de.tum.cit.aet.artemis.core.util.junit_extensions.BucketWaveClassOrderer
 
 # Enables JUnit5 automatic detection of extensions.
 junit.jupiter.extensions.autodetection.enabled = true


### PR DESCRIPTION
### Summary

Adds visibility into the server integration-test run and a couple of low-risk optimizations on top of it. After a run, the suite now prints a **Test Bucket Timing Summary** (per-bucket wall/class/gap time + slowest classes) and a **Test CPU Usage Summary** (system/JVM CPU utilization + parallelization headroom), so we can see which buckets dominate and how much parallel headroom exists. It also rebalances two classes off the heaviest bucket and adds an opt-in prototype for bounding cached Spring contexts on smaller machines.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

The server integration tests take ~10–11 min and we had no per-bucket breakdown of where the time goes or whether the run is CPU- or parallelism-bound. This change instruments the run so further optimizations can be measured, and it lands a few safe improvements found with that instrumentation. It is purely test-infrastructure — no production code changes.

### Description

- **`TestBucketTiming`** aggregates per-bucket wall time, accumulated class time, the gap between them, and the slowest classes; printed once by `GlobalCleanupListener` after the JUnit test plan finishes.
- **`CpuUsageMonitor`** samples system- and JVM-wide CPU load during the run and prints an average/peak summary plus a parallelization headroom hint (it revealed the run is parallelism-bound — the per-bucket `@ResourceLock` caps concurrency to ~the number of buckets, leaving cores idle).
- **Rebalance**: `ConductAgreementServiceTest` and `ExamRoomDistributionIntegrationTest` (both Weaviate-free) move from `BucketIndependent` to `BucketIndependentBatch` to shorten the heaviest bucket; trimmed unused programming-exercise setup from the LDAP/internal-auth integration tests.
- **`BucketWaveClassOrderer`** (opt-in prototype, disabled by default): with `-Dartemis.test.wave-ordering.enabled=true -Dspring.test.context.cache.maxSize=<waveSize>` it groups buckets into waves so finished waves' contexts can be evicted, bounding peak server starts to ~cores on smaller machines. When disabled it falls back to class-name ordering, so default behavior is unchanged.

### Steps for Testing

1. Run the server integration tests and confirm the `Test Bucket Timing Summary` and `Test CPU Usage Summary` are printed at the end:
   ```bash
   ./gradlew test -x webapp
   ```
2. Confirm the two rebalanced classes pass in their new bucket:
   ```bash
   ./gradlew test -x webapp --tests 'ConductAgreementServiceTest' --tests 'ExamRoomDistributionIntegrationTest'
   ```

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-06-08 13:32:33 UTC_


### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on interpreting test performance metrics, identifying slow tests, analyzing CPU utilization, and configuring test concurrency limits.

* **Tests**
  * Added runtime performance and CPU monitoring with summarized reporting and parallelization hints.
  * Introduced wave-based test ordering to reduce resource contention and improve test scheduling.
  * Streamlined and simplified integration-test setups and improved console logging for parallel test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->