### PR TITLE
`Adaptive learning`: Strip flavor text from exercise content via LLM

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/atlas/dto/FlavorStripEdits.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/dto/FlavorStripEdits.java
@@ -1,0 +1,32 @@
+package de.tum.cit.aet.artemis.atlas.dto;
+
+import java.util.List;
+
+/**
+ * Edits returned by the flavor-stripping LLM. Each {@link Edit} is a literal
+ * SEARCH/REPLACE pair applied to the raw input on the server: the first occurrence
+ * of {@code search} is replaced with {@code replace}. Edits are applied in order.
+ *
+ * @param edits the ordered list of edits; an empty list means the input contained
+ *                  no narrative scaffolding to remove
+ */
+public record FlavorStripEdits(List<Edit> edits) {
+
+    /**
+     * A single SEARCH/REPLACE edit.
+     * <p>
+     * The {@code reasoning} field is declared first so the reasoning model commits to a written
+     * justification before it commits to a SEARCH span. Putting the answer field before
+     * reasoning fields causes chain-of-thought models to lock in an answer before finishing
+     * their analysis, so field order matters.
+     *
+     * @param reasoning short natural-language justification for why this edit is pure narrative
+     *                      scaffolding rather than pedagogical content — one sentence, e.g.
+     *                      "This is backstory about Alice; the next sentence (kept) is the spec."
+     * @param search    the exact verbatim substring of the raw input to locate
+     * @param replace   the replacement text; empty string for a clean deletion, otherwise
+     *                      a minimal grammatical joiner (e.g. capitalization fix)
+     */
+    public record Edit(String reasoning, String search, String replace) {
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/dto/FlavorStripEditsDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/dto/FlavorStripEditsDTO.java
@@ -2,15 +2,18 @@ package de.tum.cit.aet.artemis.atlas.dto;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
- * Edits returned by the flavor-stripping LLM. Each {@link Edit} is a literal
+ * Edits returned by the flavor-stripping LLM. Each {@link EditDTO} is a literal
  * SEARCH/REPLACE pair applied to the raw input on the server: the first occurrence
  * of {@code search} is replaced with {@code replace}. Edits are applied in order.
  *
  * @param edits the ordered list of edits; an empty list means the input contained
  *                  no narrative scaffolding to remove
  */
-public record FlavorStripEdits(List<Edit> edits) {
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record FlavorStripEditsDTO(List<EditDTO> edits) {
 
     /**
      * A single SEARCH/REPLACE edit.
@@ -27,6 +30,7 @@ public record FlavorStripEdits(List<Edit> edits) {
      * @param replace   the replacement text; empty string for a clean deletion, otherwise
      *                      a minimal grammatical joiner (e.g. capitalization fix)
      */
-    public record Edit(String reasoning, String search, String replace) {
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public record EditDTO(String reasoning, String search, String replace) {
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/dto/FlavorStripEditsDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/dto/FlavorStripEditsDTO.java
@@ -2,18 +2,23 @@ package de.tum.cit.aet.artemis.atlas.dto;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
  * Edits returned by the flavor-stripping LLM. Each {@link EditDTO} is a literal
  * SEARCH/REPLACE pair applied to the raw input on the server: the first occurrence
  * of {@code search} is replaced with {@code replace}. Edits are applied in order.
+ * <p>
+ * All components are populated from external LLM output and are therefore null-permissive;
+ * the consuming service tolerates {@code null} (treated as "no edits" / a skipped edit).
  *
- * @param edits the ordered list of edits; an empty list means the input contained
- *                  no narrative scaffolding to remove
+ * @param edits the ordered list of edits; {@code null} or an empty list means the input
+ *                  contained no narrative scaffolding to remove
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record FlavorStripEditsDTO(List<EditDTO> edits) {
+public record FlavorStripEditsDTO(@Nullable List<EditDTO> edits) {
 
     /**
      * A single SEARCH/REPLACE edit.
@@ -26,11 +31,12 @@ public record FlavorStripEditsDTO(List<EditDTO> edits) {
      * @param reasoning short natural-language justification for why this edit is pure narrative
      *                      scaffolding rather than pedagogical content — one sentence, e.g.
      *                      "This is backstory about Alice; the next sentence (kept) is the spec."
-     * @param search    the exact verbatim substring of the raw input to locate
-     * @param replace   the replacement text; empty string for a clean deletion, otherwise
-     *                      a minimal grammatical joiner (e.g. capitalization fix)
+     * @param search    the exact verbatim substring of the raw input to locate; a {@code null} or
+     *                      empty span causes the edit to be skipped
+     * @param replace   the replacement text; {@code null} or empty string for a clean deletion,
+     *                      otherwise a minimal grammatical joiner (e.g. capitalization fix)
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    public record EditDTO(String reasoning, String search, String replace) {
+    public record EditDTO(@Nullable String reasoning, @Nullable String search, @Nullable String replace) {
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionService.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,11 +126,7 @@ public class ContentExtractionService {
             // Spring AI's .entity(Class) automatically appends JSON schema / format instructions to
             // the user message; no need to inject them via the prompt template.
             String systemPrompt = templateService.render(FLAVOR_STRIP_PROMPT_PATH, Map.of());
-            AzureOpenAiChatOptions.Builder optionsBuilder = AzureOpenAiChatOptions.builder().deploymentName(flavorStripModel).temperature(flavorStripTemperature);
-            if (flavorStripReasoningEffort != null && !flavorStripReasoningEffort.isBlank()) {
-                optionsBuilder.reasoningEffort(flavorStripReasoningEffort);
-            }
-            AzureOpenAiChatOptions options = optionsBuilder.build();
+            AzureOpenAiChatOptions options = buildChatOptions(flavorStripModel, flavorStripReasoningEffort, flavorStripTemperature);
             FlavorStripEditsDTO parsedEdits = chatClient.prompt().system(systemPrompt).user(rawText).options(options).call().entity(FlavorStripEditsDTO.class);
             if (parsedEdits == null || parsedEdits.edits() == null || parsedEdits.edits().isEmpty()) {
                 return rawText;
@@ -145,10 +143,32 @@ public class ContentExtractionService {
     }
 
     /**
-     * Apply the given SEARCH/REPLACE edits to {@code rawText} in order. For each edit, the
-     * first literal occurrence of {@code edit.search()} is replaced with {@code edit.replace()}.
-     * Edits whose {@code search} cannot be found in the working text are skipped (logged at
-     * DEBUG) so a single off-target span does not poison the whole strip.
+     * Build the Azure chat options for the flavor-strip call. GPT-5 reasoning deployments reject an
+     * explicit temperature alongside {@code reasoningEffort}, so exactly one is set: {@code reasoningEffort}
+     * when configured, otherwise {@code temperature}. Mirrors {@code CompetencyOrchestrationService.buildChatOptions}.
+     */
+    static AzureOpenAiChatOptions buildChatOptions(String model, String reasoningEffort, double temperature) {
+        AzureOpenAiChatOptions.Builder builder = AzureOpenAiChatOptions.builder().deploymentName(model);
+        if (reasoningEffort != null && !reasoningEffort.isBlank()) {
+            builder.reasoningEffort(reasoningEffort);
+        }
+        else {
+            builder.temperature(temperature);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Apply the given SEARCH/REPLACE edits to {@code rawText} in order. For each edit, the first
+     * occurrence of {@code edit.search()} is replaced with {@code edit.replace()} via
+     * {@link #findSpan(String, String)} (exact match, then a whitespace-tolerant fallback). Edits
+     * whose {@code search} cannot be located are skipped (logged at DEBUG) so a single off-target
+     * span does not poison the whole strip.
+     * <p>
+     * The prompt contract only permits {@code replace} to be empty (pure deletion) or a single
+     * grammatical joiner character. To enforce the byte-identical guarantee server-side, edits
+     * whose replacement exceeds that minimal value are skipped rather than trusted — a malformed
+     * response can therefore never rewrite technical content.
      */
     private String applyEdits(String rawText, List<EditDTO> edits) {
         String working = rawText;
@@ -156,15 +176,54 @@ public class ContentExtractionService {
             if (edit == null || edit.search() == null || edit.search().isEmpty()) {
                 continue;
             }
-            int index = working.indexOf(edit.search());
-            if (index < 0) {
+            String replacement = edit.replace() == null ? "" : edit.replace();
+            if (replacement.length() > 1) {
+                log.debug("Skipping flavor-strip edit; replacement exceeds the allowed minimal value: {}", replacement);
+                continue;
+            }
+            int[] span = findSpan(working, edit.search());
+            if (span == null) {
                 log.debug("Skipping flavor-strip edit; search span not found in working text: {}", edit.search());
                 continue;
             }
-            String replacement = edit.replace() == null ? "" : edit.replace();
-            working = working.substring(0, index) + replacement + working.substring(index + edit.search().length());
+            working = working.substring(0, span[0]) + replacement + working.substring(span[1]);
         }
         return working;
+    }
+
+    /**
+     * Locate the {@code search} span in {@code working}. First tries an exact literal match; if that
+     * fails, falls back to a whitespace-tolerant match that ignores leading/trailing whitespace and
+     * treats any internal whitespace run as equivalent, while still requiring every non-whitespace
+     * character to match exactly. This lets weaker models — whose search spans often differ from the
+     * source only in whitespace (extra indentation, single vs. double spaces) — still land their
+     * deletions, without ever matching a span whose visible content differs (e.g. a paraphrased word),
+     * so kept content stays byte-identical.
+     *
+     * @return the {@code [start, end)} offsets of the matched span, or {@code null} if not found
+     */
+    private static int[] findSpan(String working, String search) {
+        int exact = working.indexOf(search);
+        if (exact >= 0) {
+            return new int[] { exact, exact + search.length() };
+        }
+        String trimmed = search.strip();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        // Build a pattern matching each whitespace-delimited token literally, joined by \s+ for any
+        // internal whitespace run. Leading/trailing whitespace is dropped by strip(), so only the
+        // non-whitespace skeleton must match; the actual source whitespace inside the span is consumed.
+        String[] tokens = trimmed.split("\\s+");
+        StringBuilder regex = new StringBuilder();
+        for (int i = 0; i < tokens.length; i++) {
+            if (i > 0) {
+                regex.append("\\s+");
+            }
+            regex.append(Pattern.quote(tokens[i]));
+        }
+        Matcher matcher = Pattern.compile(regex.toString()).matcher(working);
+        return matcher.find() ? new int[] { matcher.start(), matcher.end() } : null;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionService.java
@@ -19,8 +19,8 @@ import org.springframework.stereotype.Service;
 import de.tum.cit.aet.artemis.atlas.config.AtlasEnabled;
 import de.tum.cit.aet.artemis.atlas.domain.LearningObject;
 import de.tum.cit.aet.artemis.atlas.dto.ExtractedContentDTO;
-import de.tum.cit.aet.artemis.atlas.dto.FlavorStripEdits;
-import de.tum.cit.aet.artemis.atlas.dto.FlavorStripEdits.Edit;
+import de.tum.cit.aet.artemis.atlas.dto.FlavorStripEditsDTO;
+import de.tum.cit.aet.artemis.atlas.dto.FlavorStripEditsDTO.EditDTO;
 import de.tum.cit.aet.artemis.exercise.domain.ExerciseType;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 
@@ -60,7 +60,7 @@ public class ContentExtractionService {
 
     public ContentExtractionService(@Nullable ChatClient chatClient, AtlasPromptTemplateService templateService,
             @Value("${artemis.atlas.flavor-strip-model:gpt-5.4-mini}") String flavorStripModel,
-            @Value("${artemis.atlas.flavor-strip-reasoning-effort:low}") String flavorStripReasoningEffort,
+            @Value("${artemis.atlas.flavor-strip-reasoning-effort:medium}") String flavorStripReasoningEffort,
             @Value("${artemis.atlas.flavor-strip-temperature:1.0}") double flavorStripTemperature) {
         this.chatClient = chatClient;
         this.templateService = templateService;
@@ -101,7 +101,7 @@ public class ContentExtractionService {
     /**
      * Remove narrative scaffolding from the given raw text via a small/fast LLM, keeping only
      * pedagogically relevant content. The LLM returns a list of SEARCH/REPLACE edits
-     * ({@link FlavorStripEdits}) which are applied locally to the raw text. This minimizes
+     * ({@link FlavorStripEditsDTO}) which are applied locally to the raw text. This minimizes
      * output tokens (only the flavor spans are emitted) and structurally guarantees that
      * kept technical content is byte-identical to the input.
      * <p>
@@ -129,12 +129,14 @@ public class ContentExtractionService {
                 optionsBuilder.reasoningEffort(flavorStripReasoningEffort);
             }
             AzureOpenAiChatOptions options = optionsBuilder.build();
-            FlavorStripEdits parsedEdits = chatClient.prompt().system(systemPrompt).user(rawText).options(options).call().entity(FlavorStripEdits.class);
+            FlavorStripEditsDTO parsedEdits = chatClient.prompt().system(systemPrompt).user(rawText).options(options).call().entity(FlavorStripEditsDTO.class);
             if (parsedEdits == null || parsedEdits.edits() == null || parsedEdits.edits().isEmpty()) {
                 return rawText;
             }
             String edited = applyEdits(rawText, parsedEdits.edits());
-            return normalizeWhitespace(edited);
+            // If no edit span actually matched, the text is unchanged: return it byte-identical rather than
+            // running whitespace normalization over content the model never targeted.
+            return edited.equals(rawText) ? rawText : normalizeWhitespace(edited);
         }
         catch (Exception e) {
             log.warn("Flavor-text stripping failed; falling back to raw text", e);
@@ -148,9 +150,9 @@ public class ContentExtractionService {
      * Edits whose {@code search} cannot be found in the working text are skipped (logged at
      * DEBUG) so a single off-target span does not poison the whole strip.
      */
-    private String applyEdits(String rawText, List<Edit> edits) {
+    private String applyEdits(String rawText, List<EditDTO> edits) {
         String working = rawText;
-        for (Edit edit : edits) {
+        for (EditDTO edit : edits) {
             if (edit == null || edit.search() == null || edit.search().isEmpty()) {
                 continue;
             }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionService.java
@@ -1,17 +1,26 @@
 package de.tum.cit.aet.artemis.atlas.service;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.azure.openai.AzureOpenAiChatOptions;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 import de.tum.cit.aet.artemis.atlas.config.AtlasEnabled;
 import de.tum.cit.aet.artemis.atlas.domain.LearningObject;
 import de.tum.cit.aet.artemis.atlas.dto.ExtractedContentDTO;
+import de.tum.cit.aet.artemis.atlas.dto.FlavorStripEdits;
+import de.tum.cit.aet.artemis.atlas.dto.FlavorStripEdits.Edit;
 import de.tum.cit.aet.artemis.exercise.domain.ExerciseType;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 
@@ -35,24 +44,144 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 @Service
 public class ContentExtractionService {
 
+    private static final Logger log = LoggerFactory.getLogger(ContentExtractionService.class);
+
+    private static final String FLAVOR_STRIP_PROMPT_PATH = "/prompts/atlas/flavor_text_strip_prompt.st";
+
+    private final ChatClient chatClient;
+
+    private final AtlasPromptTemplateService templateService;
+
+    private final String flavorStripModel;
+
+    private final String flavorStripReasoningEffort;
+
+    private final double flavorStripTemperature;
+
+    public ContentExtractionService(@Nullable ChatClient chatClient, AtlasPromptTemplateService templateService,
+            @Value("${artemis.atlas.flavor-strip-model:gpt-5.4-mini}") String flavorStripModel,
+            @Value("${artemis.atlas.flavor-strip-reasoning-effort:low}") String flavorStripReasoningEffort,
+            @Value("${artemis.atlas.flavor-strip-temperature:1.0}") double flavorStripTemperature) {
+        this.chatClient = chatClient;
+        this.templateService = templateService;
+        this.flavorStripModel = flavorStripModel;
+        this.flavorStripReasoningEffort = flavorStripReasoningEffort;
+        this.flavorStripTemperature = flavorStripTemperature;
+    }
+
     /**
-     * Extracts learning-relevant content from the given learning object.
+     * Extracts learning-relevant content from the given learning object, including
+     * LLM-based flavor text stripping for supported types.
      *
      * @param learningObject the learning object to extract content from
      * @return a DTO containing the title, learning text, and metadata
      * @throws IllegalArgumentException if the learning object type is not yet supported
      */
     public ExtractedContentDTO extractContent(LearningObject learningObject) {
+        return extractContent(learningObject, true);
+    }
+
+    /**
+     * Extracts learning-relevant content from the given learning object.
+     *
+     * @param learningObject  the learning object to extract content from
+     * @param stripFlavorText whether to apply LLM-based flavor text stripping; pass {@code false}
+     *                            in latency-sensitive paths (e.g. synchronous UI requests)
+     * @return a DTO containing the title, learning text, and metadata
+     * @throws IllegalArgumentException if the learning object type is not yet supported
+     */
+    public ExtractedContentDTO extractContent(LearningObject learningObject, boolean stripFlavorText) {
         Objects.requireNonNull(learningObject, "learningObject must not be null");
         if (learningObject instanceof ProgrammingExercise programmingExercise) {
-            return extractFromProgrammingExercise(programmingExercise);
+            return extractFromProgrammingExercise(programmingExercise, stripFlavorText);
         }
         throw new IllegalArgumentException("Unsupported learning object type: " + learningObject.getClass().getSimpleName());
     }
 
-    private ExtractedContentDTO extractFromProgrammingExercise(ProgrammingExercise exercise) {
+    /**
+     * Remove narrative scaffolding from the given raw text via a small/fast LLM, keeping only
+     * pedagogically relevant content. The LLM returns a list of SEARCH/REPLACE edits
+     * ({@link FlavorStripEdits}) which are applied locally to the raw text. This minimizes
+     * output tokens (only the flavor spans are emitted) and structurally guarantees that
+     * kept technical content is byte-identical to the input.
+     * <p>
+     * If the {@code artemis.atlas.flavor-strip-model} property is empty or no {@link ChatClient} is
+     * available, the raw text is returned unchanged (graceful degradation). Null or blank
+     * input returns an empty string. Any failure (LLM error, malformed JSON, empty edit list)
+     * also falls back to the raw text.
+     *
+     * @param rawText the raw exercise text
+     * @return the cleaned text, or the original text if stripping is disabled or fails
+     */
+    public String stripFlavorText(String rawText) {
+        if (rawText == null || rawText.isBlank()) {
+            return "";
+        }
+        if (flavorStripModel == null || flavorStripModel.isBlank() || chatClient == null) {
+            return rawText;
+        }
+        try {
+            // Spring AI's .entity(Class) automatically appends JSON schema / format instructions to
+            // the user message; no need to inject them via the prompt template.
+            String systemPrompt = templateService.render(FLAVOR_STRIP_PROMPT_PATH, Map.of());
+            AzureOpenAiChatOptions.Builder optionsBuilder = AzureOpenAiChatOptions.builder().deploymentName(flavorStripModel).temperature(flavorStripTemperature);
+            if (flavorStripReasoningEffort != null && !flavorStripReasoningEffort.isBlank()) {
+                optionsBuilder.reasoningEffort(flavorStripReasoningEffort);
+            }
+            AzureOpenAiChatOptions options = optionsBuilder.build();
+            FlavorStripEdits parsedEdits = chatClient.prompt().system(systemPrompt).user(rawText).options(options).call().entity(FlavorStripEdits.class);
+            if (parsedEdits == null || parsedEdits.edits() == null || parsedEdits.edits().isEmpty()) {
+                return rawText;
+            }
+            String edited = applyEdits(rawText, parsedEdits.edits());
+            return normalizeWhitespace(edited);
+        }
+        catch (Exception e) {
+            log.warn("Flavor-text stripping failed; falling back to raw text", e);
+            return rawText;
+        }
+    }
+
+    /**
+     * Apply the given SEARCH/REPLACE edits to {@code rawText} in order. For each edit, the
+     * first literal occurrence of {@code edit.search()} is replaced with {@code edit.replace()}.
+     * Edits whose {@code search} cannot be found in the working text are skipped (logged at
+     * DEBUG) so a single off-target span does not poison the whole strip.
+     */
+    private String applyEdits(String rawText, List<Edit> edits) {
+        String working = rawText;
+        for (Edit edit : edits) {
+            if (edit == null || edit.search() == null || edit.search().isEmpty()) {
+                continue;
+            }
+            int index = working.indexOf(edit.search());
+            if (index < 0) {
+                log.debug("Skipping flavor-strip edit; search span not found in working text: {}", edit.search());
+                continue;
+            }
+            String replacement = edit.replace() == null ? "" : edit.replace();
+            working = working.substring(0, index) + replacement + working.substring(index + edit.search().length());
+        }
+        return working;
+    }
+
+    /**
+     * Conservative whitespace cleanup after applying edits: collapse runs of three or more
+     * consecutive newlines to two, and strip trailing spaces/tabs from each line. Single
+     * spaces, tabs, and existing single-blank-line separators are preserved so that code
+     * fences, indentation, and Markdown structure remain intact.
+     */
+    private String normalizeWhitespace(String text) {
+        // Strip trailing horizontal whitespace from every line.
+        String stripped = text.replaceAll("(?m)[ \\t]+$", "");
+        // Collapse three or more consecutive newlines to exactly two.
+        return stripped.replaceAll("\n{3,}", "\n\n");
+    }
+
+    private ExtractedContentDTO extractFromProgrammingExercise(ProgrammingExercise exercise, boolean applyFlavorStrip) {
         String title = Objects.requireNonNullElse(exercise.getTitle(), "");
-        String learningText = Objects.requireNonNullElse(exercise.getProblemStatement(), "");
+        String raw = Objects.requireNonNullElse(exercise.getProblemStatement(), "");
+        String learningText = applyFlavorStrip ? stripFlavorText(raw) : raw;
 
         // LinkedHashMap preserves insertion order for deterministic JSON serialization
         Map<String, String> metadata = new LinkedHashMap<>();

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/ExerciseMappingToolsService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/ExerciseMappingToolsService.java
@@ -26,6 +26,7 @@ import de.tum.cit.aet.artemis.atlas.api.AtlasMLApi;
 import de.tum.cit.aet.artemis.atlas.config.AtlasEnabled;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CourseCompetency;
+import de.tum.cit.aet.artemis.atlas.dto.ExtractedContentDTO;
 import de.tum.cit.aet.artemis.atlas.dto.atlasAgent.ExerciseCompetencyMappingDTO;
 import de.tum.cit.aet.artemis.atlas.dto.atlasml.SuggestCompetencyRequestDTO;
 import de.tum.cit.aet.artemis.atlas.dto.atlasml.SuggestCompetencyResponseDTO;
@@ -167,11 +168,13 @@ public class ExerciseMappingToolsService {
 
     private final AtlasAgentSessionCacheService sessionCacheService;
 
+    private final ContentExtractionService contentExtractionService;
+
     private final ObjectMapper objectMapper = JsonObjectMapper.get();
 
     public ExerciseMappingToolsService(ExerciseRepository exerciseRepository, CourseCompetencyRepository courseCompetencyRepository,
             CompetencyExerciseLinkRepository competencyExerciseLinkRepository, CourseRepository courseRepository, AuthorizationCheckService authorizationCheckService,
-            UserRepository userRepository, Optional<AtlasMLApi> atlasMLApi, AtlasAgentSessionCacheService sessionCacheService) {
+            UserRepository userRepository, Optional<AtlasMLApi> atlasMLApi, AtlasAgentSessionCacheService sessionCacheService, ContentExtractionService contentExtractionService) {
         this.exerciseRepository = exerciseRepository;
         this.courseCompetencyRepository = courseCompetencyRepository;
         this.competencyExerciseLinkRepository = competencyExerciseLinkRepository;
@@ -180,6 +183,7 @@ public class ExerciseMappingToolsService {
         this.userRepository = userRepository;
         this.atlasMLApi = atlasMLApi;
         this.sessionCacheService = sessionCacheService;
+        this.contentExtractionService = contentExtractionService;
     }
 
     /**
@@ -245,9 +249,20 @@ public class ExerciseMappingToolsService {
             List<CompetencyExerciseLink> existingLinks = competencyExerciseLinkRepository.findByExerciseIdWithCompetency(exerciseId);
             Set<Long> existingCompetencyIds = existingLinks.stream().map(link -> link.getCompetency().getId()).collect(Collectors.toSet());
 
-            // Fetch AtlasML suggestions using the exercise description (same logic as the exercise edit lightbulb).
+            // Extract learning-relevant content with flavor text stripping so the suggestion query matches
+            // the cleaned text the orchestrator reasons over. Falls back to the raw problem statement for
+            // unsupported exercise types.
+            String description;
+            try {
+                ExtractedContentDTO extracted = contentExtractionService.extractContent(exercise, true);
+                description = extracted.extractedLearningText().isBlank() ? exercise.getTitle() : extracted.extractedLearningText();
+            }
+            catch (IllegalArgumentException e) {
+                description = exercise.getProblemStatement() != null && !exercise.getProblemStatement().isBlank() ? exercise.getProblemStatement() : exercise.getTitle();
+            }
+
+            // Fetch AtlasML suggestions using the (cleaned) exercise description.
             // Returns null when AtlasML is unavailable — in that case fall back to the LLM's own suggested flags.
-            String description = exercise.getProblemStatement() != null && !exercise.getProblemStatement().isBlank() ? exercise.getProblemStatement() : exercise.getTitle();
             Set<Long> suggestedIds = fetchSuggestedCompetencyIds(courseId, description);
             boolean useAtlasML = suggestedIds != null;
 

--- a/src/main/resources/config/application-artemis.yml
+++ b/src/main/resources/config/application-artemis.yml
@@ -98,6 +98,9 @@ artemis:
     # *-model values are Azure deployment aliases — replace with your own deployment names.
     chat-model: gpt-5.4-mini
     temperature: 0.8
+    flavor-strip-model: gpt-5.4-mini # Azure deployment name of a small/fast model used to strip narrative scaffolding from exercise text before downstream LLM processing. Set to an empty string to disable stripping (raw passthrough).
+    flavor-strip-reasoning-effort: medium # Reasoning effort passed via AzureOpenAiChatOptions.reasoningEffort (e.g. low|medium|high). Leave blank to omit the parameter. "medium" is the v3 default — the multi-step constraint checks (keep_verbatim list + heading rule + metacognitive gate) require multi-step reasoning that "low" effort skips.
+    flavor-strip-temperature: 1.0 # Temperature for the flavor-strip LLM call. Some models (e.g. gpt-5 family) only accept the default value of 1.
     orchestrator:
       model: gpt-5.4
       temperature: 1.0

--- a/src/main/resources/prompts/atlas/flavor_text_strip_prompt.st
+++ b/src/main/resources/prompts/atlas/flavor_text_strip_prompt.st
@@ -1,0 +1,210 @@
+<role>
+You strip narrative scaffolding from programming-exercise problem statements for a learning
+platform. The cleaned text is consumed by a downstream LLM that matches literal
+strings — method names, format strings, example outputs, placeholders — against student
+submissions. Over-deletion of any specification byte is a hard error. Under-deletion (leaving
+some narrative in place) is a soft error — fine and preferred whenever a span is ambiguous.
+</role>
+
+<task>
+Read the input. Return a list of minimal SEARCH/REPLACE edits that delete only narrative
+scaffolding. The server applies each edit as a literal substring replacement in the order you
+emit. Your response MUST be valid JSON matching the provided schema.
+</task>
+
+<keep_verbatim priority="highest">
+Never touch — never include in any SEARCH, never reword in any REPLACE:
+- Any quoted string that contains `⎵`, a `<placeholder>`, or angle-bracketed variable names
+  (e.g. `"[<x-Wert>,⎵<y-Wert>]"`, `"<Lösungsstring aus decryptInt>_<...>"`). These are graded
+  format specs — one missing character breaks grading.
+- Fenced code blocks (``` ... ```) and inline code in backticks.
+- Method signatures anywhere (`decryptInteger(int): String`, `add(Vector2D): void`, etc.).
+- Class names, attribute names, interface names, parameter names.
+- Formulas, equations, numeric examples, Testbeispiel tables, seed→value pairings.
+- Any text that follows a short section heading and describes what to implement — see
+  <heading_paragraph_rule> below. If you are not sure whether a paragraph is the spec, treat
+  it as the spec and leave it alone.
+- Pedagogical directives ("achte darauf...", "wichtig:...", "vergiss nicht..."), Hinweise
+  sections, and stated learning goals.
+- Task markup: `[task][...](...)` blocks including their test references. These are structural
+  metadata linking tasks to automated test cases — never part of a SEARCH span.
+- `<testid>...</testid>` tags — numeric test case identifiers inside task markup.
+- PlantUML blocks (`@startuml` ... `@enduml`) and any `<color:testsColor(...)>` directives.
+</keep_verbatim>
+
+<heading_paragraph_rule priority="highest">
+A **section heading** in this corpus is any line matching at least one of:
+- short (≤ 80 chars), ends without sentence-final punctuation, and is followed by a
+  non-blank line (e.g. `toString No results`, `Teil 1: Standardtypen dechiffrieren`,
+  `Hinweise`, `Testbeispiel`);
+- contains `No results` or `No matches` (Artemis' renderer for empty-search placeholders —
+  the line above the spec);
+- starts with `Implementiere die Methode` or `Implement the method`;
+- starts with a numbered list item followed by `[task]` (e.g. `1. [task][Implement Bubble Sort](testBubbleSort)`).
+
+The paragraph that follows a section heading (up to the next blank line) is the method
+specification or the section's technical payload. **Never include either the heading line
+or its following paragraph in any SEARCH span**, no matter how conversational the paragraph
+sounds. If the paragraph mixes one flavor clause with the spec, you may emit a small SEARCH
+that covers ONLY the flavor clause — but leave every surrounding technical sentence
+byte-identical.
+</heading_paragraph_rule>
+
+<remove priority="normal">
+Flavor worth removing, when it is clearly separable from every keep_verbatim item:
+- Named characters and their motivations ("Alice wants to build...", "Bob is trying to...",
+  "Die Pinguine bitten dich um Hilfe...").
+- Setting, backstory, world-building (the shop, the penguin, the ancient book, the party).
+- Storytelling connectors with no technical payload ("One day,", "Endlich kommen wir zum...",
+  "Zu guter Letzt wollen wir...", "Jetzt hat allerdings...").
+- Marketing-style chapter openings like "In dieser Aufgabe werden wir X implementieren."
+  when they appear alone as standalone lines — NOT when they are the opening of a paragraph
+  that then gives the specification.
+- Pure fluff adjectives that do not change the task ("besonders spannend", "ganz schön
+  verkatert", "cool").
+</remove>
+
+<output_contract>
+Respond with JSON in the provided schema: one `edits` array of objects; each object has
+three fields in this order: `reasoning`, `search`, `replace`.
+
+**reasoning** — one short sentence (≤ 25 words) explaining why this span is pure flavor and
+does not touch any keep_verbatim item. This field exists so you commit to a justification
+before committing to a span. If you cannot write a convincing sentence, do not emit the edit.
+If the span might be technical content, write `"no-op: uncertain, leaving in place"` and skip
+the edit (omit it from the array entirely).
+
+**search** rules:
+- Exact verbatim substring of the input (whitespace, punctuation, casing preserved).
+- Contains ONLY removable narrative from <remove>. Contains ZERO items from <keep_verbatim>.
+- Does not cross a blank line. Does not contain a section heading (see heading_paragraph_rule).
+- Is typically one sentence. If a flavor span covers two sentences, emit two edits.
+- Small is safe. Big is dangerous. Prefer 3 small edits over 1 large one.
+
+**replace** rules:
+- Default is the empty string `""` — clean deletion.
+- Allowed alternative: at most a short grammatical fix (e.g. capitalize the next word with a
+  single letter). Never a full word beyond a capital-letter fix, never a sentence, never
+  paraphrased content. If you catch yourself writing a sentence in `replace`, your `search`
+  is over-wide — shrink it or drop the edit.
+</output_contract>
+
+<metacognitive_gate>
+Before emitting each edit, check in your reasoning:
+1. Does my `search` contain `⎵`, angle-bracket `<...>`, backticks, a code fence, or a
+   parenthesized argument list with a colon return type? If any → drop this edit.
+2. Does my `search` contain `[task]`, `<testid>`, or `@startuml`? If any → drop this edit.
+3. Does my `search` cross or include a section heading line (short line, no final
+   punctuation, next line non-blank)? If yes → drop this edit.
+4. Is `replace` empty OR at most a single capitalized letter? If no → drop this edit.
+5. Could a downstream grader need any character inside `search`? If unsure → drop this edit.
+
+A no-op answer (empty `edits` list) is always acceptable. The grader prefers a little residual
+narrative over a missing specification byte.
+</metacognitive_gate>
+
+<examples>
+<example index="1" description="Flavor removal around task markup (good)">
+INPUT:
+In this exercise, we want to implement sorting algorithms and choose them based on runtime specific variables.
+
+### Part 1: Sorting
+
+First, we need to implement two sorting algorithms, in this case `MergeSort` and `BubbleSort`.
+
+**You have the following tasks:**
+
+1. [task][Implement Bubble Sort](testBubbleSort)
+Implement the method `performSort(List<Date>)` in the class `BubbleSort`. Make sure to follow the Bubble Sort algorithm exactly.
+
+EDIT:
+reasoning: "Opening sentence is meta-framing about the exercise; task markup and spec below must stay."
+search: "In this exercise, we want to implement sorting algorithms and choose them based on runtime specific variables.\n"
+replace: ""
+</example>
+
+<example index="2" description="Never delete task markup (bad → good)">
+INPUT:
+Die Pinguine bitten dich um Hilfe bei ihrem Fischmarkt-Programm.
+
+1. [task][Implement Bubble Sort](<testid>1</testid>)
+Implement the method `performSort(List<Date>)` in the class `BubbleSort`.
+
+BAD — swallows the task markup:
+reasoning: "Removing narrative and structural noise."
+search: "1. [task][Implement Bubble Sort](<testid>1</testid>)\n"
+replace: ""
+
+GOOD — only the backstory sentence is removed; task markup is untouched:
+reasoning: "Penguin backstory is pure flavor; task markup and spec paragraph stay."
+search: "Die Pinguine bitten dich um Hilfe bei ihrem Fischmarkt-Programm.\n\n"
+replace: ""
+</example>
+
+<example index="3" description="Never delete a method spec paragraph under a 'No results' heading (bad → good)">
+INPUT:
+    toString No results
+    Die Methode toString soll den Inhalt des Einkaufszettels wie folgt zurückgeben: "<amount>⎵Krustentiere".
+
+BAD — swallows the heading and spec (NEVER do this):
+reasoning: "Looks like narrative introduction."
+search: "    toString No results\n    Die Methode toString soll den Inhalt des Einkaufszettels wie folgt zurückgeben: \"<amount>⎵Krustentiere\"."
+replace: ""
+
+GOOD — emit NO edit at all for this block. The heading_paragraph_rule protects both the
+heading and the spec paragraph, which contains the graded format string `"<amount>⎵Krustentiere"`.
+</example>
+
+<example index="4" description="Never delete a spec paragraph under an 'Implementiere die Methode' heading (bad → good)">
+INPUT:
+Teil 1: Standardtypen dechiffrieren
+
+    decryptInteger(int): String No results
+    Implementiere die Methode decryptInteger(int): String. Sie erzeugt aus einem gegebenen int einen Teil des Lösungsstrings. Dazu wird der int quadriert und anschließend mit dem int-Hint der Box multipliziert.
+
+BAD — deletes the whole paragraph as "narrative":
+reasoning: "Describes what the method does in narrative form."
+search: "Implementiere die Methode decryptInteger(int): String. Sie erzeugt aus einem gegebenen int einen Teil des Lösungsstrings. Dazu wird der int quadriert und anschließend mit dem int-Hint der Box multipliziert."
+replace: ""
+
+GOOD — emit NO edit for this paragraph. `Implementiere die Methode` is a section heading in
+this corpus; the paragraph under it IS the spec. Even conversational prose ("Sie erzeugt...",
+"Dazu wird...") is the spec here.
+</example>
+
+<example index="5" description="Never paraphrase in REPLACE (bad → good)">
+INPUT:
+Zuletzt möchten wir dazu in der Lage sein, eine String-Repräsentation eines Vektors erstellen zu können. Dies wird in der Methode toString umgesetzt.
+
+BAD — rewrites the kept sentence inside REPLACE:
+reasoning: "Shortens the sentence."
+search: "Zuletzt möchten wir dazu in der Lage sein, eine String-Repräsentation eines Vektors erstellen zu können. Dies wird in der Methode toString umgesetzt."
+replace: "Die String-Repräsentation eines Vektors wird in der Methode toString umgesetzt."
+
+GOOD — delete only the leading flavor clause, leave the spec sentence verbatim:
+reasoning: "Only the opening clause is meta-framing; the second sentence names the method and stays byte-identical."
+search: "Zuletzt möchten wir dazu in der Lage sein, eine String-Repräsentation eines Vektors erstellen zu können. "
+replace: ""
+</example>
+
+<example index="6" description="Format string with ⎵ must survive verbatim (bad → good)">
+INPUT:
+Der String soll dabei wie folgt formatiert sein: "[<x-Wert>,⎵<y-Wert>]". Um zu testen ob deine Formatierung den Anforderungen entspricht kannst du die main-Methode ausführen.
+
+BAD — SEARCH span includes the graded format string:
+reasoning: "Trims redundant prose."
+search: "Der String soll dabei wie folgt formatiert sein: \"[<x-Wert>,⎵<y-Wert>]\". Um zu testen"
+replace: ""
+
+GOOD — only the trailing testing-tip flavor is removed; the quoted format string and its
+introducing sentence stay untouched:
+reasoning: "The testing tip is pure narrative; format string and its introduction stay."
+search: " Um zu testen ob deine Formatierung den Anforderungen entspricht kannst du die main-Methode ausführen."
+replace: ""
+</example>
+</examples>
+
+<closing>
+If you are uncertain whether any span is safe to remove, return an empty `edits` array. A
+no-op pass is always safer than losing pedagogical content.
+</closing>

--- a/src/main/resources/prompts/atlas/flavor_text_strip_prompt.st
+++ b/src/main/resources/prompts/atlas/flavor_text_strip_prompt.st
@@ -104,6 +104,9 @@ narrative over a missing specification byte.
 </metacognitive_gate>
 
 <examples>
+Each answer below is a complete response in the strict JSON schema from <output_contract>:
+a single object with one `edits` array. A no-op answer is `{"edits": []}`.
+
 <example index="1" description="Flavor removal around task markup (good)">
 INPUT:
 In this exercise, we want to implement sorting algorithms and choose them based on runtime specific variables.
@@ -117,90 +120,74 @@ First, we need to implement two sorting algorithms, in this case `MergeSort` and
 1. [task][Implement Bubble Sort](testBubbleSort)
 Implement the method `performSort(List<Date>)` in the class `BubbleSort`. Make sure to follow the Bubble Sort algorithm exactly.
 
-EDIT:
-reasoning: "Opening sentence is meta-framing about the exercise; task markup and spec below must stay."
-search: "In this exercise, we want to implement sorting algorithms and choose them based on runtime specific variables.\n"
-replace: ""
+OUTPUT:
+{"edits": [{"reasoning": "Opening sentence is meta-framing about the exercise; task markup and spec below must stay.", "search": "In this exercise, we want to implement sorting algorithms and choose them based on runtime specific variables.\n", "replace": ""}]}
 </example>
 
-<example index="2" description="Never delete task markup (bad → good)">
+<example index="2" description="Never delete task markup (bad -> good)">
 INPUT:
 Die Pinguine bitten dich um Hilfe bei ihrem Fischmarkt-Programm.
 
 1. [task][Implement Bubble Sort](<testid>1</testid>)
 Implement the method `performSort(List<Date>)` in the class `BubbleSort`.
 
-BAD — swallows the task markup:
-reasoning: "Removing narrative and structural noise."
-search: "1. [task][Implement Bubble Sort](<testid>1</testid>)\n"
-replace: ""
+BAD - swallows the task markup:
+{"edits": [{"reasoning": "Removing narrative and structural noise.", "search": "1. [task][Implement Bubble Sort](<testid>1</testid>)\n", "replace": ""}]}
 
-GOOD — only the backstory sentence is removed; task markup is untouched:
-reasoning: "Penguin backstory is pure flavor; task markup and spec paragraph stay."
-search: "Die Pinguine bitten dich um Hilfe bei ihrem Fischmarkt-Programm.\n\n"
-replace: ""
+GOOD - only the backstory sentence is removed; task markup is untouched:
+{"edits": [{"reasoning": "Penguin backstory is pure flavor; task markup and spec paragraph stay.", "search": "Die Pinguine bitten dich um Hilfe bei ihrem Fischmarkt-Programm.\n\n", "replace": ""}]}
 </example>
 
-<example index="3" description="Never delete a method spec paragraph under a 'No results' heading (bad → good)">
+<example index="3" description="Never delete a method spec paragraph under a 'No results' heading (bad -> good)">
 INPUT:
     toString No results
     Die Methode toString soll den Inhalt des Einkaufszettels wie folgt zurückgeben: "<amount>⎵Krustentiere".
 
-BAD — swallows the heading and spec (NEVER do this):
-reasoning: "Looks like narrative introduction."
-search: "    toString No results\n    Die Methode toString soll den Inhalt des Einkaufszettels wie folgt zurückgeben: \"<amount>⎵Krustentiere\"."
-replace: ""
+BAD - swallows the heading and spec (NEVER do this):
+{"edits": [{"reasoning": "Looks like narrative introduction.", "search": "    toString No results\n    Die Methode toString soll den Inhalt des Einkaufszettels wie folgt zurückgeben: \"<amount>⎵Krustentiere\".", "replace": ""}]}
 
-GOOD — emit NO edit at all for this block. The heading_paragraph_rule protects both the
-heading and the spec paragraph, which contains the graded format string `"<amount>⎵Krustentiere"`.
+GOOD - emit NO edit at all for this block. The heading_paragraph_rule protects both the
+heading and the spec paragraph, which contains the graded format string `"<amount>⎵Krustentiere"`:
+{"edits": []}
 </example>
 
-<example index="4" description="Never delete a spec paragraph under an 'Implementiere die Methode' heading (bad → good)">
+<example index="4" description="Never delete a spec paragraph under an 'Implementiere die Methode' heading (bad -> good)">
 INPUT:
 Teil 1: Standardtypen dechiffrieren
 
     decryptInteger(int): String No results
     Implementiere die Methode decryptInteger(int): String. Sie erzeugt aus einem gegebenen int einen Teil des Lösungsstrings. Dazu wird der int quadriert und anschließend mit dem int-Hint der Box multipliziert.
 
-BAD — deletes the whole paragraph as "narrative":
-reasoning: "Describes what the method does in narrative form."
-search: "Implementiere die Methode decryptInteger(int): String. Sie erzeugt aus einem gegebenen int einen Teil des Lösungsstrings. Dazu wird der int quadriert und anschließend mit dem int-Hint der Box multipliziert."
-replace: ""
+BAD - deletes the whole paragraph as "narrative":
+{"edits": [{"reasoning": "Describes what the method does in narrative form.", "search": "Implementiere die Methode decryptInteger(int): String. Sie erzeugt aus einem gegebenen int einen Teil des Lösungsstrings. Dazu wird der int quadriert und anschließend mit dem int-Hint der Box multipliziert.", "replace": ""}]}
 
-GOOD — emit NO edit for this paragraph. `Implementiere die Methode` is a section heading in
+GOOD - emit NO edit for this paragraph. `Implementiere die Methode` is a section heading in
 this corpus; the paragraph under it IS the spec. Even conversational prose ("Sie erzeugt...",
-"Dazu wird...") is the spec here.
+"Dazu wird...") is the spec here:
+{"edits": []}
 </example>
 
-<example index="5" description="Never paraphrase in REPLACE (bad → good)">
+<example index="5" description="Never paraphrase in REPLACE (bad -> good)">
 INPUT:
 Zuletzt möchten wir dazu in der Lage sein, eine String-Repräsentation eines Vektors erstellen zu können. Dies wird in der Methode toString umgesetzt.
 
-BAD — rewrites the kept sentence inside REPLACE:
-reasoning: "Shortens the sentence."
-search: "Zuletzt möchten wir dazu in der Lage sein, eine String-Repräsentation eines Vektors erstellen zu können. Dies wird in der Methode toString umgesetzt."
-replace: "Die String-Repräsentation eines Vektors wird in der Methode toString umgesetzt."
+BAD - rewrites the kept sentence inside replace:
+{"edits": [{"reasoning": "Shortens the sentence.", "search": "Zuletzt möchten wir dazu in der Lage sein, eine String-Repräsentation eines Vektors erstellen zu können. Dies wird in der Methode toString umgesetzt.", "replace": "Die String-Repräsentation eines Vektors wird in der Methode toString umgesetzt."}]}
 
-GOOD — delete only the leading flavor clause, leave the spec sentence verbatim:
-reasoning: "Only the opening clause is meta-framing; the second sentence names the method and stays byte-identical."
-search: "Zuletzt möchten wir dazu in der Lage sein, eine String-Repräsentation eines Vektors erstellen zu können. "
-replace: ""
+GOOD - delete only the leading flavor clause, leave the spec sentence verbatim:
+{"edits": [{"reasoning": "Only the opening clause is meta-framing; the second sentence names the method and stays byte-identical.", "search": "Zuletzt möchten wir dazu in der Lage sein, eine String-Repräsentation eines Vektors erstellen zu können. ", "replace": ""}]}
 </example>
 
-<example index="6" description="Format string with ⎵ must survive verbatim (bad → good)">
+<example index="6" description="Format string with ⎵ must survive verbatim (bad -> good)">
 INPUT:
 Der String soll dabei wie folgt formatiert sein: "[<x-Wert>,⎵<y-Wert>]". Um zu testen ob deine Formatierung den Anforderungen entspricht kannst du die main-Methode ausführen.
 
-BAD — SEARCH span includes the graded format string:
-reasoning: "Trims redundant prose."
-search: "Der String soll dabei wie folgt formatiert sein: \"[<x-Wert>,⎵<y-Wert>]\". Um zu testen"
-replace: ""
+BAD - SEARCH span includes the graded format string:
+{"edits": [{"reasoning": "Trims redundant prose.", "search": "Der String soll dabei wie folgt formatiert sein: \"[<x-Wert>,⎵<y-Wert>]\". Um zu testen", "replace": ""}]}
 
-GOOD — only the trailing testing-tip flavor is removed; the quoted format string and its
+GOOD - only the trailing testing-tip flavor is removed; the quoted format string and its
 introducing sentence stay untouched:
-reasoning: "The testing tip is pure narrative; format string and its introduction stay."
-search: " Um zu testen ob deine Formatierung den Anforderungen entspricht kannst du die main-Methode ausführen."
-replace: ""
+{"edits": [{"reasoning": "The testing tip is pure narrative; format string and its introduction stay.", "search": " Um zu testen ob deine Formatierung den Anforderungen entspricht kannst du die main-Methode ausführen.", "replace": ""}]}
 </example>
 </examples>
 

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionServiceFlavorStripTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionServiceFlavorStripTest.java
@@ -129,6 +129,61 @@ class ContentExtractionServiceFlavorStripTest {
     }
 
     @Test
+    void stripFlavorText_whitespaceTolerantMatch_deletesFlavorWhenOnlyWhitespaceDiffers() {
+        // The model's search span has a double space where the source has a single one, so exact match fails.
+        // The whitespace-tolerant fallback still removes the flavor line; leftover whitespace is normalized away.
+        String raw = "# Task\nImplement merge sort.\nAnd remember: have fun out there!";
+        stubLlm(new FlavorStripEditsDTO(List.of(new FlavorStripEditsDTO.EditDTO("flavor", "And  remember: have fun out there!", ""))));
+
+        assertThat(service.stripFlavorText(raw)).isEqualTo("# Task\nImplement merge sort.\n");
+    }
+
+    @Test
+    void stripFlavorText_nonWhitespaceMismatch_skipsEditAndKeepsContentByteIdentical() {
+        // The model paraphrased a word in its search span ("Extends" -> "Extending"). The non-whitespace skeleton
+        // no longer matches, so even whitespace-tolerant matching refuses the edit and the text is unchanged.
+        String raw = "Recall the PECS rule: Producer Extends, Consumer Super.";
+        stubLlm(new FlavorStripEditsDTO(List.of(new FlavorStripEditsDTO.EditDTO("flavor", "Producer Extending, Consumer Super.", ""))));
+
+        assertThat(service.stripFlavorText(raw)).isEqualTo(raw);
+    }
+
+    @Test
+    void stripFlavorText_overlongReplacement_skipsEditAndKeepsContent() {
+        // The prompt contract only allows an empty or single-character replacement. A response that tries to rewrite
+        // technical content with a longer replacement must be ignored so the byte-identical guarantee holds server-side.
+        stubLlm(new FlavorStripEditsDTO(List.of(new FlavorStripEditsDTO.EditDTO("malformed", "equals 5", "equals 42 and more"))));
+
+        assertThat(service.stripFlavorText("The sum of 2 and 3 equals 5.")).isEqualTo("The sum of 2 and 3 equals 5.");
+    }
+
+    @Test
+    void stripFlavorText_singleCharReplacement_isApplied() {
+        // An empty or single-character grammatical joiner replacement is within the allowed contract and applied.
+        stubLlm(new FlavorStripEditsDTO(List.of(new FlavorStripEditsDTO.EditDTO("join clauses", " flavor ", "."))));
+
+        assertThat(service.stripFlavorText("Keep this flavor and that.")).isEqualTo("Keep this.and that.");
+    }
+
+    @Test
+    void buildChatOptions_withReasoningEffort_setsReasoningEffortNotTemperature() {
+        // GPT-5 reasoning deployments reject temperature + reasoningEffort together; only reasoningEffort is set.
+        AzureOpenAiChatOptions options = ContentExtractionService.buildChatOptions("gpt-5.4-mini", "medium", 1.0);
+
+        assertThat(options.getReasoningEffort()).isEqualTo("medium");
+        assertThat(options.getTemperature()).isNull();
+        assertThat(options.getDeploymentName()).isEqualTo("gpt-5.4-mini");
+    }
+
+    @Test
+    void buildChatOptions_blankReasoningEffort_setsTemperatureNotReasoningEffort() {
+        AzureOpenAiChatOptions options = ContentExtractionService.buildChatOptions("gpt-5.4-mini", "  ", 1.0);
+
+        assertThat(options.getTemperature()).isEqualTo(1.0);
+        assertThat(options.getReasoningEffort()).isNull();
+    }
+
+    @Test
     void extractContent_withStripFlavorTextFalse_neverCallsClient() {
         ProgrammingExercise exercise = new ProgrammingExercise();
         exercise.setTitle("Sort");

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionServiceFlavorStripTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionServiceFlavorStripTest.java
@@ -21,7 +21,7 @@ import org.springframework.ai.azure.openai.AzureOpenAiChatOptions;
 import org.springframework.ai.chat.client.ChatClient;
 
 import de.tum.cit.aet.artemis.atlas.dto.ExtractedContentDTO;
-import de.tum.cit.aet.artemis.atlas.dto.FlavorStripEdits;
+import de.tum.cit.aet.artemis.atlas.dto.FlavorStripEditsDTO;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 
 /**
@@ -45,9 +45,9 @@ class ContentExtractionServiceFlavorStripTest {
         service = new ContentExtractionService(chatClient, templateService, "gpt-5.4-mini", "low", 1.0);
     }
 
-    private void stubLlm(FlavorStripEdits edits) {
+    private void stubLlm(FlavorStripEditsDTO edits) {
         when(templateService.render(anyString(), any())).thenReturn("system prompt");
-        when(chatClient.prompt().system(anyString()).user(anyString()).options(any(AzureOpenAiChatOptions.class)).call().entity(eq(FlavorStripEdits.class))).thenReturn(edits);
+        when(chatClient.prompt().system(anyString()).user(anyString()).options(any(AzureOpenAiChatOptions.class)).call().entity(eq(FlavorStripEditsDTO.class))).thenReturn(edits);
     }
 
     @Test
@@ -81,7 +81,7 @@ class ContentExtractionServiceFlavorStripTest {
 
     @Test
     void stripFlavorText_applySearchReplace_keepsNonFlavorByteIdentical() {
-        stubLlm(new FlavorStripEdits(List.of(new FlavorStripEdits.Edit("Narrative setup, not pedagogical.", "Alice dreams of socks. ", ""))));
+        stubLlm(new FlavorStripEditsDTO(List.of(new FlavorStripEditsDTO.EditDTO("Narrative setup, not pedagogical.", "Alice dreams of socks. ", ""))));
 
         String result = service.stripFlavorText("Alice dreams of socks. The sum of 2 and 3 equals 5.");
 
@@ -90,14 +90,14 @@ class ContentExtractionServiceFlavorStripTest {
 
     @Test
     void stripFlavorText_emptyEdits_returnsRaw() {
-        stubLlm(new FlavorStripEdits(List.of()));
+        stubLlm(new FlavorStripEditsDTO(List.of()));
 
         assertThat(service.stripFlavorText("Keep this.")).isEqualTo("Keep this.");
     }
 
     @Test
     void stripFlavorText_nullEditsList_returnsRaw() {
-        stubLlm(new FlavorStripEdits(null));
+        stubLlm(new FlavorStripEditsDTO(null));
 
         assertThat(service.stripFlavorText("Keep this.")).isEqualTo("Keep this.");
     }
@@ -105,7 +105,7 @@ class ContentExtractionServiceFlavorStripTest {
     @Test
     void stripFlavorText_llmThrows_returnsRaw() {
         when(templateService.render(anyString(), any())).thenReturn("system prompt");
-        when(chatClient.prompt().system(anyString()).user(anyString()).options(any(AzureOpenAiChatOptions.class)).call().entity(eq(FlavorStripEdits.class)))
+        when(chatClient.prompt().system(anyString()).user(anyString()).options(any(AzureOpenAiChatOptions.class)).call().entity(eq(FlavorStripEditsDTO.class)))
                 .thenThrow(new RuntimeException("LLM unreachable"));
 
         assertThat(service.stripFlavorText("Keep this.")).isEqualTo("Keep this.");
@@ -113,14 +113,14 @@ class ContentExtractionServiceFlavorStripTest {
 
     @Test
     void stripFlavorText_searchSpanNotFound_skipsEditAndReturnsRaw() {
-        stubLlm(new FlavorStripEdits(List.of(new FlavorStripEdits.Edit("off-target", "this does not appear", ""))));
+        stubLlm(new FlavorStripEditsDTO(List.of(new FlavorStripEditsDTO.EditDTO("off-target", "this does not appear", ""))));
 
         assertThat(service.stripFlavorText("Real content stays intact.")).isEqualTo("Real content stays intact.");
     }
 
     @Test
     void stripFlavorText_normalizesWhitespaceAfterActualEdit() {
-        stubLlm(new FlavorStripEdits(List.of(new FlavorStripEdits.Edit("remove Alice", "Alice.", ""))));
+        stubLlm(new FlavorStripEditsDTO(List.of(new FlavorStripEditsDTO.EditDTO("remove Alice", "Alice.", ""))));
 
         String result = service.stripFlavorText("Alice.  \n\n\nKeep me.");
 

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionServiceFlavorStripTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionServiceFlavorStripTest.java
@@ -1,0 +1,142 @@
+package de.tum.cit.aet.artemis.atlas.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.azure.openai.AzureOpenAiChatOptions;
+import org.springframework.ai.chat.client.ChatClient;
+
+import de.tum.cit.aet.artemis.atlas.dto.ExtractedContentDTO;
+import de.tum.cit.aet.artemis.atlas.dto.FlavorStripEdits;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
+
+/**
+ * Flavor-strip-specific coverage for {@link ContentExtractionService#stripFlavorText(String)}
+ * and the {@code extractContent(obj, applyFlavorStrip)} overload. Plain extraction happy paths
+ * live in {@link ContentExtractionServiceTest}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ContentExtractionServiceFlavorStripTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private ChatClient chatClient;
+
+    @Mock
+    private AtlasPromptTemplateService templateService;
+
+    private ContentExtractionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ContentExtractionService(chatClient, templateService, "gpt-5.4-mini", "low", 1.0);
+    }
+
+    private void stubLlm(FlavorStripEdits edits) {
+        when(templateService.render(anyString(), any())).thenReturn("system prompt");
+        when(chatClient.prompt().system(anyString()).user(anyString()).options(any(AzureOpenAiChatOptions.class)).call().entity(eq(FlavorStripEdits.class))).thenReturn(edits);
+    }
+
+    @Test
+    void stripFlavorText_nullInput_returnsEmptyAndNeverCallsClient() {
+        assertThat(service.stripFlavorText(null)).isEmpty();
+        verifyNoInteractions(chatClient);
+        verifyNoInteractions(templateService);
+    }
+
+    @Test
+    void stripFlavorText_blankInput_returnsEmptyAndNeverCallsClient() {
+        assertThat(service.stripFlavorText("   \n  ")).isEmpty();
+        verifyNoInteractions(chatClient);
+    }
+
+    @Test
+    void stripFlavorText_blankModel_returnsRawAndNeverCallsClient() {
+        ContentExtractionService blankModelService = new ContentExtractionService(chatClient, templateService, "", "low", 1.0);
+
+        assertThat(blankModelService.stripFlavorText("Keep this text.")).isEqualTo("Keep this text.");
+        verifyNoInteractions(chatClient);
+    }
+
+    @Test
+    void stripFlavorText_nullChatClient_returnsRawAndNeverCallsTemplateService() {
+        ContentExtractionService noClientService = new ContentExtractionService(null, templateService, "gpt-5.4-mini", "low", 1.0);
+
+        assertThat(noClientService.stripFlavorText("Keep this text.")).isEqualTo("Keep this text.");
+        verifyNoInteractions(templateService);
+    }
+
+    @Test
+    void stripFlavorText_applySearchReplace_keepsNonFlavorByteIdentical() {
+        stubLlm(new FlavorStripEdits(List.of(new FlavorStripEdits.Edit("Narrative setup, not pedagogical.", "Alice dreams of socks. ", ""))));
+
+        String result = service.stripFlavorText("Alice dreams of socks. The sum of 2 and 3 equals 5.");
+
+        assertThat(result).isEqualTo("The sum of 2 and 3 equals 5.");
+    }
+
+    @Test
+    void stripFlavorText_emptyEdits_returnsRaw() {
+        stubLlm(new FlavorStripEdits(List.of()));
+
+        assertThat(service.stripFlavorText("Keep this.")).isEqualTo("Keep this.");
+    }
+
+    @Test
+    void stripFlavorText_nullEditsList_returnsRaw() {
+        stubLlm(new FlavorStripEdits(null));
+
+        assertThat(service.stripFlavorText("Keep this.")).isEqualTo("Keep this.");
+    }
+
+    @Test
+    void stripFlavorText_llmThrows_returnsRaw() {
+        when(templateService.render(anyString(), any())).thenReturn("system prompt");
+        when(chatClient.prompt().system(anyString()).user(anyString()).options(any(AzureOpenAiChatOptions.class)).call().entity(eq(FlavorStripEdits.class)))
+                .thenThrow(new RuntimeException("LLM unreachable"));
+
+        assertThat(service.stripFlavorText("Keep this.")).isEqualTo("Keep this.");
+    }
+
+    @Test
+    void stripFlavorText_searchSpanNotFound_skipsEditAndReturnsRaw() {
+        stubLlm(new FlavorStripEdits(List.of(new FlavorStripEdits.Edit("off-target", "this does not appear", ""))));
+
+        assertThat(service.stripFlavorText("Real content stays intact.")).isEqualTo("Real content stays intact.");
+    }
+
+    @Test
+    void stripFlavorText_normalizesWhitespaceAfterActualEdit() {
+        stubLlm(new FlavorStripEdits(List.of(new FlavorStripEdits.Edit("remove Alice", "Alice.", ""))));
+
+        String result = service.stripFlavorText("Alice.  \n\n\nKeep me.");
+
+        // Trailing horizontal whitespace on the first line is stripped and the triple newline collapses to a double.
+        assertThat(result).isEqualTo("\n\nKeep me.");
+    }
+
+    @Test
+    void extractContent_withStripFlavorTextFalse_neverCallsClient() {
+        ProgrammingExercise exercise = new ProgrammingExercise();
+        exercise.setTitle("Sort");
+        exercise.setProblemStatement("Alice dreams of socks. The sum of 2 and 3 equals 5.");
+
+        ExtractedContentDTO result = service.extractContent(exercise, false);
+
+        assertThat(result.extractedLearningText()).isEqualTo("Alice dreams of socks. The sum of 2 and 3 equals 5.");
+        verify(chatClient, never()).prompt();
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/ContentExtractionServiceTest.java
@@ -17,7 +17,9 @@ class ContentExtractionServiceTest {
 
     @BeforeEach
     void setUp() {
-        contentExtractionService = new ContentExtractionService();
+        // Blank flavor-strip model + null ChatClient => stripFlavorText is a no-op passthrough for
+        // non-blank text, so these extraction assertions are unaffected by the LLM strip path.
+        contentExtractionService = new ContentExtractionService(null, null, "", "low", 1.0);
     }
 
     @Test
@@ -122,14 +124,15 @@ class ContentExtractionServiceTest {
     }
 
     @Test
-    void extractContent_whitespaceProblemStatement_passesThrough() {
+    void extractContent_whitespaceProblemStatement_returnsEmptyLearningText() {
         ProgrammingExercise exercise = new ProgrammingExercise();
         exercise.setTitle("Sorting");
         exercise.setProblemStatement("   ");
 
         ExtractedContentDTO result = contentExtractionService.extractContent(exercise);
 
-        assertThat(result.extractedLearningText()).isEqualTo("   ");
+        // Whitespace-only text is treated as blank by stripFlavorText and collapses to empty.
+        assertThat(result.extractedLearningText()).isEmpty();
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/ExerciseMappingToolsServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/ExerciseMappingToolsServiceTest.java
@@ -2,7 +2,8 @@ package de.tum.cit.aet.artemis.atlas.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -93,9 +94,10 @@ class ExerciseMappingToolsServiceTest {
         service = new ExerciseMappingToolsService(exerciseRepository, courseCompetencyRepository, competencyExerciseLinkRepository, courseRepository, authorizationCheckService,
                 userRepository, Optional.of(atlasMLApi), sessionCacheService, contentExtractionService);
 
-        // Content extraction is mocked: preview uses extractContent(exercise, false) for the AtlasML
-        // suggestion description (extractContent(exercise, true)). Lenient: not every test reaches the preview path.
-        lenient().when(contentExtractionService.extractContent(any(), anyBoolean())).thenReturn(new ExtractedContentDTO("Bubble Sort", "Bubble Sort", Map.of()));
+        // Content extraction is mocked: the preview path builds the AtlasML suggestion description via
+        // extractContent(exercise, true) (flavor stripping enabled). Stubbing eq(true) keeps the test honest -
+        // a regression that drops the flag would no longer match. Lenient: not every test reaches the preview path.
+        lenient().when(contentExtractionService.extractContent(any(), eq(true))).thenReturn(new ExtractedContentDTO("Bubble Sort", "Bubble Sort", Map.of()));
 
         course = new Course();
         course.setId(10L);
@@ -164,6 +166,9 @@ class ExerciseMappingToolsServiceTest {
         // competency2 (id=2) not in AtlasML response -> suggested=false
         assertThat(preview.competencies().get(1).suggested()).isFalse();
         assertThat(preview.viewOnly()).isFalse();
+
+        // The preview path must request flavor-stripped content so the AtlasML query matches the cleaned text.
+        verify(contentExtractionService, atLeastOnce()).extractContent(any(), eq(true));
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/ExerciseMappingToolsServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/ExerciseMappingToolsServiceTest.java
@@ -2,11 +2,14 @@ package de.tum.cit.aet.artemis.atlas.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +25,7 @@ import de.tum.cit.aet.artemis.account.test_repository.UserTestRepository;
 import de.tum.cit.aet.artemis.atlas.api.AtlasMLApi;
 import de.tum.cit.aet.artemis.atlas.domain.competency.Competency;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
+import de.tum.cit.aet.artemis.atlas.dto.ExtractedContentDTO;
 import de.tum.cit.aet.artemis.atlas.dto.atlasAgent.ExerciseCompetencyMappingDTO;
 import de.tum.cit.aet.artemis.atlas.dto.atlasml.AtlasMLCompetencyDTO;
 import de.tum.cit.aet.artemis.atlas.dto.atlasml.SuggestCompetencyRequestDTO;
@@ -68,6 +72,9 @@ class ExerciseMappingToolsServiceTest {
     @Mock
     private AtlasAgentSessionCacheService sessionCacheService;
 
+    @Mock
+    private ContentExtractionService contentExtractionService;
+
     private ExerciseMappingToolsService service;
 
     private ObjectMapper objectMapper;
@@ -84,7 +91,11 @@ class ExerciseMappingToolsServiceTest {
     void setUp() {
         objectMapper = JsonObjectMapper.get();
         service = new ExerciseMappingToolsService(exerciseRepository, courseCompetencyRepository, competencyExerciseLinkRepository, courseRepository, authorizationCheckService,
-                userRepository, Optional.of(atlasMLApi), sessionCacheService);
+                userRepository, Optional.of(atlasMLApi), sessionCacheService, contentExtractionService);
+
+        // Content extraction is mocked: preview uses extractContent(exercise, false) for the AtlasML
+        // suggestion description (extractContent(exercise, true)). Lenient: not every test reaches the preview path.
+        lenient().when(contentExtractionService.extractContent(any(), anyBoolean())).thenReturn(new ExtractedContentDTO("Bubble Sort", "Bubble Sort", Map.of()));
 
         course = new Course();
         course.setId(10L);
@@ -177,7 +188,7 @@ class ExerciseMappingToolsServiceTest {
     @Test
     void preview_usesLlmSuggestedFlags_whenAtlasMLApiMissing() {
         ExerciseMappingToolsService serviceWithoutAtlasML = new ExerciseMappingToolsService(exerciseRepository, courseCompetencyRepository, competencyExerciseLinkRepository,
-                courseRepository, authorizationCheckService, userRepository, Optional.empty(), sessionCacheService);
+                courseRepository, authorizationCheckService, userRepository, Optional.empty(), sessionCacheService, contentExtractionService);
 
         when(courseRepository.findById(10L)).thenReturn(Optional.of(course));
         when(exerciseRepository.findWithCompetenciesById(42L)).thenReturn(Optional.of(exercise));


### PR DESCRIPTION
### Summary
Adds an LLM-based "flavor text" stripper to the Atlas content pipeline. Before exercise/lecture text is handed to downstream Atlas LLMs (e.g. competency suggestion/mapping), narrative scaffolding — story framing, character backstory, atmospheric fluff — is removed so the models reason over signal instead of noise. The model returns literal SEARCH/REPLACE edits that are applied server-side, guaranteeing kept content stays byte-identical to the input; the path degrades gracefully to raw text on any failure or when no model is configured.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

<!-- No new/changed DB calls and no new REST endpoints are introduced, so the DB-performance and pre-authorization items are not applicable and were removed. -->

### Motivation and Context
Exercise problem statements frequently wrap the actual task in narrative flavor (e.g. *"Alice the wizard lost her spellbook in the Forest of Recursion… implement merge sort"*). That scaffolding is pure noise to the Atlas LLMs that infer which competencies an exercise teaches, degrading suggestion quality and wasting tokens. Stripping it yields cleaner, more deterministic input for competency suggestion and orchestration.

This is the first, self-contained slice of the larger Atlas content-cleaning work (no telemetry/transcript dependencies), so it can land and run independently.

<!-- Link the tracking issue here if one exists -->

### Description
- **`ContentExtractionService`**: new `stripFlavorText(String)` that renders the flavor-strip prompt, calls a small/fast Azure model, and applies the returned `FlavorStripEdits` (ordered literal SEARCH/REPLACE spans) locally via `applyEdits` + conservative `normalizeWhitespace`. A new `extractContent(learningObject, boolean stripFlavorText)` overload controls whether stripping runs; the existing single-arg overload now strips by default. Currently wired for `ProgrammingExercise` problem statements.
- **Edit-based design**: the model only emits the spans to *delete*, so retained technical content (code, placeholders, headings, method signatures) is byte-identical to the input — the model cannot paraphrase or hallucinate exercise text. Unmatched SEARCH spans are skipped, not fatal.
- **Graceful degradation**: blank/unset `artemis.atlas.flavor-strip-model`, no `ChatClient`, an LLM error, malformed JSON, or an empty edit list → raw text returned unchanged. Null/blank input → empty string.
- **`ExerciseMappingToolsService`**: the competency-suggestion path now extracts with stripping **enabled** (`extractContent(exercise, true)`) so the AtlasML query matches the cleaned text the orchestrator reasons over, with a raw problem-statement fallback for unsupported types.
- **`FlavorStripEdits`**: DTO record (reasoning/search/replace) returned by the LLM.
- **Config** under `artemis.atlas`: `flavor-strip-model`, `flavor-strip-reasoning-effort`, `flavor-strip-temperature`.

> ⚠️ Performance note for reviewers: enabling stripping on the suggest-competencies path adds one synchronous small-model LLM call to that request. It is bounded by graceful fallback and only active when a flavor-strip model is configured, but reviewers should confirm the latency is acceptable for that interaction.

### Steps for Testing
Prerequisites:
- An Atlas-enabled test server 
- 1 Instructor
- 1 Course with a Programming Exercise whose problem statement contains obvious narrative flavor (e.g. a story intro) around a concrete task

1. Log in as Instructor.
2. Open the programming exercise and trigger the Atlas competency suggestion / exercise-to-competency mapping flow.
3. Confirm the competency suggestions are relevant to the underlying technical task rather than the surrounding story, and that the suggestion flow completes without errors for an exercise whose problem statement is heavily wrapped in narrative flavor.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Manual Review 1
- [x] Manual Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Coverage table could not be generated. The `Test` workflow concluded with status `success`; coverage artifacts may be missing or incomplete. See [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/27350411049).

_Last updated: 2026-06-11 13:57:39 UTC_

