### PR TITLE
`General`: Fix practice mode becoming unavailable after the due date

### DIFF
--- a/src/main/webapp/app/course/overview/submission-result-status/submission-result-status.component.spec.ts
+++ b/src/main/webapp/app/course/overview/submission-result-status/submission-result-status.component.spec.ts
@@ -211,6 +211,42 @@ describe('SubmissionResultStatusComponent', () => {
             expect(span?.attributes['jhiTranslate']).toBe('artemisApp.courseOverview.exerciseList.userParticipatingShort');
         });
 
+        it('should show the live result for a programming practice participation without any result, so build feedback is visible', async () => {
+            // Practice always happens after the due date. The live result (queued / building) must
+            // still be shown, otherwise submitting in practice mode gives no feedback until the
+            // first build result arrives.
+            fixture.componentRef.setInput('exercise', {
+                type: ExerciseType.PROGRAMMING,
+                dueDate: dayjs().subtract(1, 'hours'),
+            } as Exercise);
+            fixture.componentRef.setInput('isPractice', true);
+            fixture.componentRef.setInput('studentParticipation', {
+                initializationState: InitializationState.INITIALIZED,
+                testRun: true,
+            } as StudentParticipation);
+            TestBed.tick();
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            expect(comp.shouldShowResult()).toBe(true);
+            expect(fixture.debugElement.query(By.css('#submission-result-graded'))).not.toBeNull();
+        });
+
+        it('should not show the live result for a graded programming participation without results after the due date', async () => {
+            fixture.componentRef.setInput('exercise', {
+                type: ExerciseType.PROGRAMMING,
+                dueDate: dayjs().subtract(1, 'hours'),
+            } as Exercise);
+            fixture.componentRef.setInput('studentParticipation', {
+                initializationState: InitializationState.INITIALIZED,
+            } as StudentParticipation);
+            TestBed.tick();
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            expect(comp.shouldShowResult()).toBe(false);
+        });
+
         it('should show the result once a practice participation with a result exists', async () => {
             fixture.componentRef.setInput('exercise', {
                 type: ExerciseType.QUIZ,

--- a/src/main/webapp/app/course/overview/submission-result-status/submission-result-status.component.ts
+++ b/src/main/webapp/app/course/overview/submission-result-status/submission-result-status.component.ts
@@ -113,8 +113,11 @@ export class SubmissionResultStatusComponent {
         if (exercise?.type === ExerciseType.QUIZ) {
             return !!getAllResultsOfAllSubmissions(studentParticipation?.submissions).length;
         } else if (exercise?.type === ExerciseType.PROGRAMMING) {
+            // A practice participation is not bound by the due date — submissions are always possible — so the
+            // live result (queued / building / result) must be shown just like before the due date. Otherwise a
+            // student submitting in practice mode would get no feedback until the first build result arrives.
             return (
-                (!!getAllResultsOfAllSubmissions(studentParticipation?.submissions).length || !this.afterDueDate()) &&
+                (!!getAllResultsOfAllSubmissions(studentParticipation?.submissions).length || !this.afterDueDate() || this.isPractice()) &&
                 !!studentParticipation?.initializationState &&
                 this.initializationStatesToShowProgrammingResult.includes(studentParticipation.initializationState)
             );

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.html
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.html
@@ -43,8 +43,8 @@
             class="ms-auto flex-shrink-0"
             [mode]="participationMode()"
             (modeChange)="participationMode.set($event)"
-            [hasPractice]="hasPracticeSubmission()"
-            [hasGraded]="hasGradedSubmission()"
+            [hasPractice]="hasPracticeParticipation()"
+            [hasGraded]="hasGradedParticipation()"
         />
     </div>
 </div>

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.html
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.html
@@ -43,8 +43,8 @@
             class="ms-auto flex-shrink-0"
             [mode]="participationMode()"
             (modeChange)="participationMode.set($event)"
-            [hasPractice]="hasPracticeParticipation()"
-            [hasGraded]="hasGradedParticipation()"
+            [hasPractice]="showPracticeMode()"
+            [hasGraded]="showGradedMode()"
         />
     </div>
 </div>

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
@@ -161,7 +161,7 @@ describe('ExerciseHeaderComponent', () => {
             expect(fixture.componentInstance.showPracticeMode()).toBe(false);
         });
 
-        it('should be true when practice participation has a submitted submission', () => {
+        it('should be true when a practice participation exists, regardless of its submissions', () => {
             const exercise = new ModelingExercise(UMLDiagramType.ClassDiagram, undefined, undefined);
             exercise.type = ExerciseType.MODELING;
             const practiceParticipation = new StudentParticipation();

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
@@ -14,6 +14,7 @@ import { ModelingExercise } from 'app/modeling/shared/entities/modeling-exercise
 import { QuizExercise } from 'app/quiz/shared/entities/quiz-exercise.model';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
+import { SubmissionType } from 'app/exercise/shared/entities/submission/submission.model';
 import { UMLDiagramType } from '@tumaet/apollon';
 import { QuizExerciseService } from 'app/quiz/manage/service/quiz-exercise.service';
 import { AlertService } from 'app/foundation/service/alert.service';
@@ -146,6 +147,24 @@ describe('ExerciseHeaderComponent', () => {
             fixture.detectChanges();
 
             expect(fixture.componentInstance.hasGradedSubmission()).toBe(true);
+        });
+
+        it('should be false for a quiz submission that was only collected automatically when the quiz ended', () => {
+            // The quiz evaluation marks unsubmitted submissions as submitted with type TIMEOUT —
+            // the student still missed the deadline and must not get a "Graded" badge.
+            const exercise = new QuizExercise(undefined, undefined);
+            exercise.type = ExerciseType.QUIZ;
+            exercise.dueDate = dayjs().subtract(1, 'hours');
+            const participation = new StudentParticipation();
+            participation.submissions = [{ submitted: true, type: SubmissionType.TIMEOUT }];
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('studentParticipation', participation);
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.hasGradedSubmission()).toBe(false);
+            expect(fixture.componentInstance.showGradedMode()).toBe(false);
         });
     });
 

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
@@ -12,6 +12,7 @@ import { ParticipationModeToggleComponent } from 'app/exercise/exercise-headers/
 import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { ModelingExercise } from 'app/modeling/shared/entities/modeling-exercise.model';
 import { QuizExercise } from 'app/quiz/shared/entities/quiz-exercise.model';
+import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { UMLDiagramType } from '@tumaet/apollon';
 import { QuizExerciseService } from 'app/quiz/manage/service/quiz-exercise.service';
@@ -148,7 +149,7 @@ describe('ExerciseHeaderComponent', () => {
         });
     });
 
-    describe('hasPracticeSubmission', () => {
+    describe('hasPracticeParticipation', () => {
         it('should be false when there is no practice participation and mode is graded', () => {
             const exercise = new ModelingExercise(UMLDiagramType.ClassDiagram, undefined, undefined);
             exercise.type = ExerciseType.MODELING;
@@ -157,7 +158,7 @@ describe('ExerciseHeaderComponent', () => {
             fixture.componentRef.setInput('courseId', 5);
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.hasPracticeSubmission()).toBe(false);
+            expect(fixture.componentInstance.hasPracticeParticipation()).toBe(false);
         });
 
         it('should be true when practice participation has a submitted submission', () => {
@@ -171,7 +172,26 @@ describe('ExerciseHeaderComponent', () => {
             fixture.componentRef.setInput('practiceParticipation', practiceParticipation);
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.hasPracticeSubmission()).toBe(true);
+            expect(fixture.componentInstance.hasPracticeParticipation()).toBe(true);
+        });
+
+        it('should be true when a practice participation without submissions exists and mode is graded', () => {
+            const exercise = new ProgrammingExercise(undefined, undefined);
+            exercise.type = ExerciseType.PROGRAMMING;
+            exercise.dueDate = dayjs().subtract(1, 'hours');
+            const gradedParticipation = new StudentParticipation();
+            gradedParticipation.submissions = [{ submitted: true }];
+            const practiceParticipation = new StudentParticipation();
+            practiceParticipation.testRun = true;
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('studentParticipation', gradedParticipation);
+            fixture.componentRef.setInput('practiceParticipation', practiceParticipation);
+            fixture.componentRef.setInput('participationMode', 'graded');
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.hasPracticeParticipation()).toBe(true);
         });
 
         it('should be true when mode is practice even without a practice participation', () => {
@@ -186,7 +206,119 @@ describe('ExerciseHeaderComponent', () => {
             fixture.componentRef.setInput('participationMode', 'practice');
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.hasPracticeSubmission()).toBe(true);
+            expect(fixture.componentInstance.hasPracticeParticipation()).toBe(true);
+        });
+    });
+
+    describe('hasGradedParticipation', () => {
+        it('should be false for a graded participation without submissions when no practice participation exists', () => {
+            const exercise = new QuizExercise(undefined, undefined);
+            exercise.type = ExerciseType.QUIZ;
+            exercise.dueDate = dayjs().subtract(1, 'hours');
+            const gradedParticipation = new StudentParticipation();
+            gradedParticipation.submissions = [{ submitted: false }];
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('studentParticipation', gradedParticipation);
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.hasGradedParticipation()).toBe(false);
+        });
+
+        it('should be true for a graded participation without submissions when a practice participation exists', () => {
+            const exercise = new ProgrammingExercise(undefined, undefined);
+            exercise.type = ExerciseType.PROGRAMMING;
+            exercise.dueDate = dayjs().subtract(1, 'hours');
+            const gradedParticipation = new StudentParticipation();
+            const practiceParticipation = new StudentParticipation();
+            practiceParticipation.testRun = true;
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('studentParticipation', gradedParticipation);
+            fixture.componentRef.setInput('practiceParticipation', practiceParticipation);
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.hasGradedParticipation()).toBe(true);
+        });
+
+        it('should be true when the graded participation has a submitted submission', () => {
+            const exercise = new QuizExercise(undefined, undefined);
+            exercise.type = ExerciseType.QUIZ;
+            exercise.dueDate = dayjs().subtract(1, 'hours');
+            const gradedParticipation = new StudentParticipation();
+            gradedParticipation.submissions = [{ submitted: true }];
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('studentParticipation', gradedParticipation);
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.hasGradedParticipation()).toBe(true);
+        });
+    });
+
+    describe('onNewParticipation', () => {
+        it('should switch to practice mode and keep the practice option for a new practice participation', () => {
+            const exercise = new ProgrammingExercise(undefined, undefined);
+            exercise.type = ExerciseType.PROGRAMMING;
+            exercise.dueDate = dayjs().subtract(1, 'hours');
+            const gradedParticipation = new StudentParticipation();
+            gradedParticipation.submissions = [{ submitted: true }];
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('studentParticipation', gradedParticipation);
+            fixture.detectChanges();
+
+            const emitSpy = vi.spyOn(fixture.componentInstance.newParticipation, 'emit');
+            const practiceParticipation = new StudentParticipation();
+            practiceParticipation.testRun = true;
+            fixture.componentInstance.onNewParticipation(practiceParticipation);
+
+            expect(emitSpy).toHaveBeenCalledWith(practiceParticipation);
+            expect(fixture.componentInstance.participationMode()).toBe('practice');
+            expect(fixture.componentInstance.effectivePracticeParticipation()).toBe(practiceParticipation);
+            expect(fixture.componentInstance.hasPracticeParticipation()).toBe(true);
+            expect(fixture.componentInstance.hasGradedParticipation()).toBe(true);
+        });
+
+        it('should keep the graded mode for a new graded participation', () => {
+            const exercise = new ProgrammingExercise(undefined, undefined);
+            exercise.type = ExerciseType.PROGRAMMING;
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.detectChanges();
+
+            const emitSpy = vi.spyOn(fixture.componentInstance.newParticipation, 'emit');
+            const gradedParticipation = new StudentParticipation();
+            fixture.componentInstance.onNewParticipation(gradedParticipation);
+
+            expect(emitSpy).toHaveBeenCalledWith(gradedParticipation);
+            expect(fixture.componentInstance.participationMode()).toBe('graded');
+            expect(fixture.componentInstance.hasPracticeParticipation()).toBe(false);
+        });
+    });
+
+    describe('viewing a past submission', () => {
+        it('should hide the submit action and offer the continue action instead', () => {
+            const exercise = new ModelingExercise(UMLDiagramType.ClassDiagram, undefined, undefined);
+            exercise.type = ExerciseType.MODELING;
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('onSubmitExercise', submitCallback);
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.effectiveOnSubmitExercise()).toBe(submitCallback);
+            expect(fixture.componentInstance.onContinueExercise()).toBeUndefined();
+
+            fixture.componentInstance.isViewingSubmission.set(true);
+
+            expect(fixture.componentInstance.effectiveOnSubmitExercise()).toBeUndefined();
+            expect(fixture.componentInstance.onContinueExercise()).toBeDefined();
         });
     });
 

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
@@ -149,7 +149,7 @@ describe('ExerciseHeaderComponent', () => {
         });
     });
 
-    describe('hasPracticeParticipation', () => {
+    describe('showPracticeMode', () => {
         it('should be false when there is no practice participation and mode is graded', () => {
             const exercise = new ModelingExercise(UMLDiagramType.ClassDiagram, undefined, undefined);
             exercise.type = ExerciseType.MODELING;
@@ -158,7 +158,7 @@ describe('ExerciseHeaderComponent', () => {
             fixture.componentRef.setInput('courseId', 5);
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.hasPracticeParticipation()).toBe(false);
+            expect(fixture.componentInstance.showPracticeMode()).toBe(false);
         });
 
         it('should be true when practice participation has a submitted submission', () => {
@@ -172,7 +172,7 @@ describe('ExerciseHeaderComponent', () => {
             fixture.componentRef.setInput('practiceParticipation', practiceParticipation);
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.hasPracticeParticipation()).toBe(true);
+            expect(fixture.componentInstance.showPracticeMode()).toBe(true);
         });
 
         it('should be true when a practice participation without submissions exists and mode is graded', () => {
@@ -191,7 +191,7 @@ describe('ExerciseHeaderComponent', () => {
             fixture.componentRef.setInput('participationMode', 'graded');
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.hasPracticeParticipation()).toBe(true);
+            expect(fixture.componentInstance.showPracticeMode()).toBe(true);
         });
 
         it('should be true when mode is practice even without a practice participation', () => {
@@ -206,11 +206,11 @@ describe('ExerciseHeaderComponent', () => {
             fixture.componentRef.setInput('participationMode', 'practice');
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.hasPracticeParticipation()).toBe(true);
+            expect(fixture.componentInstance.showPracticeMode()).toBe(true);
         });
     });
 
-    describe('hasGradedParticipation', () => {
+    describe('showGradedMode', () => {
         it('should be false for a graded participation without submissions when no practice participation exists', () => {
             const exercise = new QuizExercise(undefined, undefined);
             exercise.type = ExerciseType.QUIZ;
@@ -223,7 +223,7 @@ describe('ExerciseHeaderComponent', () => {
             fixture.componentRef.setInput('studentParticipation', gradedParticipation);
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.hasGradedParticipation()).toBe(false);
+            expect(fixture.componentInstance.showGradedMode()).toBe(false);
         });
 
         it('should be true for a graded participation without submissions when a practice participation exists', () => {
@@ -240,7 +240,7 @@ describe('ExerciseHeaderComponent', () => {
             fixture.componentRef.setInput('practiceParticipation', practiceParticipation);
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.hasGradedParticipation()).toBe(true);
+            expect(fixture.componentInstance.showGradedMode()).toBe(true);
         });
 
         it('should be true when the graded participation has a submitted submission', () => {
@@ -255,7 +255,39 @@ describe('ExerciseHeaderComponent', () => {
             fixture.componentRef.setInput('studentParticipation', gradedParticipation);
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.hasGradedParticipation()).toBe(true);
+            expect(fixture.componentInstance.showGradedMode()).toBe(true);
+        });
+
+        it('should be true without any graded participation when a practice participation exists, so the student can see the missed graded mode', () => {
+            const exercise = new ProgrammingExercise(undefined, undefined);
+            exercise.type = ExerciseType.PROGRAMMING;
+            exercise.dueDate = dayjs().subtract(1, 'hours');
+            const practiceParticipation = new StudentParticipation();
+            practiceParticipation.testRun = true;
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('practiceParticipation', practiceParticipation);
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.showGradedMode()).toBe(true);
+        });
+
+        it('should be true during a quiz practice run of a missed quiz (no submitted graded submission, practice participation not yet created)', () => {
+            const exercise = new QuizExercise(undefined, undefined);
+            exercise.type = ExerciseType.QUIZ;
+            exercise.dueDate = dayjs().subtract(1, 'hours');
+            const gradedParticipation = new StudentParticipation();
+            gradedParticipation.submissions = [{ submitted: false }];
+
+            fixture.componentRef.setInput('exercise', exercise);
+            fixture.componentRef.setInput('courseId', 5);
+            fixture.componentRef.setInput('studentParticipation', gradedParticipation);
+            fixture.componentRef.setInput('participationMode', 'practice');
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.showPracticeMode()).toBe(true);
+            expect(fixture.componentInstance.showGradedMode()).toBe(true);
         });
     });
 
@@ -280,8 +312,8 @@ describe('ExerciseHeaderComponent', () => {
             expect(emitSpy).toHaveBeenCalledWith(practiceParticipation);
             expect(fixture.componentInstance.participationMode()).toBe('practice');
             expect(fixture.componentInstance.effectivePracticeParticipation()).toBe(practiceParticipation);
-            expect(fixture.componentInstance.hasPracticeParticipation()).toBe(true);
-            expect(fixture.componentInstance.hasGradedParticipation()).toBe(true);
+            expect(fixture.componentInstance.showPracticeMode()).toBe(true);
+            expect(fixture.componentInstance.showGradedMode()).toBe(true);
         });
 
         it('should keep the graded mode for a new graded participation', () => {
@@ -298,7 +330,7 @@ describe('ExerciseHeaderComponent', () => {
 
             expect(emitSpy).toHaveBeenCalledWith(gradedParticipation);
             expect(fixture.componentInstance.participationMode()).toBe('graded');
-            expect(fixture.componentInstance.hasPracticeParticipation()).toBe(false);
+            expect(fixture.componentInstance.showPracticeMode()).toBe(false);
         });
     });
 

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.ts
@@ -3,6 +3,7 @@ import { Exercise, ExerciseType, getIcon } from 'app/exercise/shared/entities/ex
 import { hasExerciseDueDatePassed } from 'app/exercise/util/exercise.utils';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { SubmissionPolicy } from 'app/exercise/shared/entities/submission/submission-policy.model';
+import { SubmissionType } from 'app/exercise/shared/entities/submission/submission.model';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ExerciseHeadersInformationComponent } from 'app/exercise/exercise-headers/exercise-headers-information/exercise-headers-information.component';
 import { ExerciseHeaderActionsComponent } from 'app/exercise/exercise-headers/exercise-header-actions/exercise-header-actions.component';
@@ -46,8 +47,11 @@ export class ExerciseHeaderComponent {
         return this.practiceParticipation() ?? this.localPracticeParticipation();
     });
 
+    // A TIMEOUT submission is collected automatically when the quiz ends without the student pressing
+    // submit — the quiz evaluation marks it as submitted, but the student still missed the deadline, so
+    // it must not produce a "Graded" badge.
     readonly hasGradedSubmission = computed(() => {
-        return !!this.studentParticipation()?.submissions?.some((s) => s.submitted);
+        return !!this.studentParticipation()?.submissions?.some((s) => s.submitted && s.type !== SubmissionType.TIMEOUT);
     });
 
     // A practice participation is only ever created by an explicit student action, so for any exercise

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.ts
@@ -50,11 +50,19 @@ export class ExerciseHeaderComponent {
         return !!this.studentParticipation()?.submissions?.some((s) => s.submitted);
     });
 
-    // Also treat practice as present when the mode is explicitly set to 'practice'
-    // with a graded participation, even if the practice participation hasn't been
-    // created yet (e.g. quiz practice just started).
-    readonly hasPracticeSubmission = computed(() => {
-        return !!this.effectivePracticeParticipation()?.submissions?.some((s) => s.submitted) || this.participationMode() === 'practice';
+    // A practice participation is only ever created by an explicit student action, so for any exercise
+    // type its existence alone keeps the practice mode selectable — even without a submission (e.g. a
+    // programming practice repository before the first push). The mode check additionally covers practice
+    // runs whose participation has not been created yet (e.g. quiz practice just started).
+    readonly hasPracticeParticipation = computed(() => {
+        return !!this.effectivePracticeParticipation() || this.participationMode() === 'practice';
+    });
+
+    // Show the graded side of the toggle once a graded submission exists. A graded participation without
+    // any submission only counts while practice is available, so the student can still switch between the
+    // two modes; on its own it must not produce a (misleading) "Graded" badge.
+    readonly hasGradedParticipation = computed(() => {
+        return this.hasGradedSubmission() || (!!this.studentParticipation() && this.hasPracticeParticipation());
     });
 
     readonly activeParticipation = computed(() => {

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.ts
@@ -54,15 +54,16 @@ export class ExerciseHeaderComponent {
     // type its existence alone keeps the practice mode selectable — even without a submission (e.g. a
     // programming practice repository before the first push). The mode check additionally covers practice
     // runs whose participation has not been created yet (e.g. quiz practice just started).
-    readonly hasPracticeParticipation = computed(() => {
+    readonly showPracticeMode = computed(() => {
         return !!this.effectivePracticeParticipation() || this.participationMode() === 'practice';
     });
 
-    // Show the graded side of the toggle once a graded submission exists. A graded participation without
-    // any submission only counts while practice is available, so the student can still switch between the
-    // two modes; on its own it must not produce a (misleading) "Graded" badge.
-    readonly hasGradedParticipation = computed(() => {
-        return this.hasGradedSubmission() || (!!this.studentParticipation() && this.hasPracticeParticipation());
+    // The graded side of the toggle is shown once a graded submission exists. While practice is available
+    // it is always shown, so the student can switch back to the graded view — including the case where
+    // the graded mode was missed entirely and the view explains the missed due date. Without practice, a
+    // graded participation without submissions must not produce a (misleading) "Graded" badge.
+    readonly showGradedMode = computed(() => {
+        return this.hasGradedSubmission() || this.showPracticeMode();
     });
 
     readonly activeParticipation = computed(() => {

--- a/src/main/webapp/app/exercise/result/updating-result/updating-result.component.ts
+++ b/src/main/webapp/app/exercise/result/updating-result/updating-result.component.ts
@@ -114,8 +114,11 @@ export class UpdatingResultComponent implements OnInit, OnChanges, OnDestroy {
             this.resultSubscription.unsubscribe();
         }
         if (this.submissionSubscription) {
-            this.submissionService.unsubscribeForLatestSubmissionOfParticipation(participation.id!);
+            // Release this component's subscription first, so the service only sees remaining observers
+            // (e.g. the exercise header and the code editor show the same participation simultaneously)
+            // when deciding whether the shared websocket state may be torn down.
             this.submissionSubscription.unsubscribe();
+            this.submissionService.unsubscribeForLatestSubmissionOfParticipation(participation.id!);
         }
     }
 

--- a/src/main/webapp/app/localvc/repository-view/repository-view.component.ts
+++ b/src/main/webapp/app/localvc/repository-view/repository-view.component.ts
@@ -194,8 +194,11 @@ export class RepositoryViewComponent implements OnInit, OnDestroy {
             map((participation: ProgrammingExerciseStudentParticipation) => {
                 const results = participation.submissions?.last()?.results;
                 if (results && results.length) {
-                    // connect result and submission
+                    // connect result, submission, and participation — the result component derives the
+                    // participation (and through it the exercise) from this back-reference when no
+                    // participation input is provided
                     results[0].submission = participation.submissions?.last();
+                    results[0].submission!.participation = participation;
                     this.result = results[0];
                     this.resultHasInlineFeedback = this.result.feedbacks?.some((feedback) => Feedback.getReferenceLine(feedback) !== undefined) ?? false;
                 }

--- a/src/main/webapp/app/programming/shared/code-editor/services/code-editor-submission.service.ts
+++ b/src/main/webapp/app/programming/shared/code-editor/services/code-editor-submission.service.ts
@@ -43,6 +43,10 @@ export class CodeEditorSubmissionService extends DomainDependentService implemen
     setDomain(domain: DomainChange) {
         super.setDomain(domain);
         const [domainType, domainValue] = domain;
+        // Release the subscription of the previous domain — this service is a root singleton, so a leftover
+        // subscription would keep the previous participation's shared submission state observed forever and
+        // prevent its websocket teardown.
+        this.submissionSubscription?.unsubscribe();
         // Subscribe to the submission state of the currently selected participation, map the submission to the isBuilding state.
         if (domainType === DomainType.PARTICIPATION) {
             this.participationId = domainValue.id;

--- a/src/main/webapp/app/programming/shared/code-editor/services/code-editor-submission.service.ts
+++ b/src/main/webapp/app/programming/shared/code-editor/services/code-editor-submission.service.ts
@@ -45,8 +45,13 @@ export class CodeEditorSubmissionService extends DomainDependentService implemen
         const [domainType, domainValue] = domain;
         // Release the subscription of the previous domain — this service is a root singleton, so a leftover
         // subscription would keep the previous participation's shared submission state observed forever and
-        // prevent its websocket teardown.
+        // prevent its websocket teardown. Afterwards ask the submission service to release the shared state
+        // of the previous participation, which only happens once no other component observes it anymore.
+        const previousParticipationId = this.participationId;
         this.submissionSubscription?.unsubscribe();
+        if (previousParticipationId) {
+            this.submissionService.unsubscribeForLatestSubmissionOfParticipation(previousParticipationId);
+        }
         // Subscribe to the submission state of the currently selected participation, map the submission to the isBuilding state.
         if (domainType === DomainType.PARTICIPATION) {
             this.participationId = domainValue.id;

--- a/src/main/webapp/app/programming/shared/services/programming-submission.service.spec.ts
+++ b/src/main/webapp/app/programming/shared/services/programming-submission.service.spec.ts
@@ -466,6 +466,29 @@ describe('ProgrammingSubmissionService', () => {
         expect(submissionTopicSubscriptions.has(submissionTopic)).toBe(false);
     });
 
+    it('should keep the shared submission state alive while another component still observes it', () => {
+        httpGetStub.mockReturnValue(of(currentSubmission));
+        // Two components (e.g. the exercise header and the embedded code editor) observe the same participation
+        const observable = submissionService.getLatestPendingSubmissionByParticipationId(participationId, 10, true);
+        const firstComponent = observable.subscribe();
+        const secondComponent = submissionService.getLatestPendingSubmissionByParticipationId(participationId, 10, true).subscribe();
+
+        // One component is destroyed: it releases its own subscription first, then asks the service to clean up
+        firstComponent.unsubscribe();
+        submissionService.unsubscribeForLatestSubmissionOfParticipation(participationId);
+
+        // The shared subject and the websocket topic must survive for the remaining component
+        const submissionTopicSubscriptions = (submissionService as any).submissionTopicSubscriptions as Map<string, any>;
+        expect((submissionService as any).submissionSubjects[participationId]).toBeDefined();
+        expect(submissionTopicSubscriptions.has(submissionTopic)).toBe(true);
+
+        // Once the last component is gone, the cleanup proceeds
+        secondComponent.unsubscribe();
+        submissionService.unsubscribeForLatestSubmissionOfParticipation(participationId);
+        expect((submissionService as any).submissionSubjects[participationId]).toBeUndefined();
+        expect(submissionTopicSubscriptions.has(submissionTopic)).toBe(false);
+    });
+
     it('should only unsubscribe if no other participations use the topic with localci', () => {
         submissionService.isLocalCIEnabled = true;
         httpGetStub.mockReturnValue(of(currentSubmission));

--- a/src/main/webapp/app/programming/shared/services/programming-submission.service.ts
+++ b/src/main/webapp/app/programming/shared/services/programming-submission.service.ts
@@ -951,6 +951,13 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      * @param participationId
      */
     public unsubscribeForLatestSubmissionOfParticipation(participationId: number) {
+        // Multiple components can display the same participation at once (e.g. the exercise header and the
+        // embedded code editor). While any of them is still subscribed to the shared subject, the websocket
+        // registration and the subject must stay alive — deleting them here would leave the remaining
+        // components with an orphaned subject that no longer receives any submission state updates.
+        if (this.submissionSubjects[participationId]?.observed) {
+            return;
+        }
         const submissionTopic = this.submissionTopicsSubscribed.get(participationId);
         if (submissionTopic) {
             this.submissionTopicsSubscribed.delete(participationId);

--- a/src/main/webapp/app/programming/shared/services/programming-submission.service.ts
+++ b/src/main/webapp/app/programming/shared/services/programming-submission.service.ts
@@ -947,7 +947,11 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
     }
 
     /**
-     * Unsubscribe from the submission
+     * Unsubscribe from the submission.
+     *
+     * Callers must release their own subscription to the submission state observable before calling this
+     * method — the shared state is only torn down once no observers remain.
+     *
      * @param participationId
      */
     public unsubscribeForLatestSubmissionOfParticipation(participationId: number) {

--- a/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.spec.ts
@@ -223,6 +223,22 @@ describe('QuizExerciseUpdateComponent', () => {
                 expect(initStub).toHaveBeenCalledOnce();
             });
 
+            it('should default quizQuestions to an empty array when the server omits them', () => {
+                // GIVEN a quiz without questions, whose empty collection is dropped during serialization
+                configureStubs();
+                resetQuizExercise();
+                quizExercise.quizQuestions = undefined;
+
+                // WHEN
+                comp.course = course;
+                comp.ngOnInit();
+
+                // THEN the editor works on a real array (e.g. for the max score calculation)
+                expect(comp.quizExercise.quizQuestions).toEqual([]);
+                expect(comp.calculateMaxExerciseScore()).toBe(0);
+                resetQuizExercise();
+            });
+
             afterEach(() => {
                 vi.clearAllMocks();
             });
@@ -825,6 +841,13 @@ describe('QuizExerciseUpdateComponent', () => {
                 saQuestion.points = 3;
                 comp.quizExercise.quizQuestions = [multiQuestion, dndQuestion, saQuestion];
                 expect(comp.calculateMaxExerciseScore()).toBe(6);
+            });
+
+            it('should return 0 when the quiz has no questions (server omits empty collections)', () => {
+                resetQuizExercise();
+                comp.quizExercise = quizExercise;
+                comp.quizExercise.quizQuestions = undefined;
+                expect(comp.calculateMaxExerciseScore()).toBe(0);
             });
         });
 

--- a/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.spec.ts
@@ -848,6 +848,7 @@ describe('QuizExerciseUpdateComponent', () => {
                 comp.quizExercise = quizExercise;
                 comp.quizExercise.quizQuestions = undefined;
                 expect(comp.calculateMaxExerciseScore()).toBe(0);
+                resetQuizExercise();
             });
         });
 

--- a/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.ts
+++ b/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.ts
@@ -773,6 +773,8 @@ export class QuizExerciseUpdateComponent extends QuizExerciseValidationDirective
         this.reconcileMappingReferences(quizExercise);
         this.prepareEntity(quizExercise);
         this.quizExercise = quizExercise;
+        // The server omits empty collections during serialization — keep the editor working on a real array.
+        this.quizExercise.quizQuestions ??= [];
         // Prefer the server-provided editability flag (e.g. exam-date-aware) when present; otherwise fall back to the
         // local check. The create/update endpoints currently omit the field, which is why the unconditional overwrite
         // by the previous implementation flipped the banner on for fresh, not-yet-started quizzes.

--- a/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.ts
+++ b/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.ts
@@ -329,6 +329,9 @@ export class QuizExerciseUpdateComponent extends QuizExerciseValidationDirective
         if (quizId) {
             this.quizExerciseService.find(quizId).subscribe((response: HttpResponse<QuizExercise>) => {
                 this.quizExercise = response.body!;
+                // The server omits empty collections during serialization, so a quiz without questions
+                // arrives without the quizQuestions field — the editor relies on it being an array.
+                this.quizExercise.quizQuestions ??= [];
                 this.init();
                 if (this.testRunExistsAndShouldNotBeIgnored()) {
                     this.alertService.warning(this.translateService.instant('artemisApp.quizExercise.edit.testRunSubmissionsExist'));

--- a/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.ts
+++ b/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.ts
@@ -620,7 +620,9 @@ export class QuizExerciseUpdateComponent extends QuizExerciseValidationDirective
      */
     calculateMaxExerciseScore(): number {
         let scoreSum = 0;
-        this.quizExercise.quizQuestions!.forEach((question) => (scoreSum += question.points!));
+        if (this.quizExercise.quizQuestions) {
+            this.quizExercise.quizQuestions.forEach((question) => (scoreSum += question.points!));
+        }
         return scoreSum;
     }
 

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExercisePracticeMode.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExercisePracticeMode.spec.ts
@@ -7,6 +7,7 @@ import javaAllSuccessfulSubmission from '../../../fixtures/exercise/programming/
 import { admin, studentOne } from '../../../support/users';
 import { test } from '../../../support/fixtures';
 import { SEED_COURSES } from '../../../support/seedData';
+import { BUILD_RESULT_TIMEOUT } from '../../../support/timeouts';
 
 const course = { id: SEED_COURSES.programmingParticipation.id } as any;
 
@@ -35,7 +36,7 @@ test.describe('Programming exercise practice mode', { tag: '@slow' }, () => {
             }
         });
 
-        test('Keeps the practice mode selectable when switching back to graded', async ({ login, page }) => {
+        test('Keeps the practice mode selectable when switching back to graded', async ({ login, page, programmingExerciseEditor }) => {
             test.slow();
             await login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
             await startPracticeFromExercisePage(page, exercise.id!, 'Practice with template repository');
@@ -59,6 +60,12 @@ test.describe('Programming exercise practice mode', { tag: '@slow' }, () => {
             await page.goto(`/courses/${course.id}/exercises/${exercise.id}`);
             await expect(page.locator('#practice-mode-button')).toBeVisible({ timeout: 15000 });
             await expect(page.locator('#graded-mode-button')).toBeVisible();
+
+            // Submitting in practice mode must process the submission and update the shown result
+            await page.locator('#practice-mode-button').click();
+            await programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, javaAllSuccessfulSubmission, async () => {
+                await expect(page.locator('#exercise-headers-information')).toContainText('100%', { timeout: BUILD_RESULT_TIMEOUT });
+            });
         });
     });
 
@@ -98,6 +105,22 @@ test.describe('Programming exercise practice mode', { tag: '@slow' }, () => {
             await expect(page.locator('#practice-mode-button')).toBeVisible({ timeout: 15000 });
             await expect(page.locator('#graded-mode-button')).toBeVisible();
             await expect(page.locator('.code-button')).toBeVisible();
+        });
+
+        test('Shows the submission state when submitting in the practice mode code editor', async ({ login, page, programmingExerciseEditor }) => {
+            test.slow();
+            await login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
+            await startPracticeFromExercisePage(page, exercise.id!, 'Practice');
+            await expect(page.locator('#practice-mode-button')).toHaveClass(/segmented-control__button--active/);
+
+            // The live submission state is shown in practice mode even though the due date has passed
+            // (instead of a static "currently participating" text that never updates)
+            await expect(page.locator('#exercise-headers-information')).toContainText('No result');
+
+            // Submitting in practice mode must process the submission and show its result
+            await programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, javaAllSuccessfulSubmission, async () => {
+                await expect(page.locator('#exercise-headers-information')).toContainText('100%', { timeout: BUILD_RESULT_TIMEOUT });
+            });
         });
     });
 });

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExercisePracticeMode.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExercisePracticeMode.spec.ts
@@ -1,0 +1,107 @@
+import dayjs from 'dayjs';
+
+import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
+
+import { Page, expect } from '@playwright/test';
+import javaAllSuccessfulSubmission from '../../../fixtures/exercise/programming/java/all_successful/submission.json';
+import { admin, studentOne } from '../../../support/users';
+import { test } from '../../../support/fixtures';
+import { SEED_COURSES } from '../../../support/seedData';
+
+const course = { id: SEED_COURSES.programmingParticipation.id } as any;
+
+/**
+ * Regression tests for the practice mode of programming exercises (issue #12780): after the due date,
+ * starting practice must keep the practice mode reachable — both while switching between graded and
+ * practice and across a full page reload — even though the fresh practice participation has no
+ * submission yet (a programming practice participation only receives a submission on the first push).
+ */
+test.describe('Programming exercise practice mode', { tag: '@slow' }, () => {
+    test.describe('After the due date with a graded submission', () => {
+        let exercise: ProgrammingExercise;
+        let dueDate: dayjs.Dayjs;
+
+        test.beforeEach('Create exercise and make a graded submission before the due date', async ({ login, page, exerciseAPIRequests }) => {
+            await login(admin);
+            dueDate = dayjs().add(30, 'seconds');
+            exercise = await exerciseAPIRequests.createProgrammingExercise({ course, dueDate });
+            await login(studentOne);
+            const response = await exerciseAPIRequests.startExerciseParticipation(exercise.id!);
+            const participation = await response.json();
+            await exerciseAPIRequests.makeProgrammingExerciseSubmission(participation.id!, javaAllSuccessfulSubmission);
+            const now = dayjs();
+            if (now.isBefore(dueDate)) {
+                await page.waitForTimeout(dueDate.diff(now, 'ms') + 2000);
+            }
+        });
+
+        test('Keeps the practice mode selectable when switching back to graded', async ({ login, page }) => {
+            test.slow();
+            await login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
+            await startPracticeFromExercisePage(page, exercise.id!, 'Practice with template repository');
+
+            const practiceButton = page.locator('#practice-mode-button');
+            const gradedButton = page.locator('#graded-mode-button');
+            await expect(practiceButton).toBeVisible();
+            await expect(gradedButton).toBeVisible();
+            await expect(practiceButton).toHaveClass(/segmented-control__button--active/);
+
+            // Switching back to graded must not remove the practice option
+            await gradedButton.click();
+            await expect(gradedButton).toHaveClass(/segmented-control__button--active/);
+            await expect(practiceButton).toBeVisible();
+
+            // ... and practice can be selected again
+            await practiceButton.click();
+            await expect(practiceButton).toHaveClass(/segmented-control__button--active/);
+
+            // The toggle also survives a fresh page load, even though no practice submission exists yet
+            await page.goto(`/courses/${course.id}/exercises/${exercise.id}`);
+            await expect(page.locator('#practice-mode-button')).toBeVisible({ timeout: 15000 });
+            await expect(page.locator('#graded-mode-button')).toBeVisible();
+        });
+    });
+
+    test.describe('After the due date without a graded participation', () => {
+        let exercise: ProgrammingExercise;
+
+        test.beforeEach('Create exercise whose due date has already passed', async ({ login, exerciseAPIRequests }) => {
+            await login(admin);
+            exercise = await exerciseAPIRequests.createProgrammingExercise({
+                course,
+                releaseDate: dayjs().subtract(1, 'hour'),
+                dueDate: dayjs().subtract(5, 'minutes'),
+            });
+        });
+
+        test('Starts the practice mode and keeps it after a page reload', async ({ login, page }) => {
+            await login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
+            await startPracticeFromExercisePage(page, exercise.id!, 'Practice');
+
+            // Without a graded participation only the practice badge is shown
+            await expect(page.locator('#mode-badge')).toContainText('Practice');
+            await expect(page.locator('.code-button')).toBeVisible();
+
+            // The practice mode survives a fresh page load, even though no practice submission exists yet
+            await page.goto(`/courses/${course.id}/exercises/${exercise.id}`);
+            await expect(page.locator('#mode-badge')).toContainText('Practice', { timeout: 15000 });
+            await expect(page.locator('.code-button')).toBeVisible();
+        });
+    });
+});
+
+/**
+ * Opens the start-practice popover on the exercise details page and starts the practice mode via the
+ * option with the given label ('Practice with template repository' / 'Practice with graded participation'
+ * when a graded participation exists, plain 'Practice' otherwise).
+ */
+async function startPracticeFromExercisePage(page: Page, exerciseId: number, optionLabel: string): Promise<void> {
+    const startPracticeButton = page.locator(`#start-practice-${exerciseId} button`);
+    await startPracticeButton.waitFor({ state: 'visible', timeout: 15000 });
+    await startPracticeButton.click();
+    const popover = page.locator('.start-practice-popover');
+    await popover.waitFor({ state: 'visible' });
+    const responsePromise = page.waitForResponse((response) => response.url().includes(`/exercises/${exerciseId}/participations/practice`) && response.status() === 201);
+    await popover.locator('button', { hasText: optionLabel }).first().click();
+    await responsePromise;
+}

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExercisePracticeMode.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExercisePracticeMode.spec.ts
@@ -24,7 +24,9 @@ test.describe('Programming exercise practice mode', { tag: '@slow' }, () => {
 
         test.beforeEach('Create exercise and make a graded submission before the due date', async ({ login, page, exerciseAPIRequests }) => {
             await login(admin);
-            dueDate = dayjs().add(30, 'seconds');
+            // The budget must also cover the exercise creation (template/solution/test repo provisioning)
+            // and the graded submission, which all happen before the due date passes.
+            dueDate = dayjs().add(45, 'seconds');
             exercise = await exerciseAPIRequests.createProgrammingExercise({ course, dueDate });
             await login(studentOne);
             const response = await exerciseAPIRequests.startExerciseParticipation(exercise.id!);

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExercisePracticeMode.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExercisePracticeMode.spec.ts
@@ -74,17 +74,29 @@ test.describe('Programming exercise practice mode', { tag: '@slow' }, () => {
             });
         });
 
-        test('Starts the practice mode and keeps it after a page reload', async ({ login, page }) => {
+        test('Starts the practice mode and allows switching to the missed graded mode', async ({ login, page }) => {
             await login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
             await startPracticeFromExercisePage(page, exercise.id!, 'Practice');
 
-            // Without a graded participation only the practice badge is shown
-            await expect(page.locator('#mode-badge')).toContainText('Practice');
+            const practiceButton = page.locator('#practice-mode-button');
+            const gradedButton = page.locator('#graded-mode-button');
+            await expect(practiceButton).toBeVisible();
+            await expect(practiceButton).toHaveClass(/segmented-control__button--active/);
             await expect(page.locator('.code-button')).toBeVisible();
+
+            // The graded mode stays reachable, so the student can recognize that they missed the due date
+            await gradedButton.click();
+            await expect(gradedButton).toHaveClass(/segmented-control__button--active/);
+            await expect(page.locator('#exercise-headers-information')).toContainText('Missed due date');
+
+            // ... and practice can be selected again
+            await practiceButton.click();
+            await expect(practiceButton).toHaveClass(/segmented-control__button--active/);
 
             // The practice mode survives a fresh page load, even though no practice submission exists yet
             await page.goto(`/courses/${course.id}/exercises/${exercise.id}`);
-            await expect(page.locator('#mode-badge')).toContainText('Practice', { timeout: 15000 });
+            await expect(page.locator('#practice-mode-button')).toBeVisible({ timeout: 15000 });
+            await expect(page.locator('#graded-mode-button')).toBeVisible();
             await expect(page.locator('.code-button')).toBeVisible();
         });
     });


### PR DESCRIPTION
### Summary

Fixes a critical regression: after the due date, starting the practice mode and then switching back to "Graded" (or simply reloading the page) made the practice mode completely unreachable — the toggle collapsed to a "Graded"-only badge and the practice repository was orphaned in the UI.

Additionally, students who missed the graded mode entirely can now still switch to the graded view while practicing, where the "Missed due date" status makes clear that the graded participation was missed — previously they were stuck in practice with only a "Currently participating" status.

Manual testing during review surfaced three more related bugs that are fixed as well: missing CI feedback when submitting in practice mode, the repository view showing "No result" although a result exists, and the "Graded" badge reappearing for missed quizzes once the quiz evaluation ran.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).

### Motivation and Context

Closes #12780.

PR #12683 changed the participation-mode toggle to only show the "Practice" option when the practice participation contains a *submitted* submission (to hide a misleading "Graded" badge for empty quiz participations, #12664). However, a programming practice participation has **no submission until the first push** — the server only copies the repository. As a result:

1. A student starts the practice mode after the due date (toggle appears because the mode is `practice`).
2. The student switches back to "Graded" → both visibility conditions for the practice side are now false → the toggle collapses to a "Graded"-only badge. Practice mode is gone and cannot be re-entered.
3. A page reload is equally broken, since the mode initializes to `graded`. The "Code" button then points to the graded repository again, and pushes to the practice repository are no longer reflected in the UI (exactly the report in #12780).

### Description

`exercise-header.component.ts`:
- `hasPracticeSubmission` → `showPracticeMode`: the practice side of the toggle is offered whenever a practice participation **exists** — it is only ever created by an explicit student action — or the mode is currently `practice` (quiz practice run before its participation exists).
- `hasGradedSubmission` stays the gate for the standalone "Graded" badge; the new `showGradedMode` additionally offers the graded side whenever practice is available, so the student can always switch back to the graded view — including the case where the graded mode was missed entirely. The graded view then shows the "Missed due date" status instead of leaving the student stuck in practice with a "Currently participating" status. A lone graded participation without submissions still shows no misleading "Graded" badge, preserving the behavior introduced for #12664.

`submission-result-status.component.ts`:
- The live submission state was gated on the due date, so submitting in practice mode (always after the due date) gave **no feedback** until the first build result arrived. Practice participations are now exempt from the due-date gate, so the header shows the live state (no result / queued / building / result) just like before the due date.

`updating-result.component.ts` / `programming-submission.service.ts`:
- Destroying one result component (e.g. while switching between graded and practice, where the header and the embedded code editor show the same participation) removed the **shared** per-participation websocket subject, leaving the remaining components without any submission state updates. The shared state now stays alive while any component still observes it, and a component releases its own subscription before the service decides about teardown.

`quiz-exercise-update.component.ts` (ride-along fix):
- Editing a quiz without questions crashed (`Cannot read properties of undefined (reading 'forEach')`): the server omits empty collections during serialization, so `quizQuestions` was undefined. The editor now normalizes the field after loading (and after saving) and the max-score calculation is defensive.

Findings from manual review testing (thanks @az108):
- `exercise-header.component.ts`: when a quiz ends, the evaluation collects open submissions and marks them as submitted with type `TIMEOUT`. These must not produce a "Graded" badge — the student missed the deadline — so the badge check now excludes them. Previously the #12683 behavior only held in the window before the quiz evaluation ran.
- `repository-view.component.ts`: the repository view connected the loaded result to its submission but never set the submission → participation back-reference, which the result component needs to evaluate the display state. The view therefore showed "No result" even when a result existed (e.g. a build error in the practice repository). With the back-reference set, the latest result (including build failures) is displayed correctly.

New Playwright spec `ProgrammingExercisePracticeMode.spec.ts` covers practice mode end-to-end: the mode toggle with and without a graded submission (the "with graded submission" test fails on the previous code exactly at the mode-switch step), and the editor submission flow in practice mode (the "submission state" test fails on the previous code at the "No result" assertion, where the old code showed a static "Currently participating" text that never updated).

### Steps for Testing

Prerequisites:
- 1 Student
- 1 Programming exercise with a due date in the past (case A: the student has a graded submission from before the due date, case B: the student never participated)

1. Log in as the student and navigate to the programming exercise
2. Click "Start Practice" (case A: choose either repository option)
3. Verify the Practice/Graded toggle appears (both cases — in case B the graded view shows "Missed due date")
4. **Case A: switch to "Graded" and verify the "Practice" button is still shown; switch back to "Practice"**
5. **Reload the page and verify the practice mode is still selectable / active (do not push to the practice repository before this step)**
6. Verify the "Code" button in practice mode points to the practice repository
7. For a quiz exercise where a student opened but never submitted the graded quiz: verify that no "Graded" badge is shown — also after the quiz has ended and was evaluated (the auto-collected TIMEOUT submission must not count)
8. Submit in the practice mode code editor and verify the status shows the live submission state (queued / building / result)
9. Open the practice repository view after a failed build and verify the build-error result is shown (instead of "No result")

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Coverage table could not be generated. The `Test` workflow concluded with status `success`; coverage artifacts may be missing or incomplete. See [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/27277909400).

_Last updated: 2026-06-10 14:43:20 UTC_


### Screenshots

The toggle after switching back to "Graded" right after starting practice (previously it collapsed to a "Graded"-only badge):

_(see e2e test `ProgrammingExercisePracticeMode.spec.ts` for the automated verification of this flow)_