### PR TITLE
`Development`: Improve input validation for communication requests

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/AnswerMessageService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/AnswerMessageService.java
@@ -113,6 +113,10 @@ public class AnswerMessageService extends PostingService {
         newAnswerMessage.setContent(answerMessage.content());
 
         Post post = conversationMessageRepository.findMessagePostByIdElseThrow(answerMessage.post().id());
+        // the path courseId is authoritative: reject answers targeting a conversation that belongs to a different course.
+        // this must happen before isMemberOrCreateForCourseWideElseThrow, which would otherwise persist a course-wide auto-join for a mismatching course.
+        ensureConversationBelongsToCourseElseThrow(post.getConversation(), courseId);
+
         var conversationId = post.getConversation().getId();
         // For group chats we need the participants to generate the conversation title
         var conversation = conversationService.isMemberOrCreateForCourseWideElseThrow(conversationId, author, Optional.empty())
@@ -205,6 +209,7 @@ public class AnswerMessageService extends PostingService {
         AnswerPost updatedAnswerMessage;
 
         Conversation conversation = conversationService.getConversationById(existingAnswerMessage.getPost().getConversation().getId());
+        ensureConversationBelongsToCourseElseThrow(conversation, courseId);
         var course = preCheckUserAndCourseForMessaging(user, courseId);
         parseUserMentions(course, answerMessage.content());
         // only the content of the message can be updated
@@ -262,6 +267,7 @@ public class AnswerMessageService extends PostingService {
         // checks
         AnswerPost answerMessage = this.findById(answerMessageId);
         Conversation conversation = mayUpdateOrDeleteAnswerMessageElseThrow(answerMessage, user);
+        ensureConversationBelongsToCourseElseThrow(conversation, courseId);
         var course = preCheckUserAndCourseForMessaging(user, courseId);
 
         // we need to explicitly remove the answer post from the answers of the broadcast post to share up-to-date information

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
@@ -119,8 +119,11 @@ public class ConversationMessagingService extends PostingService {
 
         var conversationId = message.conversation().id();
 
-        var conversation = conversationService.isMemberOrCreateForCourseWideElseThrow(conversationId, author, Optional.empty())
-                .orElse(conversationService.loadConversationWithParticipantsIfGroupChat(conversationId));
+        var conversation = conversationService.loadConversationWithParticipantsIfGroupChat(conversationId);
+        // the path courseId is authoritative: reject messages targeting a conversation that belongs to a different course.
+        // this must happen before isMemberOrCreateForCourseWideElseThrow, which would otherwise persist a course-wide auto-join for a mismatching course.
+        ensureConversationBelongsToCourseElseThrow(conversation, courseId);
+        conversationService.isMemberOrCreateForCourseWideElseThrow(conversationId, author, Optional.empty());
         log.debug("      createMessage:conversationService.isMemberOrCreateForCourseWideElseThrow DONE");
 
         newMessage.setConversation(conversation);
@@ -341,6 +344,7 @@ public class ConversationMessagingService extends PostingService {
 
         Post existingMessage = conversationMessageRepository.findMessagePostByIdElseThrow(postId);
         Conversation conversation = mayUpdateOrDeleteMessageElseThrow(existingMessage, user);
+        ensureConversationBelongsToCourseElseThrow(conversation, courseId);
         var course = preCheckUserAndCourseForMessaging(user, courseId);
 
         parseUserMentions(course, messagePost.content());
@@ -375,6 +379,7 @@ public class ConversationMessagingService extends PostingService {
         // checks
         Post post = conversationMessageRepository.findMessagePostByIdElseThrow(postId);
         var conversation = mayUpdateOrDeleteMessageElseThrow(post, user);
+        ensureConversationBelongsToCourseElseThrow(conversation, courseId);
         var course = preCheckUserAndCourseForMessaging(user, courseId);
         post.setConversation(conversation);
 
@@ -410,6 +415,8 @@ public class ConversationMessagingService extends PostingService {
         preCheckUserAndCourseForCommunicationOrMessaging(user, course);
 
         Post message = conversationMessageRepository.findMessagePostByIdElseThrow(postId);
+        // the path courseId is authoritative: reject before isMemberOrCreateForCourseWideElseThrow can persist a course-wide auto-join for a mismatching course
+        ensureConversationBelongsToCourseElseThrow(message.getConversation(), courseId);
 
         Conversation conversation = conversationService.isMemberOrCreateForCourseWideElseThrow(message.getConversation().getId(), user, Optional.empty())
                 .orElse(message.getConversation());

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/PostingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/PostingService.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -213,6 +214,24 @@ public abstract class PostingService {
 
         if (course.getCourseInformationSharingConfiguration() == CourseInformationSharingConfiguration.DISABLED) {
             throw new BadRequestAlertException("Communication and messaging is disabled for this course", getEntityName(), "400", true);
+        }
+    }
+
+    /**
+     * Ensures that the given conversation belongs to the course identified by the (authoritative) path {@code courseId}.
+     * <p>
+     * The course context comes from the URL path and is used for authorization, while the target conversation is resolved
+     * from the request body / loaded entity. If the two diverge, a user authorized for one course could read or write in a
+     * conversation of another course (cross-course injection / broken access control). Reject such inconsistent requests.
+     *
+     * @param conversation the conversation the posting targets
+     * @param courseId     the id of the course taken from the API path
+     * @throws BadRequestAlertException if the conversation does not belong to the given course
+     */
+    protected void ensureConversationBelongsToCourseElseThrow(Conversation conversation, Long courseId) {
+        // Conversation#course is eagerly fetched, so this is a no-DB-cost id comparison
+        if (!Objects.equals(conversation.getCourse().getId(), courseId)) {
+            throw new BadRequestAlertException("The conversation does not belong to the specified course", getEntityName(), "conversationCourseMismatch");
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/AnswerMessageResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/AnswerMessageResource.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,16 +138,17 @@ public class AnswerMessageResource {
             throw new BadRequestAlertException("Invalid answer post ID found", answerMessageService.getEntityName(), "invalidAnswerPostId");
         }
 
-        // authorization: the caller may only retrieve answer posts they can access (course-wide channel or participant of the conversation).
-        // Set.copyOf de-duplicates because the access helper compares COUNT(DISTINCT id) against the number of requested ids.
-        User user = userRepository.getUser();
-        answerPostRepository.userHasAccessToAllAnswerPostsElseThrow(Set.copyOf(answerPostIds), user.getId());
-
         List<AnswerPost> answerPosts = answerMessageService.findByIdIn(answerPostIds);
 
         if (answerPosts.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
+
+        // authorization: the caller may only retrieve answer posts they can access (course-wide channel or participant of the conversation).
+        // We check access against the posts that were actually found (not the requested IDs) so that non-existent IDs yield 404, not 403.
+        User user = userRepository.getUser();
+        Set<Long> foundAnswerPostIds = answerPosts.stream().map(AnswerPost::getId).collect(Collectors.toSet());
+        answerPostRepository.userHasAccessToAllAnswerPostsElseThrow(foundAnswerPostIds, user.getId());
 
         if (answerPosts.stream().anyMatch(post -> !post.getPost().getConversation().getCourse().getId().equals(courseId))) {
             throw new BadRequestAlertException("Some answer posts do not belong to the specified course", answerMessageService.getEntityName(), "invalidCourse");

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/AnswerMessageResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/AnswerMessageResource.java
@@ -5,6 +5,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,10 +22,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import de.tum.cit.aet.artemis.account.domain.User;
+import de.tum.cit.aet.artemis.account.repository.UserRepository;
 import de.tum.cit.aet.artemis.communication.domain.AnswerPost;
 import de.tum.cit.aet.artemis.communication.dto.AnswerPostResponseDTO;
 import de.tum.cit.aet.artemis.communication.dto.CreateAnswerPostDTO;
 import de.tum.cit.aet.artemis.communication.dto.UpdatePostingDTO;
+import de.tum.cit.aet.artemis.communication.repository.AnswerPostRepository;
 import de.tum.cit.aet.artemis.communication.service.AnswerMessageService;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastStudent;
@@ -41,8 +45,14 @@ public class AnswerMessageResource {
 
     private final AnswerMessageService answerMessageService;
 
-    public AnswerMessageResource(AnswerMessageService answerMessageService) {
+    private final UserRepository userRepository;
+
+    private final AnswerPostRepository answerPostRepository;
+
+    public AnswerMessageResource(AnswerMessageService answerMessageService, UserRepository userRepository, AnswerPostRepository answerPostRepository) {
         this.answerMessageService = answerMessageService;
+        this.userRepository = userRepository;
+        this.answerPostRepository = answerPostRepository;
     }
 
     /**
@@ -122,6 +132,15 @@ public class AnswerMessageResource {
         if (answerPostIds == null || answerPostIds.isEmpty()) {
             throw new BadRequestAlertException("AnswerPost IDs cannot be null or empty", answerMessageService.getEntityName(), "invalidAnswerPostIds");
         }
+
+        if (answerPostIds.stream().anyMatch(id -> id <= 0)) {
+            throw new BadRequestAlertException("Invalid answer post ID found", answerMessageService.getEntityName(), "invalidAnswerPostId");
+        }
+
+        // authorization: the caller may only retrieve answer posts they can access (course-wide channel or participant of the conversation).
+        // Set.copyOf de-duplicates because the access helper compares COUNT(DISTINCT id) against the number of requested ids.
+        User user = userRepository.getUser();
+        answerPostRepository.userHasAccessToAllAnswerPostsElseThrow(Set.copyOf(answerPostIds), user.getId());
 
         List<AnswerPost> answerPosts = answerMessageService.findByIdIn(answerPostIds);
 

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/ConversationMessageResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/ConversationMessageResource.java
@@ -7,6 +7,7 @@ import java.net.URISyntaxException;
 import java.security.Principal;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import jakarta.validation.Valid;
 
@@ -232,16 +233,17 @@ public class ConversationMessageResource {
             throw new BadRequestAlertException("Invalid post ID found", conversationMessagingService.getEntityName(), "invalidPostId");
         }
 
-        // authorization: the caller may only retrieve posts they can access (course-wide channel or participant of the conversation).
-        // Set.copyOf de-duplicates because the access helper compares COUNT(DISTINCT id) against the number of requested ids.
-        User user = userRepository.getUser();
-        postRepository.userHasAccessToAllPostsElseThrow(Set.copyOf(postIds), user.getId());
-
         List<Post> posts = conversationMessagingService.getMessageByIds(postIds);
 
         if (posts.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
+
+        // authorization: the caller may only retrieve posts they can access (course-wide channel or participant of the conversation).
+        // We check access against the posts that were actually found (not the requested IDs) so that non-existent IDs yield 404, not 403.
+        User user = userRepository.getUser();
+        Set<Long> foundPostIds = posts.stream().map(Post::getId).collect(Collectors.toSet());
+        postRepository.userHasAccessToAllPostsElseThrow(foundPostIds, user.getId());
 
         if (posts.stream().anyMatch(post -> !post.getConversation().getCourse().getId().equals(courseId))) {
             throw new BadRequestAlertException("Some posts do not belong to the specified course", conversationMessagingService.getEntityName(), "invalidCourse");

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/ConversationMessageResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/ConversationMessageResource.java
@@ -6,6 +6,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.Principal;
 import java.util.List;
+import java.util.Set;
 
 import jakarta.validation.Valid;
 
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.repository.UserRepository;
 import de.tum.cit.aet.artemis.communication.domain.CreatedConversationMessage;
 import de.tum.cit.aet.artemis.communication.domain.DisplayPriority;
@@ -36,6 +38,7 @@ import de.tum.cit.aet.artemis.communication.dto.CreatePostDTO;
 import de.tum.cit.aet.artemis.communication.dto.PostContextFilterDTO;
 import de.tum.cit.aet.artemis.communication.dto.PostResponseDTO;
 import de.tum.cit.aet.artemis.communication.dto.UpdatePostingDTO;
+import de.tum.cit.aet.artemis.communication.repository.PostRepository;
 import de.tum.cit.aet.artemis.communication.service.ConversationMessagingService;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.security.Role;
@@ -65,12 +68,15 @@ public class ConversationMessageResource {
 
     private final CourseRepository courseRepository;
 
+    private final PostRepository postRepository;
+
     public ConversationMessageResource(ConversationMessagingService conversationMessagingService, UserRepository userRepository,
-            AuthorizationCheckService authorizationCheckService, CourseRepository courseRepository) {
+            AuthorizationCheckService authorizationCheckService, CourseRepository courseRepository, PostRepository postRepository) {
         this.conversationMessagingService = conversationMessagingService;
         this.userRepository = userRepository;
         this.authorizationCheckService = authorizationCheckService;
         this.courseRepository = courseRepository;
+        this.postRepository = postRepository;
     }
 
     /**
@@ -225,6 +231,11 @@ public class ConversationMessageResource {
         if (postIds.stream().anyMatch(id -> id <= 0)) {
             throw new BadRequestAlertException("Invalid post ID found", conversationMessagingService.getEntityName(), "invalidPostId");
         }
+
+        // authorization: the caller may only retrieve posts they can access (course-wide channel or participant of the conversation).
+        // Set.copyOf de-duplicates because the access helper compares COUNT(DISTINCT id) against the number of requested ids.
+        User user = userRepository.getUser();
+        postRepository.userHasAccessToAllPostsElseThrow(Set.copyOf(postIds), user.getId());
 
         List<Post> posts = conversationMessagingService.getMessageByIds(postIds);
 

--- a/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.spec.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.spec.ts
@@ -13,7 +13,7 @@ import { MetisConversationService } from 'app/communication/service/metis-conver
 import { DialogService } from 'primeng/dynamicdialog';
 import { MetisService } from 'app/communication/service/metis.service';
 import { Post } from 'app/communication/shared/entities/post.model';
-import { BehaviorSubject, of } from 'rxjs';
+import { BehaviorSubject, of, throwError } from 'rxjs';
 import { Conversation, ConversationDTO, ConversationType } from 'app/communication/shared/entities/conversation/conversation.model';
 import { generateExampleChannelDTO, generateExampleGroupChatDTO, generateOneToOneChatDTO } from 'test/helpers/sample/conversationExampleModels';
 import { Directive, NO_ERRORS_SCHEMA, input, output } from '@angular/core';
@@ -23,7 +23,7 @@ import { ChannelDTO, getAsChannelDTO } from 'app/communication/shared/entities/c
 import { PostCreateEditModalComponent } from 'app/communication/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component';
 import dayjs from 'dayjs/esm';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
-import { HttpResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { ForwardedMessage } from 'app/communication/shared/entities/forwarded-message.model';
 import { AnswerPost } from 'app/communication/shared/entities/answer-post.model';
 import { PostingType } from '../../../shared/entities/posting.model';
@@ -448,6 +448,27 @@ examples.forEach((activeConversation) => {
                     }
                 });
             }
+        });
+
+        it('should still render messages when a forwarded-source fetch fails', () => {
+            const mockForwardedMessages: ForwardedMessage[] = [
+                { id: 101, sourceId: 10, sourceType: 'POST' } as unknown as ForwardedMessage,
+                { id: 102, sourceId: 11, sourceType: 'ANSWER' } as unknown as ForwardedMessage,
+            ];
+            const mockSourceAnswerPosts: AnswerPost[] = [{ id: 11, content: 'Forwarded Answer Content', resolvesPost: true } as AnswerPost];
+
+            vi.spyOn(metisService, 'getForwardedMessagesByIds').mockReturnValue(of(new HttpResponse({ body: [{ id: 1, messages: mockForwardedMessages }] })));
+            // the source post is inaccessible to the viewer -> the server replies 403; it must not break the rest of the rendering
+            vi.spyOn(metisService, 'getSourcePostsByIds').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 403 })));
+            vi.spyOn(metisService, 'getSourceAnswerPostsByIds').mockReturnValue(of(mockSourceAnswerPosts));
+
+            component.allPosts = [{ id: 1, content: 'Some content...', hasForwardedMessages: true } as Post];
+            component.setPosts();
+
+            // the message list still renders and the accessible answer source is attached; the inaccessible post source is dropped to undefined
+            expect(component.posts).toHaveLength(1);
+            expect(component.posts[0].forwardedPosts).toEqual([undefined]);
+            expect(component.posts[0].forwardedAnswerPosts?.[0]?.id).toBe(11);
         });
 
         it('should filter posts to show only pinned posts when showOnlyPinned is true', () => {

--- a/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/core';
 import { faArrowDown, faCircleNotch, faEnvelope, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { Conversation, ConversationDTO } from 'app/communication/shared/entities/conversation/conversation.model';
-import { Observable, Subject, forkJoin, map, takeUntil } from 'rxjs';
+import { Observable, Subject, catchError, forkJoin, map, of, takeUntil } from 'rxjs';
 import { Post } from 'app/communication/shared/entities/post.model';
 import { Course } from 'app/course/shared/entities/course.model';
 import { PageType, PostContextFilter, PostSortCriterion, SortDirection, getUnreadPostsByLastReadDate } from 'app/communication/metis.util';
@@ -524,12 +524,15 @@ export class ConversationMessagesComponent implements OnInit, AfterViewInit, OnD
     private buildSourceRequests(sourcePostIds: number[], sourceAnswerIds: number[]): Observable<Posting[] | undefined>[] {
         const requests: Observable<Posting[] | undefined>[] = [];
 
+        // forwarded-source previews are non-critical: a source may live in a conversation the viewer cannot access (403),
+        // or the fetch may otherwise fail. Swallow any error to undefined so one bad source does not break rendering of the
+        // whole message list (extractFetchedSources tolerates undefined).
         if (sourcePostIds.length > 0) {
-            requests.push(this.metisService.getSourcePostsByIds(sourcePostIds));
+            requests.push(this.metisService.getSourcePostsByIds(sourcePostIds).pipe(catchError(() => of(undefined))));
         }
 
         if (sourceAnswerIds.length > 0) {
-            requests.push(this.metisService.getSourceAnswerPostsByIds(sourceAnswerIds));
+            requests.push(this.metisService.getSourceAnswerPostsByIds(sourceAnswerIds).pipe(catchError(() => of(undefined))));
         }
 
         return requests;

--- a/src/test/java/de/tum/cit/aet/artemis/communication/AnswerMessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/AnswerMessageIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -608,13 +609,13 @@ class AnswerMessageIntegrationTest extends AbstractSpringIntegrationIndependentT
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testEditAnswerPostWithWrongCourseId_badRequest() throws Exception {
-        AnswerPost answerPostToUpdate = createAnswerPost(existingPostsWithAnswersCourseWide.getFirst());
+        // persist the answer post and pass a matching body/path id so the 400 genuinely originates from the course-mismatch validation, not from id parsing
+        AnswerPost answerPostToUpdate = saveAnswerPost(TEST_PREFIX + "student1", existingPostsWithAnswersCourseWide.getFirst());
         Course dummyCourse = courseUtilService.createCourse();
 
         AnswerPostResponseDTO updatedAnswerPostServer = request.putWithResponseBody(
                 "/api/communication/courses/" + dummyCourse.getId() + "/answer-messages/" + answerPostToUpdate.getId(),
-                // answerPostToUpdate is unsaved (id == null); the 400 stems from the course/answer mismatch, so the body id is irrelevant.
-                new UpdatePostingDTO(0L, answerPostToUpdate.getContent(), null, false), AnswerPostResponseDTO.class, HttpStatus.BAD_REQUEST);
+                new UpdatePostingDTO(answerPostToUpdate.getId(), answerPostToUpdate.getContent(), null, false), AnswerPostResponseDTO.class, HttpStatus.BAD_REQUEST);
         assertThat(updatedAnswerPostServer).isNull();
 
         // conversation participants should not be notified
@@ -715,7 +716,137 @@ class AnswerMessageIntegrationTest extends AbstractSpringIntegrationIndependentT
         });
     }
 
+    // GET answer-messages-source-posts (forwarded-message source previews must not leak answer posts the caller cannot access)
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetSourceAnswerPostsByIds_courseWideChannel_returnsAnswerPost() throws Exception {
+        Course course = courseRepository.findByIdElseThrow(courseId);
+        Channel courseWideChannel = conversationUtilService.createCourseWideChannel(course, "answer-source-cw");
+        Post parent = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student2", courseWideChannel);
+        AnswerPost accessibleAnswer = saveAnswerPost(TEST_PREFIX + "student2", parent);
+
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("answerPostIds", accessibleAnswer.getId().toString());
+
+        List<AnswerPostResponseDTO> answers = request.getList("/api/communication/courses/" + courseId + "/answer-messages-source-posts", HttpStatus.OK,
+                AnswerPostResponseDTO.class, params);
+        assertThat(answers).hasSize(1);
+        assertThat(answers.getFirst().id()).isEqualTo(accessibleAnswer.getId());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetSourceAnswerPostsByIds_notParticipantOfNonCourseWideChannel_isForbidden() throws Exception {
+        Course course = courseRepository.findByIdElseThrow(courseId);
+        Channel nonCourseWideChannel = conversationUtilService.createPublicChannel(course, "answer-source-non-cw");
+        conversationUtilService.addParticipantToConversation(nonCourseWideChannel, TEST_PREFIX + "student2");
+        Post parent = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student2", nonCourseWideChannel);
+        AnswerPost hiddenAnswer = saveAnswerPost(TEST_PREFIX + "student2", parent);
+
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("answerPostIds", hiddenAnswer.getId().toString());
+
+        // student1 is not a participant of the non-course-wide channel, so they must not be able to read the answer post by its id
+        request.getList("/api/communication/courses/" + courseId + "/answer-messages-source-posts", HttpStatus.FORBIDDEN, AnswerPostResponseDTO.class, params);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetSourceAnswerPostsByIds_mixedAccessibleAndInaccessible_isForbidden() throws Exception {
+        Course course = courseRepository.findByIdElseThrow(courseId);
+        Channel courseWideChannel = conversationUtilService.createCourseWideChannel(course, "answer-source-cw-mixed");
+        Post accessibleParent = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student2", courseWideChannel);
+        AnswerPost accessibleAnswer = saveAnswerPost(TEST_PREFIX + "student2", accessibleParent);
+        Channel nonCourseWideChannel = conversationUtilService.createPublicChannel(course, "answer-source-non-cw-mixed");
+        conversationUtilService.addParticipantToConversation(nonCourseWideChannel, TEST_PREFIX + "student2");
+        Post hiddenParent = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student2", nonCourseWideChannel);
+        AnswerPost hiddenAnswer = saveAnswerPost(TEST_PREFIX + "student2", hiddenParent);
+
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("answerPostIds", accessibleAnswer.getId() + "," + hiddenAnswer.getId());
+
+        // one inaccessible id must reject the whole request
+        request.getList("/api/communication/courses/" + courseId + "/answer-messages-source-posts", HttpStatus.FORBIDDEN, AnswerPostResponseDTO.class, params);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetSourceAnswerPostsByIds_duplicateAccessibleIds_returnsAnswerPost() throws Exception {
+        Course course = courseRepository.findByIdElseThrow(courseId);
+        Channel courseWideChannel = conversationUtilService.createCourseWideChannel(course, "answer-source-cw-dup");
+        Post parent = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student2", courseWideChannel);
+        AnswerPost accessibleAnswer = saveAnswerPost(TEST_PREFIX + "student2", parent);
+
+        var params = new LinkedMultiValueMap<String, String>();
+        // duplicate ids must not trigger a false forbidden via the COUNT(DISTINCT) access check
+        params.add("answerPostIds", accessibleAnswer.getId() + "," + accessibleAnswer.getId());
+
+        List<AnswerPostResponseDTO> answers = request.getList("/api/communication/courses/" + courseId + "/answer-messages-source-posts", HttpStatus.OK,
+                AnswerPostResponseDTO.class, params);
+        assertThat(answers).hasSize(1);
+    }
+
+    // F-003: the path courseId is authoritative; an answer targeting a conversation of another course must be rejected
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testCreateAnswerMessage_conversationInDifferentCourse_isBadRequest() throws Exception {
+        Course otherCourse = courseUtilService.createCourse();
+        courseUtilService.enableMessagingForCourse(otherCourse);
+        Channel channelInOtherCourse = conversationUtilService.createCourseWideChannel(otherCourse, "f003-answer-create");
+        Post parent = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student1", channelInOtherCourse);
+
+        CreateAnswerPostDTO answerDTO = new CreateAnswerPostDTO("cross-course answer", new ParentPostDTO(parent.getId()));
+
+        AnswerPostResponseDTO notCreated = request.postWithResponseBody("/api/communication/courses/" + courseId + "/answer-messages", answerDTO, AnswerPostResponseDTO.class,
+                HttpStatus.BAD_REQUEST);
+        assertThat(notCreated).isNull();
+
+        // sanity check: the same answer via the conversation's actual course path succeeds
+        AnswerPostResponseDTO created = request.postWithResponseBody("/api/communication/courses/" + otherCourse.getId() + "/answer-messages", answerDTO,
+                AnswerPostResponseDTO.class, HttpStatus.CREATED);
+        assertThat(created).isNotNull();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testUpdateAnswerMessage_conversationInDifferentCourse_isBadRequest() throws Exception {
+        Course otherCourse = courseUtilService.createCourse();
+        courseUtilService.enableMessagingForCourse(otherCourse);
+        Channel channelInOtherCourse = conversationUtilService.createCourseWideChannel(otherCourse, "f003-answer-update");
+        Post parent = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student1", channelInOtherCourse);
+        AnswerPost answer = saveAnswerPost(TEST_PREFIX + "student1", parent);
+
+        UpdatePostingDTO updateDTO = new UpdatePostingDTO(answer.getId(), "updated answer", null, false);
+        AnswerPostResponseDTO notUpdated = request.putWithResponseBody("/api/communication/courses/" + courseId + "/answer-messages/" + answer.getId(), updateDTO,
+                AnswerPostResponseDTO.class, HttpStatus.BAD_REQUEST);
+        assertThat(notUpdated).isNull();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testDeleteAnswerMessage_conversationInDifferentCourse_isBadRequest() throws Exception {
+        Course otherCourse = courseUtilService.createCourse();
+        courseUtilService.enableMessagingForCourse(otherCourse);
+        Channel channelInOtherCourse = conversationUtilService.createCourseWideChannel(otherCourse, "f003-answer-delete");
+        Post parent = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student1", channelInOtherCourse);
+        AnswerPost answer = saveAnswerPost(TEST_PREFIX + "student1", parent);
+
+        request.delete("/api/communication/courses/" + courseId + "/answer-messages/" + answer.getId(), HttpStatus.BAD_REQUEST);
+        assertThat(answerPostRepository.findById(answer.getId())).isPresent();
+    }
+
     // HELPER METHODS
+
+    private AnswerPost saveAnswerPost(String login, Post parent) {
+        AnswerPost answerPost = new AnswerPost();
+        answerPost.setAuthor(userUtilService.getUserByLogin(login));
+        answerPost.setContent("answer post");
+        answerPost.setCreationDate(ZonedDateTime.now());
+        answerPost.setPost(parent);
+        return answerPostRepository.save(answerPost);
+    }
 
     private AnswerPost createAnswerPost(Post post) {
         AnswerPost answerPost = new AnswerPost();

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -229,7 +229,8 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         // 4 calls are for user authentication checks, 3 calls to update database
         // + 1 additional query from Hibernate 7 entity/collection loading changes
         // further database calls are made in async code
-        assertThatDb(() -> request.postWithResponseBody("/api/communication/courses/" + courseId + "/messages", postDTOToSave, PostResponseDTO.class, HttpStatus.CREATED))
+        // Note: post via the channel's own course — the path courseId must match the conversation's course (see ensureConversationBelongsToCourseElseThrow)
+        assertThatDb(() -> request.postWithResponseBody("/api/communication/courses/" + course.getId() + "/messages", postDTOToSave, PostResponseDTO.class, HttpStatus.CREATED))
                 .hasBeenCalledTimes(8);
     }
 
@@ -1233,6 +1234,132 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     private CreatePostDTO toCreatePostDTO(Post post) {
         return new CreatePostDTO(post.getContent(), post.getTitle(), false, new CreatePostConversationDTO(post.getConversation().getId()));
+    }
+
+    // GET messages-source-posts (forwarded-message source previews must not leak posts the caller cannot access)
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetSourcePostsByIds_courseWideChannel_returnsPost() throws Exception {
+        Channel courseWideChannel = conversationUtilService.createCourseWideChannel(course, "source-cw");
+        Post accessiblePost = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student2", courseWideChannel);
+
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("postIds", accessiblePost.getId().toString());
+
+        List<PostResponseDTO> posts = request.getList("/api/communication/courses/" + courseId + "/messages-source-posts", HttpStatus.OK, PostResponseDTO.class, params);
+        assertThat(posts).hasSize(1);
+        assertThat(posts.getFirst().id()).isEqualTo(accessiblePost.getId());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetSourcePostsByIds_notParticipantOfNonCourseWideChannel_isForbidden() throws Exception {
+        Channel nonCourseWideChannel = conversationUtilService.createPublicChannel(course, "source-non-cw");
+        conversationUtilService.addParticipantToConversation(nonCourseWideChannel, TEST_PREFIX + "student2");
+        Post hiddenPost = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student2", nonCourseWideChannel);
+
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("postIds", hiddenPost.getId().toString());
+
+        // student1 is not a participant of the non-course-wide channel, so they must not be able to read the post by its id
+        request.getList("/api/communication/courses/" + courseId + "/messages-source-posts", HttpStatus.FORBIDDEN, PostResponseDTO.class, params);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetSourcePostsByIds_mixedAccessibleAndInaccessible_isForbidden() throws Exception {
+        Channel courseWideChannel = conversationUtilService.createCourseWideChannel(course, "source-cw-mixed");
+        Post accessiblePost = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student2", courseWideChannel);
+        Channel nonCourseWideChannel = conversationUtilService.createPublicChannel(course, "source-non-cw-mixed");
+        conversationUtilService.addParticipantToConversation(nonCourseWideChannel, TEST_PREFIX + "student2");
+        Post hiddenPost = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student2", nonCourseWideChannel);
+
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("postIds", accessiblePost.getId() + "," + hiddenPost.getId());
+
+        // one inaccessible id must reject the whole request
+        request.getList("/api/communication/courses/" + courseId + "/messages-source-posts", HttpStatus.FORBIDDEN, PostResponseDTO.class, params);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testGetSourcePostsByIds_duplicateAccessibleIds_returnsPost() throws Exception {
+        Channel courseWideChannel = conversationUtilService.createCourseWideChannel(course, "source-cw-dup");
+        Post accessiblePost = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student2", courseWideChannel);
+
+        var params = new LinkedMultiValueMap<String, String>();
+        // duplicate ids must not trigger a false forbidden via the COUNT(DISTINCT) access check
+        params.add("postIds", accessiblePost.getId() + "," + accessiblePost.getId());
+
+        List<PostResponseDTO> posts = request.getList("/api/communication/courses/" + courseId + "/messages-source-posts", HttpStatus.OK, PostResponseDTO.class, params);
+        assertThat(posts).hasSize(1);
+    }
+
+    // F-003: the path courseId is authoritative; a conversation belonging to another course must be rejected
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testCreateMessage_conversationInDifferentCourse_isBadRequest() throws Exception {
+        Course otherCourse = courseUtilService.createCourse();
+        courseUtilService.enableMessagingForCourse(otherCourse);
+        Channel channelInOtherCourse = conversationUtilService.createCourseWideChannel(otherCourse, "f003-create");
+
+        CreatePostDTO postDTOToSave = new CreatePostDTO("cross-course injection", "", false, new CreatePostConversationDTO(channelInOtherCourse.getId()));
+
+        // posting via this course's path while targeting a conversation of otherCourse must be rejected
+        PostResponseDTO notCreated = request.postWithResponseBody("/api/communication/courses/" + courseId + "/messages", postDTOToSave, PostResponseDTO.class,
+                HttpStatus.BAD_REQUEST);
+        assertThat(notCreated).isNull();
+        // the rejected request must not have left a side effect: no course-wide auto-join into the other course's channel
+        User student1 = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
+        assertThat(conversationParticipantRepository.existsByConversationIdAndUserId(channelInOtherCourse.getId(), student1.getId())).isFalse();
+
+        // sanity check: the same message via the conversation's actual course path succeeds
+        PostResponseDTO created = request.postWithResponseBody("/api/communication/courses/" + otherCourse.getId() + "/messages", postDTOToSave, PostResponseDTO.class,
+                HttpStatus.CREATED);
+        assertThat(created).isNotNull();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testUpdateMessage_conversationInDifferentCourse_isBadRequest() throws Exception {
+        Course otherCourse = courseUtilService.createCourse();
+        courseUtilService.enableMessagingForCourse(otherCourse);
+        Channel channelInOtherCourse = conversationUtilService.createCourseWideChannel(otherCourse, "f003-update");
+        Post post = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student1", channelInOtherCourse);
+
+        UpdatePostingDTO updateDTO = new UpdatePostingDTO(post.getId(), "updated content", post.getTitle(), false);
+        PostResponseDTO notUpdated = request.putWithResponseBody("/api/communication/courses/" + courseId + "/messages/" + post.getId(), updateDTO, PostResponseDTO.class,
+                HttpStatus.BAD_REQUEST);
+        assertThat(notUpdated).isNull();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testDeleteMessage_conversationInDifferentCourse_isBadRequest() throws Exception {
+        Course otherCourse = courseUtilService.createCourse();
+        courseUtilService.enableMessagingForCourse(otherCourse);
+        Channel channelInOtherCourse = conversationUtilService.createCourseWideChannel(otherCourse, "f003-delete");
+        Post post = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student1", channelInOtherCourse);
+
+        request.delete("/api/communication/courses/" + courseId + "/messages/" + post.getId(), HttpStatus.BAD_REQUEST);
+        assertThat(conversationMessageRepository.findById(post.getId())).isPresent();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testChangeDisplayPriority_conversationInDifferentCourse_isBadRequest() throws Exception {
+        Course otherCourse = courseUtilService.createCourse();
+        courseUtilService.enableMessagingForCourse(otherCourse);
+        Channel channelInOtherCourse = conversationUtilService.createCourseWideChannel(otherCourse, "f003-pin");
+        Post post = conversationUtilService.addMessageToConversation(TEST_PREFIX + "student1", channelInOtherCourse);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("displayPriority", DisplayPriority.PINNED.toString());
+        PostResponseDTO notUpdated = request.putWithResponseBodyAndParams("/api/communication/courses/" + courseId + "/messages/" + post.getId() + "/display-priority", null,
+                PostResponseDTO.class, HttpStatus.BAD_REQUEST, params);
+        assertThat(notUpdated).isNull();
     }
 
     private UpdatePostingDTO toUpdatePostingDTO(Post post) {

--- a/src/test/playwright/e2e/course/CourseMessageInteractions.spec.ts
+++ b/src/test/playwright/e2e/course/CourseMessageInteractions.spec.ts
@@ -3,6 +3,7 @@ import { test } from '../../support/fixtures';
 import { admin, instructor, studentOne } from '../../support/users';
 import { generateUUID } from '../../support/utils';
 import { Post } from 'app/communication/shared/entities/post.model';
+import { Channel } from 'app/communication/shared/entities/conversation/channel.model';
 import { SEED_COURSES, SEED_CHANNELS } from '../../support/seedData';
 
 const writeCourse = { id: SEED_COURSES.channel2.id };
@@ -344,6 +345,54 @@ test.describe('Message interactions', { tag: '@fast' }, () => {
             await expect(page.getByRole('heading', { name: /search results/i })).toBeVisible({ timeout: 15000 });
             // Verify no message posts are shown in the results area (markdown-preview contains message content)
             await expect(page.locator('.markdown-preview', { hasText: noMatchText })).toHaveCount(0, { timeout: 5000 });
+        });
+    });
+
+    test.describe('Message forwarding', () => {
+        // self-contained source + destination channels so membership and names are deterministic
+        let sourceChannel: Channel;
+        let destinationChannel: Channel;
+        let sourcePost: Post;
+        let reply: Post;
+
+        test.beforeEach('Create source/destination channels, a message and a reply', async ({ login, communicationAPIRequests }) => {
+            await login(admin);
+            const uid = generateUUID().slice(0, 8);
+            const courseRef = { id: writeCourse.id } as any;
+            sourceChannel = await communicationAPIRequests.createCourseMessageChannel(courseRef, `fwd-src-${uid}`, 'Forward source', false, true);
+            destinationChannel = await communicationAPIRequests.createCourseMessageChannel(courseRef, `fwd-dst-${uid}`, 'Forward destination', false, true);
+            // the forwarder (instructor) must participate in both: in the source to forward from it, in the destination to target and view it
+            await communicationAPIRequests.joinUserIntoChannel(courseRef, sourceChannel.id!, instructor);
+            await communicationAPIRequests.joinUserIntoChannel(courseRef, destinationChannel.id!, instructor);
+            sourcePost = await communicationAPIRequests.createCourseMessage(courseRef, sourceChannel.id!, 'channel', `Forward source message ${uid}`);
+            reply = await communicationAPIRequests.createCourseMessageReply(courseRef, sourcePost, `Forward reply message ${uid}`);
+        });
+
+        test('Forwarded post renders its preview in the destination conversation', async ({ login, courseMessages, page }) => {
+            await login(instructor, `/courses/${writeCourse.id}/communication?conversationId=${sourceChannel.id}`);
+            await courseMessages.checkMessage(sourcePost.id!, sourcePost.content!);
+
+            await courseMessages.forwardMessageToChannel(sourcePost.id!, destinationChannel.name!);
+
+            // opening the destination triggers the source-post fetch that the access check guards; it must succeed for an accessible source
+            const sourcePostsResponse = page.waitForResponse((resp) => resp.url().includes('/messages-source-posts') && resp.request().method() === 'GET');
+            await courseMessages.openConversation(writeCourse.id, destinationChannel.id!);
+            expect((await sourcePostsResponse).status()).toBe(200);
+
+            await courseMessages.checkForwardedPreview(sourcePost.content!);
+        });
+
+        test('Forwarded reply renders its preview in the destination conversation', async ({ login, courseMessages, page }) => {
+            await login(instructor, `/courses/${writeCourse.id}/communication?conversationId=${sourceChannel.id}`);
+            await courseMessages.checkMessage(sourcePost.id!, sourcePost.content!);
+
+            await courseMessages.forwardReplyToChannel(sourcePost.id!, reply.id!, destinationChannel.name!);
+
+            const answerSourceResponse = page.waitForResponse((resp) => resp.url().includes('/answer-messages-source-posts') && resp.request().method() === 'GET');
+            await courseMessages.openConversation(writeCourse.id, destinationChannel.id!);
+            expect((await answerSourceResponse).status()).toBe(200);
+
+            await courseMessages.checkForwardedPreview(reply.content!);
         });
     });
 });

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -773,6 +773,72 @@ export class CourseMessagesPage {
     }
 
     /**
+     * Completes an already-open forward dialog: selects the destination conversation by name and sends.
+     * @param destinationName - The name of the destination channel/conversation to forward to.
+     * @param extraContent - Optional additional message content to include with the forward.
+     */
+    private async completeForwardDialog(destinationName: string, extraContent?: string) {
+        const dialog = this.page.locator('jhi-forward-message-dialog');
+        await dialog.locator('input.tag-input').fill(destinationName);
+        // the dialog selects on (mousedown) so the option is chosen before the input blur closes the dropdown
+        const option = dialog.locator('.autocomplete-dropdown .list-group-item-action', { hasText: destinationName }).first();
+        await option.waitFor({ state: 'visible', timeout: 5000 });
+        await option.dispatchEvent('mousedown');
+        if (extraContent) {
+            await setMonacoEditorContent(this.page, 'jhi-forward-message-dialog jhi-markdown-editor-monaco', extraContent);
+        }
+        // forwarding first creates the container post, then the forwarded-message link(s)
+        const forwardResponse = this.page.waitForResponse((resp) => resp.url().includes('/forwarded-messages') && resp.request().method() === 'POST');
+        await dialog.locator('.modal-footer button.btn-primary').click();
+        await forwardResponse;
+        await dialog.waitFor({ state: 'hidden', timeout: 10000 });
+    }
+
+    /**
+     * Forwards a message to a destination channel and waits until the forward is persisted.
+     * @param messageId - The ID of the message to forward.
+     * @param destinationName - The name of the destination channel.
+     * @param extraContent - Optional additional message content.
+     */
+    async forwardMessageToChannel(messageId: number, destinationName: string, extraContent?: string) {
+        await this.forwardMessage(messageId);
+        await this.completeForwardDialog(destinationName, extraContent);
+    }
+
+    /**
+     * Forwards a thread reply (answer post) to a destination channel.
+     * @param parentMessageId - The ID of the message whose thread contains the reply.
+     * @param replyId - The ID of the reply to forward.
+     * @param destinationName - The name of the destination channel.
+     * @param extraContent - Optional additional message content.
+     */
+    async forwardReplyToChannel(parentMessageId: number, replyId: number, destinationName: string, extraContent?: string) {
+        await this.openThreadForMessage(parentMessageId);
+        const replyLocator = this.page.locator(`.expanded-thread #item-${replyId}`);
+        await replyLocator.scrollIntoViewIfNeeded();
+        for (let attempt = 0; attempt < 3; attempt++) {
+            await replyLocator.locator('.message-container').click({ button: 'right' });
+            try {
+                await this.page.locator('.dropdown-menu.show').waitFor({ state: 'visible', timeout: 3000 });
+                break;
+            } catch {
+                if (attempt === 2) throw new Error('Context menu did not appear after 3 right-click attempts');
+            }
+        }
+        await replyLocator.locator('.dropdown-menu.show .forward').click();
+        await this.completeForwardDialog(destinationName, extraContent);
+    }
+
+    /**
+     * Asserts that a forwarded-message preview containing the given source content is visible in the open conversation.
+     * @param expectedSourceContent - The content of the original (forwarded) posting.
+     */
+    async checkForwardedPreview(expectedSourceContent: string) {
+        const forwarded = this.page.locator('.forwarded-message-container', { hasText: expectedSourceContent });
+        await expect(forwarded.first()).toBeVisible({ timeout: 10000 });
+    }
+
+    /**
      * Pins or unpins a message via the context menu.
      * @param messageId - The ID of the message to pin/unpin.
      */


### PR DESCRIPTION
### Summary
The `courseId` in the request path is the context Artemis uses to authorize communication actions, but several message endpoints determined the actual target conversation from the request body or a loaded entity and never checked that the two were consistent. This PR makes the path `courseId` the authoritative context: every message / answer-message write validates that the target conversation actually belongs to that course, and the ID-based "source post" lookups (used for forwarded-message previews) now only return postings the caller is allowed to see. A small client change keeps the message list rendering robust when a single forwarded-source preview cannot be fetched.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
For communication actions the authorized course context comes from the URL path (`/courses/{courseId}/...`), while the concrete conversation/posting is taken from the request body or resolved by id. These two were not consistently reconciled:

- A message or answer-message create/update/delete (and pin/unpin) accepted a conversation that belonged to a **different** course than the one in the path, so the request was validated against the wrong course context (e.g. a course's "communication disabled" setting or the author's course role).
- The `messages-source-posts` / `answer-messages-source-posts` endpoints (used to render forwarded-message previews) returned postings purely by id, validating only course membership and not whether the caller may access the **conversation** the posting lives in.

Both are input/consistency validation gaps. Treating the path `courseId` as authoritative and validating conversation membership for id-based lookups makes the API behave predictably and keeps the path context meaningful for everything keyed on it (per-course settings, author role, notifications).

### Description
**Server**
- Added a shared guard `PostingService#ensureConversationBelongsToCourseElseThrow(conversation, courseId)` that rejects (HTTP 400) when the target conversation does not belong to the path course. `Conversation#course` is eagerly fetched, so this is a no-extra-query id comparison.
- Applied it to all seven message write paths: `createMessage`, `updateMessage`, `deleteMessageById`, `changeDisplayPriority` (`ConversationMessagingService`) and `createAnswerMessage`, `updateAnswerMessage`, `deleteAnswerMessageById` (`AnswerMessageService`). For the create / pin paths the check runs **before** the course-wide auto-join, so a rejected request leaves no participant side effect.
- `getSourcePostsByIds` / `getSourceAnswerPostsByIds` now reuse the existing `userHasAccessToAllPostsElseThrow` / `userHasAccessToAllAnswerPostsElseThrow` helpers (already used by forwarded/saved posts) so callers only receive postings in a course-wide channel or in a conversation they participate in. Requested ids are de-duplicated before the access check, and an `id <= 0` validation was added to the answer endpoint for parity with the post endpoint.

**Client**
- `conversation-messages.component.ts`: the forwarded-source preview fetches are wrapped in `catchError(() => of(undefined))`. These previews are non-critical, so a single non-fetchable source no longer breaks rendering of the whole message list (`extractFetchedSources` already tolerates `undefined`).

**Tests**
- New Spring integration tests in `MessageIntegrationTest` and `AnswerMessageIntegrationTest`: course/conversation mismatch on create/update/delete/pin → 400 (with a same-course positive control and a participant-side-effect-absence assertion); id-based source lookups → posting returned for an accessible (course-wide) source, 403 for a non-participant of a non-course-wide channel, 403 for a mixed batch, and 200 for duplicate accessible ids. Also corrected a pre-existing answer test whose 400 came from id parsing rather than the course validation it claimed to test.
- New Vitest case asserting the message list still renders (and the accessible source still attaches) when a forwarded-source fetch fails.

No new REST routes, DTOs, or database migrations were introduced; no user-visible UI change.

### Steps for Testing
Prerequisites:
- 1 Instructor, 2 Students
- 2 Courses (A and B) with messaging enabled; the same student enrolled in both

1. Log in as the student.
2. In Course A, open a channel and post a message — it works as before.
3. Using the browser dev tools (or any REST client with the student's session), send `POST /api/communication/courses/{A}/messages` with a body whose `conversation.id` is a conversation of Course B. Expect **400 Bad Request** (previously this was accepted).
4. Repeat for update/delete and for `PUT .../messages/{id}/display-priority`, and for the `answer-messages` equivalents — all should return **400** when the path course and the conversation's course differ, and behave normally when they match.
5. Open a conversation that contains a forwarded message whose original lives in a channel the student cannot access; confirm the conversation still loads (the forwarded preview is simply not shown) instead of failing to render.
6. As a member of a course-wide channel, confirm forwarded-message previews of accessible sources still render correctly.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Warning:** Coverage table could not be generated. The `Test` workflow concluded with status `success`; coverage artifacts may be missing or incomplete. See [workflow logs](https://github.com/ls1intum/Artemis/actions/runs/27376112797).

_Last updated: 2026-06-11 21:07:56 UTC_

