### PR TITLE
`Development`: Fix global search indexing of dates without seconds

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/WeaviateDateUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/WeaviateDateUtil.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.globalsearch.dto;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,6 +30,19 @@ public final class WeaviateDateUtil {
             SearchableEntitySchema.Properties.EXAM_VISIBLE_DATE, SearchableEntitySchema.Properties.EXAM_START_DATE, SearchableEntitySchema.Properties.EXAM_END_DATE);
 
     private WeaviateDateUtil() {
+    }
+
+    /**
+     * Formats a date for writing to Weaviate. Weaviate requires full RFC3339 including the seconds
+     * component; formatters like {@link DateTimeFormatter#ISO_OFFSET_DATE_TIME} (or {@code toString()})
+     * omit the seconds for exact-minute times (e.g. {@code 2026-04-23T11:00Z}), which Weaviate
+     * rejects with HTTP 422. This formatter always emits seconds and milliseconds.
+     *
+     * @param date the date to format (must not be {@code null})
+     * @return the RFC3339 representation accepted by Weaviate
+     */
+    public static String format(TemporalAccessor date) {
+        return FORMAT.format(date);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/WeaviateDateUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/WeaviateDateUtil.java
@@ -10,8 +10,8 @@ import java.util.Set;
 import de.tum.cit.aet.artemis.globalsearch.config.schema.entityschemas.SearchableEntitySchema;
 
 /**
- * Normalizes date values read back from Weaviate to a consistent ISO 8601 format
- * ({@code yyyy-MM-dd'T'HH:mm:ss.SSSXXX}, always three fractional digits).
+ * Normalizes date values read back from Weaviate and formats dates written to Weaviate,
+ * using a consistent ISO 8601 format ({@code yyyy-MM-dd'T'HH:mm:ss.SSSXXX}, always three fractional digits).
  * <p>
  * Weaviate may return DATE properties as {@link OffsetDateTime}, {@link ZonedDateTime},
  * or {@link String} depending on the client version. This utility normalizes them all
@@ -38,7 +38,9 @@ public final class WeaviateDateUtil {
      * omit the seconds for exact-minute times (e.g. {@code 2026-04-23T11:00Z}), which Weaviate
      * rejects with HTTP 422. This formatter always emits seconds and milliseconds.
      *
-     * @param date the date to format (must not be {@code null})
+     * @param date the date to format (must not be {@code null} and must support date, time, and offset
+     *                 fields, e.g. {@link OffsetDateTime} or {@link ZonedDateTime} — an {@link java.time.Instant}
+     *                 would throw, as it has no date fields or offset)
      * @return the RFC3339 representation accepted by Weaviate
      */
     public static String format(TemporalAccessor date) {

--- a/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/WeaviateDateUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/WeaviateDateUtil.java
@@ -25,7 +25,7 @@ public final class WeaviateDateUtil {
     /**
      * All property keys in the {@link SearchableEntitySchema} that use the Weaviate DATE type.
      */
-    private static final Set<String> DATE_PROPERTY_KEYS = Set.of(SearchableEntitySchema.Properties.RELEASE_DATE, SearchableEntitySchema.Properties.START_DATE,
+    public static final Set<String> DATE_PROPERTY_KEYS = Set.of(SearchableEntitySchema.Properties.RELEASE_DATE, SearchableEntitySchema.Properties.START_DATE,
             SearchableEntitySchema.Properties.END_DATE, SearchableEntitySchema.Properties.DUE_DATE, SearchableEntitySchema.Properties.VISIBLE_DATE,
             SearchableEntitySchema.Properties.EXAM_VISIBLE_DATE, SearchableEntitySchema.Properties.EXAM_START_DATE, SearchableEntitySchema.Properties.EXAM_END_DATE);
 

--- a/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/ExamSearchableEntityDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/ExamSearchableEntityDTO.java
@@ -1,12 +1,12 @@
 package de.tum.cit.aet.artemis.globalsearch.dto.searchableentity;
 
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
 import de.tum.cit.aet.artemis.exam.domain.Exam;
 import de.tum.cit.aet.artemis.globalsearch.config.schema.entityschemas.SearchableEntitySchema;
+import de.tum.cit.aet.artemis.globalsearch.dto.WeaviateDateUtil;
 
 /**
  * Snapshot of the data needed to upsert an exam into the unified {@code SearchableEntities} Weaviate collection.
@@ -64,13 +64,13 @@ public record ExamSearchableEntityDTO(Long examId, Long courseId, String examTit
             properties.put(SearchableEntitySchema.Properties.DESCRIPTION, description);
         }
         if (visibleDate != null) {
-            properties.put(SearchableEntitySchema.Properties.VISIBLE_DATE, visibleDate.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+            properties.put(SearchableEntitySchema.Properties.VISIBLE_DATE, WeaviateDateUtil.format(visibleDate));
         }
         if (startDate != null) {
-            properties.put(SearchableEntitySchema.Properties.START_DATE, startDate.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+            properties.put(SearchableEntitySchema.Properties.START_DATE, WeaviateDateUtil.format(startDate));
         }
         if (endDate != null) {
-            properties.put(SearchableEntitySchema.Properties.END_DATE, endDate.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+            properties.put(SearchableEntitySchema.Properties.END_DATE, WeaviateDateUtil.format(endDate));
         }
         return properties;
     }

--- a/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/ExerciseSearchableEntityDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/ExerciseSearchableEntityDTO.java
@@ -1,7 +1,6 @@
 package de.tum.cit.aet.artemis.globalsearch.dto.searchableentity;
 
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -11,6 +10,7 @@ import de.tum.cit.aet.artemis.exam.domain.Exam;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.fileupload.domain.FileUploadExercise;
 import de.tum.cit.aet.artemis.globalsearch.config.schema.entityschemas.SearchableEntitySchema;
+import de.tum.cit.aet.artemis.globalsearch.dto.WeaviateDateUtil;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.quiz.domain.QuizExercise;
@@ -132,6 +132,6 @@ public record ExerciseSearchableEntityDTO(Long exerciseId, Long courseId, String
     }
 
     private static String formatDate(ZonedDateTime dateTime) {
-        return dateTime != null ? dateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) : null;
+        return dateTime != null ? WeaviateDateUtil.format(dateTime) : null;
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/LectureSearchableEntityDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/LectureSearchableEntityDTO.java
@@ -1,11 +1,11 @@
 package de.tum.cit.aet.artemis.globalsearch.dto.searchableentity;
 
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
 import de.tum.cit.aet.artemis.globalsearch.config.schema.entityschemas.SearchableEntitySchema;
+import de.tum.cit.aet.artemis.globalsearch.dto.WeaviateDateUtil;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 
 /**
@@ -44,10 +44,10 @@ public record LectureSearchableEntityDTO(Long lectureId, Long courseId, String l
             properties.put(SearchableEntitySchema.Properties.DESCRIPTION, description);
         }
         if (startDate != null) {
-            properties.put(SearchableEntitySchema.Properties.START_DATE, startDate.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+            properties.put(SearchableEntitySchema.Properties.START_DATE, WeaviateDateUtil.format(startDate));
         }
         if (endDate != null) {
-            properties.put(SearchableEntitySchema.Properties.END_DATE, endDate.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+            properties.put(SearchableEntitySchema.Properties.END_DATE, WeaviateDateUtil.format(endDate));
         }
         return properties;
     }

--- a/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/LectureUnitSearchableEntityDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/LectureUnitSearchableEntityDTO.java
@@ -1,11 +1,11 @@
 package de.tum.cit.aet.artemis.globalsearch.dto.searchableentity;
 
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
 import de.tum.cit.aet.artemis.globalsearch.config.schema.entityschemas.SearchableEntitySchema;
+import de.tum.cit.aet.artemis.globalsearch.dto.WeaviateDateUtil;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
@@ -89,7 +89,7 @@ public record LectureUnitSearchableEntityDTO(Long lectureUnitId, Long courseId, 
             properties.put(SearchableEntitySchema.Properties.DESCRIPTION, description);
         }
         if (releaseDate != null) {
-            properties.put(SearchableEntitySchema.Properties.RELEASE_DATE, releaseDate.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+            properties.put(SearchableEntitySchema.Properties.RELEASE_DATE, WeaviateDateUtil.format(releaseDate));
         }
         return properties;
     }

--- a/src/main/java/de/tum/cit/aet/artemis/globalsearch/service/migration/V0ToV1Migration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/globalsearch/service/migration/V0ToV1Migration.java
@@ -1,6 +1,9 @@
 package de.tum.cit.aet.artemis.globalsearch.service.migration;
 
 import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -12,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.tum.cit.aet.artemis.globalsearch.config.schema.entityschemas.SearchableEntitySchema;
+import de.tum.cit.aet.artemis.globalsearch.dto.WeaviateDateUtil;
 import de.tum.cit.aet.artemis.globalsearch.service.WeaviateUuidUtil;
 import io.weaviate.client6.v1.api.WeaviateApiException;
 import io.weaviate.client6.v1.api.WeaviateClient;
@@ -221,8 +225,8 @@ public class V0ToV1Migration implements WeaviateMigration {
         for (String prop : DIRECT_MAPPINGS) {
             Object value = oldProps.get(prop);
             if (value != null) {
-                if (DATE_PROPERTIES.contains(prop) && value instanceof String dateStr) {
-                    value = normalizeRfc3339Date(dateStr);
+                if (DATE_PROPERTIES.contains(prop)) {
+                    value = normalizeRfc3339Date(value);
                 }
                 newProps.put(prop, value);
             }
@@ -237,19 +241,28 @@ public class V0ToV1Migration implements WeaviateMigration {
     }
 
     /**
-     * Ensures a date string has the seconds component required by RFC3339.
-     * Weaviate rejects dates like {@code 2026-04-24T20:25Z} — this method
-     * normalizes them to {@code 2026-04-24T20:25:00Z}.
+     * Ensures a date value is an RFC3339 string with the seconds component required by Weaviate.
+     * <p>
+     * The Weaviate client may return DATE-typed properties as {@link OffsetDateTime} or {@link ZonedDateTime}
+     * instead of {@link String}. Passing such objects through unchanged makes the client serialize them via
+     * {@code toString()}, which omits zero seconds (e.g. {@code 2026-04-24T20:25Z}) and is rejected by Weaviate
+     * with HTTP 422. String values may carry the same defect from the legacy v0 indexing code.
      *
-     * @param dateStr the date string from the legacy collection
+     * @param value the date value from the legacy collection
      * @return the normalized RFC3339 date string
      */
-    static String normalizeRfc3339Date(String dateStr) {
-        Matcher matcher = MISSING_SECONDS.matcher(dateStr);
-        if (matcher.find()) {
-            return matcher.replaceFirst("$1:00$2");
+    static Object normalizeRfc3339Date(Object value) {
+        if (value instanceof OffsetDateTime || value instanceof ZonedDateTime) {
+            return WeaviateDateUtil.format((TemporalAccessor) value);
         }
-        return dateStr;
+        if (value instanceof String dateStr) {
+            Matcher matcher = MISSING_SECONDS.matcher(dateStr);
+            if (matcher.find()) {
+                return matcher.replaceFirst("$1:00$2");
+            }
+            return dateStr;
+        }
+        return value;
     }
 
 }

--- a/src/main/java/de/tum/cit/aet/artemis/globalsearch/service/migration/V0ToV1Migration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/globalsearch/service/migration/V0ToV1Migration.java
@@ -251,18 +251,17 @@ public class V0ToV1Migration implements WeaviateMigration {
      * @param value the date value from the legacy collection
      * @return the normalized RFC3339 date string
      */
-    static Object normalizeRfc3339Date(Object value) {
+    static String normalizeRfc3339Date(Object value) {
         if (value instanceof OffsetDateTime || value instanceof ZonedDateTime) {
             return WeaviateDateUtil.format((TemporalAccessor) value);
         }
-        if (value instanceof String dateStr) {
-            Matcher matcher = MISSING_SECONDS.matcher(dateStr);
-            if (matcher.find()) {
-                return matcher.replaceFirst("$1:00$2");
-            }
-            return dateStr;
+        // Strings from the legacy v0 indexing code (and, defensively, any other type) get the missing-seconds repair
+        String dateStr = value.toString();
+        Matcher matcher = MISSING_SECONDS.matcher(dateStr);
+        if (matcher.find()) {
+            return matcher.replaceFirst("$1:00$2");
         }
-        return value;
+        return dateStr;
     }
 
 }

--- a/src/main/java/de/tum/cit/aet/artemis/globalsearch/service/migration/V0ToV1Migration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/globalsearch/service/migration/V0ToV1Migration.java
@@ -56,10 +56,10 @@ public class V0ToV1Migration implements WeaviateMigration {
 
     /**
      * Date properties that may need RFC3339 normalization during migration.
+     * Reuses the canonical set from {@link WeaviateDateUtil} so that newly added date properties
+     * are automatically covered without maintaining a separate list.
      */
-    private static final Set<String> DATE_PROPERTIES = Set.of(SearchableEntitySchema.Properties.RELEASE_DATE, SearchableEntitySchema.Properties.START_DATE,
-            SearchableEntitySchema.Properties.DUE_DATE, SearchableEntitySchema.Properties.EXAM_VISIBLE_DATE, SearchableEntitySchema.Properties.EXAM_START_DATE,
-            SearchableEntitySchema.Properties.EXAM_END_DATE);
+    private static final Set<String> DATE_PROPERTIES = WeaviateDateUtil.DATE_PROPERTY_KEYS;
 
     /**
      * Properties that kept the same name between the v0 {@code Exercises} and v1

--- a/src/test/java/de/tum/cit/aet/artemis/globalsearch/dto/WeaviateDateUtilTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/globalsearch/dto/WeaviateDateUtilTest.java
@@ -1,0 +1,30 @@
+package de.tum.cit.aet.artemis.globalsearch.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link WeaviateDateUtil}.
+ */
+class WeaviateDateUtilTest {
+
+    @Test
+    void format_keepsSecondsForExactMinuteTimes() {
+        // Weaviate requires full RFC3339 with seconds; formatters like ISO_OFFSET_DATE_TIME or toString()
+        // drop the seconds for exact-minute times, which Weaviate rejects with HTTP 422
+        ZonedDateTime date = ZonedDateTime.of(2026, 4, 23, 11, 0, 0, 0, ZoneOffset.UTC);
+
+        assertThat(WeaviateDateUtil.format(date)).isEqualTo("2026-04-23T11:00:00.000Z");
+    }
+
+    @Test
+    void format_includesOffsetForNonUtcZones() {
+        ZonedDateTime date = ZonedDateTime.of(2026, 4, 23, 11, 0, 0, 0, ZoneOffset.ofHours(2));
+
+        assertThat(WeaviateDateUtil.format(date)).isEqualTo("2026-04-23T11:00:00.000+02:00");
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/ExamSearchableEntityDTOTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/ExamSearchableEntityDTOTest.java
@@ -1,0 +1,28 @@
+package de.tum.cit.aet.artemis.globalsearch.dto.searchableentity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import de.tum.cit.aet.artemis.globalsearch.config.schema.entityschemas.SearchableEntitySchema;
+
+/**
+ * Unit tests for {@link ExamSearchableEntityDTO}.
+ */
+class ExamSearchableEntityDTOTest {
+
+    @Test
+    void toPropertyMap_keepsSecondsInDatesForExactMinuteTimes() {
+        // Weaviate requires full RFC3339 with seconds and rejects dates like "2026-04-23T11:00Z" with HTTP 422
+        ZonedDateTime startDate = ZonedDateTime.of(2026, 4, 23, 11, 0, 0, 0, ZoneOffset.UTC);
+        var dto = new ExamSearchableEntityDTO(1L, 2L, "Final Exam", null, null, startDate, null, false);
+
+        Map<String, Object> properties = dto.toPropertyMap();
+
+        assertThat(properties.get(SearchableEntitySchema.Properties.START_DATE)).isEqualTo("2026-04-23T11:00:00.000Z");
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/ExerciseSearchableEntityDTOTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/ExerciseSearchableEntityDTOTest.java
@@ -1,0 +1,29 @@
+package de.tum.cit.aet.artemis.globalsearch.dto.searchableentity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import de.tum.cit.aet.artemis.globalsearch.config.schema.entityschemas.SearchableEntitySchema;
+
+/**
+ * Unit tests for {@link ExerciseSearchableEntityDTO}.
+ */
+class ExerciseSearchableEntityDTOTest {
+
+    @Test
+    void toPropertyMap_keepsSecondsInDatesForExactMinuteTimes() {
+        // Weaviate requires full RFC3339 with seconds and rejects dates like "2026-04-23T11:00Z" with HTTP 422
+        ZonedDateTime startDate = ZonedDateTime.of(2026, 4, 23, 11, 0, 0, 0, ZoneOffset.UTC);
+        var dto = new ExerciseSearchableEntityDTO(1L, 2L, "Title", "programming", 5.0, "ts", null, null, startDate, null, null, false, null, null, null, null, null, null, null,
+                null, null, null, null, null);
+
+        Map<String, Object> properties = dto.toPropertyMap();
+
+        assertThat(properties.get(SearchableEntitySchema.Properties.START_DATE)).isEqualTo("2026-04-23T11:00:00.000Z");
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/LectureSearchableEntityDTOTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/LectureSearchableEntityDTOTest.java
@@ -1,0 +1,28 @@
+package de.tum.cit.aet.artemis.globalsearch.dto.searchableentity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import de.tum.cit.aet.artemis.globalsearch.config.schema.entityschemas.SearchableEntitySchema;
+
+/**
+ * Unit tests for {@link LectureSearchableEntityDTO}.
+ */
+class LectureSearchableEntityDTOTest {
+
+    @Test
+    void toPropertyMap_keepsSecondsInDatesForExactMinuteTimes() {
+        // Weaviate requires full RFC3339 with seconds and rejects dates like "2026-04-23T11:00Z" with HTTP 422
+        ZonedDateTime startDate = ZonedDateTime.of(2026, 4, 23, 11, 0, 0, 0, ZoneOffset.UTC);
+        var dto = new LectureSearchableEntityDTO(1L, 2L, "Lecture 1", null, startDate, null);
+
+        Map<String, Object> properties = dto.toPropertyMap();
+
+        assertThat(properties.get(SearchableEntitySchema.Properties.START_DATE)).isEqualTo("2026-04-23T11:00:00.000Z");
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/LectureUnitSearchableEntityDTOTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/globalsearch/dto/searchableentity/LectureUnitSearchableEntityDTOTest.java
@@ -1,0 +1,28 @@
+package de.tum.cit.aet.artemis.globalsearch.dto.searchableentity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import de.tum.cit.aet.artemis.globalsearch.config.schema.entityschemas.SearchableEntitySchema;
+
+/**
+ * Unit tests for {@link LectureUnitSearchableEntityDTO}.
+ */
+class LectureUnitSearchableEntityDTOTest {
+
+    @Test
+    void toPropertyMap_keepsSecondsInDatesForExactMinuteTimes() {
+        // Weaviate requires full RFC3339 with seconds and rejects dates like "2026-04-23T11:00Z" with HTTP 422
+        ZonedDateTime releaseDate = ZonedDateTime.of(2026, 4, 23, 11, 0, 0, 0, ZoneOffset.UTC);
+        var dto = new LectureUnitSearchableEntityDTO(1L, 2L, 3L, "Unit 1", null, "text", releaseDate);
+
+        Map<String, Object> properties = dto.toPropertyMap();
+
+        assertThat(properties.get(SearchableEntitySchema.Properties.RELEASE_DATE)).isEqualTo("2026-04-23T11:00:00.000Z");
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/globalsearch/service/migration/V0ToV1MigrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/globalsearch/service/migration/V0ToV1MigrationTest.java
@@ -2,6 +2,9 @@ package de.tum.cit.aet.artemis.globalsearch.service.migration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -216,6 +219,39 @@ class V0ToV1MigrationTest {
         Map<String, Object> newProps = V0ToV1Migration.transformProperties(oldProps);
 
         assertThat(newProps.get(SearchableEntitySchema.Properties.EXERCISE_TYPE)).isEqualTo("file-upload");
+    }
+
+    @Test
+    void transformProperties_normalizesSecondlessStringDates() {
+        Map<String, Object> oldProps = minimalV0Properties();
+        oldProps.put("start_date", "2026-04-23T11:00Z");
+
+        Map<String, Object> newProps = V0ToV1Migration.transformProperties(oldProps);
+
+        assertThat(newProps.get(SearchableEntitySchema.Properties.START_DATE)).isEqualTo("2026-04-23T11:00:00Z");
+    }
+
+    @Test
+    void transformProperties_normalizesOffsetDateTimeDates() {
+        // The Weaviate client can return DATE-typed properties as OffsetDateTime instead of String. Passing the object
+        // through unchanged makes the client serialize it via toString(), which drops zero seconds
+        // (e.g. "2026-04-23T11:00Z") and is rejected by Weaviate with HTTP 422 (observed on production with release 9.4).
+        Map<String, Object> oldProps = minimalV0Properties();
+        oldProps.put("start_date", OffsetDateTime.of(2026, 4, 23, 11, 0, 0, 0, ZoneOffset.UTC));
+
+        Map<String, Object> newProps = V0ToV1Migration.transformProperties(oldProps);
+
+        assertThat(newProps.get(SearchableEntitySchema.Properties.START_DATE)).isEqualTo("2026-04-23T11:00:00.000Z");
+    }
+
+    @Test
+    void transformProperties_normalizesZonedDateTimeDates() {
+        Map<String, Object> oldProps = minimalV0Properties();
+        oldProps.put("exam_start_date", ZonedDateTime.of(2026, 4, 23, 11, 0, 0, 0, ZoneOffset.UTC));
+
+        Map<String, Object> newProps = V0ToV1Migration.transformProperties(oldProps);
+
+        assertThat(newProps.get(SearchableEntitySchema.Properties.EXAM_START_DATE)).isEqualTo("2026-04-23T11:00:00.000Z");
     }
 
     @Test


### PR DESCRIPTION
### Summary
On 9.4, the Weaviate v0→v1 search migration failed for **every affected exercise on each node start** with `HTTP 422: invalid date property 'start_date' ... '2026-04-23T11:00Z' is not RFC3339`, leaving those exercises missing from global search and the legacy collection never cleaned up. Weaviate requires the seconds component in RFC3339 dates; two write paths produced second-less strings for exact-minute times. Both are fixed by funneling all date formatting through `WeaviateDateUtil`.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
Since the 9.4 deployment, every Artemis node logs `V0→V1: Migration failed for <n> exercises. Aborting cleanup to prevent data loss.` on startup, preceded by one warning per exercise like `invalid date property 'start_date' ... requires a string with a RFC3339 formatted date, but the given value is '2026-04-23T11:00Z'`. Until fixed, global search misses these exercises, the legacy `Exercises` collection is never deleted, and the error recurs on every restart.

### Description
Root cause (verified against the io.weaviate `client6` 6.2.1 sources):
1. **Migration path:** `fetchObjects` returns DATE properties as `OffsetDateTime` (gRPC read path), never as `String`. The migration's normalization only handled `String` values, so the objects passed through unchanged; on insert, the client serializes `OffsetDateTime` via `toString()` (Gson adapter), which omits zero seconds, e.g. `2026-04-23T11:00Z`, which Weaviate rejects.
2. **Fresh indexing path:** the searchable-entity DTOs (exercise, exam, lecture, lecture unit) formatted dates with `DateTimeFormatter.ISO_OFFSET_DATE_TIME`, which also omits zero seconds, so indexing any entity with an exact-minute date would hit the same 422.

Fix:
- `WeaviateDateUtil` exposes a `format(TemporalAccessor)` using its existing pattern that always emits seconds (`yyyy-MM-dd'T'HH:mm:ss.SSSXXX`).
- `V0ToV1Migration.normalizeRfc3339Date` now handles `OffsetDateTime`/`ZonedDateTime` via that formatter and keeps the regex repair for legacy `String` values.
- All four DTOs format dates via `WeaviateDateUtil.format` instead of `ISO_OFFSET_DATE_TIME`.

The format change is read-compatible: the search read path already normalizes all date properties to this exact format (`WeaviateDateUtil.normalizeDateProperties`), Weaviate date range filters compare instants (precision-neutral), and the client parses the values with dayjs.

The migration retries on every startup, so after deploying this fix the 252 missing exercises are migrated and the legacy collection is cleaned up automatically; no manual re-indexing is needed.

### Steps for Testing
Prerequisites: 1 Instructor, local setup with Weaviate (e.g. via the global search docker profile)

1. Create or edit an exercise with a release/start/due date at an exact minute (seconds = 00, e.g. 11:00:00)
2. Verify the server logs show no Weaviate 422 errors and the exercise appears in global search
3. Same for an exam and a lecture with exact-minute dates
4. (Migration) With a pre-9.4 `Exercises` collection present, start the server and verify `V0→V1: Data migration complete — migrated: n, skipped: 0, failed: 0` and that the legacy collection is deleted

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized ISO 8601/RFC3339 date formatting with milliseconds across exports.
  * Date normalization now preserves seconds and milliseconds and correctly handles dates from varied input types (string and datetime).

* **Tests**
  * Added comprehensive tests covering date formatting, serialization, and migration/normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->