### PR TITLE
`Development`: Update DB changes approval guidelines

### DIFF
--- a/documentation/docs/developer/guidelines/database.mdx
+++ b/documentation/docs/developer/guidelines/database.mdx
@@ -113,7 +113,7 @@ Please prepare for the meeting and enter your PR and a short description of the 
 ### Approval Process
 
 - **Mandatory Review:** Every change affecting the database or configuration must be explicitly discussed and approved during the weekly meeting. Final approval is granted by [Stephan Krusche](https://github.com/krusche) or [Patrick Bassner](https://github.com/bassner).
-- **Deployment Restrictions:** Database-affecting deployments cannot proceed without prior approval from designated reviewers to ensure accountability and prevent unauthorized changes. For test server deployments, approval is required from [Phoebe Morrien](https://github.com/Hialus) or [Benjamin Schmitz](https://github.com/bensofficial).
+- **Deployment Restrictions:** Database-affecting deployments cannot proceed without prior approval from designated reviewers to ensure accountability and prevent unauthorized changes. For test server deployments, approval is required from [Benjamin Schmitz](https://github.com/bensofficial).
 
 ### Database Review Guidelines
 


### PR DESCRIPTION
### Summary
Remove an outdated approver from the database deployment approval guidelines so test server deployment approvals are routed only to currently responsible reviewers.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
The approver list in the database guidelines was out of date and could mislead contributors about who to request approval from for database-affecting test server deployments.

### Description
Updated `documentation/docs/developer/guidelines/database.mdx` — the entry for one of the listed test-server approvers was outdated, so it has been removed. Test server database-affecting deployments now require approval from Benjamin Schmitz only.

### Steps for Testing
1. Open `documentation/docs/developer/guidelines/database.mdx`.
2. Locate the **Approval Process** section.
3. Verify the **Deployment Restrictions** bullet lists only Benjamin Schmitz as the test server approver.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

