### PR TITLE
`Adaptive learning`: Fix potentially incorrect results when searching in the competency import dialog

### DIFF
--- a/src/main/webapp/app/atlas/manage/import-list/import-table.component.spec.ts
+++ b/src/main/webapp/app/atlas/manage/import-list/import-table.component.spec.ts
@@ -3,7 +3,7 @@ import '@angular/localize/init';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PagingService } from 'app/exercise/services/paging.service';
 import { Course } from 'app/course/shared/entities/course.model';
-import { Observable, of } from 'rxjs';
+import { Observable, Subject, of } from 'rxjs';
 import { SearchResult, SortingOrder } from 'app/foundation/pagination/pageable-table';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
@@ -205,6 +205,34 @@ describe('ImportTableComponent', () => {
         await fixture.whenStable();
 
         expect(errorSpy).toHaveBeenCalledOnce();
+    });
+
+    it('should discard a stale out-of-order search response', async () => {
+        // Reproduces the race the guard in loadData() fixes: an earlier request (e.g. the initial unfiltered
+        // load) and a newer request (a search term the user typed) are both in flight. The newer request
+        // resolves first and is applied; the slower earlier request must NOT overwrite it afterwards.
+        const loadData = () => (component as unknown as { loadData: () => Promise<void> }).loadData();
+        const staleResponse = new Subject<SearchResult<Course>>();
+        const currentResponse = new Subject<SearchResult<Course>>();
+        searchSpy.mockReturnValueOnce(staleResponse).mockReturnValueOnce(currentResponse);
+
+        // Earlier request issued with the default empty search term.
+        const stalePromise = loadData();
+        // The user types: a newer request is issued with a different search term.
+        component.searchTerm.set('Object 02');
+        const currentPromise = loadData();
+
+        // The newer request resolves first and is applied.
+        currentResponse.next(<SearchResult<Course>>{ resultsOnPage: [objectList[1]], numberOfPages: 1 });
+        currentResponse.complete();
+        await currentPromise;
+        expect(component.resultsOnPage()).toEqual([objectList[1]]);
+
+        // The slower earlier request resolves afterwards and must be discarded, not applied.
+        staleResponse.next(<SearchResult<Course>>{ resultsOnPage: objectList, numberOfPages: 2 });
+        staleResponse.complete();
+        await stalePromise;
+        expect(component.resultsOnPage()).toEqual([objectList[1]]);
     });
 
     async function loadDataAndClickColumn(columnIndex: number, timesClicking: number, compareSortedColumn: string, compareSortingOrder: SortingOrder, compareCellContent: string) {

--- a/src/main/webapp/app/atlas/manage/import-list/import-table.component.ts
+++ b/src/main/webapp/app/atlas/manage/import-list/import-table.component.ts
@@ -71,6 +71,14 @@ export class ImportTableComponent<T extends BaseEntity> {
         });
     }
 
+    /**
+     * Runs the current paginated search and applies its result to the table.
+     *
+     * Several searches can be in flight simultaneously (the initial unfiltered load plus debounced loads
+     * issued while typing) and their responses may return out of order. A response is therefore only applied
+     * when the search state it was issued with still matches the current state; otherwise a newer request has
+     * superseded it and the stale response is discarded so the table never shows results for an old query.
+     */
     private async loadData(): Promise<void> {
         try {
             this.isLoading.set(true);
@@ -82,11 +90,7 @@ export class ImportTableComponent<T extends BaseEntity> {
                 pageSize: this.pageSize(),
             };
             const result = await lastValueFrom(this.pagingService.search(searchState));
-            // Discard stale / out-of-order responses. Several searches can be in flight at once: the initial
-            // unfiltered load triggered by the constructor effect plus debounced loads issued as the user types.
-            // Their responses can return out of order, and a slower earlier (e.g. unfiltered) response must not
-            // overwrite the results for the current search term. Only apply a response whose request still
-            // matches the current search state; otherwise a newer request has already superseded it.
+            // A newer request has superseded this one; discard its (now stale) response.
             if (
                 searchState.searchTerm !== this.searchTerm() ||
                 searchState.page !== this.page() ||

--- a/src/main/webapp/app/atlas/manage/import-list/import-table.component.ts
+++ b/src/main/webapp/app/atlas/manage/import-list/import-table.component.ts
@@ -82,6 +82,19 @@ export class ImportTableComponent<T extends BaseEntity> {
                 pageSize: this.pageSize(),
             };
             const result = await lastValueFrom(this.pagingService.search(searchState));
+            // Discard stale / out-of-order responses. Several searches can be in flight at once: the initial
+            // unfiltered load triggered by the constructor effect plus debounced loads issued as the user types.
+            // Their responses can return out of order, and a slower earlier (e.g. unfiltered) response must not
+            // overwrite the results for the current search term. Only apply a response whose request still
+            // matches the current search state; otherwise a newer request has already superseded it.
+            if (
+                searchState.searchTerm !== this.searchTerm() ||
+                searchState.page !== this.page() ||
+                searchState.sortedColumn !== this.sortedColumn() ||
+                searchState.sortingOrder !== this.sortingOrder()
+            ) {
+                return;
+            }
             const filteredResults = this.filterSearchResult(result);
             this.searchResult.set(filteredResults);
         } catch (error) {


### PR DESCRIPTION
### Summary

When importing competencies from another course, the search field in the import dialog could briefly show the wrong results — typically the full, unfiltered list instead of the entries matching what was just typed. This was a client-side race between concurrent search requests whose responses returned out of order. This PR makes the import table always display the results for the most recent search.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the client coding guidelines.
- [x] I added integration tests (Vitest) related to the feature (with a high test coverage), while following the test guidelines.

### Motivation and Context

ImportTableComponent issues a paginated search whenever the page loads, the user types, or sorting/paging changes. Multiple of these requests can be in flight at the same time — most commonly the initial unfiltered load triggered on init plus a debounced load issued while the user is typing. The responses are not guaranteed to arrive in the order the requests were sent: a slower earlier response (e.g. the unfiltered list) could resolve after a newer one and overwrite the freshly filtered results, so the table showed entries that did not match the current search term.

This manifested as intermittent failures of the CompetencyImport E2E test and, for users, as the competency import dialog occasionally listing competencies that did not match what they had typed.

### Description

In loadData(), after a search response resolves, the component now compares the search state the request was issued with (searchTerm, page, sortedColumn, sortingOrder) against the component's current state. If they no longer match, a newer request has already superseded this one, so the stale response is discarded instead of being applied. pageSize is not compared because it is a read-only constant.

No additional REST calls are introduced; the guard only decides whether an already-received response is still relevant.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 2 Courses, the second containing several competencies with varied titles

1. Log in as the instructor.
2. Open the target course, then Competency Management, then Import.
3. In the import dialog, type a search term quickly (a few characters) into the search field.
4. Verify that the table only ever shows competencies matching the current search term — it must never flash back to the full, unfiltered list after a search.
5. Repeat with sorting and paging while typing; the displayed rows must always correspond to the latest interaction.

### Testserver States
You can manage test servers using Helios. Check environment statuses in the environment list. To deploy to a test server, go to the CI/CD page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/27558369071) did not pass (`failure`). Coverage below may be partial.

#### Client

Coverage data not found. Run tests first or check if coverage-summary.json exists.

_Last updated: 2026-06-15 17:55:46 UTC_

