### PR TITLE
`Exam mode`: Fix free text exam summary showing the last exercise for all

### DIFF
--- a/src/main/webapp/app/text/overview/text-editor/text-editor.component.spec.ts
+++ b/src/main/webapp/app/text/overview/text-editor/text-editor.component.spec.ts
@@ -21,6 +21,7 @@ import { TextEditorComponent } from 'app/text/overview/text-editor/text-editor.c
 import { textEditorRoute } from 'app/text/overview/text-editor.route';
 import { TextExercise } from 'app/text/shared/entities/text-exercise.model';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
+import { ParticipationWebsocketService } from 'app/course/shared/services/participation-websocket.service';
 import { ButtonComponent } from 'app/shared-ui/components/buttons/button/button.component';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { ComplaintsFormComponent } from 'app/assessment/overview/complaint-form/complaints-form.component';
@@ -179,6 +180,34 @@ describe('TextEditorComponent', () => {
         expect(updateParticipationSpy).not.toHaveBeenCalled();
         expect(setupComponentWithInputValuesSpy).toHaveBeenCalled();
         expect(comp.answer()).toBeDefined();
+    });
+
+    it('should ignore participation changes that belong to a different participation', () => {
+        // Regression test: subscribeForParticipationChanges() is backed by a single app-wide BehaviorSubject.
+        // When several text editors are rendered together (e.g. multiple text exercises in the exam summary),
+        // an emission for another participation must not overwrite this instance's state.
+        fixture.componentRef.setInput('inputExercise', textExercise);
+        fixture.componentRef.setInput('inputParticipation', participation);
+        fixture.componentRef.setInput('inputSubmission', { id: 1, text: 'test' });
+        fixture.detectChanges();
+
+        // @ts-ignore updateParticipation is private
+        const updateParticipationSpy = vi.spyOn(comp, 'updateParticipation').mockImplementation(() => {});
+        const participationSubject = TestBed.inject(ParticipationWebsocketService).subscribeForParticipationChanges();
+
+        const otherParticipation = new StudentParticipation();
+        otherParticipation.id = 99;
+        otherParticipation.exercise = { id: 2 } as TextExercise;
+        otherParticipation.submissions = [new TextSubmission()];
+        participationSubject.next(otherParticipation);
+
+        expect(updateParticipationSpy).not.toHaveBeenCalled();
+
+        // an emission for our own participation must still be applied
+        participationSubject.next(participation);
+        expect(updateParticipationSpy).toHaveBeenCalledExactlyOnceWith(participation, undefined, undefined);
+
+        fixture.destroy();
     });
 
     it('should not allow to submit after the due date if there is no due date', async () => {

--- a/src/main/webapp/app/text/overview/text-editor/text-editor.component.spec.ts
+++ b/src/main/webapp/app/text/overview/text-editor/text-editor.component.spec.ts
@@ -210,6 +210,60 @@ describe('TextEditorComponent', () => {
         fixture.destroy();
     });
 
+    it('should not be overwritten by a sibling text editor for a different participation (multi-instance)', () => {
+        // The actual reported bug: several text editors render together in the exam summary and share the app-wide
+        // participation-change subject. When a sibling editor initializes (addParticipation), its emission must not
+        // overwrite this editor's exercise/submission.
+        fixture.componentRef.setInput('inputExercise', textExercise);
+        fixture.componentRef.setInput('inputParticipation', participation);
+        fixture.componentRef.setInput('inputSubmission', { id: 1, text: 'A' });
+        fixture.detectChanges();
+        expect(comp.textExercise().id).toBe(1);
+        expect(comp.submission().id).toBe(1);
+
+        // A second editor for a DIFFERENT text exercise/participation initializes and pushes its participation.
+        const fixture2 = TestBed.createComponent(TextEditorComponent);
+        const otherExercise = { id: 2 } as TextExercise;
+        const otherParticipation = new StudentParticipation();
+        otherParticipation.id = 99;
+        otherParticipation.exercise = otherExercise;
+        otherParticipation.submissions = [{ id: 5, text: 'B' } as TextSubmission];
+        fixture2.componentRef.setInput('inputExercise', otherExercise);
+        fixture2.componentRef.setInput('inputParticipation', otherParticipation);
+        fixture2.componentRef.setInput('inputSubmission', { id: 5, text: 'B' });
+        fixture2.detectChanges();
+
+        // This editor must still show its own exercise/submission, not the sibling's.
+        expect(comp.textExercise().id).toBe(1);
+        expect(comp.submission().id).toBe(1);
+
+        fixture2.destroy();
+        fixture.destroy();
+    });
+
+    it('should apply a participation-change emission with the same id but a different object reference', () => {
+        // Real result updates arrive as a different object (the cached clone) with the same participation id. The guard
+        // must compare by id, not by reference, so such own-participation updates are still applied.
+        fixture.componentRef.setInput('inputExercise', textExercise);
+        fixture.componentRef.setInput('inputParticipation', participation);
+        fixture.componentRef.setInput('inputSubmission', { id: 1, text: 'test' });
+        fixture.detectChanges();
+
+        // @ts-ignore updateParticipation is private
+        const updateParticipationSpy = vi.spyOn(comp, 'updateParticipation').mockImplementation(() => {});
+        const participationSubject = TestBed.inject(ParticipationWebsocketService).subscribeForParticipationChanges();
+
+        const sameIdDifferentObject = new StudentParticipation();
+        sameIdDifferentObject.id = participation.id; // 42 - same participation, different object
+        sameIdDifferentObject.exercise = textExercise;
+        sameIdDifferentObject.submissions = [new TextSubmission()];
+        participationSubject.next(sameIdDifferentObject);
+
+        expect(updateParticipationSpy).toHaveBeenCalledExactlyOnceWith(sameIdDifferentObject, undefined, undefined);
+
+        fixture.destroy();
+    });
+
     it('should not allow to submit after the due date if there is no due date', async () => {
         const participationSubject = new BehaviorSubject<StudentParticipation>(participation);
         getTextForParticipationStub.mockReturnValue(participationSubject);

--- a/src/main/webapp/app/text/overview/text-editor/text-editor.component.ts
+++ b/src/main/webapp/app/text/overview/text-editor/text-editor.component.ts
@@ -197,6 +197,15 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
             .subscribeForParticipationChanges()
             .pipe(skip(1))
             .subscribe((changedParticipation: StudentParticipation) => {
+                // subscribeForParticipationChanges() is backed by a single app-wide BehaviorSubject, so every
+                // text-editor instance receives every participation change (including the ones emitted by other
+                // instances when they call addParticipation()). Without this guard, multiple editors rendered
+                // together - e.g. several text exercises in the exam result summary - would all overwrite their
+                // own exercise/submission state with whichever participation was added last, making every text
+                // summary display the last exercise. Only react to changes for our own participation.
+                if (changedParticipation?.id !== this.participation()?.id) {
+                    return;
+                }
                 const results = changedParticipation.submissions?.flatMap((submission) => submission.results ?? []) || [];
                 const oldResults = this.participation().submissions?.flatMap((submission) => submission.results ?? []) || [];
                 const lastResult = results?.last();

--- a/src/test/playwright/e2e/exam/ExamTextSummaryIsolation.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamTextSummaryIsolation.spec.ts
@@ -1,0 +1,136 @@
+import { test } from '../../support/fixtures';
+import { Exam } from 'app/exam/shared/entities/exam.model';
+import { expect } from '@playwright/test';
+import { admin, studentTwo } from '../../support/users';
+import { generateUUID, getExercise } from '../../support/utils';
+import dayjs from 'dayjs';
+import { TextExercise } from 'app/text/shared/entities/text-exercise.model';
+import { ExamAPIRequests } from '../../support/requests/ExamAPIRequests';
+import { SEED_COURSES } from '../../support/seedData';
+import textExerciseTemplate from '../../fixtures/exercise/text/template.json';
+
+/**
+ * CRITICAL REGRESSION TEST: free-text exam summary isolation (issue #12937).
+ *
+ * This test guards against a production bug where, with multiple free-text (TEXT) exercises in an exam,
+ * the student summary showed the problem statement and answer of only the LAST text exercise for EVERY
+ * text exercise. Assessment and the database were correct; the bug was purely in the summary UI.
+ *
+ * Root cause: every <jhi-text-editor> instance subscribed to the app-wide shared participation
+ * BehaviorSubject (ParticipationWebsocketService.subscribeForParticipationChanges) and applied EVERY
+ * emission to its own state. When the last editor called addParticipation(...) on init, that emission
+ * overwrote the exercise + submission of all the other editors, so every text summary converged on the
+ * last exercise. The fix makes each editor ignore participation changes that are not its own.
+ *
+ * This test creates 3 TEXT exercises with DISTINCT problem statements and the student types a DISTINCT
+ * answer into each. On the summary it verifies that each exercise shows its OWN answer and problem
+ * statement, not another exercise's. Before the fix, exercises A and B would show exercise C's content.
+ */
+
+// Distinct, easily distinguishable markers so cross-contamination is unambiguous.
+const PROBLEM_STATEMENT_A = '# Exercise Alpha\n\nALPHA_PROBLEM_STATEMENT_MARKER: describe the alpha algorithm.';
+const PROBLEM_STATEMENT_B = '# Exercise Beta\n\nBETA_PROBLEM_STATEMENT_MARKER: describe the beta algorithm.';
+const PROBLEM_STATEMENT_C = '# Exercise Gamma\n\nGAMMA_PROBLEM_STATEMENT_MARKER: describe the gamma algorithm.';
+
+const ANSWER_A = 'ALPHA_ANSWER_MARKER: my answer to the alpha exercise.';
+const ANSWER_B = 'BETA_ANSWER_MARKER: my answer to the beta exercise.';
+const ANSWER_C = 'GAMMA_ANSWER_MARKER: my answer to the gamma exercise.';
+
+const course = { id: SEED_COURSES.examParticipation.id } as any;
+
+test.describe('Exam free-text summary isolation', { tag: '@slow' }, () => {
+    let exam: Exam;
+    let exerciseA: TextExercise;
+    let exerciseB: TextExercise;
+    let exerciseC: TextExercise;
+    let groupTitleA: string;
+    let groupTitleB: string;
+    let groupTitleC: string;
+
+    test.beforeEach('Create exam with 3 text exercises', async ({ login, examAPIRequests, exerciseAPIRequests }) => {
+        await login(admin);
+
+        exam = await createExam(course, examAPIRequests, {
+            title: 'Text Summary Isolation ' + generateUUID(),
+            examMaxPoints: 30,
+            numberOfExercisesInExam: 3,
+        });
+
+        // Create 3 exercise groups with text exercises, each with a DISTINCT problem statement.
+        groupTitleA = 'Group Alpha ' + generateUUID();
+        const exerciseGroupA = await examAPIRequests.addExerciseGroupForExam(exam, groupTitleA);
+        exerciseA = await exerciseAPIRequests.createTextExercise({ exerciseGroup: exerciseGroupA }, 'Exercise Alpha ' + generateUUID(), {
+            ...textExerciseTemplate,
+            problemStatement: PROBLEM_STATEMENT_A,
+        });
+
+        groupTitleB = 'Group Beta ' + generateUUID();
+        const exerciseGroupB = await examAPIRequests.addExerciseGroupForExam(exam, groupTitleB);
+        exerciseB = await exerciseAPIRequests.createTextExercise({ exerciseGroup: exerciseGroupB }, 'Exercise Beta ' + generateUUID(), {
+            ...textExerciseTemplate,
+            problemStatement: PROBLEM_STATEMENT_B,
+        });
+
+        groupTitleC = 'Group Gamma ' + generateUUID();
+        const exerciseGroupC = await examAPIRequests.addExerciseGroupForExam(exam, groupTitleC);
+        exerciseC = await exerciseAPIRequests.createTextExercise({ exerciseGroup: exerciseGroupC }, 'Exercise Gamma ' + generateUUID(), {
+            ...textExerciseTemplate,
+            problemStatement: PROBLEM_STATEMENT_C,
+        });
+
+        await examAPIRequests.registerStudentForExam(exam, studentTwo);
+        await examAPIRequests.generateMissingIndividualExams(exam);
+        await examAPIRequests.prepareExerciseStartForExam(exam);
+    });
+
+    test('shows each text exercise its own problem statement and answer in the summary', async ({ page, examParticipation, examNavigation, examStartEnd, textExerciseEditor }) => {
+        await examParticipation.startParticipation(studentTwo, course, exam);
+
+        // Type a DISTINCT answer into each text exercise. Opening the next exercise triggers a save of the previous one.
+        await examNavigation.openOrSaveExerciseByTitle(groupTitleA);
+        await textExerciseEditor.typeSubmission(exerciseA.id!, ANSWER_A);
+        await examNavigation.openOrSaveExerciseByTitle(groupTitleB);
+        await textExerciseEditor.typeSubmission(exerciseB.id!, ANSWER_B);
+        await examNavigation.openOrSaveExerciseByTitle(groupTitleC);
+        await textExerciseEditor.typeSubmission(exerciseC.id!, ANSWER_C);
+
+        await examParticipation.handInEarly();
+        await examStartEnd.pressShowSummary();
+
+        // Each exercise must show its OWN answer in its OWN summary card (scoped via #exercise-{id}).
+        // Before the fix, every text editor showed the LAST exercise's answer (ANSWER_C) here.
+        await expect(getExercise(page, exerciseA.id!).locator('#text-editor')).toHaveValue(ANSWER_A, { timeout: 20000 });
+        await expect(getExercise(page, exerciseB.id!).locator('#text-editor')).toHaveValue(ANSWER_B, { timeout: 20000 });
+        await expect(getExercise(page, exerciseC.id!).locator('#text-editor')).toHaveValue(ANSWER_C, { timeout: 20000 });
+
+        // Each exercise must also show its OWN problem statement (and not another exercise's), which the
+        // shared-subject bug equally corrupted.
+        await expect(getExercise(page, exerciseA.id!).locator('.markdown-preview')).toContainText('ALPHA_PROBLEM_STATEMENT_MARKER', { timeout: 20000 });
+        await expect(getExercise(page, exerciseB.id!).locator('.markdown-preview')).toContainText('BETA_PROBLEM_STATEMENT_MARKER', { timeout: 20000 });
+        await expect(getExercise(page, exerciseC.id!).locator('.markdown-preview')).toContainText('GAMMA_PROBLEM_STATEMENT_MARKER', { timeout: 20000 });
+
+        // Explicit cross-contamination guard: A's problem-statement panel must not contain B's or C's markers.
+        // (#exercise-{id} intentionally matches both the summary card and the nested text-editor div, so scope the
+        // negative check to the unique .markdown-preview to avoid a strict-mode multiple-element match.)
+        await expect(getExercise(page, exerciseA.id!).locator('.markdown-preview')).not.toContainText('BETA_PROBLEM_STATEMENT_MARKER');
+        await expect(getExercise(page, exerciseA.id!).locator('.markdown-preview')).not.toContainText('GAMMA_PROBLEM_STATEMENT_MARKER');
+    });
+
+    test.afterEach('Delete exam', async ({ login, examAPIRequests }) => {
+        await login(admin);
+        await examAPIRequests.deleteExam(exam);
+    });
+});
+
+async function createExam(course: any, examAPIRequests: ExamAPIRequests, customExamConfig?: any) {
+    const defaultExamConfig = {
+        course,
+        title: 'exam' + generateUUID(),
+        visibleDate: dayjs().subtract(3, 'minutes'),
+        startDate: dayjs().subtract(2, 'minutes'),
+        endDate: dayjs().add(1, 'hour'),
+        examMaxPoints: 10,
+        numberOfExercisesInExam: 1,
+    };
+    return await examAPIRequests.createExam({ ...defaultExamConfig, ...customExamConfig });
+}


### PR DESCRIPTION
### Summary

In an exam result summary with **multiple text (free-text) exercises**, every text exercise displayed the problem statement and answer of only the **last** text exercise. Assessment and database entries were correct, so this was a pure UI bug. Reported by an instructor during live exams (v9.3; root cause still present on `develop`).

### Motivation and Context

`ParticipationWebsocketService.subscribeForParticipationChanges()` exposes a **single, app-wide `BehaviorSubject`** (`providedIn: 'root'`). Each `<jhi-text-editor>` instance both:

1. pushes its own participation onto that subject on init (`addParticipation()` → `participationObservable.next(...)`), and
2. subscribes to the same subject and runs `updateParticipation(changedParticipation)`, overwriting its own `textExercise`/`submission` state on every emission.

When several text editors are rendered together (one per text exercise in the exam result summary), the **last** `addParticipation()` emits the last participation to **all** instances, so every editor converged on the last exercise.

### Description

Guard the `subscribeForParticipationChanges()` subscriber in `text-editor.component.ts` so each editor only reacts to changes for **its own** participation (`changedParticipation?.id === this.participation()?.id`). Legitimate result updates for the editor's own participation are still applied; emissions for other participations are ignored. Low-risk, targeted change.

### Steps for Testing

Prerequisites:
- 1 Exam with **≥ 2 text (free-text) exercises**
- 1 Student with submissions to each text exercise

1. As the student, submit different answers to each text exercise.
2. Open the exam result summary.
3. Verify each text exercise shows **its own** problem statement and submitted answer (previously all showed the last exercise's).

### Verification
- Added a Vitest regression test asserting an emission for a different participation id is ignored while the own participation is still applied. Full `text-editor.component.spec.ts` suite passes (31 tests). ESLint clean.

> Note (draft): needs a linked issue, test-server verification, and a screenshot of the multi-text-exercise summary before marking ready for review. The same shared-subject pattern may warrant a defensive check in sibling exam-summary editors (modeling/file-upload) as a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented interference between multiple text editor instances by ignoring websocket participation updates that don’t match the current participation for that instance.
* **Tests**
  * Added end-to-end regression coverage to verify free-text exam summary isolation across multiple separate text exercises, including checks that prevent cross-exercise marker leakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->