### PR TITLE
`Quiz exercises`: Fix a potential issue with multiple choice answer loss

### DIFF
--- a/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.spec.ts
+++ b/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.spec.ts
@@ -223,7 +223,7 @@ describe('MultipleChoiceQuestionComponent', () => {
         component.toggleSelection(answerOptions[2]);
 
         expect(emitted).toBeDefined();
-        const emittedIds = emitted!.map((option) => option.id).sort();
+        const emittedIds = emitted!.map((option) => option.id).sort((a, b) => (a ?? 0) - (b ?? 0));
         expect(emittedIds).toEqual([1, 2, 3]);
     });
 
@@ -257,8 +257,8 @@ describe('MultipleChoiceQuestionComponent', () => {
         component.toggleSelection(answerOptions[3]);
 
         expect(emissions).toHaveLength(2);
-        expect(emissions[0].map((o) => o.id).sort()).toEqual([1, 2, 3]);
-        expect(emissions[1].map((o) => o.id).sort()).toEqual([1, 2, 3, 4]);
+        expect(emissions[0].map((o) => o.id).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([1, 2, 3]);
+        expect(emissions[1].map((o) => o.id).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([1, 2, 3, 4]);
     });
 
     it('should reset the working copy when the input changes, then build on the new input', () => {
@@ -285,13 +285,13 @@ describe('MultipleChoiceQuestionComponent', () => {
         component.selectedAnswerOptionsChange.subscribe((v) => (emitted = v));
 
         component.toggleSelection(answerOptions[1]);
-        expect(emitted!.map((o) => o.id).sort()).toEqual([1, 2]);
+        expect(emitted!.map((o) => o.id).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([1, 2]);
 
         // The authoritative input is replaced (e.g. a reload restoring only option 3); the next toggle must build on it.
         fixture.componentRef.setInput('selectedAnswerOptions', [answerOptions[2]]);
         fixture.changeDetectorRef.detectChanges();
         component.toggleSelection(answerOptions[0]);
-        expect(emitted!.map((o) => o.id).sort()).toEqual([1, 3]);
+        expect(emitted!.map((o) => o.id).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([1, 3]);
     });
 
     it('should remove a pre-existing option when toggled off (multi-select)', () => {

--- a/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.spec.ts
+++ b/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.spec.ts
@@ -191,6 +191,42 @@ describe('MultipleChoiceQuestionComponent', () => {
         expect(component.isAnswerOptionSelected(answerOptions[1])).toBe(false);
     });
 
+    it('should keep pre-existing selections when adding another option (multi-select)', () => {
+        // Regression test for answer loss in exams: when the component is initialized with
+        // already-selected options (e.g. a resumed exam, a page reload, or a recreated
+        // component after hand-in-early), selecting a further option must keep the existing
+        // selections instead of replacing them with only the newly clicked one.
+        const answerOptions: AnswerOption[] = [
+            { id: 1, invalid: false },
+            { id: 2, invalid: false },
+            { id: 3, invalid: false },
+        ];
+
+        const question: MultipleChoiceQuestion = {
+            text: 'some-text',
+            exportQuiz: false,
+            randomizeOrder: true,
+            invalid: false,
+            answerOptions,
+            scoringType: ScoringType.ALL_OR_NOTHING,
+        };
+
+        fixture.componentRef.setInput('question', question);
+        // Pre-existing selections, as if loaded from a previously saved submission.
+        fixture.componentRef.setInput('selectedAnswerOptions', [answerOptions[0], answerOptions[1]]);
+        fixture.changeDetectorRef.detectChanges();
+
+        let emitted: AnswerOption[] | undefined;
+        component.selectedAnswerOptionsChange.subscribe((v) => (emitted = v));
+
+        // Add a third option.
+        component.toggleSelection(answerOptions[2]);
+
+        expect(emitted).toBeDefined();
+        const emittedIds = emitted!.map((option) => option.id).sort();
+        expect(emittedIds).toEqual([1, 2, 3]);
+    });
+
     it('should toggle answer options, but only allow one to be selected for single choice questions', () => {
         const answerOptions: AnswerOption[] = [
             { id: 1, invalid: false },

--- a/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.spec.ts
+++ b/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.spec.ts
@@ -227,6 +227,172 @@ describe('MultipleChoiceQuestionComponent', () => {
         expect(emittedIds).toEqual([1, 2, 3]);
     });
 
+    it('should accumulate rapid successive toggles before the input round-trips (no answer loss)', () => {
+        // In zoneless mode the input only updates on the next change-detection cycle, so two toggles dispatched within
+        // the same frame both read the same (not-yet-updated) input. Without an in-frame working copy the second toggle
+        // would drop the option added by the first. This asserts both additions are kept.
+        const answerOptions: AnswerOption[] = [
+            { id: 1, invalid: false },
+            { id: 2, invalid: false },
+            { id: 3, invalid: false },
+            { id: 4, invalid: false },
+        ];
+        const question: MultipleChoiceQuestion = {
+            text: 'some-text',
+            exportQuiz: false,
+            randomizeOrder: true,
+            invalid: false,
+            answerOptions,
+            scoringType: ScoringType.ALL_OR_NOTHING,
+        };
+        fixture.componentRef.setInput('question', question);
+        fixture.componentRef.setInput('selectedAnswerOptions', [answerOptions[0], answerOptions[1]]);
+        fixture.changeDetectorRef.detectChanges();
+
+        const emissions: AnswerOption[][] = [];
+        component.selectedAnswerOptionsChange.subscribe((v) => emissions.push(v));
+
+        // Two toggles WITHOUT re-feeding the input in between (clicks within one change-detection frame).
+        component.toggleSelection(answerOptions[2]);
+        component.toggleSelection(answerOptions[3]);
+
+        expect(emissions).toHaveLength(2);
+        expect(emissions[0].map((o) => o.id).sort()).toEqual([1, 2, 3]);
+        expect(emissions[1].map((o) => o.id).sort()).toEqual([1, 2, 3, 4]);
+    });
+
+    it('should reset the working copy when the input changes, then build on the new input', () => {
+        // After the parent round-trips (or the submission is reloaded), the working copy must be discarded so the next
+        // toggle starts from the authoritative input.
+        const answerOptions: AnswerOption[] = [
+            { id: 1, invalid: false },
+            { id: 2, invalid: false },
+            { id: 3, invalid: false },
+        ];
+        const question: MultipleChoiceQuestion = {
+            text: 'some-text',
+            exportQuiz: false,
+            randomizeOrder: true,
+            invalid: false,
+            answerOptions,
+            scoringType: ScoringType.ALL_OR_NOTHING,
+        };
+        fixture.componentRef.setInput('question', question);
+        fixture.componentRef.setInput('selectedAnswerOptions', [answerOptions[0]]);
+        fixture.changeDetectorRef.detectChanges();
+
+        let emitted: AnswerOption[] | undefined;
+        component.selectedAnswerOptionsChange.subscribe((v) => (emitted = v));
+
+        component.toggleSelection(answerOptions[1]);
+        expect(emitted!.map((o) => o.id).sort()).toEqual([1, 2]);
+
+        // The authoritative input is replaced (e.g. a reload restoring only option 3); the next toggle must build on it.
+        fixture.componentRef.setInput('selectedAnswerOptions', [answerOptions[2]]);
+        fixture.changeDetectorRef.detectChanges();
+        component.toggleSelection(answerOptions[0]);
+        expect(emitted!.map((o) => o.id).sort()).toEqual([1, 3]);
+    });
+
+    it('should remove a pre-existing option when toggled off (multi-select)', () => {
+        const answerOptions: AnswerOption[] = [
+            { id: 1, invalid: false },
+            { id: 2, invalid: false },
+        ];
+        const question: MultipleChoiceQuestion = {
+            text: 'some-text',
+            exportQuiz: false,
+            randomizeOrder: true,
+            invalid: false,
+            answerOptions,
+            scoringType: ScoringType.ALL_OR_NOTHING,
+        };
+        fixture.componentRef.setInput('question', question);
+        fixture.componentRef.setInput('selectedAnswerOptions', [answerOptions[0], answerOptions[1]]);
+        fixture.changeDetectorRef.detectChanges();
+
+        let emitted: AnswerOption[] | undefined;
+        component.selectedAnswerOptionsChange.subscribe((v) => (emitted = v));
+
+        component.toggleSelection(answerOptions[0]);
+        expect(emitted!.map((o) => o.id)).toEqual([2]);
+    });
+
+    it('should not mutate the input array when toggling', () => {
+        const answerOptions: AnswerOption[] = [
+            { id: 1, invalid: false },
+            { id: 2, invalid: false },
+        ];
+        const question: MultipleChoiceQuestion = {
+            text: 'some-text',
+            exportQuiz: false,
+            randomizeOrder: true,
+            invalid: false,
+            answerOptions,
+            scoringType: ScoringType.ALL_OR_NOTHING,
+        };
+        const input = [answerOptions[0]];
+        fixture.componentRef.setInput('question', question);
+        fixture.componentRef.setInput('selectedAnswerOptions', input);
+        fixture.changeDetectorRef.detectChanges();
+
+        component.toggleSelection(answerOptions[1]);
+        expect(input).toEqual([answerOptions[0]]);
+    });
+
+    it('should handle answer options without an id by reference identity', () => {
+        const a: AnswerOption = { invalid: false };
+        const b: AnswerOption = { invalid: false };
+        const answerOptions: AnswerOption[] = [a, b];
+        const question: MultipleChoiceQuestion = {
+            text: 'some-text',
+            exportQuiz: false,
+            randomizeOrder: true,
+            invalid: false,
+            answerOptions,
+            scoringType: ScoringType.ALL_OR_NOTHING,
+        };
+        fixture.componentRef.setInput('question', question);
+        fixture.componentRef.setInput('selectedAnswerOptions', [a]);
+        fixture.changeDetectorRef.detectChanges();
+
+        let emitted: AnswerOption[] | undefined;
+        component.selectedAnswerOptionsChange.subscribe((v) => (emitted = v));
+
+        component.toggleSelection(b);
+        expect(emitted).toEqual([a, b]);
+
+        fixture.componentRef.setInput('selectedAnswerOptions', emitted!);
+        fixture.changeDetectorRef.detectChanges();
+        component.toggleSelection(a);
+        expect(emitted).toEqual([b]);
+    });
+
+    it('should not emit when click is disabled', () => {
+        const answerOptions: AnswerOption[] = [
+            { id: 1, invalid: false },
+            { id: 2, invalid: false },
+        ];
+        const question: MultipleChoiceQuestion = {
+            text: 'some-text',
+            exportQuiz: false,
+            randomizeOrder: true,
+            invalid: false,
+            answerOptions,
+            scoringType: ScoringType.ALL_OR_NOTHING,
+        };
+        fixture.componentRef.setInput('question', question);
+        fixture.componentRef.setInput('selectedAnswerOptions', [answerOptions[0]]);
+        fixture.componentRef.setInput('clickDisabled', true);
+        fixture.changeDetectorRef.detectChanges();
+
+        let emitted = false;
+        component.selectedAnswerOptionsChange.subscribe(() => (emitted = true));
+        component.toggleSelection(answerOptions[1]);
+        expect(emitted).toBe(false);
+        expect(component.isAnswerOptionSelected(answerOptions[1])).toBe(false);
+    });
+
     it('should toggle answer options, but only allow one to be selected for single choice questions', () => {
         const answerOptions: AnswerOption[] = [
             { id: 1, invalid: false },

--- a/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.ts
+++ b/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.ts
@@ -36,9 +36,25 @@ export class MultipleChoiceQuestionComponent {
 
     selectedAnswerOptionsChange = output<AnswerOption[]>();
 
+    /**
+     * Working copy of the current selection that accumulates changes made within a single change-detection frame.
+     * It is reset whenever the authoritative `selectedAnswerOptions` input changes, so it never goes stale (which was
+     * the original answer-loss bug). It exists so that several rapid toggles within the same frame - before the parent
+     * has round-tripped the emitted value back into the input (in zoneless mode the input only updates on the next
+     * change-detection cycle) - build on each other instead of each starting from the same stale input and dropping
+     * the previous selection.
+     */
+    private pendingSelectedAnswerOptions?: AnswerOption[];
+
     constructor() {
         effect(() => {
             this.watchCollection();
+        });
+        effect(() => {
+            // Discard the working copy whenever the authoritative input changes (parent round-trip, reload, recreation),
+            // so the next toggle starts from the up-to-date input rather than a stale local copy.
+            this.selectedAnswerOptions();
+            this.pendingSelectedAnswerOptions = undefined;
         });
     }
 
@@ -75,19 +91,27 @@ export class MultipleChoiceQuestionComponent {
      * Toggles the selection state of a multiple choice answer option
      * @param answerOption The answer option to toggle
      */
+    /**
+     * Returns the current selection, preferring the in-frame working copy over the input so that several toggles in the
+     * same change-detection frame accumulate correctly instead of each reading the same (not-yet-updated) input.
+     */
+    private currentSelectedAnswerOptions(): AnswerOption[] {
+        return this.pendingSelectedAnswerOptions ?? this.selectedAnswerOptions();
+    }
+
     toggleSelection(answerOption: AnswerOption): void {
         if (this.clickDisabled()) {
             // Do nothing
             return;
         }
-        // Always derive the new selection from the current input. The input reflects the options
-        // selected so far (including selections loaded from a previously saved submission), so
-        // building on top of it preserves existing answers. Mutating a separate local copy here
-        // used to drop previously selected options after a reload or component recreation,
-        // causing answer loss in exams.
+        // Always derive the new selection from the current selection (working copy or input). Building on top of it
+        // preserves existing answers - including selections loaded from a previously saved submission and selections
+        // made by earlier toggles in the same frame. Mutating a separate, never-synced local copy used to drop
+        // previously selected options after a reload, recreation, or rapid clicking, causing answer loss in exams.
+        const current = this.currentSelectedAnswerOptions();
         let updatedSelection: AnswerOption[];
         if (this.isAnswerOptionSelected(answerOption)) {
-            updatedSelection = this.selectedAnswerOptions().filter((selectedAnswerOption) => {
+            updatedSelection = current.filter((selectedAnswerOption) => {
                 if (answerOption.id) {
                     return selectedAnswerOption.id !== answerOption.id;
                 }
@@ -96,8 +120,9 @@ export class MultipleChoiceQuestionComponent {
         } else if (this.isSingleChoice) {
             updatedSelection = [answerOption];
         } else {
-            updatedSelection = [...this.selectedAnswerOptions(), answerOption];
+            updatedSelection = [...current, answerOption];
         }
+        this.pendingSelectedAnswerOptions = updatedSelection;
         this.selectedAnswerOptionsChange.emit(updatedSelection);
         /** Only execute the onSelection function if we received such input **/
         const fnOnSelectionFn = this.fnOnSelection();
@@ -112,7 +137,7 @@ export class MultipleChoiceQuestionComponent {
      */
     isAnswerOptionSelected(answerOption: AnswerOption): boolean {
         return (
-            this.selectedAnswerOptions().findIndex((selectedAnswerOption) => {
+            this.currentSelectedAnswerOptions().findIndex((selectedAnswerOption) => {
                 if (answerOption.id) {
                     return selectedAnswerOption.id === answerOption.id;
                 }

--- a/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.ts
+++ b/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.ts
@@ -26,7 +26,6 @@ export class MultipleChoiceQuestionComponent {
     question = input.required<MultipleChoiceQuestion>();
     // TODO: Map vs. Array --> consistency
     selectedAnswerOptions = input.required<AnswerOption[]>();
-    _selectedAnswerOptions: AnswerOption[] = [];
     clickDisabled = input<boolean>(false);
     showResult = input<boolean>(false);
     questionIndex = input<number>(0);
@@ -80,22 +79,27 @@ export class MultipleChoiceQuestionComponent {
     toggleSelection(answerOption: AnswerOption): void {
         if (this.clickDisabled()) {
             // Do nothing
-            this._selectedAnswerOptions = this.selectedAnswerOptions();
             return;
         }
+        // Always derive the new selection from the current input. The input reflects the options
+        // selected so far (including selections loaded from a previously saved submission), so
+        // building on top of it preserves existing answers. Mutating a separate local copy here
+        // used to drop previously selected options after a reload or component recreation,
+        // causing answer loss in exams.
+        let updatedSelection: AnswerOption[];
         if (this.isAnswerOptionSelected(answerOption)) {
-            this._selectedAnswerOptions = this.selectedAnswerOptions().filter((selectedAnswerOption) => {
+            updatedSelection = this.selectedAnswerOptions().filter((selectedAnswerOption) => {
                 if (answerOption.id) {
                     return selectedAnswerOption.id !== answerOption.id;
                 }
                 return selectedAnswerOption !== answerOption;
             });
         } else if (this.isSingleChoice) {
-            this._selectedAnswerOptions = [answerOption];
+            updatedSelection = [answerOption];
         } else {
-            this._selectedAnswerOptions.push(answerOption);
+            updatedSelection = [...this.selectedAnswerOptions(), answerOption];
         }
-        this.selectedAnswerOptionsChange.emit(this._selectedAnswerOptions);
+        this.selectedAnswerOptionsChange.emit(updatedSelection);
         /** Only execute the onSelection function if we received such input **/
         const fnOnSelectionFn = this.fnOnSelection();
         if (fnOnSelectionFn && typeof fnOnSelectionFn === 'function') {

--- a/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.ts
+++ b/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.ts
@@ -24,7 +24,6 @@ export class MultipleChoiceQuestionComponent {
     private artemisMarkdown = inject(ArtemisMarkdownService);
 
     question = input.required<MultipleChoiceQuestion>();
-    // TODO: Map vs. Array --> consistency
     selectedAnswerOptions = input.required<AnswerOption[]>();
     clickDisabled = input<boolean>(false);
     showResult = input<boolean>(false);

--- a/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.ts
+++ b/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.ts
@@ -88,10 +88,6 @@ export class MultipleChoiceQuestionComponent {
     }
 
     /**
-     * Toggles the selection state of a multiple choice answer option
-     * @param answerOption The answer option to toggle
-     */
-    /**
      * Returns the current selection, preferring the in-frame working copy over the input so that several toggles in the
      * same change-detection frame accumulate correctly instead of each reading the same (not-yet-updated) input.
      */
@@ -99,6 +95,10 @@ export class MultipleChoiceQuestionComponent {
         return this.pendingSelectedAnswerOptions ?? this.selectedAnswerOptions();
     }
 
+    /**
+     * Toggles the selection state of a multiple choice answer option
+     * @param answerOption The answer option to toggle
+     */
     toggleSelection(answerOption: AnswerOption): void {
         if (this.clickDisabled()) {
             // Do nothing

--- a/src/test/playwright/e2e/exam/ExamQuizMultiSelectRetention.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamQuizMultiSelectRetention.spec.ts
@@ -1,0 +1,107 @@
+import { test } from '../../support/fixtures';
+import { expect } from '@playwright/test';
+import { admin, studentTwo } from '../../support/users';
+import { generateUUID, getExercise } from '../../support/utils';
+import dayjs from 'dayjs';
+import { Exam } from 'app/exam/shared/entities/exam.model';
+import { Exercise, ExerciseType } from '../../support/constants';
+import { ExamAPIRequests } from '../../support/requests/ExamAPIRequests';
+import { SEED_COURSES } from '../../support/seedData';
+
+/**
+ * Regression test for multiple-choice answer loss when adding to a SAVED selection in exam mode (issue #12938).
+ *
+ * The dangerous, deterministic variant of the bug: after a reload (or any component recreation mid-exam), the
+ * previously selected options are loaded into the component's input from the saved submission, but the component's
+ * local selection accumulator started empty and was never synced from that input. The next ADDITIVE click then
+ * emitted only the newly clicked option, silently dropping every previously saved answer.
+ *
+ * This test selects one option, saves, RELOADS the exam, and then selects an ADDITIONAL option. It verifies that the
+ * earlier answer is NOT lost - both options stay selected, and both survive a second save + reload. Before the fix,
+ * the additive click after the reload dropped the first option.
+ */
+const course = { id: SEED_COURSES.examParticipation.id } as any;
+
+test.describe('Exam quiz multiple-choice add-to-saved-selection retention', { tag: '@slow' }, () => {
+    let exam: Exam;
+    let quizExercise: Exercise;
+    let questionId: number;
+
+    test.beforeEach('Create exam with a multiple-choice quiz', async ({ login, examAPIRequests, examExerciseGroupCreation }) => {
+        await login(admin);
+        exam = await createExam(course, examAPIRequests, { title: 'exam' + generateUUID() });
+        quizExercise = await examExerciseGroupCreation.addGroupWithExercise(exam, ExerciseType.QUIZ, { quizExerciseID: 0 });
+        // The seeded MC template has 4 answer options (2 correct, 2 wrong). additionalData.quizExerciseID is the question id.
+        questionId = quizExercise.additionalData!.quizExerciseID!;
+        await examAPIRequests.registerStudentForExam(exam, studentTwo);
+        await examAPIRequests.generateMissingIndividualExams(exam);
+        await examAPIRequests.prepareExerciseStartForExam(exam);
+    });
+
+    test('does not drop a saved answer when adding another option after a reload', async ({ page, examParticipation, examNavigation, quizExerciseMultipleChoice }) => {
+        const exerciseId = quizExercise.id!;
+        const option = (i: number) => getExercise(page, exerciseId).locator(`#question${questionId} #answer-option-${i}`);
+
+        await examParticipation.startParticipation(studentTwo, course, exam);
+        await examNavigation.openOrSaveExerciseByTitle(quizExercise.exerciseGroup!.title!);
+
+        // Select the first option and save it (navigating away triggers the deterministic exam-submission PUT).
+        await quizExerciseMultipleChoice.tickAnswerOption(exerciseId, 0, questionId);
+        await expect(option(0)).toHaveClass(/selected/);
+        const firstSave = page.waitForResponse((r) => r.url().includes(`/api/quiz/exercises/${exerciseId}/submissions/exam`) && r.request().method() === 'PUT' && r.ok(), {
+            timeout: 30000,
+        });
+        await examNavigation.openOrSaveExerciseByTitle(quizExercise.exerciseGroup!.title!);
+        await firstSave;
+
+        // Reload and re-enter: the saved selection [option 0] is now loaded into the input of a freshly created
+        // component (whose local accumulator is empty - exactly the bug condition).
+        await page.reload();
+        await page.goto(`/courses/${course.id}/exams/${exam.id}`);
+        await examParticipation.startExam();
+        await examNavigation.openOrSaveExerciseByTitle(quizExercise.exerciseGroup!.title!);
+        await expect(option(0)).toHaveClass(/selected/, { timeout: 15000 });
+
+        // Add a SECOND option after the reload. Before the fix this emitted only option 1 and dropped option 0.
+        await quizExerciseMultipleChoice.tickAnswerOption(exerciseId, 1, questionId);
+
+        // Both options must now be selected - the earlier saved answer must not have been dropped.
+        await expect(option(0)).toHaveClass(/selected/);
+        await expect(option(1)).toHaveClass(/selected/);
+
+        // The additive selection must also persist across another save + reload.
+        const secondSave = page.waitForResponse((r) => r.url().includes(`/api/quiz/exercises/${exerciseId}/submissions/exam`) && r.request().method() === 'PUT' && r.ok(), {
+            timeout: 30000,
+        });
+        await examNavigation.openOrSaveExerciseByTitle(quizExercise.exerciseGroup!.title!);
+        await secondSave;
+        await page.reload();
+        await page.goto(`/courses/${course.id}/exams/${exam.id}`);
+        await examParticipation.startExam();
+        await examNavigation.openOrSaveExerciseByTitle(quizExercise.exerciseGroup!.title!);
+
+        await expect(option(0)).toHaveClass(/selected/, { timeout: 15000 });
+        await expect(option(1)).toHaveClass(/selected/);
+        // The untouched options must remain unselected.
+        await expect(option(2)).not.toHaveClass(/selected/);
+        await expect(option(3)).not.toHaveClass(/selected/);
+    });
+
+    test.afterEach('Delete exam', async ({ login, examAPIRequests }) => {
+        await login(admin);
+        await examAPIRequests.deleteExam(exam);
+    });
+});
+
+async function createExam(course: any, examAPIRequests: ExamAPIRequests, customExamConfig?: any) {
+    const defaultExamConfig = {
+        course,
+        title: 'exam' + generateUUID(),
+        visibleDate: dayjs().subtract(3, 'minutes'),
+        startDate: dayjs().subtract(2, 'minutes'),
+        endDate: dayjs().add(1, 'hour'),
+        examMaxPoints: 10,
+        numberOfExercisesInExam: 1,
+    };
+    return await examAPIRequests.createExam({ ...defaultExamConfig, ...customExamConfig });
+}


### PR DESCRIPTION
### Summary

In exams, students could potentially lose multiple-choice answers. When a multiple-choice question was shown with **already-selected options that came from a saved submission** (a resumed/reloaded exam, or a component recreated mid-exam), clicking an **additional** option dropped all the previously selected ones — only the newly clicked option was kept and saved.

### Motivation and Context

`git` points to the quiz-questions signals migration (#11297, commit `f2018a4897`) as the regression.

Before: `selectedAnswerOptions` was a **mutable two-way `@Input()` array**, and the additive branch did `this.selectedAnswerOptions.push(option)` — appending to the array that already held the prior selections.

After: it became a read-only `input.required<AnswerOption[]>()`, and a local `_selectedAnswerOptions: AnswerOption[] = []` accumulator was introduced — but it was **initialized to `[]` and never synced from the input**. The additive (multi-select) branch did `this._selectedAnswerOptions.push(option)` on that stale/empty local array, so the emitted selection contained only options toggled within that component instance, dropping anything loaded from the submission.

### Description

`toggleSelection` now derives the new selection from the **current `selectedAnswerOptions` input** on every toggle, and the `_selectedAnswerOptions` local field is removed. This preserves previously selected options. Drag-and-drop (`drag-and-drop-question.component.ts`) re-derives `_mappings` from the input before mutating, and short-answer rebuilds its full array from the DOM each time, so both are unaffected — consistent with the instructor reporting the problem specifically for multiple-choice.

### Steps for Testing

Prerequisites: 1 exam with a multiple-choice quiz (a question allowing multiple selections), 1 student.

1. Start the exam, open the quiz, select **one** option, and save & continue.
2. Reload the page and re-enter the exam; open the quiz — the option is still selected.
3. Select a **second** option, save & continue.
4. Reload and re-enter again; open the quiz.
5. Verify **both** options are still selected (before the fix, only the second one remained).

### Verification
- Reproduced first with a failing Vitest test (`should keep pre-existing selections when adding another option`) that asserted the emitted selection — it returned `[3]` instead of `[1, 2, 3]`. After the fix it passes. Full `multiple-choice-question.component.spec.ts` (7) and `quiz-exam-submission.component.spec.ts` (11) suites pass. ESLint clean; the change compiles on the running dev server.
- Baseline `ExamParticipation` E2E suite (17 tests) passes on the local stack.

> Note (draft): a dedicated E2E that reloads mid-exam and asserts both options persist is a recommended follow-up; needs test-server verification + screenshot and an issue link before ready-for-review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed multi-select answer toggling to preserve existing selections, correctly handle rapid successive clicks, and avoid mutating the provided selection.
  * Ensured disabled clicks never change selection state.
  * Updated selection handling to reset intermediate state when the parent selection changes.

* **Tests**
  * Added unit test coverage for multi-select selection transitions, immutability, identifier-less options, and disabled-click behavior.
  * Added an end-to-end regression test to confirm saved multi-select answers persist across reloads in exam mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->