### PR TITLE
`Assessment`: Keep assessment cards stable by tracking text blocks

### DIFF
--- a/src/main/webapp/app/text/manage/assess/text-assessment-area/text-assessment-area.component.html
+++ b/src/main/webapp/app/text/manage/assess/text-assessment-area/text-assessment-area.component.html
@@ -1,5 +1,5 @@
 @if (autoTextBlockAssessment()) {
-    @for (ref of textBlockRefs(); track ref; let i = $index) {
+    @for (ref of textBlockRefs(); track ref.block; let i = $index) {
         <jhi-text-block-assessment-card
             id="text-feedback-block-{{ i }}"
             [textBlockRef]="ref"

--- a/src/main/webapp/app/text/manage/assess/text-assessment-area/text-assessment-area.component.spec.ts
+++ b/src/main/webapp/app/text/manage/assess/text-assessment-area/text-assessment-area.component.spec.ts
@@ -27,6 +27,14 @@ describe('TextAssessmentAreaComponent', () => {
 
     const submission = { id: 1, text: 'Test submission text' } as TextSubmission;
 
+    const newBlock = (startIndex: number, endIndex: number): TextBlock => {
+        const block = new TextBlock();
+        block.startIndex = startIndex;
+        block.endIndex = endIndex;
+        block.setTextFromSubmission(submission);
+        return block;
+    };
+
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             imports: [TextAssessmentAreaComponent],
@@ -139,6 +147,46 @@ describe('TextAssessmentAreaComponent', () => {
         // Same DOM nodes => Angular reused the cards instead of recreating them (this would fail when tracking by the ref wrapper).
         expect(cardsAfter[0]).toBe(cardsBefore[0]);
         expect(cardsAfter[1]).toBe(cardsBefore[1]);
+    });
+
+    it('should reuse the existing cards and only add one when a block is inserted via a re-match', () => {
+        const block1 = newBlock(0, 4);
+        const block2 = newBlock(10, 14);
+        fixture.componentRef.setInput('textBlockRefs', [new TextBlockRef(block1), new TextBlockRef(block2)]);
+        fixture.changeDetectorRef.detectChanges();
+        const cardsBefore = fixture.debugElement.queryAll(By.directive(TextBlockAssessmentCardComponent)).map((card) => card.nativeElement);
+        expect(cardsBefore).toHaveLength(2);
+
+        // A new block is inserted between the two (e.g. a manual block / split), re-wrapping the same block1/block2.
+        const inserted = newBlock(5, 9);
+        fixture.componentRef.setInput('textBlockRefs', [new TextBlockRef(block1), new TextBlockRef(inserted), new TextBlockRef(block2)]);
+        fixture.changeDetectorRef.detectChanges();
+        const cardsAfter = fixture.debugElement.queryAll(By.directive(TextBlockAssessmentCardComponent)).map((card) => card.nativeElement);
+
+        expect(cardsAfter).toHaveLength(3);
+        // The two original cards are reused (same DOM nodes); only the inserted block gets a new card.
+        expect(cardsAfter).toContain(cardsBefore[0]);
+        expect(cardsAfter).toContain(cardsBefore[1]);
+    });
+
+    it('should reuse surviving cards and drop only the removed one when a block is deleted via a re-match', () => {
+        const block1 = newBlock(0, 4);
+        const block2 = newBlock(5, 9);
+        const block3 = newBlock(10, 14);
+        fixture.componentRef.setInput('textBlockRefs', [new TextBlockRef(block1), new TextBlockRef(block2), new TextBlockRef(block3)]);
+        fixture.changeDetectorRef.detectChanges();
+        const cardsBefore = fixture.debugElement.queryAll(By.directive(TextBlockAssessmentCardComponent)).map((card) => card.nativeElement);
+        expect(cardsBefore).toHaveLength(3);
+
+        // The middle block is removed; the survivors are re-wrapped in fresh refs.
+        fixture.componentRef.setInput('textBlockRefs', [new TextBlockRef(block1), new TextBlockRef(block3)]);
+        fixture.changeDetectorRef.detectChanges();
+        const cardsAfter = fixture.debugElement.queryAll(By.directive(TextBlockAssessmentCardComponent)).map((card) => card.nativeElement);
+
+        expect(cardsAfter).toHaveLength(2);
+        // Both surviving cards are reused (their DOM nodes were among the original ones); the removed block's card is gone.
+        expect(cardsBefore).toContain(cardsAfter[0]);
+        expect(cardsBefore).toContain(cardsAfter[1]);
     });
 
     it('should remove TextBlockRef if text block is deleted', () => {

--- a/src/main/webapp/app/text/manage/assess/text-assessment-area/text-assessment-area.component.spec.ts
+++ b/src/main/webapp/app/text/manage/assess/text-assessment-area/text-assessment-area.component.spec.ts
@@ -164,9 +164,13 @@ describe('TextAssessmentAreaComponent', () => {
         const cardsAfter = fixture.debugElement.queryAll(By.directive(TextBlockAssessmentCardComponent)).map((card) => card.nativeElement);
 
         expect(cardsAfter).toHaveLength(3);
-        // The two original cards are reused (same DOM nodes); only the inserted block gets a new card.
-        expect(cardsAfter).toContain(cardsBefore[0]);
-        expect(cardsAfter).toContain(cardsBefore[1]);
+        // Pin the exact reuse: block1's card stays at index 0, block2's card is pushed to index 2, and only the inserted
+        // block gets a fresh card at index 1. (By.directive returns nodes in document order; the sorted blocks
+        // 0-4 / 5-9 / 10-14 keep this positional mapping.) Asserting only membership would still pass under a
+        // track-$index regression that repurposes the wrong card.
+        expect(cardsAfter[0]).toBe(cardsBefore[0]);
+        expect(cardsAfter[2]).toBe(cardsBefore[1]);
+        expect(cardsBefore).not.toContain(cardsAfter[1]);
     });
 
     it('should reuse surviving cards and drop only the removed one when a block is deleted via a re-match', () => {
@@ -184,9 +188,12 @@ describe('TextAssessmentAreaComponent', () => {
         const cardsAfter = fixture.debugElement.queryAll(By.directive(TextBlockAssessmentCardComponent)).map((card) => card.nativeElement);
 
         expect(cardsAfter).toHaveLength(2);
-        // Both surviving cards are reused (their DOM nodes were among the original ones); the removed block's card is gone.
-        expect(cardsBefore).toContain(cardsAfter[0]);
-        expect(cardsBefore).toContain(cardsAfter[1]);
+        // Pin the exact survivors: block1's and block3's cards are reused (in document order) and block2's (the removed
+        // middle) card is gone. Asserting only membership would still pass if the wrong original card survived (e.g. the
+        // middle card kept and an end card dropped under a track-$index regression).
+        expect(cardsAfter[0]).toBe(cardsBefore[0]);
+        expect(cardsAfter[1]).toBe(cardsBefore[2]);
+        expect(cardsAfter).not.toContain(cardsBefore[1]);
     });
 
     it('should remove TextBlockRef if text block is deleted', () => {

--- a/src/main/webapp/app/text/manage/assess/text-assessment-area/text-assessment-area.component.spec.ts
+++ b/src/main/webapp/app/text/manage/assess/text-assessment-area/text-assessment-area.component.spec.ts
@@ -12,6 +12,7 @@ import { By } from '@angular/platform-browser';
 import { MockProvider } from 'ng-mocks';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
+import { TextBlock } from 'app/text/shared/entities/text-block.model';
 import { TranslateService } from '@ngx-translate/core';
 import { ActivatedRoute } from '@angular/router';
 import { MockActivatedRoute } from 'test/helpers/mocks/activated-route/mock-activated-route';
@@ -109,6 +110,35 @@ describe('TextAssessmentAreaComponent', () => {
 
         expect(component.textBlockRefsAddedRemoved.emit).toHaveBeenCalledOnce();
         expect(component.textBlockRefs()).toHaveLength(5);
+    });
+
+    it('should preserve assessment cards across a re-match that re-wraps the same text blocks', () => {
+        // The parent re-matches blocks with feedback on many occasions (validating feedback, Athena suggestions, etc.),
+        // which creates NEW TextBlockRef wrappers around the SAME TextBlock objects. The cards must be reused rather than
+        // destroyed and recreated, otherwise the assessor's in-progress feedback editing gets churned ("blocks mixed up").
+        const block1 = new TextBlock();
+        block1.startIndex = 0;
+        block1.endIndex = 4;
+        block1.setTextFromSubmission(submission);
+        const block2 = new TextBlock();
+        block2.startIndex = 5;
+        block2.endIndex = 9;
+        block2.setTextFromSubmission(submission);
+
+        fixture.componentRef.setInput('textBlockRefs', [new TextBlockRef(block1), new TextBlockRef(block2)]);
+        fixture.changeDetectorRef.detectChanges();
+        const cardsBefore = fixture.debugElement.queryAll(By.directive(TextBlockAssessmentCardComponent)).map((card) => card.nativeElement);
+        expect(cardsBefore).toHaveLength(2);
+
+        // Re-match: brand-new wrappers, but around the same block objects.
+        fixture.componentRef.setInput('textBlockRefs', [new TextBlockRef(block1), new TextBlockRef(block2)]);
+        fixture.changeDetectorRef.detectChanges();
+        const cardsAfter = fixture.debugElement.queryAll(By.directive(TextBlockAssessmentCardComponent)).map((card) => card.nativeElement);
+
+        expect(cardsAfter).toHaveLength(2);
+        // Same DOM nodes => Angular reused the cards instead of recreating them (this would fail when tracking by the ref wrapper).
+        expect(cardsAfter[0]).toBe(cardsBefore[0]);
+        expect(cardsAfter[1]).toBe(cardsBefore[1]);
     });
 
     it('should remove TextBlockRef if text block is deleted', () => {


### PR DESCRIPTION
### Summary

Instructors reported that during manual text assessment, "assessment blocks get mixed up all the time." This makes the assessment cards stable so the assessor's in-progress feedback editing is no longer churned.

### Motivation and Context

The parent re-matches blocks with feedback on many occasions (validating feedback, receiving Athena suggestions, manual block operations). Each re-match calls `TextAssessmentService.matchBlocksWithFeedbacks`, which wraps the **same** `TextBlock` objects in **brand-new** `TextBlockRef` wrappers. The assessment area rendered cards with `@for (... track ref)` — tracking the *wrapper* by object identity — so every re-match destroyed and recreated **all** cards, churning the assessor's in-progress feedback editing and selection.

### Description

Track by the underlying text block (`track ref.block`) instead of the wrapper. The block objects are reused across re-matches, so Angular now reuses the cards. The block object is always present and unique per block, so — unlike `track ref.block.id` — it cannot collide for manually created blocks that don't have a computed `id` yet (e.g. `TextBlockRef.new()`).

### Steps for Testing

Prerequisites: 1 text exercise with a student submission, 1 tutor.

1. Open the submission in the assessment editor (automatic blocks present).
2. Start editing feedback on a block; trigger a re-match (e.g. add feedback to another block, or let Athena suggestions arrive).
3. Verify the cards and your in-progress editing/selection stay put instead of jumping/resetting.

### Verification
- Added a Vitest regression test asserting the card DOM nodes are **reused** across a re-match that re-wraps the same blocks. It fails with `track ref` (cards recreated) and passes with `track ref.block`. Full `text-assessment-area.component.spec.ts` suite passes (7 tests).

> Note: this is a targeted fix for the most likely "mixed up" mechanism (card churn on re-match). If the instructor's symptom turns out to be something else (e.g. wrong feedback-to-block association rather than editing churn), please share repro steps and I'll dig further.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering reuse for text assessment cards by refining how list items are tracked during updates, reducing unnecessary DOM re-renders when blocks are unchanged.

* **Tests**
  * Expanded the component test suite to cover “re-match” scenarios, verifying card DOM nodes are preserved when blocks are re-wrapped, inserted, or removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->