### PR TITLE
`Exam mode`: Fix a potential rendering issue for PlantUML diagrams when switching between exercises

### DIFF
--- a/src/main/webapp/app/exam/overview/exercises/programming/programming-exam-submission.component.spec.ts
+++ b/src/main/webapp/app/exam/overview/exercises/programming/programming-exam-submission.component.spec.ts
@@ -91,4 +91,28 @@ describe('ProgrammingExamSubmissionComponent', () => {
 
         expect(component.hasUnsavedChanges()).toBe(false);
     });
+
+    it('should force a re-render of the problem statement on activation to restore PlantUML diagrams', () => {
+        // Regression test for the exam bug where switching between exercises removed already-rendered PlantUML diagrams.
+        // onActivate() must force a re-render (which bypasses the "unchanged problem statement" optimization) instead of
+        // calling updateMarkdown(), so the diagrams are reliably restored when the exercise becomes visible again.
+        const forceReRenderProblemStatement = vi.fn();
+        const updateMarkdown = vi.fn();
+        // Replace the required viewChild signal with a stub instructions component.
+        (component as unknown as { instructions: () => unknown }).instructions = () => ({ forceReRenderProblemStatement, updateMarkdown });
+        const updateDomainSpy = vi.spyOn(component, 'updateDomain').mockImplementation(() => {});
+        const reattachSpy = vi.spyOn((component as unknown as { changeDetectorReference: { reattach: () => void } }).changeDetectorReference, 'reattach');
+
+        component.onActivate();
+
+        // The re-render is forced (not the optimized updateMarkdown which would skip the unchanged statement).
+        expect(forceReRenderProblemStatement).toHaveBeenCalledOnce();
+        expect(updateMarkdown).not.toHaveBeenCalled();
+        // The domain is refreshed and change detection is reattached for the now-visible exercise.
+        expect(updateDomainSpy).toHaveBeenCalledOnce();
+        expect(reattachSpy).toHaveBeenCalledOnce();
+        // Change detection must be reattached (super.onActivate) BEFORE the re-render, so the diagram injection runs
+        // against a live, attached component rather than the detached DOM that caused the original bug.
+        expect(reattachSpy.mock.invocationCallOrder[0]).toBeLessThan(forceReRenderProblemStatement.mock.invocationCallOrder[0]);
+    });
 });

--- a/src/main/webapp/app/exam/overview/exercises/programming/programming-exam-submission.component.ts
+++ b/src/main/webapp/app/exam/overview/exercises/programming/programming-exam-submission.component.ts
@@ -115,7 +115,10 @@ export class ProgrammingExamSubmissionComponent extends ExamSubmissionComponent 
 
     onActivate() {
         super.onActivate();
-        this.instructions().updateMarkdown();
+        // Force a re-render (not just updateMarkdown, which skips unchanged problem statements): while this exercise was
+        // hidden its change detection was detached, so a render that happened in the meantime may have injected the
+        // PlantUML diagrams into stale DOM. Re-rendering now that the exercise is visible restores them reliably.
+        this.instructions().forceReRenderProblemStatement();
         this.updateDomain();
     }
 

--- a/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.spec.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.spec.ts
@@ -808,6 +808,39 @@ describe('ProgrammingExerciseInstructionComponent - PlantUML exam mode isolation
         instance.comp.ngOnDestroy();
     });
 
+    it('should force a re-render via forceReRenderProblemStatement even when the problem statement is undefined', () => {
+        // Guards the undefined-problem-statement edge case: forceReRenderProblemStatement must NOT rely on resetting
+        // lastRenderedProblemStatement to undefined, because when the current problem statement is also undefined the
+        // optimization (undefined === undefined) would wrongly skip the re-render. It uses an explicit force flag instead.
+        const instance = createComponentInstance();
+        const exercise = {
+            id: 10,
+            course: { id: 1 },
+            numberOfAssessmentsOfCorrectionRounds: [],
+            secondCorrectionEnabled: false,
+            studentAssignedTeamIdComputed: false,
+        } as ProgrammingExercise;
+        instance.fixture.componentRef.setInput('exercise', exercise);
+        instance.fixture.componentRef.setInput('participation', { id: 110 });
+        internals(instance.comp).setupMarkdownSubscriptions();
+
+        // Initial render records lastRenderedProblemStatement = undefined (the exercise has no problem statement).
+        instance.comp.updateMarkdown();
+        internals(instance.comp).isInitial = false;
+
+        const renderSpy = vi.spyOn(instance.comp as unknown as { renderMarkdown: () => void }, 'renderMarkdown');
+
+        // A plain updateMarkdown() early-returns (undefined === undefined, not initial), so it does NOT re-render.
+        instance.comp.updateMarkdown();
+        expect(renderSpy).not.toHaveBeenCalled();
+
+        // forceReRenderProblemStatement() bypasses the optimization and re-renders even with an undefined statement.
+        instance.comp.forceReRenderProblemStatement();
+        expect(renderSpy).toHaveBeenCalledOnce();
+
+        instance.comp.ngOnDestroy();
+    });
+
     it('should not accumulate task components across repeated forceReRenderProblemStatement calls', async () => {
         // Each render destroys the previously created task components before recreating them (destroyTaskComponents at
         // the start of updateMarkdown). forceReRenderProblemStatement() goes through that same path, so repeatedly

--- a/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.spec.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.spec.ts
@@ -69,6 +69,7 @@ type InstructionInternals = Omit<
     isLoading: WritableSignal<boolean>;
     tasks: WritableSignal<TaskArray>;
     setupMarkdownSubscriptions: () => void;
+    taskComponentRefs: { destroy: () => void; hostView: { destroyed: boolean } }[];
 };
 
 const internals = (c: ProgrammingExerciseInstructionComponent): InstructionInternals => c as unknown as InstructionInternals;
@@ -755,8 +756,10 @@ describe('ProgrammingExerciseInstructionComponent - PlantUML exam mode isolation
 
         injectSpy.mockClear();
 
-        internals(instanceA.comp).lastRenderedProblemStatement = undefined;
-        instanceA.comp.updateMarkdown();
+        // Use the production re-render entry point (forceReRenderProblemStatement) rather than poking the private
+        // lastRenderedProblemStatement field: this is exactly the call onActivate() makes when an exam exercise becomes
+        // visible again, so the test guards the real navigation path.
+        instanceA.comp.forceReRenderProblemStatement();
         await new Promise((resolve) => setTimeout(resolve, 10));
 
         const secondRenderIds = new Set(injectSpy.mock.calls.map((call) => call[1] as string).filter((id) => (id as string).startsWith('plantUml-10-')));
@@ -765,6 +768,76 @@ describe('ProgrammingExerciseInstructionComponent - PlantUML exam mode isolation
 
         instanceA.comp.ngOnDestroy();
         instanceB.comp.ngOnDestroy();
+    });
+
+    it('should re-inject PlantUML diagrams via forceReRenderProblemStatement even when the problem statement is unchanged', async () => {
+        // Regression test for the exam bug where switching between exercises removed already-rendered PlantUML diagrams.
+        // On return to an exercise the problem statement is unchanged, so plain updateMarkdown() skips the re-render and
+        // the diagrams (which may have been injected into stale/detached DOM while hidden) are never restored.
+        // forceReRenderProblemStatement() must bypass that optimization and re-inject the diagrams.
+        const injectSpy = vi.spyOn(plantUmlExtension as any, 'loadAndInjectPlantUml');
+
+        const instance = createComponentInstance();
+        const exercise = createExercise(10, exerciseA_problemStatement);
+        instance.fixture.componentRef.setInput('exercise', exercise);
+        instance.fixture.componentRef.setInput('participation', { id: 110 });
+        internals(instance.comp).setupMarkdownSubscriptions();
+
+        // Initial render injects both diagrams of exercise A.
+        instance.comp.updateMarkdown();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(new Set(injectSpy.mock.calls.map((call) => call[1] as string))).toEqual(new Set(['plantUml-10-0', 'plantUml-10-1']));
+
+        // Mark the component as past its initial render (as it is after the first processInputChanges in production),
+        // so the "unchanged problem statement" optimization in updateMarkdown is active.
+        internals(instance.comp).isInitial = false;
+
+        // A second updateMarkdown() with the SAME problem statement is a no-op (the "unchanged problem statement"
+        // optimization): nothing is re-injected. This is exactly what made the diagrams disappear on navigation.
+        injectSpy.mockClear();
+        instance.comp.updateMarkdown();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(injectSpy).not.toHaveBeenCalled();
+
+        // forceReRenderProblemStatement() bypasses the optimization and re-injects the diagrams, restoring them.
+        injectSpy.mockClear();
+        instance.comp.forceReRenderProblemStatement();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(new Set(injectSpy.mock.calls.map((call) => call[1] as string))).toEqual(new Set(['plantUml-10-0', 'plantUml-10-1']));
+
+        instance.comp.ngOnDestroy();
+    });
+
+    it('should not accumulate task components across repeated forceReRenderProblemStatement calls', async () => {
+        // Each render destroys the previously created task components before recreating them (destroyTaskComponents at
+        // the start of updateMarkdown). forceReRenderProblemStatement() goes through that same path, so repeatedly
+        // re-rendering an exam exercise on navigation must not leak/duplicate task components.
+        const instance = createComponentInstance();
+        const exercise = createExercise(10, exerciseA_problemStatement);
+        instance.fixture.componentRef.setInput('exercise', exercise);
+        instance.fixture.componentRef.setInput('participation', { id: 110 });
+        internals(instance.comp).setupMarkdownSubscriptions();
+
+        // Seed stale task component refs as if a previous render had created them. They report their host view as
+        // already destroyed so the cleanup path simply drops them (no real DOM detach needed in the unit test).
+        const destroySpy = vi.fn();
+        internals(instance.comp).taskComponentRefs = [
+            { destroy: destroySpy, hostView: { destroyed: true } },
+            { destroy: destroySpy, hostView: { destroyed: true } },
+        ];
+
+        instance.comp.forceReRenderProblemStatement();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        // The stale refs were cleared and, since exercise A has no tasks, none were recreated: the array did not grow.
+        expect(internals(instance.comp).taskComponentRefs).toHaveLength(0);
+
+        // A second force re-render still does not accumulate refs.
+        instance.comp.forceReRenderProblemStatement();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(internals(instance.comp).taskComponentRefs).toHaveLength(0);
+
+        instance.comp.ngOnDestroy();
     });
 
     it('should call setExerciseId with the exercise ID before each render', async () => {

--- a/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.ts
@@ -299,12 +299,16 @@ export class ProgrammingExerciseInstructionComponent implements OnInit, OnDestro
 
     /**
      * Render the markdown into html.
+     *
+     * @param force when true, re-render even if the problem statement is unchanged (bypasses the live-preview
+     *     optimization). Used when the rendered output must be rebuilt regardless of the problem statement, e.g. when an
+     *     exam exercise becomes visible again and its asynchronously injected PlantUML diagrams must be re-injected.
      */
-    updateMarkdown() {
+    updateMarkdown(force = false) {
         const exercise = this.exercise();
         // Skip re-render if problem statement hasn't changed (optimization for live preview)
         const currentProblemStatement = exercise?.problemStatement?.trim();
-        if (currentProblemStatement === this.lastRenderedProblemStatement && !this.isInitial) {
+        if (!force && currentProblemStatement === this.lastRenderedProblemStatement && !this.isInitial) {
             return;
         }
         this.lastRenderedProblemStatement = currentProblemStatement;
@@ -332,10 +336,13 @@ export class ProgrammingExerciseInstructionComponent implements OnInit, OnDestro
      * injection has settled), the injection can target stale or detached DOM and the rendered diagram is lost. Calling
      * this once the exercise becomes visible again re-runs the render and injection against the live DOM, reliably
      * restoring the PlantUML diagrams.
+     *
+     * Uses the explicit force flag rather than resetting {@link lastRenderedProblemStatement}, so it re-renders even
+     * when the problem statement is undefined/empty (in that case resetting to undefined would still equal the current
+     * value and the optimization would wrongly skip the re-render).
      */
     forceReRenderProblemStatement() {
-        this.lastRenderedProblemStatement = undefined;
-        this.updateMarkdown();
+        this.updateMarkdown(true);
     }
 
     /**

--- a/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.ts
@@ -324,6 +324,21 @@ export class ProgrammingExerciseInstructionComponent implements OnInit, OnDestro
     }
 
     /**
+     * Forces a re-render of the problem statement, bypassing the "unchanged problem statement" optimization in
+     * {@link updateMarkdown}.
+     *
+     * In exam mode an exercise's change detection is detached while it is hidden. If a render runs during that time
+     * (for example because the student rapidly switches between exercises before the asynchronous PlantUML/task
+     * injection has settled), the injection can target stale or detached DOM and the rendered diagram is lost. Calling
+     * this once the exercise becomes visible again re-runs the render and injection against the live DOM, reliably
+     * restoring the PlantUML diagrams.
+     */
+    forceReRenderProblemStatement() {
+        this.lastRenderedProblemStatement = undefined;
+        this.updateMarkdown();
+    }
+
+    /**
      * Destroy all dynamically created task components to prevent memory leaks.
      */
     private destroyTaskComponents(): void {

--- a/src/test/playwright/e2e/exam/ExamPlantUmlDiagramIsolation.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamPlantUmlDiagramIsolation.spec.ts
@@ -227,7 +227,7 @@ test.describe('Exam PlantUML diagram isolation', { tag: '@slow' }, () => {
         await expect(page.locator(`#plantUml-${exerciseB.id}-0 svg`)).toBeAttached({ timeout: 30000 });
         // Navigate BACK to A: its diagram must still be there.
         await examNavigation.openOrSaveExerciseByTitle(groupTitleA);
-        await expect(page.locator(`#plantUml-${exerciseA.id}-0 svg`)).toBeAttached({ timeout: 15000 });
+        await expect(page.locator(`#plantUml-${exerciseA.id}-0 svg`)).toBeAttached({ timeout: 30000 });
 
         // --- Part 2: rapid switching without waiting for the SVG to render in between ---
         await examNavigation.openOrSaveExerciseByTitle(groupTitleB);
@@ -237,10 +237,10 @@ test.describe('Exam PlantUML diagram isolation', { tag: '@slow' }, () => {
         await examNavigation.openOrSaveExerciseByTitle(groupTitleC);
 
         // Every diagram must still be attached (hidden exercises keep their DOM via [hidden]).
-        await expect(page.locator(`#plantUml-${exerciseA.id}-0 svg`)).toBeAttached({ timeout: 15000 });
-        await expect(page.locator(`#plantUml-${exerciseB.id}-0 svg`)).toBeAttached({ timeout: 15000 });
-        await expect(page.locator(`#plantUml-${exerciseC.id}-0 svg`)).toBeAttached({ timeout: 15000 });
-        await expect(page.locator(`#plantUml-${exerciseC.id}-1 svg`)).toBeAttached({ timeout: 15000 });
+        await expect(page.locator(`#plantUml-${exerciseA.id}-0 svg`)).toBeAttached({ timeout: 30000 });
+        await expect(page.locator(`#plantUml-${exerciseB.id}-0 svg`)).toBeAttached({ timeout: 30000 });
+        await expect(page.locator(`#plantUml-${exerciseC.id}-0 svg`)).toBeAttached({ timeout: 30000 });
+        await expect(page.locator(`#plantUml-${exerciseC.id}-1 svg`)).toBeAttached({ timeout: 30000 });
     });
 
     test.afterEach('Delete exam', async ({ examAPIRequests }) => {

--- a/src/test/playwright/e2e/exam/ExamPlantUmlDiagramIsolation.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamPlantUmlDiagramIsolation.spec.ts
@@ -210,6 +210,39 @@ test.describe('Exam PlantUML diagram isolation', { tag: '@slow' }, () => {
         expect(ids).toContain(`plantUml-${exerciseC.id}-1`);
     });
 
+    /**
+     * Reproduction attempt for the instructor report that "switching between exercises removes the PlantUML diagram".
+     * Tries two patterns the existing isolation test does not cover:
+     *  1) navigating BACK to an already-visited exercise, and
+     *  2) rapid switching between exercises without waiting for the (async) SVG injection to settle.
+     * After the navigation, every exercise's PlantUML SVG must still be attached to the DOM.
+     */
+    test('PlantUML diagrams survive navigating back and forth and rapid switching', async ({ page, examParticipation, examNavigation }) => {
+        await examParticipation.startParticipation(studentTwo, course, exam);
+
+        // --- Part 1: forward, then BACK navigation ---
+        await examNavigation.openOrSaveExerciseByTitle(groupTitleA);
+        await expect(page.locator(`#plantUml-${exerciseA.id}-0 svg`)).toBeAttached({ timeout: 30000 });
+        await examNavigation.openOrSaveExerciseByTitle(groupTitleB);
+        await expect(page.locator(`#plantUml-${exerciseB.id}-0 svg`)).toBeAttached({ timeout: 30000 });
+        // Navigate BACK to A: its diagram must still be there.
+        await examNavigation.openOrSaveExerciseByTitle(groupTitleA);
+        await expect(page.locator(`#plantUml-${exerciseA.id}-0 svg`)).toBeAttached({ timeout: 15000 });
+
+        // --- Part 2: rapid switching without waiting for the SVG to render in between ---
+        await examNavigation.openOrSaveExerciseByTitle(groupTitleB);
+        await examNavigation.openOrSaveExerciseByTitle(groupTitleC);
+        await examNavigation.openOrSaveExerciseByTitle(groupTitleA);
+        await examNavigation.openOrSaveExerciseByTitle(groupTitleB);
+        await examNavigation.openOrSaveExerciseByTitle(groupTitleC);
+
+        // Every diagram must still be attached (hidden exercises keep their DOM via [hidden]).
+        await expect(page.locator(`#plantUml-${exerciseA.id}-0 svg`)).toBeAttached({ timeout: 15000 });
+        await expect(page.locator(`#plantUml-${exerciseB.id}-0 svg`)).toBeAttached({ timeout: 15000 });
+        await expect(page.locator(`#plantUml-${exerciseC.id}-0 svg`)).toBeAttached({ timeout: 15000 });
+        await expect(page.locator(`#plantUml-${exerciseC.id}-1 svg`)).toBeAttached({ timeout: 15000 });
+    });
+
     test.afterEach('Delete exam', async ({ examAPIRequests }) => {
         await examAPIRequests.deleteExam(exam);
     });


### PR DESCRIPTION
### Summary

During exams, switching between exercises sometimes removed the PlantUML diagrams from a programming exercise's problem statement (workaround so far: reload the tab). This fixes it and adds E2E + unit regression tests.

### Motivation and Context

In exam mode an exercise's change detection is **detached while it is hidden**. PlantUML diagrams are injected into the rendered markdown **asynchronously** (server-rendered SVG injected via `afterNextRender`). When a student **rapidly switches** between exercises, an exercise can be hidden while its injection is still in flight, so the SVG is injected into stale/detached DOM and lost. On returning, `updateMarkdown()` skips the re-render (problem statement unchanged), so the diagram is never re-injected and stays missing. This is timing-dependent, which matches the instructor's "in some cases".

### Description

When a programming exercise becomes active again in the exam (`programming-exam-submission.onActivate`), force a re-render via a new `ProgrammingExerciseInstructionComponent.forceReRenderProblemStatement()` (which bypasses the unchanged-problem-statement optimization) instead of calling `updateMarkdown()`. The render and its content injection then run while the exercise is **visible and attached**, reliably restoring the diagrams. The optimization is unchanged for all other render paths.

### Steps for Testing

Prerequisites: 1 exam with ≥2 programming exercises whose problem statements contain PlantUML (`@startuml … @enduml`), 1 student.

1. Start the exam and open exercise A; confirm its diagram renders.
2. Rapidly switch A → B → A → B a few times.
3. Confirm the diagrams remain visible on every exercise (before the fix, a diagram intermittently vanished and only a tab reload brought it back).

### Verification
- **Reproduced first**: added an E2E (`ExamPlantUmlDiagramIsolation` › "PlantUML diagrams survive navigating back and forth and rapid switching") that navigates back and forth and rapidly switches between 3 programming exercises with PlantUML, asserting each SVG stays attached via deterministic `toBeAttached` waits. Against the local stack on `develop` it **flakily loses a diagram**; with the fix it passes **reliably (6/6 clean)**.
- **Deterministic unit regression guards** (each verified to fail against the pre-fix source and pass with the fix; 3x stable):
  - `programming-exercise-instruction.component.spec.ts`: `forceReRenderProblemStatement()` re-injects the PlantUML diagrams even when the problem statement is unchanged, whereas a plain `updateMarkdown()` (post-initial) early-returns and injects nothing. A second test asserts repeated force re-renders do not accumulate/leak task components. The existing stable-ID re-render test now drives the production `forceReRenderProblemStatement()` entry point instead of poking the private cache field.
  - `programming-exam-submission.component.spec.ts`: `onActivate()` forces a re-render (not the optimized `updateMarkdown`) and change detection is reattached (`super.onActivate`) **before** the re-render, so injection runs against a live, attached component.
- Full unit specs green: `programming-exercise-instruction.component.spec.ts` (17) and `programming-exam-submission.component.spec.ts` (5). ESLint + Prettier clean.

> Note: the reproduction is inherently timing-dependent; the new E2E documents the scenario and is stable with the fix. Test-server verification + a screenshot recommended before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PlantUML diagrams/task UI not reliably re-injecting when returning to programming exam exercises (including cases where the rendered content hasn’t changed).

* **Tests**
  * Added an end-to-end regression test for rapid switching and back-and-forth navigation to ensure PlantUML SVG containers persist.
  * Added/updated unit tests to verify forced re-render behavior, edge cases, and prevention of duplicate task components across repeated re-renders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->