### PR TITLE
`Development`: Make required CI failures clear and actionable

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -40,6 +40,9 @@ jobs:
   server-tests:
     name: Server Tests (PostgreSQL)
     runs-on: aet-large-ubuntu
+    # Outermost bound of the hang ladder: watchdog 45m (run_with_hang_dump.sh) < Gradle Test timeout
+    # 55m (gradle/test.gradle) < this 80m. Keep it above 55 so a hang fails as a deterministic Gradle
+    # `failure`, not an opaque job-level `cancelled`.
     timeout-minutes: 80
     permissions:
       contents: read
@@ -65,6 +68,8 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
       - name: Java Tests (module-affected)
         if: ${{ !inputs.run_all_tests }}
+        # Wrapped in run_with_hang_dump.sh so a hung test is thread-dumped before the Gradle task
+        # timeout (gradle/test.gradle) fires — the only forensic data a silent hang leaves.
         env:
           DEFAULT_BRANCH: ${{ inputs.base_branch }}
         run: |
@@ -78,17 +83,27 @@ jobs:
           if [ -n "${CHANGED_MODULES}" ]; then
             TEST_MODULE_TAGS="-DincludeModules=${CHANGED_MODULES}"
             echo "Executing tests for modules: $CHANGED_MODULES"
-            ./gradlew --console=plain test jacocoTestReport -x webapp -x jacocoTestCoverageVerification "$TEST_MODULE_TAGS" 2>&1 | tee tests.log
+            ./supporting_scripts/run_with_hang_dump.sh ./gradlew --console=plain test jacocoTestReport -x webapp -x jacocoTestCoverageVerification "$TEST_MODULE_TAGS"
             exit 0
           fi
 
           echo "No module-specific changes detected — executing all tests."
-          ./gradlew --console=plain test jacocoTestReport -x webapp -x jacocoTestCoverageVerification 2>&1 | tee tests.log
+          ./supporting_scripts/run_with_hang_dump.sh ./gradlew --console=plain test jacocoTestReport -x webapp -x jacocoTestCoverageVerification
       - name: Java Tests (All)
         if: ${{ inputs.run_all_tests }}
         run: |
           set -Eeuo pipefail
-          ./gradlew --console=plain test jacocoTestReport -x webapp -x jacocoTestCoverageVerification 2>&1 | tee tests.log
+          ./supporting_scripts/run_with_hang_dump.sh ./gradlew --console=plain test jacocoTestReport -x webapp -x jacocoTestCoverageVerification
+      - name: Upload Thread Dumps (on hang)
+        # `always()`, not `!cancelled()`: if a wedge defeats the Gradle timeout and the job hits its
+        # own 80-min cap, the run is `cancelled` — and that is exactly when the watchdog's dump is the
+        # only forensic data. `if-no-files-found: ignore` keeps the normal (no-hang) path quiet.
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: Server Test Thread Dumps
+          path: build/hang-thread-dumps/*.txt
+          if-no-files-found: ignore
       - name: Upload JUnit Test Results
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,25 +466,53 @@ jobs:
       - version-consistency
       - bean-instantiations
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions: {}  # reads only the `needs` context; no checkout, no token scope
     timeout-minutes: 5
     steps:
+      # Renders an actionable report to the job summary on failure and fails closed on any
+      # non-`success`/non-`skipped` result. `cancelled` is never waved through, preserving the
+      # skipped==pass invariant above. Kept inline (like `ci-summary`) so the required gate needs no
+      # checkout and no token scope.
       - name: Evaluate gate
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
-          # Fail closed: a jq error must not leave `failing` empty and pass the gate green.
           set -Eeuo pipefail
-          failing=$(jq -r '
-            to_entries[]
-            | select(.value.result != "success" and .value.result != "skipped")
-            | "\(.key): \(.value.result)"
-          ' <<< "$NEEDS")
-          if [ -n "$failing" ]; then
-            echo "::error::One or more required CI jobs did not pass:"
-            echo "$failing"
-            exit 1
+          # Fail closed: malformed/empty NEEDS must abort red, never pass green. `jq -e` on a
+          # non-object exits non-zero (aborting under set -e); command substitution (not `< <(jq)`)
+          # makes a parse error abort here too, instead of the loop reading nothing and passing.
+          jq -e 'type == "object" and length > 0' <<< "$NEEDS" > /dev/null
+          parsed=$(jq -r 'to_entries[] | "\(.key)\t\(.value.result)"' <<< "$NEEDS")
+
+          declare -a failed=() cancelled=()
+          while IFS=$'\t' read -r job result; do
+            case "$result" in
+              success | skipped) ;;
+              cancelled) cancelled+=("$job") ;;
+              *) failed+=("$job") ;;  # failure or any unrecognised result -> fail closed
+            esac
+          done <<< "$parsed"
+
+          if [ "$(( ${#failed[@]} + ${#cancelled[@]} ))" -eq 0 ]; then
+            echo "::notice::All required CI checks passed."
+            exit 0
           fi
+
+          code_list() { local out='' j; for j in "$@"; do out+="${out:+, }\`$j\`"; done; printf '%s' "$out"; }
+          {
+            echo "## ❌ Required CI did not pass"
+            [ "${#failed[@]}" -gt 0 ] && printf '\n### ❌ Failed — fix before merging\n\n%s — open each failed check from the **Checks** tab to see the error.\n' "$(code_list "${failed[@]}")"
+            [ "${#cancelled[@]}" -gt 0 ] && printf '\n### 🚫 Cancelled — not a test failure\n\n%s — a job hit its timeout, was preempted, or a newer push superseded this run. Re-run it if this run is still current.\n' "$(code_list "${cancelled[@]}")"
+            for j in "${failed[@]}" "${cancelled[@]}"; do
+              [ "$j" = test ] && { printf "\n> 💡 If \`test\` hung, a JVM thread dump is attached under **Artifacts → Server Test Thread Dumps**.\n"; break; }
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          annotation='Required CI did not pass —'
+          [ "${#failed[@]}" -gt 0 ] && annotation+=" failed: $(code_list "${failed[@]}");"
+          [ "${#cancelled[@]}" -gt 0 ] && annotation+=" cancelled: $(code_list "${cancelled[@]}");"
+          echo "::error::$annotation see the job summary for what to do."
+          exit 1
 
   # Informational Summary-page report (timeline + per-job table); never required, never in
   # another job's `needs:`, so it cannot block merging.

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -1,8 +1,17 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
+import java.time.Duration
+
 // Taken from here: https://stackoverflow.com/questions/3963708/gradle-how-to-display-test-results-in-the-console-in-real-time
 tasks.withType(Test).configureEach {
+
+    // Hard backstop against a hung test/deadlock (suite normally finishes in ~30 min). On timeout the
+    // build fails as `failure`, not the opaque `cancelled` a GitHub job-timeout produces, so the merge
+    // gate shows a real failure. A global JUnit per-method timeout is deliberately NOT used:
+    // SAME_THREAD cannot interrupt a deadlock, and SEPARATE_THREAD breaks the ~288 tests relying on the
+    // thread-bound Spring SecurityContext (@WithMockUser).
+    timeout = Duration.ofMinutes(55)
 
     jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
     // Required by the Weaviate Java client v6, which uses Gson's reflection-based serialization on internal java.lang classes.

--- a/supporting_scripts/run_with_hang_dump.sh
+++ b/supporting_scripts/run_with_hang_dump.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Runs a Gradle test command and, if it hangs, thread-dumps every JVM before CI kills the run.
+# A deadlocked test produces no output and is otherwise killed by the Gradle task timeout
+# (gradle/test.gradle) with no clue which thread hung. jstack -l (deadlock + lock info) to a separate
+# artifact is used over `kill -3`, whose dump would be buried in the multi-100k-line tests.log.
+# Usage: run_with_hang_dump.sh <command> [args...]
+set -euo pipefail
+
+# Must stay below the Gradle Test task timeout (55 min) so the JVMs are still alive when dumped.
+readonly WATCHDOG_MINUTES=45
+readonly DUMP_DIR=build/hang-thread-dumps
+
+dump_hung_jvms() {
+    # `|| return`: when the watchdog is reaped on a normal finish the sleep is interrupted, so skip
+    # the dump — only a sleep that runs its full course means the command actually hung.
+    sleep "$(( WATCHDOG_MINUTES * 60 ))" || return
+    echo "::warning::No completion after ${WATCHDOG_MINUTES} min — dumping JVM threads (likely hang); see the Server Test Thread Dumps artifact."
+    mkdir -p "$DUMP_DIR"
+    jcmd -l | awk '{print $1}' | while read -r pid; do
+        # `timeout`: attaching to a truly wedged JVM can itself hang; don't let one block the rest.
+        timeout 60 jstack -l "$pid" > "$DUMP_DIR/threaddump-${pid}.txt" 2>&1 || true
+    done
+}
+
+dump_hung_jvms &
+watchdog_pid=$!
+# Reap the watchdog *and* its `sleep` child (`pkill -P`); killing the subshell alone leaves the sleep
+# orphaned for the runner to clean up on every run.
+trap 'pkill -P "$watchdog_pid" 2>/dev/null || true; kill "$watchdog_pid" 2>/dev/null || true' EXIT INT TERM
+
+"$@" 2>&1 | tee tests.log


### PR DESCRIPTION
### Summary
When a required CI check fails, the **All required CI Passed** gate printed only a bare line such as `test: cancelled` — with no indication of whether a test actually *failed* or the job was merely *killed by a timeout*, and nothing about what to do next. Developers had to guess, and a hung test produced the least useful signal of all: an opaque `cancelled` after 80 minutes, with no diagnostic data.

This PR makes every required-CI failure **self-explanatory**, and fixes the failure mode that left developers most in the dark (a hung test) so it fails fast and leaves something to debug. It touches **CI configuration only** — no application code and no test-execution behaviour.

> **Transparency:** the hang handling does **not** fix the root cause of a hang itself (still unknown — precisely because the original incident left no forensic data). It makes the failure fast, deterministic, clearly reported, and *diagnosable*, so the next occurrence can be root-caused.

### Checklist
#### General
- [x] Small, **CI-only** change (two workflow edits, one Gradle build setting, one shell helper — **no application code**), verified locally (`shellcheck`, YAML validation, and a replay of real recent CI failures — see *Steps for Testing*) and exercised by the CI pipeline on this PR.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

<!-- Server / Client / Programming Exercise checklist subsections removed: this PR changes no application code, only CI workflows, a Gradle build setting, and a shell helper. -->

### Motivation and Context
The CI consolidation in #12745 introduced a single required gate (`all-required-ci-passed`) that fails closed when any required job is not `success`/`skipped`. That is correct, but its **feedback** was minimal — a one-line `<job>: <result>` and nothing else — which causes two recurring pain points, both still present on `develop` today:

1. **`cancelled` reads like a test failure but isn't.** A job killed by `timeout-minutes`, preempted, or superseded by a newer push reports as `cancelled`. The author sees `test: cancelled`, assumes their tests broke, and hunts for a failure that doesn't exist.
2. **A hung test gave the worst signal of all.** It ran out the 80-minute job timeout, reported `cancelled`, and left **no thread dump** — the original incident had a ~37-minute silent gap, so the deadlock could not be diagnosed.

### Description
**1. A clear, actionable required-gate report** — `.github/workflows/ci.yml`
On failure, the gate now writes an actionable report to the **job summary** instead of a bare line:
- an **“❌ Failed — fix before merging”** group listing the failed checks (→ open their logs in the Checks tab);
- a **“🚫 Cancelled — not a test failure”** group explaining it was a timeout/preemption/superseded run and to re-run if the run is still current;
- a pointer to the **thread-dump artifact** when the `test` job is affected;
- a concise `::error::`/`::notice::` annotation.

A passing run stays quiet (just a `::notice::`). The logic is kept **inline** (like the neighbouring `ci-summary` job) so the merge-blocking gate needs **no checkout and no token scope** (`permissions: {}`) — no added failure surface on the required check. It **still fails closed**: any non-`success`/non-`skipped` result fails the gate, `cancelled` is never waved through (preserving the documented `skipped == pass` invariant), and malformed/empty input aborts rather than passing green. It does not duplicate `ci-summary`, which remains the full-picture informational table (including advisory jobs the gate can't see).

**2. Fast, diagnosable test hangs** — `gradle/test.gradle`, `.github/workflows/ci-test.yml`, `supporting_scripts/run_with_hang_dump.sh`
- A 55-minute Gradle `Test` task timeout turns a hung suite into a deterministic `failure` (not the opaque `cancelled` an 80-minute job timeout produces — which the gate now reports clearly). The three bounds nest deliberately: **watchdog 45 min < Gradle 55 min < job 80 min**.
- A small watchdog wrapping the test command thread-dumps every JVM (time-boxed `jstack -l`) shortly before that timeout, uploaded as the `Server Test Thread Dumps` artifact with `if: always()` so the dump survives even if a wedge forces a job-level cancel. (`jstack`-to-artifact rather than `kill -3`, whose dump would be lost in the multi-100k-line build log; the watchdog runs *concurrently* because after the timeout the JVM is gone.)
- A global JUnit per-method timeout was **deliberately rejected**: `SAME_THREAD` mode cannot interrupt a deadlock, and `SEPARATE_THREAD` mode runs test bodies on a worker thread that does not inherit the thread-bound Spring `SecurityContext`, which would break the ~288 tests using `@WithMockUser`. The Gradle task timeout is the safe, zero-behaviour-risk backstop.

Automatic retry and suite sharding were considered and left out (retry risks the merge queue’s status-check timeout; sharding needs runner-pool capacity) — reasonable follow-ups.

### Steps for Testing
This is a CI-only change, verified by replaying **real, recent CI failures** through the new gate rather than by feature testing on a test server.

**Validation performed (safety-critical: the new gate must never change the merge verdict):**
- Replayed the exact `needs` payloads logged by the live gate on **14 recent real runs** (8 `failure` + 6 `cancelled`, across `develop` and other branches) through both the old and the new gate. **All 14 produced an identical pass/fail verdict** — including `test:failure`, `test+quality:failure`, mass `build+test+quality:cancelled` (superseded run), `test:cancelled` (the original hang shape), and an advisory-only failure that both gates correctly **pass**. Only the reporting differs.
- **Fails closed** on every malformed input (empty/whitespace/array/`null`/non-object `needs`, missing `.result`, unrecognised result) → non-zero; only all-`success`/`skipped` → 0.

**Reproduce locally:**
1. Gate logic — copy the `Evaluate gate` step's `run:` block into a file and run:
   ```bash
   NEEDS='{"test":{"result":"cancelled"},"build":{"result":"success"}}' GITHUB_STEP_SUMMARY=/tmp/s.md bash file; echo $?   # → 1, renders the "Cancelled" group
   NEEDS='garbage' GITHUB_STEP_SUMMARY=/dev/null bash file; echo $?                                                        # → non-zero (fails closed)
   ```
2. Hang wrapper:
   ```bash
   shellcheck supporting_scripts/run_with_hang_dump.sh
   ./supporting_scripts/run_with_hang_dump.sh bash -c 'exit 5'; echo $?   # → 5, exit code propagates
   ```
   Lower `WATCHDOG_MINUTES` and run a `sleep` to see a `Full thread dump` written under `build/hang-thread-dumps/`.
3. On this PR: open the **All required CI Passed** check's **Summary** — on failure it shows the grouped guidance; on success it stays quiet.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-02 15:14:36 UTC_

