### PR TITLE
`Exercises`: Allow non-ASCII letters such as umlauts in exercise titles

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/Constants.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/Constants.java
@@ -89,7 +89,12 @@ public final class Constants {
 
     public static final Pattern FILE_ENDING_PATTERN = Pattern.compile(FILE_ENDING_REGEX);
 
-    public static final Pattern TITLE_NAME_PATTERN = Pattern.compile("^[a-zA-Z0-9_\\-\\s]*");
+    // Allowed characters for exercise titles: Unicode letters (\p{L}, e.g. umlauts like "Lärche"), combining marks
+    // (\p{M}, for decomposed accented characters), numbers (\p{N}), underscore, hyphen and whitespace. Titles are
+    // display-only and never used to derive VCS/CI artifacts (those come from the ASCII-validated short name), so
+    // allowing international letters here is safe. Previously this was ASCII-only, which rejected legitimate titles such
+    // as "Lärche" on edit while create/import accepted them.
+    public static final Pattern TITLE_NAME_PATTERN = Pattern.compile("^[\\p{L}\\p{M}\\p{N}_\\-\\s]*");
 
     public static final String TUM_LDAP_MATRIKEL_NUMBER = "imMatrikelNr";
 

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/StringUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/StringUtil.java
@@ -30,10 +30,17 @@ public class StringUtil {
      * extraction when exercise/exam titles contain international letters. Display contexts (e.g. notifications) must use
      * the raw title instead of this method, so users still see the original characters.
      *
-     * @param input String to sanitize
-     * @return sanitized, ASCII-only string safe for use in file names
+     * Note: the result may be empty (e.g. for an input consisting only of non-ASCII letters such as "テスト"). Callers
+     * that use the result as a standalone file or directory name must guard against this to avoid name collisions
+     * (see e.g. {@code BaseExercise#getSanitizedExerciseTitle()}).
+     *
+     * @param input String to sanitize (may be {@code null})
+     * @return sanitized, ASCII-only string safe for use in file names, or an empty string if the input is {@code null}
      */
     public static String sanitizeStringForFileName(String input) {
+        if (input == null) {
+            return "";
+        }
         String asciiReduced = Normalizer.normalize(input, Normalizer.Form.NFD).replaceAll("[^\\x00-\\x7F]", "");
         return asciiReduced.replaceAll("\\s+", "_").replaceAll("[\\\\/:*?#+%$§\"<>|]", "");
     }

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/StringUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/StringUtil.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.core.util;
 
+import java.text.Normalizer;
+
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -20,12 +22,19 @@ public class StringUtil {
     }
 
     /**
-     * Replaces whitespace with underscores and removes illegal characters, which allows to use the string in file names
+     * Sanitizes a string so it is safe to use as a file or directory name across filesystems and archive tools.
+     * <p>
+     * It reduces the input to ASCII (decomposing accented letters to their base form, e.g. "ä" -&gt; "a", then dropping
+     * any remaining non-ASCII character), collapses whitespace to underscores and removes filesystem-reserved
+     * characters. Reducing to ASCII avoids problems with non-UTF-8 mounts, ZIP entry encoding and cross-platform
+     * extraction when exercise/exam titles contain international letters. Display contexts (e.g. notifications) must use
+     * the raw title instead of this method, so users still see the original characters.
      *
      * @param input String to sanitize
-     * @return sanitized string
+     * @return sanitized, ASCII-only string safe for use in file names
      */
     public static String sanitizeStringForFileName(String input) {
-        return input.replaceAll("\\s+", "_").replaceAll("[\\\\/:*?#+%$§\"<>|]", "");
+        String asciiReduced = Normalizer.normalize(input, Normalizer.Form.NFD).replaceAll("[^\\x00-\\x7F]", "");
+        return asciiReduced.replaceAll("\\s+", "_").replaceAll("[\\\\/:*?#+%$§\"<>|]", "");
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exam/domain/Exam.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/domain/Exam.java
@@ -526,9 +526,19 @@ public class Exam extends DomainObject {
         this.quizExamMaxPoints = quizExamMaxPoints;
     }
 
+    /**
+     * Returns the exam title in a form that is safe to use in file or directory names.
+     *
+     * @return the sanitized exam title, or a stable unique fallback if the title has no ASCII representation
+     */
     @JsonIgnore
     public String getSanitizedExamTitle() {
-        // exam titles are non-nullable
-        return StringUtil.sanitizeStringForFileName(this.title);
+        // exam titles are non-nullable, but may sanitize to an empty string when they consist only of non-ASCII letters
+        // (sanitizeStringForFileName reduces the input to ASCII). Fall back to a stable, unique name in that case.
+        String sanitizedTitle = this.title == null ? "" : StringUtil.sanitizeStringForFileName(this.title);
+        if (sanitizedTitle.isBlank()) {
+            return getId() != null ? "exam_" + getId() : "exam";
+        }
+        return sanitizedTitle;
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/BaseExercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/BaseExercise.java
@@ -247,10 +247,14 @@ public abstract class BaseExercise extends DomainObject {
      **/
     @JsonIgnore
     public String getSanitizedExerciseTitle() {
-        if (title == null) {
-            return "exercise";
+        String sanitizedTitle = title == null ? "" : StringUtil.sanitizeStringForFileName(title);
+        if (sanitizedTitle.isBlank()) {
+            // The title may sanitize to an empty string when it consists only of non-ASCII letters (e.g. "テスト"),
+            // because sanitizeStringForFileName reduces the input to ASCII. Fall back to a stable, unique name so that
+            // exercise export directories derived from the title cannot collide.
+            return getId() != null ? "exercise_" + getId() : "exercise";
         }
-        return StringUtil.sanitizeStringForFileName(title);
+        return sanitizedTitle;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionExportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionExportService.java
@@ -187,8 +187,9 @@ public abstract class SubmissionExportService {
                 return Optional.<Path>empty();
             }
 
-            // create file path
-            String submissionFileName = exercise.getTitle() + "-" + participation.getParticipantIdentifier() + "-" + latestSubmission.getId()
+            // create file path (sanitize the title-based name so the submission file stays filesystem-safe, consistent
+            // with the zip group name above; the exercise title may contain spaces or international letters)
+            String submissionFileName = FileUtil.sanitizeFilename(exercise.getTitle() + "-" + participation.getParticipantIdentifier() + "-" + latestSubmission.getId())
                     + this.getFileEndingForSubmission(latestSubmission);
             Path submissionFilePath = outputDir.resolve(submissionFileName);
 

--- a/src/main/java/de/tum/cit/aet/artemis/notification/service/notifications/SingleUserNotificationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/service/notifications/SingleUserNotificationService.java
@@ -103,8 +103,8 @@ public class SingleUserNotificationService {
         Double score = Objects.requireNonNull(studentParticipation.get().findLatestResult()).getScore();
 
         Long examId = exercise.isExamExercise() ? exercise.getExerciseGroup().getExam().getId() : null;
-        var exerciseAssessedNotification = new ExerciseAssessedNotification(course.getId(), course.getTitle(), course.getCourseIcon(), exercise.getId(),
-                exercise.getSanitizedExerciseTitle(), exercise.getType(), exercise.getMaxPoints().longValue(), score.longValue(), examId);
+        var exerciseAssessedNotification = new ExerciseAssessedNotification(course.getId(), course.getTitle(), course.getCourseIcon(), exercise.getId(), exercise.getTitle(),
+                exercise.getType(), exercise.getMaxPoints().longValue(), score.longValue(), examId);
 
         courseNotificationService.sendCourseNotification(exerciseAssessedNotification, List.of(recipient));
     }
@@ -152,7 +152,7 @@ public class SingleUserNotificationService {
 
         Long examId = plagiarismCaseExercise.isExamExercise() ? plagiarismCaseExercise.getExerciseGroup().getExam().getId() : null;
         var newPlagiarismCaseNotification = new NewPlagiarismCaseNotification(course.getId(), course.getTitle(), course.getCourseIcon(), plagiarismCaseExercise.getId(),
-                plagiarismCaseExercise.getSanitizedExerciseTitle(), plagiarismCaseExercise.getType(), plagiarismCase.getPost().getContent(), examId);
+                plagiarismCaseExercise.getTitle(), plagiarismCaseExercise.getType(), plagiarismCase.getPost().getContent(), examId);
 
         courseNotificationService.sendCourseNotification(newPlagiarismCaseNotification, List.of(student));
     }
@@ -170,7 +170,7 @@ public class SingleUserNotificationService {
 
         Long examId = plagiarismCaseExercise.isExamExercise() ? plagiarismCaseExercise.getExerciseGroup().getExam().getId() : null;
         var newCpcPlagiarismCaseNotification = new NewCpcPlagiarismCaseNotification(course.getId(), course.getTitle(), course.getCourseIcon(), plagiarismCaseExercise.getId(),
-                plagiarismCaseExercise.getSanitizedExerciseTitle(), plagiarismCaseExercise.getType(), plagiarismCase.getPost().getContent(), examId);
+                plagiarismCaseExercise.getTitle(), plagiarismCaseExercise.getType(), plagiarismCase.getPost().getContent(), examId);
 
         courseNotificationService.sendCourseNotification(newCpcPlagiarismCaseNotification, List.of(student));
     }
@@ -187,7 +187,7 @@ public class SingleUserNotificationService {
 
         Long examId = plagiarismCaseExercise.isExamExercise() ? plagiarismCaseExercise.getExerciseGroup().getExam().getId() : null;
         var plagiarismCaseVerdictNotification = new PlagiarismCaseVerdictNotification(course.getId(), course.getTitle(), course.getCourseIcon(), plagiarismCaseExercise.getId(),
-                plagiarismCaseExercise.getSanitizedExerciseTitle(), plagiarismCaseExercise.getType(), plagiarismCase.getVerdict().toString(), examId);
+                plagiarismCaseExercise.getTitle(), plagiarismCaseExercise.getType(), plagiarismCase.getVerdict().toString(), examId);
 
         courseNotificationService.sendCourseNotification(plagiarismCaseVerdictNotification, List.of(student));
     }

--- a/src/main/java/de/tum/cit/aet/artemis/notification/service/notifications/SingleUserNotificationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/service/notifications/SingleUserNotificationService.java
@@ -103,8 +103,8 @@ public class SingleUserNotificationService {
         Double score = Objects.requireNonNull(studentParticipation.get().findLatestResult()).getScore();
 
         Long examId = exercise.isExamExercise() ? exercise.getExerciseGroup().getExam().getId() : null;
-        var exerciseAssessedNotification = new ExerciseAssessedNotification(course.getId(), course.getTitle(), course.getCourseIcon(), exercise.getId(), exercise.getTitle(),
-                exercise.getType(), exercise.getMaxPoints().longValue(), score.longValue(), examId);
+        var exerciseAssessedNotification = new ExerciseAssessedNotification(course.getId(), course.getTitle(), course.getCourseIcon(), exercise.getId(),
+                exercise.getExerciseNotificationTitle(), exercise.getType(), exercise.getMaxPoints().longValue(), score.longValue(), examId);
 
         courseNotificationService.sendCourseNotification(exerciseAssessedNotification, List.of(recipient));
     }
@@ -152,7 +152,7 @@ public class SingleUserNotificationService {
 
         Long examId = plagiarismCaseExercise.isExamExercise() ? plagiarismCaseExercise.getExerciseGroup().getExam().getId() : null;
         var newPlagiarismCaseNotification = new NewPlagiarismCaseNotification(course.getId(), course.getTitle(), course.getCourseIcon(), plagiarismCaseExercise.getId(),
-                plagiarismCaseExercise.getTitle(), plagiarismCaseExercise.getType(), plagiarismCase.getPost().getContent(), examId);
+                plagiarismCaseExercise.getExerciseNotificationTitle(), plagiarismCaseExercise.getType(), plagiarismCase.getPost().getContent(), examId);
 
         courseNotificationService.sendCourseNotification(newPlagiarismCaseNotification, List.of(student));
     }
@@ -170,7 +170,7 @@ public class SingleUserNotificationService {
 
         Long examId = plagiarismCaseExercise.isExamExercise() ? plagiarismCaseExercise.getExerciseGroup().getExam().getId() : null;
         var newCpcPlagiarismCaseNotification = new NewCpcPlagiarismCaseNotification(course.getId(), course.getTitle(), course.getCourseIcon(), plagiarismCaseExercise.getId(),
-                plagiarismCaseExercise.getTitle(), plagiarismCaseExercise.getType(), plagiarismCase.getPost().getContent(), examId);
+                plagiarismCaseExercise.getExerciseNotificationTitle(), plagiarismCaseExercise.getType(), plagiarismCase.getPost().getContent(), examId);
 
         courseNotificationService.sendCourseNotification(newCpcPlagiarismCaseNotification, List.of(student));
     }
@@ -187,7 +187,7 @@ public class SingleUserNotificationService {
 
         Long examId = plagiarismCaseExercise.isExamExercise() ? plagiarismCaseExercise.getExerciseGroup().getExam().getId() : null;
         var plagiarismCaseVerdictNotification = new PlagiarismCaseVerdictNotification(course.getId(), course.getTitle(), course.getCourseIcon(), plagiarismCaseExercise.getId(),
-                plagiarismCaseExercise.getTitle(), plagiarismCaseExercise.getType(), plagiarismCase.getVerdict().toString(), examId);
+                plagiarismCaseExercise.getExerciseNotificationTitle(), plagiarismCaseExercise.getType(), plagiarismCase.getVerdict().toString(), examId);
 
         courseNotificationService.sendCourseNotification(plagiarismCaseVerdictNotification, List.of(student));
     }

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/StringUtilTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/StringUtilTest.java
@@ -53,4 +53,20 @@ class StringUtilTest {
         // even letters without an ASCII decomposition (e.g. ß, ø) must not leave non-ASCII characters in a file name
         assertThat(sanitizeStringForFileName("Maß Sørensen")).containsPattern("^[\\x00-\\x7F]*$");
     }
+
+    @Test
+    void sanitizeStringForFileNameReturnsEmptyForNullOrOnlyNonAsciiInput() {
+        // a title with no ASCII representation sanitizes to empty; callers must add a uniqueness fallback
+        // (see BaseExercise#getSanitizedExerciseTitle) so export directories cannot collide
+        assertThat(sanitizeStringForFileName(null)).isEmpty();
+        assertThat(sanitizeStringForFileName("テスト")).isEmpty();
+        assertThat(sanitizeStringForFileName("Σθμ")).isEmpty();
+        assertThat(sanitizeStringForFileName("😀")).isEmpty();
+    }
+
+    @Test
+    void sanitizeStringForFileNameKeepsAsciiPartsOfMixedInput() {
+        // non-ASCII letters are dropped while surrounding ASCII content is preserved and whitespace collapses to underscores
+        assertThat(sanitizeStringForFileName("A テスト B")).isEqualTo("A_B");
+    }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/StringUtilTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/StringUtilTest.java
@@ -1,10 +1,13 @@
 package de.tum.cit.aet.artemis.core.util;
 
 import static de.tum.cit.aet.artemis.core.util.StringUtil.ILLEGAL_CHARACTERS;
+import static de.tum.cit.aet.artemis.core.util.StringUtil.sanitizeStringForFileName;
 import static de.tum.cit.aet.artemis.core.util.StringUtil.stripIllegalCharacters;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class StringUtilTest {
 
@@ -31,5 +34,23 @@ class StringUtilTest {
     @Test
     void testWithIllegal() {
         assertThat(stripIllegalCharacters("a^b\"c$d%e&f/g(ä)ö?ü")).isEqualTo("a^bcdefg(ä)öü");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            // umlauts and accents are reduced to their ASCII base letter so file names stay ASCII-only
+            "Lärche, Larche", "Müller Übung, Muller_Ubung", "naïve café, naive_cafe",
+            // whitespace collapses to a single underscore; filesystem-reserved characters are removed
+            "'exercise abc?+#', exercise_abc", "'a   b', a_b", "'a/b\\c:d*e', abcde",
+            // plain ASCII is unchanged
+            "Algorithmen-1, Algorithmen-1" })
+    void sanitizeStringForFileNameReducesToAsciiAndRemovesReservedCharacters(String input, String expected) {
+        assertThat(sanitizeStringForFileName(input)).isEqualTo(expected);
+    }
+
+    @Test
+    void sanitizeStringForFileNameProducesAsciiOnlyOutput() {
+        // even letters without an ASCII decomposition (e.g. ß, ø) must not leave non-ASCII characters in a file name
+        assertThat(sanitizeStringForFileName("Maß Sørensen")).containsPattern("^[\\x00-\\x7F]*$");
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTitleValidationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTitleValidationTest.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.artemis.exercise;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -24,7 +25,9 @@ class ExerciseTitleValidationTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "Lärche", "Müller Übung", "naïve café", "Sør-Trøndelag", "Größe", "Algorithmen 1", "test_exercise-1" })
+    @ValueSource(strings = { "Lärche", "Müller Übung", "naïve café", "Sør-Trøndelag", "Größe", "Algorithmen 1", "test_exercise-1",
+            // non-Latin scripts are Unicode letters (\p{L}) and must be accepted, not just Latin accents
+            "Тест-задача", "Άλγεβρα", "テスト課題" })
     void shouldAcceptTitlesWithUnicodeLettersAndAllowedCharacters(String title) {
         // Regression test for "Lärche": umlauts and other Unicode letters must be accepted in exercise titles. The
         // pattern was previously ASCII-only, which rejected such titles on edit (create/import used the same pattern).
@@ -32,15 +35,29 @@ class ExerciseTitleValidationTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "title<script>", "title$value", "title;drop", "100%done", "a/b" })
+    @ValueSource(strings = { "title<script>", "title$value", "title;drop", "100%done", "a/b", "a\\b", "a:b", "a.b", "title|pipe" })
     void shouldRejectTitlesWithDisallowedSymbols(String title) {
         // Letters/marks/numbers, underscore, hyphen and whitespace are allowed; other symbols (which could break VCS,
-        // headers, or rendering) must still be rejected.
+        // file paths, headers, or rendering) must still be rejected.
         assertThatExceptionOfType(BadRequestAlertException.class).isThrownBy(() -> exerciseWithTitle(title).validateTitle());
     }
 
     @Test
     void shouldRejectTitleThatIsTooShort() {
         assertThatExceptionOfType(BadRequestAlertException.class).isThrownBy(() -> exerciseWithTitle("ab").validateTitle());
+    }
+
+    @Test
+    void getSanitizedExerciseTitleFallsBackToUniqueNameWhenTitleHasNoAsciiRepresentation() {
+        // A title consisting only of non-ASCII letters sanitizes to an empty string; the sanitized title must still be
+        // non-empty and unique (include the id) so two such exercises cannot export into the same directory.
+        Exercise cjkExercise = exerciseWithTitle("テスト課題");
+        cjkExercise.setId(42L);
+        assertThat(cjkExercise.getSanitizedExerciseTitle()).isEqualTo("exercise_42");
+
+        // a title that does have an ASCII representation is reduced as usual (not replaced by the fallback)
+        Exercise umlautExercise = exerciseWithTitle("Lärche Übung");
+        umlautExercise.setId(7L);
+        assertThat(umlautExercise.getSanitizedExerciseTitle()).isEqualTo("Larche_Ubung");
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTitleValidationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTitleValidationTest.java
@@ -1,0 +1,46 @@
+package de.tum.cit.aet.artemis.exercise;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
+import de.tum.cit.aet.artemis.exercise.domain.Exercise;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
+
+/**
+ * Unit tests for {@link Exercise#validateTitle()}, the shared title validation used by all exercise create/import and
+ * edit flows (it is the exact point that rejected titles like "Lärche").
+ */
+class ExerciseTitleValidationTest {
+
+    private static Exercise exerciseWithTitle(String title) {
+        Exercise exercise = new TextExercise();
+        exercise.setTitle(title);
+        return exercise;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "Lärche", "Müller Übung", "naïve café", "Sør-Trøndelag", "Größe", "Algorithmen 1", "test_exercise-1" })
+    void shouldAcceptTitlesWithUnicodeLettersAndAllowedCharacters(String title) {
+        // Regression test for "Lärche": umlauts and other Unicode letters must be accepted in exercise titles. The
+        // pattern was previously ASCII-only, which rejected such titles on edit (create/import used the same pattern).
+        assertThatCode(() -> exerciseWithTitle(title).validateTitle()).doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "title<script>", "title$value", "title;drop", "100%done", "a/b" })
+    void shouldRejectTitlesWithDisallowedSymbols(String title) {
+        // Letters/marks/numbers, underscore, hyphen and whitespace are allowed; other symbols (which could break VCS,
+        // headers, or rendering) must still be rejected.
+        assertThatExceptionOfType(BadRequestAlertException.class).isThrownBy(() -> exerciseWithTitle(title).validateTitle());
+    }
+
+    @Test
+    void shouldRejectTitleThatIsTooShort() {
+        assertThatExceptionOfType(BadRequestAlertException.class).isThrownBy(() -> exerciseWithTitle("ab").validateTitle());
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
@@ -464,6 +464,18 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateTextExercise_withUnicodeLettersInTitle_succeeds() throws Exception {
+        // Regression test for "Lärche": editing an exercise to a title containing umlauts / other Unicode letters must
+        // succeed. The shared title validation (Exercise#validateTitle, also used by the programming edit path that the
+        // bug was reported on) previously rejected such titles with an ASCII-only pattern.
+        textExercise.setTitle("Lärche Übung");
+        TextExercise updated = request.putWithResponseBody("/api/text/text-exercises", de.tum.cit.aet.artemis.text.dto.UpdateTextExerciseDTO.of(textExercise), TextExercise.class,
+                HttpStatus.OK);
+        assertThat(updated.getTitle()).isEqualTo("Lärche Übung");
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void updateTextExercise_IncludedAsBonusInvalidBonusPoints() throws Exception {
         textExercise.setMaxPoints(10.0);
         textExercise.setBonusPoints(1.0);


### PR DESCRIPTION
### Checklist
- [x] I tested all changes and their related features with all corresponding user types.

### Motivation and Context

An instructor reported that creating/importing a programming exercise with an umlaut in the title (e.g. "Lärche") worked, but **editing** it failed with "The title is invalid.". The exercise title validation used an ASCII-only pattern (`TITLE_NAME_PATTERN = ^[a-zA-Z0-9_\-\s]*`), applied via `matches()` in `Exercise.validateTitle()` (the edit path, `ProgrammingExerciseUpdateResource`). International letters are legitimate in titles (German/other-language course content), so they should be accepted.

### Description

1. **Allow Unicode letters in titles.** `TITLE_NAME_PATTERN` now allows Unicode letters (`\p{L}`), combining marks (`\p{M}`) and numbers (`\p{N}`) in addition to underscore, hyphen and whitespace. This is the single pattern used by both `Exercise.validateTitle()` (all exercise types, edit) and `ProgrammingExerciseRepository.validateTitle()` (create/import), so titles like "Lärche" are now accepted consistently.

2. **Keep file/directory names ASCII-safe.** Titles are display-only and must never break server-side file operations. `StringUtil.sanitizeStringForFileName` (which backs `Exercise#getSanitizedExerciseTitle` and the exam equivalent, used to build export directories and file names) now reduces its input to ASCII — it decomposes accented letters to their base form (`ä` → `a`) and drops any remaining non-ASCII — in addition to its existing whitespace/reserved-character handling. This guards against non-UTF-8 mounts, ZIP entry encoding and cross-platform extraction issues. `SubmissionExportService` also now sanitizes the per-submission file name (it previously used the raw title).

3. **Show the real title in notifications.** The four `SingleUserNotificationService` messages (exercise assessed, new/CPC plagiarism case, plagiarism verdict) used the *sanitized* title for display; they now use the raw title so users see the original characters.

Audit of where the title reaches the filesystem: all other export paths already route through `FileUtil.sanitizeFilename` (allowlist `[a-zA-Z0-9.\-]`), which already stripped non-ASCII, so they were unaffected.

### Steps for Testing

1. Create a programming exercise with an umlaut in the title (e.g. "Lärche"). It is created successfully.
2. Edit the exercise (change anything) and save. **Before:** "The title is invalid." **After:** the edit saves successfully.
3. Export the course / a submission for that exercise and inspect the archive: the generated file and directory names are ASCII (e.g. "Larche…"), with no broken characters.
4. Trigger an "exercise assessed" or plagiarism-case notification for the exercise: the notification shows the real title ("Lärche").

### Server tests
- `ExerciseTitleValidationTest` (new): accepts Unicode-letter titles and still rejects disallowed symbols / too-short titles. Verified to fail on the previous ASCII-only pattern.
- `StringUtilTest` (extended): asserts `sanitizeStringForFileName` reduces accented letters to ASCII, collapses whitespace, removes reserved characters, and produces ASCII-only output.

### Review Progress
- [x] Code Review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exercise titles now support Unicode characters, enabling international language support (e.g., letters from any language, diacritical marks).

* **Bug Fixes**
  * Improved filesystem-safe filename generation for exported submissions.
  * Enhanced exercise title processing in notifications.
  * Added fallback identifiers for titles containing only non-ASCII characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->