### PR TITLE
`Development`: Update Spring AI to 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,7 @@ dependencies {
     // Align all Spring AI modules to the same version
     // 2.0.0-M6+ fixes GHSA-q62f-h9x2-gcqc (ChatMemory DEFAULT_CONVERSATION_ID cross-user leakage).
     // Artemis was not exposed (explicit per-(course,user) conversation ids), but the scanner flags the range.
-    implementation platform("org.springframework.ai:spring-ai-bom:2.0.0-RC2")
+    implementation platform("org.springframework.ai:spring-ai-bom:2.0.0")
     implementation "org.springframework.ai:spring-ai-starter-model-chat-memory-repository-jdbc"
     // OpenAI module (official com.openai SDK). Since 2.0.0-M5/M6 this single module serves both
     // Azure OpenAI / Microsoft Foundry (prod) and OpenAI-compatible local servers (dev) —


### PR DESCRIPTION
### Motivation and Context

Spring AI was pinned to a release candidate (`spring-ai-bom:2.0.0-RC2`). This bumps it to the `2.0.0` GA release.

### Description

- `build.gradle`: `org.springframework.ai:spring-ai-bom` `2.0.0-RC2` → `2.0.0`.

RC2 → GA is an API-stable finalization. The server compiles unchanged against 2.0.0 (`./gradlew compileJava` succeeds), so no code changes are required. The existing explanatory comments referencing earlier milestones (M5/M6) remain accurate.

### Steps for Testing

1. `./gradlew compileJava -x webapp` resolves `spring-ai-bom:2.0.0` and compiles.
2. Smoke-test the AI-backed features (Iris chat / Hyperion) against the configured model to confirm runtime behavior is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Spring AI framework dependency to the latest stable release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->