### PR TITLE
`Development`: Update pnpm to 11.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "email": "krusche@tum.de",
         "url": "https://aet.cit.tum.de/krusche"
     },
-    "packageManager": "pnpm@11.6.0",
+    "packageManager": "pnpm@11.7.0",
     "dependencies": {
         "@angular/animations": "21.2.17",
         "@angular/cdk": "21.2.14",


### PR DESCRIPTION
### Motivation and Context

Keep the pinned pnpm version current.

### Description

- `package.json`: `packageManager` `pnpm@11.6.0` → `pnpm@11.7.0` (latest).

corepack resolves 11.7.0 from the field and `pnpm install --frozen-lockfile` passes unchanged (same lockfile format), so there are no lockfile or dependency changes. The `engines.pnpm` floor (`>=11.1.0`) still holds.

### Steps for Testing

1. `corepack enable && pnpm --version` → `11.7.0`.
2. `pnpm install --frozen-lockfile` succeeds without modifying `pnpm-lock.yaml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated required package manager version to pnpm@11.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->