### PR TITLE
`Development`: Keep Gradle plugin resolution off the slow Maven Central mirror

### DIFF
--- a/gradle/openapi.gradle
+++ b/gradle/openapi.gradle
@@ -3,12 +3,13 @@
 
     buildscript {
         repositories {
-            // Preferred Maven Central mirror hosted in TUM AET infrastructure (avoids upstream 429 rate-limit errors)
+            mavenCentral()
+            // Reposilite mirror as a fallback only (see settings.gradle): keeps the fast Maven Central
+            // path for the openapi-generator buildscript classpath while remaining available if needed.
             maven {
                 name = "reposiliteRepository"
                 url = "https://reposilite.aet.cit.tum.de/releases"
             }
-            mavenCentral()
         }
         dependencies {
             classpath "org.yaml:snakeyaml:${rootProject.property('snakeyaml_version')}"

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,13 +3,16 @@ import org.apache.tools.ant.DirectoryScanner
 pluginManagement {
     repositories {
         mavenLocal()
-        // Preferred Maven Central mirror hosted in TUM AET infrastructure (avoids upstream 429 rate-limit errors during plugin resolution)
+        mavenCentral()
+        gradlePluginPortal()
+        // Reposilite mirror kept only as a fallback here: plugin/buildscript resolution is low-volume
+        // (so not the source of Maven Central 429s) and the mirror's latency otherwise dominates the
+        // configuration phase. The mirror stays the PRIMARY repository for the high-volume main
+        // dependency downloads in build.gradle, where the rate-limiting actually occurs.
         maven {
             name = "reposiliteRepository"
             url = "https://reposilite.aet.cit.tum.de/releases"
         }
-        mavenCentral()
-        gradlePluginPortal()
     }
     plugins {
         id "org.liquibase.gradle" version "${liquibase_plugin_version}"


### PR DESCRIPTION
### Summary

After [#12927](https://github.com/ls1intum/Artemis/pull/12927) introduced the TUM Reposilite Maven mirror, the **Build .war artifact** CI job slowed down from ~4 min to ~9 min. This PR restores the fast build while **keeping the mirror's rate‑limit protection where it matters**: the mirror stays the primary repository for the high‑volume dependency *downloads*, and the low‑volume Gradle plugin/buildscript resolution goes back to the fast Maven Central + Gradle Plugin Portal path.

Net change: 5 lines of repository ordering in `settings.gradle` and `gradle/openapi.gradle`. `build.gradle` is intentionally left untouched.

### Checklist
#### General
- [x] This is a small, infrastructure-only change (Gradle repository ordering) that I verified locally; no functional/runtime behavior changes.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

#12927 added the mirror (`https://reposilite.aet.cit.tum.de/releases`) as the **first** repository in three places — `build.gradle`, `settings.gradle` (`pluginManagement`) and `gradle/openapi.gradle` (`buildscript`) — to avoid Maven Central `429 Too Many Requests` errors during CI dependency resolution. That goal is correct and worth keeping.

The side effect: the mirror is queried **first** for everything, and it responds **~10–16× slower per request** than Maven Central's CDN (measured TTFB ≈ 0.3–0.7 s vs ≈ 0.04 s; the gap is larger still from GitHub's Azure runners to Munich). Investigating the CI logs, the regression is **entirely in the Gradle configuration phase**:

| Phase | Before mirror | After mirror |
|---|---|---|
| Daemon start → first task (config + plugin/buildscript resolution) | ~30 s | **~5 min 43 s** |
| `compileJava` | ~23 s | ~23 s (unchanged) |
| **Build .war step (total)** | **~74–120 s** | **~290–390 s** |

So the compilation is unchanged — the cost is plugin/buildscript metadata resolution being routed through the slow mirror during configuration. The main dependencies resolve fine because that path is well cached (which is also why `compileJava` stayed at ~23 s).

A subtlety that shapes the fix: **Gradle does not fall through to the next repository on an HTTP 429** — it fails the build. So simply putting Maven Central first everywhere would reintroduce exactly the failures #12927 fixed. The mirror therefore has to stay primary for the path that actually triggers 429s (the high‑volume dependency downloads), and only the low‑volume plugin path is safe to move.

Related: [#12927](https://github.com/ls1intum/Artemis/pull/12927) (the mirror), [#12745](https://github.com/ls1intum/Artemis/pull/12745) (the CI umbrella consolidation — investigated and ruled out; the build job itself is unchanged by it).

### Description

- **`settings.gradle` (`pluginManagement`)** — moved the Reposilite mirror after `mavenCentral()` and `gradlePluginPortal()`. Plugin resolution now uses the fast path; the mirror remains as a fallback.
- **`gradle/openapi.gradle` (`buildscript`)** — moved the Reposilite mirror after `mavenCentral()` for the `openapi-generator` buildscript classpath, same reasoning.
- **`build.gradle` — unchanged.** The mirror stays the *primary* repository for the main dependency downloads, so the 429 protection from #12927 is fully preserved exactly where rate limiting occurs.

Why this is safe:
- Plugin/buildscript resolution is **low volume** (a few dozen plugins, mostly served by the Gradle Plugin Portal) — it is not the source of Maven Central rate limiting, which comes from downloading the ~1,300‑artifact dependency graph.
- All current plugins resolve from Maven Central / the Plugin Portal, so the fallback‑positioned mirror is not queried on the hot path; it stays available if a plugin is ever only present there.

#### Measured impact (local, warm artifact cache, cold metadata — i.e. a fresh CI resolution)

| Configuration | Cold full resolution |
|---|---|
| Current (`develop`) — mirror first everywhere | **2 min 57 s** |
| This PR — mirror primary only for downloads | **1 min 32 s** (~48% faster) |

The improvement is expected to be at least as large on GitHub runners, where the mirror's latency relative to Maven Central is wider. Final numbers will be visible in this PR's own CI run.

### Steps for Testing

This is a build‑infrastructure change with no runtime/UI effect, verifiable from CI and locally.

1. **CI**: Compare the **Build .war artifact** job duration on this PR against recent `develop` runs. The configuration phase (daemon start → `compileJava`) should drop back from minutes to seconds.
2. **Local A/B** (warm cache, forced cold metadata to simulate a fresh CI resolution):
   ```bash
   ./gradlew --stop
   rm -rf ~/.gradle/caches/modules-2/metadata-* ~/.gradle/caches/*/plugin-resolution*
   time ./gradlew -q dependencies --configuration compileClasspath
   ```
   Run on `develop` vs this branch; this branch resolves markedly faster.
3. **Sanity**: `./gradlew help` and a normal `./gradlew -Pprod -Pwar bootWar -x webapp` build still configure and succeed.

### Transparency notes

- I verified the project still configures cleanly (`./gradlew help`) and that resolution succeeds. I did **not** run a full local WAR build (Angular + Gradle) — CI exercises that end‑to‑end.
- This fixes the configuration‑phase regression. The main‑dependency download path deliberately stays on the mirror (429‑safe); its cost is already well cached on CI and is not part of this regression.
- If Maven Central rate limits should ever extend to plugin resolution, the mirror remains declared as a fallback and `build.gradle` can be revisited — but that has not been observed.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
