### PR TITLE
`Development`: Update hono to the latest patch release

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   express: 5.2.1
   fast-uri: 3.1.2
   globals: 17.6.0
-  hono: 4.12.23
+  hono: 4.12.25
   '@hono/node-server': 1.19.13
   ip-address: 10.2.0
   js-yaml: 4.2.0
@@ -1747,7 +1747,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.23
+      hono: 4.12.25
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -4691,8 +4691,8 @@ packages:
   hls.js@1.6.16:
     resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   hookified@1.15.1:
@@ -8597,9 +8597,9 @@ snapshots:
   '@harperfast/extended-iterable@1.0.3':
     optional: true
 
-  '@hono/node-server@1.19.13(hono@4.12.23)':
+  '@hono/node-server@1.19.13(hono@4.12.25)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.25
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -8946,7 +8946,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.23)
+      '@hono/node-server': 1.19.13(hono@4.12.25)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -8956,7 +8956,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.23
+      hono: 4.12.25
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -11604,7 +11604,7 @@ snapshots:
 
   hls.js@1.6.16: {}
 
-  hono@4.12.23: {}
+  hono@4.12.25: {}
 
   hookified@1.15.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,7 +66,7 @@ overrides:
     express: '5.2.1'
     fast-uri: '3.1.2'
     globals: '17.6.0'
-    hono: '4.12.23'
+    hono: '4.12.25'
     '@hono/node-server': '1.19.13'
     ip-address: '10.2.0'
     js-yaml: '4.2.0'


### PR DESCRIPTION
### Summary
Updates the pinned `hono` override from `4.12.23` to the current latest patch release `4.12.25` and regenerates the root lockfile. This keeps the transitive dependency current and clears the related open Dependabot alerts (#570–#574).

### Checklist
#### General
- [x] This is a small change (dependency update) that I verified locally.
- [x] I chose a title conforming to the naming conventions for pull requests.

### Motivation and Context
`hono` is a transitive dependency pinned via the `overrides:` block in the root `pnpm-workspace.yaml`. The pin was lagging one patch release behind (`4.12.23`), which Dependabot flagged. This bumps the pin to `4.12.25`.

### Description
- `pnpm-workspace.yaml`: `hono` override `4.12.23` → `4.12.25`.
- `pnpm-lock.yaml`: regenerated. `hono` resolves to `4.12.25`, and `@hono/node-server@1.19.13` now binds to `hono@4.12.25`.

### Steps for Testing
1. `pnpm install --frozen-lockfile` succeeds (lockfile is consistent with the manifest).
2. The lockfile resolves `hono@4.12.25`.