### PR TITLE
`Development`: Fix the client coverage table never rendering on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,9 @@ jobs:
         continue-on-error: true
         with:
           name: Client Coverage Summaries
-          path: build/test-results/
+          # Nested path is deliberate: the single-file artifact unpacks flat, and it must land where
+          # local-pr-coverage.mjs reads it (VITEST_COVERAGE_SUMMARY). Don't shorten to build/test-results/.
+          path: build/test-results/vitest/coverage/
       - name: Setup Node.js
         if: steps.changes.outputs.has_client_changes == 'true' || steps.changes.outputs.has_server_changes == 'true'
         uses: actions/setup-node@v6

--- a/.github/workflows/pullrequest-coverage-reporter.yml
+++ b/.github/workflows/pullrequest-coverage-reporter.yml
@@ -130,9 +130,9 @@ jobs:
         continue-on-error: true
         with:
           name: Client Coverage Summaries
-          # Archive holds vitest/coverage/coverage-summary.json; download under build/test-results/
-          # so it lands where the coverage script reads it.
-          path: build/test-results/
+          # Nested path is deliberate: the single-file artifact unpacks flat, and it must land where
+          # local-pr-coverage.mjs reads it (VITEST_COVERAGE_SUMMARY). Don't shorten to build/test-results/.
+          path: build/test-results/vitest/coverage/
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 


### PR DESCRIPTION
### Summary

Client test coverage never shows up in the PR description — every PR with client changes renders:

> #### Client
> Coverage data not found. Run tests first or check if coverage-summary.json exists.

The cause is a one‑directory path mismatch in how the coverage reporter downloads the client coverage artifact. This PR fixes the download path in both the in‑run reporter (`ci.yml`) and the fork reporter (`pullrequest-coverage-reporter.yml`). 6‑line change, no functional/runtime impact.

### Checklist
#### General
- [x] This is a small, CI‑only change that I reproduced and verified locally (see Steps for Testing); no application behavior changes.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

The coverage reporter builds the **Client** table by downloading the `Client Coverage Summaries` artifact and then running `local-pr-coverage.mjs --skip-tests`, which reads the file from:

```
build/test-results/vitest/coverage/coverage-summary.json   // VITEST_COVERAGE_SUMMARY
```

That artifact is uploaded as a **single file** (`ci-test.yml`):

```yaml
- name: Upload Client Coverage Summaries
  with:
    name: Client Coverage Summaries
    path: build/test-results/vitest/coverage/coverage-summary.json
```

`actions/upload-artifact` strips the longest common ancestor of the uploaded paths. For a single file that is its entire parent directory, so the archive contains just `coverage-summary.json` at the root (verified by downloading the artifact from a real run — it contains exactly one entry: `coverage-summary.json`).

Both reporters then download it into `build/test-results/`, so the file lands at `build/test-results/coverage-summary.json` — one directory short of where the script reads it. The script doesn't find it and prints "Coverage data not found".

A stale comment in the workflow asserted the archive holds `vitest/coverage/coverage-summary.json`; it does not, which is why the "restore the stripped ancestor" download path was wrong.

This surfaced after [#12745](https://github.com/ls1intum/Artemis/pull/12745) (CI consolidation), which added the in‑run `coverage-report` job that internal PRs now rely on and carried the same incorrect download path that the fork reporter already had.

### Description

- **`.github/workflows/ci.yml`** (in‑run `Report PR Coverage` job) — download the client artifact into `build/test-results/vitest/coverage/` instead of `build/test-results/`.
- **`.github/workflows/pullrequest-coverage-reporter.yml`** (fork PR path) — same fix, and corrected the misleading comment.
- **`ci-test.yml` (the uploader) is intentionally unchanged**, and **server (JaCoCo) coverage is unaffected** — its artifact is uploaded with a glob that preserves the module subdirectories, so downloading into `build/reports/jacoco/` already reconstructs the paths the script expects.

### Steps for Testing

Reproduced end‑to‑end against the real artifact from a recent PR run:

1. Download the `Client Coverage Summaries` artifact from any recent PR's CI run and confirm it contains a single root entry `coverage-summary.json`.
2. Place it at the **current (buggy)** location and run the reporter command — the Client section prints "Coverage data not found":
   ```bash
   mkdir -p build/test-results && cp coverage-summary.json build/test-results/
   node supporting_scripts/code-coverage/local-pr-coverage/local-pr-coverage.mjs \
     --skip-tests --print --client-only --client-modules course,exercise --changed-files "<changed .ts files>"
   ```
3. Place it at the **fixed** location and run the same command — the `#### Client` coverage table renders with per‑file rows:
   ```bash
   mkdir -p build/test-results/vitest/coverage && cp coverage-summary.json build/test-results/vitest/coverage/
   node supporting_scripts/code-coverage/local-pr-coverage/local-pr-coverage.mjs \
     --skip-tests --print --client-only --client-modules course,exercise --changed-files "<changed .ts files>"
   ```
4. On CI: open/refresh any PR that touches client files and confirm the **Test Coverage → Client** section now shows a coverage table instead of the "Coverage data not found" message.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
