### PR TITLE
`Programming exercises`: Auto-generate the short name in simple mode again

### DIFF
--- a/src/main/webapp/app/programming/manage/update/update-components/information/programming-exercise-information.component.html
+++ b/src/main/webapp/app/programming/manage/update/update-components/information/programming-exercise-information.component.html
@@ -16,6 +16,7 @@
             [isImport]="isImport()"
             [isEditFieldDisplayedRecord]="isEditFieldDisplayedRecord()"
             [courseId]="courseId()"
+            (onTitleChange)="updateShortName($event)"
         />
     </div>
     @if (isEditFieldDisplayedRecord().shortName || (!programmingExerciseCreationConfig().isExamMode && isEditFieldDisplayedRecord().categories)) {

--- a/src/main/webapp/app/programming/manage/update/update-components/information/programming-exercise-information.component.spec.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/information/programming-exercise-information.component.spec.ts
@@ -7,6 +7,8 @@ import { ActivatedRoute } from '@angular/router';
 import { Subject, of } from 'rxjs';
 
 import { ProgrammingExerciseInformationComponent } from 'app/programming/manage/update/update-components/information/programming-exercise-information.component';
+import { By } from '@angular/platform-browser';
+import { ExerciseTitleChannelNameComponent } from 'app/exercise/exercise-title-channel-name/exercise-title-channel-name.component';
 import { NgModel } from '@angular/forms';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { ProgrammingExerciseBuildConfig } from 'app/programming/shared/entities/programming-exercise-build.config';
@@ -141,6 +143,20 @@ describe('ProgrammingExerciseInformationComponent', () => {
             fixture.changeDetectorRef.detectChanges();
 
             expect(comp.programmingExercise().shortName).toMatch('TestExercise');
+        });
+
+        it('should derive shortname when the title changes via the title component output (simple mode)', () => {
+            // Regression: typing a title must auto-generate the short name in simple mode. This goes through the real
+            // (onTitleChange) output binding of jhi-exercise-title-channel-name instead of setting the title property
+            // directly, so it covers the reactive wiring (output binding -> updateShortName -> generation effect).
+            fixture.componentRef.setInput('isSimpleMode', true);
+            fixture.detectChanges();
+
+            const titleComponent = fixture.debugElement.query(By.directive(ExerciseTitleChannelNameComponent)).componentInstance as ExerciseTitleChannelNameComponent;
+            titleComponent.updateTitle('My New Exercise');
+            fixture.detectChanges();
+
+            expect(comp.programmingExercise().shortName).toMatch('MyNewExercise');
         });
 
         it('should derive shortname from title when directly derived shortname is already taken', () => {

--- a/src/main/webapp/app/programming/manage/update/update-components/information/programming-exercise-information.component.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/information/programming-exercise-information.component.ts
@@ -169,19 +169,21 @@ export class ProgrammingExerciseInformationComponent implements AfterViewInit, O
         // tableEditableFields() and re-invokes this method.
         this.tableEditableFields().forEach((field) => this.inputFieldSubscriptions.push(field.editingInput?.valueChanges?.subscribe(() => this.calculateFormValid())));
 
-        this.exerciseTitleChannelComponent()
-            .titleChannelNameComponent()
-            .field_title?.valueChanges?.subscribe((newTitle: string) => {
-                if (this.isSimpleMode()) {
-                    this.updateShortName(newTitle);
-                }
-            });
+        // Title changes are handled via the (onTitleChange) output binding of jhi-exercise-title-channel-name in the
+        // template (see updateShortName). A manual subscription to the deeply-nested title NgModel is not reliable here: it
+        // is only registered once and the nested viewChild may not be resolved yet, so under zoneless change detection the
+        // auto-generated short name was never updated in simple mode.
 
         this.shortNameField()?.valueChanges?.subscribe(() => {
             this.updateIsShortNameValid();
         });
     }
 
+    /**
+     * Reacts to a title change emitted by the title/channel-name component. Updating {@link exerciseTitle} re-triggers the
+     * short-name generation effect, which (in simple mode) derives a unique short name from the new title.
+     * @param newTitle the new exercise title
+     */
     updateShortName(newTitle: string) {
         this.exerciseTitle.set(newTitle);
     }


### PR DESCRIPTION
### Summary

In simple mode, creating a programming exercise (in a course or an exam) no longer auto-fills the short name from the title. Because the short name field is hidden in simple mode, the exercise cannot be saved (the short name is required), and the only workaround is to switch to advanced mode and enter it manually. This PR restores the automatic short-name generation.

### Checklist
#### General
- [x] I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context

`ProgrammingExerciseInformationComponent` derives a unique short name from the title via a `generateShortNameWhenInSimpleMode` effect that reads a working `exerciseTitle` signal. That signal was only updated through a manual subscription to the deeply-nested title `NgModel` (`exerciseTitleChannelComponent().titleChannelNameComponent().field_title.valueChanges`), registered once in `ngAfterViewInit`. After the zoneless / signals migration, that nested view query is not reliably resolved at registration time and is never retried, so typing a title never updated `exerciseTitle` and the short name stayed empty.

### Description

- Bind the `(onTitleChange)` output of `jhi-exercise-title-channel-name` directly in the information component template. Angular wires output bindings reliably regardless of view-query timing, so every title change now updates the working title and re-triggers short-name generation.
- Remove the fragile manual `field_title.valueChanges` subscription (now redundant).
- The generation logic itself is unchanged (it still only generates in simple mode and preserves a short name entered in advanced mode).

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Course and 1 Exam

1. Log in as the instructor.
2. Create a new programming exercise in a course in simple mode. Type a title (4+ characters).
3. Verify the short name is auto-generated from the title and the exercise can be saved without switching to advanced mode.
4. Repeat for a programming exercise inside an exam (Exam → exercise group → create programming exercise, simple mode).
5. Verify advanced mode still works: switch to advanced mode, edit the short name manually, switch back to simple mode, and confirm the manually entered short name is preserved.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Course programming exercise, simple mode: short name auto-generated, saveable
- [ ] Exam programming exercise, simple mode: short name auto-generated, saveable
- [ ] Advanced-mode short name is preserved when switching back to simple mode

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/27752046307) did not pass (`failure`). Coverage below may be partial.

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| programming-exercise-information.component.ts | 94.65% | 284 | 13 | 4.6 |

_Last updated: 2026-06-18 10:26:31 UTC_

