### PR TITLE
`Notifications`: Report Hermes relay as down when push delivery fails

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/RestTemplateConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/RestTemplateConfiguration.java
@@ -44,6 +44,12 @@ public class RestTemplateConfiguration {
 
     private static final int VERY_SHORT_READ_TIMEOUT = 1000;
 
+    // The Hermes health check pings /api/health, which must fail fast: it blocks the Actuator /health endpoint
+    // and every metrics scrape, so a hung relay must not tie up those threads for the full short timeout.
+    private static final int HERMES_HEALTH_CONNECTION_TIMEOUT = 3 * 1000;
+
+    private static final int HERMES_HEALTH_READ_TIMEOUT = 3 * 1000;
+
     @Bean
     @Profile(PROFILE_JENKINS)
     public RestTemplate jenkinsRestTemplate(JenkinsAuthorizationInterceptor jenkinsInterceptor) {
@@ -104,7 +110,8 @@ public class RestTemplateConfiguration {
 
     @Bean
     public RestTemplate shortTimeoutHermesRestTemplate() {
-        return createShortTimeoutRestTemplate();
+        final var requestFactory = getSimpleClientHttpRequestFactory(HERMES_HEALTH_READ_TIMEOUT, HERMES_HEALTH_CONNECTION_TIMEOUT);
+        return new RestTemplate(requestFactory);
     }
 
     // Note: for certain requests, e.g. the Athena submission selection, we would like to have even shorter timeouts.

--- a/src/main/java/de/tum/cit/aet/artemis/notification/config/HermesHealthIndicator.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/config/HermesHealthIndicator.java
@@ -3,28 +3,59 @@ package de.tum.cit.aet.artemis.notification.config;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.util.HashMap;
+import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.health.contributor.Health;
 import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import de.tum.cit.aet.artemis.core.service.connectors.ConnectorHealth;
+import de.tum.cit.aet.artemis.core.util.JsonObjectMapper;
 
 /**
- * Service determining the health of the Hermes push notification service.
+ * Service determining the health of the Hermes push notification relay.
+ * <p>
+ * The verdict is based on the dedicated {@code /api/health} endpoint, which is the only signal that reflects
+ * the actual state of the relay (its Firebase / APNs connectivity). Hermes is reported as {@code DOWN} when
+ * that endpoint is unreachable, times out, returns a non-2xx status, or reports a disconnected push provider
+ * ({@code isApnsConnected} or {@code isFirebaseConnected} is {@code false}). The latter matters because such a
+ * relay still answers 2xx while silently dropping every notification &mdash; e.g. after a missing or expired
+ * APNs certificate on the Hermes host.
+ * </p>
+ * <p>
+ * We deliberately do <b>not</b> fall back to pinging the base URL: it is served by the reverse proxy (nginx)
+ * and returns 2xx even when the relay itself is down, which would mask an outage as a healthy {@code UP}
+ * (a false positive).
+ * </p>
+ * <p>
+ * Detection of a disconnected provider relies on Hermes reporting the condition truthfully via these flags.
+ * A relay that reports {@code isApnsConnected=true} while actually unable to deliver cannot be detected from
+ * the outside; closing that gap requires {@code /api/health} on Hermes to genuinely validate the certificate
+ * and provider connection.
+ * </p>
  */
 @Profile(PROFILE_CORE)
 @Component
 @Lazy
 public class HermesHealthIndicator implements HealthIndicator {
+
+    private static final Logger log = LoggerFactory.getLogger(HermesHealthIndicator.class);
+
+    private static final String URL_KEY = "url";
+
+    private final ObjectMapper objectMapper = JsonObjectMapper.get();
 
     private final RestTemplate shortTimeoutRestTemplate;
 
@@ -36,45 +67,78 @@ public class HermesHealthIndicator implements HealthIndicator {
     }
 
     /**
-     * Ping Hermes and check if the service is available.
+     * Ping Hermes at {@code /api/health} and report whether the push notification relay can deliver.
+     *
+     * @return the connector health; {@code UP} only when {@code /api/health} responds successfully and reports
+     *         every push provider as connected
      */
     @Override
     public Health health() {
         var additionalInfo = new HashMap<String, Object>();
-        additionalInfo.put("url", hermesUrl);
-        ConnectorHealth health;
+        additionalInfo.put(URL_KEY, hermesUrl);
         try {
-            ResponseEntity<HermesHealthReport> healthResponse = shortTimeoutRestTemplate.getForEntity(hermesUrl + "/api/health", HermesHealthReport.class);
-
-            var response = healthResponse.getBody();
-
-            if (response != null) {
-                additionalInfo.put("version", response.versionNumber);
-                additionalInfo.put("firebase_up", response.isFirebaseConnected ? "up" : "down");
-                additionalInfo.put("apns_up", response.isApnsConnected ? "up" : "down");
+            ResponseEntity<String> response = shortTimeoutRestTemplate.getForEntity(hermesUrl + "/api/health", String.class);
+            boolean up = response.getStatusCode().is2xxSuccessful();
+            HermesHealthReport report = parseReport(response.getBody());
+            if (report != null) {
+                addReportDetails(additionalInfo, report);
+                // A reachable relay that reports a disconnected provider returns 2xx but silently drops
+                // notifications (e.g. a missing/expired APNs certificate on the Hermes host), so treat it as DOWN.
+                up = up && isConnected(report.isApnsConnected()) && isConnected(report.isFirebaseConnected());
             }
-
-            health = new ConnectorHealth(healthResponse.getStatusCode().is2xxSuccessful(), additionalInfo);
-
-            return health.asActuatorHealth();
-        }
-        catch (RestClientException e) {
-            // Older version of Hermes might be running, which does not provide the /health api
-        }
-
-        try {
-            ResponseEntity<String> response = shortTimeoutRestTemplate.getForEntity(hermesUrl, String.class);
-            HttpStatusCode statusCode = response.getStatusCode();
-
-            health = new ConnectorHealth(statusCode.is2xxSuccessful(), additionalInfo);
+            return new ConnectorHealth(up, additionalInfo).asActuatorHealth();
         }
         catch (RestClientException error) {
-            health = new ConnectorHealth(error);
+            log.warn("Hermes push notification relay health check failed for {}/api/health: {}", hermesUrl, error.getMessage());
+            additionalInfo.put("error", error.getMessage());
+            return new ConnectorHealth(false, additionalInfo, error).asActuatorHealth();
         }
-
-        return health.asActuatorHealth();
     }
 
-    private record HermesHealthReport(boolean isApnsConnected, boolean isFirebaseConnected, String versionNumber) {
+    /**
+     * A missing flag is not penalized (the relay may not report it); only an explicit {@code false} marks the
+     * provider as disconnected.
+     *
+     * @param connected the reported connectivity flag, may be {@code null} when not present in the response
+     * @return {@code true} unless the flag is explicitly {@code false}
+     */
+    private static boolean isConnected(Boolean connected) {
+        return connected == null || connected;
+    }
+
+    /**
+     * Parses the {@code /api/health} response body into a {@link HermesHealthReport}, tolerating unknown fields.
+     * A body that cannot be parsed (e.g. because the relay added or renamed fields) yields {@code null} rather
+     * than failing the health check: reachability of {@code /api/health} already contributed to the verdict.
+     *
+     * @param body the raw response body from {@code /api/health}, may be {@code null} or blank
+     * @return the parsed report, or {@code null} if the body is empty or unparseable
+     */
+    private HermesHealthReport parseReport(String body) {
+        if (body == null || body.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(body, HermesHealthReport.class);
+        }
+        catch (JsonProcessingException e) {
+            log.warn("Could not parse Hermes health report from {}/api/health: {}", hermesUrl, e.getMessage());
+            return null;
+        }
+    }
+
+    private static void addReportDetails(Map<String, Object> additionalInfo, HermesHealthReport report) {
+        if (report.isFirebaseConnected() != null) {
+            additionalInfo.put("firebase_up", report.isFirebaseConnected() ? "up" : "down");
+        }
+        if (report.isApnsConnected() != null) {
+            additionalInfo.put("apns_up", report.isApnsConnected() ? "up" : "down");
+        }
+        if (report.versionNumber() != null) {
+            additionalInfo.put("version", report.versionNumber());
+        }
+    }
+
+    private record HermesHealthReport(Boolean isApnsConnected, Boolean isFirebaseConnected, String versionNumber) {
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/notification/config/HermesHealthIndicatorTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/config/HermesHealthIndicatorTest.java
@@ -1,0 +1,105 @@
+package de.tum.cit.aet.artemis.notification.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withException;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.net.SocketTimeoutException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Unit tests for {@link HermesHealthIndicator}.
+ * <p>
+ * Verify that the verdict is based solely on the relay's {@code /api/health} endpoint and that the indicator
+ * reports {@code DOWN} both when that endpoint fails (no false-positive {@code UP} from a base-URL fallback)
+ * and when the relay reports a disconnected push provider (e.g. a missing/expired APNs certificate).
+ * </p>
+ */
+class HermesHealthIndicatorTest {
+
+    private static final String HERMES_URL = "https://hermes-test.example.com";
+
+    private MockRestServiceServer mockServer;
+
+    private HermesHealthIndicator hermesHealthIndicator;
+
+    @BeforeEach
+    void setUp() {
+        RestTemplate restTemplate = new RestTemplate();
+        mockServer = MockRestServiceServer.createServer(restTemplate);
+        hermesHealthIndicator = new HermesHealthIndicator(restTemplate);
+        ReflectionTestUtils.setField(hermesHealthIndicator, "hermesUrl", HERMES_URL);
+    }
+
+    @Test
+    void healthUp_whenAllProvidersConnected() {
+        mockServer.expect(requestTo(HERMES_URL + "/api/health"))
+                .andRespond(withSuccess("{\"isApnsConnected\":true,\"isFirebaseConnected\":true,\"versionNumber\":\"1.2.3\"}", MediaType.APPLICATION_JSON));
+
+        Health health = hermesHealthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("firebase_up", "up").containsEntry("apns_up", "up").containsEntry("version", "1.2.3").containsEntry("url", HERMES_URL);
+        mockServer.verify();
+    }
+
+    @Test
+    void healthDown_whenApnsDisconnected() {
+        // Reproduces a missing/expired APNs certificate on the Hermes host: the relay still answers 2xx but
+        // cannot deliver, so the indicator must report DOWN rather than hide the outage behind UP.
+        mockServer.expect(requestTo(HERMES_URL + "/api/health"))
+                .andRespond(withSuccess("{\"isApnsConnected\":false,\"isFirebaseConnected\":true,\"versionNumber\":\"1.2.3\"}", MediaType.APPLICATION_JSON));
+
+        Health health = hermesHealthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("apns_up", "down").containsEntry("firebase_up", "up");
+        mockServer.verify();
+    }
+
+    @Test
+    void healthUp_whenFlagsAbsent_doesNotPenalize() {
+        // A relay that does not report the connectivity flags (or adds unknown fields) must not flip to DOWN:
+        // only an explicit `false` marks a provider as disconnected.
+        mockServer.expect(requestTo(HERMES_URL + "/api/health")).andRespond(withSuccess("{\"versionNumber\":\"1.2.3\",\"newUnknownField\":42}", MediaType.APPLICATION_JSON));
+
+        Health health = hermesHealthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("version", "1.2.3").doesNotContainKey("apns_up");
+        mockServer.verify();
+    }
+
+    @Test
+    void healthDown_onServerError() {
+        mockServer.expect(requestTo(HERMES_URL + "/api/health")).andRespond(withServerError());
+
+        Health health = hermesHealthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsKey("error").containsEntry("url", HERMES_URL);
+        mockServer.verify();
+    }
+
+    @Test
+    void healthDown_onTimeout_withoutBaseUrlFallback() {
+        // Reproduces the hung /api/health observed in production: the request times out. Only /api/health is
+        // expected, so if the indicator fell back to pinging the base URL this test would fail on an unexpected request.
+        mockServer.expect(requestTo(HERMES_URL + "/api/health")).andRespond(withException(new SocketTimeoutException("Read timed out")));
+
+        Health health = hermesHealthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        mockServer.verify();
+    }
+}


### PR DESCRIPTION
### Summary
The `HermesHealthIndicator` reported the push notification relay as `UP` even when it could not deliver notifications. Two flaws caused this: (1) if `/api/health` failed, the indicator fell back to pinging the relay's base URL — which is served by the reverse proxy (nginx) and returns `2xx` even when the relay itself is down — masking outages as healthy; and (2) it ignored the reported provider-connectivity flags, so a disconnected APNs/FCM provider (e.g. a missing or expired APNs certificate on the Hermes host) stayed hidden behind `UP`. This PR bases the verdict solely on `/api/health` and its reported provider state, so real outages surface as `DOWN`.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).
- [x] I added tests related to the feature (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
A missing/expired APNs certificate on the Hermes host caused push notifications to silently fail for about a week, while Artemis' health endpoint kept reporting Hermes as `UP` — so the outage went unnoticed. The root cause on the Artemis side is that the health indicator never let a `/api/health` failure (or a reported disconnected provider) reach the verdict: a failed call fell back to a base-URL ping that the reverse proxy always answers with `2xx`, and the `isApnsConnected`/`isFirebaseConnected` flags were only stored as details, never used for the `UP`/`DOWN` decision.

A separate, intermittent symptom from the same indicator: when `/api/health` hangs, the call blocked for the full 10s short timeout, adding ~10s to every `/management/health` request and every Prometheus scrape (the metrics gauge invokes `health()` per scrape).

### Description
- **Verdict from `/api/health` only.** Removed the base-URL fallback. Hermes is reported `DOWN` when `/api/health` is unreachable, times out, or returns a non-2xx status.
- **Provider connectivity affects the verdict.** A reachable relay that reports `isApnsConnected=false` or `isFirebaseConnected=false` is now `DOWN` (it answers `2xx` but cannot deliver). An **absent** flag is not penalized — only an explicit `false` marks a provider as disconnected — so a relay schema change cannot false-trip the check.
- **Robust, non-fatal detail parsing.** The body is parsed with the shared tolerant `ObjectMapper`; a successful-but-unparseable response no longer flips the verdict and is logged instead of silently swallowed.
- **Fast-failing timeout.** The dedicated Hermes health `RestTemplate` (used only by this indicator) now uses a 3s connect/read timeout instead of the shared 10s, so a hung relay no longer ties up `/management/health` and the metrics scrape.
- **Known limitation (out of scope, Hermes-side):** if Hermes' `/api/health` reports `isApnsConnected=true` while actually unable to deliver, no external probe can detect it. Closing that gap requires `/api/health` on Hermes to genuinely validate the certificate and provider connection (and ideally end-to-end delivery monitoring).

Added focused unit tests (`MockRestServiceServer`) covering: all-providers-connected → `UP`; APNs disconnected → `DOWN` (the missing-certificate case); absent flags → not penalized; server error → `DOWN`; timeout → `DOWN` with no base-URL fallback.

### Steps for Testing
This is a server-only change to the Hermes health indicator; it has no UI. Verify against the `/management/health` actuator endpoint.

Prerequisites:
- 1 Admin (to access `/management/health`)
- An Artemis instance configured with `artemis.push-notification-relay` pointing at a reachable Hermes relay

1. Start Artemis with a working Hermes relay and open `GET /management/health`. Confirm the `hermes` component shows `status: UP` with `apns_up: up`, `firebase_up: up`, and a `version` detail.
2. Point `artemis.push-notification-relay` at an unreachable host (or block `/api/health`). Reload `/management/health` and confirm the `hermes` component now shows `status: DOWN` (previously it stayed `UP` via the base-URL fallback). Confirm the request returns promptly (~3s), not after ~10s.
3. Point at a relay whose `/api/health` returns `2xx` with `isApnsConnected: false`. Confirm the `hermes` component shows `status: DOWN` with `apns_up: down` — the missing-certificate scenario is no longer hidden.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/27759526152) did not pass (`failure`). Coverage below may be partial.

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| RestTemplateConfiguration.java | not found (modified) | 131 |
| HermesHealthIndicator.java | not found (modified) | 82 |

_Last updated: 2026-06-18 12:59:00 UTC_

