### PR TITLE
`Administration`: Show whether passkeys are required for admins in the feature overview

### DIFF
--- a/src/main/webapp/app/admin/features/admin-feature-toggle.component.spec.ts
+++ b/src/main/webapp/app/admin/features/admin-feature-toggle.component.spec.ts
@@ -12,7 +12,7 @@ import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service
 import { MockFeatureToggleService } from 'test/helpers/mocks/service/mock-feature-toggle.service';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
-import { MODULE_FEATURE_ATHENA, MODULE_FEATURE_ATLAS, MODULE_FEATURE_EXAM, MODULE_FEATURE_IRIS, PROFILE_JENKINS } from 'app/app.constants';
+import { MODULE_FEATURE_ATHENA, MODULE_FEATURE_ATLAS, MODULE_FEATURE_EXAM, MODULE_FEATURE_IRIS, MODULE_FEATURE_PASSKEY_REQUIRE_ADMIN, PROFILE_JENKINS } from 'app/app.constants';
 
 describe('AdminFeatureToggleComponentTest', () => {
     setupTestBed({ zoneless: true });
@@ -138,7 +138,7 @@ describe('AdminFeatureToggleComponentTest', () => {
         it('ngOnInit should load module features', () => {
             expect(comp.moduleFeatures()).toHaveLength(0);
             comp.ngOnInit();
-            expect(comp.moduleFeatures()).toHaveLength(18);
+            expect(comp.moduleFeatures()).toHaveLength(19);
         });
 
         it('should set isActive based on active module features', () => {
@@ -164,6 +164,20 @@ describe('AdminFeatureToggleComponentTest', () => {
             const iris = modules.find((m) => m.feature === MODULE_FEATURE_IRIS);
             expect(iris?.documentationLink).toBeDefined();
             expect(iris?.documentationLink).toContain('docs.artemis.tum.de');
+        });
+
+        it('should include the passkey admin requirement module feature', () => {
+            vi.spyOn(mockProfileService, 'isModuleFeatureActive').mockImplementation((feature: string) => {
+                return feature === MODULE_FEATURE_PASSKEY_REQUIRE_ADMIN;
+            });
+
+            comp.ngOnInit();
+            const modules = comp.moduleFeatures();
+
+            const passkeyAdmin = modules.find((m) => m.feature === MODULE_FEATURE_PASSKEY_REQUIRE_ADMIN);
+            expect(passkeyAdmin).toBeDefined();
+            expect(passkeyAdmin?.isActive).toBe(true);
+            expect(passkeyAdmin?.documentationLink).toContain('docs.artemis.tum.de');
         });
     });
 

--- a/src/main/webapp/app/admin/features/admin-feature-toggle.component.ts
+++ b/src/main/webapp/app/admin/features/admin-feature-toggle.component.ts
@@ -22,6 +22,7 @@ import {
     MODULE_FEATURE_LTI,
     MODULE_FEATURE_MODELING,
     MODULE_FEATURE_PASSKEY,
+    MODULE_FEATURE_PASSKEY_REQUIRE_ADMIN,
     MODULE_FEATURE_PLAGIARISM,
     MODULE_FEATURE_SAML2,
     MODULE_FEATURE_SHARING,
@@ -103,6 +104,7 @@ export class AdminFeatureToggleComponent implements OnInit {
         MODULE_FEATURE_LDAP,
         MODULE_FEATURE_SAML2,
         MODULE_FEATURE_PASSKEY,
+        MODULE_FEATURE_PASSKEY_REQUIRE_ADMIN,
         MODULE_FEATURE_THEIA,
     ];
 
@@ -147,6 +149,7 @@ export class AdminFeatureToggleComponent implements OnInit {
         [MODULE_FEATURE_LDAP]: 'https://docs.artemis.tum.de/admin/production-setup/security#ldap-authentication',
         [MODULE_FEATURE_SAML2]: 'https://docs.artemis.tum.de/admin/saml2-login-registration',
         [MODULE_FEATURE_PASSKEY]: 'https://docs.artemis.tum.de/admin/production-setup/security#passkey-authentication',
+        [MODULE_FEATURE_PASSKEY_REQUIRE_ADMIN]: 'https://docs.artemis.tum.de/admin/production-setup/security#passkey-authentication',
         [MODULE_FEATURE_THEIA]: 'https://docs.artemis.tum.de',
     };
 

--- a/src/main/webapp/i18n/de/featureToggles.json
+++ b/src/main/webapp/i18n/de/featureToggles.json
@@ -112,6 +112,10 @@
                 "passkey": {
                     "name": "Passkey-Authentifizierung",
                     "description": "Aktiviert passwortlose Authentifizierung mit FIDO2/WebAuthn-Passkeys für erhöhte Sicherheit."
+                },
+                "passkey-admin": {
+                    "name": "Passkey für Administrator-Funktionen erforderlich",
+                    "description": "Wenn aktiviert, müssen sich Administratoren mit einem Passkey authentifizieren, um auf Administrator-Funktionen zuzugreifen. Setzt voraus, dass die Passkey-Authentifizierung aktiv ist."
                 }
             },
             "toggles": {

--- a/src/main/webapp/i18n/en/featureToggles.json
+++ b/src/main/webapp/i18n/en/featureToggles.json
@@ -112,6 +112,10 @@
                 "passkey": {
                     "name": "Passkey Authentication",
                     "description": "Enables passwordless authentication using FIDO2/WebAuthn passkeys for enhanced security."
+                },
+                "passkey-admin": {
+                    "name": "Passkey Required for Admin Features",
+                    "description": "When enabled, administrators must authenticate with a passkey to access admin features. Requires Passkey Authentication to be active."
                 }
             },
             "toggles": {


### PR DESCRIPTION
### Summary

Admins currently cannot tell from the UI whether the configuration property `artemis.user-management.passkey.require-for-administrator-features` is active. This PR surfaces that state as a module feature row in the admin feature overview (`/admin/features`), placed directly under the existing "Passkey Authentication" row, so admins can see at a glance whether a passkey is required to access admin features.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context

The property `artemis.user-management.passkey.require-for-administrator-features` controls whether administrators must authenticate with a passkey to access admin features. When enabled, it has a noticeable effect on the admin experience, but until now nothing in the UI indicated whether it is active. Admins had to inspect the server configuration to find out. This change makes the effective state visible in the admin feature overview, next to the related "Passkey Authentication" module feature.

### Description

The backend already publishes this state. `ArtemisConfigHelper.getEnabledFeatures()` adds the `passkey-admin` feature flag to `activeModuleFeatures` (exposed via the Actuator `/management/info` endpoint) when passkey is enabled and `require-for-administrator-features` is `true`. The client already defined the matching constant `MODULE_FEATURE_PASSKEY_REQUIRE_ADMIN` and consumed it elsewhere (admin sidebar, admin container, passkey guard).

This PR adds a new "Passkey Required for Admin Features" row to the Module Features section of the admin feature overview, placed directly under "Passkey Authentication". It shows **Active** when the requirement is in effect and **Inactive** otherwise, reusing the existing `ProfileService.isModuleFeatureActive(...)` mechanism, so no additional REST calls are introduced. English and German translations and a documentation link were added.

No server changes were required, because `ConfigurationValidator` already rejects the invalid combination (requirement enabled while passkey disabled) at startup, so the displayed Active/Inactive state always reflects the effective configuration.

### Steps for Testing

Prerequisites:
- 1 Admin
- A server with `artemis.user-management.passkey.enabled: true`

1. Log in as an admin.
2. Navigate to Admin > Features (`/admin/features`).
3. Scroll to the "Module Features" section.
4. Confirm a "Passkey Required for Admin Features" row appears directly under "Passkey Authentication".
5. With `artemis.user-management.passkey.require-for-administrator-features: true`, confirm the row shows **Active**.
6. Restart with the property set to `false` and confirm the row shows **Inactive**.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/27824789066) did not pass (`failure`). Coverage below may be partial.

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| admin-feature-toggle.component.ts | 91.17% | 193 | 34 | 17.6 |

_Last updated: 2026-06-19 12:42:02 UTC_


### Screenshots

The change adds one row to the Module Features list, styled identically to the existing rows (feature name, description, Active/Inactive badge, and documentation link). The new "Passkey Required for Admin Features" row appears directly below "Passkey Authentication". A screenshot from a test server will be added during review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new feature toggle enabling passkey authentication requirements for administrator access to admin features.

* **Tests**
  * Updated test specifications to verify the new passkey admin feature is properly loaded and configured.

* **Documentation**
  * Added English and German language support for the new passkey admin feature toggle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->