### PR TITLE
`Development`: Align weaviate server version

### DIFF
--- a/.env
+++ b/.env
@@ -24,7 +24,7 @@ VALKEY_VERSION=8.1.5
 
 # Search
 # Weaviate must be compatible with the Java client: https://docs.weaviate.io/weaviate/release-notes
-WEAVIATE_SERVER_VERSION=1.34.14
+WEAVIATE_SERVER_VERSION=1.37.9
 
 # Web & proxy
 NGINX_VERSION=1.31.1

--- a/docker/weaviate-embeddings.yml
+++ b/docker/weaviate-embeddings.yml
@@ -19,7 +19,7 @@ services:
       - --scheme
       - http
     # Must be compatible with the Java client: https://docs.weaviate.io/weaviate/release-notes
-    image: cr.weaviate.io/semitechnologies/weaviate:${WEAVIATE_SERVER_VERSION:-1.34.14}
+    image: cr.weaviate.io/semitechnologies/weaviate:${WEAVIATE_SERVER_VERSION:-1.37.9}
     expose:
       - 8001
       - 50051

--- a/docker/weaviate.yml
+++ b/docker/weaviate.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
     # Must be compatible with the Java client: https://docs.weaviate.io/weaviate/release-notes
-    image: cr.weaviate.io/semitechnologies/weaviate:${WEAVIATE_SERVER_VERSION:-1.34.14}
+    image: cr.weaviate.io/semitechnologies/weaviate:${WEAVIATE_SERVER_VERSION:-1.37.9}
     expose:
       - 8001
       - 50051

--- a/documentation/docs/developer/weaviate-setup.mdx
+++ b/documentation/docs/developer/weaviate-setup.mdx
@@ -510,7 +510,7 @@ You can also define a custom Weaviate version if needed, but make sure to use a 
 ```bash
 WEAVIATE_REST_PORT=8002
 WEAVIATE_GRPC_PORT=50052
-WEAVIATE_SERVER_VERSION=1.34.14
+WEAVIATE_SERVER_VERSION=1.37.9
 ```
 
 If you also run Pyris against the same Weaviate instance, remember to update the Pyris configuration accordingly.

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ netty_version=4.2.15.Final
 bucket4j_version=8.19.0
 weaviate_client_version=6.2.1
 # Must be compatible with the Java client: https://docs.weaviate.io/weaviate/release-notes
-weaviate_server_version=1.34.14
+weaviate_server_version=1.37.9
 commons_lang3_version=3.20.0
 commons_text_version=1.15.0
 redisson_version=4.4.0


### PR DESCRIPTION
### Summary

Aligns the Weaviate server version used by the integration tests and local docker compose with the version used in deployments (1.37). They were pinned to 1.34.14 — so the testcontainers validated the `io.weaviate:client6` client against an older server than production actually uses.

### Motivation and Context

`weaviate_server_version` (`gradle.properties`) and `WEAVIATE_SERVER_VERSION` (`.env`) are not dead code — they feed three live consumers:

- `docker/weaviate.yml` and `docker/weaviate-embeddings.yml` — the compose image tag
- `gradle/test.gradle` → the `weaviate.server.version` system property → `WeaviateTestContainerFactory`, which builds `cr.weaviate.io/semitechnologies/weaviate:<version>` for the integration tests

Both were `1.34.14`, so the `WeaviateClientIntegrationTest` ran against 1.34.14 even though production (and the Weaviate Java client v6) target 1.37. This is a test/prod drift.

### Description

Bump every reference to **1.37.9** (latest 1.37 patch):

- `gradle.properties` — `weaviate_server_version`
- `.env` — `WEAVIATE_SERVER_VERSION`
- `docker/weaviate.yml` and `docker/weaviate-embeddings.yml` — the `${WEAVIATE_SERVER_VERSION:-...}` fallback default
- `documentation/docs/developer/weaviate-setup.mdx` — the example in the setup guide

The Weaviate Java client `io.weaviate:client6:6.2.1` requires server `>= 1.32`, so 1.37.9 is compatible. This aligns integration tests, local compose, and production on the same server line.

### Steps for Testing

1. `WeaviateClientIntegrationTest` now starts a `weaviate:1.37.9` testcontainer. Verified locally: **3 tests, 3 passed, 0 skipped** (client readiness, direct local connection, and collection create/exists/delete).
2. `docker compose -f docker/weaviate.yml up -d` pulls `weaviate:1.37.9` and the client connects.

> Confirm 1.37.9 is the intended patch level; adjust the pin if a different 1.37.x patch is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Weaviate server version from 1.34.14 to 1.37.9 in Docker configuration and build properties.
  * Updated developer documentation to reflect the new Weaviate server version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->