### PR TITLE
`Administration`: Show the admin passkey management table whenever passkeys are enabled

### DIFF
--- a/src/main/webapp/app/admin/admin-container/admin-container.component.html
+++ b/src/main/webapp/app/admin/admin-container/admin-container.component.html
@@ -15,7 +15,6 @@
                     [atlasEnabled]="atlasEnabled()"
                     [examEnabled]="examEnabled()"
                     [passkeyEnabled]="passkeyEnabled()"
-                    [passkeyRequiredForAdmin]="passkeyRequiredForAdmin()"
                     [isSuperAdmin]="isSuperAdmin()"
                     [irisEnabled]="irisEnabled()"
                     (toggleCollapseState)="toggleCollapseState()"

--- a/src/main/webapp/app/admin/admin-container/admin-container.component.spec.ts
+++ b/src/main/webapp/app/admin/admin-container/admin-container.component.spec.ts
@@ -131,7 +131,6 @@ describe('AdminContainerComponent', () => {
         expect(component.examEnabled()).toBe(false);
         expect(component.standardizedCompetenciesEnabled()).toBe(false);
         expect(component.passkeyEnabled()).toBe(false);
-        expect(component.passkeyRequiredForAdmin()).toBe(false);
         expect(component.isSuperAdmin()).toBe(false);
     });
 
@@ -149,15 +148,14 @@ describe('AdminContainerComponent', () => {
         expect(newComponent.examEnabled()).toBe(true);
     });
 
-    it('should detect passkey feature flags from profile info', () => {
-        vi.spyOn(profileService, 'isModuleFeatureActive').mockImplementation((feature: string) => ['passkey', 'passkey-admin'].includes(feature));
+    it('should detect passkey feature flag from profile info', () => {
+        vi.spyOn(profileService, 'isModuleFeatureActive').mockImplementation((feature: string) => feature === 'passkey');
 
         const newFixture = TestBed.createComponent(AdminContainerComponent);
         const newComponent = newFixture.componentInstance;
         newFixture.detectChanges();
 
         expect(newComponent.passkeyEnabled()).toBe(true);
-        expect(newComponent.passkeyRequiredForAdmin()).toBe(true);
     });
 
     describe('onResize', () => {

--- a/src/main/webapp/app/admin/admin-container/admin-container.component.ts
+++ b/src/main/webapp/app/admin/admin-container/admin-container.component.ts
@@ -7,15 +7,7 @@ import { Subscription, filter } from 'rxjs';
 import { AdminSidebarComponent } from 'app/admin/admin-sidebar/admin-sidebar.component';
 import { AdminTitleBarComponent } from 'app/admin/shared/admin-title-bar/admin-title-bar.component';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
-import {
-    MODULE_FEATURE_ATLAS,
-    MODULE_FEATURE_EXAM,
-    MODULE_FEATURE_IRIS,
-    MODULE_FEATURE_LTI,
-    MODULE_FEATURE_PASSKEY,
-    MODULE_FEATURE_PASSKEY_REQUIRE_ADMIN,
-    PROFILE_LOCALCI,
-} from 'app/app.constants';
+import { MODULE_FEATURE_ATLAS, MODULE_FEATURE_EXAM, MODULE_FEATURE_IRIS, MODULE_FEATURE_LTI, MODULE_FEATURE_PASSKEY, PROFILE_LOCALCI } from 'app/app.constants';
 import { FeatureToggle, FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
 import { LayoutService } from 'app/foundation/breakpoints/layout.service';
 import { CustomBreakpointNames } from 'app/foundation/breakpoints/breakpoints.service';
@@ -53,7 +45,6 @@ export class AdminContainerComponent implements OnInit, OnDestroy {
     readonly examEnabled = signal(false);
     readonly standardizedCompetenciesEnabled = signal(false);
     readonly passkeyEnabled = signal(false);
-    readonly passkeyRequiredForAdmin = signal(false);
     readonly isSuperAdmin = signal(false);
     readonly irisEnabled = signal(false);
 
@@ -66,7 +57,6 @@ export class AdminContainerComponent implements OnInit, OnDestroy {
         this.localCIActive.set(this.profileService.isProfileActive(PROFILE_LOCALCI));
         this.ltiEnabled.set(this.profileService.isModuleFeatureActive(MODULE_FEATURE_LTI));
         this.passkeyEnabled.set(this.profileService.isModuleFeatureActive(MODULE_FEATURE_PASSKEY));
-        this.passkeyRequiredForAdmin.set(this.profileService.isModuleFeatureActive(MODULE_FEATURE_PASSKEY_REQUIRE_ADMIN));
         this.isSuperAdmin.set(this.accountService.hasAnyAuthorityDirect(IS_AT_LEAST_SUPER_ADMIN));
         this.irisEnabled.set(this.profileService.isModuleFeatureActive(MODULE_FEATURE_IRIS));
 

--- a/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.spec.ts
+++ b/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.spec.ts
@@ -45,7 +45,6 @@ describe('AdminSidebarComponent', () => {
         expect(component.atlasEnabled()).toBe(false);
         expect(component.examEnabled()).toBe(false);
         expect(component.passkeyEnabled()).toBe(false);
-        expect(component.passkeyRequiredForAdmin()).toBe(false);
         expect(component.isSuperAdmin()).toBe(false);
     });
 
@@ -82,9 +81,8 @@ describe('AdminSidebarComponent', () => {
         expect(toggleSpy).toHaveBeenCalled();
     });
 
-    it('should include passkey management link when all conditions are met', () => {
+    it('should include passkey management link when passkeys are enabled and user is super admin', () => {
         fixture.componentRef.setInput('passkeyEnabled', true);
-        fixture.componentRef.setInput('passkeyRequiredForAdmin', true);
         fixture.componentRef.setInput('isSuperAdmin', true);
         fixture.detectChanges();
 
@@ -101,22 +99,6 @@ describe('AdminSidebarComponent', () => {
 
     it('should not include passkey management link when passkey is not enabled', () => {
         fixture.componentRef.setInput('passkeyEnabled', false);
-        fixture.componentRef.setInput('passkeyRequiredForAdmin', true);
-        fixture.componentRef.setInput('isSuperAdmin', true);
-        fixture.detectChanges();
-
-        const groups = component.sidebarGroups();
-        const userManagementGroup = groups.find((g) => g.translation === 'global.menu.admin.groups.usersAndOrganizations');
-        expect(userManagementGroup).toBeTruthy();
-        expect(userManagementGroup!.items).toHaveLength(3); // User Management, Organizations, Data Exports only
-
-        const passkeyManagementItem = userManagementGroup!.items.find((i) => i.routerLink === '/admin/passkey-management');
-        expect(passkeyManagementItem).toBeFalsy();
-    });
-
-    it('should not include passkey management link when passkey is not required for admin', () => {
-        fixture.componentRef.setInput('passkeyEnabled', true);
-        fixture.componentRef.setInput('passkeyRequiredForAdmin', false);
         fixture.componentRef.setInput('isSuperAdmin', true);
         fixture.detectChanges();
 
@@ -131,7 +113,6 @@ describe('AdminSidebarComponent', () => {
 
     it('should not include passkey management link when user is not super admin', () => {
         fixture.componentRef.setInput('passkeyEnabled', true);
-        fixture.componentRef.setInput('passkeyRequiredForAdmin', true);
         fixture.componentRef.setInput('isSuperAdmin', false);
         fixture.detectChanges();
 

--- a/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.ts
+++ b/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.ts
@@ -65,7 +65,6 @@ export class AdminSidebarComponent {
     atlasEnabled = input<boolean>(false);
     examEnabled = input<boolean>(false);
     passkeyEnabled = input<boolean>(false);
-    passkeyRequiredForAdmin = input<boolean>(false);
     isSuperAdmin = input<boolean>(false);
     irisEnabled = input<boolean>(false);
 
@@ -105,7 +104,9 @@ export class AdminSidebarComponent {
                 testId: 'admin-user-management',
             },
         ];
-        if (this.passkeyEnabled() && this.passkeyRequiredForAdmin() && this.isSuperAdmin()) {
+        // Show the passkey management table whenever passkeys are enabled, independent of whether passkeys are required for
+        // admin features. A super admin can then review and approve admin passkeys before that requirement is turned on.
+        if (this.passkeyEnabled() && this.isSuperAdmin()) {
             accountGroupItems.push({
                 routerLink: '/admin/passkey-management',
                 icon: faKey,


### PR DESCRIPTION
### Summary
Super admins can now open the admin **Passkey Management** table whenever passkeys are enabled, regardless of whether the separate "require passkey for admin features" flag is turned on. This lets a super admin review and approve admin passkeys *before* the requirement is enabled.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).

### Motivation and Context
The admin "Passkey Management" page lets a super admin review all registered passkeys and approve the ones used by administrators. Until now, its sidebar entry only appeared when **both** the passkey feature **and** the "require passkey for admin features" flag (`passkey-admin`) were enabled.

That coupling is unhelpful: an administrator who wants to roll out the requirement in the future first needs to validate and approve the existing admin passkeys. With the old behavior, the management table was only reachable once the requirement was already on, which is exactly when it is too late to prepare for it.

The requirement flag is a security setting, not a visibility gate for the management UI. The two concerns should be independent.

### Description
- The admin sidebar now shows the **Passkey Management** entry when `passkeyEnabled() && isSuperAdmin()`, dropping the previous additional `passkeyRequiredForAdmin()` condition (`admin-sidebar.component.ts`).
- Removed the now-unused `passkeyRequiredForAdmin` input from `AdminSidebarComponent`, and the corresponding signal, profile-info read, and template binding from `AdminContainerComponent`.
- The `MODULE_FEATURE_PASSKEY_REQUIRE_ADMIN` constant is kept, since it is still used by the passkey authentication guard and the admin feature-toggle page.
- Updated the affected unit tests accordingly.

This aligns the client with the server, where the passkey endpoints are already gated only by `@Conditional(PasskeyEnabled.class)` at the controller level and `@EnforceSuperAdmin` on the admin endpoints. There is no server-side `require-for-admin` gating, so the link now matches what the backend actually allows. The route `/admin/passkey-management` is also already guarded by `IS_AT_LEAST_SUPER_ADMIN` only.

The user-facing passkey self-service settings table is unaffected (it was already gated on the passkey feature alone).

### Steps for Testing
Prerequisites:
- 1 Super Admin
- Server started with passkeys **enabled** but the "require passkey for admin features" flag **disabled**
  (`artemis.user-management.passkey.enabled: true`, `artemis.user-management.passkey.require-for-administrator-features: false`)

1. Log in as a super admin.
2. Open the admin area and look at the left sidebar under "Users & Organizations".
3. Confirm the **Passkey Management** entry is now visible even though the require-for-admin flag is off.
4. Open it and confirm the passkey table loads and approval actions work.
5. Set `require-for-administrator-features: true`, restart, and confirm the entry still appears (no regression).
6. Disable passkeys entirely and confirm the entry disappears.
7. Log in as a non-super-admin and confirm the entry is not shown.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/27845759088) did not pass (`failure`). Coverage below may be partial.

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| admin-container.component.ts | 100.00% | 78 | 24 | 30.8 |
| admin-sidebar.component.ts | 88.37% | 285 | 27 | 9.5 |

_Last updated: 2026-06-19 20:38:04 UTC_


### Screenshots
Visual change only: the **Passkey Management** sidebar entry (key icon) under "Users & Organizations" now appears for super admins whenever passkeys are enabled, instead of only when passkeys are required for admin features.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified passkey management feature access in the admin panel by removing an unnecessary configuration requirement. Feature visibility now depends on fewer conditions.

* **Tests**
  * Updated test coverage to reflect simplified passkey feature flag logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->