### PR TITLE
`Administration`: Fix an issue when assigning an organization in course settings

### DIFF
--- a/src/main/webapp/app/admin/organization-management/organization-management.service.spec.ts
+++ b/src/main/webapp/app/admin/organization-management/organization-management.service.spec.ts
@@ -137,6 +137,26 @@ describe('Organization Service', () => {
         expect(result.ok).toBe(true);
     });
 
+    it('should add a course to an Organization', async () => {
+        const resultPromise = firstValueFrom(service.addCourseToOrganization(7, 42));
+
+        const req = httpMock.expectOne({ method: 'POST', url: 'api/admin/organizations/7/courses/42' });
+        req.flush({ status: 200 });
+
+        const result = await resultPromise;
+        expect(result.ok).toBe(true);
+    });
+
+    it('should remove a course from an Organization', async () => {
+        const resultPromise = firstValueFrom(service.removeCourseFromOrganization(7, 42));
+
+        const req = httpMock.expectOne({ method: 'DELETE', url: 'api/admin/organizations/7/courses/42' });
+        req.flush({ status: 200 });
+
+        const result = await resultPromise;
+        expect(result.ok).toBe(true);
+    });
+
     function createTestReturnElement() {
         const elem2 = new Organization();
         elem2.id = 1;

--- a/src/main/webapp/app/admin/organization-management/organization-management.service.ts
+++ b/src/main/webapp/app/admin/organization-management/organization-management.service.ts
@@ -112,6 +112,24 @@ export class OrganizationManagementService {
     }
 
     /**
+     * Send a POST request to add a course to an organization
+     * @param organizationId the id of the organization to add the course to
+     * @param courseId the id of the course to add
+     */
+    addCourseToOrganization(organizationId: number, courseId: number): Observable<HttpResponse<void>> {
+        return this.http.post<void>(`${this.adminResourceUrl}/${organizationId}/courses/${courseId}`, {}, { observe: 'response' });
+    }
+
+    /**
+     * Send a DELETE request to remove a course from an organization
+     * @param organizationId the id of the organization to remove the course from
+     * @param courseId the id of the course to remove
+     */
+    removeCourseFromOrganization(organizationId: number, courseId: number): Observable<HttpResponse<void>> {
+        return this.http.delete<void>(`${this.adminResourceUrl}/${organizationId}/courses/${courseId}`, { observe: 'response' });
+    }
+
+    /**
      * Send GET request to retrieve a paginated list of users belonging to an organization
      * @param organizationId the id of the organization
      * @param params         the search and pagination parameters

--- a/src/main/webapp/app/course/manage/update/course-update.component.spec.ts
+++ b/src/main/webapp/app/course/manage/update/course-update.component.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
-import { HttpResponse, provideHttpClient } from '@angular/common/http';
+import { HttpErrorResponse, HttpResponse, provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -15,7 +15,7 @@ import { Course, CourseInformationSharingConfiguration, isCommunicationEnabled, 
 import { LocalStorageService } from 'app/foundation/service/local-storage.service';
 import { SessionStorageService } from 'app/foundation/service/session-storage.service';
 import { MockProvider } from 'ng-mocks';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { ImageCropperComponent } from 'app/shared-ui/image-cropper/component/image-cropper.component';
 import { OrganizationManagementService } from 'app/admin/organization-management/organization-management.service';
 import { Organization } from 'app/admin/organization-management/organization.model';
@@ -366,6 +366,48 @@ describe('Course Management Update Component', () => {
             // THEN
             expect(addStub).not.toHaveBeenCalled();
             expect(removeStub).not.toHaveBeenCalled();
+            expect(comp.isSaving()).toBe(false);
+        });
+
+        it('should only re-issue the failed organization change after a partial failure on retry', async () => {
+            // GIVEN: admin loads a course initially assigned to organizations 1 and 2
+            vi.spyOn(accountService, 'isAdmin').mockReturnValue(true);
+            vi.spyOn(organizationService, 'getOrganizationsByCourse').mockReturnValue(of([orgWithId(1), orgWithId(2)]));
+            comp.ngOnInit();
+            fixture.detectChanges();
+            await Promise.resolve();
+
+            // change selection: keep 1, remove 2, add 3
+            comp.courseOrganizations.set([orgWithId(1), orgWithId(3)]);
+
+            const savedCourse = new Course();
+            savedCourse.id = course.id;
+            vi.spyOn(courseManagementService, 'update').mockReturnValue(of(new HttpResponse({ body: savedCourse })));
+            const addStub = vi.spyOn(organizationService, 'addCourseToOrganization').mockReturnValue(of(new HttpResponse<void>({ status: 200 })));
+            // the removal fails on the first attempt and succeeds on the retry
+            const removeStub = vi
+                .spyOn(organizationService, 'removeCourseFromOrganization')
+                .mockReturnValueOnce(throwError(() => new HttpErrorResponse({ status: 500 })))
+                .mockReturnValue(of(new HttpResponse<void>({ status: 200 })));
+
+            // WHEN: first save - the add succeeds, the remove fails
+            comp.save();
+            fixture.detectChanges();
+            await Promise.resolve();
+
+            // THEN: both were attempted once and saving is reset
+            expect(addStub).toHaveBeenCalledExactlyOnceWith(3, course.id);
+            expect(removeStub).toHaveBeenCalledExactlyOnceWith(2, course.id);
+            expect(comp.isSaving()).toBe(false);
+
+            // WHEN: the admin saves again
+            comp.save();
+            fixture.detectChanges();
+            await Promise.resolve();
+
+            // THEN: the already-succeeded add is not re-issued, only the failed removal is retried
+            expect(addStub).toHaveBeenCalledOnce();
+            expect(removeStub).toHaveBeenCalledTimes(2);
             expect(comp.isSaving()).toBe(false);
         });
     });

--- a/src/main/webapp/app/course/manage/update/course-update.component.spec.ts
+++ b/src/main/webapp/app/course/manage/update/course-update.component.spec.ts
@@ -309,6 +309,67 @@ describe('Course Management Update Component', () => {
         });
     });
 
+    describe('save organization sync', () => {
+        const orgWithId = (id: number): Organization => {
+            const organization = new Organization();
+            organization.id = id;
+            return organization;
+        };
+
+        it('should persist added and removed organizations via the dedicated admin endpoints on save', async () => {
+            // GIVEN: admin loads a course initially assigned to organizations 1 and 2
+            vi.spyOn(accountService, 'isAdmin').mockReturnValue(true);
+            vi.spyOn(organizationService, 'getOrganizationsByCourse').mockReturnValue(of([orgWithId(1), orgWithId(2)]));
+            comp.ngOnInit();
+            fixture.detectChanges();
+            await Promise.resolve();
+
+            // change selection: keep 1, remove 2, add 3
+            comp.courseOrganizations.set([orgWithId(1), orgWithId(3)]);
+
+            const savedCourse = new Course();
+            savedCourse.id = course.id;
+            vi.spyOn(courseManagementService, 'update').mockReturnValue(of(new HttpResponse({ body: savedCourse })));
+            const addStub = vi.spyOn(organizationService, 'addCourseToOrganization').mockReturnValue(of(new HttpResponse<void>({ status: 200 })));
+            const removeStub = vi.spyOn(organizationService, 'removeCourseFromOrganization').mockReturnValue(of(new HttpResponse<void>({ status: 200 })));
+
+            // WHEN
+            comp.save();
+            fixture.detectChanges();
+            await Promise.resolve();
+
+            // THEN
+            expect(addStub).toHaveBeenCalledExactlyOnceWith(3, course.id);
+            expect(removeStub).toHaveBeenCalledExactlyOnceWith(2, course.id);
+            expect(comp.isSaving()).toBe(false);
+        });
+
+        it('should not call any organization endpoint when the selection is unchanged', async () => {
+            // GIVEN
+            vi.spyOn(accountService, 'isAdmin').mockReturnValue(true);
+            vi.spyOn(organizationService, 'getOrganizationsByCourse').mockReturnValue(of([orgWithId(1)]));
+            comp.ngOnInit();
+            fixture.detectChanges();
+            await Promise.resolve();
+
+            const savedCourse = new Course();
+            savedCourse.id = course.id;
+            vi.spyOn(courseManagementService, 'update').mockReturnValue(of(new HttpResponse({ body: savedCourse })));
+            const addStub = vi.spyOn(organizationService, 'addCourseToOrganization');
+            const removeStub = vi.spyOn(organizationService, 'removeCourseFromOrganization');
+
+            // WHEN
+            comp.save();
+            fixture.detectChanges();
+            await Promise.resolve();
+
+            // THEN
+            expect(addStub).not.toHaveBeenCalled();
+            expect(removeStub).not.toHaveBeenCalled();
+            expect(comp.isSaving()).toBe(false);
+        });
+    });
+
     describe('onSelectedColor', () => {
         it('should update form', () => {
             const selectedColor = 'testSelectedColor';

--- a/src/main/webapp/app/course/manage/update/course-update.component.ts
+++ b/src/main/webapp/app/course/manage/update/course-update.component.ts
@@ -5,7 +5,7 @@ import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, ValidatorFn, 
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { AlertService, AlertType } from 'app/foundation/service/alert.service';
 import { HasAnyAuthorityDirective } from 'app/foundation/auth/has-any-authority.directive';
-import { Observable, OperatorFunction, Subject, debounceTime, distinctUntilChanged, filter, firstValueFrom, forkJoin, map, merge, of } from 'rxjs';
+import { Observable, OperatorFunction, Subject, debounceTime, distinctUntilChanged, filter, firstValueFrom, forkJoin, map, merge, of, tap } from 'rxjs';
 import { regexValidator } from 'app/shared-ui/form/shortname-validator.directive';
 import { Course, CourseInformationSharingConfiguration, isCommunicationEnabled, isMessagingEnabled, unsetCourseIcon } from 'app/course/shared/entities/course.model';
 import { CourseManagementService } from '../services/course-management.service';
@@ -170,7 +170,7 @@ export class CourseUpdateComponent implements OnInit {
                 this.croppedImage.set(course.courseIconPath);
                 this.organizationService.getOrganizationsByCourse(course.id).subscribe((organizations) => {
                     this.courseOrganizations.set(organizations);
-                    this.initialOrganizationIds = new Set(organizations.map((organization) => organization.id!));
+                    this.initialOrganizationIds = this.toOrganizationIdSet(organizations);
                 });
                 this.originalTimeZone = this.course.timeZone;
                 // complaints are only enabled when at least one complaint is allowed and the complaint duration is positive
@@ -410,25 +410,34 @@ export class CourseUpdateComponent implements OnInit {
     /**
      * Persists the difference between the initially loaded organizations and the current selection by
      * calling the dedicated admin endpoints. Completes once all add/remove requests have finished.
+     * Each request updates the initial snapshot on success, so a retry after a partial failure only
+     * re-issues the operations that did not yet succeed.
      * @param courseId the id of the saved course
      */
-    private syncCourseOrganizations(courseId: number): Observable<unknown> {
-        const currentOrganizations = this.courseOrganizations() ?? [];
-        const currentOrganizationIds = new Set(currentOrganizations.map((organization) => organization.id!));
+    private syncCourseOrganizations(courseId: number): Observable<HttpResponse<void>[]> {
+        const currentOrganizationIds = this.toOrganizationIdSet(this.courseOrganizations() ?? []);
 
         const requests: Observable<HttpResponse<void>>[] = [];
-        for (const organization of currentOrganizations) {
-            if (!this.initialOrganizationIds.has(organization.id!)) {
-                requests.push(this.organizationService.addCourseToOrganization(organization.id!, courseId));
+        currentOrganizationIds.forEach((organizationId) => {
+            if (!this.initialOrganizationIds.has(organizationId)) {
+                requests.push(this.organizationService.addCourseToOrganization(organizationId, courseId).pipe(tap(() => this.initialOrganizationIds.add(organizationId))));
             }
-        }
-        for (const organizationId of this.initialOrganizationIds) {
+        });
+        this.initialOrganizationIds.forEach((organizationId) => {
             if (!currentOrganizationIds.has(organizationId)) {
-                requests.push(this.organizationService.removeCourseFromOrganization(organizationId, courseId));
+                requests.push(this.organizationService.removeCourseFromOrganization(organizationId, courseId).pipe(tap(() => this.initialOrganizationIds.delete(organizationId))));
             }
-        }
+        });
 
-        return requests.length > 0 ? forkJoin(requests) : of(undefined);
+        return requests.length > 0 ? forkJoin(requests) : of([]);
+    }
+
+    /**
+     * Collects the ids of the given organizations into a set, skipping any without an id.
+     * @param organizations the organizations to collect the ids from
+     */
+    private toOrganizationIdSet(organizations: Organization[]): Set<number> {
+        return new Set(organizations.map((organization) => organization.id).filter((id): id is number => id !== undefined));
     }
 
     /**

--- a/src/main/webapp/app/course/manage/update/course-update.component.ts
+++ b/src/main/webapp/app/course/manage/update/course-update.component.ts
@@ -5,7 +5,7 @@ import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, ValidatorFn, 
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { AlertService, AlertType } from 'app/foundation/service/alert.service';
 import { HasAnyAuthorityDirective } from 'app/foundation/auth/has-any-authority.directive';
-import { Observable, OperatorFunction, Subject, debounceTime, distinctUntilChanged, filter, firstValueFrom, map, merge } from 'rxjs';
+import { Observable, OperatorFunction, Subject, debounceTime, distinctUntilChanged, filter, firstValueFrom, forkJoin, map, merge, of } from 'rxjs';
 import { regexValidator } from 'app/shared-ui/form/shortname-validator.directive';
 import { Course, CourseInformationSharingConfiguration, isCommunicationEnabled, isMessagingEnabled, unsetCourseIcon } from 'app/course/shared/entities/course.model';
 import { CourseManagementService } from '../services/course-management.service';
@@ -138,6 +138,8 @@ export class CourseUpdateComponent implements OnInit {
     readonly requestMoreFeedbackEnabled = signal(true);
     readonly customizeGroupNames = signal(false);
     readonly courseOrganizations = signal<Organization[]>(undefined!);
+    /** Snapshot of the organization ids loaded from the server, used to diff add/remove on save. */
+    private initialOrganizationIds = new Set<number>();
     readonly isAdmin = signal(false);
 
     communicationEnabled = true;
@@ -168,6 +170,7 @@ export class CourseUpdateComponent implements OnInit {
                 this.croppedImage.set(course.courseIconPath);
                 this.organizationService.getOrganizationsByCourse(course.id).subscribe((organizations) => {
                     this.courseOrganizations.set(organizations);
+                    this.initialOrganizationIds = new Set(organizations.map((organization) => organization.id!));
                 });
                 this.originalTimeZone = this.course.timeZone;
                 // complaints are only enabled when at least one complaint is allowed and the complaint duration is positive
@@ -236,7 +239,6 @@ export class CourseUpdateComponent implements OnInit {
                 instructorGroupName: new FormControl(this.course.instructorGroupName),
                 description: new FormControl(this.course.description),
                 courseInformationSharingMessagingCodeOfConduct: new FormControl(this.course.courseInformationSharingMessagingCodeOfConduct),
-                organizations: new FormControl(this.courseOrganizations()),
                 startDate: new FormControl(this.course.startDate),
                 endDate: new FormControl(this.course.endDate),
                 semester: new FormControl(this.course.semester),
@@ -338,9 +340,6 @@ export class CourseUpdateComponent implements OnInit {
      */
     save() {
         this.isSaving.set(true);
-        if (this.courseForm.controls['organizations'] !== undefined) {
-            this.courseForm.controls['organizations'].setValue(this.courseOrganizations());
-        }
         let file = undefined;
         const croppedImage = this.croppedImage();
         if (this.courseImageUploadFile && croppedImage) {
@@ -393,9 +392,49 @@ export class CourseUpdateComponent implements OnInit {
     }
 
     /**
-     * Action on successful course creation or edit
+     * Action on successful course creation or edit.
+     * Organization assignments are persisted via dedicated admin endpoints (the course update payload
+     * intentionally does not carry organizations), so the diff is synced here before finalizing.
      */
     private onSaveSuccess(updatedCourse: Course | null) {
+        if (updatedCourse?.id !== undefined && this.isAdmin()) {
+            this.syncCourseOrganizations(updatedCourse.id).subscribe({
+                next: () => this.finalizeSave(updatedCourse),
+                error: (res: HttpErrorResponse) => this.onSaveError(res),
+            });
+        } else {
+            this.finalizeSave(updatedCourse);
+        }
+    }
+
+    /**
+     * Persists the difference between the initially loaded organizations and the current selection by
+     * calling the dedicated admin endpoints. Completes once all add/remove requests have finished.
+     * @param courseId the id of the saved course
+     */
+    private syncCourseOrganizations(courseId: number): Observable<unknown> {
+        const currentOrganizations = this.courseOrganizations() ?? [];
+        const currentOrganizationIds = new Set(currentOrganizations.map((organization) => organization.id!));
+
+        const requests: Observable<HttpResponse<void>>[] = [];
+        for (const organization of currentOrganizations) {
+            if (!this.initialOrganizationIds.has(organization.id!)) {
+                requests.push(this.organizationService.addCourseToOrganization(organization.id!, courseId));
+            }
+        }
+        for (const organizationId of this.initialOrganizationIds) {
+            if (!currentOrganizationIds.has(organizationId)) {
+                requests.push(this.organizationService.removeCourseFromOrganization(organizationId, courseId));
+            }
+        }
+
+        return requests.length > 0 ? forkJoin(requests) : of(undefined);
+    }
+
+    /**
+     * Broadcasts the modification, updates the local course store and navigates back to the course.
+     */
+    private finalizeSave(updatedCourse: Course | null) {
         this.isSaving.set(false);
 
         if (this.course != updatedCourse) {


### PR DESCRIPTION
### Summary
When an admin assigned a course to an organization in the course **Settings** and clicked **Save**, the assignment was silently dropped — the blue chip disappeared after reload and the organization listed no course. This PR makes the assignment persist. It is a client-only fix: the assignment is now written through the existing, admin-only organization endpoints instead of relying on the course update payload (which intentionally omits `organizations`).

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
Closes #12934.

The "Course Organizations" section in the course settings is admin-only. Adding/removing an organization updated a local signal and showed a blue chip, but on **Save** the value was lost: `CourseUpdateDTO` (both client and server) does not contain an `organizations` field, so the change never reached the database. The platform already exposes dedicated, tested, admin-only endpoints for this exact relationship — they were simply never called by the UI.

### Description
- `organization-management.service.ts`: added `addCourseToOrganization(orgId, courseId)` (POST) and `removeCourseFromOrganization(orgId, courseId)` (DELETE), targeting the existing admin endpoints `api/admin/organizations/{orgId}/courses/{courseId}`.
- `course-update.component.ts`:
  - Snapshot the initially loaded organization ids when the course is opened.
  - On **save success**, diff the current selection against that snapshot and call the add/remove endpoints (guarded by `isAdmin()`), using the returned course id so it also works for newly created courses. Navigation/finalization happens only after the sync completes; failures surface via the existing error handler.
  - Removed the now-redundant `organizations` form control so the `courseOrganizations` signal is the single source of truth.
- No server changes (the endpoints and their `@EnforceAdmin` authorization already exist and are covered by `OrganizationIntegrationTest`).

Verified locally: full client Vitest suite passes (15520 tests), ESLint and Prettier are clean on the changed files.

### Steps for Testing
Prerequisites:
- 1 Admin
- 1 Course

1. Log in as an admin.
2. Go to **Administration → Organization** and create an organization.
3. Go to **Course Management**, open a course, then **Settings**.
4. Click **Add** next to **Course Organizations** and select the organization — it appears as a blue chip.
5. Click **Save**.
6. Re-open the course **Settings** → the blue chip is still shown (previously it disappeared).
7. Go to **Administration → Organization** → the organization now lists the course (previously empty).
8. Back in **Settings**, remove the chip, **Save**, reopen → the chip stays removed and the organization no longer lists the course.
9. Create-flow check: create a new course as admin, add an organization before the first **Save**, save, reopen → the assignment persisted.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/27864701704) did not pass (`failure`). Coverage below may be partial.

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| organization-management.service.ts | 69.56% | 97 | 10 | 10.3 |
| course-update.component.ts | 94.07% | 581 | 253 | 43.5 |

_Last updated: 2026-06-20 08:17:22 UTC_

