### PR TITLE
`Development`: Stabilize flaky server tests and fix plagiarism answer-post data loss

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/PlagiarismAnswerPostService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/PlagiarismAnswerPostService.java
@@ -74,7 +74,12 @@ public class PlagiarismAnswerPostService extends PostingService {
         // on creation of an answer post, we set the resolves_post field to false per default
         answerPost.setResolvesPost(false);
         AnswerPost savedAnswerPost = answerPostRepository.save(answerPost);
-        postRepository.save(post);
+        // Do not re-save the parent post here. The answer is already persisted on its owning side (answerPost.post).
+        // Post.answers is @OneToMany(orphanRemoval = true, fetch = EAGER); with open-in-view off and no surrounding
+        // transaction, the parent post is detached and its answers collection does not contain the just-created
+        // answer. Merging it back (postRepository.save(post)) lets Hibernate treat the new answer as an orphan and
+        // delete it, intermittently losing the answer that was just created (see AnswerMessageService, which also
+        // does not re-save the parent post on answer creation).
 
         preparePostAndBroadcast(savedAnswerPost, course);
 

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/service/ResultServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/service/ResultServiceTest.java
@@ -375,7 +375,12 @@ class ResultServiceTest extends AbstractSpringIntegrationIndependentBatchTest {
         result = resultRepository.save(result);
         Long resultId = result.getId();
 
-        complaintUtilService.addComplaintToSubmission(result.getSubmission(), TEST_PREFIX + "student1", ComplaintType.COMPLAINT);
+        // Re-fetch the submission with its results eagerly: result.getSubmission() is detached here (open-in-view is
+        // off and this test is not @Transactional), so addComplaintToSubmission -> getLatestResult() would lazily
+        // initialize Submission.results without an open session and throw a LazyInitializationException. Whether the
+        // merged submission's results bag is still initialized at this point varies, which made the test flaky.
+        Submission submission = submissionTestRepository.findByIdWithResultsElseThrow(result.getSubmission().getId());
+        complaintUtilService.addComplaintToSubmission(submission, TEST_PREFIX + "student1", ComplaintType.COMPLAINT);
 
         assertThat(complaintRepository.findByResultId(resultId)).isPresent();
 

--- a/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismAnswerPostIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/plagiarism/PlagiarismAnswerPostIntegrationTest.java
@@ -121,6 +121,23 @@ class PlagiarismAnswerPostIntegrationTest extends AbstractSpringIntegrationIndep
         courseRepository.saveAndFlush(persistedCourse);
     }
 
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testCreateAnswerPostPersistsAndIsNotOrphanRemoved() throws Exception {
+        // Regression test for the orphan-removal bug in PlagiarismAnswerPostService.createAnswerPost: it used to
+        // re-save the (detached) parent post after saving the new answer. Because Post.answers is
+        // @OneToMany(orphanRemoval = true), that merge could delete the just-created answer, intermittently losing it.
+        // The created answer must remain persisted.
+        Post parentPost = existingPostsWithAnswers.getFirst();
+        PlagiarismAnswerPostCreateRequestDTO createRequest = new PlagiarismAnswerPostCreateRequestDTO(new ParentPostDTO(parentPost.getId()), "Content Answer Post", false);
+
+        AnswerPostResponseDTO createdAnswerPost = request.postWithResponseBody("/api/plagiarism/courses/" + courseId + "/answer-posts", createRequest, AnswerPostResponseDTO.class,
+                HttpStatus.CREATED);
+
+        assertThat(createdAnswerPost.id()).isNotNull();
+        assertThat(answerPostRepository.findById(createdAnswerPost.id())).as("the created plagiarism answer post must not be orphan-removed by a parent-post re-save").isPresent();
+    }
+
     // Note: the previous testCreateExistingAnswerPost_badRequest case (creating with an existing id and expecting
     // BAD_REQUEST) is no longer expressible — the request DTO has no id field by construction, so the only way the
     // server could observe the case has been removed.

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/RepositoryExportTestUtil.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/RepositoryExportTestUtil.java
@@ -25,7 +25,6 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.revwalk.RevWalk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -405,28 +404,19 @@ public final class RepositoryExportTestUtil {
      * @param commitHash the commit hash that must be resolvable
      */
     public static void waitForBareRepositoryToContainCommit(LocalRepository repo, String commitHash) {
+        if (commitHash == null || commitHash.length() != 40) {
+            throw new IllegalArgumentException("Expected a full 40-character commit hash but got: " + commitHash);
+        }
+        ObjectId commitId = ObjectId.fromString(commitHash);
         Awaitility.await().atMost(60, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(() -> {
-            // Check directly on the file system first — JGit can cache pack files / object database
-            // state per Repository instance, so a freshly-opened Git handle may still return null
-            // from resolve(...) immediately after a push. The loose-object path is updated atomically
-            // by JGit's push, so its presence is the authoritative signal that the commit landed.
-            if (commitHash == null || commitHash.length() != 40) {
-                return false;
-            }
-            Path looseObjectPath = repo.remoteBareGitRepoFile.toPath().resolve("objects").resolve(commitHash.substring(0, 2)).resolve(commitHash.substring(2));
-            if (Files.exists(looseObjectPath)) {
-                return true;
-            }
-            // Fallback for the case where the commit has already been packed (rare for fresh pushes).
+            // A local JGit push writes the commit into a pack file (not a loose object) on JGit 7.6+, so the former
+            // loose-object fast-path was always false and every poll fell through to resolve() + parseCommit().
+            // Parsing reads the commit object data and memory-maps the pack through JGit's process-wide WindowCache,
+            // which is heavily contended under parallel CI (it holds pack locks until a GC runs, see JGitConfig) and
+            // could make the poll time out. ObjectDatabase.has(...) inspects loose objects and pack indexes only, so
+            // it confirms the commit landed without mapping the pack data.
             try (Git git = Git.open(repo.remoteBareGitRepoFile)) {
-                var resolved = git.getRepository().resolve(commitHash);
-                if (resolved == null) {
-                    return false;
-                }
-                try (RevWalk revWalk = new RevWalk(git.getRepository())) {
-                    revWalk.parseCommit(resolved);
-                }
-                return true;
+                return git.getRepository().getObjectDatabase().has(commitId);
             }
             catch (Exception e) {
                 log.debug("Bare repository does not yet contain commit {}: {}", commitHash, e.getMessage());
@@ -445,21 +435,17 @@ public final class RepositoryExportTestUtil {
      */
     public static void waitForBareRepositoryReady(LocalRepository repo) {
         Awaitility.await().atMost(60, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(() -> {
-            try {
-                // Try to open the bare repository and resolve HEAD
-                // This verifies the repo is accessible and has a valid HEAD reference
-                try (Git git = Git.open(repo.remoteBareGitRepoFile)) {
-                    var headRef = git.getRepository().resolve("HEAD");
-                    if (headRef == null) {
-                        log.debug("Bare repository HEAD is null, waiting...");
-                        return false;
-                    }
-                    // Verify we can read the commit object
-                    try (RevWalk revWalk = new RevWalk(git.getRepository())) {
-                        revWalk.parseCommit(headRef);
-                    }
-                    return true;
+            try (Git git = Git.open(repo.remoteBareGitRepoFile)) {
+                // Resolve HEAD (a cheap ref read) and confirm the referenced commit object is present via
+                // ObjectDatabase.has(...). We deliberately avoid RevWalk.parseCommit here: parsing reads the commit
+                // object data and memory-maps the pack through JGit's contended process-wide WindowCache (see
+                // waitForBareRepositoryToContainCommit), which made this wait flaky under parallel CI.
+                var headRef = git.getRepository().resolve("HEAD");
+                if (headRef == null) {
+                    log.debug("Bare repository HEAD is null, waiting...");
+                    return false;
                 }
+                return git.getRepository().getObjectDatabase().has(headRef);
             }
             catch (Exception e) {
                 log.debug("Bare repository not ready yet: {}", e.getMessage());


### PR DESCRIPTION
### Summary

Root-causes and fixes three intermittently failing server tests. One of them turned out to be a real data-loss bug, not just flakiness.

### Description

**1. Plagiarism answer-post data loss (production bug)**

`PlagiarismAnswerPostService.createAnswerPost` saved the new answer and then re-saved the parent `Post`. `Post.answers` is `@OneToMany(orphanRemoval = true, fetch = EAGER)`, and with open-in-view off the parent post is detached, so its `answers` collection does not contain the just-created answer. Merging the detached post back lets Hibernate treat the new answer as an orphan and delete it, intermittently losing an answer that was just created. The non-flaky sibling `AnswerMessageService.createAnswerMessage` never re-saves the parent post. Fix: remove the redundant `postRepository.save(post)`. The answer is already persisted on its owning side. This also stabilizes `testPostingNotAllowedIfDisabledSetting`, which asserted on a global answer-post count delta.

**2. `ResultServiceTest.testDeleteResultWithComplaint` (LazyInitializationException)**

The test passed a detached submission (returned by a `merge`, with open-in-view off and no `@Transactional`) to a helper that calls `getLatestResult()`, lazily initializing `Submission.results` with no open session. It surfaced after the recent removal of the Hibernate L2 cache. Fix: re-fetch the submission with its results eagerly via `submissionTestRepository.findByIdWithResultsElseThrow(...)` before use, the pattern already used elsewhere in that test class.

**3. `ProgrammingExerciseLocalVCIntegrationTest.…ShouldRedirect` (Awaitility timeout)**

`RepositoryExportTestUtil`'s bare-repository waits used a loose-object fast-path that is always false on JGit 7.6 (local pushes write the commit into a pack, not a loose object). Every poll therefore fell through to `resolve()` + `parseCommit()`, which reads the commit object data and memory-maps the pack through JGit's process-wide `WindowCache`. Under parallel CI that cache is heavily contended (it holds pack locks until a GC runs, as documented in `JGitConfig`) and the poll could time out. Fix: use `ObjectDatabase.has(...)`, which checks loose objects and pack indexes only, so it confirms the commit landed without mapping the pack data.

### Testing

- **#1**: Reproduced the data loss deterministically by temporarily restoring the redundant save: both the original `testPostingNotAllowedIfDisabledSetting` and a new regression test (`testCreateAnswerPostPersistsAndIsNotOrphanRemoved`) failed. With the fix, all 34 tests in `PlagiarismAnswerPostIntegrationTest` pass.
- **#2**: `ResultServiceTest.testDeleteResultWithComplaint_deletesResultAndComplaint` passes; the eager fetch removes the lazy-access path entirely.
- **#3**: `ProgrammingExerciseLocalVCIntegrationTest.testGetParticipationFilesWithContentAtCommitShouldRedirect` passes locally. Note: this flake only manifests under full concurrent CI load and cannot be reproduced locally, so the fix is a reasoned best-effort that removes the contended pack-data mapping. Its effectiveness should be confirmed by watching CI over the next runs.

### Steps for Testing

This is a test-stabilization and bug-fix change with no user-facing UI. Reviewers can verify by running the three affected test classes, and by inspecting that `PlagiarismAnswerPostService.createAnswerPost` no longer re-saves the parent post.


https://claude.ai/code/session_01TjGMDbMSFBhxb5ChaTxduN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where newly created plagiarism answer posts could be intermittently deleted due to orphan removal side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->