### PR TITLE
`Development`: Migrate notifications and settings endpoints to DTOs

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/notification/dto/CourseNotificationWithStatusDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/dto/CourseNotificationWithStatusDTO.java
@@ -1,10 +1,20 @@
 package de.tum.cit.aet.artemis.notification.dto;
 
+import java.time.ZonedDateTime;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.cit.aet.artemis.notification.domain.CourseNotification;
-import de.tum.cit.aet.artemis.notification.domain.UserCourseNotificationStatus;
+import de.tum.cit.aet.artemis.notification.domain.UserCourseNotificationStatusType;
 
+/**
+ * DTO projection for course notifications together with the requesting user's status.
+ *
+ * @param notificationId   the unique identifier of the course notification
+ * @param courseId         the identifier of the course the notification belongs to
+ * @param notificationType the internal notification type identifier
+ * @param creationDate     the date when the notification was created
+ * @param status           the requesting user's status for the notification
+ */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record CourseNotificationWithStatusDTO(CourseNotification notification, UserCourseNotificationStatus status) {
+public record CourseNotificationWithStatusDTO(Long notificationId, Long courseId, Short notificationType, ZonedDateTime creationDate, UserCourseNotificationStatusType status) {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/notification/dto/GlobalNotificationSettingDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/dto/GlobalNotificationSettingDTO.java
@@ -1,0 +1,28 @@
+package de.tum.cit.aet.artemis.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.notification.domain.GlobalNotificationSetting;
+import de.tum.cit.aet.artemis.notification.domain.GlobalNotificationType;
+
+/**
+ * DTO for returning a persisted global notification setting.
+ *
+ * @param id               the unique identifier of the setting
+ * @param userId           the identifier of the user owning the setting
+ * @param notificationType the global notification type controlled by the setting
+ * @param enabled          whether notifications of this type are enabled for the user
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record GlobalNotificationSettingDTO(Long id, Long userId, GlobalNotificationType notificationType, boolean enabled) {
+
+    /**
+     * Creates a response DTO from a global notification setting entity.
+     *
+     * @param setting the persisted global notification setting to convert
+     * @return the response DTO containing the REST-safe setting fields
+     */
+    public static GlobalNotificationSettingDTO from(GlobalNotificationSetting setting) {
+        return new GlobalNotificationSettingDTO(setting.getId(), setting.getUserId(), setting.getNotificationType(), setting.getEnabled());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/notification/dto/SystemNotificationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/dto/SystemNotificationDTO.java
@@ -1,0 +1,36 @@
+package de.tum.cit.aet.artemis.notification.dto;
+
+import java.time.ZonedDateTime;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.notification.domain.SystemNotificationType;
+import de.tum.cit.aet.artemis.notification.domain.notification.SystemNotification;
+
+/**
+ * DTO for returning system notifications through REST endpoints.
+ *
+ * @param id               the unique identifier of the system notification
+ * @param title            the optional notification title
+ * @param text             the optional notification text
+ * @param notificationDate the optional date from which the notification should be shown
+ * @param expireDate       the optional date after which the notification expires
+ * @param type             the optional type of the system notification
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record SystemNotificationDTO(Long id, @Nullable String title, @Nullable String text, @Nullable ZonedDateTime notificationDate, @Nullable ZonedDateTime expireDate,
+        @Nullable SystemNotificationType type) {
+
+    /**
+     * Creates a response DTO from a system notification entity.
+     *
+     * @param notification the system notification entity to convert
+     * @return the response DTO containing the REST-safe notification fields
+     */
+    public static SystemNotificationDTO from(SystemNotification notification) {
+        return new SystemNotificationDTO(notification.getId(), notification.getTitle(), notification.getText(), notification.getNotificationDate(), notification.getExpireDate(),
+                notification.getType());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/notification/repository/CourseNotificationRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/repository/CourseNotificationRepository.java
@@ -38,7 +38,13 @@ public interface CourseNotificationRepository extends ArtemisJpaRepository<Cours
      * @return list of course notifications that match the criteria
      */
     @Query("""
-            SELECT new de.tum.cit.aet.artemis.notification.dto.CourseNotificationWithStatusDTO(cn, us)
+            SELECT new de.tum.cit.aet.artemis.notification.dto.CourseNotificationWithStatusDTO(
+                cn.id,
+                cn.course.id,
+                cn.type,
+                cn.creationDate,
+                us.status
+            )
             FROM CourseNotification cn
                 JOIN cn.userStatuses us
             WHERE us.user.id = :userId

--- a/src/main/java/de/tum/cit/aet/artemis/notification/service/CourseNotificationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/service/CourseNotificationService.java
@@ -121,19 +121,18 @@ public class CourseNotificationService {
             + "+ (#pageable != null ? (#pageable.isPaged() ? #pageable.pageNumber : 'unpaged') : 'null') + '_' "
             + "+ (#pageable != null ? (#pageable.isPaged() ? #pageable.pageSize : 'unpaged') : 'null')", unless = "#result.totalElements() == 0")
     public CourseNotificationPageableDTO<CourseNotificationDTO> getCourseNotifications(Pageable pageable, long courseId, long userId) {
-        var courseNotificationsEntityPage = courseNotificationRepository.findCourseNotificationsByUserIdAndCourseIdAndStatusNotArchived(userId, courseId, pageable);
+        var courseNotificationPage = courseNotificationRepository.findCourseNotificationsByUserIdAndCourseIdAndStatusNotArchived(userId, courseId, pageable);
 
-        return CourseNotificationPageableDTO.from(courseNotificationsEntityPage.map((courseNotificationEntityDTO) -> {
-            var courseNotificationEntity = courseNotificationEntityDTO.notification();
-            var classType = courseNotificationRegistryService.getNotificationClass(courseNotificationEntity.getType());
+        return CourseNotificationPageableDTO.from(courseNotificationPage.map((courseNotificationDTO) -> {
+            var classType = courseNotificationRegistryService.getNotificationClass(courseNotificationDTO.notificationType());
 
             try {
-                var parameters = courseNotificationParameterRepository.findByCourseNotificationIdEquals(courseNotificationEntity.getId());
+                var parameters = courseNotificationParameterRepository.findByCourseNotificationIdEquals(courseNotificationDTO.notificationId());
 
-                CourseNotification courseNotification = classType.getDeclaredConstructor(Long.class, Long.class, ZonedDateTime.class, Map.class).newInstance(
-                        courseNotificationEntity.getId(), courseNotificationEntity.getCourse().getId(), courseNotificationEntity.getCreationDate(), parametersToMap(parameters));
+                CourseNotification courseNotification = classType.getDeclaredConstructor(Long.class, Long.class, ZonedDateTime.class, Map.class)
+                        .newInstance(courseNotificationDTO.notificationId(), courseNotificationDTO.courseId(), courseNotificationDTO.creationDate(), parametersToMap(parameters));
 
-                return convertToCourseNotificationDTO(courseNotification, courseNotificationEntityDTO.status().getStatus());
+                return convertToCourseNotificationDTO(courseNotification, courseNotificationDTO.status());
             }
             catch (InstantiationException | IllegalAccessException | IllegalArgumentException | ExceptionInInitializerError | InvocationTargetException | SecurityException
                     | NoSuchMethodException e) {

--- a/src/main/java/de/tum/cit/aet/artemis/notification/service/SystemNotificationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/service/SystemNotificationService.java
@@ -22,6 +22,7 @@ import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.security.SecurityUtils;
 import de.tum.cit.aet.artemis.notification.domain.notification.SystemNotification;
 import de.tum.cit.aet.artemis.notification.dto.MailRecipientDTO;
+import de.tum.cit.aet.artemis.notification.dto.SystemNotificationDTO;
 import de.tum.cit.aet.artemis.notification.repository.MaintenanceEmailRecipientRepository;
 import de.tum.cit.aet.artemis.notification.repository.SystemNotificationRepository;
 import de.tum.cit.aet.artemis.notification.service.notifications.MailSendingService;
@@ -76,7 +77,7 @@ public class SystemNotificationService {
      */
     @SuppressWarnings("deprecation")
     public void distributeActiveAndFutureNotificationsToClients() {
-        List<SystemNotification> notifications = findAllActiveAndFutureSystemNotifications();
+        List<SystemNotificationDTO> notifications = findAllActiveAndFutureSystemNotifications().stream().map(SystemNotificationDTO::from).toList();
         websocketMessagingService.sendMessage(SYSTEM_NOTIFICATION_TOPIC, notifications);
         // Mirror to the legacy destination so older subscribers continue to receive updates during the migration window.
         websocketMessagingService.sendMessage(LEGACY_SYSTEM_NOTIFICATION_TOPIC, notifications);

--- a/src/main/java/de/tum/cit/aet/artemis/notification/service/SystemNotificationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/service/SystemNotificationService.java
@@ -63,6 +63,15 @@ public class SystemNotificationService {
         return systemNotificationRepository.findAllActiveAndFutureSystemNotifications(ZonedDateTime.now());
     }
 
+    /**
+     * Finds all active and future system notifications and maps them to DTOs.
+     *
+     * @return the list of notification DTOs
+     */
+    public List<SystemNotificationDTO> findAllActiveAndFutureSystemNotificationDTOs() {
+        return findAllActiveAndFutureSystemNotifications().stream().map(SystemNotificationDTO::from).toList();
+    }
+
     static final String SYSTEM_NOTIFICATION_TOPIC = "/topic/notification/system-notification";
 
     // Legacy STOMP destination kept in parallel during the migration to /topic/notification/...
@@ -77,7 +86,7 @@ public class SystemNotificationService {
      */
     @SuppressWarnings("deprecation")
     public void distributeActiveAndFutureNotificationsToClients() {
-        List<SystemNotificationDTO> notifications = findAllActiveAndFutureSystemNotifications().stream().map(SystemNotificationDTO::from).toList();
+        List<SystemNotificationDTO> notifications = findAllActiveAndFutureSystemNotificationDTOs();
         websocketMessagingService.sendMessage(SYSTEM_NOTIFICATION_TOPIC, notifications);
         // Mirror to the legacy destination so older subscribers continue to receive updates during the migration window.
         websocketMessagingService.sendMessage(LEGACY_SYSTEM_NOTIFICATION_TOPIC, notifications);

--- a/src/main/java/de/tum/cit/aet/artemis/notification/web/GlobalNotificationSettingResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/web/GlobalNotificationSettingResource.java
@@ -18,8 +18,8 @@ import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastStudent;
 import de.tum.cit.aet.artemis.notification.config.NotificationLegacyRestPaths;
-import de.tum.cit.aet.artemis.notification.domain.GlobalNotificationSetting;
 import de.tum.cit.aet.artemis.notification.domain.GlobalNotificationType;
+import de.tum.cit.aet.artemis.notification.dto.GlobalNotificationSettingDTO;
 import de.tum.cit.aet.artemis.notification.dto.UpdateGlobalNotificationSettingDTO;
 import de.tum.cit.aet.artemis.notification.repository.GlobalNotificationSettingRepository;
 import de.tum.cit.aet.artemis.notification.service.GlobalNotificationSettingService;
@@ -55,19 +55,20 @@ public class GlobalNotificationSettingResource {
 
     /**
      * {@code PUT /global-notification-settings/{notificationType}} : Update (or create) the
-     * {@link GlobalNotificationSetting} for the given {@code notificationType}.
+     * global notification setting for the given {@code notificationType}.
      *
      * @param notificationType the name of the {@link GlobalNotificationType};
      * @param request          the JSON request body, e.g. {@code {"enabled":true}}
-     * @return {@link ResponseEntity} containing the persisted setting and HTTP 200 on success;
+     * @return {@link ResponseEntity} containing the persisted setting DTO and HTTP 200 on success;
      *         HTTP 400 if the body is missing the {@code enabled} property or if {@code notificationType} is unknown
      */
     @PutMapping("global-notification-settings/{notificationType}")
     @EnforceAtLeastStudent
-    public ResponseEntity<GlobalNotificationSetting> updateSetting(@PathVariable GlobalNotificationType notificationType, @RequestBody UpdateGlobalNotificationSettingDTO request) {
+    public ResponseEntity<GlobalNotificationSettingDTO> updateSetting(@PathVariable GlobalNotificationType notificationType,
+            @RequestBody UpdateGlobalNotificationSettingDTO request) {
         User user = userRepository.getUserWithGroupsAndAuthorities();
         boolean enabled = request.enabled();
-        return ResponseEntity.ok(globalNotificationSettingService.createOrUpdateSetting(user, notificationType, enabled));
+        return ResponseEntity.ok(GlobalNotificationSettingDTO.from(globalNotificationSettingService.createOrUpdateSetting(user, notificationType, enabled)));
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/notification/web/SystemNotificationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/web/SystemNotificationResource.java
@@ -58,7 +58,7 @@ public class SystemNotificationResource {
     @GetMapping("system-notifications")
     @EnforceAtLeastTutor
     public ResponseEntity<List<SystemNotificationDTO>> getAllSystemNotifications(Pageable pageable) {
-        log.debug("REST request to get all Courses the user has access to");
+        log.debug("REST request to get all SystemNotifications");
         final Page<SystemNotification> page = systemNotificationRepository.findAll(pageable);
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
         return new ResponseEntity<>(page.getContent().stream().map(SystemNotificationDTO::from).toList(), headers, HttpStatus.OK);

--- a/src/main/java/de/tum/cit/aet/artemis/notification/web/SystemNotificationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/web/SystemNotificationResource.java
@@ -26,6 +26,7 @@ import de.tum.cit.aet.artemis.core.web.util.PaginationUtil;
 import de.tum.cit.aet.artemis.core.web.util.ResponseUtil;
 import de.tum.cit.aet.artemis.notification.config.NotificationLegacyRestPaths;
 import de.tum.cit.aet.artemis.notification.domain.notification.SystemNotification;
+import de.tum.cit.aet.artemis.notification.dto.SystemNotificationDTO;
 import de.tum.cit.aet.artemis.notification.repository.SystemNotificationRepository;
 
 /**
@@ -56,11 +57,11 @@ public class SystemNotificationResource {
      */
     @GetMapping("system-notifications")
     @EnforceAtLeastTutor
-    public ResponseEntity<List<SystemNotification>> getAllSystemNotifications(Pageable pageable) {
+    public ResponseEntity<List<SystemNotificationDTO>> getAllSystemNotifications(Pageable pageable) {
         log.debug("REST request to get all Courses the user has access to");
         final Page<SystemNotification> page = systemNotificationRepository.findAll(pageable);
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
-        return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
+        return new ResponseEntity<>(page.getContent().stream().map(SystemNotificationDTO::from).toList(), headers, HttpStatus.OK);
     }
 
     /**
@@ -71,9 +72,9 @@ public class SystemNotificationResource {
      */
     @GetMapping("system-notifications/{notificationId}")
     @EnforceAtLeastEditor
-    public ResponseEntity<SystemNotification> getSystemNotification(@PathVariable Long notificationId) {
+    public ResponseEntity<SystemNotificationDTO> getSystemNotification(@PathVariable Long notificationId) {
         log.debug("REST request to get SystemNotification : {}", notificationId);
-        Optional<SystemNotification> systemNotification = systemNotificationRepository.findById(notificationId);
+        Optional<SystemNotificationDTO> systemNotification = systemNotificationRepository.findById(notificationId).map(SystemNotificationDTO::from);
         return ResponseUtil.wrapOrNotFound(systemNotification);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/notification/web/admin/AdminSystemNotificationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/web/admin/AdminSystemNotificationResource.java
@@ -26,6 +26,7 @@ import de.tum.cit.aet.artemis.core.security.annotations.EnforceAdmin;
 import de.tum.cit.aet.artemis.core.util.HeaderUtil;
 import de.tum.cit.aet.artemis.notification.config.NotificationLegacyRestPaths;
 import de.tum.cit.aet.artemis.notification.domain.notification.SystemNotification;
+import de.tum.cit.aet.artemis.notification.dto.SystemNotificationDTO;
 import de.tum.cit.aet.artemis.notification.dto.SystemNotificationUpdateDTO;
 import de.tum.cit.aet.artemis.notification.repository.SystemNotificationRepository;
 import de.tum.cit.aet.artemis.notification.service.SystemNotificationService;
@@ -68,7 +69,7 @@ public class AdminSystemNotificationResource {
      * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PostMapping("system-notifications")
-    public ResponseEntity<SystemNotification> createSystemNotification(@RequestBody SystemNotificationUpdateDTO dto,
+    public ResponseEntity<SystemNotificationDTO> createSystemNotification(@RequestBody SystemNotificationUpdateDTO dto,
             @RequestParam(defaultValue = "false") boolean sendMaintenanceEmail) throws URISyntaxException {
         log.debug("REST request to save SystemNotification : {}", dto);
         if (dto.id() != null) {
@@ -89,7 +90,7 @@ public class AdminSystemNotificationResource {
         }
 
         return ResponseEntity.created(new URI("/api/notifications/" + result.getId()))
-                .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getId().toString())).body(result);
+                .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getId().toString())).body(SystemNotificationDTO.from(result));
     }
 
     /**
@@ -111,7 +112,7 @@ public class AdminSystemNotificationResource {
      *         status 500 (Internal Server Error) if the system notification couldn't be updated
      */
     @PutMapping("system-notifications")
-    public ResponseEntity<SystemNotification> updateSystemNotification(@RequestBody SystemNotificationUpdateDTO updateDTO) {
+    public ResponseEntity<SystemNotificationDTO> updateSystemNotification(@RequestBody SystemNotificationUpdateDTO updateDTO) {
         log.debug("REST request to update SystemNotification : {}", updateDTO);
         if (updateDTO.id() == null) {
             throw new BadRequestAlertException("ID must not be null", ENTITY_NAME, "idNull");
@@ -127,7 +128,8 @@ public class AdminSystemNotificationResource {
         this.systemNotificationService.validateDatesElseThrow(existingNotification);
         SystemNotification result = systemNotificationRepository.save(existingNotification);
         systemNotificationService.distributeActiveAndFutureNotificationsToClients();
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, result.getId().toString())).body(result);
+        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, result.getId().toString()))
+                .body(SystemNotificationDTO.from(result));
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/notification/web/open/PublicSystemNotificationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/web/open/PublicSystemNotificationResource.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceNothing;
 import de.tum.cit.aet.artemis.notification.config.NotificationLegacyRestPaths;
-import de.tum.cit.aet.artemis.notification.domain.notification.SystemNotification;
+import de.tum.cit.aet.artemis.notification.dto.SystemNotificationDTO;
 import de.tum.cit.aet.artemis.notification.service.SystemNotificationService;
 
 /**
@@ -46,8 +46,8 @@ public class PublicSystemNotificationResource {
      */
     @GetMapping("system-notifications/active")
     @EnforceNothing
-    public ResponseEntity<List<SystemNotification>> getActiveAndFutureSystemNotifications() {
+    public ResponseEntity<List<SystemNotificationDTO>> getActiveAndFutureSystemNotifications() {
         log.debug("REST request to get relevant system notifications");
-        return ResponseEntity.ok(systemNotificationService.findAllActiveAndFutureSystemNotifications());
+        return ResponseEntity.ok(systemNotificationService.findAllActiveAndFutureSystemNotifications().stream().map(SystemNotificationDTO::from).toList());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/notification/web/open/PublicSystemNotificationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/web/open/PublicSystemNotificationResource.java
@@ -48,6 +48,6 @@ public class PublicSystemNotificationResource {
     @EnforceNothing
     public ResponseEntity<List<SystemNotificationDTO>> getActiveAndFutureSystemNotifications() {
         log.debug("REST request to get relevant system notifications");
-        return ResponseEntity.ok(systemNotificationService.findAllActiveAndFutureSystemNotifications().stream().map(SystemNotificationDTO::from).toList());
+        return ResponseEntity.ok(systemNotificationService.findAllActiveAndFutureSystemNotificationDTOs());
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/notification/GlobalNotificationSettingsIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/GlobalNotificationSettingsIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.service.user.UserService;
 import de.tum.cit.aet.artemis.notification.domain.GlobalNotificationType;
+import de.tum.cit.aet.artemis.notification.dto.GlobalNotificationSettingDTO;
 import de.tum.cit.aet.artemis.notification.repository.GlobalNotificationSettingRepository;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
@@ -65,6 +66,20 @@ class GlobalNotificationSettingsIntegrationTest extends AbstractSpringIntegratio
 
         request.put("/api/notification/global-notification-settings/" + GlobalNotificationType.SSH_KEY_EXPIRED, requestBody, HttpStatus.OK);
         assertThat(globalNotificationSettingRepository.isNotificationEnabled(testUser.getId(), GlobalNotificationType.SSH_KEY_EXPIRED)).isFalse();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void shouldReturnGlobalNotificationSettingDTOWhenUpdatingSetting() throws Exception {
+        Map<String, Boolean> requestBody = Map.of("enabled", false);
+
+        GlobalNotificationSettingDTO response = request.putWithResponseBody("/api/notification/global-notification-settings/" + GlobalNotificationType.NEW_LOGIN, requestBody,
+                GlobalNotificationSettingDTO.class, HttpStatus.OK);
+
+        assertThat(response.id()).isNotNull();
+        assertThat(response.userId()).isEqualTo(testUser.getId());
+        assertThat(response.notificationType()).isEqualTo(GlobalNotificationType.NEW_LOGIN);
+        assertThat(response.enabled()).isFalse();
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/notification/architecture/NotificationEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/architecture/NotificationEntityUsageArchitectureTest.java
@@ -5,8 +5,6 @@ import de.tum.cit.aet.artemis.shared.architecture.module.AbstractModuleEntityUsa
 /**
  * Architecture test to verify that REST controllers in the Notification module
  * do not use @Entity types directly. Controllers should use DTOs instead.
- * <p>
- * TODO: Reduce violation counts to 0 by introducing DTOs for all endpoints.
  */
 class NotificationEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitectureTest {
 
@@ -15,21 +13,18 @@ class NotificationEntityUsageArchitectureTest extends AbstractModuleEntityUsageA
         return ARTEMIS_PACKAGE + ".notification";
     }
 
-    // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getExpectedEntityReturnViolations() {
-        return 6;
+        return 0;
     }
 
-    // This module is already compliant for input violations
     @Override
     protected int getExpectedEntityInputViolations() {
         return 0;
     }
 
-    // TODO: Reduce this to 0 by removing entity references from DTOs
     @Override
     protected int getExpectedDtoEntityFieldViolations() {
-        return 2;
+        return 0;
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/notification/notification/SystemNotificationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/notification/SystemNotificationIntegrationTest.java
@@ -18,6 +18,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.cit.aet.artemis.core.config.LegacyApiPathDeprecationInterceptor;
 import de.tum.cit.aet.artemis.notification.domain.notification.SystemNotification;
+import de.tum.cit.aet.artemis.notification.dto.SystemNotificationDTO;
+import de.tum.cit.aet.artemis.notification.dto.SystemNotificationUpdateDTO;
 import de.tum.cit.aet.artemis.notification.repository.SystemNotificationRepository;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
@@ -90,10 +92,11 @@ class SystemNotificationIntegrationTest extends AbstractSpringIntegrationIndepen
 
     private void getActiveSystemNotification() throws Exception {
         // Do the actual request that is tested here.
-        List<SystemNotification> notification = request.getList("/api/notification/public/system-notifications/active", HttpStatus.OK, SystemNotification.class);
+        List<SystemNotificationDTO> notification = request.getList("/api/notification/public/system-notifications/active", HttpStatus.OK, SystemNotificationDTO.class);
 
         // The returned notification must be an active notification.
-        assertThat(notification).hasSize(2).as("Returned notifications are active or scheduled.").containsExactly(systemNotificationActive, systemNotificationFuture);
+        assertThat(notification).hasSize(2).as("Returned notifications are active or scheduled.").extracting(SystemNotificationDTO::id)
+                .containsExactly(systemNotificationActive.getId(), systemNotificationFuture.getId());
         assertThat(systemNotificationActive.getExpireDate()).as("Returned notification 0 has not expired yet.").isAfterOrEqualTo(ZonedDateTime.now());
         assertThat(systemNotificationActive.getNotificationDate()).as("Returned notification 0 is active.").isBeforeOrEqualTo(ZonedDateTime.now());
         assertThat(systemNotificationFuture.getExpireDate()).as("Returned notification 1 has not expired yet.").isAfterOrEqualTo(ZonedDateTime.now());
@@ -103,30 +106,30 @@ class SystemNotificationIntegrationTest extends AbstractSpringIntegrationIndepen
     @Test
     @WithMockUser(username = "admin1", roles = "ADMIN")
     void testCreateSystemNotification() throws Exception {
-        SystemNotification response = request.postWithResponseBody("/api/notification/admin/system-notifications", systemNotification, SystemNotification.class);
+        SystemNotificationDTO response = request.postWithResponseBody("/api/notification/admin/system-notifications", toUpdateDTO(systemNotification), SystemNotificationDTO.class);
 
-        assertThat(systemNotificationRepo.findById(response.getId())).as("Saved system notification").isNotNull();
-        assertThat(systemNotificationRepo.existsById(response.getId())).as("Saved notification exists").isTrue();
+        assertThat(systemNotificationRepo.findById(response.id())).as("Saved system notification").isNotNull();
+        assertThat(systemNotificationRepo.existsById(response.id())).as("Saved notification exists").isTrue();
     }
 
     @Test
     @WithMockUser(username = "admin1", roles = "ADMIN")
     void testCreateSystemNotification_BadRequest() throws Exception {
         systemNotification.setId(1L);
-        request.post("/api/notification/admin/system-notifications", systemNotification, HttpStatus.BAD_REQUEST);
+        request.post("/api/notification/admin/system-notifications", toUpdateDTO(systemNotification), HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testCreateSystemNotification_asInstructor_Forbidden() throws Exception {
-        request.post("/api/notification/admin/system-notifications", systemNotification, HttpStatus.FORBIDDEN);
+        request.post("/api/notification/admin/system-notifications", toUpdateDTO(systemNotification), HttpStatus.FORBIDDEN);
     }
 
     @Test
     @WithMockUser(roles = "USER")
     void testCreateSystemNotification_asUser_Forbidden() throws Exception {
         systemNotification.setId(1L);
-        request.post("/api/notification/admin/system-notifications", systemNotification, HttpStatus.FORBIDDEN);
+        request.post("/api/notification/admin/system-notifications", toUpdateDTO(systemNotification), HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -135,9 +138,11 @@ class SystemNotificationIntegrationTest extends AbstractSpringIntegrationIndepen
         systemNotificationRepo.save(systemNotification);
         String updatedText = "updated text";
         systemNotification.setText(updatedText);
-        SystemNotification response = request.putWithResponseBody("/api/notification/admin/system-notifications", systemNotification, SystemNotification.class, HttpStatus.OK);
-        assertThat(response.getText()).as("response has updated text").isEqualTo(updatedText);
-        assertThat(systemNotificationRepo.findById(systemNotification.getId())).get().as("repository contains updated notification").isEqualTo(response);
+        SystemNotificationDTO response = request.putWithResponseBody("/api/notification/admin/system-notifications", toUpdateDTO(systemNotification), SystemNotificationDTO.class,
+                HttpStatus.OK);
+        assertThat(response.text()).as("response has updated text").isEqualTo(updatedText);
+        assertThat(systemNotificationRepo.findById(response.id())).get().as("repository contains updated notification").extracting(SystemNotification::getText)
+                .isEqualTo(updatedText);
     }
 
     @Test
@@ -145,38 +150,38 @@ class SystemNotificationIntegrationTest extends AbstractSpringIntegrationIndepen
     void testUpdateSystemNotification_asInstructor_Forbidden() throws Exception {
         systemNotificationRepo.save(systemNotification);
         systemNotification.setText("updated text");
-        request.put("/api/notification/admin/system-notifications", systemNotification, HttpStatus.FORBIDDEN);
+        request.put("/api/notification/admin/system-notifications", toUpdateDTO(systemNotification), HttpStatus.FORBIDDEN);
     }
 
     @Test
     @WithMockUser(username = "admin1", roles = "ADMIN")
     void testUpdateSystemNotification_BadRequest() throws Exception {
         SystemNotification systemNotification = generateSystemNotification(ZonedDateTime.now().minusDays(3), ZonedDateTime.now().plusDays(3));
-        request.put("/api/notification/admin/system-notifications", systemNotification, HttpStatus.BAD_REQUEST);
+        request.put("/api/notification/admin/system-notifications", toUpdateDTO(systemNotification), HttpStatus.BAD_REQUEST);
     }
 
     @Test
     @WithMockUser(username = "admin1", roles = "ADMIN")
     void testGetAllSystemNotifications() throws Exception {
-        List<SystemNotification> response = request.getList("/api/notification/system-notifications", HttpStatus.OK, SystemNotification.class);
+        List<SystemNotificationDTO> response = request.getList("/api/notification/system-notifications", HttpStatus.OK, SystemNotificationDTO.class);
         assertThat(response).as("system notification are present").isNotEmpty();
     }
 
     @Test
     @WithMockUser(username = "admin1", roles = "ADMIN")
     void testGetSystemNotification() throws Exception {
-        SystemNotification response = request.postWithResponseBody("/api/notification/admin/system-notifications", systemNotification, SystemNotification.class);
-        assertThat(systemNotificationRepo.findById(response.getId())).get().as("system notification is not null").isNotNull();
-        request.get("/api/notification/system-notifications/" + response.getId(), HttpStatus.OK, SystemNotification.class);
-        request.get("/api/notification/system-notifications/" + response.getId() + 1, HttpStatus.NOT_FOUND, SystemNotification.class);
+        SystemNotificationDTO response = request.postWithResponseBody("/api/notification/admin/system-notifications", toUpdateDTO(systemNotification), SystemNotificationDTO.class);
+        assertThat(systemNotificationRepo.findById(response.id())).get().as("system notification is not null").isNotNull();
+        request.get("/api/notification/system-notifications/" + response.id(), HttpStatus.OK, SystemNotificationDTO.class);
+        request.get("/api/notification/system-notifications/" + response.id() + 1, HttpStatus.NOT_FOUND, SystemNotificationDTO.class);
     }
 
     @Test
     @WithMockUser(username = "admin1", roles = "ADMIN")
     void testDeleteSystemNotification() throws Exception {
-        SystemNotification response = request.postWithResponseBody("/api/notification/admin/system-notifications", systemNotification, SystemNotification.class);
-        assertThat(systemNotificationRepo.findById(response.getId())).get().as("system notification is not null").isNotNull();
-        request.delete("/api/notification/admin/system-notifications/" + response.getId(), HttpStatus.OK);
+        SystemNotificationDTO response = request.postWithResponseBody("/api/notification/admin/system-notifications", toUpdateDTO(systemNotification), SystemNotificationDTO.class);
+        assertThat(systemNotificationRepo.findById(response.id())).get().as("system notification is not null").isNotNull();
+        request.delete("/api/notification/admin/system-notifications/" + response.id(), HttpStatus.OK);
     }
 
     @Test
@@ -199,5 +204,10 @@ class SystemNotificationIntegrationTest extends AbstractSpringIntegrationIndepen
         systemNotification.setNotificationDate(notificationDate);
         systemNotification.setExpireDate(expiryDate);
         return systemNotification;
+    }
+
+    private static SystemNotificationUpdateDTO toUpdateDTO(SystemNotification notification) {
+        return new SystemNotificationUpdateDTO(notification.getId(), notification.getTitle(), notification.getText(), notification.getNotificationDate(),
+                notification.getExpireDate(), notification.getType());
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/notification/service/CourseNotificationServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/service/CourseNotificationServiceTest.java
@@ -32,7 +32,6 @@ import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.notification.domain.CourseNotification;
 import de.tum.cit.aet.artemis.notification.domain.CourseNotificationParameter;
 import de.tum.cit.aet.artemis.notification.domain.NotificationChannelOption;
-import de.tum.cit.aet.artemis.notification.domain.UserCourseNotificationStatus;
 import de.tum.cit.aet.artemis.notification.domain.UserCourseNotificationStatusType;
 import de.tum.cit.aet.artemis.notification.domain.course_notifications.CourseNotificationCategory;
 import de.tum.cit.aet.artemis.notification.dto.CourseNotificationDTO;
@@ -128,14 +127,12 @@ class CourseNotificationServiceTest {
         CourseNotification entity = createTestCourseNotificationEntity(1L);
         CourseNotificationParameter param1 = new CourseNotificationParameter(entity, "key1", "value1");
         CourseNotificationParameter param2 = new CourseNotificationParameter(entity, "key2", "value2");
-        entity.setParameters(Set.of(param1, param2));
-        UserCourseNotificationStatus status = new UserCourseNotificationStatus();
-        status.setCourseNotification(entity);
-        status.setStatus(UserCourseNotificationStatusType.SEEN);
 
-        PageImpl<CourseNotificationWithStatusDTO> page = new PageImpl<>(List.of(new CourseNotificationWithStatusDTO(entity, status)));
+        PageImpl<CourseNotificationWithStatusDTO> page = new PageImpl<>(List.of(new CourseNotificationWithStatusDTO(entity.getId(), entity.getCourse().getId(), entity.getType(),
+                entity.getCreationDate(), UserCourseNotificationStatusType.SEEN)));
 
         when(courseNotificationRepository.findCourseNotificationsByUserIdAndCourseIdAndStatusNotArchived(userId, courseId, pageable)).thenReturn(page);
+        when(courseNotificationParameterRepository.findByCourseNotificationIdEquals(entity.getId())).thenReturn(Set.of(param1, param2));
         when(courseNotificationRegistryService.getNotificationClass(any())).thenReturn((Class) TestNotification.class);
 
         CourseNotificationPageableDTO<CourseNotificationDTO> result = courseNotificationService.getCourseNotifications(pageable, courseId, userId);

--- a/src/test/java/de/tum/cit/aet/artemis/notification/service/SystemNotificationServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/service/SystemNotificationServiceTest.java
@@ -1,0 +1,73 @@
+package de.tum.cit.aet.artemis.notification.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import de.tum.cit.aet.artemis.communication.service.WebsocketMessagingService;
+import de.tum.cit.aet.artemis.notification.domain.SystemNotificationType;
+import de.tum.cit.aet.artemis.notification.domain.notification.SystemNotification;
+import de.tum.cit.aet.artemis.notification.dto.SystemNotificationDTO;
+import de.tum.cit.aet.artemis.notification.repository.MaintenanceEmailRecipientRepository;
+import de.tum.cit.aet.artemis.notification.repository.SystemNotificationRepository;
+import de.tum.cit.aet.artemis.notification.service.notifications.MailSendingService;
+
+@ExtendWith(MockitoExtension.class)
+class SystemNotificationServiceTest {
+
+    @Mock
+    private WebsocketMessagingService websocketMessagingService;
+
+    @Mock
+    private SystemNotificationRepository systemNotificationRepository;
+
+    @Mock
+    private MaintenanceEmailRecipientRepository maintenanceEmailRecipientRepository;
+
+    @Mock
+    private MailSendingService mailSendingService;
+
+    private SystemNotificationService systemNotificationService;
+
+    @BeforeEach
+    void setUp() {
+        systemNotificationService = new SystemNotificationService(websocketMessagingService, systemNotificationRepository, maintenanceEmailRecipientRepository,
+                mailSendingService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @SuppressWarnings({ "deprecation", "removal" })
+    void shouldSendSystemNotificationDtosToCurrentAndLegacyTopics() {
+        ZonedDateTime notificationDate = ZonedDateTime.now();
+        SystemNotification notification = new SystemNotification();
+        notification.setId(1L);
+        notification.setTitle("Maintenance");
+        notification.setText("Artemis will be unavailable.");
+        notification.setNotificationDate(notificationDate);
+        notification.setExpireDate(notificationDate.plusHours(1));
+        notification.setType(SystemNotificationType.WARNING);
+        when(systemNotificationRepository.findAllActiveAndFutureSystemNotifications(any(ZonedDateTime.class))).thenReturn(List.of(notification));
+
+        systemNotificationService.distributeActiveAndFutureNotificationsToClients();
+
+        List<SystemNotificationDTO> expectedNotifications = List.of(SystemNotificationDTO.from(notification));
+        verify(websocketMessagingService).sendMessage(SystemNotificationService.SYSTEM_NOTIFICATION_TOPIC, expectedNotifications);
+        verify(websocketMessagingService).sendMessage(SystemNotificationService.LEGACY_SYSTEM_NOTIFICATION_TOPIC, expectedNotifications);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/notification/service/SystemNotificationServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/service/SystemNotificationServiceTest.java
@@ -42,8 +42,7 @@ class SystemNotificationServiceTest {
 
     @BeforeEach
     void setUp() {
-        systemNotificationService = new SystemNotificationService(websocketMessagingService, systemNotificationRepository, maintenanceEmailRecipientRepository,
-                mailSendingService);
+        systemNotificationService = new SystemNotificationService(websocketMessagingService, systemNotificationRepository, maintenanceEmailRecipientRepository, mailSendingService);
     }
 
     @AfterEach


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 
This PR completes the notification settings DTO migration slice by preventing notification REST endpoints and projection DTOs from exposing JPA entities. It introduces dedicated response DTOs for system notifications and global notification settings, converts the course notification status projection to scalar fields, and lowers the notification entity-usage architecture-test budget to zero.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The notification module still exposed entities through REST response types and through an entity-backed DTO projection. This is part of the planned DTO/entity architecture cleanup and removes the remaining notification/settings architecture-test violations without changing endpoint paths or public JSON field names.


### Description
<!-- Describe your changes in detail -->
- Added `SystemNotificationDTO` and return it from public, tutor/editor, and admin system-notification REST endpoints.
- Added `GlobalNotificationSettingDTO` and return it from the global notification setting update endpoint.
- Converted `CourseNotificationWithStatusDTO` from entity fields to scalar projection fields.
- Updated the course notification repository query and service mapping to use scalar projection data while preserving the existing `CourseNotificationDTO` response shape.
- Updated focused system notification and course notification service tests to use the new DTO contracts.
- Lowered the notification entity-usage architecture-test budgets from `6 / 0 / 2` to `0 / 0 / 0`.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Admin
- 1 Student
- 1 Course with course notifications

#### **1. As an Admin**
1. Log in as an **Admin**.
2. Go to **Server Administration** -> **System Notifications**.
3. Create a new system notification with a `notificationDate` in the past and `expireDate` in the future (so it is currently active).
4. Verify that the creation request completes successfully.
5. In your browser's Developer Tools (**Network tab**), inspect the `POST` response for `system-notifications`.
   * **Verify:** The returned JSON object contains only the DTO fields (`id`, `title`, `text`, `notificationDate`, `expireDate`, `type`) and no JPA-related entity internals.
6. Perform an update (PUT) and a fetch (GET) on system notifications, verifying the response matches the same DTO structure.
7. Navigate to your Course -> **Messages** (Communication) tab.
8. Under the **announcement** channel, create and post a new message. This will automatically trigger a course notification for all enrolled students.

#### **2. Unauthenticated (No Login Required)**
9. Open a new private/incognito browser window (to simulate an unauthenticated user).
10. Navigate to the Artemis landing page.
11. Open your browser's Developer Tools (**Network tab**) and find the request to `/api/notification/public/system-notifications/active` triggered by the landing page.
    * **Verify:** The response returns successfully with the active system notification you created in Step 3, represented as a `SystemNotificationDTO` object containing only `id`, `title`, `text`, `notificationDate`, `expireDate`, and `type`.
  
#### **3. As a Student**
12. Log in as a **Student** enrolled in the course.
13. Go to **Settings** -> **Notifications**.
14. Toggle any global notification setting to update it.
15. Check the **Network tab** for the response of the `PUT` request to `/api/notification/global-notification-settings/{notificationType}`.
    * **Verify:** The response is returned successfully as a `GlobalNotificationSettingDTO` containing only `id`, `userId`, `notificationType`, and `enabled`.
16. Navigate to the course page -> **Communication** and click on the **Notification Bell** (top right) or view the course notification list.
17. Inspect the network response for `GET /api/notification/courses/{courseId}` and check the notification list in the UI.
    * **Verify:** The notification list loads successfully, and the notification cards show the correct titles and parameter values (e.g., showing the announcement title and details you posted in Step 8, rather than empty placeholders).

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->


#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| CourseNotificationWithStatusDTO.java | 100.00% | 7 |
| GlobalNotificationSettingDTO.java | 100.00% | 10 |
| SystemNotificationDTO.java | 100.00% | 14 |
| CourseNotificationRepository.java | 93.75% | 43 |
| CourseNotificationService.java | 91.67% | 124 |
| SystemNotificationService.java | 34.69% | 104 |
| GlobalNotificationSettingResource.java | 100.00% | 52 |
| SystemNotificationResource.java | 100.00% | 53 |
| AdminSystemNotificationResource.java | 83.33% | 95 |
| PublicSystemNotificationResource.java | 100.00% | 33 |

_Last updated: 2026-07-17 13:39:11 UTC_

