### PR TITLE
`General`: Add browser-delegated login handoff for external clients

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/ExternalLoginProperties.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/ExternalLoginProperties.java
@@ -1,0 +1,64 @@
+package de.tum.cit.aet.artemis.core.config;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Configuration for the external-client browser-delegated login handoff (e.g. the VS Code extension).
+ * <p>
+ * Lets an external client obtain a full Artemis JWT after the user authenticates in the browser with
+ * any method (passkey, SAML SSO, password), using a one-time code + PKCE exchange. The feature is
+ * <strong>disabled by default</strong>: with an empty {@link #allowedRedirectSchemes} no callback is
+ * ever accepted.
+ */
+@Profile(PROFILE_CORE)
+@Configuration
+@ConfigurationProperties(prefix = "artemis.external-login")
+public class ExternalLoginProperties {
+
+    /**
+     * Allowed custom URI schemes for the extension callback (e.g. {@code vscode}, {@code vscode-insiders}).
+     * Empty (default) disables the feature. {@code http} and {@code https} are always rejected.
+     */
+    private List<String> allowedRedirectSchemes = List.of();
+
+    /**
+     * Optional allowlist of callback authorities (the host part, e.g. the extension id
+     * {@code aet-tum.iris-thaumantias}). Empty means any authority is accepted for an allowed scheme.
+     * Setting this prevents another extension from receiving the one-time code.
+     */
+    private List<String> allowedRedirectAuthorities = List.of();
+
+    /**
+     * @return the allowed callback URI schemes ({@code http}/{@code https} are always rejected)
+     */
+    public List<String> getAllowedRedirectSchemes() {
+        return allowedRedirectSchemes;
+    }
+
+    /**
+     * @param allowedRedirectSchemes the allowed callback URI schemes
+     */
+    public void setAllowedRedirectSchemes(List<String> allowedRedirectSchemes) {
+        this.allowedRedirectSchemes = allowedRedirectSchemes;
+    }
+
+    /**
+     * @return the optional allowlist of callback authorities (empty = any authority allowed)
+     */
+    public List<String> getAllowedRedirectAuthorities() {
+        return allowedRedirectAuthorities;
+    }
+
+    /**
+     * @param allowedRedirectAuthorities the allowed callback authorities
+     */
+    public void setAllowedRedirectAuthorities(List<String> allowedRedirectAuthorities) {
+        this.allowedRedirectAuthorities = allowedRedirectAuthorities;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/ExternalLoginProperties.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/ExternalLoginProperties.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 
 /**
@@ -17,6 +18,7 @@ import org.springframework.context.annotation.Profile;
  * ever accepted.
  */
 @Profile(PROFILE_CORE)
+@Lazy
 @Configuration
 @ConfigurationProperties(prefix = "artemis.external-login")
 public class ExternalLoginProperties {

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/ExternalLoginProperties.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/ExternalLoginProperties.java
@@ -14,8 +14,8 @@ import org.springframework.context.annotation.Profile;
  * <p>
  * Lets an external client obtain a full Artemis JWT after the user authenticates in the browser with
  * any method (passkey, SAML SSO, password), using a one-time code + PKCE exchange. The feature is
- * <strong>disabled by default</strong>: with an empty {@link #allowedRedirectSchemes} no callback is
- * ever accepted.
+ * <strong>disabled by default</strong> and requires <strong>both</strong> {@link #allowedRedirectSchemes}
+ * and {@link #allowedRedirectAuthorities} to be non-empty: if either is empty no callback is ever accepted.
  */
 @Profile(PROFILE_CORE)
 @Lazy
@@ -30,9 +30,9 @@ public class ExternalLoginProperties {
     private List<String> allowedRedirectSchemes = List.of();
 
     /**
-     * Optional allowlist of callback authorities (the host part, e.g. the extension id
-     * {@code aet-tum.iris-thaumantias}). Empty means any authority is accepted for an allowed scheme.
-     * Setting this prevents another extension from receiving the one-time code.
+     * Allowlist of callback authorities (the host part, e.g. the extension id
+     * {@code aet-tum.iris-thaumantias}). <strong>Required</strong> when the feature is enabled: an empty list
+     * disables the feature, so that an allowed scheme alone cannot deliver the one-time code to an arbitrary handler.
      */
     private List<String> allowedRedirectAuthorities = List.of();
 
@@ -51,7 +51,7 @@ public class ExternalLoginProperties {
     }
 
     /**
-     * @return the optional allowlist of callback authorities (empty = any authority allowed)
+     * @return the allowlist of callback authorities (required when the feature is enabled; empty disables the feature)
      */
     public List<String> getAllowedRedirectAuthorities() {
         return allowedRedirectAuthorities;

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/ExternalLoginCodeRequestDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/ExternalLoginCodeRequestDTO.java
@@ -1,0 +1,13 @@
+package de.tum.cit.aet.artemis.core.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Request to issue a one-time external-login code.
+ *
+ * @param codeChallenge the PKCE S256 code challenge (base64url, no padding)
+ * @param callback      the extension callback URI to redirect to with the code
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ExternalLoginCodeRequestDTO(String codeChallenge, String callback) {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/ExternalLoginCodeResponseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/ExternalLoginCodeResponseDTO.java
@@ -1,0 +1,12 @@
+package de.tum.cit.aet.artemis.core.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Response containing the one-time external-login code the web app redirects to the extension with.
+ *
+ * @param code the one-time code
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ExternalLoginCodeResponseDTO(String code) {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/ExternalLoginTokenRequestDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/ExternalLoginTokenRequestDTO.java
@@ -1,0 +1,13 @@
+package de.tum.cit.aet.artemis.core.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Request to exchange a one-time code (with its PKCE verifier) for a full JWT.
+ *
+ * @param code         the one-time code received via the extension callback
+ * @param codeVerifier the PKCE code verifier matching the challenge sent at issue time
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ExternalLoginTokenRequestDTO(String code, String codeVerifier) {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/ExternalLoginTokenResponseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/ExternalLoginTokenResponseDTO.java
@@ -1,12 +1,16 @@
 package de.tum.cit.aet.artemis.core.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Response containing the full Artemis JWT for an external client.
+ * <p>
+ * Serialized as {@code access_token} to match the documented contract and the existing
+ * {@code /api/core/public/authenticate} endpoint, so external clients can read a single, consistent field.
  *
  * @param accessToken the JWT (to be stored and sent as the {@code jwt} cookie by the client)
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record ExternalLoginTokenResponseDTO(String accessToken) {
+public record ExternalLoginTokenResponseDTO(@JsonProperty("access_token") String accessToken) {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/dto/ExternalLoginTokenResponseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/dto/ExternalLoginTokenResponseDTO.java
@@ -1,0 +1,12 @@
+package de.tum.cit.aet.artemis.core.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Response containing the full Artemis JWT for an external client.
+ *
+ * @param accessToken the JWT (to be stored and sent as the {@code jwt} cookie by the client)
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ExternalLoginTokenResponseDTO(String accessToken) {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/repository/externallogin/HazelcastExternalLoginCodeRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/repository/externallogin/HazelcastExternalLoginCodeRepository.java
@@ -1,0 +1,72 @@
+package de.tum.cit.aet.artemis.core.repository.externallogin;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import java.util.concurrent.TimeUnit;
+
+import jakarta.annotation.PostConstruct;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
+
+import de.tum.cit.aet.artemis.core.security.externallogin.ExternalLoginCodeData;
+
+/**
+ * Hazelcast-backed one-time-code store for the external-client browser login flow.
+ * <p>
+ * Codes are single-use (atomically consumed on lookup) and expire after a short per-entry TTL.
+ * Distributed so the issue and exchange requests can hit different nodes in a cluster.
+ */
+@Profile(PROFILE_CORE)
+@Lazy
+@Repository
+public class HazelcastExternalLoginCodeRepository {
+
+    private static final String MAP_NAME = "external-login-code-map";
+
+    private static final int CODE_TTL_SECONDS = 60;
+
+    private final HazelcastInstance hazelcastInstance;
+
+    private IMap<String, ExternalLoginCodeData> codeMap;
+
+    public HazelcastExternalLoginCodeRepository(@Qualifier("hazelcastInstance") HazelcastInstance hazelcastInstance) {
+        this.hazelcastInstance = hazelcastInstance;
+    }
+
+    /**
+     * Resolves the distributed code map. Hazelcast access must not happen in the constructor
+     * (see {@code ArchitectureTest.testNoHazelcastUsageInConstructors}), hence the {@code @PostConstruct}.
+     */
+    @PostConstruct
+    public void init() {
+        this.codeMap = hazelcastInstance.getMap(MAP_NAME);
+    }
+
+    /**
+     * Stores the code data with a short per-entry TTL so abandoned flows expire automatically.
+     *
+     * @param code the one-time code
+     * @param data the data bound to the code
+     */
+    public void save(String code, ExternalLoginCodeData data) {
+        codeMap.put(code, data, CODE_TTL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Atomically retrieves and removes the data for the given code (single-use).
+     *
+     * @param code the one-time code
+     * @return the data, or {@code null} if unknown, expired, or already consumed
+     */
+    @Nullable
+    public ExternalLoginCodeData consume(String code) {
+        return codeMap.remove(code);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/externallogin/ExternalLoginCodeData.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/externallogin/ExternalLoginCodeData.java
@@ -1,0 +1,15 @@
+package de.tum.cit.aet.artemis.core.security.externallogin;
+
+import java.io.Serializable;
+
+/**
+ * Data bound to a one-time external-login code, stored server-side (distributed) until the external
+ * client exchanges the code together with its PKCE verifier for the JWT.
+ *
+ * @param jwt           the full Artemis JWT minted at issue time (already capped to the originating
+ *                          session's remaining validity)
+ * @param codeChallenge the PKCE S256 code challenge (base64url, no padding)
+ * @param callback      the validated extension callback URI
+ */
+public record ExternalLoginCodeData(String jwt, String codeChallenge, String callback) implements Serializable {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/externallogin/ExternalLoginRedirectUriValidator.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/externallogin/ExternalLoginRedirectUriValidator.java
@@ -1,0 +1,98 @@
+package de.tum.cit.aet.artemis.core.security.externallogin;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Validates extension callback URIs for the external-client browser login flow.
+ * <p>
+ * Only custom URI schemes in the configured allowlist are accepted; {@code http} and {@code https}
+ * are always rejected, which prevents classic open-redirect token theft. Optionally restricts the
+ * callback authority (the host part, e.g. the extension id) to a configured allowlist.
+ */
+public class ExternalLoginRedirectUriValidator {
+
+    private static final Set<String> BLOCKED_SCHEMES = Set.of("http", "https");
+
+    static final int MAX_URI_BYTES = 512;
+
+    private final List<String> allowedSchemes;
+
+    private final List<String> allowedAuthorities;
+
+    /**
+     * @param allowedSchemes     the allowed custom URI schemes (lower-cased internally)
+     * @param allowedAuthorities the optional allowlist of callback authorities (empty = any)
+     */
+    public ExternalLoginRedirectUriValidator(List<String> allowedSchemes, List<String> allowedAuthorities) {
+        this.allowedSchemes = allowedSchemes.stream().map(scheme -> scheme.toLowerCase(Locale.ROOT)).toList();
+        this.allowedAuthorities = allowedAuthorities.stream().map(authority -> authority.toLowerCase(Locale.ROOT)).toList();
+    }
+
+    /**
+     * @return {@code true} if at least one scheme is allowlisted (i.e. the feature is enabled)
+     */
+    public boolean isFeatureEnabled() {
+        return !allowedSchemes.isEmpty();
+    }
+
+    /**
+     * Validates a callback URI against the configured allowlist and security rules.
+     *
+     * @param callback the callback URI to validate
+     * @return empty if valid, or a short rejection reason
+     */
+    public Optional<String> validate(String callback) {
+        if (callback == null || callback.isBlank()) {
+            return Optional.of("callback is empty");
+        }
+        if (callback.getBytes(StandardCharsets.UTF_8).length > MAX_URI_BYTES) {
+            return Optional.of("callback exceeds maximum length of " + MAX_URI_BYTES + " bytes");
+        }
+
+        URI uri;
+        try {
+            uri = URI.create(callback);
+        }
+        catch (IllegalArgumentException e) {
+            return Optional.of("callback is not a valid URI: " + e.getMessage());
+        }
+
+        if (!uri.isAbsolute()) {
+            return Optional.of("callback must be an absolute URI");
+        }
+
+        // Opaque URIs (e.g. "vscode:callback" without "//") cannot reliably carry query parameters.
+        if (uri.isOpaque()) {
+            return Optional.of("callback must be a hierarchical URI");
+        }
+
+        String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+        if (BLOCKED_SCHEMES.contains(scheme)) {
+            return Optional.of("http/https callbacks are not allowed");
+        }
+        if (!allowedSchemes.contains(scheme)) {
+            return Optional.of("URI scheme '" + scheme + "' is not in the allowlist");
+        }
+
+        if (!allowedAuthorities.isEmpty()) {
+            String host = uri.getHost();
+            if (host == null || !allowedAuthorities.contains(host.toLowerCase(Locale.ROOT))) {
+                return Optional.of("callback authority is not in the allowlist");
+            }
+        }
+
+        if (uri.getUserInfo() != null) {
+            return Optional.of("callback must not contain user info");
+        }
+        if (uri.getFragment() != null) {
+            return Optional.of("callback must not contain a fragment");
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/externallogin/ExternalLoginRedirectUriValidator.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/externallogin/ExternalLoginRedirectUriValidator.java
@@ -11,8 +11,10 @@ import java.util.Set;
  * Validates extension callback URIs for the external-client browser login flow.
  * <p>
  * Only custom URI schemes in the configured allowlist are accepted; {@code http} and {@code https}
- * are always rejected, which prevents classic open-redirect token theft. Optionally restricts the
- * callback authority (the host part, e.g. the extension id) to a configured allowlist.
+ * are always rejected, which prevents classic open-redirect token theft. The callback authority (the
+ * host part, e.g. the extension id) must also match a configured allowlist: a non-empty authority
+ * allowlist is <strong>required</strong> for the feature to be active, so that an allowed scheme on
+ * its own can never deliver a JWT to an arbitrary handler.
  */
 public class ExternalLoginRedirectUriValidator {
 
@@ -26,7 +28,7 @@ public class ExternalLoginRedirectUriValidator {
 
     /**
      * @param allowedSchemes     the allowed custom URI schemes (lower-cased internally)
-     * @param allowedAuthorities the optional allowlist of callback authorities (empty = any)
+     * @param allowedAuthorities the allowlist of callback authorities (lower-cased internally); required (non-empty) for the feature to be active
      */
     public ExternalLoginRedirectUriValidator(List<String> allowedSchemes, List<String> allowedAuthorities) {
         this.allowedSchemes = allowedSchemes.stream().map(scheme -> scheme.toLowerCase(Locale.ROOT)).toList();
@@ -34,10 +36,13 @@ public class ExternalLoginRedirectUriValidator {
     }
 
     /**
-     * @return {@code true} if at least one scheme is allowlisted (i.e. the feature is enabled)
+     * The feature requires both a scheme and an authority allowlist: an allowed scheme without an authority allowlist
+     * would trust every handler for that scheme, so such a (misconfigured) setup is treated as disabled.
+     *
+     * @return {@code true} if at least one scheme and at least one authority are allowlisted (i.e. the feature is enabled)
      */
     public boolean isFeatureEnabled() {
-        return !allowedSchemes.isEmpty();
+        return !allowedSchemes.isEmpty() && !allowedAuthorities.isEmpty();
     }
 
     /**
@@ -79,11 +84,11 @@ public class ExternalLoginRedirectUriValidator {
             return Optional.of("URI scheme '" + scheme + "' is not in the allowlist");
         }
 
-        if (!allowedAuthorities.isEmpty()) {
-            String host = uri.getHost();
-            if (host == null || !allowedAuthorities.contains(host.toLowerCase(Locale.ROOT))) {
-                return Optional.of("callback authority is not in the allowlist");
-            }
+        // The authority allowlist is mandatory: an empty allowlist rejects every callback (fail closed), so an allowed
+        // scheme alone can never deliver the one-time code (and the JWT it unlocks) to an arbitrary handler.
+        String host = uri.getHost();
+        if (host == null || !allowedAuthorities.contains(host.toLowerCase(Locale.ROOT))) {
+            return Optional.of("callback authority is not in the allowlist");
         }
 
         if (uri.getUserInfo() != null) {

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/externallogin/PkceUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/externallogin/PkceUtil.java
@@ -4,13 +4,49 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.regex.Pattern;
+
+import org.jspecify.annotations.Nullable;
 
 /**
  * PKCE (RFC 7636) S256 helper for the external-login code exchange.
  */
 public final class PkceUtil {
 
+    /**
+     * An S256 code challenge is {@code base64url(SHA-256(verifier))} without padding: a SHA-256 digest is 32 bytes,
+     * which base64url-encodes to exactly 43 characters from the URL-safe alphabet.
+     */
+    private static final Pattern S256_CODE_CHALLENGE = Pattern.compile("^[A-Za-z0-9_-]{43}$");
+
+    /**
+     * RFC 7636 code verifier: 43-128 characters from the unreserved set {@code [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~"}.
+     */
+    private static final Pattern CODE_VERIFIER = Pattern.compile("^[A-Za-z0-9._~-]{43,128}$");
+
     private PkceUtil() {
+    }
+
+    /**
+     * Validates that a code challenge has the RFC 7636 S256 shape (43 base64url characters, no padding), so malformed
+     * challenges are rejected before a JWT-bearing code is minted and stored.
+     *
+     * @param codeChallenge the PKCE code challenge to validate
+     * @return {@code true} if the challenge is a well-formed S256 challenge
+     */
+    public static boolean isValidS256Challenge(@Nullable String codeChallenge) {
+        return codeChallenge != null && S256_CODE_CHALLENGE.matcher(codeChallenge).matches();
+    }
+
+    /**
+     * Validates that a code verifier has the RFC 7636 shape (43-128 unreserved characters), so blank, overlong or
+     * otherwise malformed verifiers are rejected before any hashing or repository work.
+     *
+     * @param codeVerifier the PKCE code verifier to validate
+     * @return {@code true} if the verifier is a well-formed RFC 7636 verifier
+     */
+    public static boolean isValidCodeVerifier(@Nullable String codeVerifier) {
+        return codeVerifier != null && CODE_VERIFIER.matcher(codeVerifier).matches();
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/externallogin/PkceUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/externallogin/PkceUtil.java
@@ -1,0 +1,47 @@
+package de.tum.cit.aet.artemis.core.security.externallogin;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+/**
+ * PKCE (RFC 7636) S256 helper for the external-login code exchange.
+ */
+public final class PkceUtil {
+
+    private PkceUtil() {
+    }
+
+    /**
+     * Computes the S256 code challenge for a verifier: {@code base64url(SHA-256(verifier))} without padding.
+     *
+     * @param codeVerifier the PKCE code verifier
+     * @return the S256 code challenge
+     */
+    public static String s256Challenge(String codeVerifier) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    /**
+     * Constant-time comparison of the challenge derived from the verifier against the expected challenge.
+     *
+     * @param codeVerifier          the PKCE code verifier presented at exchange
+     * @param expectedCodeChallenge the stored code challenge
+     * @return {@code true} if the verifier matches the challenge
+     */
+    public static boolean matches(String codeVerifier, String expectedCodeChallenge) {
+        if (codeVerifier == null || expectedCodeChallenge == null) {
+            return false;
+        }
+        String actual = s256Challenge(codeVerifier);
+        return MessageDigest.isEqual(actual.getBytes(StandardCharsets.US_ASCII), expectedCodeChallenge.getBytes(StandardCharsets.US_ASCII));
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/jwt/JWTFilter.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/jwt/JWTFilter.java
@@ -101,8 +101,12 @@ public class JWTFilter extends GenericFilterBean {
             long newTokenExpirationTimeInMs = Math.min(nowInMs + tokenValidityInMs, issuedAt.getTime() + Math.multiplyExact(this.tokenValidityInSecondsForPasskey, 1000));
             // Determine the lifetime of the rotated token
             long rotatedTokenDurationInMs = newTokenExpirationTimeInMs - nowInMs;
-            // Create the rotated token with updated expiration and same issued time/tools
-            var rotatedToken = this.tokenProvider.createToken(authentication, issuedAt, new Date(newTokenExpirationTimeInMs), this.tokenProvider.getTools(jwtToken), true);
+            // Create the rotated token with updated expiration and same issued time/tools. Only passkey tokens are
+            // rotated (see the guard above), so record PASSKEY explicitly and carry over the passkey-approval claim
+            // from the source token; the rebuilt authentication no longer carries either.
+            boolean isPasskeyApproved = this.tokenProvider.isPasskeySuperAdminApproved(jwtToken);
+            var rotatedToken = this.tokenProvider.createToken(authentication, issuedAt, new Date(newTokenExpirationTimeInMs), this.tokenProvider.getTools(jwtToken),
+                    AuthenticationMethod.PASSKEY, isPasskeyApproved);
 
             // Build and set the new token as a response cookie
             ResponseCookie responseCookie = jwtCookieService.buildRotatedCookie(rotatedToken, rotatedTokenDurationInMs);

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/jwt/TokenProvider.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/jwt/TokenProvider.java
@@ -138,8 +138,6 @@ public class TokenProvider {
      */
     @NonNull
     public String createToken(Authentication authentication, @Nullable Date issuedAt, Date expiration, @Nullable ToolTokenType tool, @Nullable Boolean authenticatedWithPasskey) {
-        String authorities = authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.joining(","));
-
         AuthenticationMethod authenticationMethod = AuthenticationMethod.fromAuthentication(authentication);
         if (authenticatedWithPasskey != null && authenticatedWithPasskey) {
             authenticationMethod = AuthenticationMethod.PASSKEY;
@@ -149,6 +147,47 @@ public class TokenProvider {
         if (authenticationMethod == AuthenticationMethod.PASSKEY && authentication.getDetails() instanceof Map<?, ?> details) {
             isPasskeyApproved = Boolean.TRUE.equals(details.get(IS_PASSKEY_SUPER_ADMIN_APPROVED));
         }
+
+        return buildToken(authentication, issuedAt, expiration, tool, authenticationMethod, isPasskeyApproved);
+    }
+
+    /**
+     * Creates a JWT for the given authentication with <b>explicitly supplied</b> authentication-method and
+     * passkey-approval claims, instead of deriving them from the (often claim-less) {@link Authentication}.
+     * <p>
+     * Used when re-minting a token from an existing session JWT (the external-client login handoff and the silent
+     * passkey token rotation), where the source {@link Authentication} is a plain
+     * {@link UsernamePasswordAuthenticationToken} rebuilt from claims and therefore no longer carries the original
+     * authentication method or passkey-approval. Passing them explicitly prevents a passkey/SAML session from
+     * silently degrading to a {@code password} token and prevents an approved passkey from losing its approval.
+     *
+     * @param authentication       the principal and authorities source
+     * @param issuedAt             the issued-at date, or now if {@code null}
+     * @param expiration           the expiration date
+     * @param tool                 the tool this token is used for, or {@code null} for a general access token
+     * @param authenticationMethod the authentication method to record; falls back to the authentication and then to
+     *                                 {@link AuthenticationMethod#PASSWORD} if {@code null}
+     * @param isPasskeyApproved    whether the passkey was super-admin approved
+     * @return JWT Token
+     */
+    @NonNull
+    public String createToken(Authentication authentication, @Nullable Date issuedAt, Date expiration, @Nullable ToolTokenType tool,
+            @Nullable AuthenticationMethod authenticationMethod, boolean isPasskeyApproved) {
+        AuthenticationMethod method = authenticationMethod != null ? authenticationMethod : AuthenticationMethod.fromAuthentication(authentication);
+        if (method == null) {
+            method = AuthenticationMethod.PASSWORD;
+        }
+        return buildToken(authentication, issuedAt, expiration, tool, method, isPasskeyApproved);
+    }
+
+    /**
+     * Builds and signs the JWT with the given claims. Shared by the claim-deriving and the explicit-claim
+     * {@code createToken} overloads so the token shape stays identical regardless of how the claims were obtained.
+     */
+    @NonNull
+    private String buildToken(Authentication authentication, @Nullable Date issuedAt, Date expiration, @Nullable ToolTokenType tool,
+            @Nullable AuthenticationMethod authenticationMethod, boolean isPasskeyApproved) {
+        String authorities = authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority).collect(Collectors.joining(","));
 
         // @formatter:off
         JwtBuilder jwtBuilder = Jwts.builder()

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/ExternalLoginResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/ExternalLoginResource.java
@@ -119,6 +119,12 @@ public class ExternalLoginResource {
         if (authentication == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
+        // Never upgrade a tool-scoped token into a full (unscoped) Artemis JWT. The ToolsInterceptor already rejects
+        // tool tokens on this non-public endpoint; this explicit guard keeps the invariant local to the mint and
+        // independent of that wiring.
+        if (tokenProvider.getTools(current.jwt()) != null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
 
         // Mint a full (unscoped) JWT for the current principal, stored server-side until the code is exchanged.
         // Preserve the originating session's authentication method and passkey-approval claims so a passkey/SAML

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/ExternalLoginResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/ExternalLoginResource.java
@@ -53,7 +53,7 @@ public class ExternalLoginResource {
 
     private static final int CODE_BYTES = 32; // 256 bits of entropy
 
-    private final ExternalLoginRedirectUriValidator validator;
+    private final ExternalLoginProperties externalLoginProperties;
 
     private final HazelcastExternalLoginCodeRepository codeRepository;
 
@@ -61,12 +61,22 @@ public class ExternalLoginResource {
 
     private final TokenProvider tokenProvider;
 
-    public ExternalLoginResource(ExternalLoginProperties properties, HazelcastExternalLoginCodeRepository codeRepository, JWTCookieService jwtCookieService,
+    public ExternalLoginResource(ExternalLoginProperties externalLoginProperties, HazelcastExternalLoginCodeRepository codeRepository, JWTCookieService jwtCookieService,
             TokenProvider tokenProvider) {
-        this.validator = new ExternalLoginRedirectUriValidator(properties.getAllowedRedirectSchemes(), properties.getAllowedRedirectAuthorities());
+        this.externalLoginProperties = externalLoginProperties;
         this.codeRepository = codeRepository;
         this.jwtCookieService = jwtCookieService;
         this.tokenProvider = tokenProvider;
+    }
+
+    /**
+     * Builds the callback validator from the current configuration. Constructed per request (cheap) so that the
+     * feature flag and the allowlists reflect the live configuration instead of being frozen at construction time.
+     *
+     * @return the redirect URI validator for the current configuration
+     */
+    private ExternalLoginRedirectUriValidator validator() {
+        return new ExternalLoginRedirectUriValidator(externalLoginProperties.getAllowedRedirectSchemes(), externalLoginProperties.getAllowedRedirectAuthorities());
     }
 
     /**
@@ -79,6 +89,7 @@ public class ExternalLoginResource {
     @PostMapping("code")
     @EnforceAtLeastStudent
     public ResponseEntity<ExternalLoginCodeResponseDTO> issueCode(@RequestBody ExternalLoginCodeRequestDTO body, HttpServletRequest request) {
+        ExternalLoginRedirectUriValidator validator = validator();
         if (!validator.isFeatureEnabled()) {
             return ResponseEntity.notFound().build();
         }

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/ExternalLoginResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/ExternalLoginResource.java
@@ -4,6 +4,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.Date;
 import java.util.Optional;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,6 +15,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,7 +28,8 @@ import de.tum.cit.aet.artemis.core.repository.externallogin.HazelcastExternalLog
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastStudent;
 import de.tum.cit.aet.artemis.core.security.externallogin.ExternalLoginCodeData;
 import de.tum.cit.aet.artemis.core.security.externallogin.ExternalLoginRedirectUriValidator;
-import de.tum.cit.aet.artemis.core.security.jwt.JWTCookieService;
+import de.tum.cit.aet.artemis.core.security.externallogin.PkceUtil;
+import de.tum.cit.aet.artemis.core.security.jwt.AuthenticationMethod;
 import de.tum.cit.aet.artemis.core.security.jwt.JWTFilter;
 import de.tum.cit.aet.artemis.core.security.jwt.JwtWithSource;
 import de.tum.cit.aet.artemis.core.security.jwt.TokenProvider;
@@ -53,19 +56,17 @@ public class ExternalLoginResource {
 
     private static final int CODE_BYTES = 32; // 256 bits of entropy
 
+    private static final int MAX_LOGGED_REJECTION_REASON_LENGTH = 200;
+
     private final ExternalLoginProperties externalLoginProperties;
 
     private final HazelcastExternalLoginCodeRepository codeRepository;
 
-    private final JWTCookieService jwtCookieService;
-
     private final TokenProvider tokenProvider;
 
-    public ExternalLoginResource(ExternalLoginProperties externalLoginProperties, HazelcastExternalLoginCodeRepository codeRepository, JWTCookieService jwtCookieService,
-            TokenProvider tokenProvider) {
+    public ExternalLoginResource(ExternalLoginProperties externalLoginProperties, HazelcastExternalLoginCodeRepository codeRepository, TokenProvider tokenProvider) {
         this.externalLoginProperties = externalLoginProperties;
         this.codeRepository = codeRepository;
-        this.jwtCookieService = jwtCookieService;
         this.tokenProvider = tokenProvider;
     }
 
@@ -93,12 +94,15 @@ public class ExternalLoginResource {
         if (!validator.isFeatureEnabled()) {
             return ResponseEntity.notFound().build();
         }
-        if (body == null || body.codeChallenge() == null || body.codeChallenge().isBlank()) {
+        // Reject malformed PKCE challenges up front: a non-S256-shaped challenge could never be matched at exchange,
+        // so we fail fast with 400 instead of minting a dead-on-arrival, JWT-bearing code.
+        if (body == null || !PkceUtil.isValidS256Challenge(body.codeChallenge())) {
             return ResponseEntity.badRequest().build();
         }
         Optional<String> rejection = validator.validate(body.callback());
         if (rejection.isPresent()) {
-            log.warn("External-login callback rejected: {}", rejection.get());
+            // The rejection reason can embed attacker-controlled callback input, so sanitize it before logging.
+            log.warn("External-login callback rejected: {}", sanitizeForLog(rejection.get()));
             return ResponseEntity.badRequest().build();
         }
 
@@ -107,13 +111,21 @@ public class ExternalLoginResource {
         if (current == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
-        long remaining = tokenProvider.getExpirationDate(current.jwt()).getTime() - System.currentTimeMillis();
-        if (remaining <= 0) {
+        Date sessionExpiry = tokenProvider.getExpirationDate(current.jwt());
+        if (sessionExpiry.getTime() - System.currentTimeMillis() <= 0) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        Authentication authentication = tokenProvider.getAuthentication(current.jwt());
+        if (authentication == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
         // Mint a full (unscoped) JWT for the current principal, stored server-side until the code is exchanged.
-        String jwt = jwtCookieService.buildLoginCookie(remaining, null).getValue();
+        // Preserve the originating session's authentication method and passkey-approval claims so a passkey/SAML
+        // browser login does not silently degrade to a password token (which would break passkey-approved admins).
+        AuthenticationMethod authenticationMethod = tokenProvider.getAuthenticationMethod(current.jwt());
+        boolean isPasskeyApproved = tokenProvider.isPasskeySuperAdminApproved(current.jwt());
+        String jwt = tokenProvider.createToken(authentication, null, sessionExpiry, null, authenticationMethod, isPasskeyApproved);
         String code = generateCode();
         codeRepository.save(code, new ExternalLoginCodeData(jwt, body.codeChallenge(), body.callback()));
 
@@ -124,5 +136,17 @@ public class ExternalLoginResource {
         byte[] bytes = new byte[CODE_BYTES];
         SECURE_RANDOM.nextBytes(bytes);
         return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    /**
+     * Strips line breaks and bounds the length of a callback-rejection reason before it is logged, so attacker-controlled
+     * callback input cannot inject forged log lines (log poisoning) or bloat the logs.
+     *
+     * @param reason the rejection reason from the validator
+     * @return a single-line, length-bounded version safe to log
+     */
+    private static String sanitizeForLog(String reason) {
+        String singleLine = reason.replace('\n', ' ').replace('\r', ' ');
+        return singleLine.length() > MAX_LOGGED_REJECTION_REASON_LENGTH ? singleLine.substring(0, MAX_LOGGED_REJECTION_REASON_LENGTH) : singleLine;
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/ExternalLoginResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/ExternalLoginResource.java
@@ -1,0 +1,117 @@
+package de.tum.cit.aet.artemis.core.web;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.tum.cit.aet.artemis.core.config.ExternalLoginProperties;
+import de.tum.cit.aet.artemis.core.dto.ExternalLoginCodeRequestDTO;
+import de.tum.cit.aet.artemis.core.dto.ExternalLoginCodeResponseDTO;
+import de.tum.cit.aet.artemis.core.repository.externallogin.HazelcastExternalLoginCodeRepository;
+import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastStudent;
+import de.tum.cit.aet.artemis.core.security.externallogin.ExternalLoginCodeData;
+import de.tum.cit.aet.artemis.core.security.externallogin.ExternalLoginRedirectUriValidator;
+import de.tum.cit.aet.artemis.core.security.jwt.JWTCookieService;
+import de.tum.cit.aet.artemis.core.security.jwt.JWTFilter;
+import de.tum.cit.aet.artemis.core.security.jwt.JwtWithSource;
+import de.tum.cit.aet.artemis.core.security.jwt.TokenProvider;
+
+/**
+ * Authenticated endpoint that issues a one-time code for the external-client browser login handoff
+ * (e.g. the VS Code extension).
+ * <p>
+ * Called same-origin from the Artemis web app's external-login page after the user has logged in by
+ * any method (passkey, SAML, password). The full JWT is minted here, capped to the current session's
+ * remaining validity (so this flow can never extend a session), bound to the one-time code, and only
+ * released after the external client proves possession of the PKCE verifier (see
+ * {@link de.tum.cit.aet.artemis.core.web.open.PublicExternalLoginResource}).
+ */
+@Profile(PROFILE_CORE)
+@Lazy
+@RestController
+@RequestMapping("api/core/external-login/")
+public class ExternalLoginResource {
+
+    private static final Logger log = LoggerFactory.getLogger(ExternalLoginResource.class);
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private static final int CODE_BYTES = 32; // 256 bits of entropy
+
+    private final ExternalLoginRedirectUriValidator validator;
+
+    private final HazelcastExternalLoginCodeRepository codeRepository;
+
+    private final JWTCookieService jwtCookieService;
+
+    private final TokenProvider tokenProvider;
+
+    public ExternalLoginResource(ExternalLoginProperties properties, HazelcastExternalLoginCodeRepository codeRepository, JWTCookieService jwtCookieService,
+            TokenProvider tokenProvider) {
+        this.validator = new ExternalLoginRedirectUriValidator(properties.getAllowedRedirectSchemes(), properties.getAllowedRedirectAuthorities());
+        this.codeRepository = codeRepository;
+        this.jwtCookieService = jwtCookieService;
+        this.tokenProvider = tokenProvider;
+    }
+
+    /**
+     * Issues a one-time code that an external client can exchange (with its PKCE verifier) for a full JWT.
+     *
+     * @param body    the PKCE S256 code challenge and the extension callback URI
+     * @param request the HTTP request, used to read the current session's JWT for the lifetime cap
+     * @return 200 with the one-time code; 400 on invalid input; 404 if the feature is disabled; 401 if the session token is missing
+     */
+    @PostMapping("code")
+    @EnforceAtLeastStudent
+    public ResponseEntity<ExternalLoginCodeResponseDTO> issueCode(@RequestBody ExternalLoginCodeRequestDTO body, HttpServletRequest request) {
+        if (!validator.isFeatureEnabled()) {
+            return ResponseEntity.notFound().build();
+        }
+        if (body == null || body.codeChallenge() == null || body.codeChallenge().isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        Optional<String> rejection = validator.validate(body.callback());
+        if (rejection.isPresent()) {
+            log.warn("External-login callback rejected: {}", rejection.get());
+            return ResponseEntity.badRequest().build();
+        }
+
+        // Cap the minted token to the current session's remaining validity, so this flow can never extend a session.
+        JwtWithSource current = JWTFilter.extractValidJwt(request, tokenProvider);
+        if (current == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        long remaining = tokenProvider.getExpirationDate(current.jwt()).getTime() - System.currentTimeMillis();
+        if (remaining <= 0) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        // Mint a full (unscoped) JWT for the current principal, stored server-side until the code is exchanged.
+        String jwt = jwtCookieService.buildLoginCookie(remaining, null).getValue();
+        String code = generateCode();
+        codeRepository.save(code, new ExternalLoginCodeData(jwt, body.codeChallenge(), body.callback()));
+
+        return ResponseEntity.ok(new ExternalLoginCodeResponseDTO(code));
+    }
+
+    private String generateCode() {
+        byte[] bytes = new byte[CODE_BYTES];
+        SECURE_RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicExternalLoginResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicExternalLoginResource.java
@@ -1,0 +1,62 @@
+package de.tum.cit.aet.artemis.core.web.open;
+
+import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
+
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import de.tum.cit.aet.artemis.core.dto.ExternalLoginTokenRequestDTO;
+import de.tum.cit.aet.artemis.core.dto.ExternalLoginTokenResponseDTO;
+import de.tum.cit.aet.artemis.core.repository.externallogin.HazelcastExternalLoginCodeRepository;
+import de.tum.cit.aet.artemis.core.security.RateLimitType;
+import de.tum.cit.aet.artemis.core.security.annotations.EnforceNothing;
+import de.tum.cit.aet.artemis.core.security.annotations.LimitRequestsPerMinute;
+import de.tum.cit.aet.artemis.core.security.externallogin.ExternalLoginCodeData;
+import de.tum.cit.aet.artemis.core.security.externallogin.PkceUtil;
+
+/**
+ * Public endpoint that exchanges a one-time code + PKCE verifier for a full JWT.
+ * <p>
+ * Public because the external client is not yet authenticated; possession of the PKCE verifier (which
+ * never reaches the browser) authorizes the exchange. The code is single-use and short-lived, and the
+ * endpoint is rate-limited.
+ */
+@Profile(PROFILE_CORE)
+@Lazy
+@RestController
+@RequestMapping("api/core/public/external-login/")
+public class PublicExternalLoginResource {
+
+    private final HazelcastExternalLoginCodeRepository codeRepository;
+
+    public PublicExternalLoginResource(HazelcastExternalLoginCodeRepository codeRepository) {
+        this.codeRepository = codeRepository;
+    }
+
+    /**
+     * Exchanges a one-time code and PKCE verifier for the full JWT minted at issue time.
+     *
+     * @param body the one-time code and the PKCE code verifier
+     * @return 200 with the access token on success; 401 if the code is unknown/expired/consumed or the verifier is wrong
+     */
+    @PostMapping("token")
+    @EnforceNothing
+    @LimitRequestsPerMinute(type = RateLimitType.AUTHENTICATION)
+    public ResponseEntity<ExternalLoginTokenResponseDTO> exchangeCode(@RequestBody ExternalLoginTokenRequestDTO body) {
+        if (body == null || body.code() == null || body.codeVerifier() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        // Single-use: atomically consume the code, then verify the PKCE verifier against the stored challenge.
+        ExternalLoginCodeData data = codeRepository.consume(body.code());
+        if (data == null || !PkceUtil.matches(body.codeVerifier(), data.codeChallenge())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        return ResponseEntity.ok(new ExternalLoginTokenResponseDTO(data.jwt()));
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicExternalLoginResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicExternalLoginResource.java
@@ -49,7 +49,8 @@ public class PublicExternalLoginResource {
     @EnforceNothing
     @LimitRequestsPerMinute(type = RateLimitType.AUTHENTICATION)
     public ResponseEntity<ExternalLoginTokenResponseDTO> exchangeCode(@RequestBody ExternalLoginTokenRequestDTO body) {
-        if (body == null || body.code() == null || body.codeVerifier() == null) {
+        // Reject blank codes and malformed/overlong PKCE verifiers before any repository or hashing work.
+        if (body == null || body.code() == null || body.code().isBlank() || !PkceUtil.isValidCodeVerifier(body.codeVerifier())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         // Single-use: atomically consume the code, then verify the PKCE verifier against the stored challenge.

--- a/src/main/webapp/app/app.routes.ts
+++ b/src/main/webapp/app/app.routes.ts
@@ -114,6 +114,16 @@ const routes: Routes = [
         canActivate: [UserRouteAccessService],
     },
     {
+        path: 'external-login',
+        loadComponent: () => import('app/core/auth/external-login/external-login.component').then((m) => m.ExternalLoginComponent),
+        data: {
+            authorities: IS_AT_LEAST_STUDENT,
+            pageTitle: 'artemisApp.externalLogin.pageTitle',
+            usesModuleBackground: true,
+        },
+        canActivate: [UserRouteAccessService],
+    },
+    {
         path: 'imprint',
         loadComponent: () => import('app/core/legal/imprint.component').then((m) => m.ImprintComponent),
         data: {

--- a/src/main/webapp/app/core/auth/account.service.spec.ts
+++ b/src/main/webapp/app/core/auth/account.service.spec.ts
@@ -91,6 +91,18 @@ describe('AccountService', () => {
         expect(sshKey.label).toBe('test-label');
     });
 
+    it('should issue an external-login code', () => {
+        const body = { codeChallenge: 'the-challenge', callback: 'vscode://aet-tum.iris-thaumantias/external-login-callback' };
+        let received: { code: string } | undefined;
+        accountService.issueExternalLoginCode(body).subscribe((res) => (received = res));
+
+        const req = httpMock.expectOne({ method: 'POST', url: 'api/core/external-login/code' });
+        expect(req.request.body).toEqual(body);
+        req.flush({ code: 'one-time-code' });
+
+        expect(received).toEqual({ code: 'one-time-code' });
+    });
+
     it('should fetch the user on identity if the userIdentity is defined yet (force=true)', async () => {
         accountService.userIdentity.set(user);
         expect(accountService.userIdentity()).toEqual(user);

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -370,6 +370,17 @@ export class AccountService implements IAccountService {
     }
 
     /**
+     * Issues a one-time code for the external-client browser login handoff (e.g. the VS Code extension).
+     * Called from the guarded external-login page after the user has authenticated by any method.
+     *
+     * @param body the PKCE S256 code challenge and the external client's callback URI
+     * @return the one-time code to hand back to the external client
+     */
+    issueExternalLoginCode(body: { codeChallenge: string; callback: string }): Observable<{ code: string }> {
+        return this.http.post<{ code: string }>('api/core/external-login/code', body);
+    }
+
+    /**
      * Sends a request to the server to obtain the VCS access token for a specific participation.
      * Users can use this access token to clone the repository belonging to a participation.
      *

--- a/src/main/webapp/app/core/auth/external-login/external-login.component.html
+++ b/src/main/webapp/app/core/auth/external-login/external-login.component.html
@@ -1,16 +1,14 @@
 <div class="d-flex flex-column align-items-center justify-content-center gap-3 text-center py-5">
     @if (status() === 'redirecting') {
-        <div class="spinner-border text-primary" role="status">
-            <span class="visually-hidden">{{ 'artemisApp.externalLogin.redirecting' | artemisTranslate }}</span>
-        </div>
+        <p-progressSpinner [ariaLabel]="'artemisApp.externalLogin.redirecting' | artemisTranslate" strokeWidth="6" />
         <h2>{{ 'artemisApp.externalLogin.redirecting' | artemisTranslate }}</h2>
         <p>{{ 'artemisApp.externalLogin.openHint' | artemisTranslate }}</p>
         @if (deepLink()) {
-            <button type="button" class="btn btn-primary" (click)="openManually()">{{ 'artemisApp.externalLogin.openManually' | artemisTranslate }}</button>
+            <p-button type="button" (click)="openManually()" [label]="'artemisApp.externalLogin.openManually' | artemisTranslate" />
         }
     } @else {
         <h2>{{ 'artemisApp.externalLogin.error.title' | artemisTranslate }}</h2>
         <p>{{ 'artemisApp.externalLogin.error.description' | artemisTranslate }}</p>
-        <a class="btn btn-primary" routerLink="/">{{ 'artemisApp.externalLogin.backHome' | artemisTranslate }}</a>
+        <p-button routerLink="/" [label]="'artemisApp.externalLogin.backHome' | artemisTranslate" />
     }
 </div>

--- a/src/main/webapp/app/core/auth/external-login/external-login.component.html
+++ b/src/main/webapp/app/core/auth/external-login/external-login.component.html
@@ -1,0 +1,16 @@
+<div class="d-flex flex-column align-items-center justify-content-center gap-3 text-center py-5">
+    @if (status() === 'redirecting') {
+        <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">{{ 'artemisApp.externalLogin.redirecting' | artemisTranslate }}</span>
+        </div>
+        <h2>{{ 'artemisApp.externalLogin.redirecting' | artemisTranslate }}</h2>
+        <p>{{ 'artemisApp.externalLogin.openHint' | artemisTranslate }}</p>
+        @if (deepLink()) {
+            <button type="button" class="btn btn-primary" (click)="openManually()">{{ 'artemisApp.externalLogin.openManually' | artemisTranslate }}</button>
+        }
+    } @else {
+        <h2>{{ 'artemisApp.externalLogin.error.title' | artemisTranslate }}</h2>
+        <p>{{ 'artemisApp.externalLogin.error.description' | artemisTranslate }}</p>
+        <a class="btn btn-primary" routerLink="/">{{ 'artemisApp.externalLogin.backHome' | artemisTranslate }}</a>
+    }
+</div>

--- a/src/main/webapp/app/core/auth/external-login/external-login.component.spec.ts
+++ b/src/main/webapp/app/core/auth/external-login/external-login.component.spec.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { MockProvider } from 'ng-mocks';
+import { ExternalLoginComponent } from 'app/core/auth/external-login/external-login.component';
+import { AccountService } from 'app/core/auth/account.service';
+import { AlertService } from 'app/foundation/service/alert.service';
+
+describe('ExternalLoginComponent', () => {
+    setupTestBed({ zoneless: true });
+
+    let fixture: ComponentFixture<ExternalLoginComponent>;
+    let component: ExternalLoginComponent;
+    let accountService: AccountService;
+    let alertService: AlertService;
+    let redirectSpy: ReturnType<typeof vi.spyOn>;
+
+    const CALLBACK = 'vscode://aet-tum.iris-thaumantias/external-login-callback';
+
+    function setup(queryParams: Record<string, string>): void {
+        TestBed.configureTestingModule({
+            imports: [ExternalLoginComponent],
+            providers: [
+                MockProvider(AccountService),
+                MockProvider(AlertService),
+                { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: convertToParamMap(queryParams) } } },
+            ],
+        }).overrideTemplate(ExternalLoginComponent, '');
+
+        fixture = TestBed.createComponent(ExternalLoginComponent);
+        component = fixture.componentInstance;
+        accountService = TestBed.inject(AccountService);
+        alertService = TestBed.inject(AlertService);
+        // window.location navigation is not exercised in jsdom; spy on the seam instead.
+        redirectSpy = vi.spyOn(component as any, 'redirect').mockImplementation(() => {});
+    }
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should issue a code and redirect to the callback with code and state on success', () => {
+        setup({ code_challenge: 'the-challenge', callback: CALLBACK, state: 'the-state' });
+        const issueSpy = vi.spyOn(accountService, 'issueExternalLoginCode').mockReturnValue(of({ code: 'one-time-code' }));
+
+        component.ngOnInit();
+
+        expect(issueSpy).toHaveBeenCalledWith({ codeChallenge: 'the-challenge', callback: CALLBACK });
+        expect(redirectSpy).toHaveBeenCalledWith(`${CALLBACK}?code=one-time-code&state=the-state`);
+        expect(component['status']()).toBe('redirecting');
+    });
+
+    it('should append code and state when the callback already has a query', () => {
+        const callbackWithQuery = `${CALLBACK}?foo=bar`;
+        setup({ code_challenge: 'c', callback: callbackWithQuery, state: 's' });
+        vi.spyOn(accountService, 'issueExternalLoginCode').mockReturnValue(of({ code: 'x' }));
+
+        component.ngOnInit();
+
+        expect(redirectSpy).toHaveBeenCalledWith(`${callbackWithQuery}&code=x&state=s`);
+    });
+
+    it('should overwrite any pre-existing code/state on the callback (no duplicate params)', () => {
+        setup({ code_challenge: 'c', callback: `${CALLBACK}?code=stale&state=stale`, state: 'fresh-state' });
+        vi.spyOn(accountService, 'issueExternalLoginCode').mockReturnValue(of({ code: 'fresh-code' }));
+
+        component.ngOnInit();
+
+        expect(redirectSpy).toHaveBeenCalledWith(`${CALLBACK}?code=fresh-code&state=fresh-state`);
+    });
+
+    it('should show an error and not redirect when required params are missing', () => {
+        setup({ callback: CALLBACK });
+        const issueSpy = vi.spyOn(accountService, 'issueExternalLoginCode');
+        const errorSpy = vi.spyOn(alertService, 'error').mockReturnValue({} as any);
+
+        component.ngOnInit();
+
+        expect(issueSpy).not.toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledWith('artemisApp.externalLogin.error.missingParams');
+        expect(redirectSpy).not.toHaveBeenCalled();
+        expect(component['status']()).toBe('error');
+    });
+
+    it('should show an error when state is missing', () => {
+        setup({ code_challenge: 'c', callback: CALLBACK });
+        const issueSpy = vi.spyOn(accountService, 'issueExternalLoginCode');
+        const errorSpy = vi.spyOn(alertService, 'error').mockReturnValue({} as any);
+
+        component.ngOnInit();
+
+        expect(issueSpy).not.toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledWith('artemisApp.externalLogin.error.missingParams');
+        expect(redirectSpy).not.toHaveBeenCalled();
+    });
+
+    it('should show an error and not redirect when issuing the code fails', () => {
+        setup({ code_challenge: 'c', callback: CALLBACK, state: 's' });
+        vi.spyOn(accountService, 'issueExternalLoginCode').mockReturnValue(throwError(() => new Error('400')));
+        const errorSpy = vi.spyOn(alertService, 'error').mockReturnValue({} as any);
+
+        component.ngOnInit();
+
+        expect(errorSpy).toHaveBeenCalledWith('artemisApp.externalLogin.error.codeIssuanceFailed');
+        expect(redirectSpy).not.toHaveBeenCalled();
+        expect(component['status']()).toBe('error');
+    });
+});

--- a/src/main/webapp/app/core/auth/external-login/external-login.component.ts
+++ b/src/main/webapp/app/core/auth/external-login/external-login.component.ts
@@ -1,0 +1,86 @@
+import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
+import { AccountService } from 'app/core/auth/account.service';
+import { AlertService } from 'app/foundation/service/alert.service';
+
+/**
+ * Bridges a browser login back to an external client (e.g. the VS Code extension).
+ *
+ * The external client opens this guarded page with a PKCE {@code code_challenge}, a custom-scheme
+ * {@code callback} and an opaque {@code state}. After the user has authenticated in the browser by any
+ * method (passkey, SAML2 SSO, password), this page exchanges the challenge for a one-time code via
+ * {@link AccountService#issueExternalLoginCode} and redirects the browser to
+ * {@code callback?code=<code>&state=<state>}, handing control back to the client.
+ *
+ * The server validates the callback when minting the code, so a rejected callback never produces a redirect.
+ */
+@Component({
+    selector: 'jhi-external-login',
+    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    imports: [ArtemisTranslatePipe, RouterLink],
+    templateUrl: './external-login.component.html',
+})
+export class ExternalLoginComponent implements OnInit {
+    private readonly route = inject(ActivatedRoute);
+    private readonly accountService = inject(AccountService);
+    private readonly alertService = inject(AlertService);
+
+    protected readonly status = signal<'redirecting' | 'error'>('redirecting');
+    protected readonly deepLink = signal<string | undefined>(undefined);
+
+    ngOnInit(): void {
+        const params = this.route.snapshot.queryParamMap;
+        const codeChallenge = params.get('code_challenge');
+        const callback = params.get('callback');
+        const state = params.get('state');
+
+        if (!codeChallenge || !callback || !state) {
+            this.fail('artemisApp.externalLogin.error.missingParams');
+            return;
+        }
+
+        this.accountService.issueExternalLoginCode({ codeChallenge, callback }).subscribe({
+            next: ({ code }) => this.redirectToCallback(callback, code, state),
+            error: () => this.fail('artemisApp.externalLogin.error.codeIssuanceFailed'),
+        });
+    }
+
+    /**
+     * Redirects the browser to the (server-validated) callback with the one-time code and state appended as
+     * canonical query parameters, overwriting any pre-existing {@code code}/{@code state} so the external
+     * client can never receive ambiguous or duplicated security-relevant parameters.
+     */
+    private redirectToCallback(callback: string, code: string, state: string): void {
+        let target: URL;
+        try {
+            target = new URL(callback);
+        } catch {
+            this.fail('artemisApp.externalLogin.error.codeIssuanceFailed');
+            return;
+        }
+        target.searchParams.set('code', code);
+        target.searchParams.set('state', state);
+        const url = target.toString();
+        this.deepLink.set(url);
+        this.redirect(url);
+    }
+
+    protected openManually(): void {
+        const target = this.deepLink();
+        if (target) {
+            this.redirect(target);
+        }
+    }
+
+    private fail(translationKey: string): void {
+        this.status.set('error');
+        this.alertService.error(translationKey);
+    }
+
+    /** Navigates the browser to the (custom-scheme) callback. Kept as a seam so tests can spy on it. */
+    protected redirect(url: string): void {
+        window.location.href = url;
+    }
+}

--- a/src/main/webapp/app/core/auth/external-login/external-login.component.ts
+++ b/src/main/webapp/app/core/auth/external-login/external-login.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
+import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
 import { AccountService } from 'app/core/auth/account.service';
 import { AlertService } from 'app/foundation/service/alert.service';
@@ -19,7 +21,7 @@ import { AlertService } from 'app/foundation/service/alert.service';
     selector: 'jhi-external-login',
     standalone: true,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [ArtemisTranslatePipe, RouterLink],
+    imports: [ArtemisTranslatePipe, RouterLink, ButtonModule, ProgressSpinnerModule],
     templateUrl: './external-login.component.html',
 })
 export class ExternalLoginComponent implements OnInit {

--- a/src/main/webapp/i18n/de/externalLogin.json
+++ b/src/main/webapp/i18n/de/externalLogin.json
@@ -1,0 +1,17 @@
+{
+    "artemisApp": {
+        "externalLogin": {
+            "pageTitle": "Bei externem Client anmelden",
+            "redirecting": "Anmeldung läuft…",
+            "openHint": "Falls sich dein Editor nicht automatisch öffnet, nutze die Schaltfläche unten.",
+            "openManually": "Editor öffnen",
+            "backHome": "Zurück zu Artemis",
+            "error": {
+                "title": "Anmeldung konnte nicht abgeschlossen werden",
+                "description": "Die Anmeldeanfrage ist ungültig oder wurde abgelehnt. Bitte starte die Anmeldung erneut aus deinem Editor.",
+                "missingParams": "Dem Anmeldelink fehlen erforderliche Informationen. Bitte starte die Anmeldung erneut aus deinem Editor.",
+                "codeIssuanceFailed": "Die Anmeldeanfrage konnte nicht abgeschlossen werden. Bitte starte die Anmeldung erneut aus deinem Editor."
+            }
+        }
+    }
+}

--- a/src/main/webapp/i18n/en/externalLogin.json
+++ b/src/main/webapp/i18n/en/externalLogin.json
@@ -1,0 +1,17 @@
+{
+    "artemisApp": {
+        "externalLogin": {
+            "pageTitle": "Sign in to external client",
+            "redirecting": "Signing you in…",
+            "openHint": "If your editor does not open automatically, use the button below.",
+            "openManually": "Open editor",
+            "backHome": "Back to Artemis",
+            "error": {
+                "title": "Sign-in could not be completed",
+                "description": "The sign-in request is invalid or was rejected. Please start the sign-in again from your editor.",
+                "missingParams": "The sign-in link is missing required information. Please start the sign-in again from your editor.",
+                "codeIssuanceFailed": "The sign-in request could not be completed. Please start the sign-in again from your editor."
+            }
+        }
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/ExternalLoginResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/ExternalLoginResourceIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.net.URI;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import jakarta.servlet.http.Cookie;
 
@@ -32,6 +33,7 @@ import de.tum.cit.aet.artemis.core.dto.ExternalLoginTokenRequestDTO;
 import de.tum.cit.aet.artemis.core.dto.ExternalLoginTokenResponseDTO;
 import de.tum.cit.aet.artemis.core.security.Role;
 import de.tum.cit.aet.artemis.core.security.externallogin.PkceUtil;
+import de.tum.cit.aet.artemis.core.security.jwt.AuthenticationMethod;
 import de.tum.cit.aet.artemis.core.security.jwt.TokenProvider;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
@@ -93,7 +95,7 @@ class ExternalLoginResourceIntegrationTest extends AbstractSpringIntegrationInde
     }
 
     private void withFeatureEnabled(Executable test) throws Throwable {
-        withFeatureEnabled(List.of("vscode", "vscode-insiders"), List.of(), test);
+        withFeatureEnabled(List.of("vscode", "vscode-insiders"), List.of("aet-tum.iris-thaumantias"), test);
     }
 
     // --- request helpers -------------------------------------------------------------------------
@@ -159,6 +161,29 @@ class ExternalLoginResourceIntegrationTest extends AbstractSpringIntegrationInde
         });
     }
 
+    @Test
+    void shouldPreservePasskeyClaimsThroughExchange() throws Throwable {
+        withFeatureEnabled(() -> {
+            // A source session JWT representing an approved passkey login (auth-method PASSKEY, super-admin approved).
+            long now = System.currentTimeMillis();
+            var authentication = new UsernamePasswordAuthenticationToken(USERNAME, USERNAME, List.of(new SimpleGrantedAuthority(Role.STUDENT.getAuthority())));
+            authentication.setDetails(Map.of(TokenProvider.IS_PASSKEY_SUPER_ADMIN_APPROVED, true));
+            String passkeySessionJwt = tokenProvider.createToken(authentication, new Date(now), new Date(now + 24 * 60 * 60 * 1000), null, true);
+            // Sanity: the source token carries the passkey claims.
+            assertThat(tokenProvider.getAuthenticationMethod(passkeySessionJwt)).isEqualTo(AuthenticationMethod.PASSKEY);
+            assertThat(tokenProvider.isPasskeySuperAdminApproved(passkeySessionJwt)).isTrue();
+
+            MvcResult result = issue(new ExternalLoginCodeRequestDTO(CHALLENGE, CALLBACK), passkeySessionJwt, HttpStatus.OK);
+            ExternalLoginCodeResponseDTO codeResponse = request.getObjectMapper().readValue(result.getResponse().getContentAsString(), ExternalLoginCodeResponseDTO.class);
+            ExternalLoginTokenResponseDTO token = exchange(codeResponse.code(), VERIFIER, HttpStatus.OK);
+
+            // The exchanged handoff token must not degrade to a password token: it preserves the originating session's
+            // auth method and passkey-approval, so passkey-approved admins keep working with the returned JWT.
+            assertThat(tokenProvider.getAuthenticationMethod(token.accessToken())).isEqualTo(AuthenticationMethod.PASSKEY);
+            assertThat(tokenProvider.isPasskeySuperAdminApproved(token.accessToken())).isTrue();
+        });
+    }
+
     // --- exchange security -----------------------------------------------------------------------
 
     @Test
@@ -173,8 +198,8 @@ class ExternalLoginResourceIntegrationTest extends AbstractSpringIntegrationInde
     void shouldBurnCodeEvenWhenVerifierIsWrong() throws Throwable {
         withFeatureEnabled(() -> {
             String code = issueCodeSuccessfully(CALLBACK);
-            // A failed exchange (wrong verifier) must still consume the single-use code (consume-before-verify),
-            assertThat(exchange(code, "a-wrong-verifier-value-1122334455667788", HttpStatus.UNAUTHORIZED)).isNull();
+            // A failed exchange with a well-formed but wrong verifier must still consume the single-use code (consume-before-verify),
+            assertThat(exchange(code, "a-wrong-verifier-value-1122334455667788-abcdefgh", HttpStatus.UNAUTHORIZED)).isNull();
             // so the same code cannot subsequently be redeemed even with the correct verifier (no brute-force on one code).
             assertThat(exchange(code, VERIFIER, HttpStatus.UNAUTHORIZED)).isNull();
         });
@@ -202,6 +227,15 @@ class ExternalLoginResourceIntegrationTest extends AbstractSpringIntegrationInde
         assertThat(exchange("some-code", null, HttpStatus.UNAUTHORIZED)).isNull();
     }
 
+    @Test
+    void shouldRejectMalformedVerifier() throws Throwable {
+        withFeatureEnabled(() -> {
+            String code = issueCodeSuccessfully(CALLBACK);
+            // A verifier shorter than the RFC 7636 minimum (43 chars) is malformed and rejected before any code work.
+            assertThat(exchange(code, "too-short-verifier", HttpStatus.UNAUTHORIZED)).isNull();
+        });
+    }
+
     // --- issue endpoint guards -------------------------------------------------------------------
 
     @Test
@@ -211,8 +245,21 @@ class ExternalLoginResourceIntegrationTest extends AbstractSpringIntegrationInde
     }
 
     @Test
+    void shouldReturnNotFoundWhenSchemesSetButAuthoritiesEmpty() throws Throwable {
+        // A scheme allowlist without an authority allowlist is treated as disabled (fail closed), so the endpoint 404s.
+        withFeatureEnabled(List.of("vscode", "vscode-insiders"), List.of(),
+                () -> issue(new ExternalLoginCodeRequestDTO(CHALLENGE, CALLBACK), studentSessionJwt(), HttpStatus.NOT_FOUND));
+    }
+
+    @Test
     void shouldRejectBlankCodeChallenge() throws Throwable {
         withFeatureEnabled(() -> issue(new ExternalLoginCodeRequestDTO("  ", CALLBACK), studentSessionJwt(), HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void shouldRejectMalformedCodeChallenge() throws Throwable {
+        // A non-S256-shaped challenge (wrong length / illegal characters) is rejected before a JWT-bearing code is minted.
+        withFeatureEnabled(() -> issue(new ExternalLoginCodeRequestDTO("not-a-valid-s256-challenge", CALLBACK), studentSessionJwt(), HttpStatus.BAD_REQUEST));
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/core/ExternalLoginResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/ExternalLoginResourceIntegrationTest.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.net.URI;
@@ -182,6 +183,18 @@ class ExternalLoginResourceIntegrationTest extends AbstractSpringIntegrationInde
             // auth method and passkey-approval, so passkey-approved admins keep working with the returned JWT.
             assertThat(tokenProvider.getAuthenticationMethod(token.accessToken())).isEqualTo(AuthenticationMethod.PASSKEY);
             assertThat(tokenProvider.isPasskeySuperAdminApproved(token.accessToken())).isTrue();
+        });
+    }
+
+    @Test
+    void shouldSerializeAccessTokenAsSnakeCaseField() throws Throwable {
+        withFeatureEnabled(() -> {
+            String code = issueCodeSuccessfully(CALLBACK);
+            // The exchange response must use the documented snake_case contract (access_token), matching the existing
+            // /api/core/public/authenticate endpoint, so clients read a single consistent field.
+            var builder = post(new URI(TOKEN_ENDPOINT)).contentType(MediaType.APPLICATION_JSON)
+                    .content(request.getObjectMapper().writeValueAsString(new ExternalLoginTokenRequestDTO(code, VERIFIER)));
+            request.performMvcRequest(builder).andExpect(status().isOk()).andExpect(jsonPath("$.access_token").isNotEmpty()).andExpect(jsonPath("$.accessToken").doesNotExist());
         });
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/core/ExternalLoginResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/ExternalLoginResourceIntegrationTest.java
@@ -1,0 +1,239 @@
+package de.tum.cit.aet.artemis.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.net.URI;
+import java.util.Date;
+import java.util.List;
+
+import jakarta.servlet.http.Cookie;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MvcResult;
+
+import de.tum.cit.aet.artemis.core.config.Constants;
+import de.tum.cit.aet.artemis.core.config.ExternalLoginProperties;
+import de.tum.cit.aet.artemis.core.dto.ExternalLoginCodeRequestDTO;
+import de.tum.cit.aet.artemis.core.dto.ExternalLoginCodeResponseDTO;
+import de.tum.cit.aet.artemis.core.dto.ExternalLoginTokenRequestDTO;
+import de.tum.cit.aet.artemis.core.dto.ExternalLoginTokenResponseDTO;
+import de.tum.cit.aet.artemis.core.security.Role;
+import de.tum.cit.aet.artemis.core.security.externallogin.PkceUtil;
+import de.tum.cit.aet.artemis.core.security.jwt.TokenProvider;
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
+
+/**
+ * Integration tests for the external-client browser login handoff: the authenticated code-issue endpoint
+ * ({@link de.tum.cit.aet.artemis.core.web.ExternalLoginResource}) and the public code/PKCE exchange endpoint
+ * ({@link de.tum.cit.aet.artemis.core.web.open.PublicExternalLoginResource}).
+ * <p>
+ * Runs single-threaded because the feature flag is toggled on the shared {@link ExternalLoginProperties} bean.
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+class ExternalLoginResourceIntegrationTest extends AbstractSpringIntegrationIndependentTest {
+
+    private static final String TEST_PREFIX = "externallogin";
+
+    private static final String USERNAME = TEST_PREFIX + "student1";
+
+    private static final String CODE_ENDPOINT = "/api/core/external-login/code";
+
+    private static final String TOKEN_ENDPOINT = "/api/core/public/external-login/token";
+
+    private static final String CALLBACK = "vscode://aet-tum.iris-thaumantias/auth-complete";
+
+    // A PKCE verifier (RFC 7636 allows 43-128 unreserved characters) and its S256 challenge.
+    private static final String VERIFIER = "verifier-with-enough-entropy-0123456789-abcdefghij";
+
+    private static final String CHALLENGE = PkceUtil.s256Challenge(VERIFIER);
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    private ExternalLoginProperties externalLoginProperties;
+
+    @BeforeEach
+    void setUp() {
+        userUtilService.addUsers(TEST_PREFIX, 1, 0, 0, 0);
+    }
+
+    // --- feature flag toggling -------------------------------------------------------------------
+
+    /**
+     * Temporarily enables the (default-off) feature by swapping the allowlists on the shared properties bean,
+     * runs the test, and restores the previous values afterwards. The resource reads the properties per request,
+     * so no Spring context restart is required (which would also violate the context-configuration architecture rules).
+     */
+    private void withFeatureEnabled(List<String> schemes, List<String> authorities, Executable test) throws Throwable {
+        Object previousSchemes = ReflectionTestUtils.getField(externalLoginProperties, "allowedRedirectSchemes");
+        Object previousAuthorities = ReflectionTestUtils.getField(externalLoginProperties, "allowedRedirectAuthorities");
+        ReflectionTestUtils.setField(externalLoginProperties, "allowedRedirectSchemes", schemes);
+        ReflectionTestUtils.setField(externalLoginProperties, "allowedRedirectAuthorities", authorities);
+        try {
+            test.execute();
+        }
+        finally {
+            ReflectionTestUtils.setField(externalLoginProperties, "allowedRedirectSchemes", previousSchemes);
+            ReflectionTestUtils.setField(externalLoginProperties, "allowedRedirectAuthorities", previousAuthorities);
+        }
+    }
+
+    private void withFeatureEnabled(Executable test) throws Throwable {
+        withFeatureEnabled(List.of("vscode", "vscode-insiders"), List.of(), test);
+    }
+
+    // --- request helpers -------------------------------------------------------------------------
+
+    private String studentSessionJwt() {
+        var authentication = new UsernamePasswordAuthenticationToken(USERNAME, USERNAME, List.of(new SimpleGrantedAuthority(Role.STUDENT.getAuthority())));
+        return tokenProvider.createToken(authentication, 24 * 60 * 60 * 1000, null);
+    }
+
+    private MvcResult issue(ExternalLoginCodeRequestDTO body, String sessionJwt, HttpStatus expectedStatus) throws Exception {
+        var builder = post(new URI(CODE_ENDPOINT)).contentType(MediaType.APPLICATION_JSON).content(request.getObjectMapper().writeValueAsString(body));
+        if (sessionJwt != null) {
+            builder = builder.cookie(new Cookie(Constants.JWT_COOKIE_NAME, sessionJwt));
+        }
+        return request.performMvcRequest(builder).andExpect(status().is(expectedStatus.value())).andReturn();
+    }
+
+    private String issueCodeSuccessfully(String callback) throws Exception {
+        MvcResult result = issue(new ExternalLoginCodeRequestDTO(CHALLENGE, callback), studentSessionJwt(), HttpStatus.OK);
+        ExternalLoginCodeResponseDTO response = request.getObjectMapper().readValue(result.getResponse().getContentAsString(), ExternalLoginCodeResponseDTO.class);
+        assertThat(response.code()).isNotBlank();
+        return response.code();
+    }
+
+    private ExternalLoginTokenResponseDTO exchange(String code, String verifier, HttpStatus expectedStatus) throws Exception {
+        return request.postWithResponseBody(TOKEN_ENDPOINT, new ExternalLoginTokenRequestDTO(code, verifier), ExternalLoginTokenResponseDTO.class, expectedStatus);
+    }
+
+    // --- happy path ------------------------------------------------------------------------------
+
+    @Test
+    void shouldIssueAndExchangeCodeForAValidJwt() throws Throwable {
+        withFeatureEnabled(() -> {
+            String code = issueCodeSuccessfully(CALLBACK);
+            ExternalLoginTokenResponseDTO token = exchange(code, VERIFIER, HttpStatus.OK);
+
+            assertThat(token.accessToken()).isNotBlank();
+            // The exchanged token is a valid Artemis JWT minted for the originating principal.
+            assertThat(tokenProvider.validateTokenForAuthority(token.accessToken(), null)).isTrue();
+            var authentication = tokenProvider.getAuthentication(token.accessToken());
+            assertThat(authentication.getName()).isEqualTo(USERNAME);
+            assertThat(authentication.getAuthorities().stream().map(GrantedAuthority::getAuthority)).contains(Role.STUDENT.getAuthority());
+        });
+    }
+
+    @Test
+    void shouldCapMintedTokenToOriginatingSessionLifetime() throws Throwable {
+        withFeatureEnabled(() -> {
+            // A source session JWT that expires well before the default JWT validity, so the cap is observable.
+            long now = System.currentTimeMillis();
+            Date sessionExpiry = new Date(now + 10 * 60 * 1000); // 10 minutes
+            var authentication = new UsernamePasswordAuthenticationToken(USERNAME, USERNAME, List.of(new SimpleGrantedAuthority(Role.STUDENT.getAuthority())));
+            String shortLivedSessionJwt = tokenProvider.createToken(authentication, new Date(now), sessionExpiry, null, null);
+
+            MvcResult result = issue(new ExternalLoginCodeRequestDTO(CHALLENGE, CALLBACK), shortLivedSessionJwt, HttpStatus.OK);
+            ExternalLoginCodeResponseDTO codeResponse = request.getObjectMapper().readValue(result.getResponse().getContentAsString(), ExternalLoginCodeResponseDTO.class);
+            ExternalLoginTokenResponseDTO token = exchange(codeResponse.code(), VERIFIER, HttpStatus.OK);
+
+            // The minted token must not outlive the originating session: capped to its remaining validity, not the default JWT validity.
+            Date mintedExpiry = tokenProvider.getExpirationDate(token.accessToken());
+            assertThat(mintedExpiry).isBeforeOrEqualTo(new Date(sessionExpiry.getTime() + 5000));
+            assertThat(mintedExpiry).isAfter(new Date(now + 5 * 60 * 1000));
+        });
+    }
+
+    // --- exchange security -----------------------------------------------------------------------
+
+    @Test
+    void shouldRejectExchangeWithWrongVerifier() throws Throwable {
+        withFeatureEnabled(() -> {
+            String code = issueCodeSuccessfully(CALLBACK);
+            assertThat(exchange(code, "a-completely-different-verifier-value-987654321", HttpStatus.UNAUTHORIZED)).isNull();
+        });
+    }
+
+    @Test
+    void shouldBurnCodeEvenWhenVerifierIsWrong() throws Throwable {
+        withFeatureEnabled(() -> {
+            String code = issueCodeSuccessfully(CALLBACK);
+            // A failed exchange (wrong verifier) must still consume the single-use code (consume-before-verify),
+            assertThat(exchange(code, "a-wrong-verifier-value-1122334455667788", HttpStatus.UNAUTHORIZED)).isNull();
+            // so the same code cannot subsequently be redeemed even with the correct verifier (no brute-force on one code).
+            assertThat(exchange(code, VERIFIER, HttpStatus.UNAUTHORIZED)).isNull();
+        });
+    }
+
+    @Test
+    void shouldRejectReusingACodeASecondTime() throws Throwable {
+        withFeatureEnabled(() -> {
+            String code = issueCodeSuccessfully(CALLBACK);
+            exchange(code, VERIFIER, HttpStatus.OK);
+            // single-use: the same code cannot be redeemed again
+            assertThat(exchange(code, VERIFIER, HttpStatus.UNAUTHORIZED)).isNull();
+        });
+    }
+
+    @Test
+    void shouldRejectUnknownCode() throws Exception {
+        // The public exchange endpoint does not depend on the feature flag.
+        assertThat(exchange("a-code-that-was-never-issued", VERIFIER, HttpStatus.UNAUTHORIZED)).isNull();
+    }
+
+    @Test
+    void shouldRejectExchangeWithMissingFields() throws Exception {
+        assertThat(exchange(null, VERIFIER, HttpStatus.UNAUTHORIZED)).isNull();
+        assertThat(exchange("some-code", null, HttpStatus.UNAUTHORIZED)).isNull();
+    }
+
+    // --- issue endpoint guards -------------------------------------------------------------------
+
+    @Test
+    void shouldReturnNotFoundWhenFeatureDisabled() throws Exception {
+        // The feature is disabled by default (empty allowlist), so the endpoint behaves as if it does not exist.
+        issue(new ExternalLoginCodeRequestDTO(CHALLENGE, CALLBACK), studentSessionJwt(), HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void shouldRejectBlankCodeChallenge() throws Throwable {
+        withFeatureEnabled(() -> issue(new ExternalLoginCodeRequestDTO("  ", CALLBACK), studentSessionJwt(), HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void shouldRejectHttpCallback() throws Throwable {
+        withFeatureEnabled(() -> issue(new ExternalLoginCodeRequestDTO(CHALLENGE, "http://example.com/callback"), studentSessionJwt(), HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void shouldRejectCallbackWithDisallowedScheme() throws Throwable {
+        withFeatureEnabled(() -> issue(new ExternalLoginCodeRequestDTO(CHALLENGE, "evilapp://host/callback"), studentSessionJwt(), HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void shouldRejectCallbackWithDisallowedAuthority() throws Throwable {
+        withFeatureEnabled(List.of("vscode"), List.of("aet-tum.iris-thaumantias"),
+                () -> issue(new ExternalLoginCodeRequestDTO(CHALLENGE, "vscode://some-other-extension/callback"), studentSessionJwt(), HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void shouldRequireAuthenticationToIssueCode() throws Exception {
+        // Without a session JWT the request is rejected by the security layer before the handler runs.
+        issue(new ExternalLoginCodeRequestDTO(CHALLENGE, CALLBACK), null, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/ExternalLoginResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/ExternalLoginResourceIntegrationTest.java
@@ -32,6 +32,7 @@ import de.tum.cit.aet.artemis.core.dto.ExternalLoginCodeResponseDTO;
 import de.tum.cit.aet.artemis.core.dto.ExternalLoginTokenRequestDTO;
 import de.tum.cit.aet.artemis.core.dto.ExternalLoginTokenResponseDTO;
 import de.tum.cit.aet.artemis.core.security.Role;
+import de.tum.cit.aet.artemis.core.security.allowedTools.ToolTokenType;
 import de.tum.cit.aet.artemis.core.security.externallogin.PkceUtil;
 import de.tum.cit.aet.artemis.core.security.jwt.AuthenticationMethod;
 import de.tum.cit.aet.artemis.core.security.jwt.TokenProvider;
@@ -282,5 +283,17 @@ class ExternalLoginResourceIntegrationTest extends AbstractSpringIntegrationInde
     void shouldRequireAuthenticationToIssueCode() throws Exception {
         // Without a session JWT the request is rejected by the security layer before the handler runs.
         issue(new ExternalLoginCodeRequestDTO(CHALLENGE, CALLBACK), null, HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void shouldRejectToolScopedSessionJwt() throws Throwable {
+        // A tool-scoped token must never be upgraded into a full (unscoped) Artemis JWT via the handoff. On this
+        // non-public endpoint the ToolsInterceptor rejects tool tokens with 403 before the handler runs (the handler
+        // also guards against it explicitly), so no code is ever minted.
+        withFeatureEnabled(() -> {
+            var authentication = new UsernamePasswordAuthenticationToken(USERNAME, USERNAME, List.of(new SimpleGrantedAuthority(Role.STUDENT.getAuthority())));
+            String toolScopedJwt = tokenProvider.createToken(authentication, 24 * 60 * 60 * 1000, ToolTokenType.SCORPIO);
+            issue(new ExternalLoginCodeRequestDTO(CHALLENGE, CALLBACK), toolScopedJwt, HttpStatus.FORBIDDEN);
+        });
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/core/security/externallogin/ExternalLoginRedirectUriValidatorTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/security/externallogin/ExternalLoginRedirectUriValidatorTest.java
@@ -10,73 +10,87 @@ class ExternalLoginRedirectUriValidatorTest {
 
     private static final List<String> SCHEMES = List.of("vscode", "vscode-insiders");
 
+    private static final List<String> AUTHORITIES = List.of("aet-tum.iris-thaumantias", "host");
+
     private ExternalLoginRedirectUriValidator validator(List<String> schemes, List<String> authorities) {
         return new ExternalLoginRedirectUriValidator(schemes, authorities);
     }
 
     @Test
     void featureIsDisabledWhenNoSchemeIsAllowlisted() {
-        assertThat(validator(List.of(), List.of()).isFeatureEnabled()).isFalse();
+        assertThat(validator(List.of(), AUTHORITIES).isFeatureEnabled()).isFalse();
     }
 
     @Test
-    void featureIsEnabledWhenAtLeastOneSchemeIsAllowlisted() {
-        assertThat(validator(List.of("vscode"), List.of()).isFeatureEnabled()).isTrue();
+    void featureIsEnabledWhenSchemeAndAuthorityAreAllowlisted() {
+        assertThat(validator(List.of("vscode"), List.of("host")).isFeatureEnabled()).isTrue();
+    }
+
+    @Test
+    void featureIsDisabledWhenSchemeIsAllowlistedButNoAuthority() {
+        // An allowed scheme without an authority allowlist would trust every handler for that scheme, so it is disabled.
+        assertThat(validator(List.of("vscode"), List.of()).isFeatureEnabled()).isFalse();
     }
 
     @Test
     void acceptsAllowlistedCustomScheme() {
-        assertThat(validator(SCHEMES, List.of()).validate("vscode://aet-tum.iris-thaumantias/callback")).isEmpty();
+        assertThat(validator(SCHEMES, AUTHORITIES).validate("vscode://aet-tum.iris-thaumantias/callback")).isEmpty();
     }
 
     @Test
     void acceptsSchemeCaseInsensitively() {
-        assertThat(validator(SCHEMES, List.of()).validate("VSCode://host/callback")).isEmpty();
+        assertThat(validator(SCHEMES, AUTHORITIES).validate("VSCode://host/callback")).isEmpty();
     }
 
     @Test
     void rejectsNullOrBlankCallback() {
-        assertThat(validator(SCHEMES, List.of()).validate(null)).isPresent();
-        assertThat(validator(SCHEMES, List.of()).validate("   ")).isPresent();
+        assertThat(validator(SCHEMES, AUTHORITIES).validate(null)).isPresent();
+        assertThat(validator(SCHEMES, AUTHORITIES).validate("   ")).isPresent();
     }
 
     @Test
     void rejectsHttpAndHttpsEvenIfSomehowAllowlisted() {
-        var validator = validator(List.of("http", "https", "vscode"), List.of());
+        var validator = validator(List.of("http", "https", "vscode"), AUTHORITIES);
         assertThat(validator.validate("http://example.com/callback")).isPresent();
         assertThat(validator.validate("https://example.com/callback")).isPresent();
     }
 
     @Test
     void rejectsSchemeNotInAllowlist() {
-        assertThat(validator(SCHEMES, List.of()).validate("evilapp://host/callback")).isPresent();
+        assertThat(validator(SCHEMES, AUTHORITIES).validate("evilapp://host/callback")).isPresent();
+    }
+
+    @Test
+    void rejectsAnyCallbackWhenAuthorityAllowlistEmpty() {
+        // Fail closed: an empty authority allowlist must reject every callback, even with a matching scheme.
+        assertThat(validator(SCHEMES, List.of()).validate("vscode://aet-tum.iris-thaumantias/callback")).isPresent();
     }
 
     @Test
     void rejectsRelativeUri() {
-        assertThat(validator(SCHEMES, List.of()).validate("not-absolute/callback")).isPresent();
+        assertThat(validator(SCHEMES, AUTHORITIES).validate("not-absolute/callback")).isPresent();
     }
 
     @Test
     void rejectsOpaqueUri() {
         // "vscode:callback" is opaque (no "//"), which cannot reliably carry query parameters.
-        assertThat(validator(SCHEMES, List.of()).validate("vscode:callback")).isPresent();
+        assertThat(validator(SCHEMES, AUTHORITIES).validate("vscode:callback")).isPresent();
     }
 
     @Test
     void rejectsCallbackWithUserInfo() {
-        assertThat(validator(SCHEMES, List.of()).validate("vscode://user:pass@host/callback")).isPresent();
+        assertThat(validator(SCHEMES, AUTHORITIES).validate("vscode://user:pass@host/callback")).isPresent();
     }
 
     @Test
     void rejectsCallbackWithFragment() {
-        assertThat(validator(SCHEMES, List.of()).validate("vscode://host/callback#fragment")).isPresent();
+        assertThat(validator(SCHEMES, AUTHORITIES).validate("vscode://host/callback#fragment")).isPresent();
     }
 
     @Test
     void rejectsCallbackExceedingMaxLength() {
         String longCallback = "vscode://host/callback?data=" + "a".repeat(ExternalLoginRedirectUriValidator.MAX_URI_BYTES);
-        assertThat(validator(SCHEMES, List.of()).validate(longCallback)).isPresent();
+        assertThat(validator(SCHEMES, AUTHORITIES).validate(longCallback)).isPresent();
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/core/security/externallogin/ExternalLoginRedirectUriValidatorTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/security/externallogin/ExternalLoginRedirectUriValidatorTest.java
@@ -1,0 +1,96 @@
+package de.tum.cit.aet.artemis.core.security.externallogin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class ExternalLoginRedirectUriValidatorTest {
+
+    private static final List<String> SCHEMES = List.of("vscode", "vscode-insiders");
+
+    private ExternalLoginRedirectUriValidator validator(List<String> schemes, List<String> authorities) {
+        return new ExternalLoginRedirectUriValidator(schemes, authorities);
+    }
+
+    @Test
+    void featureIsDisabledWhenNoSchemeIsAllowlisted() {
+        assertThat(validator(List.of(), List.of()).isFeatureEnabled()).isFalse();
+    }
+
+    @Test
+    void featureIsEnabledWhenAtLeastOneSchemeIsAllowlisted() {
+        assertThat(validator(List.of("vscode"), List.of()).isFeatureEnabled()).isTrue();
+    }
+
+    @Test
+    void acceptsAllowlistedCustomScheme() {
+        assertThat(validator(SCHEMES, List.of()).validate("vscode://aet-tum.iris-thaumantias/callback")).isEmpty();
+    }
+
+    @Test
+    void acceptsSchemeCaseInsensitively() {
+        assertThat(validator(SCHEMES, List.of()).validate("VSCode://host/callback")).isEmpty();
+    }
+
+    @Test
+    void rejectsNullOrBlankCallback() {
+        assertThat(validator(SCHEMES, List.of()).validate(null)).isPresent();
+        assertThat(validator(SCHEMES, List.of()).validate("   ")).isPresent();
+    }
+
+    @Test
+    void rejectsHttpAndHttpsEvenIfSomehowAllowlisted() {
+        var validator = validator(List.of("http", "https", "vscode"), List.of());
+        assertThat(validator.validate("http://example.com/callback")).isPresent();
+        assertThat(validator.validate("https://example.com/callback")).isPresent();
+    }
+
+    @Test
+    void rejectsSchemeNotInAllowlist() {
+        assertThat(validator(SCHEMES, List.of()).validate("evilapp://host/callback")).isPresent();
+    }
+
+    @Test
+    void rejectsRelativeUri() {
+        assertThat(validator(SCHEMES, List.of()).validate("not-absolute/callback")).isPresent();
+    }
+
+    @Test
+    void rejectsOpaqueUri() {
+        // "vscode:callback" is opaque (no "//"), which cannot reliably carry query parameters.
+        assertThat(validator(SCHEMES, List.of()).validate("vscode:callback")).isPresent();
+    }
+
+    @Test
+    void rejectsCallbackWithUserInfo() {
+        assertThat(validator(SCHEMES, List.of()).validate("vscode://user:pass@host/callback")).isPresent();
+    }
+
+    @Test
+    void rejectsCallbackWithFragment() {
+        assertThat(validator(SCHEMES, List.of()).validate("vscode://host/callback#fragment")).isPresent();
+    }
+
+    @Test
+    void rejectsCallbackExceedingMaxLength() {
+        String longCallback = "vscode://host/callback?data=" + "a".repeat(ExternalLoginRedirectUriValidator.MAX_URI_BYTES);
+        assertThat(validator(SCHEMES, List.of()).validate(longCallback)).isPresent();
+    }
+
+    @Test
+    void acceptsAllowlistedAuthority() {
+        assertThat(validator(SCHEMES, List.of("aet-tum.iris-thaumantias")).validate("vscode://aet-tum.iris-thaumantias/callback")).isEmpty();
+    }
+
+    @Test
+    void acceptsAuthorityCaseInsensitively() {
+        assertThat(validator(SCHEMES, List.of("aet-tum.iris-thaumantias")).validate("vscode://AET-TUM.Iris-Thaumantias/callback")).isEmpty();
+    }
+
+    @Test
+    void rejectsAuthorityNotInAllowlist() {
+        assertThat(validator(SCHEMES, List.of("aet-tum.iris-thaumantias")).validate("vscode://some-other-extension/callback")).isPresent();
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/security/externallogin/PkceUtilTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/security/externallogin/PkceUtilTest.java
@@ -45,4 +45,38 @@ class PkceUtilTest {
         assertThat(PkceUtil.matches(RFC_VERIFIER, null)).isFalse();
         assertThat(PkceUtil.matches(null, null)).isFalse();
     }
+
+    @Test
+    void shouldAcceptWellFormedS256Challenge() {
+        assertThat(PkceUtil.isValidS256Challenge(RFC_CHALLENGE)).isTrue();
+        assertThat(PkceUtil.isValidS256Challenge(PkceUtil.s256Challenge("some-high-entropy-verifier-value-1234567890"))).isTrue();
+    }
+
+    @Test
+    void shouldRejectMalformedS256Challenge() {
+        assertThat(PkceUtil.isValidS256Challenge(null)).isFalse();
+        assertThat(PkceUtil.isValidS256Challenge("")).isFalse();
+        assertThat(PkceUtil.isValidS256Challenge("   ")).isFalse();
+        assertThat(PkceUtil.isValidS256Challenge("tooShort")).isFalse();
+        assertThat(PkceUtil.isValidS256Challenge(RFC_CHALLENGE + "x")).isFalse(); // 44 characters
+        assertThat(PkceUtil.isValidS256Challenge(RFC_CHALLENGE.substring(0, 42))).isFalse(); // 42 characters
+        assertThat(PkceUtil.isValidS256Challenge("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw+cM")).isFalse(); // '+' is not base64url
+    }
+
+    @Test
+    void shouldAcceptWellFormedCodeVerifier() {
+        assertThat(PkceUtil.isValidCodeVerifier(RFC_VERIFIER)).isTrue(); // 43 characters (minimum)
+        assertThat(PkceUtil.isValidCodeVerifier("A".repeat(128))).isTrue(); // 128 characters (maximum)
+        assertThat(PkceUtil.isValidCodeVerifier("abcDEF123-._~" + "a".repeat(40))).isTrue(); // full unreserved set
+    }
+
+    @Test
+    void shouldRejectMalformedCodeVerifier() {
+        assertThat(PkceUtil.isValidCodeVerifier(null)).isFalse();
+        assertThat(PkceUtil.isValidCodeVerifier("")).isFalse();
+        assertThat(PkceUtil.isValidCodeVerifier("A".repeat(42))).isFalse(); // too short
+        assertThat(PkceUtil.isValidCodeVerifier("A".repeat(129))).isFalse(); // too long
+        assertThat(PkceUtil.isValidCodeVerifier("contains spaces but is otherwise long enough 0123")).isFalse(); // space is not unreserved
+        assertThat(PkceUtil.isValidCodeVerifier("contains/slash/and/is/long/enough/0123456789xxxx")).isFalse(); // '/' is not unreserved
+    }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/core/security/externallogin/PkceUtilTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/security/externallogin/PkceUtilTest.java
@@ -1,0 +1,48 @@
+package de.tum.cit.aet.artemis.core.security.externallogin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PkceUtilTest {
+
+    // RFC 7636 Appendix B reference vector.
+    private static final String RFC_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+
+    private static final String RFC_CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+    @Test
+    void shouldComputeS256ChallengeMatchingRfcReferenceVector() {
+        assertThat(PkceUtil.s256Challenge(RFC_VERIFIER)).isEqualTo(RFC_CHALLENGE);
+    }
+
+    @Test
+    void shouldProduceBase64UrlWithoutPadding() {
+        String challenge = PkceUtil.s256Challenge("some-verifier-value");
+        assertThat(challenge).doesNotContain("=", "+", "/");
+    }
+
+    @Test
+    void shouldMatchVerifierAgainstItsOwnChallenge() {
+        String verifier = "another-high-entropy-verifier-value-1234567890";
+        assertThat(PkceUtil.matches(verifier, PkceUtil.s256Challenge(verifier))).isTrue();
+    }
+
+    @Test
+    void shouldMatchRfcReferenceVector() {
+        assertThat(PkceUtil.matches(RFC_VERIFIER, RFC_CHALLENGE)).isTrue();
+    }
+
+    @Test
+    void shouldNotMatchWrongVerifier() {
+        String challenge = PkceUtil.s256Challenge("the-real-verifier-value-0987654321");
+        assertThat(PkceUtil.matches("a-different-verifier-value", challenge)).isFalse();
+    }
+
+    @Test
+    void shouldNotMatchWhenArgumentsAreNull() {
+        assertThat(PkceUtil.matches(null, RFC_CHALLENGE)).isFalse();
+        assertThat(PkceUtil.matches(RFC_VERIFIER, null)).isFalse();
+        assertThat(PkceUtil.matches(null, null)).isFalse();
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/security/jwt/JWTFilterIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/security/jwt/JWTFilterIntegrationTest.java
@@ -175,6 +175,34 @@ class JWTFilterIntegrationTest extends AbstractSpringIntegrationIndependentTest 
                 assertThat(tokenProvider.getExpirationDate(updatedJwt)).isBefore(new Date(System.currentTimeMillis() + expectedRemainingLifetimeInMilliseconds));
             }
 
+            /**
+             * A rotated passkey token must keep the super-admin approval claim; otherwise an approved admin would silently
+             * lose approval once the cookie crosses its half-life (the claim gates {@code PasskeyAuthenticationService}).
+             */
+            @Test
+            void testRotationPreservesSuperAdminApproval() throws Exception {
+                Authentication authentication = AuthenticationFactory.createWebAuthnAuthentication(USER_NAME);
+
+                long moreThanHalfOfTokenValidityPassed = (long) (TOKEN_VALIDITY_REMEMBER_ME_IN_SECONDS * 0.6 * 1000);
+                Date issuedAt = new Date(System.currentTimeMillis() - moreThanHalfOfTokenValidityPassed);
+                Date expiration = new Date(issuedAt.getTime() + TOKEN_VALIDITY_REMEMBER_ME_IN_SECONDS * 1000);
+
+                // A super-admin approved passkey session token (auth-method PASSKEY, approval true).
+                String jwt = tokenProvider.createToken(authentication, issuedAt, expiration, null, AuthenticationMethod.PASSKEY, true);
+                assertThat(tokenProvider.isPasskeySuperAdminApproved(jwt)).isTrue();
+
+                MockHttpServletResponse response = performRequest(jwt, false);
+
+                String setCookieHeader = response.getHeader(HttpHeaders.SET_COOKIE);
+                assertThat(setCookieHeader).isNotNull();
+                ResponseCookie updatedCookie = CookieParserTestUtil.parseSetCookieHeader(setCookieHeader);
+
+                String updatedJwt = updatedCookie.getValue();
+                assertThat(updatedJwt).isNotEqualTo(jwt);
+                assertThat(tokenProvider.getAuthenticationMethod(updatedJwt)).isEqualTo(AuthenticationMethod.PASSKEY);
+                assertThat(tokenProvider.isPasskeySuperAdminApproved(updatedJwt)).isTrue();
+            }
+
         }
 
         @Nested
@@ -337,6 +365,8 @@ class JWTFilterIntegrationTest extends AbstractSpringIntegrationIndependentTest 
         assertThat(tokenProvider.getAuthentication(updatedJwt).getPrincipal()).isEqualTo(expectedAuthentication.getPrincipal());
         assertThat(tokenProvider.getAuthentication(updatedJwt).getAuthorities()).isEqualTo(expectedAuthentication.getAuthorities());
         assertThat(tokenProvider.getAuthenticationMethod(updatedJwt)).isEqualTo(AuthenticationMethod.PASSKEY);
+        // The passkey super-admin approval claim must survive rotation: it is carried over from the source token.
+        assertThat(tokenProvider.isPasskeySuperAdminApproved(updatedJwt)).isEqualTo(tokenProvider.isPasskeySuperAdminApproved(originalJwt));
         assertThat(tokenProvider.getIssuedAtDate(updatedJwt)).isCloseTo(expectedIssuedAt, 1000); // should not have changed, tolerance due to formatting
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/core/security/jwt/TokenProviderTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/security/jwt/TokenProviderTest.java
@@ -286,6 +286,46 @@ class TokenProviderTest {
 
     }
 
+    @Nested
+    class CreateTokenWithExplicitClaimsTests {
+
+        @Test
+        void shouldHonorExplicitMethodAndApproval() {
+            // A plain username/password authentication carries no passkey info, yet the explicit claims must be recorded
+            // (this is the seam used when re-minting from an existing session JWT: external-login handoff, passkey rotation).
+            Authentication authentication = AuthenticationFactory.createUsernamePasswordAuthentication(USER_NAME);
+            Date expiration = new Date(System.currentTimeMillis() + ONE_MINUTE);
+
+            String token = tokenProvider.createToken(authentication, null, expiration, null, AuthenticationMethod.PASSKEY, true);
+
+            assertThat(tokenProvider.getAuthenticationMethod(token)).isEqualTo(AuthenticationMethod.PASSKEY);
+            assertThat(tokenProvider.isPasskeySuperAdminApproved(token)).isTrue();
+        }
+
+        @Test
+        void shouldRecordSaml2MethodExplicitly() {
+            Authentication authentication = AuthenticationFactory.createUsernamePasswordAuthentication(USER_NAME);
+            Date expiration = new Date(System.currentTimeMillis() + ONE_MINUTE);
+
+            String token = tokenProvider.createToken(authentication, null, expiration, null, AuthenticationMethod.SAML2, false);
+
+            assertThat(tokenProvider.getAuthenticationMethod(token)).isEqualTo(AuthenticationMethod.SAML2);
+            assertThat(tokenProvider.isPasskeySuperAdminApproved(token)).isFalse();
+        }
+
+        @Test
+        void shouldFallBackToAuthenticationDerivedMethodWhenExplicitMethodIsNull() {
+            // A null explicit method falls back to deriving it from the authentication (here: PASSWORD), never null.
+            Authentication authentication = AuthenticationFactory.createUsernamePasswordAuthentication(USER_NAME);
+            Date expiration = new Date(System.currentTimeMillis() + ONE_MINUTE);
+
+            String token = tokenProvider.createToken(authentication, null, expiration, null, null, false);
+
+            assertThat(tokenProvider.getAuthenticationMethod(token)).isEqualTo(AuthenticationMethod.PASSWORD);
+        }
+
+    }
+
     private String createUnsupportedToken() {
         return Jwts.builder().content("payload").signWith(key, Jwts.SIG.HS512).compact();
     }


### PR DESCRIPTION
### Summary

Adds a generic, opt-in browser-delegated login handoff so external clients (the VS Code extension, and potentially the mobile apps) can obtain a full Artemis JWT after the user authenticates in the browser by any method: passkey, SAML2 SSO, or password. The JWT is released only against a PKCE verifier that the client never exposes to the browser, so no raw token ever appears in a URL. This supersedes the closed, SAML2-only #12534 with a method-agnostic, PKCE-hardened design.

Scope of this PR: the **server endpoints** and the guarded **web app** handoff page (with tests). The VS Code **extension client** lives in ls1intum/artemis-extension#326.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api#authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context

Today external clients can only authenticate with username + password (e.g. the VS Code extension posts to `/api/core/public/authenticate`). That excludes users on **passkey-only** or **SAML2-SSO-only** instances and prevents phishing-resistant login from the extension.

Rather than add a passkey-specific path, this adds one generic handoff that works after any successful browser login, so passkey + SSO + password are all covered by a single mechanism.

Related issues: #10967, #10968. Supersedes #12534.

### Description

The JWT is released only against a PKCE verifier that the client never exposes to the browser; no raw token ever appears in a URL.

```mermaid
sequenceDiagram
    autonumber
    participant Ext as External client
    participant Browser as System browser
    participant Web as Artemis SPA
    participant API as Artemis server

    Ext->>Ext: generate state and PKCE verifier with S256 challenge, persist pending
    Ext->>Browser: open the external-login page with state, code_challenge and callback
    Browser->>Web: GET the external-login route, which is guarded
    Note over Web: unauthenticated, guard stores previousUrl and redirects to sign-in
    Browser->>Web: user logs in with passkey, SAML or password
    Note over Web: handleLoginSuccess restores previousUrl and returns to external-login
    Web->>API: POST api/core/external-login/code with code_challenge and callback
    Note over API: validate callback, mint full JWT capped to session, store single-use code
    API-->>Web: respond with the one-time code
    Web->>Browser: redirect to the validated callback with code and state
    Browser->>Ext: callback opens the client, client validates state
    Ext->>API: POST api/core/public/external-login/token with code and code_verifier
    Note over API: atomically consume the code and verify S256
    API-->>Ext: respond with access_token
```

#### New endpoints
- `POST /api/core/external-login/code`: authenticated (`@EnforceAtLeastStudent`), called same-origin from the web app once the user is logged in. Validates the callback against a strict allowlist, mints a full JWT capped to the current session's remaining validity (never extends a session), binds it to a single-use code + PKCE challenge, and returns the code.
- `POST /api/core/public/external-login/token`: public, rate-limited. Exchanges `code + codeVerifier` for the JWT (atomic single-use consume + S256 verification).

#### Security model
- One-time code: 256-bit, single-use, 60s TTL, distributed (Hazelcast) so issue and exchange can hit different cluster nodes.
- PKCE (S256) binds redemption to the client; the verifier never reaches the browser.
- Callback allowlist: custom schemes only (`http`/`https` always rejected) plus a required authority allowlist. The authority allowlist is mandatory (fail closed): an allowed scheme on its own can never deliver the code to an arbitrary handler, e.g. another extension via a forged `/external-login` link.
- Minted JWT capped to the originating session's remaining validity, so there is no lifetime escalation. The auth method and passkey-approval claims of the originating session are preserved, so a passkey or SAML login does not degrade to a password token.
- Disabled by default: the feature requires both `artemis.external-login.allowed-redirect-schemes` and `allowed-redirect-authorities` to be non-empty; if either is empty the feature is off (the `code` endpoint then returns 404).

### Steps for Testing

> The feature is **disabled by default** and is **not enabled on the test servers**, so right now it can only be tested **locally**. A full end-to-end test needs this PR (server + web app) together with the extension client from ls1intum/artemis-extension#326.

Prerequisites:
- A local Artemis running from this branch.
- The VS Code extension built from ls1intum/artemis-extension#326 (Desktop, not Theia).

End-to-end (with the extension):
1. Enable the feature in `application-local.yml`:
   ```yaml
   artemis:
     external-login:
       allowed-redirect-schemes: [vscode, vscode-insiders]
       allowed-redirect-authorities: [aet-tum.iris-thaumantias]
   ```
   Optional: to exercise the passkey path, set `artemis.user-management.passkey.enabled: true` and register a passkey. SSO needs the `saml2` profile plus an IdP. Password works without either.
2. Start Artemis. In the extension, set the server URL to your local instance and click **Sign in with browser**.
3. The browser opens `/external-login`, you authenticate (passkey, SSO, or password), and you are returned to the editor signed in.

Endpoints only (without the extension):
1. Authenticated `POST /api/core/external-login/code` with an S256 `code_challenge` and a `vscode://...` callback returns a one-time `code`.
2. `POST /api/core/public/external-login/token` with that `code` and the matching `code_verifier` returns an `access_token`.
3. Reusing the same code returns 401 (single-use); a wrong verifier returns 401; with the feature disabled (empty allowlist) the `code` endpoint returns 404.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

> Note: even on a deployed test server the feature stays inactive until both `artemis.external-login.allowed-redirect-schemes` and `allowed-redirect-authorities` are set in that server's configuration.

### Review Progress
#### Performance Review
- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots

<img width="828" height="384" alt="image" src="https://github.com/user-attachments/assets/69d051fe-d24c-4a65-89c3-88bc4171876d" />

The `/external-login` page is a minimal bridge with two states: a redirecting state (hands control straight back to the editor) and an error state when the request is invalid or the callback is rejected. The user-facing entry point (the "Sign in with browser" button) is shown in ls1intum/artemis-extension#326.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser handoff flow for external clients: issue a one-time external-login code and exchange it for an access token using PKCE.
  * Introduced server-side one-time code storage with short-lived consumption and strict callback allowlisting.
  * Added the external-login UI route, component, and localized texts.

* **Bug Fixes**
  * Ensured passkey super-admin approval is preserved when rotating tokens, and standardized token minting via explicit claim handling.

* **Tests**
  * Added integration and unit tests covering the full handoff, PKCE/callback validation, one-time code security, and token claim preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->