### PR TITLE
`Development`: Stabilize the flaky forwarded-message e2e tests

### DIFF
--- a/src/test/playwright/e2e/course/CourseMessageInteractions.spec.ts
+++ b/src/test/playwright/e2e/course/CourseMessageInteractions.spec.ts
@@ -382,33 +382,27 @@ test.describe('Message interactions', { tag: '@fast' }, () => {
             reply = await communicationAPIRequests.createCourseMessageReply(courseRef, sourcePost, `Forward reply message ${uid}`);
         });
 
-        test('Forwarded post renders its preview in the destination conversation', async ({ login, courseMessages, page }) => {
+        test('Forwarded post renders its preview in the destination conversation', async ({ login, courseMessages }) => {
             await login(instructor);
             await courseMessages.openConversationAndWaitForPost(writeCourse.id, sourceChannel.id!, sourcePost.id!);
             await courseMessages.checkMessage(sourcePost.id!, sourcePost.content!);
 
             await courseMessages.forwardMessageToChannel(sourcePost.id!, destinationChannel.name!);
 
-            // opening the destination triggers the source-post fetch that the access check guards; it must succeed for an accessible source
-            const sourcePostsResponse = page.waitForResponse((resp) => resp.url().includes('/messages-source-posts') && resp.request().method() === 'GET');
-            await courseMessages.openConversation(writeCourse.id, destinationChannel.id!);
-            expect((await sourcePostsResponse).status()).toBe(200);
-
-            await courseMessages.checkForwardedPreview(sourcePost.content!);
+            // Opening the destination triggers the access-checked source-post fetch; a visible preview proves it succeeded for an
+            // accessible source. Reload-retry to absorb the multi-node lag before the just-created forward is visible to the serving node.
+            await courseMessages.openConversationAndWaitForForwardedPreview(writeCourse.id, destinationChannel.id!, sourcePost.content!);
         });
 
-        test('Forwarded reply renders its preview in the destination conversation', async ({ login, courseMessages, page }) => {
+        test('Forwarded reply renders its preview in the destination conversation', async ({ login, courseMessages }) => {
             await login(instructor);
             await courseMessages.openConversationAndWaitForPost(writeCourse.id, sourceChannel.id!, sourcePost.id!);
             await courseMessages.checkMessage(sourcePost.id!, sourcePost.content!);
 
             await courseMessages.forwardReplyToChannel(sourcePost.id!, reply.id!, destinationChannel.name!);
 
-            const answerSourceResponse = page.waitForResponse((resp) => resp.url().includes('/answer-messages-source-posts') && resp.request().method() === 'GET');
-            await courseMessages.openConversation(writeCourse.id, destinationChannel.id!);
-            expect((await answerSourceResponse).status()).toBe(200);
-
-            await courseMessages.checkForwardedPreview(reply.content!);
+            // Same as the post case, but the access check guards the source-answer fetch; a visible preview proves it returned the reply.
+            await courseMessages.openConversationAndWaitForForwardedPreview(writeCourse.id, destinationChannel.id!, reply.content!);
         });
     });
 });

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -813,11 +813,25 @@ export class CourseMessagesPage {
      */
     private async completeForwardDialog(destinationName: string, extraContent?: string) {
         const dialog = this.page.locator('jhi-forward-message-dialog');
-        await dialog.locator('input.tag-input').fill(destinationName);
+        const input = dialog.locator('input.tag-input');
         // the dialog selects on (mousedown) so the option is chosen before the input blur closes the dropdown
         const option = dialog.locator('.autocomplete-dropdown .list-group-item-action', { hasText: destinationName }).first();
-        await option.waitFor({ state: 'visible', timeout: 5000 });
-        await option.dispatchEvent('mousedown');
+        // The autocomplete dropdown re-renders as the debounced search resolves, so the matched option can detach between
+        // becoming visible and the mousedown — an unbounded dispatchEvent then hangs until the test timeout. Re-type and
+        // re-select as a unit with a bounded mousedown so a detach retries quickly instead of hanging.
+        for (let attempt = 0; attempt < 3; attempt++) {
+            await input.fill('');
+            await input.fill(destinationName);
+            try {
+                await option.waitFor({ state: 'visible', timeout: 5000 });
+                await option.dispatchEvent('mousedown', { timeout: 5000 });
+                break;
+            } catch (error) {
+                if (attempt === 2) {
+                    throw error;
+                }
+            }
+        }
         if (extraContent) {
             await setMonacoEditorContent(this.page, 'jhi-forward-message-dialog jhi-markdown-editor-monaco', extraContent);
         }
@@ -872,6 +886,40 @@ export class CourseMessagesPage {
     async checkForwardedPreview(expectedSourceContent: string) {
         const forwarded = this.page.locator('.forwarded-message-container', { hasText: expectedSourceContent });
         await expect(forwarded.first()).toBeVisible({ timeout: 10000 });
+    }
+
+    /**
+     * Opens a conversation and waits until a forwarded-message preview containing the given source content has rendered,
+     * reloading between attempts.
+     *
+     * The forwarded preview is only populated after the conversation's forwarded-messages fetch AND the (access-checked)
+     * source-post / source-answer fetch both succeed. Under heavy multi-node load the just-created forward can briefly be
+     * invisible to the node that serves the destination conversation, so {@link openConversation} (which only waits for the
+     * conversation to *activate*) returns before the forwarded-messages fetch sees it — and the source fetch then never
+     * fires. A reload re-issues those fetches against the shared database, which by then has the persisted forward. This is
+     * the same load-induced rendering-race mitigation {@link openConversationAndWaitForPost} uses for plain posts. A visible
+     * preview proves the whole chain — including the access-checked source fetch — succeeded for an accessible source.
+     *
+     * @param courseID - The ID of the course the conversation belongs to.
+     * @param conversationID - The ID of the destination conversation to open.
+     * @param expectedSourceContent - The content of the original (forwarded) posting that must appear in the preview.
+     */
+    async openConversationAndWaitForForwardedPreview(courseID: number, conversationID: number, expectedSourceContent: string) {
+        const forwarded = this.page.locator('.forwarded-message-container', { hasText: expectedSourceContent });
+        for (let attempt = 0; attempt < 3; attempt++) {
+            if (attempt === 0) {
+                await this.openConversation(courseID, conversationID);
+            } else {
+                await this.page.reload({ waitUntil: 'domcontentloaded' });
+            }
+            try {
+                await expect(forwarded.first()).toBeVisible({ timeout: 12000 });
+                return;
+            } catch {
+                // Forwarded message not yet propagated/rendered — fall through to a reload, which re-fetches it.
+            }
+        }
+        throw new Error(`Forwarded preview containing "${expectedSourceContent}" did not render in conversation ${conversationID} after opening and reloading`);
     }
 
     /**


### PR DESCRIPTION
### Summary

The Playwright e2e test `Message forwarding › Forwarded reply renders its preview in the destination conversation` hard-failed (~50%) on multi-node CI; the `Forwarded post` variant shares the same race. This PR makes both forwarded-message e2e tests reliable. It is a **test-only** change (Playwright spec + page object); no production code is touched.

### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).
- [x] I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).

#### Changes affecting Programming Exercises
- [x] I verified the change on a locally running **integrated lifecycle (LocalVC + LocalCI), multi-node** stack (the only setup that reproduces the race).

### Motivation and Context

Reproduced on the local multi-node stack (`run-e2e-tests-local-multinode-fast.sh`): the test waited for the `/answer-messages-source-posts` GET, but under multi-node read-after-write lag the just-created forward is briefly invisible to the node serving the destination conversation. `openConversation` only waits for the conversation to **activate**, not for the forwarded preview to render, so the client never issues the source fetch and the test hangs to the timeout. A second, rarer race surfaced under repetition: the destination autocomplete option detaches between `waitFor` and an unbounded `dispatchEvent('mousedown')`, also hanging to the timeout.

### Description

- Replaced the brittle `waitForResponse(...)` with a new `openConversationAndWaitForForwardedPreview`, which reload-retries until the forwarded preview renders (mirroring the existing `openConversationAndWaitForPost`). A visible preview proves the access-checked source fetch succeeded for an accessible source, preserving the test's intent.
- Hardened `completeForwardDialog`: re-type and re-select the destination with a bounded `mousedown` so a detaching autocomplete option retries quickly instead of hanging.

### Steps for Testing

This is a test-infrastructure fix; verify by running the affected e2e tests on a multi-node stack:

```
./run-e2e-tests-local-multinode-fast.sh --filter "Forwarded (reply|post) renders its preview"
```

Verified locally: **40/40** runs of both forward tests pass (`--repeat-each=20 --workers=6`), reproducibly failing before the fix.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.