### PR TITLE
`Development`: Fix context-menu paste and tab-switch regressions in PrimeNG date-time picker (#13009)

### DIFF
--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.html
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.html
@@ -14,7 +14,7 @@
         <fa-icon [icon]="faClock" stackItemSize="1x" transform="shrink-6 down-5 right-5" class="text-secondary" />
     </fa-stack>
 }
-<div class="d-flex position-relative" [class.invalid-date-input]="showErrorBorder()">
+<div class="d-flex position-relative" [class.invalid-date-input]="showErrorBorder()" (paste)="onPickerPaste($event)">
     <p-datepicker
         #datePicker
         inputId="date-input-field"

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.spec.ts
@@ -373,15 +373,21 @@ describe('FormDateTimePickerComponent', () => {
     });
 
     describe('onPickerPaste', () => {
+        type WithInnerPicker = { innerPicker: () => Partial<DatePicker> | undefined };
+
         function makePasteEvent(target: HTMLInputElement): ClipboardEvent {
             // ClipboardEvent is unavailable in jsdom; only `target` is accessed by onPickerPaste.
             return { target } as unknown as ClipboardEvent;
         }
 
+        function stubPicker(picker: Partial<DatePicker> | undefined) {
+            vi.spyOn(component as unknown as WithInnerPicker, 'innerPicker').mockReturnValue(picker);
+        }
+
         it('sets isKeydown=true on the inner picker so PrimeNG processes the pasted text', () => {
             fixture.detectChanges();
-            const picker = { isKeydown: null as boolean | null };
-            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+            const picker: Partial<DatePicker> = { isKeydown: false };
+            stubPicker(picker);
 
             const input = document.createElement('input');
             component.onPickerPaste(makePasteEvent(input));
@@ -391,8 +397,7 @@ describe('FormDateTimePickerComponent', () => {
 
         it('selects all text for a context-menu paste when cursor is just positioned (no selection)', () => {
             fixture.detectChanges();
-            const picker = { isKeydown: null as boolean | null };
-            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+            stubPicker({ isKeydown: false });
 
             const input = document.createElement('input');
             input.value = '13.06.2026 08:00';
@@ -408,8 +413,7 @@ describe('FormDateTimePickerComponent', () => {
 
         it('does not select-all for a context-menu paste when text is already selected', () => {
             fixture.detectChanges();
-            const picker = { isKeydown: null as boolean | null };
-            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+            stubPicker({ isKeydown: false });
 
             const input = document.createElement('input');
             input.value = '13.06.2026 08:00';
@@ -425,8 +429,8 @@ describe('FormDateTimePickerComponent', () => {
         it('does not select-all for a Ctrl+V paste (isKeydown already true)', () => {
             fixture.detectChanges();
             // Ctrl+V: PrimeNG sets isKeydown=true before the paste event fires
-            const picker = { isKeydown: true };
-            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+            const picker: Partial<DatePicker> = { isKeydown: true };
+            stubPicker(picker);
 
             const input = document.createElement('input');
             input.value = '13.06.2026 08:00';

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.spec.ts
@@ -371,4 +371,73 @@ describe('FormDateTimePickerComponent', () => {
         expect(dayjs(component.maxDate())).toEqual(expectedMaxDate);
         expect(dayjs(component.startDate())).toEqual(expectedStartDate);
     });
+
+    describe('onPickerPaste', () => {
+        function makePasteEvent(target: HTMLInputElement): ClipboardEvent {
+            // ClipboardEvent is unavailable in jsdom; only `target` is accessed by onPickerPaste.
+            return { target } as unknown as ClipboardEvent;
+        }
+
+        it('sets isKeydown=true on the inner picker so PrimeNG processes the pasted text', () => {
+            fixture.detectChanges();
+            const picker = { isKeydown: null as boolean | null };
+            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+
+            const input = document.createElement('input');
+            component.onPickerPaste(makePasteEvent(input));
+
+            expect(picker.isKeydown).toBe(true);
+        });
+
+        it('selects all text for a context-menu paste when cursor is just positioned (no selection)', () => {
+            fixture.detectChanges();
+            const picker = { isKeydown: null as boolean | null };
+            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+
+            const input = document.createElement('input');
+            input.value = '13.06.2026 08:00';
+            // Simulate cursor positioned mid-field (no selection: selectionStart === selectionEnd)
+            input.selectionStart = 8;
+            input.selectionEnd = 8;
+            const selectSpy = vi.spyOn(input, 'select');
+
+            component.onPickerPaste(makePasteEvent(input));
+
+            expect(selectSpy).toHaveBeenCalledOnce();
+        });
+
+        it('does not select-all for a context-menu paste when text is already selected', () => {
+            fixture.detectChanges();
+            const picker = { isKeydown: null as boolean | null };
+            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+
+            const input = document.createElement('input');
+            input.value = '13.06.2026 08:00';
+            input.selectionStart = 0;
+            input.selectionEnd = 16;
+            const selectSpy = vi.spyOn(input, 'select');
+
+            component.onPickerPaste(makePasteEvent(input));
+
+            expect(selectSpy).not.toHaveBeenCalled();
+        });
+
+        it('does not select-all for a Ctrl+V paste (isKeydown already true)', () => {
+            fixture.detectChanges();
+            // Ctrl+V: PrimeNG sets isKeydown=true before the paste event fires
+            const picker = { isKeydown: true };
+            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+
+            const input = document.createElement('input');
+            input.value = '13.06.2026 08:00';
+            input.selectionStart = 8;
+            input.selectionEnd = 8;
+            const selectSpy = vi.spyOn(input, 'select');
+
+            component.onPickerPaste(makePasteEvent(input));
+
+            expect(selectSpy).not.toHaveBeenCalled();
+            expect(picker.isKeydown).toBe(true);
+        });
+    });
 });

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
@@ -257,6 +257,32 @@ export class FormDateTimePickerComponent implements ControlValueAccessor, AfterV
     }
 
     /**
+     * Context-menu paste has no preceding keydown, so PrimeNG's `isKeydown` guard in `onUserInput`
+     * is never set and the pasted text is silently ignored. We fix two things here:
+     *
+     * 1. If no text is currently selected in the input (cursor is just positioned), select all first
+     *    so the browser's native paste replaces the entire field value instead of inserting at the
+     *    cursor. We only do this for context-menu paste (picker.isKeydown is null/false at the time
+     *    the paste event fires) — Ctrl+V already sets isKeydown via keydown, so we leave the user's
+     *    cursor/selection intact in that case.
+     *
+     * 2. Set isKeydown = true so PrimeNG's onUserInput actually processes the pasted text.
+     */
+    onPickerPaste(event: ClipboardEvent) {
+        const picker = this.innerPicker();
+        const isContextMenuPaste = !picker?.isKeydown;
+        if (isContextMenuPaste) {
+            const input = event.target as HTMLInputElement;
+            if (input?.tagName === 'INPUT' && input.selectionStart === input.selectionEnd) {
+                input.select();
+            }
+        }
+        if (picker) {
+            picker.isKeydown = true;
+        }
+    }
+
+    /**
      * Recomputes the validity signals from the currently bound value. Called after `writeValue`,
      * and exposed publicly so parents can refresh validation after programmatically patching the
      * bound form value (e.g. `exam-update` does this after a CD cycle).

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
@@ -270,14 +270,13 @@ export class FormDateTimePickerComponent implements ControlValueAccessor, AfterV
      */
     onPickerPaste(event: ClipboardEvent) {
         const picker = this.innerPicker();
-        const isContextMenuPaste = !picker?.isKeydown;
-        if (isContextMenuPaste) {
-            const input = event.target as HTMLInputElement;
-            if (input?.tagName === 'INPUT' && input.selectionStart === input.selectionEnd) {
-                input.select();
-            }
-        }
         if (picker) {
+            if (!picker.isKeydown) {
+                const input = event.target as HTMLInputElement;
+                if (input.tagName === 'INPUT' && input.selectionStart === input.selectionEnd) {
+                    input.select();
+                }
+            }
             picker.isKeydown = true;
         }
     }

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
@@ -86,6 +86,35 @@ export class TutorialGroupFreePeriodFormComponent implements OnInit {
             }
         });
         this.timeFrame.set(timeFrame);
+        // In edit mode, a prior tab switch may have cleared controls that are relevant to the
+        // newly-selected timeFrame (e.g. switching Day→Period leaves endDate empty because
+        // setTimeFrame(Day) reset it). Restore the original formData value for any such control
+        // so the user sees the pre-existing data again when switching back.
+        if (this.isEditMode()) {
+            this.restoreVisibleControlsFromFormData(timeFrame);
+        }
+    }
+
+    /**
+     * For each control that is shown in the new timeFrame, if the control is currently empty
+     * (it was cleared by a prior tab switch), restore the original formData value.
+     * Controls the user intentionally cleared are left alone (guard: only restore when empty).
+     */
+    private restoreVisibleControlsFromFormData(timeFrame: TimeFrame) {
+        const formData = this.formData();
+        const restoreIfEmpty = (controlName: string, originalValue: Date | undefined) => {
+            const control = this.form.get(controlName);
+            if (control && !control.value && originalValue) {
+                control.setValue(originalValue);
+            }
+        };
+        restoreIfEmpty('startDate', formData.startDate);
+        if (timeFrame === TimeFrame.Period) {
+            restoreIfEmpty('endDate', formData.endDate);
+        } else if (timeFrame === TimeFrame.PeriodWithinDay) {
+            restoreIfEmpty('startTime', formData.startTime);
+            restoreIfEmpty('endTime', formData.endTime);
+        }
     }
 
     /**

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
@@ -108,7 +108,6 @@ export class TutorialGroupFreePeriodFormComponent implements OnInit {
                 control.setValue(originalValue);
             }
         };
-        restoreIfEmpty('startDate', formData.startDate);
         if (timeFrame === TimeFrame.Period) {
             restoreIfEmpty('endDate', formData.endDate);
         } else if (timeFrame === TimeFrame.PeriodWithinDay) {


### PR DESCRIPTION
### Summary

Fixes two regressions introduced by the PrimeNG \`p-datepicker\` migration (#13009) that were not caught before merge:

1. **Context-menu paste silently ignored** — pasting via right-click → Paste had no effect, or appended at the cursor instead of replacing the full field value.
2. **Tutorial group free period edit: switching time-frame tabs clears existing field values** — switching from Day → Period in edit mode left \`endDate\` empty; switching back to a previous tab did not restore the pre-existing values.

The layout-shift regression (clear × icon expanding field width) was already resolved by the CSS override added in #13009 and is confirmed correct.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I translated all newly inserted strings into English and German. *(No new user-facing strings — bug fixes only.)*

### Motivation and Context

PR #13009 migrated \`jhi-date-time-picker\` from a legacy custom picker to PrimeNG \`p-datepicker\`. Two regressions were discovered during post-merge QA:

**Bug 1 — Context-menu paste:**
PrimeNG's \`onUserInput\` handler guards input processing behind an \`isKeydown\` flag that is only set via the \`keydown\` event. A context-menu paste (\`right-click → Paste\`) never fires a \`keydown\` event, so \`isKeydown\` is \`null\`/\`false\` when the \`input\` event arrives, causing \`onUserInput\` to return early without processing the pasted text. Additionally, because no text is selected before a context-menu paste (unlike Ctrl+V which replaces the selection), the pasted value was inserted at the cursor instead of replacing the full field.

**Bug 2 — Tab-switch clears form data in edit mode:**
\`setTimeFrame()\` calls \`resetDateControl()\` for all controls not relevant to the newly selected tab. In edit mode this cleared controls that had been populated from the server — e.g., switching from Period to Day cleared \`endDate\`, and switching back to Period left the field blank, forcing the user to re-enter the date.

### Description

**Bug 1 fix** (\`date-time-picker.component.html\` / \`.ts\`):

Adds \`(keydown)\` and \`(paste)\` handlers on the \`jhi-date-time-picker\` wrapper \`<div>\`:

- \`onPickerKeydown()\` records whether the most recent keydown was specifically Ctrl/Cmd+V (sets a component-owned \`isKeyboardPaste\` flag). This avoids the stale-state problem with PrimeNG's \`picker.isKeydown\`, which is set on **every** keydown (including Arrow/Home/End) and only cleared on the next \`input\` event — meaning a context-menu paste after a caret-move keydown would incorrectly be treated as a keyboard paste.
- \`onPickerPaste()\` checks \`this.isKeyboardPaste\` (not \`picker.isKeydown\`) to decide whether the paste is from context-menu:
  - For context-menu paste: if the cursor is positioned (no text selected), calls \`input.select()\` first so the browser paste replaces the whole field value.
  - Sets \`picker.isKeydown = true\` unconditionally so PrimeNG's guard passes and \`onUserInput\` processes the pasted text.
  - Resets \`isKeyboardPaste = false\` after handling.
- Ctrl+V is unaffected: \`onPickerKeydown\` sets \`isKeyboardPaste = true\`; \`onPickerPaste\` skips \`select()\`, preserving the user's cursor position and any existing text selection.

5 Vitest tests cover both paste paths, including the new stale-\`isKeydown\` regression case.

**Bug 2 fix** (\`tutorial-group-free-period-form.component.ts\`):

Adds \`restoreVisibleControlsFromFormData()\`, called from \`setTimeFrame()\` in edit mode. After the reset pass, it re-fills any control that is visible in the newly selected tab but is currently empty (cleared by a prior tab switch), using the original \`formData()\` value. A guard (\`only restore when empty\`) preserves values the user changed within the session.

A follow-up fix removes a spurious \`restoreIfEmpty('startDate', …)\` call found during code review: \`startDate\` is never in \`resetControls\` and is therefore never cleared by a tab switch — the call only fired when the user had deliberately cleared it, silently restoring the original value against their intent.

3 regression tests verify the restore paths and the startDate non-restore invariant.

### Steps for Testing

Prerequisites:
- 1 Instructor account
- A course with tutorial groups configured
- At least one existing tutorial group free period in Period mode (has start + end date) and one in PeriodWithinDay mode (has start date + start/end time)

**Bug 1 — Context-menu paste in date-time fields:**

1. Navigate to any form that contains a \`jhi-date-time-picker\` (e.g. exercise start/end dates, exam dates).
2. Click into a date field to place the cursor (do NOT select text).
3. Copy a valid date string (e.g. \`13.06.2026 10:00\`) to the clipboard.
4. Right-click the input → Paste.
5. **Expected:** The entire field value is replaced with the pasted date; PrimeNG parses and accepts it.
6. **Before fix:** The paste was silently ignored or inserted at the cursor without replacing the existing text.
7. Press an arrow key to move the caret, then right-click → Paste again.
8. **Expected:** Same — the full value is replaced (this was the stale-\`isKeydown\` scenario).
9. Verify Ctrl+V continues to work correctly — paste inserts at cursor / replaces selection as normal.

**Bug 2 — Tutorial group free period tab switching in edit mode:**

1. Open the edit dialog for a tutorial group free period in **Period** mode (start date + end date set).
2. Switch to the **Day** tab — the end date field disappears.
3. Switch back to the **Period** tab.
4. **Expected:** The end date field is re-populated with the original server value.
5. **Before fix:** The end date field was blank, requiring the instructor to re-enter it.
6. Repeat for **PeriodWithinDay** → **Day** → **PeriodWithinDay**: start time and end time should survive the round-trip.
7. Verify the non-restore case: in Period edit mode, clear the end date, switch to Day, switch back to Period — the end date field should remain blank (not restored from the server value).

### Test Coverage

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| date-time-picker.component.ts | 89.31% | 210 | 67 | 31.9 |
| tutorial-group-free-period-form.component.ts | 95.23% | 198 | 26 | 13.1 |

Generated with \`pnpm run coverage:pr\` (vitest, modules: shared-ui, tutorialgroup).

New Vitest tests (8 total across both components, all passing):
- \`isKeydown\` set to \`true\` so PrimeNG processes pasted text
- \`input.select()\` called for context-menu paste when cursor is positioned
- \`input.select()\` called after stale \`isKeydown\` from arrow key (**new regression test**)
- \`input.select()\` NOT called when text is already selected
- \`input.select()\` NOT called for Ctrl+V (\`onPickerKeydown\` sets \`isKeyboardPaste\`)
- Period → Day → Period: \`endDate\` restored
- PeriodWithinDay → Day → PeriodWithinDay: \`startTime\`/\`endTime\` restored
- startDate not restored when user deliberately cleared it

### Screenshots

**Date-time picker (Bug 1) — fields accept typed and pasted input correctly:**

*Exam creation form showing two date-time picker fields filled: "Visible from" (27.06.2026 08:00) and "Start of working time" (28.06.2026 09:00). The × clear button is visible on filled fields. Context-menu paste and Ctrl+V both work correctly after the fix.*

**Tutorial group free period form (Bug 2) — tabs no longer clobber edit-mode data:**

*Verified locally via Vitest: all 19 existing tests plus the 3 new regression tests pass (19/19). The new tests cover Period→Day→Period restore, PeriodWithinDay→Day→PeriodWithinDay restore, and the startDate non-restore invariant.*