### PR TITLE
`Development`: Fix context menu paste and tab switch regressions in primeng date time picker

### DIFF
--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.html
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.html
@@ -14,7 +14,7 @@
         <fa-icon [icon]="faClock" stackItemSize="1x" transform="shrink-6 down-5 right-5" class="text-secondary" />
     </fa-stack>
 }
-<div class="d-flex position-relative" [class.invalid-date-input]="showErrorBorder()" (paste)="onPickerPaste($event)">
+<div class="d-flex position-relative" [class.invalid-date-input]="showErrorBorder()" (keydown)="onPickerKeydown($event)" (paste)="onPickerPaste($event)">
     <p-datepicker
         #datePicker
         inputId="date-input-field"

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.html
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.html
@@ -14,7 +14,7 @@
         <fa-icon [icon]="faClock" stackItemSize="1x" transform="shrink-6 down-5 right-5" class="text-secondary" />
     </fa-stack>
 }
-<div class="d-flex position-relative" [class.invalid-date-input]="showErrorBorder()">
+<div class="d-flex position-relative" [class.invalid-date-input]="showErrorBorder()" (paste)="onPickerPaste($event)">
     <p-datepicker
         #datePicker
         inputId="date-input-field"

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.spec.ts
@@ -373,15 +373,21 @@ describe('FormDateTimePickerComponent', () => {
     });
 
     describe('onPickerPaste', () => {
+        type WithInnerPicker = { innerPicker: () => Partial<DatePicker> | undefined };
+
         function makePasteEvent(target: HTMLInputElement): ClipboardEvent {
             // ClipboardEvent is unavailable in jsdom; only `target` is accessed by onPickerPaste.
             return { target } as unknown as ClipboardEvent;
         }
 
+        function stubPicker(picker: Partial<DatePicker> | undefined) {
+            vi.spyOn(component as unknown as WithInnerPicker, 'innerPicker').mockReturnValue(picker);
+        }
+
         it('sets isKeydown=true on the inner picker so PrimeNG processes the pasted text', () => {
             fixture.detectChanges();
-            const picker = { isKeydown: null as boolean | null };
-            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+            const picker: Partial<DatePicker> = { isKeydown: false };
+            stubPicker(picker);
 
             const input = document.createElement('input');
             component.onPickerPaste(makePasteEvent(input));
@@ -391,8 +397,7 @@ describe('FormDateTimePickerComponent', () => {
 
         it('selects all text for a context-menu paste when cursor is just positioned (no selection)', () => {
             fixture.detectChanges();
-            const picker = { isKeydown: null as boolean | null };
-            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+            stubPicker({ isKeydown: false });
 
             const input = document.createElement('input');
             input.value = '13.06.2026 08:00';
@@ -408,8 +413,7 @@ describe('FormDateTimePickerComponent', () => {
 
         it('does not select-all for a context-menu paste when text is already selected', () => {
             fixture.detectChanges();
-            const picker = { isKeydown: null as boolean | null };
-            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+            stubPicker({ isKeydown: false });
 
             const input = document.createElement('input');
             input.value = '13.06.2026 08:00';
@@ -425,8 +429,8 @@ describe('FormDateTimePickerComponent', () => {
         it('does not select-all for a Ctrl+V paste (isKeydown already true)', () => {
             fixture.detectChanges();
             // Ctrl+V: PrimeNG sets isKeydown=true before the paste event fires
-            const picker = { isKeydown: true };
-            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+            const picker: Partial<DatePicker> = { isKeydown: true };
+            stubPicker(picker);
 
             const input = document.createElement('input');
             input.value = '13.06.2026 08:00';

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.spec.ts
@@ -462,5 +462,22 @@ describe('FormDateTimePickerComponent', () => {
             expect(selectSpy).not.toHaveBeenCalled();
             expect(picker.isKeydown).toBe(true);
         });
+
+        it('does not select-all for Shift+Insert (treated as keyboard paste)', () => {
+            const picker: Partial<DatePicker> = { isKeydown: false };
+            stubPicker(picker);
+
+            const input = document.createElement('input');
+            input.value = '13.06.2026 08:00';
+            input.selectionStart = 8;
+            input.selectionEnd = 8;
+            const selectSpy = vi.spyOn(input, 'select');
+
+            component.onPickerKeydown(new KeyboardEvent('keydown', { key: 'Insert', shiftKey: true }));
+            component.onPickerPaste(makePasteEvent(input));
+
+            expect(selectSpy).not.toHaveBeenCalled();
+            expect(picker.isKeydown).toBe(true);
+        });
     });
 });

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.spec.ts
@@ -371,4 +371,73 @@ describe('FormDateTimePickerComponent', () => {
         expect(dayjs(component.maxDate())).toEqual(expectedMaxDate);
         expect(dayjs(component.startDate())).toEqual(expectedStartDate);
     });
+
+    describe('onPickerPaste', () => {
+        function makePasteEvent(target: HTMLInputElement): ClipboardEvent {
+            // ClipboardEvent is unavailable in jsdom; only `target` is accessed by onPickerPaste.
+            return { target } as unknown as ClipboardEvent;
+        }
+
+        it('sets isKeydown=true on the inner picker so PrimeNG processes the pasted text', () => {
+            fixture.detectChanges();
+            const picker = { isKeydown: null as boolean | null };
+            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+
+            const input = document.createElement('input');
+            component.onPickerPaste(makePasteEvent(input));
+
+            expect(picker.isKeydown).toBe(true);
+        });
+
+        it('selects all text for a context-menu paste when cursor is just positioned (no selection)', () => {
+            fixture.detectChanges();
+            const picker = { isKeydown: null as boolean | null };
+            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+
+            const input = document.createElement('input');
+            input.value = '13.06.2026 08:00';
+            // Simulate cursor positioned mid-field (no selection: selectionStart === selectionEnd)
+            input.selectionStart = 8;
+            input.selectionEnd = 8;
+            const selectSpy = vi.spyOn(input, 'select');
+
+            component.onPickerPaste(makePasteEvent(input));
+
+            expect(selectSpy).toHaveBeenCalledOnce();
+        });
+
+        it('does not select-all for a context-menu paste when text is already selected', () => {
+            fixture.detectChanges();
+            const picker = { isKeydown: null as boolean | null };
+            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+
+            const input = document.createElement('input');
+            input.value = '13.06.2026 08:00';
+            input.selectionStart = 0;
+            input.selectionEnd = 16;
+            const selectSpy = vi.spyOn(input, 'select');
+
+            component.onPickerPaste(makePasteEvent(input));
+
+            expect(selectSpy).not.toHaveBeenCalled();
+        });
+
+        it('does not select-all for a Ctrl+V paste (isKeydown already true)', () => {
+            fixture.detectChanges();
+            // Ctrl+V: PrimeNG sets isKeydown=true before the paste event fires
+            const picker = { isKeydown: true };
+            (component as any).innerPicker = vi.fn().mockReturnValue(picker);
+
+            const input = document.createElement('input');
+            input.value = '13.06.2026 08:00';
+            input.selectionStart = 8;
+            input.selectionEnd = 8;
+            const selectSpy = vi.spyOn(input, 'select');
+
+            component.onPickerPaste(makePasteEvent(input));
+
+            expect(selectSpy).not.toHaveBeenCalled();
+            expect(picker.isKeydown).toBe(true);
+        });
+    });
 });

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.spec.ts
@@ -406,6 +406,25 @@ describe('FormDateTimePickerComponent', () => {
             input.selectionEnd = 8;
             const selectSpy = vi.spyOn(input, 'select');
 
+            // No preceding keydown → context-menu paste
+            component.onPickerPaste(makePasteEvent(input));
+
+            expect(selectSpy).toHaveBeenCalledOnce();
+        });
+
+        it('selects all text for a context-menu paste even when PrimeNG isKeydown is stale-true (arrow key pressed before paste)', () => {
+            fixture.detectChanges();
+            // PrimeNG sets isKeydown=true on every keydown, including arrow keys.
+            // A context-menu paste after a caret-move keydown must still select-all.
+            stubPicker({ isKeydown: true });
+
+            const input = document.createElement('input');
+            input.value = '13.06.2026 08:00';
+            input.selectionStart = 8;
+            input.selectionEnd = 8;
+            const selectSpy = vi.spyOn(input, 'select');
+
+            component.onPickerKeydown(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
             component.onPickerPaste(makePasteEvent(input));
 
             expect(selectSpy).toHaveBeenCalledOnce();
@@ -426,10 +445,9 @@ describe('FormDateTimePickerComponent', () => {
             expect(selectSpy).not.toHaveBeenCalled();
         });
 
-        it('does not select-all for a Ctrl+V paste (isKeydown already true)', () => {
+        it('does not select-all for a Ctrl+V paste', () => {
             fixture.detectChanges();
-            // Ctrl+V: PrimeNG sets isKeydown=true before the paste event fires
-            const picker: Partial<DatePicker> = { isKeydown: true };
+            const picker: Partial<DatePicker> = { isKeydown: false };
             stubPicker(picker);
 
             const input = document.createElement('input');
@@ -438,6 +456,7 @@ describe('FormDateTimePickerComponent', () => {
             input.selectionEnd = 8;
             const selectSpy = vi.spyOn(input, 'select');
 
+            component.onPickerKeydown(new KeyboardEvent('keydown', { key: 'v', ctrlKey: true }));
             component.onPickerPaste(makePasteEvent(input));
 
             expect(selectSpy).not.toHaveBeenCalled();

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
@@ -257,6 +257,32 @@ export class FormDateTimePickerComponent implements ControlValueAccessor, AfterV
     }
 
     /**
+     * Context-menu paste has no preceding keydown, so PrimeNG's `isKeydown` guard in `onUserInput`
+     * is never set and the pasted text is silently ignored. We fix two things here:
+     *
+     * 1. If no text is currently selected in the input (cursor is just positioned), select all first
+     *    so the browser's native paste replaces the entire field value instead of inserting at the
+     *    cursor. We only do this for context-menu paste (picker.isKeydown is null/false at the time
+     *    the paste event fires) — Ctrl+V already sets isKeydown via keydown, so we leave the user's
+     *    cursor/selection intact in that case.
+     *
+     * 2. Set isKeydown = true so PrimeNG's onUserInput actually processes the pasted text.
+     */
+    onPickerPaste(event: ClipboardEvent) {
+        const picker = this.innerPicker();
+        const isContextMenuPaste = !picker?.isKeydown;
+        if (isContextMenuPaste) {
+            const input = event.target as HTMLInputElement;
+            if (input?.tagName === 'INPUT' && input.selectionStart === input.selectionEnd) {
+                input.select();
+            }
+        }
+        if (picker) {
+            picker.isKeydown = true;
+        }
+    }
+
+    /**
      * Recomputes the validity signals from the currently bound value. Called after `writeValue`,
      * and exposed publicly so parents can refresh validation after programmatically patching the
      * bound form value (e.g. `exam-update` does this after a CD cycle).

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
@@ -56,6 +56,10 @@ export class FormDateTimePickerComponent implements ControlValueAccessor, AfterV
     // keepInvalid). Without this flag the `unchanged` guard in updateField would swallow the
     // re-emission when the user corrects the input back to the previously held date.
     private needsParentSync = false;
+    // Set by onPickerKeydown when Ctrl/Cmd+V is detected; cleared in onPickerPaste.
+    // Avoids relying on PrimeNG's picker.isKeydown, which is set by ANY keydown (arrow, Home/End…)
+    // and would remain stale-true when a context-menu paste follows a non-paste keydown.
+    private isKeyboardPaste = false;
 
     /** DEFAULT renders date + time; CALENDAR renders date only; TIMER renders time only. */
     protected showTime = computed(() => this.pickerType() === DateTimePickerType.DEFAULT);
@@ -256,27 +260,34 @@ export class FormDateTimePickerComponent implements ControlValueAccessor, AfterV
         this.valueChanged();
     }
 
+    /** Records whether the current paste was triggered by Ctrl/Cmd+V (not context-menu). */
+    onPickerKeydown(event: KeyboardEvent) {
+        this.isKeyboardPaste = event.key === 'v' && (event.ctrlKey || event.metaKey);
+    }
+
     /**
      * Context-menu paste has no preceding keydown, so PrimeNG's `isKeydown` guard in `onUserInput`
      * is never set and the pasted text is silently ignored. We fix two things here:
      *
      * 1. If no text is currently selected in the input (cursor is just positioned), select all first
      *    so the browser's native paste replaces the entire field value instead of inserting at the
-     *    cursor. We only do this for context-menu paste (picker.isKeydown is null/false at the time
-     *    the paste event fires) — Ctrl+V already sets isKeydown via keydown, so we leave the user's
-     *    cursor/selection intact in that case.
+     *    cursor. We only do this for context-menu paste — Ctrl/Cmd+V is tracked separately via
+     *    onPickerKeydown so we leave the user's cursor/selection intact in that case.
+     *    We intentionally avoid relying on picker.isKeydown here: PrimeNG sets that flag for ANY
+     *    keydown (including Arrow/Home/End), leaving it stale-true until the next input event.
      *
      * 2. Set isKeydown = true so PrimeNG's onUserInput actually processes the pasted text.
      */
     onPickerPaste(event: ClipboardEvent) {
         const picker = this.innerPicker();
         if (picker) {
-            if (!picker.isKeydown) {
+            if (!this.isKeyboardPaste) {
                 const input = event.target as HTMLInputElement;
                 if (input.tagName === 'INPUT' && input.selectionStart === input.selectionEnd) {
                     input.select();
                 }
             }
+            this.isKeyboardPaste = false;
             picker.isKeydown = true;
         }
     }

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
@@ -262,7 +262,7 @@ export class FormDateTimePickerComponent implements ControlValueAccessor, AfterV
 
     /** Records whether the current paste was triggered by Ctrl/Cmd+V (not context-menu). */
     onPickerKeydown(event: KeyboardEvent) {
-        this.isKeyboardPaste = event.key === 'v' && (event.ctrlKey || event.metaKey);
+        this.isKeyboardPaste = event.key.toLowerCase() === 'v' && (event.ctrlKey || event.metaKey);
     }
 
     /**

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
@@ -260,9 +260,9 @@ export class FormDateTimePickerComponent implements ControlValueAccessor, AfterV
         this.valueChanged();
     }
 
-    /** Records whether the current paste was triggered by Ctrl/Cmd+V (not context-menu). */
+    /** Records whether the current paste was triggered by a keyboard shortcut (Ctrl/Cmd+V or Shift+Insert). */
     onPickerKeydown(event: KeyboardEvent) {
-        this.isKeyboardPaste = event.key.toLowerCase() === 'v' && (event.ctrlKey || event.metaKey);
+        this.isKeyboardPaste = (event.key.toLowerCase() === 'v' && (event.ctrlKey || event.metaKey)) || (event.key === 'Insert' && event.shiftKey);
     }
 
     /**

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
@@ -270,14 +270,13 @@ export class FormDateTimePickerComponent implements ControlValueAccessor, AfterV
      */
     onPickerPaste(event: ClipboardEvent) {
         const picker = this.innerPicker();
-        const isContextMenuPaste = !picker?.isKeydown;
-        if (isContextMenuPaste) {
-            const input = event.target as HTMLInputElement;
-            if (input?.tagName === 'INPUT' && input.selectionStart === input.selectionEnd) {
-                input.select();
-            }
-        }
         if (picker) {
+            if (!picker.isKeydown) {
+                const input = event.target as HTMLInputElement;
+                if (input.tagName === 'INPUT' && input.selectionStart === input.selectionEnd) {
+                    input.select();
+                }
+            }
             picker.isKeydown = true;
         }
     }

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.spec.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.spec.ts
@@ -460,8 +460,10 @@ describe('TutorialFreePeriodFormComponent', () => {
             component.setTimeFrame(TimeFrame.Day);
             component.setTimeFrame(TimeFrame.Period);
 
-            // endDate must stay empty — the clear must not be overwritten
-            expect(component.form.get('endDate')!.value).toBeFalsy();
+            // endDate must stay empty — the clear must not be overwritten.
+            // Cleared date controls reset to null (Angular FormControl.reset()), not undefined;
+            // a restore regression would put the original Date back, which toBeNull() also catches.
+            expect(component.form.get('endDate')!.value).toBeNull();
         });
 
         it('does not restore startTime/endTime when the user deliberately cleared them before switching tabs', () => {
@@ -483,9 +485,9 @@ describe('TutorialFreePeriodFormComponent', () => {
             component.setTimeFrame(TimeFrame.Day);
             component.setTimeFrame(TimeFrame.PeriodWithinDay);
 
-            // Both time controls must stay empty
-            expect(component.form.get('startTime')!.value).toBeFalsy();
-            expect(component.form.get('endTime')!.value).toBeFalsy();
+            // Both time controls must stay empty (reset to null, see endDate test above)
+            expect(component.form.get('startTime')!.value).toBeNull();
+            expect(component.form.get('endTime')!.value).toBeNull();
         });
 
         it('does not restore startDate when the user has deliberately cleared it', () => {

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.spec.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.spec.ts
@@ -442,6 +442,52 @@ describe('TutorialFreePeriodFormComponent', () => {
             expect(component.form.get('endDate')!.value).toBe(editedEndDate);
         });
 
+        it('does not restore endDate when the user deliberately cleared it before switching tabs', () => {
+            fixture.componentRef.setInput('isEditMode', true);
+            fixture.componentRef.setInput('formData', {
+                startDate: validStartDateBerlin,
+                endDate: validEndDateBerlinFreePeriod,
+                startTime: undefined,
+                endTime: undefined,
+                reason: validReason,
+            });
+            fixture.detectChanges();
+
+            // User explicitly clears endDate while on the Period tab
+            component.form.get('endDate')!.setValue(undefined);
+
+            // Switch away and back
+            component.setTimeFrame(TimeFrame.Day);
+            component.setTimeFrame(TimeFrame.Period);
+
+            // endDate must stay empty — the clear must not be overwritten
+            expect(component.form.get('endDate')!.value).toBeFalsy();
+        });
+
+        it('does not restore startTime/endTime when the user deliberately cleared them before switching tabs', () => {
+            fixture.componentRef.setInput('isEditMode', true);
+            fixture.componentRef.setInput('formData', {
+                startDate: validStartDateBerlin,
+                endDate: undefined,
+                startTime: validStartTimeBerlin,
+                endTime: validEndTimeBerlin,
+                reason: validReason,
+            });
+            fixture.detectChanges();
+
+            // User explicitly clears the time controls while on the PeriodWithinDay tab
+            component.form.get('startTime')!.setValue(undefined);
+            component.form.get('endTime')!.setValue(undefined);
+
+            // Switch away and back
+            component.setTimeFrame(TimeFrame.Day);
+            component.setTimeFrame(TimeFrame.PeriodWithinDay);
+
+            // Both time controls must stay empty
+            expect(component.form.get('startTime')!.value).toBeFalsy();
+            expect(component.form.get('endTime')!.value).toBeFalsy();
+        });
+
         it('does not restore startDate when the user has deliberately cleared it', () => {
             fixture.componentRef.setInput('isEditMode', true);
             fixture.componentRef.setInput('formData', {

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.spec.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.spec.ts
@@ -381,6 +381,64 @@ describe('TutorialFreePeriodFormComponent', () => {
         expect(component.isStartBeforeEnd).toBe(false);
     });
 
+    describe('edit-mode tab-switch restore', () => {
+        it('restores endDate when switching Day → Period in edit mode', () => {
+            fixture.componentRef.setInput('isEditMode', true);
+            fixture.componentRef.setInput('formData', {
+                startDate: validStartDateBerlin,
+                endDate: validEndDateBerlinFreePeriod,
+                startTime: undefined,
+                endTime: undefined,
+                reason: validReason,
+            });
+            fixture.detectChanges();
+
+            component.setTimeFrame(TimeFrame.Day);
+            expect(component.form.get('endDate')!.value).toBeFalsy();
+
+            component.setTimeFrame(TimeFrame.Period);
+            expect(component.form.get('endDate')!.value).toBe(validEndDateBerlinFreePeriod);
+            expect(component.form.get('startDate')!.value).toBe(validStartDateBerlin);
+        });
+
+        it('restores startTime and endTime when switching Day → PeriodWithinDay in edit mode', () => {
+            fixture.componentRef.setInput('isEditMode', true);
+            fixture.componentRef.setInput('formData', {
+                startDate: validStartDateBerlin,
+                endDate: undefined,
+                startTime: validStartTimeBerlin,
+                endTime: validEndTimeBerlin,
+                reason: validReason,
+            });
+            fixture.detectChanges();
+
+            component.setTimeFrame(TimeFrame.Day);
+            expect(component.form.get('startTime')!.value).toBeFalsy();
+            expect(component.form.get('endTime')!.value).toBeFalsy();
+
+            component.setTimeFrame(TimeFrame.PeriodWithinDay);
+            expect(component.form.get('startTime')!.value).toBe(validStartTimeBerlin);
+            expect(component.form.get('endTime')!.value).toBe(validEndTimeBerlin);
+        });
+
+        it('does not restore startDate when the user has deliberately cleared it', () => {
+            fixture.componentRef.setInput('isEditMode', true);
+            fixture.componentRef.setInput('formData', {
+                startDate: validStartDateBerlin,
+                endDate: undefined,
+                startTime: undefined,
+                endTime: undefined,
+                reason: validReason,
+            });
+            fixture.detectChanges();
+
+            component.startDateControl!.setValue(undefined);
+
+            component.setTimeFrame(TimeFrame.Period);
+            expect(component.form.get('startDate')!.value).toBeFalsy();
+        });
+    });
+
     // === helper functions ===
     const setFormValues = (startDate: Date | undefined, endDate: Date | undefined, startTime: Date | undefined, endTime: Date | undefined, reason: string) => {
         component.startDateControl!.setValue(startDate);

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.spec.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.spec.ts
@@ -421,6 +421,27 @@ describe('TutorialFreePeriodFormComponent', () => {
             expect(component.form.get('endTime')!.value).toBe(validEndTimeBerlin);
         });
 
+        it('restores user-edited endDate (not original formData value) after a tab round-trip', () => {
+            const editedEndDate = dayjs('2021-03-15T00:00:00').tz('Europe/Berlin').toDate();
+            fixture.componentRef.setInput('isEditMode', true);
+            fixture.componentRef.setInput('formData', {
+                startDate: validStartDateBerlin,
+                endDate: validEndDateBerlinFreePeriod,
+                startTime: undefined,
+                endTime: undefined,
+                reason: validReason,
+            });
+            fixture.detectChanges();
+
+            component.form.get('endDate')!.setValue(editedEndDate);
+
+            component.setTimeFrame(TimeFrame.Day);
+            expect(component.form.get('endDate')!.value).toBeFalsy();
+
+            component.setTimeFrame(TimeFrame.Period);
+            expect(component.form.get('endDate')!.value).toBe(editedEndDate);
+        });
+
         it('does not restore startDate when the user has deliberately cleared it', () => {
             fixture.componentRef.setInput('isEditMode', true);
             fixture.componentRef.setInput('formData', {

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
@@ -58,9 +58,10 @@ export class TutorialGroupFreePeriodFormComponent implements OnInit {
     // TimeFrame to store the current time frame of the form.
     protected readonly timeFrame = signal(TimeFrame.Day);
 
-    // Caches the last non-null value of each tab-switchable control before a reset, so that a user
-    // edit (e.g. changing endDate while on the Period tab) is not lost when the user switches away
-    // and back. Falls back to formData() only if no cached value exists. Reset on each new edit load.
+    // Caches the value of each tab-switchable control before a reset — including undefined, so a
+    // deliberate clear is remembered — so that a user edit (e.g. changing endDate while on the
+    // Period tab) is not lost when the user switches away and back. Restore falls back to formData()
+    // only when the control has no cache entry at all. Reset on each new edit load.
     private preResetCache: Record<string, Date | undefined> = {};
 
     // Enum Object to be used for Comparing different TimeFrames in the template.

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
@@ -58,6 +58,11 @@ export class TutorialGroupFreePeriodFormComponent implements OnInit {
     // TimeFrame to store the current time frame of the form.
     protected readonly timeFrame = signal(TimeFrame.Day);
 
+    // Caches the last non-null value of each tab-switchable control before a reset, so that a user
+    // edit (e.g. changing endDate while on the Period tab) is not lost when the user switches away
+    // and back. Falls back to formData() only if no cached value exists. Reset on each new edit load.
+    private preResetCache: Record<string, Date | undefined> = {};
+
     // Enum Object to be used for Comparing different TimeFrames in the template.
     protected readonly TimeFrame = TimeFrame;
 
@@ -68,6 +73,7 @@ export class TutorialGroupFreePeriodFormComponent implements OnInit {
             const editMode = this.isEditMode();
             this.initializeForm();
             if (editMode && formData) {
+                this.preResetCache = {};
                 this.setFormValues(formData);
                 this.setFirstTimeFrameInEditMode(formData);
             }
@@ -79,6 +85,13 @@ export class TutorialGroupFreePeriodFormComponent implements OnInit {
      * @param {TimeFrame} timeFrame - The time frame to set. This should be one of the values from the TimeFrame enum.
      */
     setTimeFrame(timeFrame: TimeFrame) {
+        // Snapshot non-null values before reset so user edits survive a tab round-trip.
+        for (const name of ['endDate', 'startTime', 'endTime']) {
+            const val: Date | undefined = this.form.get(name)?.value ?? undefined;
+            if (val) {
+                this.preResetCache[name] = val;
+            }
+        }
         const resetControls = ['endDate', 'endTime', 'startTime'];
         resetControls.forEach((control) => {
             if (timeFrame === TimeFrame.Day || (timeFrame === TimeFrame.Period && control !== 'endDate') || (timeFrame === TimeFrame.PeriodWithinDay && control === 'endDate')) {
@@ -88,7 +101,7 @@ export class TutorialGroupFreePeriodFormComponent implements OnInit {
         this.timeFrame.set(timeFrame);
         // In edit mode, a prior tab switch may have cleared controls that are relevant to the
         // newly-selected timeFrame (e.g. switching Day→Period leaves endDate empty because
-        // setTimeFrame(Day) reset it). Restore the original formData value for any such control
+        // setTimeFrame(Day) reset it). Restore the cached/original value for any such control
         // so the user sees the pre-existing data again when switching back.
         if (this.isEditMode()) {
             this.restoreVisibleControlsFromFormData(timeFrame);
@@ -97,22 +110,24 @@ export class TutorialGroupFreePeriodFormComponent implements OnInit {
 
     /**
      * For each control that is shown in the new timeFrame, if the control is currently empty
-     * (it was cleared by a prior tab switch), restore the original formData value.
+     * (it was cleared by a prior tab switch), restore the best-known value: the pre-reset cache
+     * (preserving the user's in-session edits) or, if absent, the original formData value.
      * Controls the user intentionally cleared are left alone (guard: only restore when empty).
      */
     private restoreVisibleControlsFromFormData(timeFrame: TimeFrame) {
         const formData = this.formData();
-        const restoreIfEmpty = (controlName: string, originalValue: Date | undefined) => {
+        const restoreIfEmpty = (controlName: string) => {
             const control = this.form.get(controlName);
-            if (control && !control.value && originalValue) {
-                control.setValue(originalValue);
+            const valueToRestore = this.preResetCache[controlName] ?? (formData[controlName as keyof TutorialGroupFreePeriodFormData] as Date | undefined);
+            if (control && !control.value && valueToRestore) {
+                control.setValue(valueToRestore);
             }
         };
         if (timeFrame === TimeFrame.Period) {
-            restoreIfEmpty('endDate', formData.endDate);
+            restoreIfEmpty('endDate');
         } else if (timeFrame === TimeFrame.PeriodWithinDay) {
-            restoreIfEmpty('startTime', formData.startTime);
-            restoreIfEmpty('endTime', formData.endTime);
+            restoreIfEmpty('startTime');
+            restoreIfEmpty('endTime');
         }
     }
 

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
@@ -86,6 +86,35 @@ export class TutorialGroupFreePeriodFormComponent implements OnInit {
             }
         });
         this.timeFrame.set(timeFrame);
+        // In edit mode, a prior tab switch may have cleared controls that are relevant to the
+        // newly-selected timeFrame (e.g. switching Day→Period leaves endDate empty because
+        // setTimeFrame(Day) reset it). Restore the original formData value for any such control
+        // so the user sees the pre-existing data again when switching back.
+        if (this.isEditMode()) {
+            this.restoreVisibleControlsFromFormData(timeFrame);
+        }
+    }
+
+    /**
+     * For each control that is shown in the new timeFrame, if the control is currently empty
+     * (it was cleared by a prior tab switch), restore the original formData value.
+     * Controls the user intentionally cleared are left alone (guard: only restore when empty).
+     */
+    private restoreVisibleControlsFromFormData(timeFrame: TimeFrame) {
+        const formData = this.formData();
+        const restoreIfEmpty = (controlName: string, originalValue: Date | undefined) => {
+            const control = this.form.get(controlName);
+            if (control && !control.value && originalValue) {
+                control.setValue(originalValue);
+            }
+        };
+        restoreIfEmpty('startDate', formData.startDate);
+        if (timeFrame === TimeFrame.Period) {
+            restoreIfEmpty('endDate', formData.endDate);
+        } else if (timeFrame === TimeFrame.PeriodWithinDay) {
+            restoreIfEmpty('startTime', formData.startTime);
+            restoreIfEmpty('endTime', formData.endTime);
+        }
     }
 
     /**

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
@@ -108,7 +108,6 @@ export class TutorialGroupFreePeriodFormComponent implements OnInit {
                 control.setValue(originalValue);
             }
         };
-        restoreIfEmpty('startDate', formData.startDate);
         if (timeFrame === TimeFrame.Period) {
             restoreIfEmpty('endDate', formData.endDate);
         } else if (timeFrame === TimeFrame.PeriodWithinDay) {

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-free-periods/crud/tutorial-free-period-form/tutorial-group-free-period-form.component.ts
@@ -85,12 +85,13 @@ export class TutorialGroupFreePeriodFormComponent implements OnInit {
      * @param {TimeFrame} timeFrame - The time frame to set. This should be one of the values from the TimeFrame enum.
      */
     setTimeFrame(timeFrame: TimeFrame) {
-        // Snapshot non-null values before reset so user edits survive a tab round-trip.
-        for (const name of ['endDate', 'startTime', 'endTime']) {
-            const val: Date | undefined = this.form.get(name)?.value ?? undefined;
-            if (val) {
-                this.preResetCache[name] = val;
-            }
+        // Snapshot the values of controls that are visible in the CURRENT tab before switching
+        // away. Always store the value — even undefined — so an explicit user clear is recorded
+        // in the cache and is not overwritten when the user returns to this tab.
+        const currentTimeFrame = this.timeFrame();
+        const controlsToSnapshot = currentTimeFrame === TimeFrame.Period ? ['endDate'] : currentTimeFrame === TimeFrame.PeriodWithinDay ? ['startTime', 'endTime'] : [];
+        for (const name of controlsToSnapshot) {
+            this.preResetCache[name] = this.form.get(name)?.value ?? undefined;
         }
         const resetControls = ['endDate', 'endTime', 'startTime'];
         resetControls.forEach((control) => {
@@ -110,15 +111,19 @@ export class TutorialGroupFreePeriodFormComponent implements OnInit {
 
     /**
      * For each control that is shown in the new timeFrame, if the control is currently empty
-     * (it was cleared by a prior tab switch), restore the best-known value: the pre-reset cache
-     * (preserving the user's in-session edits) or, if absent, the original formData value.
-     * Controls the user intentionally cleared are left alone (guard: only restore when empty).
+     * (it was cleared by a prior tab switch), restore the best-known value:
+     * - If the cache has an entry for this control (user has previously visited the tab), use the
+     *   cached value. A cached `undefined` means the user deliberately cleared the field, so
+     *   nothing is restored — this prevents a stale cache entry from overwriting an explicit clear.
+     * - If the cache has no entry (first time switching to this tab in the current edit session),
+     *   fall back to the original formData value from the server.
      */
     private restoreVisibleControlsFromFormData(timeFrame: TimeFrame) {
         const formData = this.formData();
         const restoreIfEmpty = (controlName: string) => {
             const control = this.form.get(controlName);
-            const valueToRestore = this.preResetCache[controlName] ?? (formData[controlName as keyof TutorialGroupFreePeriodFormData] as Date | undefined);
+            const valueToRestore =
+                controlName in this.preResetCache ? this.preResetCache[controlName] : (formData[controlName as keyof TutorialGroupFreePeriodFormData] as Date | undefined);
             if (control && !control.value && valueToRestore) {
                 control.setValue(valueToRestore);
             }


### PR DESCRIPTION
### Summary

Fixes two regressions introduced by the PrimeNG `p-datepicker` migration (#13009) that were not caught before merge:

1. **Context-menu paste silently ignored** - pasting via right-click -> Paste had no effect, or appended at the cursor instead of replacing the full field value.
2. **Tutorial group free period edit: switching time-frame tabs clears existing field values** - switching from Day -> Period in edit mode left `endDate` empty; switching back to a previous tab did not restore the pre-existing values.

The layout-shift regression (clear x icon expanding field width) was already resolved by the CSS override added in #13009 and is confirmed correct.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I translated all newly inserted strings into English and German. *(No new user-facing strings - bug fixes only.)*

### Motivation and Context

PR #13009 migrated `jhi-date-time-picker` from a legacy custom picker to PrimeNG `p-datepicker`. Two regressions were discovered during post-merge QA:

**Bug 1 - Context-menu paste:**
PrimeNG's `onUserInput` handler guards input processing behind an `isKeydown` flag that is only set via the `keydown` event. A context-menu paste (right-click -> Paste) never fires a `keydown` event, so `isKeydown` is `null`/`false` when the `input` event arrives, causing `onUserInput` to return early without processing the pasted text. Additionally, because no text is selected before a context-menu paste (unlike Ctrl+V which replaces the selection), the pasted value was inserted at the cursor instead of replacing the full field.

**Bug 2 - Tab-switch clears form data in edit mode:**
`setTimeFrame()` calls `resetDateControl()` for all controls not relevant to the newly selected tab. In edit mode this cleared controls that had been populated from the server - e.g., switching from Period to Day cleared `endDate`, and switching back to Period left the field blank, forcing the user to re-enter the date.

### Description

**Bug 1 fix** (`date-time-picker.component.html` / `.ts`):

Adds `(keydown)` and `(paste)` handlers on the `jhi-date-time-picker` wrapper `<div>`:

- `onPickerKeydown()` records whether the most recent keydown was a keyboard paste shortcut (sets a component-owned `isKeyboardPaste` flag). Recognized shortcuts: Ctrl/Cmd+V and Shift+Insert (the standard Windows/Linux paste shortcut). This avoids the stale-state problem with PrimeNG's `picker.isKeydown`, which is set on **every** keydown (including Arrow/Home/End) and only cleared on the next `input` event - meaning a context-menu paste after a caret-move keydown would incorrectly be treated as a keyboard paste.
- `onPickerPaste()` checks `this.isKeyboardPaste` (not `picker.isKeydown`) to decide whether the paste is from context-menu:
  - For context-menu paste: if the cursor is positioned (no text selected), calls `input.select()` first so the browser paste replaces the whole field value.
  - Sets `picker.isKeydown = true` unconditionally so PrimeNG's guard passes and `onUserInput` processes the pasted text.
  - Resets `isKeyboardPaste = false` after handling.
- Ctrl+V and Shift+Insert are unaffected: `onPickerKeydown` sets `isKeyboardPaste = true`; `onPickerPaste` skips `select()`, preserving the user's cursor position and any existing text selection.

6 Vitest tests cover both paste paths, including the stale-`isKeydown` regression case and Shift+Insert.

**Bug 2 fix** (`tutorial-group-free-period-form.component.ts`):

Adds `restoreVisibleControlsFromFormData()`, called from `setTimeFrame()` in edit mode. After the reset pass, it re-fills any control that is visible in the newly selected tab but is currently empty (cleared by a prior tab switch).

Restore precedence: `preResetCache` (last non-null form value seen before a reset, capturing in-session user edits) > `formData()` (original server value). This ensures that if the user edits `endDate` and then switches tabs, their edit is preserved rather than silently overwritten by the server value on tab-switch back. The cache is cleared on each new edit-mode load.

4 regression tests verify the restore paths, the user-edit round-trip, and the startDate non-restore invariant.

### Steps for Testing

Prerequisites:
- 1 Instructor account
- A course with tutorial groups configured
- At least one existing tutorial group free period in Period mode (has start + end date) and one in PeriodWithinDay mode (has start date + start/end time)

**Bug 1 - Context-menu paste in date-time fields:**

1. Navigate to any form that contains a `jhi-date-time-picker` (e.g. exercise start/end dates, exam dates).
2. Click into a date field to place the cursor (do NOT select text).
3. Copy a valid date string (e.g. `13.06.2026 10:00`) to the clipboard.
4. Right-click the input -> Paste.
5. **Expected:** The entire field value is replaced with the pasted date; PrimeNG parses and accepts it.
6. **Before fix:** The paste was silently ignored or inserted at the cursor without replacing the existing text.
7. Press an arrow key to move the caret, then right-click -> Paste again.
8. **Expected:** Same - the full value is replaced (this was the stale-`isKeydown` scenario).
9. Verify Ctrl+V continues to work correctly - paste inserts at cursor / replaces selection as normal.

**Bug 2 - Tutorial group free period tab switching in edit mode:**

1. Open the edit dialog for a tutorial group free period in **Period** mode (start date + end date set).
2. Switch to the **Day** tab - the end date field disappears.
3. Switch back to the **Period** tab.
4. **Expected:** The end date field is re-populated with the original server value.
5. **Before fix:** The end date field was blank, requiring the instructor to re-enter it.
6. Repeat for **PeriodWithinDay** -> **Day** -> **PeriodWithinDay**: start time and end time should survive the round-trip.
7. Verify the non-restore case: in Period edit mode, clear the end date, switch to Day, switch back to Period - the end date field should remain blank (not restored from the server value).

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| date-time-picker.component.ts | 90.83% | 210 | 69 | 32.9 |
| tutorial-group-free-period-form.component.ts | 95.60% | 207 | 31 | 15.0 |

_Last updated: 2026-06-29 22:58:44 UTC_


### Screenshots

Screenshots will be added after deploying to a test server via Helios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paste behavior in the date-time picker so pasted values are more reliably accepted, including right-click paste and keyboard shortcuts.
  * Preserved entered values when switching between time-frame tabs in the free-period form, reducing accidental data loss in edit mode.
  * Kept manually cleared fields empty when changing tabs, instead of restoring old values unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->