### PR TITLE
`Development`: Stabilize the flaky competency-exercise-linking e2e tests

### DIFF
--- a/src/test/playwright/e2e/atlas/CompetencyExerciseInteractions.spec.ts
+++ b/src/test/playwright/e2e/atlas/CompetencyExerciseInteractions.spec.ts
@@ -28,7 +28,7 @@ test.describe('Competency Exercise Linking', { tag: '@fast' }, () => {
 
     test('Links exercise to single competency', async ({ page, courseManagementExercises, competencyManagement }) => {
         await page.goto(`/course-management/${course.id}/exercises`);
-        await courseManagementExercises.getExercise(exercise.id!).getByRole('link', { name: 'Edit' }).click();
+        await courseManagementExercises.openExerciseEditForm(exercise.id!);
 
         // Link competency
         await page.getByRole('checkbox', { name: competenciesData[0].title }).check();
@@ -36,8 +36,7 @@ test.describe('Competency Exercise Linking', { tag: '@fast' }, () => {
         await expect(page.getByText(competenciesData[0].title)).toBeVisible();
 
         // Verify exercise is linked
-        await competencyManagement.goto(course.id!);
-        await page.getByRole('link', { name: competenciesData[0].title }).click();
+        await competencyManagement.openCompetencyDetail(course.id!, competenciesData[0].title);
         await expect(page.getByRole('button', { name: 'Start exercise' })).toBeVisible();
     });
 
@@ -49,14 +48,14 @@ test.describe('Competency Exercise Linking', { tag: '@fast' }, () => {
         test.setTimeout(360_000);
         // Link to first competency
         await page.goto(`/course-management/${course.id}/exercises`);
-        await courseManagementExercises.getExercise(exercise.id!).getByRole('link', { name: 'Edit' }).click();
+        await courseManagementExercises.openExerciseEditForm(exercise.id!);
         await page.getByRole('checkbox', { name: competenciesData[0].title }).check();
         await page.getByRole('button', { name: 'Save' }).click();
         await expect(page.getByText(competenciesData[0].title)).toBeVisible();
 
         // Link to second competency
         await page.goto(`/course-management/${course.id}/exercises`);
-        await courseManagementExercises.getExercise(exercise.id!).getByRole('link', { name: 'Edit' }).click();
+        await courseManagementExercises.openExerciseEditForm(exercise.id!);
 
         // Remove first competency
         await page.getByRole('checkbox', { name: competenciesData[0].title }).uncheck();
@@ -68,30 +67,27 @@ test.describe('Competency Exercise Linking', { tag: '@fast' }, () => {
         await expect(page.getByText(competenciesData[0].title)).not.toBeVisible();
         await expect(page.getByText(competenciesData[1].title)).toBeVisible();
 
-        await competencyManagement.goto(course.id!);
-
         // Verify first competency no longer shows exercise
-        await page.getByRole('link', { name: competenciesData[0].title }).click();
+        await competencyManagement.openCompetencyDetail(course.id!, competenciesData[0].title);
         await page.waitForLoadState('domcontentloaded');
         await expect(page.getByRole('button', { name: 'Start exercise' })).toHaveCount(0);
-        await competencyManagement.goto(course.id!);
 
         // Verify second competency shows the exercise
-        await page.getByRole('link', { name: competenciesData[1].title }).click();
+        await competencyManagement.openCompetencyDetail(course.id!, competenciesData[1].title);
         await expect(page.getByRole('button', { name: 'Start exercise' })).toBeVisible();
     });
 
     test('Removes competency from exercise when unlinking', async ({ page, courseManagementExercises }) => {
         // Link exercise first
         await page.goto(`/course-management/${course.id}/exercises`);
-        await courseManagementExercises.getExercise(exercise.id!).getByRole('link', { name: 'Edit' }).click();
+        await courseManagementExercises.openExerciseEditForm(exercise.id!);
         await page.getByRole('checkbox', { name: competenciesData[0].title }).check();
         await page.getByRole('button', { name: 'Save' }).click();
         await expect(page.getByText(competenciesData[0].title)).toBeVisible();
 
         // Unlink exercise
         await page.goto(`/course-management/${course.id}/exercises`);
-        await courseManagementExercises.getExercise(exercise.id!).getByRole('link', { name: 'Edit' }).click();
+        await courseManagementExercises.openExerciseEditForm(exercise.id!);
         await page.getByRole('checkbox', { name: competenciesData[0].title }).uncheck();
         await page.getByRole('button', { name: 'Save' }).click();
 

--- a/src/test/playwright/support/pageobjects/course/CompetencyManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CompetencyManagementPage.ts
@@ -28,4 +28,33 @@ export class CompetencyManagementPage {
             await closeButton.click();
         }
     }
+
+    /**
+     * Opens the detail page of the competency with the given title from the management list.
+     *
+     * Navigates to the competency management page and clicks the competency's link. Robust against the multi-node lag
+     * where a freshly created/updated competency link is not yet rendered on the routed node: if the link does not appear,
+     * it reloads the management page (re-fetching the competency list) before clicking. Without this, clicking a link that
+     * only a reload would surface auto-waits until the whole test times out.
+     *
+     * @param courseId - The ID of the course the competency belongs to.
+     * @param title - The exact title of the competency to open.
+     */
+    async openCompetencyDetail(courseId: number, title: string) {
+        const link = this.page.getByRole('link', { name: title });
+        for (let attempt = 0; attempt < 3; attempt++) {
+            // goto() already waits for the competency-list GET (and reloads once if it is slow); navigating fresh on each
+            // attempt re-renders the list so a link that has not surfaced on the routed node yet appears on a later attempt.
+            await this.goto(courseId);
+            try {
+                await link.waitFor({ state: 'visible', timeout: 10000 });
+                await link.click();
+                return;
+            } catch (error) {
+                if (attempt === 2) {
+                    throw error;
+                }
+            }
+        }
+    }
 }

--- a/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
@@ -168,6 +168,34 @@ export class CourseManagementExercisesPage {
         await this.getExercise(exerciseId).locator('.btn', { hasText: 'Participations' }).click();
     }
 
+    /**
+     * Opens the edit form of the given exercise from the exercises list.
+     * <p>
+     * Robust against the multi-node "freshly-created exercise not yet visible on the routed node" race: waits for the
+     * exercise's Edit link in short bursts, reloading the list (which re-issues the exercise-list GET) between attempts.
+     * Without this, clicking the Edit link of a card that only a reload would surface auto-waits until the whole test
+     * times out. The per-attempt timeouts are kept short so the total stays within the fast-test budget.
+     *
+     * @param exerciseId - The ID of the exercise to edit.
+     */
+    async openExerciseEditForm(exerciseId: number): Promise<void> {
+        const editLink = this.getExercise(exerciseId).getByRole('link', { name: 'Edit' });
+        for (let attempt = 0; attempt < 3; attempt++) {
+            try {
+                await editLink.waitFor({ state: 'visible', timeout: 10_000 });
+                await editLink.click();
+                return;
+            } catch (error) {
+                if (attempt === 2) {
+                    throw error;
+                }
+                // The freshly-created exercise card has not surfaced on the routed node yet — re-issue the list GET.
+                await this.page.reload();
+                await this.page.waitForLoadState('domcontentloaded');
+            }
+        }
+    }
+
     async openQuizExerciseDetailsPage(exerciseId: number) {
         await Promise.all([this.page.waitForURL(`/course-management/*/quiz-exercises/${exerciseId}`), this.page.locator(`#exercise-id-${exerciseId} a`).click()]);
     }

--- a/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
@@ -190,8 +190,7 @@ export class CourseManagementExercisesPage {
                     throw error;
                 }
                 // The freshly-created exercise card has not surfaced on the routed node yet — re-issue the list GET.
-                await this.page.reload();
-                await this.page.waitForLoadState('domcontentloaded');
+                await this.page.reload({ waitUntil: 'domcontentloaded' });
             }
         }
     }


### PR DESCRIPTION
### Summary

The `Competency Exercise Linking › Updates competency-exercise linking` Playwright e2e is retry-flaky on multi-node CI (~67%) — it hits the per-test timeout (observed ~14m49s including retries) rather than failing an assertion. This PR stabilizes the three competency-linking tests. It is a **test-only** change (Playwright spec + page objects); no production code is touched.

### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).
- [x] I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).

### Motivation and Context

The tests clicked `getExercise(id).getByRole('link', { name: 'Edit' })` and the competency link directly. Under heavy multi-node CI load, a freshly created exercise/competency is not yet visible on the routed node, so the list surfaces it only after a reload. With no reload and no configured `actionTimeout`, the click auto-waits until the whole test times out. The exercises page object already had a reload-retry helper (`waitForExerciseCardAttached`) for exactly this race, but the competency tests bypassed it.

Note: the race only manifests under heavy multi-node CI load and is **not reproducible at realistic single-run load**, so this is a best-effort stabilization grounded in the documented multi-node visibility race.

### Description

- Added budget-aware reload-retry open helpers and used them in all three competency tests:
  - `CourseManagementExercisesPage.openExerciseEditForm` — waits for the Edit link in short bursts, reloading the exercises list between attempts.
  - `CompetencyManagementPage.openCompetencyDetail` — navigates, waits for the competency link, and re-navigates (re-fetching the list) between attempts.
- Per-attempt timeouts are kept short so the total stays within the fast-test budget instead of hanging to the test timeout.

### Steps for Testing

Test-infrastructure fix; verify by running the affected e2e tests on a multi-node stack:

```
./run-e2e-tests-local-multinode-fast.sh --filter "Competency Exercise Linking"
```

Verified locally under deliberately harsh concurrency (3 tests × 8 repeats × 4 workers = 24 runs): all pass, 0 flaky. An earlier, longer-timeout variant still failed 1/15 under the same stress; the tighter, budget-aware retry resolves it.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for competency-to-exercise linking flows.
  * Made navigation more reliable by opening exercise edit forms and competency detail pages via dedicated helpers.
  * Added retry behavior to handle delayed UI availability across routes.
  * Included an additional page load wait before asserting the “Start exercise” button state to reduce flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->