### PR TITLE
`Development`: Fix flaky build agent server tests

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentIntegrationTest.java
@@ -115,6 +115,12 @@ class BuildAgentIntegrationTest extends AbstractArtemisBuildAgentTest {
         }
     }
 
+    /**
+     * Resets the shared build-agent state after each test so it cannot leak into the next one. The distributed build
+     * job queue, processing-jobs map, and result queue are cleared <em>before</em> the agent is resumed (and once more
+     * afterwards), and the agent is un-paused if a test left it paused. See the inline comment for why the clear must
+     * precede the resume.
+     */
     @AfterEach
     void cleanup() {
         // Clear queued work BEFORE resuming the agent. If we resumed first (as the previous version did), the resume

--- a/src/test/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentIntegrationTest.java
@@ -117,12 +117,22 @@ class BuildAgentIntegrationTest extends AbstractArtemisBuildAgentTest {
 
     @AfterEach
     void cleanup() {
-        // Ensure the build agent is resumed after each test to not affect subsequent tests
+        // Clear queued work BEFORE resuming the agent. If we resumed first (as the previous version did), the resume
+        // would pick up a job that a paused test had cancelled and re-queued, and re-run it. Because some tests mock the
+        // container start to sleep far longer than the build, that re-run keeps executing in the background, leaks past
+        // this test boundary, and contaminates the next test's getRunningBuildJobIds()/build job queue -> flaky tests
+        // (notably testPauseBuildAgentBehavior). This mirrors the clear-then-resume order already used in @BeforeEach.
+        buildJobQueue.clear();
+        processingJobs.clear();
+        resultQueue.clear();
+
+        // Ensure the build agent is resumed after each test to not affect subsequent tests.
         if (sharedQueueProcessingService.isPaused()) {
             resumeBuildAgentTopic.publish(buildAgentShortName);
             await().atMost(10, TimeUnit.SECONDS).until(() -> !sharedQueueProcessingService.isPaused());
         }
-        // Clear any remaining items
+
+        // Clear once more in case the resume produced residue.
         buildJobQueue.clear();
         processingJobs.clear();
         resultQueue.clear();

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
@@ -317,8 +317,41 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
 
     @BeforeEach
     void mockMailService() throws IOException {
-        doNothing().when(javaMailSender).send(any(MimeMessage.class));
+        stubMailSenderSilently();
         Files.createDirectories(tempPath);
+    }
+
+    /**
+     * Stubs the shared {@code javaMailSender} spy to swallow outgoing mails.
+     * <p>
+     * {@link de.tum.cit.aet.artemis.notification.service.notifications.MailSendingService#sendEmail} is {@code @Async},
+     * so a mail send triggered by an earlier test may still be running on the async task executor while this
+     * {@code @BeforeEach} re-stubs the spy. Mockito stubbing is not thread-safe against a concurrent invocation of the
+     * same mock and intermittently fails the stubbing with an {@link AssertionError} (observed as flaky failures of
+     * unrelated tests such as {@code testMissingBuildJobRetryLimit}, whose {@code @BeforeEach} happened to lose the
+     * race). Retrying the stubbing until it succeeds in a window without a concurrent send makes the setup
+     * deterministic; if no clean window is found it rethrows so a genuine problem still surfaces.
+     */
+    private void stubMailSenderSilently() {
+        final int maxAttempts = 100;
+        for (int attempt = 1;; attempt++) {
+            try {
+                doNothing().when(javaMailSender).send(any(MimeMessage.class));
+                return;
+            }
+            catch (AssertionError | RuntimeException e) {
+                if (attempt >= maxAttempts) {
+                    throw e;
+                }
+                try {
+                    Thread.sleep(20);
+                }
+                catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    throw e;
+                }
+            }
+        }
     }
 
     @BeforeEach

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
@@ -315,6 +315,13 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
         return defaultReader;
     }
 
+    /**
+     * Prepares mail-related test infrastructure before each test: stubs the shared {@code javaMailSender} spy so no real
+     * mails are sent (see {@link #stubMailSenderSilently()} for the concurrency handling) and ensures the temporary
+     * directory used by mail/attachment handling exists.
+     *
+     * @throws IOException if the temporary directory cannot be created
+     */
     @BeforeEach
     void mockMailService() throws IOException {
         stubMailSenderSilently();

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
@@ -315,50 +315,10 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
         return defaultReader;
     }
 
-    /**
-     * Prepares mail-related test infrastructure before each test: stubs the shared {@code javaMailSender} spy so no real
-     * mails are sent (see {@link #stubMailSenderSilently()} for the concurrency handling) and ensures the temporary
-     * directory used by mail/attachment handling exists.
-     *
-     * @throws IOException if the temporary directory cannot be created
-     */
     @BeforeEach
     void mockMailService() throws IOException {
-        stubMailSenderSilently();
+        doNothing().when(javaMailSender).send(any(MimeMessage.class));
         Files.createDirectories(tempPath);
-    }
-
-    /**
-     * Stubs the shared {@code javaMailSender} spy to swallow outgoing mails.
-     * <p>
-     * {@link de.tum.cit.aet.artemis.notification.service.notifications.MailSendingService#sendEmail} is {@code @Async},
-     * so a mail send triggered by an earlier test may still be running on the async task executor while this
-     * {@code @BeforeEach} re-stubs the spy. Mockito stubbing is not thread-safe against a concurrent invocation of the
-     * same mock and intermittently fails the stubbing with an {@link AssertionError} (observed as flaky failures of
-     * unrelated tests such as {@code testMissingBuildJobRetryLimit}, whose {@code @BeforeEach} happened to lose the
-     * race). Retrying the stubbing until it succeeds in a window without a concurrent send makes the setup
-     * deterministic; if no clean window is found it rethrows so a genuine problem still surfaces.
-     */
-    private void stubMailSenderSilently() {
-        final int maxAttempts = 100;
-        for (int attempt = 1;; attempt++) {
-            try {
-                doNothing().when(javaMailSender).send(any(MimeMessage.class));
-                return;
-            }
-            catch (AssertionError | RuntimeException e) {
-                if (attempt >= maxAttempts) {
-                    throw e;
-                }
-                try {
-                    Thread.sleep(20);
-                }
-                catch (InterruptedException interrupted) {
-                    Thread.currentThread().interrupt();
-                    throw e;
-                }
-            }
-        }
     }
 
     @BeforeEach


### PR DESCRIPTION
### Summary
Fixes the build-agent cleanup race behind intermittent `BuildAgentIntegrationTest.testPauseBuildAgentBehavior` failures in the concurrently-executed server integration tests (`@Execution(CONCURRENT)`). This is a test-infrastructure race, not a production bug.

### Checklist
#### General
- [x] This is a small (test-only) change that I verified locally (see Steps for Testing).
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.
#### Server
- [x] The change only touches test code; it follows the server/test coding guidelines.
- [x] I documented the touched test lifecycle method using JavaDoc style.

### Motivation and Context
`BuildAgentIntegrationTest.testPauseBuildAgentBehavior` was observed failing intermittently on recent, unrelated PRs, taking down the required `All required CI Passed` gate. Investigation showed this is a pre-existing race in the build-agent test infrastructure that surfaces under concurrent test execution.

### Description
`@AfterEach` resumed the build agent **before** clearing the build job queue. On resume the agent picked up a job that a paused test had cancelled and re-queued, and re-ran it. Because some tests mock the Docker container start to sleep far longer than the build, that re-run kept executing in the background, leaked past the test boundary, and contaminated the next test's `getRunningBuildJobIds()` / build job queue. As a result, `testPauseBuildAgentBehavior`'s assertion that its job is re-queued (`buildJobQueue.peek().id()`) intermittently matched the wrong leftover job and timed out.

Fix: reorder `@AfterEach` to clear the queues **before** resuming, mirroring the order already used in `@BeforeEach`, and clear once more after resuming to remove any residue produced during resume.

Reproduction / verification: temporarily annotating the test with `@RepeatedTest(100)` reproduced **24/100 failures** on `develop` and **0/100** with this fix. The run also dropped from ~44 min to ~3.5 min, since leftover 60s-sleeping jobs no longer accumulate.

### Steps for Testing
This is a test-only change; verify by running the server tests.

1. Build-agent contamination: temporarily annotate `testPauseBuildAgentBehavior` with `@RepeatedTest(100)` and run
   `./gradlew test --tests "de.tum.cit.aet.artemis.buildagent.service.BuildAgentIntegrationTest.testPauseBuildAgentBehavior" -x webapp`.
   On `develop` this fails ~24/100; with this PR it passes 100/100. This test mocks Docker and disables JPA, so it runs without a real Docker/DB.
2. Run the full `BuildAgentIntegrationTest` class; all tests pass.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of integration test teardown by ensuring queued and processing work is fully cleared before and after resuming paused agents, reducing flaky failures from leftover tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->