### PR TITLE
`Development`: Rewrite exam room queries without window functions to keep fast server startup

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exam/repository/ExamRoomRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/repository/ExamRoomRepository.java
@@ -68,46 +68,36 @@ public interface ExamRoomRepository extends ArtemisJpaRepository<ExamRoom, Long>
      * its {@code roomNumber}.
      *
      * <p>
-     * This query uses the SQL window function {@code ROW_NUMBER()} in combination with
-     * the {@code OVER (PARTITION BY ... ORDER BY ...)} clause to identify, for each group of
-     * exam rooms that share the same {@code roomNumber}, which row represents
-     * the latest version.
+     * Exam rooms that share the same {@code roomNumber} are successive versions of the same physical room,
+     * ordered from oldest to newest by {@code createdDate} and, when two versions share the same creation
+     * timestamp (the {@code datetime(3)} column only has millisecond resolution, so rapid re-uploads can
+     * collide), by {@code id}. The latest version is therefore the row for which no other row with the same
+     * {@code roomNumber} has a more recent {@code (createdDate, id)} pair.
      *
      * <p>
-     * <b>Why {@code OVER (PARTITION BY ...)} works:</b><br>
-     * The {@code OVER} clause defines a <i>window</i> — a set of rows related to the current row —
-     * over which a window function (here {@code ROW_NUMBER()}) operates. Unlike aggregate
-     * functions (e.g., {@code MAX()}, {@code COUNT()}), window functions do not collapse rows
-     * into a single result. Instead, each row retains its identity while having access to other rows
-     * in its partition.
-     * <ul>
-     * <li>{@code PARTITION BY er.roomNumber} divides the full result set into
-     * partitions, one per unique room number.</li>
-     * <li>{@code ORDER BY er.createdDate DESC, er.id DESC} orders each partition so that the
-     * most recently created room (and, in case of ties, the one with the highest ID) appears first.</li>
-     * <li>{@code ROW_NUMBER()} then assigns an increasing row number within each partition
-     * according to this order.</li>
-     * </ul>
-     * By selecting only rows where {@code rowNumber = 1}, the query effectively filters out all
-     * but the latest version of each unique exam room.
-     *
-     * <p>
-     * This use of window functions is compliant with the SQL standard and supported by
-     * including MySQL ≥ 8.0 and PostgreSQL ≥ 9.4. Hibernate also supports such queries in JPQL/HQL,
-     * as documented in <a href="https://docs.hibernate.org/orm/current/userguide/html_single/#hql-aggregate-functions-window">the Hibernate User Guide</a>
+     * This is expressed as an anti-join via {@code NOT EXISTS}: a room is returned exactly when no "newer"
+     * room with the same {@code roomNumber} exists. We deliberately avoid the SQL window function
+     * {@code ROW_NUMBER() OVER (PARTITION BY ...)} wrapped in a derived sub-query: that pattern breaks
+     * Hibernate's query bootstrap once {@code hibernate.boot.allow_jdbc_metadata_access} is disabled (which
+     * we keep off to shorten production startup), whereas this {@code NOT EXISTS} formulation is plain SQL
+     * that Hibernate can compile without probing JDBC metadata. Since {@code id} is unique, exactly one row
+     * per {@code roomNumber} survives, and on the small {@code exam_room} table the optimizer resolves the
+     * anti-join to an efficient self-join.
      *
      * @return a {@link Set} of IDs corresponding to the latest version of each unique exam room
      */
     @Query("""
-            SELECT id
-            FROM (
-                SELECT er.id AS id, er.roomNumber AS roomNumber, er.createdDate AS createdDate, ROW_NUMBER() OVER (
-                    PARTITION BY er.roomNumber
-                    ORDER BY er.createdDate DESC, er.id DESC
-                ) AS rowNumber
-                FROM ExamRoom er
+            SELECT er.id
+            FROM ExamRoom er
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM ExamRoom newerVersion
+                WHERE newerVersion.roomNumber = er.roomNumber
+                    AND (
+                        newerVersion.createdDate > er.createdDate
+                        OR (newerVersion.createdDate = er.createdDate AND newerVersion.id > er.id)
+                    )
             )
-            WHERE rowNumber = 1
             """)
     Set<Long> findAllIdsOfNewestExamRoomVersions();
 
@@ -117,27 +107,30 @@ public interface ExamRoomRepository extends ArtemisJpaRepository<ExamRoom, Long>
     /**
      * Returns a collection of {@link ExamRoomForDistributionDTO}, which are derived from {@link ExamRoom}.
      *
-     * @implNote Uses the same PARTITION BY trick as explained in {@link #findAllIdsOfNewestExamRoomVersions}
+     * @implNote Selects the latest version of each unique exam room with the same {@code NOT EXISTS}
+     *           anti-join as {@link #findAllIdsOfNewestExamRoomVersions} and projects it directly into the DTO.
      *
      * @return Basic room information for distribution
      */
     @Query("""
             SELECT new de.tum.cit.aet.artemis.exam.dto.room.ExamRoomForDistributionDTO(
-                roomPartition.id,
-                roomPartition.roomNumber,
-                roomPartition.alternativeRoomNumber,
-                roomPartition.name,
-                roomPartition.alternativeName,
-                roomPartition.building
+                er.id,
+                er.roomNumber,
+                er.alternativeRoomNumber,
+                er.name,
+                er.alternativeName,
+                er.building
             )
-            FROM (
-                SELECT er.id AS id, er.roomNumber AS roomNumber, er.alternativeRoomNumber AS alternativeRoomNumber, er.name AS name, er.alternativeName AS alternativeName, er.building AS building, er.createdDate AS createdDate, ROW_NUMBER() OVER (
-                    PARTITION BY er.roomNumber
-                    ORDER BY er.createdDate DESC, er.id DESC
-                ) AS rowNumber
-                FROM ExamRoom er
-            ) roomPartition
-            WHERE roomPartition.rowNumber = 1
+            FROM ExamRoom er
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM ExamRoom newerVersion
+                WHERE newerVersion.roomNumber = er.roomNumber
+                    AND (
+                        newerVersion.createdDate > er.createdDate
+                        OR (newerVersion.createdDate = er.createdDate AND newerVersion.id > er.id)
+                    )
+            )
             """)
     Set<ExamRoomForDistributionDTO> findAllCurrentExamRoomsForDistribution();
 


### PR DESCRIPTION
### Summary
PR #13013 set `spring.jpa.properties.hibernate.boot.allow_jdbc_metadata_access: false` in production to skip JDBC metadata probing during bootstrap, which noticeably shortens server startup. With that flag disabled, however, the two `ExamRoomRepository` queries that used the SQL window function `ROW_NUMBER() OVER (PARTITION BY ...)` wrapped in a derived `FROM (subquery)` caused the server to no longer start reliably, because Hibernate cannot reliably bootstrap that query pattern without probing the database metadata.

This PR rewrites both queries as plain-SQL `NOT EXISTS` anti-joins. They preserve the exact behavior, compile without any JDBC metadata access, and let us keep the startup-time improvement.

### Motivation and Context
We do not want to lose the startup-time improvement from PR #13013, so we keep `hibernate.boot.allow_jdbc_metadata_access: false`. The only blocker was the window-function-based queries in `ExamRoomRepository`. Removing the `ROW_NUMBER()`/derived-table pattern makes the queries plain, standard SQL that Hibernate compiles without metadata access, so the flag can stay disabled and startup stays fast.

### Description
`ExamRoom`s that share the same `roomNumber` are successive versions of the same physical room, ordered oldest-to-newest by `created_date` and, on ties, by `id`. Two methods needed the latest version per `roomNumber`:

- `findAllIdsOfNewestExamRoomVersions()`
- `findAllCurrentExamRoomsForDistribution()`

Both previously used `ROW_NUMBER() OVER (PARTITION BY er.roomNumber ORDER BY er.createdDate DESC, er.id DESC)` inside a derived sub-query and kept the rows with `rowNumber = 1`.

They are now expressed as a `NOT EXISTS` anti-join: a row is returned exactly when no "newer" row with the same `roomNumber` exists, where "newer" means a greater `(createdDate, id)` pair. This preserves the identical ordering and tie-break semantics:

```sql
WHERE NOT EXISTS (
    SELECT 1 FROM ExamRoom newerVersion
    WHERE newerVersion.roomNumber = er.roomNumber
      AND (newerVersion.createdDate > er.createdDate
           OR (newerVersion.createdDate = er.createdDate AND newerVersion.id > er.id))
)
```

Why this is correct and performant:
- **Exact semantics**: Since `id` is a unique primary key, exactly one row per `roomNumber` survives, identical to `ROW_NUMBER() ... = 1`.
- **The `id` tie-break matters**: `exam_room.created_date` is `datetime(3)` (millisecond resolution), so rapid re-uploads can share a timestamp; the `id` tie-break resolves it.
- **No NULL hazard**: `created_date` is `NOT NULL` at the schema level, so the comparisons never yield `UNKNOWN`.
- **Performance**: `exam_room` is a small table (physical rooms), and the optimizer resolves `NOT EXISTS` to an efficient anti-join. No new index is required. The same `NOT EXISTS (SELECT 1 ...)` idiom is already used by `findAllIdsOfOutdatedAndUnusedExamRooms` in the same repository.

The `findAllIdsOfOutdatedAndUnusedExamRooms` query (which uses a CTE with standard aggregates, not a window function) is unchanged. No behavior visible to end users changes.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] The change is behavior-preserving and is covered by the existing integration tests `ExamRoomIntegrationTest` and `ExamRoomDistributionIntegrationTest` (no new tests needed).
- [x] I documented the Java code using JavaDoc style.

### Steps for Testing
Prerequisites:
- 1 Instructor

1. Log in to Artemis.
2. Navigate to Exam Room administration and upload the same exam-room zip multiple times (creating several versions with the same room number).
3. Open the exam room overview (`GET /api/exam/rooms/overview`) and confirm only the **newest** version of each room number is listed.
4. Create/configure an exam, open the room distribution, and confirm the rooms offered for distribution match the newest versions only.
5. Confirm behavior is identical to before this change.

Startup verification (optional, on a test server):
1. Deploy with `spring.jpa.properties.hibernate.boot.allow_jdbc_metadata_access: false` (production default).
2. Confirm the server starts reliably and the exam room features above work.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| ExamRoomRepository.java | 100.00% | 108 |

_Last updated: 2026-06-30 11:17:51 UTC_

