### PR TITLE
`Development`: Update Jackson to 2.22.0 to resolve jackson-databind security advisories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,21 @@ gitProperties {
 ext["thymeleaf.version"] = "3.1.5.RELEASE"
 ext["tomcat.version"] = "11.0.22"
 
+// Pin the entire Jackson 2.x family to 2.22.0, a release outside every known jackson-databind vulnerable range.
+// Spring Boot 4.1 / Spring AI manage an older 2.21.4 jackson-bom as a dependency-management constraint, which beats
+// transitive requests, so a plain dependency bump is not enough. Re-importing jackson-bom here overrides that managed
+// version while applying the BOM's authoritative per-module versions (e.g. jackson-annotations is 2.22, not 2.22.0).
+// This is done via the dependencyManagement DSL rather than ext["jackson-bom.version"], because overriding an
+// imported-BOM version property breaks io.spring.dependency-management 1.1.7 on Spring Boot 4.1 (it nulls the versions
+// of other managed sub-BOMs such as micrometer / spring-security). The Jackson 3 line (group tools.jackson.*, pinned
+// to 3.1.4 below) is intentionally untouched.
+// Fixes the jackson-databind advisories CVE-2026-54512 / 54513 / 54514 / 54515 / 54516 / 54517 / 54518.
+dependencyManagement {
+    imports {
+        mavenBom "com.fasterxml.jackson:jackson-bom:2.22.0"
+    }
+}
+
 configurations {
     mockitoAgent
 }
@@ -345,17 +360,17 @@ dependencies {
     // Prometheus requires the protobuf-java dependency, but we explicitly use the latest version to avoid security vulnerabilities
     implementation "com.google.protobuf:protobuf-java:4.35.1"
 
-    // Jackson 2 core modules — versions managed by Spring Boot BOM
+    // Jackson 2 core modules — versions supplied by the jackson-bom 2.22.0 override (dependencyManagement block above)
     implementation "com.fasterxml.jackson.core:jackson-annotations"
     implementation "com.fasterxml.jackson.core:jackson-core"
     implementation "com.fasterxml.jackson.core:jackson-databind"
     // Java Time (JSR310) support for Jackson
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     // Support JSON serialization and deserialization of Hibernate specific data types and properties; especially lazy-loading aspects
-    // Use hibernate7 variant for Hibernate 7.x compatibility
-    // NOTE: version pinned because the Spring Boot BOM does not include the hibernate7 variant.
-    // Must be kept in sync with the Jackson 2.x version managed by the BOM.
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-hibernate7:2.21.4"
+    // Use hibernate7 variant for Hibernate 7.x compatibility.
+    // NOTE: version pinned because jackson-bom does not include the hibernate7 variant (separate project).
+    // Must be kept in sync with the Jackson 2.x version (jackson-bom 2.22.0 import above).
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-hibernate7:2.22.0"
     // Support XML serialization and deserialization
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
     // Support YML serialization and deserialization


### PR DESCRIPTION
### Summary

Bumps the Jackson 2.x family to **2.22.0** to resolve **all 7 open Dependabot alerts**, which are all for the transitive `com.fasterxml.jackson.core:jackson-databind` (CVE-2026-54512 / 54513 / 54514 / 54515 / 54516 / 54517 / 54518). Build-config-only change (`build.gradle`); no production or test Java changed.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server
- [x] I implemented the changes with a very good performance (dependency version change only; no new database calls).

### Motivation and Context

GitHub Dependabot reports 7 open security advisories, all against the transitive Jackson 2.x `jackson-databind`:

| Alert | CVE | Severity | jackson-databind 2.x fix |
|------|-----|----------|--------------------------|
| #590 | CVE-2026-54512 | high | 2.21.4 |
| #591 | CVE-2026-54513 | high | 2.21.4 |
| #589 | CVE-2026-54518 | medium | 2.21.4 |
| #592 | CVE-2026-54514 | medium | 2.21.4 |
| #594 | CVE-2026-54516 | medium | 2.21.4 |
| #595 | CVE-2026-54517 | medium | 2.21.4 |
| #593 | CVE-2026-54515 | medium | 2.21.5 |

Six are fixed in 2.21.4 (already our resolved version) and one (CVE-2026-54515) in 2.21.5. **2.21.5 is not published on Maven Central** — the next 2.x release is **2.22.0** (released 2026-06-01). All seven advisories were published 2026-06-23 and none lists 2.22.0 as vulnerable (every upper bound is `<= 2.21.5`), so **2.22.0 sits outside all known vulnerable ranges and closes every alert**.

### Description

- Re-import `com.fasterxml.jackson:jackson-bom:2.22.0` via the `dependencyManagement` DSL in `build.gradle`.
- Bump the separately-pinned `jackson-datatype-hibernate7` (not part of jackson-bom) from 2.21.4 to 2.22.0 to keep it in sync.

Why this mechanism rather than the obvious one-liners:
- The family previously only reached a patched 2.21.4 as a **side effect** of the transitive `jackson-datatype-hibernate7` BOM, while Spring Boot 4.1 / Spring AI manage an **older `jackson-bom` as a dependency-management constraint that beats transitive requests** — so a plain dependency bump leaves the family pinned to the managed version.
- `ext["jackson-bom.version"]` is **intentionally avoided**: overriding an imported-BOM version property breaks `io.spring.dependency-management` 1.1.7 on Spring Boot 4.1 — it nulls the versions of other managed sub-BOMs (micrometer / spring-security / spring-data-ldap), failing the build with empty-version resolution errors.
- A blanket `resolutionStrategy` force is **also wrong**: `jackson-annotations` is published as `2.22` (not `2.22.0`), so a single forced version fails to resolve. Re-importing the BOM applies the correct authoritative per-module versions.
- The Jackson 3 line (`tools.jackson.*`, pinned to 3.1.4) is unaffected — its alerts are already fixed at 3.1.4.

Verified that the whole Jackson 2.x family resolves to 2.22.0/2.22 on both `runtimeClasspath` and `testRuntimeClasspath`, that the Jackson 3 line stays at 3.1.4, and that the other Spring sub-BOMs still resolve.

### Steps for Testing

This is a transitive dependency security bump with no functional/API changes; correct serialization behavior is the only risk.

1. `./gradlew dependencyInsight --dependency com.fasterxml.jackson.core:jackson-databind --configuration runtimeClasspath` resolves to **2.22.0**.
2. `./gradlew compileJava compileTestJava -x webapp` builds.
3. Server CI: existing serialization/DTO and integration tests pass (they round-trip JSON through the global ObjectMapper). Locally verified 98 serialization/DTO unit tests + 50 REST integration tests green.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JSON-related libraries to a newer, consistent version set to improve compatibility and reduce dependency conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->