### PR TITLE
`Programming exercises`: Fix an edge case issue where problem statements could be deleted when editing categories

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseUpdateResource.java
@@ -335,8 +335,13 @@ public class ProgrammingExerciseUpdateResource {
         exercise.validateTitle();
         exercise.setShortName(dto.shortName());
 
-        String newProblemStatement = dto.problemStatement() == null ? "" : dto.problemStatement();
-        exercise.setProblemStatement(newProblemStatement);
+        // The problem statement is owned by the collaborative (Yjs) editor and its dedicated PATCH endpoint, not by this metadata
+        // update. A blank or absent value here means the editor has not finished its initial sync yet (e.g. the user saved a
+        // category change on a slow connection before the statement loaded), so we keep the persisted statement instead of wiping
+        // it. See issue #13046.
+        if (dto.problemStatement() != null && !dto.problemStatement().isBlank()) {
+            exercise.setProblemStatement(dto.problemStatement());
+        }
 
         exercise.setChannelName(dto.channelName());
         exercise.setCategories(dto.categories());

--- a/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.spec.ts
+++ b/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.spec.ts
@@ -262,6 +262,25 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
         expect(instructionChangeSpy).toHaveBeenCalledWith('changed-during-sync');
     });
 
+    it('does not propagate a blank problem statement to the parent during initial sync, but still restores real content (#13046)', () => {
+        const instructionChangeSpy = vi.fn();
+        comp.instructionChange.subscribe(instructionChangeSpy);
+        setRequiredInputs(fixture, { ...exercise, problemStatement: 'existing content' });
+        fixture.detectChanges();
+
+        internals(comp).problemStatementSyncState = { doc: yDoc, text: yText, awareness: yAwareness } as ProblemStatementSyncState;
+        problemStatementSyncServiceMock.isAwaitingInitialSync.mockReturnValue(true);
+
+        // The internal `model.setValue('')` used to clear Monaco before the Yjs binding fires an empty value during bootstrap.
+        // It must not reach the parent, otherwise a save racing the sync would wipe the persisted problem statement.
+        comp.updateProblemStatement('');
+        expect(instructionChangeSpy).not.toHaveBeenCalled();
+
+        // Once the initial sync delivers the real content, it must still propagate so the parent model is restored.
+        comp.updateProblemStatement('existing content restored');
+        expect(instructionChangeSpy).toHaveBeenCalledExactlyOnceWith('existing content restored');
+    });
+
     it('does not emit unsaved flag for finalize hydration when a bootstrap change was suppressed', () => {
         const hasUnsavedSpy = vi.fn();
         const instructionChangeSpy = vi.fn();

--- a/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
@@ -286,6 +286,12 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
 
     updateProblemStatement(problemStatement: string) {
         if (this.exercise().problemStatement !== problemStatement) {
+            // Guard against the internal `model.setValue('')` that clears Monaco before the Yjs binding is created (see initializeProblemStatementSync). While the initial sync is
+            // still pending, a blank value is never a real user edit; propagating it to the parent would wipe the persisted problem statement if the exercise is saved before the sync
+            // finalizes (issue #13046). Non-blank content still propagates so the model is restored once the real statement arrives.
+            if (!problemStatement.trim() && this.problemStatementSyncService.isAwaitingInitialSync()) {
+                return;
+            }
             if (this.suppressUnsavedForNextProblemStatementChange) {
                 this.suppressUnsavedForNextProblemStatementChange = false;
             } else if (this.shouldMarkProblemStatementAsUnsaved()) {

--- a/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
@@ -289,7 +289,7 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
             // Guard against the internal `model.setValue('')` that clears Monaco before the Yjs binding is created (see initializeProblemStatementSync). While the initial sync is
             // still pending, a blank value is never a real user edit; propagating it to the parent would wipe the persisted problem statement if the exercise is saved before the sync
             // finalizes (issue #13046). Non-blank content still propagates so the model is restored once the real statement arrives.
-            if (!problemStatement.trim() && this.problemStatementSyncService.isAwaitingInitialSync()) {
+            if (this.problemStatementSyncService.isAwaitingInitialSync() && problemStatement.trim().length === 0) {
                 return;
             }
             if (this.suppressUnsavedForNextProblemStatementChange) {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseVersionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseVersionIntegrationTest.java
@@ -272,6 +272,30 @@ class ProgrammingExerciseVersionIntegrationTest extends AbstractProgrammingInteg
                 .isNotEqualTo(originalVersion.getExerciseSnapshot());
     }
 
+    /**
+     * Regression test for issue #13046: a metadata-only update (e.g. editing just the categories) must never delete the problem statement. The problem statement is owned by the
+     * collaborative (Yjs) editor and its dedicated PATCH endpoint, so a blank/absent value in the metadata update reflects an editor that has not finished its initial sync yet
+     * and must be treated as "unchanged" rather than wiping the persisted statement.
+     */
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testUpdateProgrammingExercise_blankProblemStatement_keepsExistingProblemStatement() throws Exception {
+        // Arrange: persist a known, non-empty problem statement via the dedicated endpoint, as the collaborative editor would.
+        final String existingStatement = "This problem statement must survive a metadata-only update";
+        final var problemStatementEndpoint = "/api/programming/programming-exercises/" + programmingExercise.getId() + "/problem-statement";
+        request.patchWithResponseBody(problemStatementEndpoint, existingStatement, ProgrammingExercise.class, HttpStatus.OK, MediaType.TEXT_PLAIN);
+
+        // Act: perform a metadata update whose problem statement arrives blank because the editor has not populated it yet (the #13046 race).
+        ExerciseVersionUtilService.updateExercise(programmingExercise);
+        programmingExercise.setProblemStatement(null);
+        request.putWithResponseBody("/api/programming/programming-exercises", de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(programmingExercise),
+                ProgrammingExercise.class, HttpStatus.OK);
+
+        // Assert: the metadata update must not have wiped the persisted problem statement.
+        ProgrammingExercise reloaded = programmingExerciseRepository.findByIdElseThrow(programmingExercise.getId());
+        assertThat(reloaded.getProblemStatement()).as("a metadata-only update must not delete the problem statement (#13046)").isEqualTo(existingStatement);
+    }
+
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testReEvaluateAndUpdateProgrammingExercise_createsExerciseVersion() throws Exception {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseVersionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseVersionIntegrationTest.java
@@ -285,9 +285,11 @@ class ProgrammingExerciseVersionIntegrationTest extends AbstractProgrammingInteg
         final var problemStatementEndpoint = "/api/programming/programming-exercises/" + programmingExercise.getId() + "/problem-statement";
         request.patchWithResponseBody(problemStatementEndpoint, existingStatement, ProgrammingExercise.class, HttpStatus.OK, MediaType.TEXT_PLAIN);
 
-        // Act: perform a metadata update whose problem statement arrives blank because the editor has not populated it yet (the #13046 race).
+        // Act: perform a metadata update whose problem statement arrives blank because the editor has not populated it yet (the #13046 race). A whitespace-only value is used on
+        // purpose: it stays present in the serialized DTO (unlike "", which @JsonInclude(NON_EMPTY) would omit), so the server-side isBlank() guard is exercised, mirroring the
+        // transient blank the client editor emits during its initial sync.
         ExerciseVersionUtilService.updateExercise(programmingExercise);
-        programmingExercise.setProblemStatement(null);
+        programmingExercise.setProblemStatement("   ");
         request.putWithResponseBody("/api/programming/programming-exercises", de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(programmingExercise),
                 ProgrammingExercise.class, HttpStatus.OK);
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseVersionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseVersionIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import de.tum.cit.aet.artemis.assessment.domain.Visibility;
 import de.tum.cit.aet.artemis.course.domain.Course;
@@ -274,24 +275,33 @@ class ProgrammingExerciseVersionIntegrationTest extends AbstractProgrammingInteg
 
     /**
      * Regression test for issue #13046: a metadata-only update (e.g. editing just the categories) must never delete the problem statement. The problem statement is owned by the
-     * collaborative (Yjs) editor and its dedicated PATCH endpoint, so a blank/absent value in the metadata update reflects an editor that has not finished its initial sync yet
-     * and must be treated as "unchanged" rather than wiping the persisted statement.
+     * collaborative (Yjs) editor and its dedicated PATCH endpoint, so a blank or absent value in the metadata update reflects an editor whose initial sync has not finished yet and
+     * must be treated as "unchanged" rather than wiping the persisted statement. During the race the client sends the field present-but-empty ("problemStatement": ""); the cases
+     * below therefore cover the empty string (the real payload), a whitespace-only value, and a completely absent attribute.
+     *
+     * @param problemStatementValue the value sent for {@code problemStatement} in the request body, or {@code null} to omit the attribute entirely
      */
-    @Test
+    @ParameterizedTest(name = "problemStatement=[{0}]")
+    @CsvSource(value = { "''", "'   '", "MISSING" }, nullValues = "MISSING")
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void testUpdateProgrammingExercise_blankProblemStatement_keepsExistingProblemStatement() throws Exception {
+    void testUpdateProgrammingExercise_blankOrMissingProblemStatement_keepsExistingProblemStatement(String problemStatementValue) throws Exception {
         // Arrange: persist a known, non-empty problem statement via the dedicated endpoint, as the collaborative editor would.
         final String existingStatement = "This problem statement must survive a metadata-only update";
         final var problemStatementEndpoint = "/api/programming/programming-exercises/" + programmingExercise.getId() + "/problem-statement";
         request.patchWithResponseBody(problemStatementEndpoint, existingStatement, ProgrammingExercise.class, HttpStatus.OK, MediaType.TEXT_PLAIN);
 
-        // Act: perform a metadata update whose problem statement arrives blank because the editor has not populated it yet (the #13046 race). A whitespace-only value is used on
-        // purpose: it stays present in the serialized DTO (unlike "", which @JsonInclude(NON_EMPTY) would omit), so the server-side isBlank() guard is exercised, mirroring the
-        // transient blank the client editor emits during its initial sync.
+        // Act: perform a metadata update (title, points, ...) whose problem statement arrives blank or absent because the editor has not populated it yet (the #13046 race).
+        // The body is built as a JSON tree so the problem statement can be sent exactly as the client sends it: present-but-empty (""), whitespace-only, or a missing attribute.
+        // Serializing the DTO directly could not express the empty string because @JsonInclude(NON_EMPTY) would drop it.
         ExerciseVersionUtilService.updateExercise(programmingExercise);
-        programmingExercise.setProblemStatement("   ");
-        request.putWithResponseBody("/api/programming/programming-exercises", de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(programmingExercise),
-                ProgrammingExercise.class, HttpStatus.OK);
+        ObjectNode body = (ObjectNode) request.getObjectMapper().valueToTree(de.tum.cit.aet.artemis.programming.dto.UpdateProgrammingExerciseDTO.of(programmingExercise));
+        if (problemStatementValue == null) {
+            body.remove("problemStatement");
+        }
+        else {
+            body.put("problemStatement", problemStatementValue);
+        }
+        request.put("/api/programming/programming-exercises", body, HttpStatus.OK);
 
         // Assert: the metadata update must not have wiped the persisted problem statement.
         ProgrammingExercise reloaded = programmingExerciseRepository.findByIdElseThrow(programmingExercise.getId());


### PR DESCRIPTION
### Summary
Editing a programming exercise's metadata (e.g. its categories) on a slow connection could silently delete the exercise's **problem statement**. This PR stops the data loss with two mutually-reinforcing guards (client + server) and adds regression tests on both layers.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server
- [x] I implemented the changes with a very good performance and prevented too many (unnecessary) and too complex database calls (the guard adds no new database calls).
- [x] I strictly followed the principle of data economy for all database calls.
- [x] I strictly followed the server coding and design guidelines and the REST API guidelines.
- [x] I added integration tests (Spring) related to the change.
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I implemented the changes with a very good performance and prevented too many (unnecessary) REST calls.
- [x] I strictly followed the principle of data economy for all client-server REST calls.
- [x] I strictly followed the client coding guidelines.
- [x] I added Vitest tests related to the change.
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
Fixes #13046.

The problem statement is edited through a collaborative (Yjs) Monaco editor and is persisted via the Yjs sync and the dedicated `PATCH .../problem-statement` endpoint — **not** through the full-form metadata update.

Root cause of the data loss:
1. When the editor initializes, it clears the Monaco model with `model.setValue('')` before attaching its Yjs binding.
2. That empty change is propagated up (`instructionChange('')`), transiently setting `exercise.problemStatement = ''`.
3. The real text is only restored once the initial Yjs sync finalizes. On a slow connection this window is wide.
4. If the user saves the form (e.g. after changing categories) inside that window, the metadata update `PUT` carries an empty problem statement, and the server persisted it (the resulting `exercise_snapshot` then no longer contained `$.problemStatement`).

This matches every clue in the report: the slow-connection correlation, that it never happens when the statement is scrolled into view first (sync already finalized), that it never happens when the statement was opened via the detail route first (warm sync), and the missing `$.problemStatement` in the snapshot.

### Description
Defense in depth:

- **Server** — `ProgrammingExerciseUpdateResource.update()`: a blank or absent `problemStatement` in the metadata update no longer overwrites the persisted statement; it is treated as "unchanged". This shared helper backs both the update and the re-evaluate endpoints, so both are protected. Legitimate clearing of a statement still works through the dedicated `PATCH .../problem-statement` endpoint (which normalizes blank to `null`).
- **Client** — `ProgrammingExerciseEditableInstructionComponent.updateProblemStatement()`: a blank value is no longer propagated to the parent exercise while `ProblemStatementSyncService.isAwaitingInitialSync()` is `true`. Non-blank content still propagates, so real edits and the post-sync restore keep working.

Either guard alone fixes the bug; together they close the whole "empty problem statement in a metadata update" class of issues.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Programming Exercise with a non-empty problem statement

1. Log in as an instructor.
2. Open Chrome DevTools -> Network tab -> set throttling to a slow profile (e.g. "Slow 3G").
3. Navigate to Course Management -> Exercises and click **Edit** on the programming exercise. Do **not** scroll down to the problem-statement editor.
4. Change the **categories** and immediately click **Save** (before the problem-statement editor finishes loading).
5. Reopen the exercise and verify the **problem statement is still present** (before this fix it would be empty).
6. Repeat without throttling and with the problem statement scrolled into view — the statement must be preserved in all cases.
7. Verify normal editing still works: change the problem statement text, save, and confirm the new text is persisted; clear the statement via the editor and confirm it can still be emptied intentionally.

#### Exam Mode Testing
This change only affects editing a programming exercise (instructor-facing); it does not change any student-facing exam view. If you maintain a programming exercise inside an exam, editing its categories must likewise preserve the problem statement.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| programming-exercise-editable-instruction.component.ts | 93.36% | 451 | 82 | 18.2 |

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| ProgrammingExerciseUpdateResource.java | 88.50% | 365 |

_Last updated: 2026-07-01 16:39:44 UTC_

