### PR TITLE
`Development`: Remove extra Spring context from Atlas orchestrator test to restore 10 server starts

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/atlas/web/CompetencyOrchestrationResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/web/CompetencyOrchestrationResourceIntegrationTest.java
@@ -1,6 +1,5 @@
 package de.tum.cit.aet.artemis.atlas.web;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -12,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.TestPropertySource;
 
 import de.tum.cit.aet.artemis.atlas.AbstractAtlasIntegrationTest;
 import de.tum.cit.aet.artemis.core.service.feature.Feature;
@@ -20,10 +18,6 @@ import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseUtilService;
 
-// The orchestrator hard-requires a clustered DistributedDataProvider (no fallback). The default
-// test context (no localci/buildagent profile) has none, so activate the LocalDataProviderService
-// via LocalDataCondition by selecting the local data store.
-@TestPropertySource(properties = "artemis.continuous-integration.data-store=Local")
 class CompetencyOrchestrationResourceIntegrationTest extends AbstractAtlasIntegrationTest {
 
     private static final String TEST_PREFIX = "atlasorchres";
@@ -58,21 +52,6 @@ class CompetencyOrchestrationResourceIntegrationTest extends AbstractAtlasIntegr
     @AfterEach
     void tearDown() {
         featureToggleService.disableFeature(Feature.AtlasAgent);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void runForProgrammingExercise_featureEnabledChatClientFails_returnsBadGateway() throws Exception {
-        // The shared test base autowires a Mockito-mocked ChatClient, so the orchestrator's
-        // null-check passes but invoking chatClient.prompt() yields null and the service catches
-        // the NPE, returning FAILED with LLM_ERROR (mapped to 502 by the controller). No tool
-        // call ever runs so no CompetencyExerciseLink can have been created.
-        request.performMvcRequest(post("/api/atlas/orchestrator/programming-exercises/{exerciseId}/run", programmingExercise.getId()).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadGateway()).andExpect(jsonPath("$.status").value("FAILED")).andExpect(jsonPath("$.failureReason").value("LLM_ERROR"))
-                // @JsonInclude(NON_EMPTY) omits the empty appliedActions list from the response; its absence asserts no actions were applied.
-                .andExpect(jsonPath("$.summary").isNotEmpty()).andExpect(jsonPath("$.appliedActions").doesNotExist());
-
-        assertThat(competencyExerciseLinkRepository.findByExerciseIdWithCompetency(programmingExercise.getId())).isEmpty();
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/shared/architecture/SpringContextConfigurationArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/architecture/SpringContextConfigurationArchitectureTest.java
@@ -75,10 +75,7 @@ class SpringContextConfigurationArchitectureTest extends AbstractArchitectureTes
      */
     private static final String[] ALLOWED_EXCEPTION_CLASSES = {
             // Redis-specific configuration requires a separate context
-            "RedissonDistributedDataTest",
-            // The Atlas orchestrator hard-requires a clustered DistributedDataProvider; the default context has none,
-            // so this test selects the local data store via @TestPropertySource, which requires a separate context
-            "CompetencyOrchestrationResourceIntegrationTest" };
+            "RedissonDistributedDataTest" };
 
     /**
      * Ensures that no test classes outside the allowed base classes use {@code @MockitoSpyBean}.

--- a/supporting_scripts/extract_number_of_server_starts.sh
+++ b/supporting_scripts/extract_number_of_server_starts.sh
@@ -9,8 +9,8 @@ then
   exit 1
 fi
 
-if [[ $numberOfStarts -gt 11 ]]
+if [[ $numberOfStarts -gt 10 ]]
 then
-  echo "The number of Server Starts should be lower than/equals 11! Please adapt this check if the change is intended or try to fix the underlying issue causing a different number of server starts!"
+  echo "The number of Server Starts should be lower than/equals 10! Please adapt this check if the change is intended or try to fix the underlying issue causing a different number of server starts!"
   exit 1
 fi


### PR DESCRIPTION
### Summary

PR #12749 introduced `CompetencyOrchestrationResourceIntegrationTest` with a class-level
`@TestPropertySource(properties = "artemis.continuous-integration.data-store=Local")`. Because the
orchestrator's `claimRun` hard-requires a clustered `DistributedDataProvider` (the local fallback was
removed in review), the test forced the local data store, which spins up a **separate Spring context**
— an 11th server start. To land the PR the CI ceiling in `extract_number_of_server_starts.sh` was bumped
10→11 and the class was added to `ALLOWED_EXCEPTION_CLASSES`. 

Only **one** of the 8 test methods (`runForProgrammingExercise_featureEnabledChatClientFails_returnsBadGateway`)
actually reaches `claimRun` and needs the `DistributedDataProvider`; the other 7 are rejected earlier at the
Spring Security layer or in `precheckExercise` (exam check before any distributed-data access). This PR drops
that single method plus the property source, so the class runs in the shared `AbstractAtlasIntegrationTest`
context again — returning the count to 10 while keeping all endpoint-security coverage — and reverts the CI
ceiling and the arch-test allow-list entry.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context

Follow-up to PR #12749 (merged as `449532565c`). The added integration test required a dedicated Spring
context, raising the server-start count from 10 to 11 and forcing a bump to the CI ceiling in
`extract_number_of_server_starts.sh`.

### Description

- **`CompetencyOrchestrationResourceIntegrationTest.java`**: Removed the class-level
  `@TestPropertySource(...=Local)` annotation and its explanatory comment, the now-unused
  `TestPropertySource` and `assertThat` imports, and the
  `runForProgrammingExercise_featureEnabledChatClientFails_returnsBadGateway` test method (the only one that
  reaches `claimRun`). The class now runs in the shared `AbstractAtlasIntegrationTest` context — no extra
  server start.
- **`SpringContextConfigurationArchitectureTest.java`**: Removed `CompetencyOrchestrationResourceIntegrationTest`
  (and its comment) from `ALLOWED_EXCEPTION_CLASSES`, leaving only `"RedissonDistributedDataTest"`; the class no
  longer uses `@TestPropertySource`.
- **`supporting_scripts/extract_number_of_server_starts.sh`**: Reverted the ceiling `-gt 11` → `-gt 10` and the
  message `lower than/equals 11` → `lower than/equals 10`.

No production code changes — the orchestrator's distributed-data requirement is unchanged. Lost coverage is
limited to the 502/`LLM_ERROR` bad-gateway path of the run endpoint; per the discussion this is acceptable (a
regression surfaces as a thrown exception developers will notice). All 7 remaining methods (authz for
student/tutor/editor/wrong-course/anonymous, feature-toggle-disabled, and exam rejection) still cover the
endpoint's security surface.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-02 13:06:40 UTC_

