### PR TITLE
`Development`: Forbid unsafe `as unknown` casts in the client with an ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -226,6 +226,7 @@ export default tseslint.config(
             'localRules/enforce-signal-apis': 'error',
             'localRules/enforce-cleanup-on-destroy': 'warn',
             'localRules/no-navigation-in-effect': 'error',
+            'localRules/no-as-unknown-cast': 'error',
         },
     },
     // Discourage `ngOnChanges` across Angular client files that have a clean baseline. Prefer computed() for derived

--- a/rules/index.mjs
+++ b/rules/index.mjs
@@ -4,6 +4,7 @@ import enforceCleanupOnDestroy from './enforce-cleanup-on-destroy.mjs';
 import preferSignalReactivityOverNgOnChanges from './prefer-signal-reactivity-over-ngonchanges.mjs';
 import preferSignalTemplateState from './prefer-signal-template-state.mjs';
 import noNavigationInEffect from './no-navigation-in-effect.mjs';
+import noAsUnknownCast from './no-as-unknown-cast.mjs';
 
 export default {
     rules: {
@@ -13,5 +14,6 @@ export default {
         'prefer-signal-reactivity-over-ngonchanges': preferSignalReactivityOverNgOnChanges,
         'prefer-signal-template-state': preferSignalTemplateState,
         'no-navigation-in-effect': noNavigationInEffect,
+        'no-as-unknown-cast': noAsUnknownCast,
     },
 };

--- a/rules/no-as-unknown-cast.mjs
+++ b/rules/no-as-unknown-cast.mjs
@@ -1,0 +1,61 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(() => '');
+
+/**
+ * Forbids `as unknown` type assertions in client PRODUCTION code under `src/main/webapp`.
+ *
+ * `x as unknown` — and especially the `x as unknown as T` double-cast — completely disables the type
+ * checker: `unknown` is assignable from anything, and asserting away from `unknown` is allowed to any
+ * type, so the compiler can no longer catch a mismatch between the real runtime shape and `T`. These
+ * casts are a recurring source of runtime errors that strict TypeScript would otherwise prevent.
+ *
+ * The correct fix is almost always to address the *underlying* type rather than paper over it: correct a
+ * wrong type annotation, fix the DTO / return type / generic at the source, add a type guard, or
+ * restructure the data flow. Widening a value to `unknown` never needs a cast — assignment to an
+ * `unknown`-typed variable/parameter is always allowed.
+ *
+ * The cast is tolerated only in test code (co-located `*.spec.ts` files), where casting to build mocks
+ * and fixtures is sometimes pragmatic and the blast radius is limited to the test.
+ */
+export default createRule({
+    name: 'no-as-unknown-cast',
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Forbid `as unknown` casts (including the `as unknown as T` double-cast) in client production code, because they bypass type safety and risk runtime errors. Allowed only in *.spec.ts test files.',
+        },
+        messages: {
+            noAsUnknown:
+                '`as unknown` casts bypass the type checker and risk runtime errors. Fix the underlying type (DTO, return type, generic), add a type guard, or narrow the value instead of casting. (Only allowed in *.spec.ts test code.)',
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create(context) {
+        // Normalize Windows backslashes so the client-code path check works across operating systems.
+        const filename = (context.filename ?? context.getFilename()).replaceAll('\\', '/');
+
+        // Apply to client production code only. Skip non-client files and co-located test specs.
+        if (!filename.includes('src/main/webapp/')) {
+            return {};
+        }
+        if (filename.endsWith('.spec.ts')) {
+            return {};
+        }
+
+        // Reports both `x as unknown` (TSAsExpression) — which is also the inner node of the
+        // `x as unknown as T` double-cast — and the legacy angle-bracket form `<unknown>x` (TSTypeAssertion).
+        const reportWhenAssertingToUnknown = (node) => {
+            if (node.typeAnnotation?.type === 'TSUnknownKeyword') {
+                context.report({ node, messageId: 'noAsUnknown' });
+            }
+        };
+
+        return {
+            TSAsExpression: reportWhenAssertingToUnknown,
+            TSTypeAssertion: reportWhenAssertingToUnknown,
+        };
+    },
+});

--- a/src/main/webapp/app/account/user/settings/passkey-settings/webauthn-api.service.ts
+++ b/src/main/webapp/app/account/user/settings/passkey-settings/webauthn-api.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@angular/core';
 import { RegisterPasskeyDTO } from 'app/account/user/settings/passkey-settings/dto/register-passkey.dto';
 import { PasskeyLoginResponseDTO } from 'app/account/user/settings/passkey-settings/dto/passkey-login-response.dto';
 import { RegisterPasskeyResponseDTO } from 'app/account/user/settings/passkey-settings/dto/register-passkey-response.dto';
+import { SerializableLoginCredential } from 'app/account/user/settings/passkey-settings/entities/serializable-login-credential';
 
 /**
  * Note: [WebAuthn4j](https://github.com/webauthn4j/webauthn4j) exposes the endpoints, the endpoints are not explicitly defined in a resource
@@ -39,7 +40,9 @@ export class WebauthnApiService extends BaseApiHttpService {
     /**
      * @see {@link https://docs.spring.io/spring-security/reference/servlet/authentication/passkeys.html#passkeys-verify-get}
      */
-    async loginWithPasskey(publicKeyCredential: PublicKeyCredential): Promise<PasskeyLoginResponseDTO> {
+    async loginWithPasskey(publicKeyCredential: Credential | SerializableLoginCredential): Promise<PasskeyLoginResponseDTO> {
+        // The credential is only JSON-serialized for the request body; it may be a real PublicKeyCredential or the
+        // SerializableLoginCredential workaround object produced for misbehaving authenticators (Bitwarden / 1Password 8).
         return await this.post<PasskeyLoginResponseDTO>(`login/webauthn`, publicKeyCredential);
     }
 }

--- a/src/main/webapp/app/account/user/settings/passkey-settings/webauthn.service.ts
+++ b/src/main/webapp/app/account/user/settings/passkey-settings/webauthn.service.ts
@@ -202,7 +202,7 @@ export class WebauthnService {
                 throw new InvalidCredentialError();
             }
 
-            const credential = getLoginCredentialWithGracefullyHandlingAuthenticatorIssues(authenticatorCredential) as unknown as PublicKeyCredential;
+            const credential = getLoginCredentialWithGracefullyHandlingAuthenticatorIssues(authenticatorCredential);
             if (!credential) {
                 // noinspection ExceptionCaughtLocallyJS - intended to be caught locally
                 throw new InvalidCredentialError();

--- a/src/main/webapp/app/assessment/shared/services/example-submission.service.ts
+++ b/src/main/webapp/app/assessment/shared/services/example-submission.service.ts
@@ -111,7 +111,7 @@ export class ExampleSubmissionService {
         if (jsonCopy.exercise) {
             jsonCopy.exercise = ExerciseService.convertExerciseDatesFromClient(jsonCopy.exercise);
             jsonCopy.exercise = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(jsonCopy.exercise!);
-            jsonCopy.exercise.categories = ExerciseService.stringifyExerciseCategories(jsonCopy.exercise);
+            ExerciseService.stringifyExerciseCategories(jsonCopy.exercise);
         }
         return jsonCopy;
     }

--- a/src/main/webapp/app/communication/faq/faq.service.ts
+++ b/src/main/webapp/app/communication/faq/faq.service.ts
@@ -78,8 +78,8 @@ export class FaqService {
      * Converts a faqs categories into a json string (to send them to the server). Does nothing if no categories exist
      * @param faq the faq
      */
-    static stringifyFaqCategories(faq: CreateFaqDTO | UpdateFaqDTO) {
-        return faq.categories?.map((category) => JSON.stringify(category) as unknown as FaqCategory);
+    static stringifyFaqCategories(faq: CreateFaqDTO | UpdateFaqDTO): string[] | undefined {
+        return faq.categories?.map((category) => JSON.stringify(category));
     }
 
     convertFaqCategoriesAsStringFromServer(categories: string[]): FaqCategory[] {
@@ -104,7 +104,8 @@ export class FaqService {
     static parseFaqCategories(faq?: Faq) {
         if (faq?.categories) {
             faq.categories = faq.categories.map((category) => {
-                const categoryObj = JSON.parse(category as unknown as string);
+                // Server sends categories as JSON strings; the model field carries FaqCategory objects after parsing.
+                const categoryObj = typeof category === 'string' ? JSON.parse(category) : category;
                 return new FaqCategory(categoryObj.category, categoryObj.color);
             });
         }

--- a/src/main/webapp/app/communication/faq/faq.service.ts
+++ b/src/main/webapp/app/communication/faq/faq.service.ts
@@ -79,7 +79,8 @@ export class FaqService {
      * @param faq the faq
      */
     static stringifyFaqCategories(faq: CreateFaqDTO | UpdateFaqDTO): string[] | undefined {
-        return faq.categories?.map((category) => JSON.stringify(category));
+        // Skip already-serialized entries so a second call does not double-encode them.
+        return faq.categories?.map((category) => (typeof category === 'string' ? category : JSON.stringify(category)));
     }
 
     convertFaqCategoriesAsStringFromServer(categories: string[]): FaqCategory[] {

--- a/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.ts
+++ b/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.ts
@@ -245,7 +245,7 @@ export class PostingReactionsBarComponent<T extends Posting> implements OnInit {
 
         let showIcon = false;
         // iterate over all answer posts
-        (this.sortedAnswerPosts() as unknown as AnswerPost[]).forEach((answerPost: Posting) => {
+        this.sortedAnswerPosts()?.forEach((answerPost: Posting) => {
             // check if the answer post is newer than the last read date
             const isAuthor = this.metisService.metisUserIsAuthorOfPosting(answerPost);
             const lastReadDate = this.lastReadDate?.();

--- a/src/main/webapp/app/communication/shared/entities/faq.model.ts
+++ b/src/main/webapp/app/communication/shared/entities/faq.model.ts
@@ -23,7 +23,7 @@ export class CreateFaqDTO {
         public faqState: FaqState,
         public questionTitle: string,
         public courseId?: number,
-        public categories?: FaqCategory[],
+        public categories?: (FaqCategory | string)[],
         public questionAnswer?: string,
     ) {}
 
@@ -41,7 +41,7 @@ export class UpdateFaqDTO {
         public id: number,
         public faqState: FaqState,
         public questionTitle: string,
-        public categories?: FaqCategory[],
+        public categories?: (FaqCategory | string)[],
         public questionAnswer?: string,
     ) {}
 

--- a/src/main/webapp/app/course/overview/course-statistics/course-statistics.component.ts
+++ b/src/main/webapp/app/course/overview/course-statistics/course-statistics.component.ts
@@ -248,7 +248,13 @@ export class CourseStatisticsComponent implements OnInit, OnDestroy, AfterViewIn
     readonly groupChartData = computed(() => {
         const dataPerGroup = new Map<ExerciseType, ChartData<'bar', number[], string>>();
         for (const [exerciseType, exerciseGroup] of this.ngxExerciseGroups()) {
-            dataPerGroup.set(exerciseType, multiSeriesToStackedBarData(exerciseGroup as unknown as ChartMultiSeriesEntry[], this.barColors()));
+            // Adapt each NgxExercise to a ChartMultiSeriesEntry: its title is optional, so fall back to an empty
+            // label (the stacked-bar adapter requires a string name); series is already structurally compatible.
+            const entries: ChartMultiSeriesEntry[] = exerciseGroup.map((ngxExercise) => ({
+                name: ngxExercise.name ?? '',
+                series: ngxExercise.series,
+            }));
+            dataPerGroup.set(exerciseType, multiSeriesToStackedBarData(entries, this.barColors()));
         }
         return dataPerGroup;
     });

--- a/src/main/webapp/app/course/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/course/overview/exercise-details/course-exercise-details.component.ts
@@ -106,9 +106,11 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
 
     // courseId is template-bound and written asynchronously (inside the route subscription), so it is backed by a
     // signal to schedule change detection. The public getter/setter preserves external assignment by the learning path parent.
-    private readonly _courseId = signal<number>(undefined as unknown as number);
+    // The backing signal is honestly typed as number | undefined (its construction-time value is genuinely undefined);
+    // the getter narrows with a single non-null assertion because courseId is always assigned before it is ever read.
+    private readonly _courseId = signal<number | undefined>(undefined);
     public get courseId(): number {
-        return this._courseId();
+        return this._courseId()!;
     }
     public set courseId(value: number) {
         this._courseId.set(value);

--- a/src/main/webapp/app/exercise/import/from-file/exercise-import-from-file.component.ts
+++ b/src/main/webapp/app/exercise/import/from-file/exercise-import-from-file.component.ts
@@ -68,7 +68,10 @@ export class ExerciseImportFromFileComponent implements OnInit {
                 // This is needed to make sure that old exported programming exercises can be imported
                 if (!progEx.buildConfig) {
                     const buildConfig = new ProgrammingExerciseBuildConfig();
-                    const raw = exerciseJson as unknown as Partial<ProgrammingExerciseBuildConfig>;
+                    // Old exports serialized the build-config fields flat on the exercise object (before they were nested
+                    // under buildConfig). Those fields are disjoint from Exercise, so we view the parsed exercise as also
+                    // carrying the optional legacy build-config fields and copy them across.
+                    const raw = exerciseJson as Exercise & Partial<ProgrammingExerciseBuildConfig>;
                     Object.assign(buildConfig, raw);
                     progEx.buildConfig = copyBuildConfigFromExerciseJson(buildConfig);
                 }

--- a/src/main/webapp/app/exercise/services/exercise.service.ts
+++ b/src/main/webapp/app/exercise/services/exercise.service.ts
@@ -388,7 +388,8 @@ export class ExerciseService {
      */
     static stringifyExerciseCategories(exercise: { categories?: (ExerciseCategory | string)[] }): void {
         if (exercise.categories) {
-            exercise.categories = exercise.categories.map((category) => JSON.stringify(category));
+            // Skip already-serialized entries so a second call (e.g. on a reused DTO) does not double-encode them.
+            exercise.categories = exercise.categories.map((category) => (typeof category === 'string' ? category : JSON.stringify(category)));
         }
     }
 

--- a/src/main/webapp/app/exercise/services/exercise.service.ts
+++ b/src/main/webapp/app/exercise/services/exercise.service.ts
@@ -381,11 +381,15 @@ export class ExerciseService {
     }
 
     /**
-     * Converts an exercises' categories into a json string (to send them to the server). Does nothing if no categories exist
-     * @param exercise the exercise
+     * Serializes an exercise's categories into JSON strings in place (to send them to the server). Does nothing if no
+     * categories exist. The parameter is a structural view that also admits the serialized string form, so the in-place
+     * conversion needs no cast; the {@link Exercise} model field stays typed as {@link ExerciseCategory}[] for all readers.
+     * @param exercise the exercise whose categories are serialized in place
      */
-    static stringifyExerciseCategories(exercise: Exercise) {
-        return exercise.categories?.map((category) => JSON.stringify(category) as unknown as ExerciseCategory);
+    static stringifyExerciseCategories(exercise: { categories?: (ExerciseCategory | string)[] }): void {
+        if (exercise.categories) {
+            exercise.categories = exercise.categories.map((category) => JSON.stringify(category));
+        }
     }
 
     /**
@@ -435,7 +439,7 @@ export class ExerciseService {
     static convertExerciseFromClient<E extends Exercise>(exercise: E): Exercise {
         let copy = Object.assign(exercise, {});
         copy = ExerciseService.convertExerciseDatesFromClient(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
         if (copy.course) {
             copy.course.exercises = [];
             copy.course.lectures = [];

--- a/src/main/webapp/app/fileupload/manage/services/file-upload-exercise.service.ts
+++ b/src/main/webapp/app/fileupload/manage/services/file-upload-exercise.service.ts
@@ -26,7 +26,7 @@ export class FileUploadExerciseService implements ExerciseServicable<FileUploadE
         let copy = ExerciseService.convertExerciseDatesFromClient(fileUploadExercise);
         copy = FileUploadExerciseService.formatFilePattern(copy);
         copy = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
         return this.http
             .post<FileUploadExercise>(this.resourceUrl, copy, { observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.exerciseService.processExerciseEntityResponse(res)));
@@ -119,7 +119,7 @@ export class FileUploadExerciseService implements ExerciseServicable<FileUploadE
         }
         let copy = ExerciseService.convertExerciseDatesFromClient(adaptedSourceFileUploadExercise);
         copy = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
         return this.http
             .post<FileUploadExercise>(`${this.resourceUrl}/import?sourceId=${adaptedSourceFileUploadExercise.id}`, copy, { observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.exerciseService.processExerciseEntityResponse(res)));

--- a/src/main/webapp/app/iris/overview/services/iris-chat-http.service.ts
+++ b/src/main/webapp/app/iris/overview/services/iris-chat-http.service.ts
@@ -32,7 +32,9 @@ export class IrisChatHttpService {
         return this.httpClient.get<IrisMessageResponseDTO[]>(`${this.apiPrefix}/sessions/${sessionId}/messages`, { observe: 'response' }).pipe(
             map((response) => {
                 const dtos = response.body;
-                if (!dtos) return response as unknown as HttpResponse<IrisMessage[]>;
+                // No body to convert: re-type the empty response via clone's generic overload (clone with no
+                // body key copies the existing body verbatim), preserving the real HttpResponse instance.
+                if (!dtos) return response.clone<IrisMessage[]>({});
 
                 const messages: IrisMessage[] = dtos.map((dto) => {
                     return Object.assign({}, dto, {
@@ -48,9 +50,7 @@ export class IrisChatHttpService {
                     return 0;
                 });
 
-                return Object.assign({}, response, {
-                    body: messages,
-                }) as HttpResponse<IrisMessage[]>;
+                return response.clone<IrisMessage[]>({ body: messages });
             }),
         );
     }

--- a/src/main/webapp/app/iris/shared/entities/iris-content-type.model.ts
+++ b/src/main/webapp/app/iris/shared/entities/iris-content-type.model.ts
@@ -127,20 +127,55 @@ export function getMcqData(content: IrisMessageContent): McqData | undefined {
     return undefined;
 }
 
-export function isMcqSetContent(content: IrisMessageContent): boolean {
+/**
+ * Validates that a plain object has the full McqQuestionData shape: a non-empty question string,
+ * a non-empty explanation string, and an options array with at least 2 valid McqOption entries.
+ * @param obj the value to validate
+ * @returns true if obj is a valid McqQuestionData
+ */
+function isValidMcqQuestion(obj: unknown): obj is McqQuestionData {
+    if (typeof obj !== 'object' || obj == null) {
+        return false;
+    }
+    const rec = obj as Record<string, unknown>;
+    if (typeof rec['question'] !== 'string' || rec['question'].length === 0) {
+        return false;
+    }
+    if (typeof rec['explanation'] !== 'string' || rec['explanation'].length === 0) {
+        return false;
+    }
+    const options = rec['options'];
+    return Array.isArray(options) && options.length >= 2 && options.every(isValidMcqOption);
+}
+
+/**
+ * Runtime type guard that checks whether the given message content is a fully valid MCQ set.
+ * Validates type ('mcq-set') and that questions is a non-empty array of valid McqQuestionData,
+ * mirroring the validation {@link isMcqContent} performs for a single MCQ.
+ * @param content the message content to check
+ * @returns true if the content is JSON content containing a valid McqSetData payload
+ */
+export function isMcqSetContent(content: IrisMessageContent): content is IrisJsonMessageContent & { attributes: McqSetData } {
     if (!isJsonContent(content)) {
         return false;
     }
-    return content.attributes?.['type'] === 'mcq-set';
+    const attrs = content.attributes;
+    if (attrs?.['type'] !== 'mcq-set') {
+        return false;
+    }
+    const questions = attrs['questions'];
+    return Array.isArray(questions) && questions.length > 0 && questions.every(isValidMcqQuestion);
 }
 
+/**
+ * Extracts typed McqSetData from a message content if it represents a valid MCQ set.
+ * Uses the isMcqSetContent type guard for full shape validation instead of an unchecked cast.
+ * @param content the message content to extract from
+ * @returns the McqSetData if the content is a valid MCQ set, undefined otherwise
+ */
 export function getMcqSetData(content: IrisMessageContent): McqSetData | undefined {
-    if (!isJsonContent(content)) {
-        return undefined;
-    }
-    const attrs = content.attributes;
-    if (attrs?.['type'] === 'mcq-set') {
-        return attrs as unknown as McqSetData;
+    if (isMcqSetContent(content)) {
+        return content.attributes;
     }
     return undefined;
 }

--- a/src/main/webapp/app/lecture/manage/lecture-units/services/exercise-unit.service.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/services/exercise-unit.service.ts
@@ -20,7 +20,7 @@ export class ExerciseUnitService {
 
     create(exerciseUnit: ExerciseUnit, lectureId: number): Observable<EntityResponseType> {
         if (exerciseUnit.exercise) {
-            exerciseUnit.exercise.categories = ExerciseService.stringifyExerciseCategories(exerciseUnit.exercise);
+            ExerciseService.stringifyExerciseCategories(exerciseUnit.exercise);
         }
 
         return this.httpClient

--- a/src/main/webapp/app/lecture/manage/lecture-units/services/lecture-unit.service.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/services/lecture-unit.service.ts
@@ -66,7 +66,7 @@ export class LectureUnitService {
         } else if (lectureUnit.type === LectureUnitType.EXERCISE) {
             if ((<ExerciseUnit>lectureUnit).exercise) {
                 (<ExerciseUnit>lectureUnit).exercise = ExerciseService.convertExerciseDatesFromClient((<ExerciseUnit>lectureUnit).exercise!);
-                (<ExerciseUnit>lectureUnit).exercise!.categories = ExerciseService.stringifyExerciseCategories((<ExerciseUnit>lectureUnit).exercise!);
+                ExerciseService.stringifyExerciseCategories((<ExerciseUnit>lectureUnit).exercise!);
                 return lectureUnit;
             }
         }

--- a/src/main/webapp/app/lecture/shared/pdf-viewer/pdf-viewer-iframe-content.component.ts
+++ b/src/main/webapp/app/lecture/shared/pdf-viewer/pdf-viewer-iframe-content.component.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
-import { NgxExtendedPdfViewerModule, PDFNotificationService, type PdfLoadedEvent, pdfDefaultOptions } from 'ngx-extended-pdf-viewer';
+import { type IPDFViewerApplication, NgxExtendedPdfViewerModule, PDFNotificationService, type PdfLoadedEvent, pdfDefaultOptions } from 'ngx-extended-pdf-viewer';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import {
     faChevronDown,
@@ -36,17 +36,14 @@ import type { IframeMessage, IframeMessageData, IframeMessageType } from './pdf-
 // Configure pdf.js default options
 pdfDefaultOptions.assetsFolder = 'assets/ngx-extended-pdf-viewer';
 
-interface PDFViewerApplication {
-    eventBus?: {
-        dispatch: (eventName: string, data?: unknown) => void;
-    };
-    appConfig?: {
-        mainContainer?: HTMLElement;
-    };
-    pdfViewer?: {
-        container?: HTMLElement;
-        currentScale?: number;
-    };
+/**
+ * The library's {@link IPDFViewerApplication}, augmented with the extra runtime fields the toolbar relies on.
+ * PDF.js exposes `appConfig.mainContainer` and `pdfViewer.container` at runtime, but they are absent from
+ * ngx-extended-pdf-viewer's type definitions, so we add them here (as a proper subtype) instead of casting through `unknown`.
+ */
+interface PDFViewerApplication extends IPDFViewerApplication {
+    appConfig: IPDFViewerApplication['appConfig'] & { mainContainer?: HTMLElement };
+    pdfViewer: IPDFViewerApplication['pdfViewer'] & { container?: HTMLElement };
 }
 
 interface FindMatchesCount {
@@ -374,7 +371,7 @@ export class PdfViewerIframeContentComponent implements OnInit, OnDestroy {
     }
 
     private getPdfViewerApplication(): PDFViewerApplication | undefined {
-        return this.pdfNotificationService.onPDFJSInitSignal() as unknown as PDFViewerApplication | undefined;
+        return this.pdfNotificationService.onPDFJSInitSignal() as PDFViewerApplication | undefined;
     }
 
     private dispatchFindCommand(type: 'find' | 'again', query: string, highlightAll: boolean, findPrevious: boolean): void {

--- a/src/main/webapp/app/modeling/manage/services/modeling-exercise.service.ts
+++ b/src/main/webapp/app/modeling/manage/services/modeling-exercise.service.ts
@@ -22,7 +22,7 @@ export class ModelingExerciseService implements ExerciseServicable<ModelingExerc
     create(modelingExercise: ModelingExercise): Observable<EntityResponseType> {
         let copy = ExerciseService.convertExerciseDatesFromClient(modelingExercise);
         copy = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
         return this.http
             .post<ModelingExercise>(this.resourceUrl, copy, { observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.exerciseService.processExerciseEntityResponse(res)));
@@ -56,7 +56,7 @@ export class ModelingExerciseService implements ExerciseServicable<ModelingExerc
     import(adaptedSourceModelingExercise: ModelingExercise) {
         let copy = ExerciseService.convertExerciseDatesFromClient(adaptedSourceModelingExercise);
         copy = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
         return this.http
             .post<ModelingExercise>(`${this.resourceUrl}/import?sourceExerciseId=${adaptedSourceModelingExercise.id}`, copy, { observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.exerciseService.processExerciseEntityResponse(res)));

--- a/src/main/webapp/app/notification/course-notification/course-notification-websocket.service.ts
+++ b/src/main/webapp/app/notification/course-notification/course-notification-websocket.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnDestroy, inject } from '@angular/core';
-import { CourseNotification } from 'app/notification/shared/entities/course-notification/course-notification';
+import { CourseNotification, courseNotificationEnumValueFromName } from 'app/notification/shared/entities/course-notification/course-notification';
 import { Subject, Subscription } from 'rxjs';
 import { CourseNotificationService } from 'app/notification/course-notification/course-notification.service';
 import { CourseNotificationCategory } from 'app/notification/shared/entities/course-notification/course-notification-category';
@@ -91,12 +91,18 @@ export class CourseNotificationWebsocketService implements OnDestroy {
             return this.courseWebsocketSubscriptions[courseId];
         }
         this.courseWebsocketSubscriptions[courseId] = this.websocketService.subscribe('/user/topic/notification/' + courseId).subscribe((notification: CourseNotification) => {
+            const category = courseNotificationEnumValueFromName(CourseNotificationCategory, notification.category);
+            const status = courseNotificationEnumValueFromName(CourseNotificationViewingStatus, notification.status);
+            // Skip malformed or forward-incompatible payloads whose category/status do not map to a known enum value.
+            if (category === undefined || status === undefined) {
+                return;
+            }
             const courseNotification = new CourseNotification(
                 notification.notificationId!,
                 notification.courseId!,
                 notification.notificationType!,
-                CourseNotificationCategory[notification.category as unknown as keyof typeof CourseNotificationCategory],
-                CourseNotificationViewingStatus[notification.status as unknown as keyof typeof CourseNotificationViewingStatus],
+                category,
+                status,
                 convertDateFromServer(notification.creationDate!)!,
                 notification.parameters!,
                 notification.relativeWebAppUrl!,

--- a/src/main/webapp/app/notification/course-notification/course-notification.service.ts
+++ b/src/main/webapp/app/notification/course-notification/course-notification.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnDestroy, inject } from '@angular/core';
 import { faComments, faPersonChalkboard, faRectangleList, faTriangleExclamation } from '@fortawesome/free-solid-svg-icons';
 import dayjs from 'dayjs/esm';
-import { CourseNotification } from 'app/notification/shared/entities/course-notification/course-notification';
+import { CourseNotification, courseNotificationEnumValueFromName } from 'app/notification/shared/entities/course-notification/course-notification';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { BehaviorSubject, Observable, Subscription, of, tap } from 'rxjs';
 import { CourseNotificationInfo } from 'app/notification/shared/entities/course-notification/course-notification-info';
@@ -498,8 +498,8 @@ export class CourseNotificationService implements OnDestroy {
         if (res.body && res.body.content) {
             res.body.content.forEach((notification) => {
                 notification.creationDate = convertDateFromServer(notification.creationDate);
-                notification.category = CourseNotificationCategory[notification.category as unknown as keyof typeof CourseNotificationCategory];
-                notification.status = CourseNotificationViewingStatus[notification.status as unknown as keyof typeof CourseNotificationViewingStatus];
+                notification.category = courseNotificationEnumValueFromName(CourseNotificationCategory, notification.category);
+                notification.status = courseNotificationEnumValueFromName(CourseNotificationViewingStatus, notification.status);
                 if (notification.parameters && notification.parameters['courseTitle']) {
                     notification.courseName = notification.parameters['courseTitle'] as string;
                 }

--- a/src/main/webapp/app/notification/shared/entities/course-notification/course-notification.ts
+++ b/src/main/webapp/app/notification/shared/entities/course-notification/course-notification.ts
@@ -57,6 +57,10 @@ export function courseNotificationEnumValueFromName<E extends number>(enumObject
     if (name === undefined) {
         return undefined;
     }
+    // Idempotent: an already-resolved numeric member is returned as-is (a valid member has a reverse-mapped name string).
+    if (typeof name === 'number') {
+        return typeof enumObject[name] === 'string' ? name : undefined;
+    }
     const member = enumObject[name];
     return typeof member === 'number' ? member : undefined;
 }

--- a/src/main/webapp/app/notification/shared/entities/course-notification/course-notification.ts
+++ b/src/main/webapp/app/notification/shared/entities/course-notification/course-notification.ts
@@ -40,3 +40,23 @@ export class CourseNotification {
         this.relativeWebAppUrl = relativeWebAppUrl;
     }
 }
+
+/**
+ * Resolves a numeric enum member from the enum NAME the server sends over the wire.
+ *
+ * {@link CourseNotificationCategory} and {@link CourseNotificationViewingStatus} are numeric enums, but
+ * Jackson serializes them by constant name (e.g. "GENERAL", "SEEN"). The raw notification therefore carries
+ * a string in `category`/`status` even though the model types them as the enum. This performs the
+ * name → numeric-member reverse lookup, returning `undefined` for an unknown or missing name instead of
+ * fabricating an invalid enum value.
+ *
+ * @param enumObject the numeric enum object (e.g. {@link CourseNotificationCategory})
+ * @param name the value received from the server (a constant name at runtime), or `undefined`
+ */
+export function courseNotificationEnumValueFromName<E extends number>(enumObject: { [key: string]: E | string }, name: string | E | undefined): E | undefined {
+    if (name === undefined) {
+        return undefined;
+    }
+    const member = enumObject[name];
+    return typeof member === 'number' ? member : undefined;
+}

--- a/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-and-editor-container.component.ts
+++ b/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-and-editor-container.component.ts
@@ -93,6 +93,10 @@ type CodeGenerationFileEventType = 'FILE_UPDATED' | 'NEW_FILE';
 type CodeGenerationRepositoryTranslationKey = `artemisApp.programmingExercise.codeGeneration.repositories.${Lowercase<SupportedCodeGenerationRepositoryType>}`;
 type CodeGenerationStateTranslationKey = `artemisApp.programmingExercise.codeGeneration.status.${CodeGenerationExecutionState}`;
 type CodeGenerationFileActionTranslationKey = `artemisApp.programmingExercise.codeGeneration.status.${'fileCreated' | 'fileUpdated'}`;
+// The generated OpenAPI CodeGenerationRequest.repositoryType uses lowercase repository names (exercise, ...),
+// but the backend deserializes RepositoryType enum names (TEMPLATE, SOLUTION, TESTS). This payload type lets the
+// request be built type-safely with the client RepositoryType enum; only repositoryType differs from the generated type.
+type CodeGenerationRequestPayload = Omit<CodeGenerationRequest, 'repositoryType'> & { repositoryType?: RepositoryType };
 
 const CODE_GENERATION_STATE_CLASSES: Record<CodeGenerationExecutionState, string> = {
     idle: 'text-body-secondary',
@@ -621,8 +625,8 @@ export class CodeEditorInstructorAndEditorContainerComponent extends CodeEditorI
      * @returns a request object matching the backend's runtime contract
      */
     private createCodeGenerationRequest(repositoryType: RepositoryType, checkOnly = false, initialAutoGeneration = false): CodeGenerationRequest {
-        // Runtime contract: backend expects RepositoryType enum names (e.g. TEMPLATE), while generated OpenAPI type currently exposes repository names (e.g. exercise).
-        const request: CodeGenerationRequest = { repositoryType, checkOnly } as unknown as CodeGenerationRequest;
+        // Built with the client RepositoryType enum so the whole construction is type-checked; see CodeGenerationRequestPayload.
+        const request: CodeGenerationRequestPayload = { repositoryType, checkOnly };
         if (initialAutoGeneration) {
             request.initialAutoGeneration = true;
         }
@@ -635,7 +639,8 @@ export class CodeEditorInstructorAndEditorContainerComponent extends CodeEditorI
                 request.selectedFeedbackThreadIds = selectedFeedbackThreadIds;
             }
         }
-        return request;
+        // Single boundary assertion to the generated OpenAPI type: only repositoryType differs (enum names vs repository names).
+        return request as CodeGenerationRequest;
     }
 
     /**
@@ -643,7 +648,7 @@ export class CodeEditorInstructorAndEditorContainerComponent extends CodeEditorI
      * @returns check-only request payload for the Hyperion endpoint
      */
     private createCheckOnlyCodeGenerationRequest(): CodeGenerationRequest {
-        return { checkOnly: true } as unknown as CodeGenerationRequest;
+        return { checkOnly: true };
     }
 
     /**

--- a/src/main/webapp/app/programming/manage/services/programming-exercise-sharing.service.ts
+++ b/src/main/webapp/app/programming/manage/services/programming-exercise-sharing.service.ts
@@ -86,7 +86,7 @@ export class ProgrammingExerciseSharingService {
             copy.solutionParticipation = { ...filteredSolutionParticipation } as SolutionProgrammingExerciseParticipation;
         }
 
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
 
         return copy as ProgrammingExercise;
     }

--- a/src/main/webapp/app/programming/manage/services/programming-exercise.service.ts
+++ b/src/main/webapp/app/programming/manage/services/programming-exercise.service.ts
@@ -68,7 +68,7 @@ export class ProgrammingExerciseService {
     automaticSetup(programmingExercise: ProgrammingExercise, emptyRepositories = false): Observable<EntityResponseType> {
         let copy = this.convertDataFromClient(programmingExercise);
         copy = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
         const params = new HttpParams().set('emptyRepositories', String(emptyRepositories));
         return this.http
             .post<ProgrammingExercise>(this.resourceUrl + '/setup', copy, { observe: 'response', params })
@@ -156,7 +156,7 @@ export class ProgrammingExerciseService {
         const options = createRequestOption(importOptions);
         const exercise = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(adaptedSourceProgrammingExercise);
 
-        exercise.categories = ExerciseService.stringifyExerciseCategories(exercise);
+        ExerciseService.stringifyExerciseCategories(exercise);
         return this.http
             .post<ProgrammingExercise>(`${this.resourceUrl}/import?sourceExerciseId=${adaptedSourceProgrammingExercise.id}`, exercise, {
                 params: options,
@@ -547,7 +547,7 @@ export class ProgrammingExerciseService {
     importFromFile(exercise: ProgrammingExercise, courseId: number): Observable<EntityResponseType> {
         let copy = this.convertDataFromClient(exercise);
         copy = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
         const formData = new FormData();
         formData.append('file', exercise.zipFileForImport!);
         const exerciseBlob = new Blob([JSON.stringify(copy)], { type: 'application/json' });

--- a/src/main/webapp/app/quiz/manage/re-evaluate/services/quiz-re-evaluate.service.ts
+++ b/src/main/webapp/app/quiz/manage/re-evaluate/services/quiz-re-evaluate.service.ts
@@ -26,7 +26,7 @@ export class QuizReEvaluateService {
      */
     private convert(quizExercise: QuizExercise): QuizExerciseReEvaluateDTO {
         const copy: QuizExercise = Object.assign({}, quizExercise);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
         return convertQuizExerciseToReEvaluateDTO(copy);
     }
 }

--- a/src/main/webapp/app/quiz/manage/service/quiz-exercise.service.ts
+++ b/src/main/webapp/app/quiz/manage/service/quiz-exercise.service.ts
@@ -35,7 +35,7 @@ export class QuizExerciseService {
      */
     create(quizExercise: QuizExercise, files: Map<string, Blob>): Observable<EntityResponseType> {
         const copy = ExerciseService.convertExerciseDatesFromClient(quizExercise);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
 
         const exerciseDTO = convertQuizExerciseToCreationDTO(copy);
 
@@ -71,7 +71,7 @@ export class QuizExerciseService {
     import(adaptedSourceQuizExercise: QuizExercise, files: Map<string, Blob>) {
         let copy = ExerciseService.convertExerciseDatesFromClient(adaptedSourceQuizExercise);
         copy = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
 
         const formData = new FormData();
         formData.append('exercise', objectToJsonBlob(copy));
@@ -94,7 +94,7 @@ export class QuizExerciseService {
     update(id: number, quizExercise: QuizExercise, files: Map<string, Blob>, req?: any): Observable<EntityResponseType> {
         const options = createRequestOption(req);
         const copy = ExerciseService.convertExerciseDatesFromClient(quizExercise);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
 
         const exerciseDTO = toQuizExerciseUpdateDTO(copy);
         const formData = new FormData();

--- a/src/main/webapp/app/text/manage/text-exercise/service/text-exercise.service.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/service/text-exercise.service.ts
@@ -28,7 +28,7 @@ export class TextExerciseService implements ExerciseServicable<TextExercise> {
     create(textExercise: TextExercise): Observable<EntityResponseType> {
         let copy = ExerciseService.convertExerciseDatesFromClient(textExercise);
         copy = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
         return this.http
             .post<TextExercise>(this.resourceUrl, copy, { observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.exerciseService.processExerciseEntityResponse(res)));
@@ -44,7 +44,7 @@ export class TextExerciseService implements ExerciseServicable<TextExercise> {
     import(adaptedSourceTextExercise: TextExercise) {
         let copy = ExerciseService.convertExerciseDatesFromClient(adaptedSourceTextExercise);
         copy = ExerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = ExerciseService.stringifyExerciseCategories(copy);
+        ExerciseService.stringifyExerciseCategories(copy);
         return this.http
             .post<TextExercise>(`${this.resourceUrl}/import?sourceExerciseId=${adaptedSourceTextExercise.id}`, copy, { observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.exerciseService.processExerciseEntityResponse(res)));


### PR DESCRIPTION
### Summary

`as unknown` casts silence the type checker and are a common source of latent runtime errors. This PR adds a local ESLint rule that forbids them in client **production** code and removes every existing one in favour of a type-safe alternative. This is a client-only, behaviour-neutral change split out of the EmbedPDF migration PR so the type-safety work can be reviewed on its own.

### Checklist
#### General
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Client
- [x] I **strictly** followed the client coding guidelines.
- [x] I documented the TypeScript code using JSDoc style.
- [x] No new user-facing strings were introduced (pure refactor + lint rule).

### Motivation and Context

`as unknown as X` (and `<unknown>`) double-casts defeat TypeScript entirely: they let any value be treated as any type with no compiler check, so a shape mismatch surfaces only at runtime. The project already aims for "100% type safety" in the client guidelines. A lint rule makes that enforceable and prevents regressions, and the accompanying fixes replace the existing casts with constructs the compiler can actually verify.

### Description

**New ESLint rule** `rules/no-as-unknown-cast.mjs` (registered as an error in `eslint.config.mjs`):
- Flags `x as unknown as T` / `x as unknown` and the equivalent `<unknown>` angle-bracket casts.
- Applies to client production code under `src/main/webapp` only; `.spec.ts` files are exempt (coercing a partial mock to a type is pragmatic in tests).

**Fixes** — every pre-existing `as unknown` cast in production code was removed with a type-safe alternative, e.g.:
- Iris MCQ content: a real recursive type guard (`isMcqSetContent` → `isValidMcqQuestion` → `isValidMcqOption`) instead of `attrs as unknown as McqSetData`.
- Websocket course notifications: a `courseNotificationEnumValueFromName` helper that does the server-name → numeric-enum reverse lookup and returns `undefined` for unknown values, instead of `CourseNotificationCategory[x as unknown as keyof …]`.
- `iris-chat-http.service`: `HttpResponse.clone<T>(…)` instead of `Object.assign({}, response, …)` (preserves a real `HttpResponse`).
- Exercise category serialization: mutate `.categories` in place with a structural parameter type instead of a widening double-cast.
- Passkey/webauthn, FAQ, exercise/quiz/text/programming/modeling services and models: honest return types and guards.

### Steps for Testing

1. `pnpm run lint` — passes; the `no-as-unknown-cast` rule reports **0** violations in production code.
2. Introduce a temporary `const x = ({} as unknown as SomeType)` in any `src/main/webapp/**/*.ts` file (not a spec) → `pnpm run lint` flags it; the same cast in a `.spec.ts` is allowed.
3. `pnpm exec tsc -p tsconfig.app.json --noEmit` — compiles clean.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| webauthn-api.service.ts | 100.00% | 22 | 22 | 100.0 |
| webauthn.service.ts | 98.30% | 229 | 98 | 42.8 |
| example-submission.service.ts | 100.00% | 81 | 35 | 43.2 |
| faq.service.ts | 98.11% | 133 | 34 | 25.6 |
| posting-reactions-bar.component.ts | 84.80% | 475 | 80 | 16.8 |
| faq.model.ts | not found (modified) | 50 | ? | ? |
| course-statistics.component.ts | 88.49% | 678 | 48 | 7.1 |
| course-exercise-details.component.ts | 78.63% | 621 | 54 | 8.7 |
| exercise-import-from-file.component.ts | 89.65% | 105 | 42 | 40.0 |
| exercise.service.ts | 88.14% | 438 | 101 | 23.1 |
| file-upload-exercise.service.ts | 100.00% | 78 | 23 | 29.5 |
| iris-chat-http.service.ts | 67.64% | 91 | 8 | 8.8 |
| iris-content-type.model.ts | not found (modified) | 118 | ? | ? |
| exercise-unit.service.ts | 90.00% | 30 | 2 | 6.7 |
| lecture-unit.service.ts | 97.36% | 177 | 26 | 14.7 |
| pdf-viewer-iframe-content.component.ts | 87.24% | 384 | 67 | 17.4 |
| modeling-exercise.service.ts | 100.00% | 61 | 7 | 11.5 |
| course-notification-websocket.service.ts | 93.33% | 95 | 29 | 30.5 |
| course-notification.service.ts | 94.70% | 318 | 83 | 26.1 |
| course-notification.ts | 88.88% | 50 | ? | ? |
| code-editor-instructor-and-editor-container.component.ts | 83.50% | 1450 | 244 | 16.8 |
| programming-exercise-sharing.service.ts | 94.44% | 87 | 6 | 6.9 |
| programming-exercise.service.ts | 88.57% | 364 | 30 | 8.2 |
| quiz-re-evaluate.service.ts | 100.00% | 25 | 58 | 232.0 |
| quiz-exercise.service.ts | 97.29% | 214 | 34 | 15.9 |
| text-exercise.service.ts | 100.00% | 85 | 10 | 11.8 |

_Last updated: 2026-07-02 09:54:47 UTC_


### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved passkey sign-in compatibility across more authenticators and reduced fragile credential casting during login.
  * Made FAQ category handling more robust and improved exercise category serialization consistency across create/import/update flows.
  * Strengthened quiz and notification processing to ignore malformed inputs and tightened MCQ-set validation to prevent incorrect displays.
  * Enhanced course statistics chart rendering and improved course exercise-details reliability; also fixed reaction icon logic and chat message handling for empty responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->