### PR TITLE
`Development`: Unify Jackson to a single 2.22.0 version on the build-script classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,14 @@ buildscript {
         }
     }
     dependencies {
+        // Force the entire Jackson 2.x family to 2.22.0 on the build-script / plugin classpath too.
+        // The org.openapi.generator and springdoc plugins otherwise drag in older jackson-databind
+        // (2.19.x requested, resolved to 2.21.3), which the GitHub dependency graph reports and
+        // Dependabot flags even though the shipped WAR only ever contains 2.22.0. enforcedPlatform
+        // applies the jackson-bom's authoritative per-module versions (e.g. jackson-annotations 2.22),
+        // so no version is invented. Build-time only, not shipped. Keep in sync with the project-level
+        // jackson-bom import below. (Jackson 3, group tools.jackson.*, is intentionally not touched.)
+        classpath enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.22.0")
         classpath "com.diffplug.spotless:spotless-plugin-gradle:${spotless_plugin_version}"
         // This is required so that the latest version of the liquibase gradle plugin works
         classpath("org.liquibase:liquibase-core:${liquibase_version}") {


### PR DESCRIPTION
### Summary
Follow-up to #13043. The shipped application already resolves a single `jackson-databind` 2.22.0, but the **build-script / plugin classpath** still resolved older versions, which GitHub's dependency graph reports and Dependabot keeps flagging. This forces the whole Jackson 2.x family to 2.22.0 on the build-script classpath too, so exactly one version resolves everywhere.

### Checklist
#### General
- [x] I chose a title conforming to the naming conventions for pull requests.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
#### Server
- [x] I implemented the changes with a very good performance and prevented too many (unnecessary) and too complex database calls (build-only change, no runtime/database impact).
- [x] I strictly followed the server coding and design guidelines.

### Motivation and Context
After #13043 pinned Jackson 2.x to `jackson-bom:2.22.0` via `dependencyManagement`, the Dependabot security page still showed several open `jackson-databind` advisories.

Root cause: `dependencyManagement` only governs the project (runtime/compile/test) configurations — those correctly resolve **only 2.22.0**. GitHub's "Automatic Dependency Submission", however, also submits the **build-script / plugin classpath**, where `org.openapi.generator` (7.21.0) and the springdoc plugin dragged in older `jackson-databind` (2.19.x requested, resolved to **2.21.3**). Because the submitted graph therefore still contained 2.19.x/2.21.3, Dependabot kept reporting the advisories fixed in 2.21.4/2.21.5 — even though those versions are never shipped in the WAR.

Note: one advisory (GHSA-5jmj-h7xm-6q6v) has a range `>= 2.22.0, < 2.22.1`; its fixes (2.21.5 / 2.22.1) are **not released yet** (2.22.0 is currently the latest `jackson-databind`), so that single alert cannot be cleared by upgrading and will remain until a fixed release is available. This PR resolves the other Jackson alerts (those matching the residual 2.19.x/2.21.3 copies).

### Description
Add `classpath enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.22.0")` to the `buildscript { dependencies { … } }` block (mirroring the existing Handlebars force already there). `enforcedPlatform` forces the BOM's authoritative per-module versions (e.g. `jackson-annotations` 2.22, `jackson-databind` 2.22.0), so no version is invented and the whole Jackson 2.x family stays internally consistent. Jackson 3 (group `tools.jackson.*`, pinned to 3.1.4) is intentionally not touched. This is a build-time-only change; the produced WAR is unaffected.

### Steps for Testing
This is a build-configuration change with no user-facing behavior; verify via Gradle:

1. `./gradlew buildEnvironment` and confirm every `com.fasterxml.jackson.core:jackson-databind` on the build-script classpath resolves to `-> 2.22.0` (no 2.19.x / 2.21.3).
2. `./gradlew dependencyInsight --configuration runtimeClasspath --dependency com.fasterxml.jackson.core:jackson-databind` still shows `2.22.0`.
3. `./gradlew openApiGenerate` (or a full build) still generates the client successfully (the plugin that pulled the old Jackson).
4. After merge, confirm on the Dependabot page that the `jackson-databind` alerts matching < 2.21.4/2.21.5 are auto-dismissed once the dependency graph is re-submitted.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependency constraints to ensure newer, patched library versions are used during builds.
  * Improved overall build reliability and reduced the risk of pulling in outdated transitive components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->