### PR TITLE
`Programming exercises`: Improve title validation

### DIFF
--- a/src/main/webapp/app/foundation/constants/input.constants.ts
+++ b/src/main/webapp/app/foundation/constants/input.constants.ts
@@ -1,5 +1,6 @@
 export const DATE_FORMAT = 'YYYY-MM-DD';
 export const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm';
+export const DEFAULT_JPA_STRING_COLUMN_LENGTH = 255;
 
 // Note: The values in Constants.java (server) need to be the same
 
@@ -26,6 +27,7 @@ export const COURSE_SHORT_NAME_MAX_LENGTH = 24;
  * Keep in sync with PROGRAMMING_EXERCISE_SHORT_NAME_MAX_LENGTH in Constants.java.
  */
 export const PROGRAMMING_EXERCISE_SHORT_NAME_MAX_LENGTH = 36;
+export const PROGRAMMING_EXERCISE_NAME_MAX_LENGTH = DEFAULT_JPA_STRING_COLUMN_LENGTH;
 /** Programming exercise titles must only contain alphanumeric characters, or whitespaces, or '_' or '-' **/
 export const EXERCISE_TITLE_NAME_PATTERN = '^[a-zA-Z0-9-_ ]+';
 export const EXERCISE_TITLE_NAME_REGEX = new RegExp(EXERCISE_TITLE_NAME_PATTERN);

--- a/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.spec.ts
@@ -29,7 +29,12 @@ import { AuxiliaryRepository } from 'app/programming/shared/entities/programming
 import { AlertService, AlertType } from 'app/foundation/service/alert.service';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { MODULE_FEATURE_THEIA } from 'app/app.constants';
-import { APP_NAME_PATTERN_FOR_SWIFT, MAX_PROGRAMMING_EXERCISE_PROBLEM_STATEMENT_LENGTH, PACKAGE_NAME_PATTERN_FOR_JAVA_KOTLIN } from 'app/foundation/constants/input.constants';
+import {
+    APP_NAME_PATTERN_FOR_SWIFT,
+    MAX_PROGRAMMING_EXERCISE_PROBLEM_STATEMENT_LENGTH,
+    PACKAGE_NAME_PATTERN_FOR_JAVA_KOTLIN,
+    PROGRAMMING_EXERCISE_NAME_MAX_LENGTH,
+} from 'app/foundation/constants/input.constants';
 import { RepositoryType } from 'app/programming/shared/code-editor/model/code-editor.model';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MockResizeObserver } from 'test/helpers/mocks/service/mock-resize-observer';
@@ -1479,6 +1484,28 @@ describe('ProgrammingExerciseUpdateComponent', () => {
             expect(comp.getInvalidReasons()).not.toContainEqual({
                 translateKey: 'artemisApp.programmingExercise.checkoutPath.invalid',
                 translateValues: {},
+            });
+        });
+
+        it('should add validation error when title exceeds max length', () => {
+            comp.programmingExercise.title = 'a'.repeat(PROGRAMMING_EXERCISE_NAME_MAX_LENGTH + 1);
+
+            const reasons = comp.getInvalidReasons();
+
+            expect(reasons).toContainEqual({
+                translateKey: 'artemisApp.exercise.form.title.maxlength',
+                translateValues: { max: PROGRAMMING_EXERCISE_NAME_MAX_LENGTH },
+            });
+        });
+
+        it('should not add validation error when title is within max length', () => {
+            comp.programmingExercise.title = 'a'.repeat(PROGRAMMING_EXERCISE_NAME_MAX_LENGTH);
+
+            const reasons = comp.getInvalidReasons();
+
+            expect(reasons).not.toContainEqual({
+                translateKey: 'artemisApp.exercise.form.title.maxlength',
+                translateValues: { max: PROGRAMMING_EXERCISE_NAME_MAX_LENGTH },
             });
         });
 

--- a/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.ts
@@ -28,6 +28,7 @@ import {
     PACKAGE_NAME_PATTERN_FOR_GO,
     PACKAGE_NAME_PATTERN_FOR_JAVA_BLACKBOX,
     PACKAGE_NAME_PATTERN_FOR_JAVA_KOTLIN,
+    PROGRAMMING_EXERCISE_NAME_MAX_LENGTH,
     PROGRAMMING_EXERCISE_SHORT_NAME_PATTERN,
 } from 'app/foundation/constants/input.constants';
 import { ExerciseCategory } from 'app/exercise/shared/entities/exercise/exercise-category.model';
@@ -121,6 +122,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
     protected readonly invalidDirectoryNamePattern = INVALID_DIRECTORY_NAME_PATTERN;
     protected readonly shortNamePattern = PROGRAMMING_EXERCISE_SHORT_NAME_PATTERN;
     private readonly maxProblemStatementLength = MAX_PROGRAMMING_EXERCISE_PROBLEM_STATEMENT_LENGTH;
+    private readonly maxNameLength = PROGRAMMING_EXERCISE_NAME_MAX_LENGTH;
 
     exerciseInfoComponent = viewChild(ProgrammingExerciseInformationComponent);
     exerciseDifficultyComponent = viewChild(ProgrammingExerciseModeComponent);
@@ -1323,6 +1325,11 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
             validationErrorReasons.push({
                 translateKey: 'artemisApp.exercise.form.title.pattern',
                 translateValues: {},
+            });
+        } else if (this.programmingExercise.title.length > this.maxNameLength) {
+            validationErrorReasons.push({
+                translateKey: 'artemisApp.exercise.form.title.maxlength',
+                translateValues: { max: this.maxNameLength },
             });
         } else if (this.exerciseInfoComponent()?.exerciseTitleChannelComponent().titleChannelNameComponent().field_title?.control?.errors?.disallowedValue) {
             validationErrorReasons.push({

--- a/src/main/webapp/i18n/de/exercise.json
+++ b/src/main/webapp/i18n/de/exercise.json
@@ -319,7 +319,7 @@
                     "undefined": "Du musst einen Titel angeben.",
                     "pattern": "Der Titel darf nur aus Buchstaben, Zahlen und '_', '-' oder Leerzeichen bestehen!",
                     "disallowedValue": "Der Titel wird bereits für eine andere Aufgabe genutzt!",
-                    "maxlength": "Der Titel muss weniger als {{max}} Zeichen lang sein!"
+                    "maxlength": "Der Titel darf höchstens {{max}} Zeichen lang sein!"
                 },
                 "channelName": {
                     "empty": "Du musst einen Kanalnamen angeben."

--- a/src/main/webapp/i18n/de/exercise.json
+++ b/src/main/webapp/i18n/de/exercise.json
@@ -318,7 +318,8 @@
                 "title": {
                     "undefined": "Du musst einen Titel angeben.",
                     "pattern": "Der Titel darf nur aus Buchstaben, Zahlen und '_', '-' oder Leerzeichen bestehen!",
-                    "disallowedValue": "Der Titel wird bereits für eine andere Aufgabe genutzt!"
+                    "disallowedValue": "Der Titel wird bereits für eine andere Aufgabe genutzt!",
+                    "maxlength": "Der Titel muss weniger als {{max}} Zeichen lang sein!"
                 },
                 "channelName": {
                     "empty": "Du musst einen Kanalnamen angeben."

--- a/src/main/webapp/i18n/en/exercise.json
+++ b/src/main/webapp/i18n/en/exercise.json
@@ -318,7 +318,8 @@
                 "title": {
                     "undefined": "You need to specify a title.",
                     "pattern": "The title must only consist of alphanumeric characters and '_', '-' or whitespaces!",
-                    "disallowedValue": "The title is already used for another exercise!"
+                    "disallowedValue": "The title is already used for another exercise!",
+                    "maxlength": "The title must be shorter than {{max}} characters!"
                 },
                 "channelName": {
                     "empty": "You need to specify a channel name."

--- a/src/main/webapp/i18n/en/exercise.json
+++ b/src/main/webapp/i18n/en/exercise.json
@@ -319,7 +319,7 @@
                     "undefined": "You need to specify a title.",
                     "pattern": "The title must only consist of alphanumeric characters and '_', '-' or whitespaces!",
                     "disallowedValue": "The title is already used for another exercise!",
-                    "maxlength": "The title must be shorter than {{max}} characters!"
+                    "maxlength": "The title can be at most {{max}} characters long!"
                 },
                 "channelName": {
                     "empty": "You need to specify a channel name."


### PR DESCRIPTION
### Summary 
User input into the title field of the programming exercise creation process could result in an internal server error. This fix is implementing client side validation to avoid user confusion and give better feedback.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
Hibernation string limitation of 255 makes the creation of programming exercises with exessive long titles invalid. User feedback should be clear and thus user input should be validated before hitting an internal server error.


### Description
Adds client validation of title length to the creation of programming exercises


### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Course

1. Log in to Artemis
2. Navigate to Course Administration
3. Create Programming Exercise
4. Try exessively long input for title field (255 characters and above)

### Review Progress
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/28575964824) did not pass (`failure`). Coverage below may be partial.

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| input.constants.ts | 100.00% | 36 | ? | ? |
| programming-exercise-update.component.ts | 87.21% | 1359 | 203 | 14.9 |

_Last updated: 2026-07-02 14:00:27 UTC_

