### PR TITLE
`Development`: Add a type-safe JSON.parse helper and type exercise category parsing

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -229,6 +229,28 @@ export default tseslint.config(
             'localRules/no-as-unknown-cast': 'error',
         },
     },
+    // Force JSON.parse results to carry an explicit type. `JSON.parse` is declared to return `any`, which
+    // silently disables type checking on everything derived from it — a typo like `obj.colour` compiles and
+    // yields `undefined` at runtime. Route parsing through `parseJson<T>()` (app/foundation/util/json.util),
+    // whose generic defaults to `unknown`, so a caller cannot touch the result's properties without stating
+    // the expected shape. Warn-level for now: existing call sites are migrated incrementally before this is
+    // raised to `error`. The wrapper itself holds the single sanctioned `JSON.parse` (line-level disabled),
+    // and test code may parse fixtures freely (specs excluded below).
+    {
+        files: ['src/main/webapp/**/*.ts'],
+        ignores: ['**/*.spec.ts'],
+        rules: {
+            'no-restricted-properties': [
+                'warn',
+                {
+                    object: 'JSON',
+                    property: 'parse',
+                    message:
+                        'Avoid untyped JSON.parse(): its result is `any`, so property access is unchecked. Use parseJson<T>() from app/foundation/util/json.util and pass the expected type.',
+                },
+            ],
+        },
+    },
     // Discourage `ngOnChanges` across Angular client files that have a clean baseline. Prefer computed() for derived
     // state and effect() for genuine side effects. `ngOnChanges` still works in Angular 21 (it fires for signal inputs),
     // so this is a consistency preference, not a correctness rule. Existing migration-backlog files are excluded above

--- a/src/main/webapp/app/course/overview/course-dashboard/course-dashboard.service.ts
+++ b/src/main/webapp/app/course/overview/course-dashboard/course-dashboard.service.ts
@@ -4,7 +4,8 @@ import { Observable, map } from 'rxjs';
 import { ExerciseInformation, LectureUnitInformation, StudentMetrics } from 'app/atlas/shared/entities/student-metrics.model';
 import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import dayjs from 'dayjs/esm';
-import { ExerciseCategory } from 'app/exercise/shared/entities/exercise/exercise-category.model';
+import { ExerciseCategory, SerializedExerciseCategory } from 'app/exercise/shared/entities/exercise/exercise-category.model';
+import { parseJson } from 'app/foundation/util/json.util';
 import { LectureUnitType } from 'app/lecture/shared/entities/lecture-unit/lectureUnit.model';
 
 @Injectable({ providedIn: 'root' })
@@ -45,7 +46,11 @@ export class CourseDashboardService {
     ): { [key: string]: ExerciseInformation } {
         return Object.keys(exerciseInformation).reduce(
             (acc, key) => {
-                const exerciseCategories = categories[key]?.map((category: string) => JSON.parse(category) as ExerciseCategory) || [];
+                const exerciseCategories =
+                    categories[key]?.map((category: string) => {
+                        const categoryObj = parseJson<SerializedExerciseCategory>(category);
+                        return new ExerciseCategory(categoryObj.category, categoryObj.color);
+                    }) || [];
                 const exercise = exerciseInformation[key];
                 acc[key] = {
                     ...exercise,

--- a/src/main/webapp/app/exercise/services/exercise.service.spec.ts
+++ b/src/main/webapp/app/exercise/services/exercise.service.spec.ts
@@ -422,6 +422,29 @@ describe('Exercise Service', () => {
         expect(converted.startDate).toBeUndefined();
     });
 
+    it('should convert category strings from server into real ExerciseCategory instances', () => {
+        const categories = [JSON.stringify({ color: '#6ae8ac', category: 'category1' }), JSON.stringify({ color: '#123456', category: 'category2' })];
+
+        const result = service.convertExerciseCategoriesAsStringFromServer(categories);
+
+        expect(result).toHaveLength(2);
+        // Must be real instances (not plain parsed objects), so the class methods are available.
+        expect(result[0]).toBeInstanceOf(ExerciseCategory);
+        expect(result[0].category).toBe('category1');
+        expect(result[0].color).toBe('#6ae8ac');
+        expect(result[0].equals(new ExerciseCategory('category1', '#6ae8ac'))).toBe(true);
+        expect(result[1].category).toBe('category2');
+    });
+
+    it('should skip malformed category strings instead of throwing', () => {
+        const categories = [JSON.stringify({ color: '#6ae8ac', category: 'category1' }), '{ not valid json', JSON.stringify({ color: '#123456', category: 'category2' })];
+
+        const result = service.convertExerciseCategoriesAsStringFromServer(categories);
+
+        expect(result).toHaveLength(2);
+        expect(result.map((c) => c.category)).toEqual(['category1', 'category2']);
+    });
+
     it('should get exercise details', () => {
         const exerciseId = 123;
 

--- a/src/main/webapp/app/exercise/services/exercise.service.ts
+++ b/src/main/webapp/app/exercise/services/exercise.service.ts
@@ -433,10 +433,17 @@ export class ExerciseService {
      */
     convertExerciseCategoriesAsStringFromServer(categories: string[]): ExerciseCategory[] {
         // Build real ExerciseCategory instances (not plain parsed objects) so callers can use equals()/compare().
-        return categories.map((category) => {
-            const categoryObj = parseJson<SerializedExerciseCategory>(category);
-            return new ExerciseCategory(categoryObj.category, categoryObj.color);
-        });
+        // Skip malformed entries instead of throwing, mirroring parseExerciseCategories above.
+        return categories
+            .map((category) => {
+                try {
+                    const categoryObj = parseJson<SerializedExerciseCategory>(category);
+                    return new ExerciseCategory(categoryObj.category, categoryObj.color);
+                } catch {
+                    return undefined;
+                }
+            })
+            .filter((category): category is ExerciseCategory => category !== undefined);
     }
 
     /**

--- a/src/main/webapp/app/exercise/services/exercise.service.ts
+++ b/src/main/webapp/app/exercise/services/exercise.service.ts
@@ -9,8 +9,9 @@ import { map, tap } from 'rxjs/operators';
 import { AccountService } from 'app/core/auth/account.service';
 import { StatsForDashboard } from 'app/assessment/shared/assessment-dashboard/stats-for-dashboard.model';
 import { TranslateService } from '@ngx-translate/core';
-import { ExerciseCategory } from 'app/exercise/shared/entities/exercise/exercise-category.model';
+import { ExerciseCategory, SerializedExerciseCategory } from 'app/exercise/shared/entities/exercise/exercise-category.model';
 import { convertDateFromClient, convertDateFromServer } from 'app/foundation/util/date.utils';
+import { parseJson } from 'app/foundation/util/json.util';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { InitializationState } from 'app/exercise/shared/entities/participation/participation.model';
 import { ModelingExercise } from 'app/modeling/shared/entities/modeling-exercise.model';
@@ -413,8 +414,9 @@ export class ExerciseService {
             exercise.categories = exercise.categories
                 .map((category) => {
                     try {
-                        // Handle both JSON strings (from some endpoints) and objects (from DTOs)
-                        const categoryObj = typeof category === 'string' ? JSON.parse(category) : category;
+                        // Handle both JSON strings (from some endpoints) and objects (from DTOs). The explicit
+                        // type makes property access below compiler-checked (JSON.parse alone returns `any`).
+                        const categoryObj: SerializedExerciseCategory = typeof category === 'string' ? parseJson<SerializedExerciseCategory>(category) : category;
                         return new ExerciseCategory(categoryObj.category, categoryObj.color);
                     } catch {
                         // Skip malformed category entries
@@ -430,7 +432,11 @@ export class ExerciseService {
      * @param categories that are converted to categories
      */
     convertExerciseCategoriesAsStringFromServer(categories: string[]): ExerciseCategory[] {
-        return categories.map((category) => JSON.parse(category));
+        // Build real ExerciseCategory instances (not plain parsed objects) so callers can use equals()/compare().
+        return categories.map((category) => {
+            const categoryObj = parseJson<SerializedExerciseCategory>(category);
+            return new ExerciseCategory(categoryObj.category, categoryObj.color);
+        });
     }
 
     /**

--- a/src/main/webapp/app/exercise/shared/entities/exercise/exercise-category.model.ts
+++ b/src/main/webapp/app/exercise/shared/entities/exercise/exercise-category.model.ts
@@ -28,3 +28,12 @@ export class ExerciseCategory {
         return displayText < otherCategoryDisplayText ? -1 : 1;
     }
 }
+
+/**
+ * The wire shape of a serialized {@link ExerciseCategory}: the JSON-string payload stored in the DB
+ * (server `Set<String>`) or a DTO object. Derived from the class via `Pick`, so it carries only the data
+ * fields — no methods — and stays in sync with the class: renaming a field breaks this at compile time
+ * instead of silently drifting. Use it to type the result of parsing a category, then build a real
+ * {@link ExerciseCategory} instance from it.
+ */
+export type SerializedExerciseCategory = Pick<ExerciseCategory, 'category' | 'color'>;

--- a/src/main/webapp/app/foundation/util/json.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/json.util.spec.ts
@@ -13,7 +13,7 @@ describe('parseJson', () => {
         expect(parseJson<string>('"hello"')).toBe('hello');
         expect(parseJson<number>('42')).toBe(42);
         expect(parseJson<boolean>('true')).toBe(true);
-        expect(parseJson<undefined>('null')).toBeNull();
+        expect(parseJson<null>('null')).toBeNull();
     });
 
     it('throws on invalid JSON, exactly like JSON.parse', () => {

--- a/src/main/webapp/app/foundation/util/json.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/json.util.spec.ts
@@ -1,0 +1,22 @@
+import { parseJson } from 'app/foundation/util/json.util';
+
+describe('parseJson', () => {
+    it('parses a JSON object', () => {
+        expect(parseJson<{ a: number; b: string }>('{"a":1,"b":"x"}')).toEqual({ a: 1, b: 'x' });
+    });
+
+    it('parses a JSON array', () => {
+        expect(parseJson<number[]>('[1,2,3]')).toEqual([1, 2, 3]);
+    });
+
+    it('parses primitives', () => {
+        expect(parseJson<string>('"hello"')).toBe('hello');
+        expect(parseJson<number>('42')).toBe(42);
+        expect(parseJson<boolean>('true')).toBe(true);
+        expect(parseJson<undefined>('null')).toBeNull();
+    });
+
+    it('throws on invalid JSON, exactly like JSON.parse', () => {
+        expect(() => parseJson('{ not valid')).toThrow(SyntaxError);
+    });
+});

--- a/src/main/webapp/app/foundation/util/json.util.ts
+++ b/src/main/webapp/app/foundation/util/json.util.ts
@@ -1,0 +1,21 @@
+/**
+ * Typed wrapper around {@link JSON.parse}.
+ *
+ * `JSON.parse` is declared to return `any`, which silently disables type checking on everything derived
+ * from its result — a typo such as `obj.colour` compiles and yields `undefined` at runtime. This wrapper
+ * localizes that single `any` boundary: the generic defaults to `unknown`, so a caller that does not
+ * supply the expected shape gets an `unknown` back and cannot access its properties without a compile
+ * error. Always call it with an explicit type argument, e.g. `parseJson<MyDto>(text)`.
+ *
+ * This is a compile-time guard against typos and refactor drift, not runtime validation: the parsed value
+ * is still whatever the input string contained. For untrusted or structurally complex payloads, validate
+ * the result after parsing (e.g. against a schema).
+ *
+ * @param value the JSON string to parse
+ * @returns the parsed value, typed as {@link T}
+ * @throws SyntaxError if `value` is not valid JSON (same as {@link JSON.parse})
+ */
+export function parseJson<T = unknown>(value: string): T {
+    // eslint-disable-next-line no-restricted-properties -- the single sanctioned JSON.parse call; this wrapper exists precisely to provide it with an explicit return type
+    return JSON.parse(value);
+}


### PR DESCRIPTION
### Summary
`JSON.parse` is typed to return `any`, so everything derived from a parsed value is unchecked — a typo like `categoryObj.colour` compiles and silently yields `undefined` at runtime. This PR adds a small type-safe wrapper, `parseJson<T>()`, plus an ESLint rule that steers code toward it, and applies it to the exercise-category (de)serialization so that hot spot becomes fully compiler-checked. No user-facing behavior changes.

### Checklist
#### General
- [x] This is a small, non-user-facing change that I verified locally (type-check, unit tests, lint, and formatting all green).
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Client
- [x] The change adds no REST calls and no data fetching; it is a pure type-safety/tooling change with no performance or data-economy impact.
- [x] I strictly followed the client coding guidelines.
- [x] I added Vitest tests for the new helper, and the changed code paths are covered by existing specs.
- [x] I documented the new TypeScript code using JSDoc style.

### Motivation and Context
Client code parses server JSON in ~50 places via bare `JSON.parse`, whose return type is `any`. That disables type checking on the result: property typos and refactor drift go unnoticed by the compiler and only surface as `undefined` at runtime. The exercise-category parsing was a concrete example — it read `categoryObj.category`/`categoryObj.color` off an untyped value, and one path cast a plain parsed object to `ExerciseCategory`, producing objects missing the class methods (`equals()`/`compare()`).

This is a small, self-contained first step toward removing that class of bug, following the pattern of the recently added `no-as-unknown-cast` rule (#13052): a targeted rule plus a typed helper, adopted incrementally rather than flipping on broad type-aware rules that would swamp the build.

### Description
- **New `parseJson<T = unknown>()` helper** (`app/foundation/util/json.util.ts`): a thin wrapper around `JSON.parse`. The generic defaults to `unknown`, so callers cannot access the result's properties without stating the expected shape (the compiler enforces it). It localizes the single unavoidable `any` boundary that `JSON.parse` otherwise scatters across the codebase. Compile-time typo/refactor protection, not runtime validation.
- **ESLint ban** (`no-restricted-properties`, warn-level, production code only): flags bare `JSON.parse` and points to `parseJson<T>()`. Warn-level because ~48 existing call sites remain to be migrated incrementally; test code and the wrapper itself are exempt.
- **Typed exercise-category parsing**: `parseExerciseCategories` and `convertExerciseCategoriesAsStringFromServer` (in `exercise.service.ts`) and the equivalent spot in `course-dashboard.service.ts` now parse into `SerializedExerciseCategory` — a `Pick<ExerciseCategory, 'category' | 'color'>` (no new interface; derived from the class so it stays in sync) — and build real `ExerciseCategory` instances, replacing an `as ExerciseCategory` cast that produced method-less objects.

Normal-path runtime behavior is unchanged. The two spots that previously returned plain parsed objects now return real instances, so callers can safely use `equals()`/`compare()`.

### Steps for Testing
This is a non-user-facing type-safety change; verification is build + automated tests + confirming category display is unaffected.

1. Check out the branch and run:
   - `pnpm run vitest:run -- src/main/webapp/app/foundation/util/json.util.spec.ts src/main/webapp/app/exercise/services/exercise.service.spec.ts src/main/webapp/app/course/overview/course-dashboard/course-dashboard.service.spec.ts` → all green.
   - `pnpm exec tsc --project tsconfig.app.json --noEmit` → no errors.
   - `pnpm run lint` → no new errors (the new rule surfaces existing bare `JSON.parse` calls as warnings only).
2. As an instructor, open a course with exercises that have categories, and confirm categories still display and that adding/removing categories in the exercise update forms still works.
3. Confirm the course dashboard exercise list still shows category chips correctly.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Category display + add/remove in exercise management
- [ ] Course dashboard category chips

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| course-dashboard.service.ts | 100.00% | 121 | 24 | 19.8 |
| exercise.service.ts | 88.94% | 448 | 109 | 24.3 |
| exercise-category.model.ts | not found (modified) | 20 | 6 | 30.0 |
| json.util.ts | 100.00% | 3 | 7 | 233.3 |

_Last updated: 2026-07-02 09:35:58 UTC_

