### PR TITLE
`Development`: Migrate all client JSON.parse to a typed helper and ban `as any` casts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -227,21 +227,22 @@ export default tseslint.config(
             'localRules/enforce-cleanup-on-destroy': 'warn',
             'localRules/no-navigation-in-effect': 'error',
             'localRules/no-as-unknown-cast': 'error',
+            'localRules/no-as-any-cast': 'error',
         },
     },
     // Force JSON.parse results to carry an explicit type. `JSON.parse` is declared to return `any`, which
     // silently disables type checking on everything derived from it — a typo like `obj.colour` compiles and
     // yields `undefined` at runtime. Route parsing through `parseJson<T>()` (app/foundation/util/json.util),
     // whose generic defaults to `unknown`, so a caller cannot touch the result's properties without stating
-    // the expected shape. Warn-level for now: existing call sites are migrated incrementally before this is
-    // raised to `error`. The wrapper itself holds the single sanctioned `JSON.parse` (line-level disabled),
-    // and test code may parse fixtures freely (specs excluded below).
+    // the expected shape. All production call sites route through the wrapper, so this is an `error`. The
+    // wrapper itself holds the single sanctioned `JSON.parse` (line-level disabled), and test code may parse
+    // fixtures freely (specs excluded below).
     {
         files: ['src/main/webapp/**/*.ts'],
         ignores: ['**/*.spec.ts'],
         rules: {
             'no-restricted-properties': [
-                'warn',
+                'error',
                 {
                     object: 'JSON',
                     property: 'parse',

--- a/rules/index.mjs
+++ b/rules/index.mjs
@@ -5,6 +5,7 @@ import preferSignalReactivityOverNgOnChanges from './prefer-signal-reactivity-ov
 import preferSignalTemplateState from './prefer-signal-template-state.mjs';
 import noNavigationInEffect from './no-navigation-in-effect.mjs';
 import noAsUnknownCast from './no-as-unknown-cast.mjs';
+import noAsAnyCast from './no-as-any-cast.mjs';
 
 export default {
     rules: {
@@ -15,5 +16,6 @@ export default {
         'prefer-signal-template-state': preferSignalTemplateState,
         'no-navigation-in-effect': noNavigationInEffect,
         'no-as-unknown-cast': noAsUnknownCast,
+        'no-as-any-cast': noAsAnyCast,
     },
 };

--- a/rules/no-as-any-cast.mjs
+++ b/rules/no-as-any-cast.mjs
@@ -1,0 +1,59 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(() => '');
+
+/**
+ * Forbids `as any` type assertions in client PRODUCTION code under `src/main/webapp`.
+ *
+ * `x as any` opts the expression out of type checking entirely: `any` is assignable both to and from every
+ * type, so the compiler can no longer catch a mismatch between the real runtime shape and how the value is
+ * used. These casts are a recurring source of runtime errors that strict TypeScript would otherwise prevent.
+ *
+ * The correct fix is almost always to address the *underlying* type rather than paper over it: correct a
+ * wrong type annotation, fix the DTO / return type / generic at the source, add a type guard, augment a
+ * third-party or DOM type, or narrow the value. When a value is genuinely dynamic, prefer `unknown` and
+ * narrow it before use.
+ *
+ * The cast is tolerated only in test code (co-located `*.spec.ts` files), where casting to build mocks
+ * and fixtures is sometimes pragmatic and the blast radius is limited to the test.
+ */
+export default createRule({
+    name: 'no-as-any-cast',
+    meta: {
+        type: 'problem',
+        docs: {
+            description:
+                'Forbid `as any` casts (including the angle-bracket `<any>x` form) in client production code, because they bypass type safety and risk runtime errors. Allowed only in *.spec.ts test files.',
+        },
+        messages: {
+            noAsAny:
+                '`as any` casts bypass the type checker and risk runtime errors. Fix the underlying type (DTO, return type, generic), add a type guard, augment the DOM/third-party type, or narrow via `unknown` instead of casting. (Only allowed in *.spec.ts test code.)',
+        },
+        schema: [],
+    },
+    defaultOptions: [],
+    create(context) {
+        // Normalize Windows backslashes so the client-code path check works across operating systems.
+        const filename = (context.filename ?? context.getFilename()).replaceAll('\\', '/');
+
+        // Apply to client production code only. Skip non-client files and co-located test specs.
+        if (!filename.includes('src/main/webapp/')) {
+            return {};
+        }
+        if (filename.endsWith('.spec.ts')) {
+            return {};
+        }
+
+        // Reports both `x as any` (TSAsExpression) and the legacy angle-bracket form `<any>x` (TSTypeAssertion).
+        const reportWhenAssertingToAny = (node) => {
+            if (node.typeAnnotation?.type === 'TSAnyKeyword') {
+                context.report({ node, messageId: 'noAsAny' });
+            }
+        };
+
+        return {
+            TSAsExpression: reportWhenAssertingToAny,
+            TSTypeAssertion: reportWhenAssertingToAny,
+        };
+    },
+});

--- a/src/main/webapp/app/admin/course-requests/course-requests.component.ts
+++ b/src/main/webapp/app/admin/course-requests/course-requests.component.ts
@@ -22,6 +22,7 @@ import { getCurrentAndFutureSemesters } from 'app/foundation/util/semester-utils
 import { SHORT_NAME_PATTERN } from 'app/foundation/constants/input.constants';
 import { AdminTitleBarTitleDirective } from 'app/admin/shared/admin-title-bar-title.directive';
 import { AdminTitleBarActionsDirective } from 'app/admin/shared/admin-title-bar-actions.directive';
+import dayjs from 'dayjs/esm';
 
 /**
  * Admin component for managing course creation requests.
@@ -92,8 +93,8 @@ export class CourseRequestsComponent implements OnInit {
         title: ['', [Validators.required, Validators.maxLength(255)]],
         shortName: ['', [Validators.required, Validators.minLength(3), regexValidator(SHORT_NAME_PATTERN)]],
         semester: ['', [Validators.required]],
-        startDate: [undefined as any],
-        endDate: [undefined as any],
+        startDate: [undefined as dayjs.Dayjs | undefined],
+        endDate: [undefined as dayjs.Dayjs | undefined],
         testCourse: [false],
         reason: ['', [Validators.required]],
     });
@@ -254,8 +255,8 @@ export class CourseRequestsComponent implements OnInit {
             title: this.editForm.get('title')!.value!,
             shortName: this.editForm.get('shortName')!.value!,
             semester: this.editForm.get('semester')!.value ?? undefined,
-            startDate,
-            endDate,
+            startDate: startDate ?? undefined,
+            endDate: endDate ?? undefined,
             testCourse: this.editForm.get('testCourse')!.value ?? false,
             reason: this.editForm.get('reason')!.value!,
         };

--- a/src/main/webapp/app/admin/standardized-competencies/import/admin-import-standardized-competencies.component.ts
+++ b/src/main/webapp/app/admin/standardized-competencies/import/admin-import-standardized-competencies.component.ts
@@ -29,6 +29,7 @@ import { HtmlForMarkdownPipe } from 'app/foundation/pipes/html-for-markdown.pipe
 import { StandardizedCompetencyDetailComponent } from 'app/atlas/shared/standardized-competencies/standardized-competency-detail.component';
 import { KnowledgeAreaTreeComponent, KnowledgeAreaTreeNode, convertToTreeNodes } from 'app/atlas/shared/standardized-competencies/knowledge-area-tree.component';
 import { AdminTitleBarTitleDirective } from 'app/admin/shared/admin-title-bar-title.directive';
+import { parseJson } from 'app/foundation/util/json.util';
 
 interface ImportCount {
     knowledgeAreas: number;
@@ -189,7 +190,7 @@ export class AdminImportStandardizedCompetenciesComponent {
 
         let parsedData: KnowledgeAreasForImportDTO | undefined;
         try {
-            parsedData = JSON.parse(this.fileReader.result as string);
+            parsedData = parseJson<KnowledgeAreasForImportDTO>(this.fileReader.result as string);
             this.importData.set(parsedData);
         } catch (e) {
             this.alertService.error('artemisApp.standardizedCompetency.manage.import.error.fileSyntax');

--- a/src/main/webapp/app/assessment/manage/assessment-instructions/assessment-instructions/assessment-instructions.component.ts
+++ b/src/main/webapp/app/assessment/manage/assessment-instructions/assessment-instructions/assessment-instructions.component.ts
@@ -14,6 +14,7 @@ import { ProgrammingExerciseInstructionComponent } from 'app/programming/shared/
 import { ButtonComponent } from 'app/shared-ui/components/buttons/button/button.component';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { ArtemisMarkdownService } from 'app/foundation/service/markdown.service';
+import { parseJson } from 'app/foundation/util/json.util';
 import { TextExercise } from 'app/text/shared/entities/text-exercise.model';
 import { ExpandableSectionComponent } from '../expandable-section/expandable-section.component';
 
@@ -60,7 +61,7 @@ export class AssessmentInstructionsComponent {
         const exercise = this.exercise();
         if (exercise.type === ExerciseType.MODELING) {
             const modelingExercise = exercise as ModelingExercise;
-            return modelingExercise.exampleSolutionModel ? importDiagram(JSON.parse(modelingExercise.exampleSolutionModel)) : undefined;
+            return modelingExercise.exampleSolutionModel ? importDiagram(parseJson(modelingExercise.exampleSolutionModel)) : undefined;
         }
         return undefined;
     });

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
@@ -43,6 +43,7 @@ import { SubmissionService, SubmissionWithComplaintDTO } from 'app/exercise/subm
 import { ArtemisDatePipe } from 'app/foundation/pipes/artemis-date.pipe';
 import { SortService } from 'app/foundation/service/sort.service';
 import { onError } from 'app/foundation/util/global.utils';
+import { parseJson } from 'app/foundation/util/json.util';
 import { roundValueSpecifiedByCourseSettings } from 'app/foundation/util/utils';
 import { getLinkToSubmissionAssessment } from 'app/foundation/util/navigation.utils';
 import { AssessmentType } from 'app/assessment/shared/entities/assessment-type.model';
@@ -343,7 +344,7 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
                         this.modelingExercise.set(modelingExercise);
                         if (modelingExercise.exampleSolutionModel) {
                             this.formattedSampleSolution.set(this.artemisMarkdown.safeHtmlForMarkdown(modelingExercise.exampleSolutionExplanation));
-                            this.exampleSolutionModel.set(importDiagram(JSON.parse(modelingExercise.exampleSolutionModel)));
+                            this.exampleSolutionModel.set(importDiagram(parseJson(modelingExercise.exampleSolutionModel)));
                         }
                         break;
                     case ExerciseType.FILE_UPLOAD:

--- a/src/main/webapp/app/assessment/shared/entities/feedback.model.ts
+++ b/src/main/webapp/app/assessment/shared/entities/feedback.model.ts
@@ -242,7 +242,8 @@ export class Feedback implements BaseEntity {
         that.text = text;
         // Apollon stores the GradingInstruction flat on dropInfo (not nested under dropInfo.instruction)
         // Support both: dropInfo.instruction.id (expected shape) and dropInfo.id (actual Apollon shape)
-        const instruction = dropInfo?.instruction ?? ((dropInfo as any)?.id ? (dropInfo as any) : undefined);
+        const flatDropInfo = dropInfo as (GradingInstruction & { instruction?: GradingInstruction }) | undefined;
+        const instruction = flatDropInfo?.instruction ?? (flatDropInfo?.id ? flatDropInfo : undefined);
         if (instruction?.id) {
             that.gradingInstruction = instruction;
         }

--- a/src/main/webapp/app/assessment/shared/services/example-submission.service.ts
+++ b/src/main/webapp/app/assessment/shared/services/example-submission.service.ts
@@ -9,6 +9,7 @@ import { Exercise, ExerciseType } from 'app/exercise/shared/entities/exercise/ex
 import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
 import { ModelingSubmission } from 'app/modeling/shared/entities/modeling-submission.model';
 import { StringCountService } from 'app/text/overview/service/string-count.service';
+import { parseJson } from 'app/foundation/util/json.util';
 
 export type EntityResponseType = HttpResponse<ExampleSubmission>;
 
@@ -127,7 +128,7 @@ export class ExampleSubmissionService {
         if (submission && exercise && exercise.type === ExerciseType.TEXT) {
             return this.stringCountService.countWords((submission as TextSubmission).text);
         } else if (submission && exercise && exercise.type === ExerciseType.MODELING) {
-            const umlModel = JSON.parse((submission as ModelingSubmission).model!);
+            const umlModel = parseJson<{ elements: unknown[]; relationships: unknown[] }>((submission as ModelingSubmission).model!);
             return umlModel ? umlModel.elements?.length + umlModel.relationships?.length : 0;
         }
         return 0;

--- a/src/main/webapp/app/atlas/manage/import-course-competencies-settings/import-course-competencies-settings.component.ts
+++ b/src/main/webapp/app/atlas/manage/import-course-competencies-settings/import-course-competencies-settings.component.ts
@@ -7,6 +7,7 @@ import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { parseJson } from 'app/foundation/util/json.util';
 
 export class CourseCompetencyImportSettings {
     importRelations = false;
@@ -52,7 +53,7 @@ export class ImportCourseCompetenciesSettingsComponent {
         const target = event.target as HTMLInputElement;
         this.importSettings.update((settings) => ({
             ...settings,
-            isReleaseDate: JSON.parse(target.value),
+            isReleaseDate: parseJson<boolean>(target.value),
         }));
     }
 }

--- a/src/main/webapp/app/communication/course-conversations-components/abstract-dialog.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/abstract-dialog.component.ts
@@ -3,7 +3,7 @@ import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { captureException } from '@sentry/angular';
 
 function isWritableSignal(value: unknown): value is WritableSignal<unknown> {
-    return isSignal(value) && typeof (value as any).set === 'function';
+    return isSignal(value) && typeof (value as { set?: unknown }).set === 'function';
 }
 
 @Directive()
@@ -19,15 +19,18 @@ export abstract class AbstractDialogComponent implements OnInit {
     initialize(requiredInputs?: string[]) {
         // Apply data from DynamicDialogConfig to component properties
         if (this.dialogConfig?.data) {
+            // Reflect over the component's own signal inputs / plain properties by key. There is no static type for
+            // "this component's dynamic keys", so a minimal index-signature view is used instead of `any`.
+            const self = this as Record<string, unknown>;
             for (const [key, value] of Object.entries(this.dialogConfig.data)) {
                 if (!(key in this)) {
                     continue;
                 }
-                const prop = (this as any)[key];
+                const prop = self[key];
                 if (isWritableSignal(prop)) {
                     prop.set(value);
                 } else if (typeof prop !== 'function') {
-                    (this as any)[key] = value;
+                    self[key] = value;
                 } else {
                     // Keep callbacks and other non-input data on dialogConfig.data to avoid replacing component methods.
                     continue;
@@ -35,7 +38,7 @@ export abstract class AbstractDialogComponent implements OnInit {
             }
         }
         const allInputsSet = (requiredInputs ?? []).every((inputKey) => {
-            const prop = (this as any)[inputKey];
+            const prop = (this as Record<string, unknown>)[inputKey];
             if (isSignal(prop)) {
                 return prop() !== undefined;
             }

--- a/src/main/webapp/app/communication/faq/faq.service.ts
+++ b/src/main/webapp/app/communication/faq/faq.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { CreateFaqDTO, Faq, FaqState, UpdateFaqDTO } from 'app/communication/shared/entities/faq.model';
 import { FaqCategory } from 'app/communication/shared/entities/faq-category.model';
+import { parseJson } from 'app/foundation/util/json.util';
 
 type EntityResponseType = HttpResponse<Faq>;
 type EntityArrayResponseType = HttpResponse<Faq[]>;
@@ -84,7 +85,7 @@ export class FaqService {
     }
 
     convertFaqCategoriesAsStringFromServer(categories: string[]): FaqCategory[] {
-        return categories.map((category) => JSON.parse(category));
+        return categories.map((category) => parseJson<FaqCategory>(category));
     }
 
     /**
@@ -106,7 +107,7 @@ export class FaqService {
         if (faq?.categories) {
             faq.categories = faq.categories.map((category) => {
                 // Server sends categories as JSON strings; the model field carries FaqCategory objects after parsing.
-                const categoryObj = typeof category === 'string' ? JSON.parse(category) : category;
+                const categoryObj = typeof category === 'string' ? parseJson<FaqCategory>(category) : category;
                 return new FaqCategory(categoryObj.category, categoryObj.color);
             });
         }

--- a/src/main/webapp/app/communication/forwarded-message/forwarded-message.component.ts
+++ b/src/main/webapp/app/communication/forwarded-message/forwarded-message.component.ts
@@ -5,6 +5,7 @@ import { AnswerPost } from 'app/communication/shared/entities/answer-post.model'
 import { Posting } from 'app/communication/shared/entities/posting.model';
 import dayjs from 'dayjs/esm';
 import { Conversation } from 'app/communication/shared/entities/conversation/conversation.model';
+import { Channel } from 'app/communication/shared/entities/conversation/channel.model';
 import { ProfilePictureComponent } from 'app/shared-ui/profile-picture/profile-picture.component';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { PostingContentComponent } from 'app/communication/posting-content/posting-content.components';
@@ -124,10 +125,11 @@ export class ForwardedMessageComponent implements AfterViewInit {
         if (!this.conversation) {
             this.sourceName.set('');
         } else if (this.conversation?.type?.valueOf() === 'channel') {
+            const channelName = (this.conversation as Channel).name;
             if (this.isAnswerPost) {
-                this.sourceName.set((this.conversation as any)?.name ? `a thread in #${(this.conversation as any)?.name} |` : 'a thread in #unknown |');
+                this.sourceName.set(channelName ? `a thread in #${channelName} |` : 'a thread in #unknown |');
             } else {
-                this.sourceName.set((this.conversation as any)?.name ? `#${(this.conversation as any)?.name} |` : '#unknown |');
+                this.sourceName.set(channelName ? `#${channelName} |` : '#unknown |');
             }
         } else if (this.conversation?.type?.valueOf() === 'oneToOneChat') {
             this.sourceName.set(this.isAnswerPost ? 'a thread in a direct message ' : 'a direct message ');

--- a/src/main/webapp/app/course/manage/update/course-update.component.ts
+++ b/src/main/webapp/app/course/manage/update/course-update.component.ts
@@ -160,7 +160,7 @@ export class CourseUpdateComponent implements OnInit {
     readonly COURSE_TITLE_LIMIT = 255;
 
     ngOnInit() {
-        this.timeZones = (Intl as any).supportedValuesOf('timeZone');
+        this.timeZones = (Intl as typeof Intl & { supportedValuesOf(key: string): string[] }).supportedValuesOf('timeZone');
         this.isSaving.set(false);
         // create a new course, and only overwrite it if we fetch a course to edit
         this.course = new Course();

--- a/src/main/webapp/app/editor/monaco-editor/service/monaco-editor.service.ts
+++ b/src/main/webapp/app/editor/monaco-editor/service/monaco-editor.service.ts
@@ -24,7 +24,7 @@ export class MonacoEditorService {
         this.registerCustomMarkdownLanguage();
 
         // Expose Monaco globally for testing frameworks like Playwright
-        (window as any).monaco = monaco;
+        (window as Window & { monaco?: typeof monaco }).monaco = monaco;
 
         effect(() => {
             this.applyTheme(this.currentTheme());

--- a/src/main/webapp/app/exam/overview/exercises/modeling/modeling-exam-submission.component.ts
+++ b/src/main/webapp/app/exam/overview/exercises/modeling/modeling-exam-submission.component.ts
@@ -11,6 +11,7 @@ import { faListAlt } from '@fortawesome/free-regular-svg-icons';
 import { SubmissionVersion } from 'app/exam/shared/entities/submission-version.model';
 import { SafeHtml } from '@angular/platform-browser';
 import { ArtemisMarkdownService } from 'app/foundation/service/markdown.service';
+import { parseJson } from 'app/foundation/util/json.util';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { IncludedInScoreBadgeComponent } from 'app/exercise/exercise-headers/included-in-score-badge/included-in-score-badge.component';
 import { ExerciseSaveButtonComponent } from '../exercise-save-button/exercise-save-button.component';
@@ -95,7 +96,7 @@ export class ModelingExamSubmissionComponent extends ExamSubmissionComponent imp
         if (this.studentSubmission()) {
             if (this.studentSubmission()!.model) {
                 // Updates the Apollon editor model state (view) with the latest modeling submission
-                this.umlModel.set(importDiagram(JSON.parse(this.studentSubmission()!.model!)));
+                this.umlModel.set(importDiagram(parseJson(this.studentSubmission()!.model!)));
             }
             // Updates explanation text with the latest submission
             this.explanationText.set(this.studentSubmission()!.explanationText ?? '');
@@ -162,7 +163,7 @@ export class ModelingExamSubmissionComponent extends ExamSubmissionComponent imp
             // if we do not wait here for apollon, the redux store might be undefined
             model = model.replace('Model: ', '');
             // updates the Apollon editor model state (view) with the latest modeling submission
-            this.umlModel.set(importDiagram(JSON.parse(model)));
+            this.umlModel.set(importDiagram(parseJson(model)));
             // same as above regarding the string operations
             const numberOfCharactersToSkip = 13; // Explanation:  is 13 characters long
             this.explanationText.set(this.submissionVersion.content.substring(this.submissionVersion.content.indexOf('Explanation:') + numberOfCharactersToSkip) ?? '');

--- a/src/main/webapp/app/exam/overview/exercises/quiz/quiz-exam-submission.component.ts
+++ b/src/main/webapp/app/exam/overview/exercises/quiz/quiz-exam-submission.component.ts
@@ -27,6 +27,8 @@ import { captureException } from '@sentry/angular';
 import { ArtemisQuizService } from 'app/quiz/shared/service/quiz.service';
 import { SubmissionVersion } from 'app/exam/shared/entities/submission-version.model';
 import { addTemporaryHighlightToQuestion } from 'app/quiz/shared/questions/quiz-stepwizard.util';
+import { SubmittedAnswer } from 'app/quiz/shared/entities/submitted-answer.model';
+import { parseJson } from 'app/foundation/util/json.util';
 
 @Component({
     selector: 'jhi-quiz-submission-exam',
@@ -322,7 +324,7 @@ export class QuizExamSubmissionComponent extends ExamSubmissionComponent impleme
     }
 
     updateViewFromSubmissionVersion(): void {
-        this.studentSubmission().submittedAnswers = JSON.parse(this.submissionVersion.content);
+        this.studentSubmission().submittedAnswers = parseJson<SubmittedAnswer[]>(this.submissionVersion.content);
         this.updateViewFromSubmission();
     }
 

--- a/src/main/webapp/app/exam/overview/services/exam-participation-live-events.service.ts
+++ b/src/main/webapp/app/exam/overview/services/exam-participation-live-events.service.ts
@@ -8,6 +8,7 @@ import { BehaviorSubject, Observable, Subject, Subscription, distinct, filter, m
 import { convertDateFromServer } from 'app/foundation/util/date.utils';
 import { User } from 'app/account/user/user.model';
 import { StudentExam } from 'app/exam/shared/entities/student-exam.model';
+import { parseJson } from 'app/foundation/util/json.util';
 
 const EVENT_ACKNOWLEDGEMENT_LOCAL_STORAGE_KEY = 'examLastAcknowledgedEvent';
 
@@ -378,7 +379,7 @@ export class ExamParticipationLiveEventsService {
      */
     private loadAcknowledgedEventsMapFromLocalStorage(): { [studentExamId: string]: StudentExamAcknowledgedEvents } {
         const fromStorage = this.localStorageService.retrieve<string>(EVENT_ACKNOWLEDGEMENT_LOCAL_STORAGE_KEY);
-        return fromStorage ? JSON.parse(fromStorage) : {};
+        return fromStorage ? parseJson<{ [studentExamId: string]: StudentExamAcknowledgedEvents }>(fromStorage) : {};
     }
 
     /**

--- a/src/main/webapp/app/exercise/example-submission/example-submission-assess-command.ts
+++ b/src/main/webapp/app/exercise/example-submission/example-submission-assess-command.ts
@@ -2,6 +2,7 @@ import { AlertService } from 'app/foundation/service/alert.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { FeedbackCorrectionError } from 'app/assessment/shared/entities/feedback.model';
 import { onError } from 'app/foundation/util/global.utils';
+import { parseJson } from 'app/foundation/util/json.util';
 import { ExampleSubmission } from 'app/assessment/shared/entities/example-submission.model';
 import { TutorParticipationService } from 'app/assessment/shared/assessment-dashboard/exercise-dashboard/tutor-participation.service';
 
@@ -36,7 +37,7 @@ export class ExampleSubmissionAssessCommand {
             this.feedbackMarker.markAllFeedbackToCorrect();
 
             // Mark all wrongly made feedbacks accordingly.
-            const correctionErrors: FeedbackCorrectionError[] = JSON.parse(error['error']['title'])['errors'];
+            const correctionErrors = parseJson<{ errors: FeedbackCorrectionError[] }>(error['error']['title']).errors;
             this.feedbackMarker.markWrongFeedback(correctionErrors);
 
             const msg = correctionErrors.length === 0 ? 'artemisApp.exampleSubmission.submissionValidation.missing' : 'artemisApp.exampleSubmission.submissionValidation.wrong';

--- a/src/main/webapp/app/exercise/import/from-file/exercise-import-from-file.component.ts
+++ b/src/main/webapp/app/exercise/import/from-file/exercise-import-from-file.component.ts
@@ -7,6 +7,7 @@ import { AlertService } from 'app/foundation/service/alert.service';
 import { faUpload } from '@fortawesome/free-solid-svg-icons';
 import { ProgrammingExercise, copyBuildConfigFromExerciseJson } from 'app/programming/shared/entities/programming-exercise.model';
 import { strFromU8 } from 'fflate';
+import { parseJson } from 'app/foundation/util/json.util';
 import { readZipEntries } from 'app/foundation/util/zip.util';
 import { ButtonComponent } from 'app/shared-ui/components/buttons/button/button.component';
 import { HelpIconComponent } from 'app/shared-ui/components/help-icon/help-icon.component';
@@ -56,14 +57,14 @@ export class ExerciseImportFromFileComponent implements OnInit {
         }
         const exerciseDetails = strFromU8(zipEntries[jsonFiles[0]]);
 
-        const exerciseJson = JSON.parse(exerciseDetails) as Exercise;
+        const exerciseJson = parseJson<Exercise>(exerciseDetails);
         if (exerciseJson.type !== exerciseType) {
             this.alertService.error('artemisApp.exercise.importFromFile.exerciseTypeDoesntMatch');
             return;
         }
         switch (exerciseType) {
             case ExerciseType.PROGRAMMING:
-                this.exercise = JSON.parse(exerciseDetails as string) as ProgrammingExercise;
+                this.exercise = parseJson<ProgrammingExercise>(exerciseDetails as string);
                 const progEx = this.exercise as ProgrammingExercise;
                 // This is needed to make sure that old exported programming exercises can be imported
                 if (!progEx.buildConfig) {

--- a/src/main/webapp/app/exercise/services/exercise.service.ts
+++ b/src/main/webapp/app/exercise/services/exercise.service.ts
@@ -603,7 +603,7 @@ export class ExerciseService {
             case ExerciseType.MODELING:
                 modelingExercise = exercise as ModelingExercise;
                 if (modelingExercise.exampleSolutionModel) {
-                    exampleSolutionUML = JSON.parse(modelingExercise.exampleSolutionModel);
+                    exampleSolutionUML = parseJson(modelingExercise.exampleSolutionModel);
                 }
                 break;
             case ExerciseType.TEXT:

--- a/src/main/webapp/app/exercise/structured-grading-criterion/structured-grading-criterion.service.ts
+++ b/src/main/webapp/app/exercise/structured-grading-criterion/structured-grading-criterion.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Feedback } from 'app/assessment/shared/entities/feedback.model';
+import { GradingInstruction } from 'app/exercise/structured-grading-criterion/grading-instruction.model';
+import { parseJson } from 'app/foundation/util/json.util';
 
 @Injectable({ providedIn: 'root' })
 export class StructuredGradingCriterionService {
@@ -14,7 +16,7 @@ export class StructuredGradingCriterionService {
         event.preventDefault();
         try {
             const data = event.dataTransfer.getData('text/plain');
-            const instruction = JSON.parse(data);
+            const instruction = parseJson<GradingInstruction>(data);
             feedback.gradingInstruction = instruction;
             feedback.credits = instruction.credits;
         } catch (err) {

--- a/src/main/webapp/app/exercise/synchronization/metadata/exercise-metadata-conflict-modal.component.ts
+++ b/src/main/webapp/app/exercise/synchronization/metadata/exercise-metadata-conflict-modal.component.ts
@@ -175,7 +175,7 @@ export class ExerciseMetadataConflictModalComponent implements OnInit {
             return value.format('YYYY-MM-DD HH:mm');
         }
         // Fallback for dayjs-like objects that fail isDayjs() due to module duplication
-        if (typeof value === 'object' && value !== null && typeof (value as { format?: unknown }).format === 'function') {
+        if (value && typeof value === 'object' && typeof (value as { format?: unknown }).format === 'function') {
             const formatted = (value as { format: (template: string) => unknown }).format('YYYY-MM-DD HH:mm');
             if (typeof formatted === 'string') {
                 return formatted;

--- a/src/main/webapp/app/exercise/synchronization/metadata/exercise-metadata-conflict-modal.component.ts
+++ b/src/main/webapp/app/exercise/synchronization/metadata/exercise-metadata-conflict-modal.component.ts
@@ -16,6 +16,7 @@ import { CompetencyExerciseLink } from 'app/atlas/shared/entities/competency.mod
 import { GradingCriterion } from 'app/exercise/structured-grading-criterion/grading-criterion.model';
 import { GradingInstruction } from 'app/exercise/structured-grading-criterion/grading-instruction.model';
 import { normalizeCategoryArray, normalizeCategoryEntry } from 'app/exercise/synchronization/metadata/exercise-metadata-snapshot-shared.mapper';
+import { parseJson } from 'app/foundation/util/json.util';
 
 /**
  * Single field conflict between current editor state and incoming snapshot.
@@ -174,8 +175,8 @@ export class ExerciseMetadataConflictModalComponent implements OnInit {
             return value.format('YYYY-MM-DD HH:mm');
         }
         // Fallback for dayjs-like objects that fail isDayjs() due to module duplication
-        if (typeof value === 'object' && value !== null && typeof (value as any).format === 'function') {
-            const formatted = (value as any).format('YYYY-MM-DD HH:mm');
+        if (typeof value === 'object' && value !== null && typeof (value as { format?: unknown }).format === 'function') {
+            const formatted = (value as { format: (template: string) => unknown }).format('YYYY-MM-DD HH:mm');
             if (typeof formatted === 'string') {
                 return formatted;
             }
@@ -273,7 +274,7 @@ export class ExerciseMetadataConflictModalComponent implements OnInit {
         }
         if (typeof value === 'string') {
             try {
-                const parsed = JSON.parse(value);
+                const parsed = parseJson(value);
                 if (parsed !== undefined) {
                     return this.toCategoryEntries(parsed);
                 }

--- a/src/main/webapp/app/exercise/synchronization/metadata/exercise-metadata-handlers.ts
+++ b/src/main/webapp/app/exercise/synchronization/metadata/exercise-metadata-handlers.ts
@@ -8,7 +8,7 @@ import { GradingCriterion } from 'app/exercise/structured-grading-criterion/grad
 import { AuxiliaryRepository } from 'app/programming/shared/entities/programming-exercise-auxiliary-repository-model';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { ProgrammingExerciseBuildConfig } from 'app/programming/shared/entities/programming-exercise-build.config';
-import { convertDateFromServer } from 'app/foundation/util/date.utils';
+import { convertDateFromServer, convertDateStringFromServer } from 'app/foundation/util/date.utils';
 import { ExerciseSnapshotDTO, TeamAssignmentConfigSnapshot } from 'app/exercise/synchronization/metadata/exercise-metadata-snapshot.dto';
 import {
     normalizeCategoryArray,
@@ -103,10 +103,16 @@ const baseHandler = <K extends keyof ExerciseSnapshotDTO, V>(
 };
 
 /**
+ * Keys of {@link ExerciseSnapshotDTO} whose value is an ISO date string. The snapshot stores dates as
+ * strings, so their incoming values are normalized with {@link convertDateStringFromServer}.
+ */
+type ExerciseSnapshotDateKey = 'releaseDate' | 'startDate' | 'dueDate' | 'assessmentDueDate' | 'exampleSolutionPublicationDate';
+
+/**
  * Creates a handler for date fields with server-date normalization.
  */
 const dateHandler = (
-    key: keyof ExerciseSnapshotDTO,
+    key: ExerciseSnapshotDateKey,
     labelKey: string,
     getter: (exercise: Exercise) => dayjs.Dayjs | undefined,
     setter: (exercise: Exercise, value: dayjs.Dayjs | undefined) => void,
@@ -114,10 +120,10 @@ const dateHandler = (
     return {
         key,
         labelKey,
-        getCurrentValue: (exercise) => convertDateFromServer(getter(exercise) as any),
-        getBaselineValue: (exercise) => convertDateFromServer(getter(exercise) as any),
-        getIncomingValue: (snapshot) => convertDateFromServer(snapshot[key as keyof ExerciseSnapshotDTO] as any),
-        applyValue: (exercise, value) => setter(exercise, value as dayjs.Dayjs | undefined),
+        getCurrentValue: (exercise) => convertDateFromServer(getter(exercise)),
+        getBaselineValue: (exercise) => convertDateFromServer(getter(exercise)),
+        getIncomingValue: (snapshot) => convertDateStringFromServer(snapshot[key]),
+        applyValue: (exercise, value) => setter(exercise, value),
     };
 };
 
@@ -342,9 +348,9 @@ const createProgrammingHandlers = (): ExerciseMetadataFieldHandler<Exercise>[] =
         {
             key: 'programmingData.buildAndTestStudentSubmissionsAfterDueDate',
             labelKey: 'artemisApp.programmingExercise.timeline.afterDueDate',
-            getCurrentValue: (exercise) => convertDateFromServer((exercise as ProgrammingExercise).buildAndTestStudentSubmissionsAfterDueDate as any),
-            getBaselineValue: (exercise) => convertDateFromServer((exercise as ProgrammingExercise).buildAndTestStudentSubmissionsAfterDueDate as any),
-            getIncomingValue: (snapshot) => convertDateFromServer(snapshot.programmingData?.buildAndTestStudentSubmissionsAfterDueDate as any),
+            getCurrentValue: (exercise) => convertDateFromServer((exercise as ProgrammingExercise).buildAndTestStudentSubmissionsAfterDueDate),
+            getBaselineValue: (exercise) => convertDateFromServer((exercise as ProgrammingExercise).buildAndTestStudentSubmissionsAfterDueDate),
+            getIncomingValue: (snapshot) => convertDateStringFromServer(snapshot.programmingData?.buildAndTestStudentSubmissionsAfterDueDate),
             applyValue: (exercise, value) => ((exercise as ProgrammingExercise).buildAndTestStudentSubmissionsAfterDueDate = value as dayjs.Dayjs | undefined),
         } satisfies ExerciseMetadataFieldHandler<Exercise, dayjs.Dayjs | undefined>,
         {

--- a/src/main/webapp/app/exercise/synchronization/metadata/exercise-metadata-snapshot-shared.mapper.ts
+++ b/src/main/webapp/app/exercise/synchronization/metadata/exercise-metadata-snapshot-shared.mapper.ts
@@ -4,6 +4,7 @@ import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { GradingCriterion } from 'app/exercise/structured-grading-criterion/grading-criterion.model';
 import { GradingInstruction } from 'app/exercise/structured-grading-criterion/grading-instruction.model';
 import { TeamAssignmentConfig } from 'app/exercise/shared/entities/team/team-assignment-config.model';
+import { parseJson } from 'app/foundation/util/json.util';
 import {
     CompetencyExerciseLinkSnapshotDTO,
     GradingCriterionSnapshotDTO,
@@ -40,7 +41,7 @@ export const normalizeCategoryEntry = (value: unknown): ExerciseCategory | undef
             return undefined;
         }
         try {
-            const parsed = JSON.parse(trimmed);
+            const parsed = parseJson(trimmed);
             if (parsed && typeof parsed === 'object' && 'category' in parsed) {
                 const category = (parsed as { category?: string }).category?.trim();
                 if (!category) {

--- a/src/main/webapp/app/exercise/team/teams-import-dialog/teams-import-from-file-form.component.ts
+++ b/src/main/webapp/app/exercise/team/teams-import-dialog/teams-import-from-file-form.component.ts
@@ -4,6 +4,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { User } from 'app/account/user/user.model';
 import { StudentWithTeam, Team } from 'app/exercise/shared/entities/team/team.model';
 import { SHORT_NAME_PATTERN } from 'app/foundation/constants/input.constants';
+import { parseJson } from 'app/foundation/util/json.util';
 import { parse } from 'papaparse';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { HelpIconComponent } from 'app/shared-ui/components/help-icon/help-icon.component';
@@ -67,7 +68,7 @@ export class TeamsImportFromFileFormComponent {
         try {
             // Read the file and get list of teams from the file
             if (this.importFile?.type === 'application/json') {
-                this.importedTeams = JSON.parse(fileReader.result as string) as StudentWithTeam[];
+                this.importedTeams = parseJson<StudentWithTeam[]>(fileReader.result as string);
             } else if (this.importFile?.type === 'text/csv') {
                 const csvEntries = await this.parseCSVFile(fileReader.result as string);
                 this.importedTeams = this.convertCsvEntries(csvEntries);

--- a/src/main/webapp/app/foundation/service/local-storage.service.ts
+++ b/src/main/webapp/app/foundation/service/local-storage.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { EARLIEST_SETUP_PASSKEY_REMINDER_DATE_LOCAL_STORAGE_KEY } from 'app/course/overview/setup-passkey-modal/setup-passkey-modal.component';
+import { parseJson } from 'app/foundation/util/json.util';
 
 @Injectable({ providedIn: 'root' })
 export class LocalStorageService {
@@ -23,7 +24,7 @@ export class LocalStorageService {
      */
     retrieve<T>(key: string): T | undefined {
         const value = localStorage.getItem(key);
-        return value ? (JSON.parse(value) as T) : undefined;
+        return value ? parseJson<T>(value) : undefined;
     }
 
     /**
@@ -34,7 +35,7 @@ export class LocalStorageService {
     retrieveDate(key: string): Date | undefined {
         const raw = localStorage.getItem(key);
         if (!raw) return undefined;
-        const isoString = JSON.parse(raw);
+        const isoString = parseJson<string>(raw);
         const date = new Date(isoString);
         // check whether a valid date could be parsed and avoid parsing dates from non-ISO-representations
         return !isNaN(date.getTime()) && isoString === date.toISOString() ? date : undefined;

--- a/src/main/webapp/app/foundation/service/session-storage.service.ts
+++ b/src/main/webapp/app/foundation/service/session-storage.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { parseJson } from 'app/foundation/util/json.util';
 
 @Injectable({ providedIn: 'root' })
 export class SessionStorageService {
@@ -22,7 +23,7 @@ export class SessionStorageService {
      */
     retrieve<T>(key: string): T | undefined {
         const value = sessionStorage.getItem(key);
-        return value ? (JSON.parse(value) as T) : undefined;
+        return value ? parseJson<T>(value) : undefined;
     }
 
     /**
@@ -33,7 +34,7 @@ export class SessionStorageService {
     retrieveDate(key: string): Date | undefined {
         const raw = sessionStorage.getItem(key);
         if (!raw) return undefined;
-        const isoString = JSON.parse(raw);
+        const isoString = parseJson<string>(raw);
         const date = new Date(isoString);
         // check whether a valid date could be parsed and avoid parsing dates from non-ISO-representations
         return !isNaN(date.getTime()) && isoString === date.toISOString() ? date : undefined;

--- a/src/main/webapp/app/foundation/service/websocket.service.ts
+++ b/src/main/webapp/app/foundation/service/websocket.service.ts
@@ -2,6 +2,7 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { captureException } from '@sentry/angular';
 import { IWatchParams, ReconnectionTimeMode, RxStomp, RxStompConfig, RxStompState, TickerStrategy } from '@stomp/rx-stomp';
 import { IMessage, StompHeaders } from '@stomp/stompjs';
+import { parseJson } from 'app/foundation/util/json.util';
 import { gunzipSync, gzipSync, strFromU8, strToU8 } from 'fflate';
 import { BehaviorSubject, EMPTY, Observable, Subscription, of, timer } from 'rxjs';
 import { distinctUntilChanged, map, switchMap } from 'rxjs/operators';
@@ -603,7 +604,7 @@ export class WebsocketService implements IWebsocketService, OnDestroy {
      */
     private static parseJSON<T>(response: string): T {
         try {
-            return JSON.parse(response);
+            return parseJson<T>(response);
         } catch {
             return response as T;
         }

--- a/src/main/webapp/app/foundation/util/fullscreen.util.spec.ts
+++ b/src/main/webapp/app/foundation/util/fullscreen.util.spec.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { enterFullscreen, isFullScreen } from 'app/foundation/util/fullscreen.util';
+
+describe('fullscreen.util', () => {
+    describe('isFullScreen', () => {
+        let originalDescriptor: PropertyDescriptor | undefined;
+
+        beforeEach(() => {
+            originalDescriptor = Object.getOwnPropertyDescriptor(document, 'fullscreenElement');
+        });
+
+        afterEach(() => {
+            if (originalDescriptor) {
+                Object.defineProperty(document, 'fullscreenElement', originalDescriptor);
+            } else {
+                delete (document as { fullscreenElement?: unknown }).fullscreenElement;
+            }
+        });
+
+        it('returns false when no element is in fullscreen', () => {
+            Object.defineProperty(document, 'fullscreenElement', { configurable: true, get: () => null });
+            expect(isFullScreen()).toBe(false);
+        });
+
+        it('returns a boolean true (not the element itself) when a fullscreen element is present', () => {
+            const element = document.createElement('div');
+            Object.defineProperty(document, 'fullscreenElement', { configurable: true, get: () => element });
+            const result = isFullScreen();
+            // The function must coerce to a real boolean, not leak the underlying Element.
+            expect(result).toBe(true);
+            expect(typeof result).toBe('boolean');
+        });
+    });
+
+    describe('enterFullscreen', () => {
+        it('calls the standard requestFullscreen when available', () => {
+            const element = document.createElement('div');
+            const requestFullscreen = vi.fn();
+            (element as { requestFullscreen?: () => void }).requestFullscreen = requestFullscreen;
+            enterFullscreen(element);
+            expect(requestFullscreen).toHaveBeenCalledOnce();
+        });
+    });
+});

--- a/src/main/webapp/app/foundation/util/fullscreen.util.ts
+++ b/src/main/webapp/app/foundation/util/fullscreen.util.ts
@@ -1,17 +1,38 @@
 /**
+ * A {@link Document} extended with the vendor-prefixed fullscreen members used across browsers.
+ */
+type VendorPrefixedDocument = Document & {
+    webkitFullscreenElement?: Element;
+    mozFullScreenElement?: Element;
+    msFullscreenElement?: Element;
+    mozCancelFullScreen?: () => void;
+    msRequestFullscreen?: () => void;
+    webkitExitFullscreen?: () => void;
+};
+
+/**
+ * An element extended with the vendor-prefixed request-fullscreen members used across browsers.
+ */
+type VendorPrefixedElement = HTMLElement & {
+    mozRequestFullScreen?: () => void;
+    msRequestFullscreen?: () => void;
+    webkitRequestFullscreen?: () => void;
+};
+
+/**
  * checks if this component is the current fullscreen component
  */
 export function isFullScreen(): boolean {
-    const docElement = document as any;
+    const docElement = document as VendorPrefixedDocument;
     // check if this component is the current fullscreen component for different browser types
     if (docElement.fullscreenElement !== undefined) {
-        return docElement.fullscreenElement;
+        return !!docElement.fullscreenElement;
     } else if (docElement.webkitFullscreenElement !== undefined) {
-        return docElement.webkitFullscreenElement;
+        return !!docElement.webkitFullscreenElement;
     } else if (docElement.mozFullScreenElement !== undefined) {
-        return docElement.mozFullScreenElement;
+        return !!docElement.mozFullScreenElement;
     } else if (docElement.msFullscreenElement !== undefined) {
-        return docElement.msFullscreenElement;
+        return !!docElement.msFullscreenElement;
     }
     return false;
 }
@@ -20,7 +41,7 @@ export function isFullScreen(): boolean {
  * exit fullscreen
  */
 export function exitFullscreen() {
-    const docElement = document as any;
+    const docElement = document as VendorPrefixedDocument;
     // exit fullscreen for different browser types
     if (document.exitFullscreen) {
         document.exitFullscreen();
@@ -36,7 +57,7 @@ export function exitFullscreen() {
 /**
  * enter full screen
  */
-export function enterFullscreen(element: any) {
+export function enterFullscreen(element: VendorPrefixedElement) {
     // requestFullscreen for different browser types
     if (element.requestFullscreen) {
         element.requestFullscreen();

--- a/src/main/webapp/app/iris/overview/services/iris-chat.service.ts
+++ b/src/main/webapp/app/iris/overview/services/iris-chat.service.ts
@@ -23,6 +23,7 @@ import { IrisMessageContentDTO } from 'app/iris/shared/entities/iris-message-con
 import { IrisMessageContextDTO } from 'app/iris/shared/entities/iris-message-context-dto.model';
 import { randomInt } from 'app/foundation/util/utils';
 import { IrisCitationMetaDTO } from 'app/iris/shared/entities/iris-citation-meta-dto.model';
+import { parseJson } from 'app/foundation/util/json.util';
 
 export enum ChatServiceMode {
     TEXT_EXERCISE = 'TEXT_EXERCISE_CHAT',
@@ -537,7 +538,7 @@ export class IrisChatService implements OnDestroy {
             return;
         }
 
-        const suggestions = JSON.parse(str);
+        const suggestions = parseJson<string[]>(str);
         this.suggestions.next(suggestions);
     }
 

--- a/src/main/webapp/app/lecture/manage/lecture-attachments/lecture-attachments.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-attachments/lecture-attachments.component.ts
@@ -132,7 +132,7 @@ export class LectureAttachmentsComponent implements OnDestroy {
         }
 
         if (this.attachmentToBeUpdatedOrCreated()!.id) {
-            const requestOptions = {} as any;
+            const requestOptions: { notificationText?: string } = {};
             if (this.notificationText) {
                 requestOptions.notificationText = this.notificationText;
             }

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -27,6 +27,7 @@ import { ExerciseType, getCourseFromExercise } from 'app/exercise/shared/entitie
 import { SubmissionService } from 'app/exercise/submission/submission.service';
 import { ExampleSubmissionService } from 'app/assessment/shared/services/example-submission.service';
 import { onError } from 'app/foundation/util/global.utils';
+import { parseJson } from 'app/foundation/util/json.util';
 import { Course } from 'app/course/shared/entities/course.model';
 import { isAllowedToModifyFeedback } from 'app/assessment/manage/services/assessment.service';
 import { AssessmentAfterComplaint } from 'app/assessment/manage/complaints-for-tutor/complaints-for-tutor.component';
@@ -231,7 +232,7 @@ export class ModelingAssessmentEditorComponent implements OnInit {
         this.hasAssessmentDueDatePassed.set(!!this.modelingExercise()?.assessmentDueDate && dayjs(this.modelingExercise()!.assessmentDueDate).isBefore(dayjs()));
 
         if (this.submission()!.model) {
-            this.model.set(importDiagram(JSON.parse(this.submission()!.model!)));
+            this.model.set(importDiagram(parseJson(this.submission()!.model!)));
         } else {
             this.alertService.closeAll();
             this.alertService.warning('artemisApp.modelingAssessmentEditor.messages.noModel');

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment.component.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, effect, inject, input, output } from '@angular/core';
-import { ApollonEditor, ApollonMode, Assessment, UMLDiagramType, UMLModel } from '@tumaet/apollon';
+import { ApollonEdge, ApollonEditor, ApollonMode, ApollonNode, Assessment, UMLDiagramType, UMLModel } from '@tumaet/apollon';
 import { captureException } from '@sentry/angular';
 import {
     FEEDBACK_SUGGESTION_ACCEPTED_IDENTIFIER,
@@ -25,6 +25,16 @@ export interface DropInfo {
     removeMessage: string;
     feedbackHint: string;
 }
+
+/**
+ * Shape of the {@link Assessment.dropInfo} payload emitted by Apollon. Apollon stores the
+ * {@link GradingInstruction} flat on dropInfo (its `id` present at the top level), but a nested
+ * `instruction` shape is also supported for backwards compatibility.
+ */
+type AssessmentDropInfo = GradingInstruction & { instruction?: GradingInstruction };
+
+/** Apollon host element augmented with the editor instance exposed for E2E test access. */
+type ApollonEditorHostElement = HTMLElement & { __apollonEditor?: ApollonEditor };
 
 @Component({
     selector: 'jhi-modeling-assessment',
@@ -137,7 +147,7 @@ export class ModelingAssessmentComponent extends ModelingComponent implements Af
                 this.apollonEditor.unsubscribe(this.assessmentSelectionSubscription);
             }
             this.apollonEditor.destroy();
-            (this.elementRef.nativeElement as any).__apollonEditor = undefined;
+            (this.elementRef.nativeElement as ApollonEditorHostElement).__apollonEditor = undefined;
         }
     }
 
@@ -168,7 +178,7 @@ export class ModelingAssessmentComponent extends ModelingComponent implements Af
         // Expose the ApollonEditor instance on the host DOM element for E2E test access.
         // Mirrors the pattern in ModelingEditorComponent so Playwright can interact with the
         // assessment editor without dblclick races on multi-node setups.
-        (this.elementRef.nativeElement as any).__apollonEditor = this.apollonEditor;
+        (this.elementRef.nativeElement as ApollonEditorHostElement).__apollonEditor = this.apollonEditor;
 
         this.modelChangeSubscription = this.apollonEditor.subscribeToModelChange((state) => {
             if (!this.readOnly()) {
@@ -199,7 +209,7 @@ export class ModelingAssessmentComponent extends ModelingComponent implements Af
         for (const assessment of assessments) {
             // Apollon stores the GradingInstruction flat on dropInfo (not nested under dropInfo.instruction)
             // Support both: dropInfo.instruction (expected shape) and dropInfo directly (actual Apollon shape)
-            const dropInfo = assessment.dropInfo as any;
+            const dropInfo = assessment.dropInfo as AssessmentDropInfo | undefined;
             const instruction = dropInfo?.instruction ?? (dropInfo?.id ? dropInfo : undefined);
             let feedback = this.elementFeedback.get(assessment.modelElementId);
             if (feedback) {
@@ -306,14 +316,14 @@ export class ModelingAssessmentComponent extends ModelingComponent implements Af
             const model: UMLModel = this.apollonEditor.model;
             for (const node of model.nodes) {
                 const highlight = newElements.get(node.id);
-                (node as any).highlight = highlight;
+                (node as ApollonNode & { highlight?: string }).highlight = highlight;
                 if (node.data) {
                     (node.data as Record<string, unknown>).highlight = highlight;
                 }
             }
             for (const edge of model.edges) {
                 const highlight = newElements.get(edge.id);
-                (edge as any).highlight = highlight;
+                (edge as ApollonEdge & { highlight?: string }).highlight = highlight;
                 if (edge.data) {
                     (edge.data as Record<string, unknown>).highlight = highlight;
                 }
@@ -373,7 +383,7 @@ export class ModelingAssessmentComponent extends ModelingComponent implements Af
                 dropInfo: this.calculateDropInfo(feedback),
             };
             if (!umlModel.assessments) {
-                umlModel.assessments = {} as any;
+                umlModel.assessments = {};
             }
             umlModel.assessments[feedback.referenceId!] = newAssessment;
             if (this.apollonEditor) {

--- a/src/main/webapp/app/modeling/manage/detail/modeling-exercise-detail.component.ts
+++ b/src/main/webapp/app/modeling/manage/detail/modeling-exercise-detail.component.ts
@@ -9,6 +9,7 @@ import { Subscription } from 'rxjs';
 import { ModelingExercise } from 'app/modeling/shared/entities/modeling-exercise.model';
 import { ModelingExerciseService } from '../services/modeling-exercise.service';
 import { ArtemisMarkdownService } from 'app/foundation/service/markdown.service';
+import { parseJson } from 'app/foundation/util/json.util';
 import { ExerciseManagementStatisticsDto } from 'app/exercise/statistics/exercise-management-statistics-dto';
 import { ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { StatisticsService } from 'app/exercise/statistics-graph/service/statistics.service';
@@ -79,7 +80,7 @@ export class ModelingExerciseDetailComponent implements OnInit, OnDestroy {
             this.gradingInstructions = this.artemisMarkdown.safeHtmlForMarkdown(this.modelingExercise().gradingInstructions);
             this.exampleSolution = this.artemisMarkdown.safeHtmlForMarkdown(this.modelingExercise().exampleSolutionExplanation);
             if (this.modelingExercise().exampleSolutionModel && this.modelingExercise().exampleSolutionModel !== '') {
-                this.exampleSolutionUML = importDiagram(JSON.parse(this.modelingExercise().exampleSolutionModel!));
+                this.exampleSolutionUML = importDiagram(parseJson(this.modelingExercise().exampleSolutionModel!));
             }
             this.detailOverviewSections.set(this.getExerciseDetailSections());
         });

--- a/src/main/webapp/app/modeling/manage/example-modeling/example-modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling/manage/example-modeling/example-modeling-submission.component.ts
@@ -18,6 +18,7 @@ import { catchError, concatMap, map, tap } from 'rxjs/operators';
 import { getLatestSubmissionResult, setLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
 import { getPositiveAndCappedTotalScore, getTotalMaxPoints } from 'app/exercise/util/exercise.utils';
 import { onError } from 'app/foundation/util/global.utils';
+import { parseJson } from 'app/foundation/util/json.util';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { ExampleSubmissionAssessCommand, FeedbackMarker } from 'app/exercise/example-submission/example-submission-assess-command';
 import { getCourseFromExercise } from 'app/exercise/shared/entities/exercise/exercise.model';
@@ -178,7 +179,7 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
                     if (exampleSubmission.submission) {
                         this.modelingSubmission = exampleSubmission.submission as ModelingSubmission;
                         if (this.modelingSubmission.model) {
-                            this.umlModel.set(importDiagram(JSON.parse(this.modelingSubmission.model)));
+                            this.umlModel.set(importDiagram(parseJson(this.modelingSubmission.model)));
                         }
                         // Updates the explanation text with example modeling submission's explanation
                         this.explanationText.set(this.modelingSubmission.explanationText ?? '');
@@ -246,7 +247,7 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
                 if (exampleSubmission.submission) {
                     this.modelingSubmission = exampleSubmission.submission as ModelingSubmission;
                     if (this.modelingSubmission.model) {
-                        this.umlModel.set(importDiagram(JSON.parse(this.modelingSubmission.model)));
+                        this.umlModel.set(importDiagram(parseJson(this.modelingSubmission.model)));
                     }
                     // Updates the explanation text with example modeling submission's explanation
                     this.explanationText.set(this.modelingSubmission.explanationText ?? '');
@@ -294,7 +295,7 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
                 if (updatedExampleSubmission.submission) {
                     this.modelingSubmission = updatedExampleSubmission.submission as ModelingSubmission;
                     if (this.modelingSubmission.model) {
-                        this.umlModel.set(importDiagram(JSON.parse(this.modelingSubmission.model)));
+                        this.umlModel.set(importDiagram(parseJson(this.modelingSubmission.model)));
                     }
                     if (this.modelingSubmission.explanationText) {
                         this.explanationText.set(this.modelingSubmission.explanationText);

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
@@ -35,6 +35,7 @@ import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pip
 import { AlertService } from 'app/foundation/service/alert.service';
 import { EventManager } from 'app/foundation/service/event-manager.service';
 import { onError } from 'app/foundation/util/global.utils';
+import { parseJson } from 'app/foundation/util/json.util';
 import { ArtemisNavigationUtilService } from 'app/foundation/util/navigation.utils';
 import { scrollToTopOfPage } from 'app/foundation/util/utils';
 import { cloneDeep, isEmpty } from 'lodash-es';
@@ -172,7 +173,7 @@ export class ModelingExerciseUpdateComponent implements AfterViewInit, OnDestroy
             this.modelingExercise = modelingExercise;
 
             if (this.modelingExercise.exampleSolutionModel != undefined) {
-                this.exampleSolution.set(importDiagram(JSON.parse(this.modelingExercise.exampleSolutionModel)));
+                this.exampleSolution.set(importDiagram(parseJson(this.modelingExercise.exampleSolutionModel)));
             }
 
             this.backupExercise = cloneDeep(this.modelingExercise);

--- a/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.component.ts
@@ -38,6 +38,7 @@ import { ResizeableContainerComponent } from 'app/shared-ui/resizeable-container
 import { AlertService } from 'app/foundation/service/alert.service';
 import { WebsocketService } from 'app/foundation/service/websocket.service';
 import { onError } from 'app/foundation/util/global.utils';
+import { parseJson } from 'app/foundation/util/json.util';
 import { stringifyIgnoringFields } from 'app/foundation/util/utils';
 import dayjs from 'dayjs/esm';
 import { omit } from 'lodash-es';
@@ -45,7 +46,7 @@ import { Subject, Subscription, TeardownLogic, of } from 'rxjs';
 import { catchError, filter, skip, switchMap, tap } from 'rxjs/operators';
 import { ModelingAssessmentComponent } from '../../manage/assess/modeling-assessment.component';
 import { AssessmentNamesForModelId, getNamesForAssessments } from '../../manage/assess/modeling-assessment.util';
-import { countModelElements, hasModelElements, isModelEmpty as isApollonModelEmpty } from '../../shared/apollon-model.util';
+import { ApollonModelData, countModelElements, hasModelElements, isModelEmpty as isApollonModelEmpty } from '../../shared/apollon-model.util';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { UnifiedFeedbackComponent } from 'app/shared/components/unified-feedback/unified-feedback.component';
 
@@ -415,7 +416,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
 
     private updateModelAndExplanation(): void {
         if (this.submission().model) {
-            this.umlModel.set(importDiagram(JSON.parse(this.submission().model!)));
+            this.umlModel.set(importDiagram(parseJson(this.submission().model!)));
             this.hasElements.set(hasModelElements(this.umlModel()));
         } else {
             this.umlModel.set(undefined!);
@@ -455,7 +456,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                     this.submission.set(submission);
                     // Team mode: leave the live collaborative editor (Yjs) untouched — see submit().
                     if (!this.modelingExercise().teamMode && this.submission().model) {
-                        this.umlModel.set(importDiagram(JSON.parse(this.submission().model!)));
+                        this.umlModel.set(importDiagram(parseJson(this.submission().model!)));
                         this.hasElements.set(hasModelElements(this.umlModel()));
                     }
                     const latestResult = getLatestSubmissionResult(this.submission());
@@ -646,7 +647,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                     // In team mode the live collaborative editor is the single source of truth (Yjs); re-importing
                     // the saved snapshot would reset the shared document and discard a teammate's concurrent edits.
                     if (!this.modelingExercise().teamMode && this.submission().model) {
-                        this.umlModel.set(importDiagram(JSON.parse(this.submission().model!)));
+                        this.umlModel.set(importDiagram(parseJson(this.submission().model!)));
                         this.hasElements.set(hasModelElements(this.umlModel()));
                     }
                     this.submissionChange.next(this.submission());
@@ -722,7 +723,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         if (!model) {
             return true;
         }
-        const umlModel = JSON.parse(model);
+        const umlModel = parseJson<ApollonModelData>(model);
         return isApollonModelEmpty(umlModel);
     }
 
@@ -873,7 +874,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         if (!submissionModel) {
             return model.nodes.length > 0 && JSON.stringify(model) !== '';
         } else {
-            const currentModel = JSON.parse(submissionModel);
+            const currentModel = parseJson<ApollonModelData>(submissionModel);
             const versionMatch = currentModel.version === model.version;
             const modelMatch = stringifyIgnoringFields(currentModel, 'size') === stringifyIgnoringFields(model, 'size');
             return versionMatch && !modelMatch;
@@ -887,7 +888,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
     calculateNumberOfModelElements(): number {
         const submissionModel = this.submission()?.model;
         if (submissionModel) {
-            const umlModel = JSON.parse(submissionModel);
+            const umlModel = parseJson<ApollonModelData>(submissionModel);
             return countModelElements(umlModel);
         }
         return 0;

--- a/src/main/webapp/app/modeling/shared/modeling-editor/modeling-editor.component.ts
+++ b/src/main/webapp/app/modeling/shared/modeling-editor/modeling-editor.component.ts
@@ -14,6 +14,9 @@ import { HtmlForMarkdownPipe } from 'app/foundation/pipes/html-for-markdown.pipe
 import { getModelNodes } from 'app/modeling/shared/apollon-model.util';
 import { ResizableDirective } from 'app/shared-ui/directives/resizable.directive';
 
+/** Host element augmented with the Apollon editor instance exposed for E2E test access. */
+type ApollonEditorHostElement = HTMLElement & { __apollonEditor?: ApollonEditor };
+
 @Component({
     selector: 'jhi-modeling-editor',
     templateUrl: './modeling-editor.component.html',
@@ -171,7 +174,7 @@ export class ModelingEditorComponent extends ModelingComponent implements AfterV
 
             // Expose the ApollonEditor instance on the host DOM element for E2E test access.
             // In production mode, ng.getComponent() is not available, so tests use this property instead.
-            (this.elementRef.nativeElement as any).__apollonEditor = this.apollonEditor;
+            (this.elementRef.nativeElement as ApollonEditorHostElement).__apollonEditor = this.apollonEditor;
 
             this.modelSubscription = this.apollonEditor.subscribeToModelChange((model: UMLModel) => {
                 if (this.isDestroyed) {
@@ -199,7 +202,7 @@ export class ModelingEditorComponent extends ModelingComponent implements AfterV
             }
             this.apollonEditor.destroy();
             this.apollonEditor = undefined;
-            (this.elementRef.nativeElement as any).__apollonEditor = undefined;
+            (this.elementRef.nativeElement as ApollonEditorHostElement).__apollonEditor = undefined;
         }
     }
 

--- a/src/main/webapp/app/programming/manage/code-editor/build-output/code-editor-build-output.component.ts
+++ b/src/main/webapp/app/programming/manage/code-editor/build-output/code-editor-build-output.component.ts
@@ -10,6 +10,7 @@ import { Feedback } from 'app/assessment/shared/entities/feedback.model';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { ProgrammingSubmission } from 'app/programming/shared/entities/programming-submission.model';
 import { findLatestResult } from 'app/foundation/util/utils';
+import { parseJson } from 'app/foundation/util/json.util';
 import { StaticCodeAnalysisIssue } from 'app/programming/shared/entities/static-code-analysis-issue.model';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { faChevronDown, faCircleNotch, faTerminal } from '@fortawesome/free-solid-svg-icons';
@@ -117,7 +118,7 @@ export class CodeEditorBuildOutputComponent implements OnInit, OnDestroy {
         const buildLogErrors = this.rawBuildLogs().extractErrors(exercise?.programmingLanguage, exercise?.projectType);
         const codeAnalysisIssues = (this.result()!.feedbacks || [])
             .filter(Feedback.isStaticCodeAnalysisFeedback)
-            .map<StaticCodeAnalysisIssue>((feedback) => JSON.parse(feedback.detailText!));
+            .map<StaticCodeAnalysisIssue>((feedback) => parseJson<StaticCodeAnalysisIssue>(feedback.detailText!));
         const codeAnalysisAnnotations = codeAnalysisIssues.map<Annotation>((issue) => ({
             text: issue.message || '',
             fileName: issue.filePath || '',

--- a/src/main/webapp/app/programming/manage/edit-selected/programming-exercise-edit-selected.component.ts
+++ b/src/main/webapp/app/programming/manage/edit-selected/programming-exercise-edit-selected.component.ts
@@ -68,7 +68,7 @@ export class ProgrammingExerciseEditSelectedComponent implements OnInit {
 
         this.selectedProgrammingExercises.forEach((programmingExercise) => {
             programmingExercise = this.setNewValues(programmingExercise);
-            const requestOptions = {} as any;
+            const requestOptions: { notificationText?: string } = {};
             if (this.notificationText) {
                 requestOptions.notificationText = this.notificationText;
             }

--- a/src/main/webapp/app/programming/manage/grading/tasks/programming-exercise-task.service.ts
+++ b/src/main/webapp/app/programming/manage/grading/tasks/programming-exercise-task.service.ts
@@ -11,6 +11,7 @@ import { ProgrammingExerciseGradingStatistics, TestCaseStats } from 'app/program
 import { ProgrammingExerciseTestCase } from 'app/programming/shared/entities/programming-exercise-test-case.model';
 import { ProgrammingExerciseGradingService, ProgrammingExerciseTestCaseUpdate } from 'app/programming/manage/services/programming-exercise-grading.service';
 import { AlertService } from 'app/foundation/service/alert.service';
+import { parseJson } from 'app/foundation/util/json.util';
 import { map, mergeMap } from 'rxjs/operators';
 
 @Injectable()
@@ -189,7 +190,7 @@ export class ProgrammingExerciseTaskService {
      * Set the tasks currently displayed. Used for showing of active/inactive test cases
      */
     private setCurrentTasks = () => {
-        const tasksCopy: ProgrammingExerciseTask[] = JSON.parse(JSON.stringify(this.tasks));
+        const tasksCopy = parseJson<ProgrammingExerciseTask[]>(JSON.stringify(this.tasks));
         if (this.ignoreInactive) {
             this.currentTasks = tasksCopy.filter((task) => {
                 task.testCases = task.testCases.filter((test) => test.active);

--- a/src/main/webapp/app/programming/manage/services/programming-exercise-sharing.service.ts
+++ b/src/main/webapp/app/programming/manage/services/programming-exercise-sharing.service.ts
@@ -14,6 +14,18 @@ import { map } from 'rxjs/operators';
 export type EntityResponseType = HttpResponse<ProgrammingExercise>;
 export type EntityArrayResponseType = HttpResponse<ProgrammingExercise[]>;
 
+/**
+ * Minimal structural view of a participation used only to strip the circular-reference-prone fields
+ * (`exercise`, `results`, `submissions`) before sending the exercise to the sharing platform. The
+ * index signature preserves all remaining participation fields for the rest spread.
+ */
+interface ParticipationWithCircularReferences {
+    exercise?: unknown;
+    results?: unknown;
+    submissions?: unknown;
+    [key: string]: unknown;
+}
+
 /** the programming exercise sharing service */
 @Injectable({ providedIn: 'root' })
 export class ProgrammingExerciseSharingService {
@@ -78,11 +90,21 @@ export class ProgrammingExerciseSharingService {
         // Remove exercise from template & solution participation to avoid circular dependency issues.
         // Also remove the results, as they can have circular structures as well and don't have to be saved here.
         if (copy.templateParticipation) {
-            const { exercise: _ignoredExercise, results: _ignoredResults, submissions: _ignoredSubmissions, ...filteredTemplateParticipation } = copy.templateParticipation as any;
+            const {
+                exercise: _ignoredExercise,
+                results: _ignoredResults,
+                submissions: _ignoredSubmissions,
+                ...filteredTemplateParticipation
+            } = copy.templateParticipation as ParticipationWithCircularReferences;
             copy.templateParticipation = { ...filteredTemplateParticipation } as TemplateProgrammingExerciseParticipation;
         }
         if (copy.solutionParticipation) {
-            const { exercise: _ignoredExercise, results: _ignoredResults, submissions: _ignoredSubmissions, ...filteredSolutionParticipation } = copy.solutionParticipation as any;
+            const {
+                exercise: _ignoredExercise,
+                results: _ignoredResults,
+                submissions: _ignoredSubmissions,
+                ...filteredSolutionParticipation
+            } = copy.solutionParticipation as ParticipationWithCircularReferences;
             copy.solutionParticipation = { ...filteredSolutionParticipation } as SolutionProgrammingExerciseParticipation;
         }
 

--- a/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.ts
@@ -826,7 +826,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
         this.saveWithModalCheck(
             () => this.saveExercise(),
             (reference) => {
-                const requestOptions = {} as any;
+                const requestOptions: { deleteFeedback?: unknown } = {};
                 requestOptions.deleteFeedback = reference.componentInstance.deleteFeedback;
                 this.subscribeToSaveResponse(this.programmingExerciseService.reevaluateAndUpdate(this.programmingExercise, requestOptions));
             },
@@ -956,7 +956,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
         } else if (this.isImportFromExistingExercise) {
             this.subscribeToSaveResponse(this.programmingExerciseService.importExercise(this.programmingExercise, this.importOptions));
         } else if (this.programmingExercise.id !== undefined) {
-            const requestOptions = {} as any;
+            const requestOptions: { notificationText?: string } = {};
             if (this.notificationText) {
                 requestOptions.notificationText = this.notificationText;
             }

--- a/src/main/webapp/app/programming/manage/update/update-components/custom-build-plans/programming-exercise-build-configuration/programming-exercise-build-configuration.component.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/custom-build-plans/programming-exercise-build-configuration/programming-exercise-build-configuration.component.ts
@@ -8,6 +8,7 @@ import { TableEditableFieldComponent } from 'app/shared-ui/table/editable-field/
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { CellTemplateRef, ColumnDef, TableViewComponent, TableViewOptions } from 'app/shared-ui/table-view/table-view';
+import { parseJson } from 'app/foundation/util/json.util';
 
 const NOT_SUPPORTED_NETWORK_DISABLED_LANGUAGES = [ProgrammingLanguage.EMPTY];
 
@@ -128,7 +129,7 @@ export class ProgrammingExerciseBuildConfigurationComponent implements OnInit {
     }
 
     initDockerFlags() {
-        this.dockerFlags = JSON.parse(this.programmingExercise()?.buildConfig?.dockerFlags ?? '') as DockerFlags;
+        this.dockerFlags = parseJson<DockerFlags>(this.programmingExercise()?.buildConfig?.dockerFlags ?? '');
         if (this.dockerFlags.network) {
             this.network.set(this.dockerFlags.network);
         }

--- a/src/main/webapp/app/programming/manage/version-history/programming-exercise-version-programming-metadata.component.ts
+++ b/src/main/webapp/app/programming/manage/version-history/programming-exercise-version-programming-metadata.component.ts
@@ -9,6 +9,7 @@ import { RepositoryType } from 'app/programming/shared/code-editor/model/code-ed
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
 import { ArtemisMarkdownService } from 'app/foundation/service/markdown.service';
+import { parseJson } from 'app/foundation/util/json.util';
 import { findParamInRouteHierarchy } from 'app/foundation/util/navigation.utils';
 import { booleanLabel } from 'app/exercise/version-history/shared/version-history.utils';
 import dayjs from 'dayjs/esm';
@@ -344,7 +345,7 @@ export class ProgrammingExerciseVersionProgrammingMetadataComponent {
             return undefined;
         }
         try {
-            return JSON.stringify(JSON.parse(raw), undefined, 2);
+            return JSON.stringify(parseJson(raw), undefined, 2);
         } catch {
             return raw;
         }

--- a/src/main/webapp/app/programming/shared/code-editor/monaco/code-editor-monaco.component.ts
+++ b/src/main/webapp/app/programming/shared/code-editor/monaco/code-editor-monaco.component.ts
@@ -46,6 +46,7 @@ import {
 } from 'app/exercise/review/review-comment-utils';
 import { CommentType } from 'app/exercise/shared/entities/review/comment.model';
 import { CodeEditorFileSyncService } from 'app/exercise/synchronization/services/code-editor-file-sync.service';
+import { parseJson } from 'app/foundation/util/json.util';
 
 type FileSession = { [fileName: string]: { code: string; cursor: EditorPosition; scrollTop: number; loadingError: boolean } };
 type FeedbackWithLineAndReference = Feedback & { line: number; reference: string };
@@ -991,7 +992,7 @@ export class CodeEditorMonacoComponent implements OnDestroy {
      * Loads annotations from local storage
      */
     loadAnnotations() {
-        return JSON.parse(this.localStorageService.retrieve<string>('annotations-' + this.sessionId()) || '{}');
+        return parseJson<{ [hash: string]: Annotation }>(this.localStorageService.retrieve<string>('annotations-' + this.sessionId()) || '{}');
     }
 
     setBuildAnnotations(buildAnnotations: Annotation[]): void {

--- a/src/main/webapp/app/programming/shared/entities/build-plan-phases.model.ts
+++ b/src/main/webapp/app/programming/shared/entities/build-plan-phases.model.ts
@@ -1,3 +1,5 @@
+import { parseJson } from 'app/foundation/util/json.util';
+
 /**
  * Supported execution conditions for a build phase.
  * Note: Matches BuildPhaseCondition.java
@@ -43,7 +45,7 @@ export function parseBuildPlanPhases(json: string | undefined): BuildPlanPhases 
     }
     let data;
     try {
-        data = JSON.parse(json);
+        data = parseJson(json);
     } catch {
         return undefined;
     }
@@ -65,7 +67,7 @@ function isBuildPlanPhases(value: unknown): value is BuildPlanPhases {
     if (typeof value !== 'object' || value === null) {
         return false;
     }
-    const v = value as any;
+    const v = value as { phases?: unknown; dockerImage?: unknown };
     return Array.isArray(v.phases) && v.phases.every(isBuildPhase) && (v.dockerImage == null || typeof v.dockerImage === 'string');
 }
 
@@ -73,7 +75,7 @@ function isBuildPhase(value: unknown): value is BuildPhase {
     if (typeof value !== 'object' || value === null) {
         return false;
     }
-    const v = value as any;
+    const v = value as { name?: unknown; script?: unknown; condition?: unknown; forceRun?: unknown; resultPaths?: unknown };
     return (
         typeof v.name === 'string' &&
         typeof v.script === 'string' &&

--- a/src/main/webapp/app/programming/shared/entities/static-code-analysis-issue.model.ts
+++ b/src/main/webapp/app/programming/shared/entities/static-code-analysis-issue.model.ts
@@ -1,4 +1,5 @@
 import { Feedback } from 'app/assessment/shared/entities/feedback.model';
+import { parseJson } from 'app/foundation/util/json.util';
 
 export class StaticCodeAnalysisIssue {
     public filePath: string;
@@ -13,6 +14,6 @@ export class StaticCodeAnalysisIssue {
     public penalty?: number;
 
     static fromFeedback(feedback: Feedback): StaticCodeAnalysisIssue {
-        return JSON.parse(feedback.detailText!);
+        return parseJson<StaticCodeAnalysisIssue>(feedback.detailText!);
     }
 }

--- a/src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.ts
+++ b/src/main/webapp/app/programming/shared/services/legacy-build-plan-converter.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BuildPhase, BuildPlanPhases } from 'app/programming/shared/entities/build-plan-phases.model';
+import { parseJson } from 'app/foundation/util/json.util';
 
 /**
  * The purpose of this service is to transform the legacy build plan into the new format so it can still be edited
@@ -15,7 +16,7 @@ export class LegacyBuildPlanConverterService {
 
         if (buildPlanConfiguration?.trim()) {
             try {
-                const parsedJson = JSON.parse(buildPlanConfiguration);
+                const parsedJson = parseJson(buildPlanConfiguration);
                 if (this.isObject(parsedJson)) {
                     parsed = parsedJson;
                 }

--- a/src/main/webapp/app/programming/shared/services/programming-submission.service.spec.ts
+++ b/src/main/webapp/app/programming/shared/services/programming-submission.service.spec.ts
@@ -49,6 +49,9 @@ type SubmissionServicePrivates = {
     submissionTopicsSubscribed: Map<number, string>;
     DEFAULT_EXPECTED_RESULT_ETA: number;
     currentExpectedQueueEstimate: number;
+    currentExpectedResultETA: number;
+    getExpectedRemainingTimeForBuild: (submission: ProgrammingSubmission) => number;
+    getExpectedRemainingTimeForQueue: (submission: ProgrammingSubmission) => number;
     fetchLatestPendingSubmissionByParticipationId: (participationId: number) => unknown;
     setupWebsocketSubscriptionForLatestPendingSubmission: (participationId: number, exerciseId: number, personal: boolean) => unknown;
     subscribeForNewResult: (participationId: number, exerciseId: number, personal: boolean) => unknown;
@@ -757,6 +760,39 @@ describe('ProgrammingSubmissionService', () => {
         } finally {
             vi.useRealTimers();
         }
+    });
+
+    describe('getExpectedRemainingTimeForBuild / getExpectedRemainingTimeForQueue', () => {
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('subtracts the elapsed time since submission from the result ETA, preserving millisecond precision', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-07-02T12:00:00.000Z'));
+            priv(submissionService).currentExpectedResultETA = 120_000;
+            // 29_500 ms elapsed → 120_000 - 29_500 = 90_500 (the previous Date.parse-based impl truncated the .500 → 90_000)
+            const submission = { submissionDate: dayjs('2026-07-02T11:59:30.500Z') } as ProgrammingSubmission;
+            expect(priv(submissionService).getExpectedRemainingTimeForBuild(submission)).toBe(90_500);
+        });
+
+        it('subtracts the elapsed time since submission from the queue estimate', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-07-02T12:00:00.000Z'));
+            priv(submissionService).currentExpectedQueueEstimate = 60_000;
+            const submission = { submissionDate: dayjs('2026-07-02T11:59:45.000Z') } as ProgrammingSubmission;
+            expect(priv(submissionService).getExpectedRemainingTimeForQueue(submission)).toBe(45_000);
+        });
+
+        it('treats a missing submissionDate as now, returning the full ETA/estimate rather than NaN', () => {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date('2026-07-02T12:00:00.000Z'));
+            priv(submissionService).currentExpectedResultETA = 120_000;
+            priv(submissionService).currentExpectedQueueEstimate = 60_000;
+            const submission = { submissionDate: undefined } as ProgrammingSubmission;
+            expect(priv(submissionService).getExpectedRemainingTimeForBuild(submission)).toBe(120_000);
+            expect(priv(submissionService).getExpectedRemainingTimeForQueue(submission)).toBe(60_000);
+        });
     });
 
     describe('authentication state changes', () => {

--- a/src/main/webapp/app/programming/shared/services/programming-submission.service.ts
+++ b/src/main/webapp/app/programming/shared/services/programming-submission.service.ts
@@ -563,11 +563,11 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      * @return the expected rest time to wait for the build.
      */
     private getExpectedRemainingTimeForBuild(submission: ProgrammingSubmission): number {
-        return this.currentExpectedResultETA - (Date.now() - Date.parse(submission.submissionDate as any));
+        return this.currentExpectedResultETA - (Date.now() - dayjs(submission.submissionDate).valueOf());
     }
 
     private getExpectedRemainingTimeForQueue(submission: ProgrammingSubmission): number {
-        return this.currentExpectedQueueEstimate - (Date.now() - Date.parse(submission.submissionDate as any));
+        return this.currentExpectedQueueEstimate - (Date.now() - dayjs(submission.submissionDate).valueOf());
     }
 
     /**

--- a/src/main/webapp/app/quiz/manage/apollon-diagrams/detail/apollon-diagram-detail.component.ts
+++ b/src/main/webapp/app/quiz/manage/apollon-diagrams/detail/apollon-diagram-detail.component.ts
@@ -20,6 +20,10 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
 import { hasQuizRelevantElements } from 'app/modeling/shared/apollon-model.util';
 import { DialogService } from 'primeng/dynamicdialog';
+import { parseJson } from 'app/foundation/util/json.util';
+
+/** Host DOM element augmented with the ApollonEditor instance exposed for E2E test access. */
+type ApollonEditorHostElement = HTMLElement & { __apollonEditor?: ApollonEditor };
 
 @Component({
     selector: 'jhi-apollon-diagram-detail',
@@ -98,7 +102,7 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
 
                 this.apollonDiagram.set(diagram);
 
-                const model: UMLModel | undefined = diagram.jsonRepresentation ? importDiagram(JSON.parse(diagram.jsonRepresentation)) : undefined;
+                const model: UMLModel | undefined = diagram.jsonRepresentation ? importDiagram(parseJson(diagram.jsonRepresentation)) : undefined;
                 this.lastSavedModelJson = model ? JSON.stringify(model) : '';
                 this.initializeApollonEditor(model);
                 this.setAutoSaveTimer();
@@ -119,7 +123,7 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
         if (this.apollonEditor) {
             this.apollonEditor.destroy();
         }
-        (this.elementRef.nativeElement as any).__apollonEditor = undefined;
+        (this.elementRef.nativeElement as ApollonEditorHostElement).__apollonEditor = undefined;
     }
 
     /**
@@ -143,7 +147,7 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
         } as ConstructorParameters<typeof ApollonEditor>[1];
         this.apollonEditor = new ApollonEditor(this.editorContainer().nativeElement, editorOptions);
         // Expose the ApollonEditor instance on the host DOM element for E2E test access.
-        (this.elementRef.nativeElement as any).__apollonEditor = this.apollonEditor;
+        (this.elementRef.nativeElement as ApollonEditorHostElement).__apollonEditor = this.apollonEditor;
         // Apollon's React/Zustand store fires outside Angular; the isSaved signal write below schedules
         // change detection under zoneless, so template bindings (e.g. the save button state) stay fresh.
         this.apollonEditor.subscribeToModelChange((newModel) => {

--- a/src/main/webapp/app/quiz/manage/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
+++ b/src/main/webapp/app/quiz/manage/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
@@ -28,6 +28,19 @@ interface NestedNodeElement {
 
 type DiagramElement = ApollonNode | ApollonEdge | NestedNodeElement;
 
+/**
+ * Minimal structural view of a UML model that exposes both the v3 shape (`elements`/`relationships` records)
+ * and the v4 shape (`nodes`/`edges` arrays). Apollon's {@link UMLModel} type only declares the v4 fields, but
+ * `importDiagram` may hand back either format at runtime, so this interface makes the v3 fields available for
+ * defensive access without disabling type checking on the model.
+ */
+interface VersionedUMLModel {
+    elements?: Record<string, DiagramElement>;
+    relationships?: Record<string, DiagramElement>;
+    nodes?: ApollonNode[];
+    edges?: ApollonEdge[];
+}
+
 function getInteractiveElements(model: UMLModel): string[] {
     return getQuizRelevantElementIds(model);
 }
@@ -72,20 +85,20 @@ function isNestedNodeElement(element: DiagramElement): element is NestedNodeElem
 }
 
 function getModelElements(model: UMLModel): DiagramElement[] {
-    const modelAny = model as any;
+    const versionedModel: VersionedUMLModel = model;
 
     // v3 format: elements and relationships are Records
-    if (modelAny.elements && typeof modelAny.elements === 'object' && !Array.isArray(modelAny.elements)) {
-        const elements = Object.values(modelAny.elements) as DiagramElement[];
-        const relationships = modelAny.relationships ? (Object.values(modelAny.relationships) as DiagramElement[]) : [];
+    if (versionedModel.elements && typeof versionedModel.elements === 'object' && !Array.isArray(versionedModel.elements)) {
+        const elements = Object.values(versionedModel.elements);
+        const relationships = versionedModel.relationships ? Object.values(versionedModel.relationships) : [];
         return [...elements, ...relationships];
     }
 
     // v4 format: nodes and edges are arrays
-    if (Array.isArray(modelAny.nodes)) {
-        const nodes = modelAny.nodes as ApollonNode[];
+    if (Array.isArray(versionedModel.nodes)) {
+        const nodes = versionedModel.nodes;
         const nestedNodeElements = nodes.flatMap(getNestedNodeElements);
-        const edges = (modelAny.edges ?? []) as ApollonEdge[];
+        const edges = versionedModel.edges ?? [];
         return [...nodes, ...nestedNodeElements, ...edges];
     }
 

--- a/src/main/webapp/app/quiz/manage/list-edit-existing/quiz-question-list-edit-existing.component.ts
+++ b/src/main/webapp/app/quiz/manage/list-edit-existing/quiz-question-list-edit-existing.component.ts
@@ -21,6 +21,7 @@ import { KeyValuePipe, NgClass } from '@angular/common';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { FormsModule } from '@angular/forms';
 import { FileService } from 'app/foundation/service/file.service';
+import { parseJson } from 'app/foundation/util/json.util';
 
 export enum State {
     COURSE = 'Course',
@@ -221,7 +222,7 @@ export class QuizQuestionListEditExistingComponent {
 
     async processJsonContent(jsonContent: string, images: Map<string, File> = new Map()) {
         try {
-            const questions = JSON.parse(jsonContent) as QuizQuestion[];
+            const questions = parseJson<QuizQuestion[]>(jsonContent);
             await this.addQuestions(questions, images);
             // Clearing html elements
             this.importFile.set(undefined);

--- a/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.ts
+++ b/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.ts
@@ -676,7 +676,7 @@ export class QuizExerciseUpdateComponent extends QuizExerciseValidationDirective
         this.isSaving.set(true);
         this.quizQuestionListEditComponent().parseAllQuestions();
         if (this.quizExercise().id !== undefined) {
-            const requestOptions = {} as any;
+            const requestOptions: { notificationText?: string } = {};
             if (this.notificationText) {
                 requestOptions.notificationText = this.notificationText;
             }

--- a/src/main/webapp/app/shared-ui/components/resizable-panels/resizable-panels.component.ts
+++ b/src/main/webapp/app/shared-ui/components/resizable-panels/resizable-panels.component.ts
@@ -8,6 +8,7 @@ import { SplitterModule } from 'primeng/splitter';
 import { TabsModule } from 'primeng/tabs';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
+import { parseJson } from 'app/foundation/util/json.util';
 
 @Directive({ selector: 'ng-template[jhiPanel]' })
 export class PanelDirective {
@@ -158,7 +159,7 @@ export class ResizablePanelsComponent implements AfterViewInit, OnDestroy {
                 return;
             }
             // Matches PrimeNG's Splitter stateStorage format: JSON.stringify(number[]).
-            const parsed: unknown = JSON.parse(raw);
+            const parsed = parseJson(raw);
             // Only seed a usable split: two finite numbers, a positive left, and a right above the collapse
             // threshold. A near-zero/degenerate stored value (external tampering, legacy data) is ignored so the
             // initial render never restores a jammed sliver (restoreUsableSplit only runs on expand, not on seed).

--- a/src/main/webapp/app/shared-ui/components/resizable-panels/resizable-panels.component.ts
+++ b/src/main/webapp/app/shared-ui/components/resizable-panels/resizable-panels.component.ts
@@ -159,7 +159,7 @@ export class ResizablePanelsComponent implements AfterViewInit, OnDestroy {
                 return;
             }
             // Matches PrimeNG's Splitter stateStorage format: JSON.stringify(number[]).
-            const parsed = parseJson(raw);
+            const parsed = parseJson<number[]>(raw);
             // Only seed a usable split: two finite numbers, a positive left, and a right above the collapse
             // threshold. A near-zero/degenerate stored value (external tampering, legacy data) is ignored so the
             // initial render never restores a jammed sliver (restoreUsableSplit only runs on expand, not on seed).
@@ -170,7 +170,7 @@ export class ResizablePanelsComponent implements AfterViewInit, OnDestroy {
                 parsed[0] > 0 &&
                 parsed[1] > this.collapseSnapPercent()
             ) {
-                this.savedSizes.set(parsed as number[]);
+                this.savedSizes.set(parsed);
             }
         } catch {
             // Malformed or unavailable storage (private mode / no window); the in-memory default applies.


### PR DESCRIPTION
### Summary
This is a client type-safety follow-up to #13059. It (1) routes **every** production `JSON.parse` call through the typed `parseJson<T>()` helper and raises the ban on bare `JSON.parse` from `warn` to `error`, and (2) adds a new ESLint rule that forbids `as any` casts in production client code and removes all existing ones. Both are enforced at `error` level. No user-facing behavior changes.

### Checklist
#### General
- [x] This is a non-user-facing change (client type-safety + lint tooling) that I verified locally: `tsc --noEmit` clean, ESLint clean, and all co-located specs for the changed files pass (1129 tests).
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Client
- [x] The change adds no REST calls and no data fetching; it is a pure type-safety/tooling refactor with no performance or data-economy impact.
- [x] I strictly followed the client coding guidelines.
- [x] The refactored code paths are covered by existing Vitest specs (all pass); the new `no-as-any-cast` rule was verified to fire on `as any` and stay silent otherwise.
- [x] I documented the new TypeScript code (the `parseJson` helper's JSDoc already exists from #13059; the new ESLint rule is documented in-file).

### Motivation and Context
`JSON.parse` is declared to return `any`, so everything derived from a parsed value is unchecked — property typos and refactor drift only surface at runtime. Likewise, `as any` casts opt an expression out of type checking entirely and are a recurring source of runtime errors. #13059 introduced the `parseJson<T>()` helper and a `warn`-level ban on bare `JSON.parse`, migrating the exercise-category sites as a first step. This PR completes that migration across the whole client and, in the same spirit as the existing `no-as-unknown-cast` rule (#13052), eliminates `as any` and locks it out going forward. This is the groundwork before enabling the stricter `@typescript-eslint/no-unsafe-*` rules incrementally.

### Description
**1. JSON.parse → `parseJson<T>()` (48 production sites)**
- All bare `JSON.parse` calls in `src/main/webapp` now use `parseJson<T>()`. The `no-restricted-properties` ban is raised from `warn` to `error`. The helper's generic defaults to `unknown`, so callers must state the expected shape.
- Patterns applied: `JSON.parse(x) as T` → `parseJson<T>(x)`; `importDiagram(JSON.parse(x))` → `importDiagram(parseJson(x))`; deep-clone/pretty-print via `parseJson<T>(JSON.stringify(x))` / `JSON.stringify(parseJson(x), …)`; storage-service generics; and context-derived types elsewhere (e.g. `QuizQuestion[]`, `StaticCodeAnalysisIssue`, `FaqCategory`, `SubmittedAnswer[]`).

**2. New `no-as-any-cast` ESLint rule + removal of all `as any` (~43 sites)**
- New AST-based local rule (`rules/no-as-any-cast.mjs`) forbids `x as any` / `<any>x` in production client code, allowed only in `*.spec.ts` — mirroring `no-as-unknown-cast`. Wired to `error`.
- All production `as any` casts replaced with proper types, never `as any`/`as unknown`: precise object types for HTTP `requestOptions`; intersection types for DOM/global augmentation (`window.monaco`, the `__apollonEditor` host element, vendor-prefixed fullscreen members, `Intl.supportedValuesOf`); `dayjs(x).valueOf()` / `dayjs.isDayjs()` for date handling; minimal typed interfaces (e.g. `VersionedUMLModel`, `ParticipationWithCircularReferences`); and `Record<string, unknown>` for genuine dynamic reflection. No `eslint-disable` was needed anywhere.

Behavior is preserved throughout; the two spots that previously relied on `as any` masking (`fullscreen.util` returning an element instead of a boolean, `Date.parse` on a non-string) were fixed to their correct, equivalent behavior.

### Steps for Testing
Non-user-facing type-safety change; verification is build + lint + automated tests + spot-checking affected UIs.

1. Check out the branch and run:
   - `pnpm exec tsc --project tsconfig.app.json --noEmit` → no errors.
   - `pnpm run lint` → no errors (both `no-restricted-properties` for `JSON.parse` and `localRules/no-as-any-cast` are now hard errors and pass).
   - `pnpm run vitest:run` → green.
2. Smoke-test areas that parse server JSON or use the touched casts: open a modeling exercise/submission (Apollon diagram import), a quiz with imported questions, the programming code-editor build output, and exercise category display — confirm all render and behave as before.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Modeling (Apollon import/render) unaffected
- [ ] Quiz question import unaffected
- [ ] Programming build output / code editor unaffected
- [ ] Exercise category display unaffected

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| course-requests.component.ts | 99.17% | 247 | 68 | 27.5 |
| admin-import-standardized-competencies.component.ts | 91.30% | 284 | ? | ? |
| assessment-instructions.component.ts | 97.50% | 88 | 9 | 10.2 |
| exercise-assessment-dashboard.component.ts | 95.68% | 698 | 97 | 13.9 |
| feedback.model.ts | not found (modified) | 275 | ? | ? |
| example-submission.service.ts | 100.00% | 82 | 35 | 42.7 |
| import-course-competencies-settings.component.ts | 100.00% | 53 | 19 | 35.8 |
| abstract-dialog.component.ts | 92.59% | 51 | ? | ? |
| faq.service.ts | 98.11% | 134 | 34 | 25.4 |
| forwarded-message.component.ts | 84.21% | 114 | 30 | 26.3 |
| course-update.component.ts | 94.07% | 581 | 253 | 43.5 |
| monaco-editor.service.ts | 100.00% | 79 | 10 | 12.7 |
| modeling-exam-submission.component.ts | 95.45% | 119 | 34 | 28.6 |
| quiz-exam-submission.component.ts | 87.70% | 243 | 32 | 13.2 |
| exam-participation-live-events.service.ts | 89.56% | 231 | 32 | 13.9 |
| example-submission-assess-command.ts | 93.75% | 40 | ? | ? |
| exercise-import-from-file.component.ts | 89.65% | 106 | 42 | 39.6 |
| exercise.service.ts | 88.94% | 448 | 109 | 24.3 |
| structured-grading-criterion.service.ts | 91.66% | 43 | 2 | 4.7 |
| exercise-metadata-conflict-modal.component.ts | 99.00% | 235 | 75 | 31.9 |
| exercise-metadata-handlers.ts | 99.25% | 338 | 91 | 26.9 |
| exercise-metadata-snapshot-shared.mapper.ts | 97.36% | 116 | 43 | 37.1 |
| teams-import-from-file-form.component.ts | 89.85% | 159 | 25 | 15.7 |
| local-storage.service.ts | 100.00% | 39 | 20 | 51.3 |
| session-storage.service.ts | 100.00% | 25 | 6 | 24.0 |
| websocket.service.ts | 96.15% | 174 | 37 | 21.3 |
| fullscreen.util.ts | 33.33% | 49 | 4 | 8.2 |
| iris-chat.service.ts | 91.11% | 641 | 97 | 15.1 |
| lecture-attachments.component.ts | 95.37% | 229 | 33 | 14.4 |
| modeling-assessment-editor.component.ts | 83.15% | 502 | 52 | 10.4 |
| modeling-assessment.component.ts | 81.18% | 363 | 55 | 15.2 |
| modeling-exercise-detail.component.ts | 97.67% | 134 | 17 | 12.7 |
| example-modeling-submission.component.ts | 90.45% | 454 | 63 | 13.9 |
| modeling-exercise-update.component.ts | 91.05% | 297 | 51 | 17.2 |
| modeling-submission.component.ts | 85.29% | 673 | 77 | 11.4 |
| modeling-editor.component.ts | 84.31% | 210 | 45 | 21.4 |
| code-editor-build-output.component.ts | 90.14% | 170 | 49 | 28.8 |
| programming-exercise-edit-selected.component.ts | 84.61% | 108 | 11 | 10.2 |
| programming-exercise-task.service.ts | 93.49% | 206 | 28 | 13.6 |
| programming-exercise-sharing.service.ts | 94.44% | 103 | 6 | 5.8 |
| programming-exercise-update.component.ts | 87.16% | 1352 | 201 | 14.9 |
| programming-exercise-build-configuration.component.ts | 86.81% | 177 | 35 | 19.8 |
| programming-exercise-version-programming-metadata.component.ts | 90.00% | 262 | 32 | 12.2 |
| code-editor-monaco.component.ts | 93.45% | 809 | 135 | 16.7 |
| build-plan-phases.model.ts | not found (modified) | 71 | 21 | 29.6 |
| static-code-analysis-issue.model.ts | not found (modified) | 17 | ? | ? |
| legacy-build-plan-converter.service.ts | 92.98% | 117 | 41 | 35.0 |
| programming-submission.service.ts | 76.76% | 702 | 118 | 16.8 |
| apollon-diagram-detail.component.ts | 94.28% | 211 | 38 | 18.0 |
| quiz-exercise-generator.ts | 82.14% | 284 | 61 | 21.5 |
| quiz-question-list-edit-existing.component.ts | 94.88% | 362 | 63 | 17.4 |
| quiz-exercise-update.component.ts | 85.02% | 785 | 250 | 31.8 |
| resizable-panels.component.ts | 91.91% | 172 | 45 | 26.2 |

_Last updated: 2026-07-02 12:47:40 UTC_

