### PR TITLE
`Development`: Upgrade checkstyle to 13.7.0 and fix a flaky LTI test

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ hazelcast_version=5.7.0
 # Jackson 2 versions are managed by the Spring Boot BOM; only jackson-datatype-hibernate7 is explicitly declared
 jgit_version=7.7.0.202606012155-r
 sshd_version=2.18.0
-checkstyle_version=13.5.0
+checkstyle_version=13.7.0
 jplag_version=6.3.0
 # not really used in Artemis, nor JPlag, nor the used version of Stanford CoreNLP, but we use the latest to avoid security vulnerability warnings
 # NOTE: we cannot need to use the latest version 9.x or 10.x here as long as Stanford CoreNLP does not reference it

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/PageUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/PageUtil.java
@@ -107,7 +107,7 @@ public class PageUtil {
      *
      * <p>
      * If the mapped column name contains a "COUNT(" expression, this method treats it as an unsafe sort expression
-     * and uses {@link JpaSort(String)} to apply sorting directly to the database column.
+     * and uses {@link JpaSort} to apply sorting directly to the database column.
      * </p>
      *
      * @param search        The {@link PageableSearchDTO} containing pagination and sorting parameters (e.g., page number, page size, sorted column, and sorting order).

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/AuxiliaryRepositoryResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/AuxiliaryRepositoryResource.java
@@ -182,7 +182,7 @@ public class AuxiliaryRepositoryResource extends RepositoryResource {
      * @param submissions           information about the file updates
      * @param commit                whether to commit after updating the files
      * @param principal             used to check if the user can update the files
-     * @return {Map<String, String>} file submissions or the appropriate http error
+     * @return {@code Map<String, String>} file submissions or the appropriate http error
      */
     @PutMapping("{auxiliaryRepositoryId}/files")
     @EnforceAtLeastTutor

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/RepositoryProgrammingExerciseParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/RepositoryProgrammingExerciseParticipationResource.java
@@ -347,7 +347,7 @@ public class RepositoryProgrammingExerciseParticipationResource extends Reposito
      * @param participationId id of participation to which the files belong
      * @param submissions     information about the file updates
      * @param commit          whether to commit after updating the files
-     * @return {Map<String, String>} file submissions or the appropriate http error
+     * @return {@code Map<String, String>} file submissions or the appropriate http error
      */
     @PutMapping({ "participations/{participationId}/repository/files", "repository/{participationId}/files" })
     @EnforceAtLeastStudent

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/TestRepositoryResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/TestRepositoryResource.java
@@ -177,7 +177,7 @@ public class TestRepositoryResource extends RepositoryResource {
      * @param submissions information about the file updates
      * @param commit      whether to commit after updating the files
      * @param principal   used to check if the user can update the files
-     * @return {Map<String, String>} file submissions or the appropriate http error
+     * @return {@code Map<String, String>} file submissions or the appropriate http error
      */
     @PutMapping({ "programming-exercises/{exerciseId}/test-repository/files", "test-repository/{exerciseId}/files" })
     @EnforceAtLeastTutor

--- a/src/test/java/de/tum/cit/aet/artemis/lti/Lti13Step3JwtValidationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/Lti13Step3JwtValidationIntegrationTest.java
@@ -124,12 +124,16 @@ class Lti13Step3JwtValidationIntegrationTest extends AbstractLtiIntegrationTest 
             claims.claim("https://purl.imsglobal.org/spec/lti/claim/message_type", "LtiResourceLinkRequest");
             claims.claim("https://purl.imsglobal.org/spec/lti/claim/version", "1.3.0");
             claims.claim("https://purl.imsglobal.org/spec/lti/claim/deployment_id", "deployment-1");
-            claims.claim("https://purl.imsglobal.org/spec/lti/claim/target_link_uri", "http://localhost/courses/1");
+            // Deliberately target a course id that cannot exist (Long.MAX_VALUE). Course ids come from a low,
+            // sequential database sequence, so this id never collides with courses that other tests create in the
+            // shared database. The previous hardcoded id 1 could be satisfied by another test's course, which sent
+            // performLaunch past the course lookup into user resolution and caused an unrelated NPE (isolation flake).
+            claims.claim("https://purl.imsglobal.org/spec/lti/claim/target_link_uri", "http://localhost/courses/" + Long.MAX_VALUE);
             // Include the full claim set so OidcTokenValidator accepts the token and the request proceeds into
-            // lti13Service.performLaunch, where no Course matches /courses/1 and BadRequestAlertException (400) is
-            // thrown. The distinct 400 status (vs. the 500s in the two negative tests below) is what lets this happy
-            // path test prove a specific outcome — JWKS fetch + signature verify + claim validation all succeeded —
-            // instead of collapsing onto the same generic "any 5xx" assertion as the rejection paths.
+            // lti13Service.performLaunch, where no Course matches the target link and a BadRequestAlertException (400)
+            // is thrown. The distinct 400 status (vs. the 500s in the two negative tests below) proves a specific
+            // outcome: JWKS fetch, signature verification, and claim validation all succeeded, instead of collapsing
+            // onto the same generic "any 5xx" assertion as the rejection paths.
             claims.claim("https://purl.imsglobal.org/spec/lti/claim/roles", java.util.List.of("http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"));
         });
 


### PR DESCRIPTION
### Summary

Two small follow-ups from the dependency-trim PR (#13061):
1. Complete the deferred **checkstyle 13.7.0** upgrade by fixing four pre-existing invalid Javadoc tags that the stricter 13.7.0 parser rejects.
2. Fix a **shared-database isolation flake** in `Lti13Step3JwtValidationIntegrationTest`.

### Motivation and Context

In #13061 the checkstyle bump to 13.7.0 was reverted because 13.7.0 parses inline Javadoc tags more strictly and failed `checkstyleMain` on four pre-existing malformed comments in unrelated files. This PR fixes those comments and re-applies the upgrade.

Separately, `Lti13Step3JwtValidationIntegrationTest.step3ValidatesSignedIdTokenAgainstJwks` fails intermittently in the full server suite (it passes in isolation). It hardcodes `target_link_uri = /courses/1` and expects "course not found" to yield a 400. When another test has created a course with id 1 (with an online configuration) in the shared database, the lookup succeeds, so `performLaunch` proceeds past the course check into user resolution and throws an unrelated `NullPointerException` (the token deliberately carries no email/username claim). This surfaced during local full-suite validation of #13061.

### Description

**Checkstyle (`gradle.properties`, 4 Java files)**
- `checkstyle_version` 13.5.0 to 13.7.0.
- `PageUtil`: `{@link JpaSort(String)}` to `{@link JpaSort}` (an inline `@link` cannot carry a bare `(String)` without a member reference).
- `AuxiliaryRepositoryResource`, `RepositoryProgrammingExerciseParticipationResource`, `TestRepositoryResource`: `@return {Map<String, String>} ...` to `@return {@code Map<String, String>} ...` (the braces were parsed as a malformed inline tag; `{@code ...}` is the correct form).

**LTI test (`Lti13Step3JwtValidationIntegrationTest`)**
- The target link now uses `/courses/{Long.MAX_VALUE}` instead of `/courses/1`. Course ids are assigned from a low, sequential database sequence, so `getCourseFromTargetLink` (`courseRepository.findById(Long.valueOf(id))`) is deterministically empty and the expected 400 is stable regardless of courses other tests create concurrently.

### Steps for Testing

Build-configuration and test-only change; validation is via CI plus the local checks below:
1. `./gradlew checkstyleMain -x webapp` passes (0 violations under 13.7.0).
2. `./gradlew spotlessCheck -x webapp` passes.
3. `Lti13Step3JwtValidationIntegrationTest` passes, and no longer depends on the absence of course id 1.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/28611498729) did not pass (`failure`). Coverage below may be partial.

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| PageUtil.java | not found (modified) | 92 |
| AuxiliaryRepositoryResource.java | not found (modified) | 177 |
| RepositoryProgrammingExerciseParticipationResource.java | not found (modified) | 316 |
| TestRepositoryResource.java | not found (modified) | 172 |

_Last updated: 2026-07-02 18:51:32 UTC_

