### PR TITLE
`Development`: Bump Helios status starter to 1.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ byte_buddy_version=1.18.10
 mysql_connector_version=9.7.0
 # micrometer versions managed by Spring Boot BOM
 snakeyaml_version=2.6
-helios_status_version=1.1.1
+helios_status_version=1.2.0
 # Pinned to override the older 4.2.x version pulled in transitively (Spring AI, reactor-netty,
 # azure-core-http-netty, …); pre-4.2.13 contains multiple high-severity CVEs.
 netty_version=4.2.15.Final


### PR DESCRIPTION
### Motivation and Context
`de.tum.cit.aet:helios-status-spring-starter` **1.2.0** was just published to Maven Central. This bumps Artemis from **1.1.1 → 1.2.0**.

What's new in 1.2.0 (see the starter [CHANGELOG](https://github.com/ls1intum/Helios/blob/staging/server/helios-status-spring-starter/CHANGELOG.md)):
- Built against **Spring Boot 4.1.0**.
- Now compiled for **Java 25** — Artemis already targets JDK 25 (`JavaLanguageVersion.of(25)`), so there is no compatibility impact.
- Build system migrated from Maven to Gradle (no source/runtime behaviour change; the published POM drops the former `provided`-scope `slf4j-api` / `hibernate-validator`, which were non-transitive anyway — consumers unaffected).

### Description
Single-line change in `gradle.properties`: `helios_status_version` `1.1.1` → `1.2.0`. No code changes — `build.gradle` already references the version via `${helios_status_version}`.

### Steps for Testing
No functional or API change. A green build (which resolves and compiles against the starter) is sufficient verification; the Helios push-based lifecycle reporting continues to work as before.

### Review Progress
#### Code Review
- [x] Code review 1

### Checklist
#### General
- [x] Change is limited to a dependency version bump; no code, API, or database changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled status-related dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->