### PR TITLE
`Development`: Reduce Iris chat callback and dto build overhead

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/IrisMessageService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/IrisMessageService.java
@@ -53,12 +53,11 @@ public class IrisMessageService {
         message.getContent().forEach(content -> content.setMessage(message));
 
         session.getMessages().add(message);
-        irisSessionRepository.save(session);
+        // saveAndFlush so the cascaded message has its generated id; the returned managed entity
+        // replaces the previous full-session reload that ran on every message save.
+        var savedSession = irisSessionRepository.saveAndFlush(session);
+        session.setMessages(savedSession.getMessages()); // Keep the caller's session instance consistent with the managed state.
 
-        var sessionWithMessages = irisSessionRepository.findByIdWithMessagesElseThrow(session.getId());
-        session.setMessages(sessionWithMessages.getMessages()); // Make sure we keep the session up to date as we overrode it. We do this to avoid unnecessarily fetching the
-                                                                // session again.
-
-        return sessionWithMessages.getMessages().getLast();
+        return savedSession.getMessages().getLast();
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineService.java
@@ -117,7 +117,9 @@ public class PyrisPipelineService {
         statusUpdater.accept(List.of(preparing.inProgress(), executing.notStarted()));
 
         var baseDto = new PyrisPipelineExecutionDTO(new PyrisPipelineExecutionSettingsDTO(jobToken, aiSelection, artemisBaseUrl, variant, supportLevel), List.of(preparing.done()));
+        long dtoBuildStart = System.nanoTime();
         var pipelineDto = dtoMapper.apply(baseDto);
+        log.info("Pyris {} pipeline DTO built in {} ms", name, (System.nanoTime() - dtoBuildStart) / 1_000_000);
 
         try {
             // Send a status update that preparation is done and pipeline execution is starting
@@ -125,7 +127,9 @@ public class PyrisPipelineService {
 
             try {
                 // Execute the pipeline using the connector service
+                long requestStart = System.nanoTime();
                 pyrisConnectorService.executePipeline(name, pipelineDto, event);
+                log.info("Pyris {} pipeline run request accepted in {} ms", name, (System.nanoTime() - requestStart) / 1_000_000);
             }
             catch (PyrisConnectorException | IrisException e) {
                 log.error("Failed to execute {} pipeline", name, e);

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineService.java
@@ -119,7 +119,7 @@ public class PyrisPipelineService {
         var baseDto = new PyrisPipelineExecutionDTO(new PyrisPipelineExecutionSettingsDTO(jobToken, aiSelection, artemisBaseUrl, variant, supportLevel), List.of(preparing.done()));
         long dtoBuildStart = System.nanoTime();
         var pipelineDto = dtoMapper.apply(baseDto);
-        log.info("Pyris {} pipeline DTO built in {} ms", name, (System.nanoTime() - dtoBuildStart) / 1_000_000);
+        log.debug("Pyris {} pipeline DTO built in {} ms", name, (System.nanoTime() - dtoBuildStart) / 1_000_000);
 
         try {
             // Send a status update that preparation is done and pipeline execution is starting
@@ -129,7 +129,7 @@ public class PyrisPipelineService {
                 // Execute the pipeline using the connector service
                 long requestStart = System.nanoTime();
                 pyrisConnectorService.executePipeline(name, pipelineDto, event);
-                log.info("Pyris {} pipeline run request accepted in {} ms", name, (System.nanoTime() - requestStart) / 1_000_000);
+                log.debug("Pyris {} pipeline run request accepted in {} ms", name, (System.nanoTime() - requestStart) / 1_000_000);
             }
             catch (PyrisConnectorException | IrisException e) {
                 log.error("Failed to execute {} pipeline", name, e);

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/session/AbstractIrisChatSessionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/session/AbstractIrisChatSessionService.java
@@ -9,6 +9,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -39,6 +41,8 @@ import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseStudentP
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingSubmissionRepository;
 
 public abstract class AbstractIrisChatSessionService<S extends IrisSession> implements IrisChatBasedFeatureInterface<S>, IrisRateLimitedFeatureInterface<S> {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractIrisChatSessionService.class);
 
     private static final int MAX_SESSION_TITLE_LENGTH = 255;
 
@@ -160,8 +164,13 @@ public abstract class AbstractIrisChatSessionService<S extends IrisSession> impl
      * @return the same job record or a new job record with the same job id if changes were made
      */
     public TrackedSessionBasedPyrisJob handleStatusUpdate(TrackedSessionBasedPyrisJob job, PyrisChatStatusUpdateDTO statusUpdate) {
+        long handlingStart = System.nanoTime();
+        // Only the result branch (saving the assistant message) needs the messages and contents;
+        // the frequent intermediate stage updates get away with a plain session load. Pyris blocks
+        // its pipeline thread on each callback, so this reload is on the chat latency critical path.
         // noinspection unchecked
-        var session = (S) irisSessionRepository.findByIdWithMessagesAndContents(job.sessionId());
+        var session = statusUpdate.result() != null ? (S) irisSessionRepository.findByIdWithMessagesAndContents(job.sessionId())
+                : (S) irisSessionRepository.findByIdElseThrow(job.sessionId());
         AtomicReference<TrackedSessionBasedPyrisJob> updatedJob = new AtomicReference<>(job);
         IrisMessage savedMessage;
 
@@ -224,6 +233,8 @@ public abstract class AbstractIrisChatSessionService<S extends IrisSession> impl
         }
 
         updateLatestSuggestions(session, statusUpdate.suggestions());
+
+        log.debug("Iris status update handled in {} ms (result present: {})", (System.nanoTime() - handlingStart) / 1_000_000, statusUpdate.result() != null);
 
         return updatedJob.get();
     }

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/session/IrisChatPipelineExecutionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/session/IrisChatPipelineExecutionService.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -68,6 +70,8 @@ import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 @Service
 @Conditional(IrisEnabled.class)
 public class IrisChatPipelineExecutionService {
+
+    private static final Logger log = LoggerFactory.getLogger(IrisChatPipelineExecutionService.class);
 
     private final IrisSessionRepository irisSessionRepository;
 
@@ -166,9 +170,12 @@ public class IrisChatPipelineExecutionService {
         var messages = pyrisDTOService.toPyrisMessageDTOList(session.getMessages());
 
         // Base data shared across all chat modes (course chat is the baseline)
+        long courseLoadStart = System.nanoTime();
         var fullCourse = pyrisPipelineService.loadCourseWithParticipationOfStudent(course.getId(), session.getUserId());
         PyrisCourseDTO courseDto = PyrisCourseDTO.of(fullCourse);
+        long metricsStart = System.nanoTime();
         StudentMetricsDTO metrics = learningMetricsApi.map(api -> api.getStudentCourseMetrics(session.getUserId(), course.getId())).orElse(null);
+        log.debug("Iris chat DTO base data loaded: course {} ms, metrics {} ms", (metricsStart - courseLoadStart) / 1_000_000, (System.nanoTime() - metricsStart) / 1_000_000);
 
         // Mode-specific fields (additive on top of base data)
         PyrisProgrammingExerciseDTO programmingExercise = null;


### PR DESCRIPTION
### Summary
Production Iris chat averages ~39s user-visible response time. Code inspection found that Pyris blocks its pipeline thread on every status callback it POSTs to Artemis, so Artemis-side callback handling sits on the chat latency critical path, and Artemis performs ~22-30 sequential DB queries per chat message. This PR trims the Artemis-side critical path (session save without a full reload, and a lazy session load for stage-only callbacks) and adds timing instrumentation to attribute where the remaining time goes. No behavior change intended.

**Edutelligence counterpart** (defers non-critical LLM work off the first-answer path on the Pyris side): ls1intum/edutelligence (companion PR, chat pipeline latency)

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
Iris chat is the most latency-sensitive part of the Iris feature set, and current production response times average ~39s from the user's perspective. Pyris calls back to Artemis synchronously on its pipeline thread for every status update it sends (including the frequent intermediate "Thinking..." stage updates), which means slow callback handling on the Artemis side directly adds to the time the student waits for a reply. Inspecting the callback and message-save paths showed two avoidable sources of overhead:
1. Every session-message save reloaded the entire session together with all of its messages, even though nothing about that reload was needed to persist a single new message.
2. Every status callback — including stage-only "Thinking..." pings that carry no assistant message — loaded the session with a `JOIN FETCH` on its messages and their contents, which is only actually needed when an assistant message must be persisted.

Both cost grow with conversation length and both were run on the synchronous callback path that blocks the Pyris pipeline thread.

### Description
**`IrisMessageService`**
- `saveMessage` no longer reloads the full session (with all messages) after every save. It uses `saveAndFlush` and returns the message from the already-managed entity, which preserves the same generated-id guarantees as before without the extra reload query. This save happens twice per chat turn (user message on the request path, assistant message on the callback path) and previously grew with conversation length.

**`AbstractIrisChatSessionService`**
- `handleStatusUpdate` now loads the session **without** the `messages`/`contents` `JOIN FETCH` for stage-only callbacks (`result == null`) — the frequent intermediate "Thinking..." updates that Pyris waits on synchronously. The full (fetch-joined) load is only performed when an assistant message actually needs to be persisted (`result != null`). All other branches used on stage-only callbacks (session title persistence, memory branches via `irisMessageRepository`, websocket sends, token usage tracking, `updateLatestSuggestions`) do not touch the messages collection, so this is safe.
- Added timing instrumentation around callback handling.

**`IrisChatPipelineExecutionService`**
- Added timing instrumentation splitting DTO-build duration into course load vs. student metrics, to help attribute where request-path time is spent.

**`PyrisPipelineService`**
- Added timing instrumentation for Pyris pipeline DTO build duration and run-request-accepted duration.

None of these changes alter externally observable behavior — they are latency and observability changes only.

### Steps for Testing
Prerequisites:
- 1 Student (or Instructor) with Iris enabled for a course

1. Log in to Artemis
2. Open an Iris chat (course chat, exercise chat, lecture chat, etc.)
3. Send a message and verify the answer, session title, and suggested follow-up questions still arrive as before
4. Check the Artemis server logs for the new timing log lines (DTO build, callback handling) to confirm the instrumentation is active
5. Continue a longer conversation (10+ messages) and confirm behavior is unchanged — messages persist correctly, history loads correctly, no regressions in session state

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| IrisMessageService.java | 100.00% | 37 |
| PyrisPipelineService.java | 94.67% | 182 |
| AbstractIrisChatSessionService.java | 91.54% | 329 |
| IrisChatPipelineExecutionService.java | 92.86% | 203 |

_Last updated: 2026-07-03 14:49:39 UTC_

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Performance Tests
- [ ] Test 1
- [ ] Test 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving chat messages and updating session state by persisting and flushing changes in a single step, ensuring message identifiers and collections stay in sync.
  * Optimized session loading during status updates: only fetches messages and contents when a final result is present, keeping intermediate updates lighter and faster.
* **Chores**
  * Added additional timing and debug logging around pipeline and connector execution, plus detailed duration logs for DTO building and update handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
