### PR TITLE
`Development`: Enable eslint `no-floating-promises` at error to improve client type safety

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -297,6 +297,18 @@ export default tseslint.config(
             'no-restricted-globals': ['error', { name: 'globalThis', message: 'Do not use globalThis in production. Use `window` for browser globals, and Sentry captureException for diagnostics instead of globalThis.console.' }],
         },
     },
+    // Require every Promise to be handled in production code. A floating Promise silently swallows rejections
+    // (unhandled errors) and hides ordering bugs. Handle it: `await` it (in an async function, typically with a
+    // try/catch that routes to `onError`), attach `.then(...)/.catch(...)`, or mark it deliberately fire-and-forget
+    // with the `void` operator (`ignoreVoid: true`). `ignoreIIFE` allows `(async () => { … })()`. This overrides the
+    // `'off'` default above for production code; specs may float promises for brevity (excluded below).
+    {
+        files: ['src/main/webapp/**/*.ts'],
+        ignores: ['**/*.spec.ts'],
+        rules: {
+            '@typescript-eslint/no-floating-promises': ['error', { ignoreVoid: true, ignoreIIFE: true }],
+        },
+    },
     // Discourage `ngOnChanges` across Angular client files that have a clean baseline. Prefer computed() for derived
     // state and effect() for genuine side effects. `ngOnChanges` still works in Angular 21 (it fires for signal inputs),
     // so this is a consistency preference, not a correctness rule. Existing migration-backlog files are excluded above

--- a/src/main/webapp/app/account/fingerprint/browser-fingerprint.service.ts
+++ b/src/main/webapp/app/account/fingerprint/browser-fingerprint.service.ts
@@ -70,8 +70,8 @@ export class BrowserFingerprintService {
      * screen resolution, installed fonts, plugins, and other attributes.
      */
     private generateBrowserFingerprint(): void {
-        FingerprintJS.load().then((fingerprintAgent: { get: () => Promise<GetResult> }) => {
-            fingerprintAgent.get().then((result) => {
+        void FingerprintJS.load().then((fingerprintAgent: { get: () => Promise<GetResult> }) => {
+            void fingerprintAgent.get().then((result) => {
                 this.browserFingerprint.next(result.visitorId);
             });
         });

--- a/src/main/webapp/app/account/password/password.component.ts
+++ b/src/main/webapp/app/account/password/password.component.ts
@@ -67,7 +67,7 @@ export class PasswordComponent implements OnInit {
      * Password change is only enabled for internal users (not SSO/external).
      */
     ngOnInit() {
-        this.accountService.identity().then((user) => {
+        void this.accountService.identity().then((user) => {
             this.user.set(user);
             // Only internal users can change their password; external/SSO users must use their identity provider
             this.passwordResetEnabled.set(user?.internal || false);

--- a/src/main/webapp/app/account/settings/settings.component.ts
+++ b/src/main/webapp/app/account/settings/settings.component.ts
@@ -88,7 +88,7 @@ export class SettingsComponent implements OnInit {
      * Loads the current user's account data and populates the form.
      */
     ngOnInit() {
-        this.accountService.identity().then((user) => {
+        void this.accountService.identity().then((user) => {
             if (user) {
                 this.settingsForm.patchValue({
                     firstName: user.firstName,

--- a/src/main/webapp/app/account/user/settings/ide-preferences/ide-settings.component.ts
+++ b/src/main/webapp/app/account/user/settings/ide-preferences/ide-settings.component.ts
@@ -46,7 +46,7 @@ export class IdeSettingsComponent implements OnInit {
             this.PREDEFINED_IDE.set(predefinedIde);
         });
 
-        this.ideSettingsService.loadIdePreferences(true).then((programmingLanguageToIdeMap) => {
+        void this.ideSettingsService.loadIdePreferences(true).then((programmingLanguageToIdeMap) => {
             if (!programmingLanguageToIdeMap.has(ProgrammingLanguage.EMPTY)) {
                 programmingLanguageToIdeMap.set(ProgrammingLanguage.EMPTY, this.PREDEFINED_IDE()[0]);
             }

--- a/src/main/webapp/app/account/user/settings/learner-profile/feedback-learner-profile/feedback-learner-profile.component.ts
+++ b/src/main/webapp/app/account/user/settings/learner-profile/feedback-learner-profile/feedback-learner-profile.component.ts
@@ -41,7 +41,7 @@ export class FeedbackLearnerProfileComponent implements OnInit {
     }
 
     onOnboardingCompleted() {
-        this.loadProfile();
+        void this.loadProfile();
     }
 
     /**

--- a/src/main/webapp/app/account/user/settings/passkey-settings/passkey-settings.component.ts
+++ b/src/main/webapp/app/account/user/settings/passkey-settings/passkey-settings.component.ts
@@ -82,7 +82,7 @@ export class PasskeySettingsComponent implements OnDestroy {
         this.loadCurrentUser();
 
         effect(() => {
-            this.loadPasskeysWhenUserDetailsChange().then();
+            void this.loadPasskeysWhenUserDetailsChange();
         });
     }
 

--- a/src/main/webapp/app/account/user/settings/passkey-settings/webauthn.service.ts
+++ b/src/main/webapp/app/account/user/settings/passkey-settings/webauthn.service.ts
@@ -83,7 +83,7 @@ export class WebauthnService {
         this.isRetryingConditionalMediation = false;
         this.conditionalMediationSuccessCallback = onSuccess;
         this.conditionalMediationActiveCallback = onMediationActive;
-        this.runConditionalMediation();
+        void this.runConditionalMediation();
         this.startConditionalMediationRefreshTimer();
     }
 
@@ -279,7 +279,7 @@ export class WebauthnService {
 
         if (this.isUserCancelledPasskeyError(error) && !this.isRetryingConditionalMediation) {
             this.isRetryingConditionalMediation = true;
-            this.runConditionalMediation();
+            void this.runConditionalMediation();
             return;
         }
 
@@ -315,7 +315,7 @@ export class WebauthnService {
 
         this.isRetryingConditionalMediation = false;
         this.abortPendingCredentialRequest();
-        this.runConditionalMediation();
+        void this.runConditionalMediation();
     }
 
     private startConditionalMediationRefreshTimer(): void {

--- a/src/main/webapp/app/account/user/settings/ssh-settings/details/ssh-user-settings-key-details.component.ts
+++ b/src/main/webapp/app/account/user/settings/ssh-settings/details/ssh-user-settings-key-details.component.ts
@@ -122,7 +122,7 @@ export class SshUserSettingsKeyDetailsComponent implements OnInit, OnDestroy {
     }
 
     goBack() {
-        this.router.navigate(['/user-settings/ssh']);
+        void this.router.navigate(['/user-settings/ssh']);
     }
 
     validateExpiryDate() {

--- a/src/main/webapp/app/admin/audits/audits.component.ts
+++ b/src/main/webapp/app/admin/audits/audits.component.ts
@@ -72,7 +72,7 @@ export class AuditsComponent implements OnInit {
 
     transition(): void {
         if (this.canLoad()) {
-            this.router.navigate(['/admin/audits'], {
+            void this.router.navigate(['/admin/audits'], {
                 queryParams: {
                     page: this.page(),
                     sort: this.predicate() + ',' + (this.ascending() ? 'asc' : 'desc'),

--- a/src/main/webapp/app/admin/lti-configuration/edit/edit-lti-configuration.component.ts
+++ b/src/main/webapp/app/admin/lti-configuration/edit/edit-lti-configuration.component.ts
@@ -170,6 +170,6 @@ export class EditLtiConfigurationComponent implements OnInit {
      * Returns to the lti configuration page
      */
     navigateToLtiConfigurationPage() {
-        this.router.navigate(['admin', 'lti-configuration']);
+        void this.router.navigate(['admin', 'lti-configuration']);
     }
 }

--- a/src/main/webapp/app/admin/lti-configuration/lti-configuration.component.ts
+++ b/src/main/webapp/app/admin/lti-configuration/lti-configuration.component.ts
@@ -105,7 +105,7 @@ export class LtiConfigurationComponent implements OnInit {
     }
 
     transition(): void {
-        this.router.navigate(['/admin/lti-configuration'], {
+        void this.router.navigate(['/admin/lti-configuration'], {
             queryParams: {
                 page: this.page(),
                 sort: this.predicate() + ',' + (this.ascending() ? 'asc' : 'desc'),

--- a/src/main/webapp/app/admin/organization-management/organization-management.component.ts
+++ b/src/main/webapp/app/admin/organization-management/organization-management.component.ts
@@ -102,7 +102,7 @@ export class OrganizationManagementComponent {
 
     onOrganizationSelect(organization: Organization | Organization[] | undefined): void {
         if (!Array.isArray(organization) && organization?.id != null) {
-            this.router.navigate([organization.id], { relativeTo: this.route });
+            void this.router.navigate([organization.id], { relativeTo: this.route });
         }
     }
 }

--- a/src/main/webapp/app/admin/passkey-management/admin-passkey-management.component.ts
+++ b/src/main/webapp/app/admin/passkey-management/admin-passkey-management.component.ts
@@ -45,7 +45,7 @@ export class AdminPasskeyManagementComponent implements OnInit {
     ]);
 
     ngOnInit(): void {
-        this.loadPasskeys().then();
+        void this.loadPasskeys();
     }
 
     /**

--- a/src/main/webapp/app/admin/standardized-competencies/import/admin-import-standardized-competencies.component.ts
+++ b/src/main/webapp/app/admin/standardized-competencies/import/admin-import-standardized-competencies.component.ts
@@ -163,7 +163,7 @@ export class AdminImportStandardizedCompetenciesComponent {
             next: () => {
                 this.isLoading.set(false);
                 this.alertService.success('artemisApp.standardizedCompetency.manage.import.success');
-                this.router.navigate(['../'], { relativeTo: this.activatedRoute });
+                void this.router.navigate(['../'], { relativeTo: this.activatedRoute });
             },
             error: (error: HttpErrorResponse) => {
                 onError(this.alertService, error);
@@ -177,7 +177,7 @@ export class AdminImportStandardizedCompetenciesComponent {
     }
 
     cancel() {
-        this.router.navigate(['../'], { relativeTo: this.activatedRoute });
+        void this.router.navigate(['../'], { relativeTo: this.activatedRoute });
     }
 
     /**

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management-update.component.ts
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management-update.component.ts
@@ -162,7 +162,7 @@ export class SystemNotificationManagementUpdateComponent implements OnInit {
      * Navigates back to the system notifications overview.
      */
     goToOverview(): void {
-        this.router.navigate(['admin', 'system-notification-management']);
+        void this.router.navigate(['admin', 'system-notification-management']);
     }
 
     /**

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
@@ -130,7 +130,7 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
      * Initializes current account and loads system notifications.
      */
     ngOnInit(): void {
-        this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User) => {
             this.currentAccount.set(user);
             this.loadAll();
             this.registerChangeInNotifications();
@@ -249,7 +249,7 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
      * Navigates to the updated route with current pagination and sorting.
      */
     transition(): void {
-        this.router.navigate(['/admin/system-notification-management'], {
+        void this.router.navigate(['/admin/system-notification-management'], {
             queryParams: {
                 page: this.page(),
                 sort: `${this.predicate()},${this.reverse() ? 'asc' : 'desc'}`,

--- a/src/main/webapp/app/admin/user-management/user-management.component.ts
+++ b/src/main/webapp/app/admin/user-management/user-management.component.ts
@@ -253,7 +253,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
         this.userSearchForm = new FormGroup({
             searchControl: new FormControl('', { updateOn: 'change' }),
         });
-        this.accountService.identity().then((user) => {
+        void this.accountService.identity().then((user) => {
             this.currentAccount.set(user);
             this.userListSubscription = this.eventManager.subscribe('userListModification', () => this.loadAll());
             this.handleNavigation();
@@ -558,7 +558,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
      * Transitions to another page and/or sorting order
      */
     transition(): void {
-        this.router.navigate(['/admin/user-management'], {
+        void this.router.navigate(['/admin/user-management'], {
             relativeTo: this.activatedRoute.parent,
             queryParams: {
                 page: this.page(),

--- a/src/main/webapp/app/app.component.ts
+++ b/src/main/webapp/app/app.component.ts
@@ -72,13 +72,13 @@ export class AppComponent implements OnInit, OnDestroy {
     readonly showPageRibbon = signal(true);
 
     constructor() {
-        this.setupErrorHandling().then(undefined);
+        void this.setupErrorHandling();
     }
 
     private async setupErrorHandling() {
         const profileInfo = this.profileService.getProfileInfo();
         // sentry is only activated if it was specified in the application.yml file
-        this.sentryErrorHandler.initSentry(profileInfo);
+        void this.sentryErrorHandler.initSentry(profileInfo);
     }
 
     private getPageTitle(routeSnapshot: ActivatedRouteSnapshot): string {
@@ -146,7 +146,7 @@ export class AppComponent implements OnInit, OnDestroy {
             }
             if (event instanceof NavigationError && event.error.status === 404) {
                 // noinspection JSIgnoredPromiseFromCall
-                this.router.navigate(['/404']);
+                void this.router.navigate(['/404']);
             }
         });
 

--- a/src/main/webapp/app/assessment/manage/grading/bonus/bonus.component.ts
+++ b/src/main/webapp/app/assessment/manage/grading/bonus/bonus.component.ts
@@ -191,7 +191,7 @@ export class BonusComponent implements OnInit {
     }
 
     private navigateToExam() {
-        this.router.navigate(['course-management', this.courseId, 'exams', this.examId]);
+        void this.router.navigate(['course-management', this.courseId, 'exams', this.examId]);
     }
 
     private setSourceGradingScale() {

--- a/src/main/webapp/app/assessment/manage/list-of-complaints/list-of-complaints.component.ts
+++ b/src/main/webapp/app/assessment/manage/list-of-complaints/list-of-complaints.component.ts
@@ -165,7 +165,7 @@ export class ListOfComplaintsComponent implements OnInit {
             undefined,
             complaint.result.id,
         );
-        this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound } });
+        void this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound } });
     }
 
     sortRows() {

--- a/src/main/webapp/app/assessment/manage/rating/rating-list/rating-list.component.ts
+++ b/src/main/webapp/app/assessment/manage/rating/rating-list/rating-list.component.ts
@@ -70,10 +70,19 @@ export class RatingListComponent implements OnInit {
 
         if (rating.exerciseType === ExerciseType.PROGRAMMING) {
             // Programming exercises use a different route structure (no resultId)
-            this.router.navigate(['/course-management', this.courseId, exerciseTypePath, rating.exerciseId, 'submissions', rating.submissionId, 'assessment']);
+            void this.router.navigate(['/course-management', this.courseId, exerciseTypePath, rating.exerciseId, 'submissions', rating.submissionId, 'assessment']);
         } else {
             // Text, Modeling, and File Upload exercises use assessments/:resultId
-            this.router.navigate(['/course-management', this.courseId, exerciseTypePath, rating.exerciseId, 'submissions', rating.submissionId, 'assessments', rating.resultId]);
+            void this.router.navigate([
+                '/course-management',
+                this.courseId,
+                exerciseTypePath,
+                rating.exerciseId,
+                'submissions',
+                rating.submissionId,
+                'assessments',
+                rating.resultId,
+            ]);
         }
     }
 

--- a/src/main/webapp/app/assessment/manage/unreferenced-feedback-detail/unreferenced-feedback-detail.component.ts
+++ b/src/main/webapp/app/assessment/manage/unreferenced-feedback-detail/unreferenced-feedback-detail.component.ts
@@ -68,7 +68,7 @@ export class UnreferencedFeedbackDetailComponent implements OnInit {
     dialogError$ = this.dialogErrorSource.asObservable();
 
     ngOnInit() {
-        this.loadLongFeedback();
+        void this.loadLongFeedback();
     }
 
     /**

--- a/src/main/webapp/app/assessment/overview/complaints-for-students/complaints-student-view.component.ts
+++ b/src/main/webapp/app/assessment/overview/complaints-for-students/complaints-student-view.component.ts
@@ -78,7 +78,7 @@ export class ComplaintsStudentViewComponent implements OnInit {
                 });
             }
             this.loadPotentialComplaint();
-            this.accountService.identity().then((user) => {
+            void this.accountService.identity().then((user) => {
                 if (user?.id) {
                     const participationValue = this.participation();
                     if (participationValue?.student) {

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/assessment-dashboard.component.ts
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/assessment-dashboard.component.ts
@@ -144,7 +144,7 @@ export class AssessmentDashboardComponent implements OnInit {
             this.exerciseGroupId = Number(this.route.snapshot.paramMap.get('exerciseGroupId'));
         }
         this.loadAll();
-        this.accountService.identity().then((user) => this.tutor.set(user!));
+        void this.accountService.identity().then((user) => this.tutor.set(user!));
         this.plagiarismEnabled.set(this.profileService.isModuleFeatureActive(MODULE_FEATURE_PLAGIARISM));
     }
 

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
@@ -736,7 +736,7 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
             queryParams.toComplete = toComplete;
         }
 
-        this.router.navigate([route], { queryParams });
+        void this.router.navigate([route], { queryParams });
     }
 
     isComplaintLocked(complaint: Complaint) {

--- a/src/main/webapp/app/atlas/manage/competency-graph-modal/competency-graph-modal.component.ts
+++ b/src/main/webapp/app/atlas/manage/competency-graph-modal/competency-graph-modal.component.ts
@@ -44,7 +44,7 @@ export class CompetencyGraphModalComponent {
 
             this.scienceService.logEvent(ScienceEventType.LEARNING_PATH__OPEN_GRAPH, learningPathId);
 
-            untracked(() => this.loadCompetencyGraph(learningPathId));
+            untracked(() => void this.loadCompetencyGraph(learningPathId));
         });
     }
 

--- a/src/main/webapp/app/atlas/manage/competency-management/competency-management.component.ts
+++ b/src/main/webapp/app/atlas/manage/competency-management/competency-management.component.ts
@@ -86,11 +86,11 @@ export class CompetencyManagementComponent implements OnInit, OnDestroy {
     constructor() {
         effect(() => {
             const courseId = this.courseId();
-            untracked(async () => await this.loadCourseCompetencies(courseId));
+            void untracked(async () => await this.loadCourseCompetencies(courseId));
         });
         effect(() => {
             const irisEnabled = this.profileService.isModuleFeatureActive(MODULE_FEATURE_IRIS);
-            untracked(async () => {
+            void untracked(async () => {
                 if (irisEnabled) {
                     await this.loadIrisEnabled();
                 }

--- a/src/main/webapp/app/atlas/manage/create/create-competency.component.ts
+++ b/src/main/webapp/app/atlas/manage/create/create-competency.component.ts
@@ -47,7 +47,7 @@ export class CreateCompetencyComponent extends CreateCourseCompetencyComponent {
             .subscribe({
                 next: () => {
                     // currently at /course-management/{courseId}/competency-management/create, going back to /course-management/{courseId}/competency-management/
-                    this.router.navigate(['../'], { relativeTo: this.activatedRoute });
+                    void this.router.navigate(['../'], { relativeTo: this.activatedRoute });
                 },
                 error: (res: HttpErrorResponse) => onError(this.alertService, res),
             });

--- a/src/main/webapp/app/atlas/manage/create/create-prerequisite.component.ts
+++ b/src/main/webapp/app/atlas/manage/create/create-prerequisite.component.ts
@@ -48,7 +48,7 @@ export class CreatePrerequisiteComponent extends CreateCourseCompetencyComponent
             .subscribe({
                 next: () => {
                     // currently at /course-management/{courseId}/prerequisite-management/create, going to /course-management/{courseId}/competency-management/, since prerequisite-management redirects to competency-management
-                    this.router.navigate(['../'], { relativeTo: this.activatedRoute });
+                    void this.router.navigate(['../'], { relativeTo: this.activatedRoute });
                 },
                 error: (res: HttpErrorResponse) => onError(this.alertService, res),
             });

--- a/src/main/webapp/app/atlas/manage/edit/edit-competency.component.ts
+++ b/src/main/webapp/app/atlas/manage/edit/edit-competency.component.ts
@@ -79,7 +79,7 @@ export class EditCompetencyComponent extends EditCourseCompetencyComponent imple
                 finalize(() => {
                     this.isLoading.set(false);
                     // currently at /course-management/{courseId}/competency-management/{competencyId}/edit, going back to /course-management/{courseId}/competency-management/
-                    this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
+                    void this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
                 }),
             )
             .subscribe({

--- a/src/main/webapp/app/atlas/manage/edit/edit-prerequisite.component.ts
+++ b/src/main/webapp/app/atlas/manage/edit/edit-prerequisite.component.ts
@@ -80,7 +80,7 @@ export class EditPrerequisiteComponent extends EditCourseCompetencyComponent imp
                 finalize(() => {
                     this.isLoading.set(false);
                     // currently at /course-management/{courseId}/prerequisite-management/{competencyId}/edit, going to /course-management/{courseId}/competency-management/
-                    this.router.navigate(['../../../competency-management/'], { relativeTo: this.activatedRoute });
+                    void this.router.navigate(['../../../competency-management/'], { relativeTo: this.activatedRoute });
                 }),
             )
             .subscribe({

--- a/src/main/webapp/app/atlas/manage/generate-competencies/generate-competencies.component.ts
+++ b/src/main/webapp/app/atlas/manage/generate-competencies/generate-competencies.component.ts
@@ -205,7 +205,7 @@ export class GenerateCompetenciesComponent implements OnInit, OnDestroy, Compone
      * Cancels the parsing and navigates back
      */
     onCancel() {
-        this.router.navigate(['../'], { relativeTo: this.activatedRoute });
+        void this.router.navigate(['../'], { relativeTo: this.activatedRoute });
     }
 
     /**
@@ -239,7 +239,7 @@ export class GenerateCompetenciesComponent implements OnInit, OnDestroy, Compone
         this.competencyService.createBulk(competenciesToSave, this.courseId).subscribe({
             next: () => {
                 this.submitted = true;
-                this.router.navigate(['../'], { relativeTo: this.activatedRoute });
+                void this.router.navigate(['../'], { relativeTo: this.activatedRoute });
             },
             error: (res: HttpErrorResponse) => onError(this.alertService, res),
         });

--- a/src/main/webapp/app/atlas/manage/import-list/import-table.component.ts
+++ b/src/main/webapp/app/atlas/manage/import-list/import-table.component.ts
@@ -68,7 +68,7 @@ export class ImportTableComponent<T extends BaseEntity> {
 
     constructor() {
         effect(() => {
-            untracked(async () => await this.loadData());
+            void untracked(async () => await this.loadData());
         });
     }
 

--- a/src/main/webapp/app/atlas/manage/import-standardized-competencies/course-import-standardized-course-competencies.component.ts
+++ b/src/main/webapp/app/atlas/manage/import-standardized-competencies/course-import-standardized-course-competencies.component.ts
@@ -132,7 +132,7 @@ export abstract class CourseImportStandardizedCourseCompetenciesComponent extend
                 next: (countImportedCompetencies) => {
                     this.isSubmitted = true;
                     this.alertService.success('artemisApp.standardizedCompetency.courseImport.success', { count: countImportedCompetencies });
-                    this.router.navigate(['../'], { relativeTo: this.activatedRoute });
+                    void this.router.navigate(['../'], { relativeTo: this.activatedRoute });
                 },
                 error: (errorResponse: HttpErrorResponse) => onError(this.alertService, errorResponse),
                 complete: () => {
@@ -142,7 +142,7 @@ export abstract class CourseImportStandardizedCourseCompetenciesComponent extend
     }
 
     protected cancel() {
-        this.router.navigate(['../'], { relativeTo: this.activatedRoute });
+        void this.router.navigate(['../'], { relativeTo: this.activatedRoute });
     }
 
     /**

--- a/src/main/webapp/app/atlas/manage/import/import-competencies.component.ts
+++ b/src/main/webapp/app/atlas/manage/import/import-competencies.component.ts
@@ -27,7 +27,7 @@ export class ImportCompetenciesComponent extends ImportCourseCompetenciesCompone
             next: (res) => {
                 this.alertService.success('artemisApp.competency.import.success', { numCompetencies: res.body?.length ?? 0 });
                 this.isSubmitted = true;
-                this.router.navigate(['../'], { relativeTo: this.activatedRoute });
+                void this.router.navigate(['../'], { relativeTo: this.activatedRoute });
             },
             error: (error: HttpErrorResponse) => onError(this.alertService, error),
         });

--- a/src/main/webapp/app/atlas/manage/import/import-course-competencies.component.ts
+++ b/src/main/webapp/app/atlas/manage/import/import-course-competencies.component.ts
@@ -198,7 +198,7 @@ export abstract class ImportCourseCompetenciesComponent implements OnInit, Compo
      * Cancels the import and navigates back
      */
     onCancel() {
-        this.router.navigate(['../'], { relativeTo: this.activatedRoute });
+        void this.router.navigate(['../'], { relativeTo: this.activatedRoute });
     }
 
     /**

--- a/src/main/webapp/app/atlas/manage/import/import-prerequisites.component.ts
+++ b/src/main/webapp/app/atlas/manage/import/import-prerequisites.component.ts
@@ -26,7 +26,7 @@ export class ImportPrerequisitesComponent extends ImportCourseCompetenciesCompon
             next: (res) => {
                 this.alertService.success('artemisApp.prerequisite.import.success', { numPrerequisites: res.body?.length ?? 0 });
                 this.isSubmitted = true;
-                this.router.navigate(['../'], { relativeTo: this.activatedRoute });
+                void this.router.navigate(['../'], { relativeTo: this.activatedRoute });
             },
             error: (error: HttpErrorResponse) => onError(this.alertService, error),
         });

--- a/src/main/webapp/app/atlas/manage/learning-path-instructor-page/learning-path-instructor-page.component.ts
+++ b/src/main/webapp/app/atlas/manage/learning-path-instructor-page/learning-path-instructor-page.component.ts
@@ -37,7 +37,7 @@ export class LearningPathInstructorPageComponent {
     constructor() {
         effect(() => {
             const courseId = this.courseId();
-            untracked(() => this.loadCourse(courseId));
+            void untracked(() => this.loadCourse(courseId));
         });
     }
 

--- a/src/main/webapp/app/atlas/manage/learning-paths-analytics/learning-paths-analytics.component.ts
+++ b/src/main/webapp/app/atlas/manage/learning-paths-analytics/learning-paths-analytics.component.ts
@@ -30,7 +30,7 @@ export class LearningPathsAnalyticsComponent {
     constructor() {
         effect(() => {
             const courseId = this.courseId();
-            untracked(() => this.loadInstructionCompetencyGraph(courseId));
+            void untracked(() => this.loadInstructionCompetencyGraph(courseId));
         });
     }
 

--- a/src/main/webapp/app/atlas/manage/learning-paths-configuration/learning-paths-configuration.component.ts
+++ b/src/main/webapp/app/atlas/manage/learning-paths-configuration/learning-paths-configuration.component.ts
@@ -35,7 +35,7 @@ export class LearningPathsConfigurationComponent {
     constructor() {
         effect(() => {
             const courseId = this.courseId();
-            untracked(() => this.loadLearningPathsConfiguration(courseId));
+            void untracked(() => this.loadLearningPathsConfiguration(courseId));
         });
     }
 

--- a/src/main/webapp/app/atlas/manage/learning-paths-state/learning-paths-state.component.ts
+++ b/src/main/webapp/app/atlas/manage/learning-paths-state/learning-paths-state.component.ts
@@ -47,7 +47,7 @@ export class LearningPathsStateComponent {
     constructor() {
         effect(() => {
             const courseId = this.courseId();
-            untracked(() => this.loadLearningPathHealthState(courseId));
+            untracked(() => void this.loadLearningPathHealthState(courseId));
         });
     }
 

--- a/src/main/webapp/app/atlas/overview/competency-accordion/competency-accordion.component.ts
+++ b/src/main/webapp/app/atlas/overview/competency-accordion/competency-accordion.component.ts
@@ -200,6 +200,6 @@ export class CompetencyAccordionComponent implements OnChanges {
         if (!course?.id) {
             return;
         }
-        this.router.navigate(['/courses', course.id, 'competencies', this.competency().id]);
+        void this.router.navigate(['/courses', course.id, 'competencies', this.competency().id]);
     }
 }

--- a/src/main/webapp/app/atlas/overview/learning-path-lecture-unit/learning-path-lecture-unit.component.ts
+++ b/src/main/webapp/app/atlas/overview/learning-path-lecture-unit/learning-path-lecture-unit.component.ts
@@ -39,7 +39,7 @@ export class LearningPathLectureUnitComponent {
     constructor() {
         effect(() => {
             const lectureUnitId = this.lectureUnitId();
-            untracked(() => this.loadLectureUnit(lectureUnitId));
+            void untracked(() => this.loadLectureUnit(lectureUnitId));
         });
     }
 

--- a/src/main/webapp/app/atlas/overview/learning-path-nav-overview-learning-objects/learning-path-nav-overview-learning-objects.component.ts
+++ b/src/main/webapp/app/atlas/overview/learning-path-nav-overview-learning-objects/learning-path-nav-overview-learning-objects.component.ts
@@ -43,7 +43,7 @@ export class LearningPathNavOverviewLearningObjectsComponent {
 
     constructor() {
         effect(() => {
-            untracked(() => this.loadLearningObjects());
+            untracked(() => void this.loadLearningObjects());
         });
     }
 

--- a/src/main/webapp/app/atlas/overview/learning-path-nav-overview/learning-path-nav-overview.component.ts
+++ b/src/main/webapp/app/atlas/overview/learning-path-nav-overview/learning-path-nav-overview.component.ts
@@ -50,7 +50,7 @@ export class LearningPathNavOverviewComponent {
 
             this.scienceService.logEvent(ScienceEventType.LEARNING_PATH__OPEN_NAVIGATION, learningPathId);
 
-            untracked(() => this.loadCompetencies(learningPathId));
+            void untracked(() => this.loadCompetencies(learningPathId));
         });
     }
 

--- a/src/main/webapp/app/atlas/overview/learning-path-student-nav/learning-path-student-nav.component.ts
+++ b/src/main/webapp/app/atlas/overview/learning-path-student-nav/learning-path-student-nav.component.ts
@@ -45,7 +45,7 @@ export class LearningPathNavComponent {
     constructor() {
         effect(() => {
             const learningPathId = this.learningPathId();
-            untracked(() => this.learningPathNavigationService.loadLearningPathNavigation(learningPathId));
+            void untracked(() => this.learningPathNavigationService.loadLearningPathNavigation(learningPathId));
         });
     }
 

--- a/src/main/webapp/app/atlas/overview/learning-path-student-page/learning-path-student-page.component.ts
+++ b/src/main/webapp/app/atlas/overview/learning-path-student-page/learning-path-student-page.component.ts
@@ -40,7 +40,7 @@ export class LearningPathStudentPageComponent {
     constructor() {
         effect(() => {
             const courseId = this.courseId();
-            untracked(() => this.loadLearningPath(courseId));
+            untracked(() => void this.loadLearningPath(courseId));
         });
     }
 

--- a/src/main/webapp/app/calendar/shared/calendar-subscription-popover/calendar-subscription-popover.component.ts
+++ b/src/main/webapp/app/calendar/shared/calendar-subscription-popover/calendar-subscription-popover.component.ts
@@ -54,7 +54,7 @@ export class CalendarSubscriptionPopoverComponent {
         const url = this.subscriptionUrl();
         if (url) {
             this.copiedUrl.set(true);
-            navigator.clipboard.writeText(url);
+            void navigator.clipboard.writeText(url);
         }
     }
 

--- a/src/main/webapp/app/communication/course-conversations-components/dialogs/conversation-detail-dialog/tabs/conversation-members/conversation-member-row/conversation-member-row.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/dialogs/conversation-detail-dialog/tabs/conversation-members/conversation-member-row/conversation-member-row.component.ts
@@ -99,7 +99,7 @@ export class ConversationMemberRowComponent implements OnInit, OnDestroy {
 
     ngOnInit(): void {
         if (this.conversationMember() && this.activeConversation()) {
-            this.accountService.identity().then((loggedInUser: User) => {
+            void this.accountService.identity().then((loggedInUser: User) => {
                 this.idOfLoggedInUser = loggedInUser.id!;
                 if (this.conversationMember()?.id === this.idOfLoggedInUser) {
                     this.isCurrentUser.set(true);

--- a/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.ts
@@ -213,7 +213,7 @@ export class ConversationMessagesComponent implements OnInit, AfterViewInit, OnD
                 this.pinnedCount.emit(pinnedPosts.length);
             });
 
-        this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User) => {
             this.currentUser = user!;
         });
 

--- a/src/main/webapp/app/communication/directive/posting.directive.ts
+++ b/src/main/webapp/app/communication/directive/posting.directive.ts
@@ -204,7 +204,7 @@ export abstract class PostingDirective<T extends Posting> implements OnInit, OnD
                 this.metisConversationService.createOneToOneChat(referencedUserLogin).subscribe();
             } else {
                 this.oneToOneChatService.create(course.id!, referencedUserLogin).subscribe((res) => {
-                    this.router.navigate(['courses', course.id, 'communication'], {
+                    void this.router.navigate(['courses', course.id, 'communication'], {
                         queryParams: {
                             conversationId: res.body!.id,
                         },
@@ -230,7 +230,7 @@ export abstract class PostingDirective<T extends Posting> implements OnInit, OnD
                 this.metisConversationService.createOneToOneChatWithId(referencedUserId).subscribe();
             } else {
                 this.oneToOneChatService.createWithId(course.id!, referencedUserId).subscribe((res) => {
-                    this.router.navigate(['courses', course.id, 'communication'], {
+                    void this.router.navigate(['courses', course.id, 'communication'], {
                         queryParams: {
                             conversationId: res.body!.id,
                         },

--- a/src/main/webapp/app/communication/faq/faq-update.component.ts
+++ b/src/main/webapp/app/communication/faq/faq-update.component.ts
@@ -146,12 +146,12 @@ export class FaqUpdateComponent implements OnInit {
                         this.faq = faqBody;
                     }
                     this.showSuccessAlert(faq, false);
-                    this.router.navigate(['course-management', this.courseId, 'faqs']);
+                    void this.router.navigate(['course-management', this.courseId, 'faqs']);
                 },
             });
         } else {
             this.showSuccessAlert(faq, true);
-            this.router.navigate(['course-management', this.courseId, 'faqs']);
+            void this.router.navigate(['course-management', this.courseId, 'faqs']);
         }
     }
 

--- a/src/main/webapp/app/communication/message/message-inline-input/message-inline-input.component.ts
+++ b/src/main/webapp/app/communication/message/message-inline-input/message-inline-input.component.ts
@@ -43,7 +43,7 @@ export class MessageInlineInputComponent extends PostingCreateEditDirective<Post
 
     ngOnInit(): void {
         super.ngOnInit();
-        this.loadCurrentUser();
+        void this.loadCurrentUser();
     }
 
     protected override onPostingChanged(): void {

--- a/src/main/webapp/app/communication/post/post.component.ts
+++ b/src/main/webapp/app/communication/post/post.component.ts
@@ -392,7 +392,7 @@ export class PostComponent extends PostingDirective<Post> implements OnInit, OnD
             if (this.isCommunicationPage()) {
                 this.metisConversationService.setActiveConversation(channelId);
             } else {
-                this.router.navigate(['courses', course.id, 'communication'], {
+                void this.router.navigate(['courses', course.id, 'communication'], {
                     queryParams: {
                         conversationId: channelId,
                     },

--- a/src/main/webapp/app/communication/service/metis-conversation.service.ts
+++ b/src/main/webapp/app/communication/service/metis-conversation.service.ts
@@ -63,7 +63,7 @@ export class MetisConversationService implements OnDestroy {
     private _isServiceSetup$: ReplaySubject<boolean> = new ReplaySubject<boolean>(1);
 
     constructor() {
-        this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User) => {
             this.userId = user.id!;
             const conversationTopic = `/topic/user/${this.userId}/notifications/conversations`;
             this.activeConversationSubscription = this.websocketService.subscribe<MetisPostDTO>(conversationTopic).subscribe((postDTO: MetisPostDTO) => {

--- a/src/main/webapp/app/communication/service/metis.service.ts
+++ b/src/main/webapp/app/communication/service/metis.service.ts
@@ -76,7 +76,7 @@ export class MetisService implements OnDestroy {
     private faqs$: BehaviorSubject<Faq[]> = new BehaviorSubject<Faq[]>([]);
 
     constructor() {
-        this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User) => {
             this.user = user!;
 
             const conversationTopic = `/topic/user/${this.user.id}/notifications/conversations`;

--- a/src/main/webapp/app/communication/shared/conversation-global-search/conversation-global-search.component.ts
+++ b/src/main/webapp/app/communication/shared/conversation-global-search/conversation-global-search.component.ts
@@ -97,7 +97,7 @@ export class ConversationGlobalSearchComponent implements OnInit, OnDestroy {
     readonly ButtonType = ButtonType;
 
     ngOnInit(): void {
-        this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User) => {
             this.user = user!;
         });
     }

--- a/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
+++ b/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
@@ -437,7 +437,7 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
         if (threadBelongsToActiveConversation) {
             queryParams.messageId = this.postInThread()!.id;
         }
-        this.router.navigate([], {
+        void this.router.navigate([], {
             relativeTo: this.activatedRoute,
             queryParams,
             replaceUrl: true,

--- a/src/main/webapp/app/communication/shared/discussion-section/discussion-section.component.ts
+++ b/src/main/webapp/app/communication/shared/discussion-section/discussion-section.component.ts
@@ -142,7 +142,7 @@ export class DiscussionSectionComponent extends CourseDiscussionDirective implem
                 this.currentPost.set(this.posts().find((post) => post.id === this.currentPostId));
             }
         });
-        this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User) => {
             this.currentUser = user!;
         });
         this.metisService.totalNumberOfPosts.pipe(takeUntil(this.ngUnsubscribe)).subscribe((totalNumberOfPosts: number) => {
@@ -284,7 +284,7 @@ export class DiscussionSectionComponent extends CourseDiscussionDirective implem
     resetCurrentPost() {
         this.currentPost.set(undefined);
         this.currentPostId = undefined;
-        this.router.navigate([], {
+        void this.router.navigate([], {
             queryParams: {
                 postId: this.currentPostId,
             },

--- a/src/main/webapp/app/communication/shared/redirect-to-iris-button/redirect-to-iris-button.component.ts
+++ b/src/main/webapp/app/communication/shared/redirect-to-iris-button/redirect-to-iris-button.component.ts
@@ -147,6 +147,6 @@ export class RedirectToIrisButtonComponent implements OnInit, OnDestroy {
      */
     redirectToIris(): void {
         const content = this.question();
-        this.router.navigate([this.channelSubTypeReferenceRouterLink], { queryParams: { irisQuestion: content } });
+        void this.router.navigate([this.channelSubTypeReferenceRouterLink], { queryParams: { irisQuestion: content } });
     }
 }

--- a/src/main/webapp/app/core/auth/passkey-authentication-guard/passkey-authentication.guard.ts
+++ b/src/main/webapp/app/core/auth/passkey-authentication-guard/passkey-authentication.guard.ts
@@ -52,7 +52,7 @@ export class PasskeyAuthenticationGuard implements CanActivate {
         }
 
         const attemptedUrl = state.url;
-        this.router.navigate(['/passkey-required'], {
+        void this.router.navigate(['/passkey-required'], {
             queryParams: { returnUrl: attemptedUrl },
         });
 

--- a/src/main/webapp/app/core/auth/passkey-authentication-page/passkey-authentication-page.component.ts
+++ b/src/main/webapp/app/core/auth/passkey-authentication-page/passkey-authentication-page.component.ts
@@ -30,10 +30,10 @@ export class PasskeyAuthenticationPageComponent implements OnInit, OnDestroy {
     private routeSubscription?: Subscription;
 
     ngOnInit() {
-        this.initializeUserIdentity().then(() => {
+        void this.initializeUserIdentity().then(() => {
             const redirectDirectlyIfUserIsAlreadyLoggedInWithPasskey = this.accountService.isUserLoggedInWithApprovedPasskey() && this.returnUrl;
             if (redirectDirectlyIfUserIsAlreadyLoggedInWithPasskey) {
-                this.router.navigateByUrl(this.returnUrl!);
+                void this.router.navigateByUrl(this.returnUrl!);
             }
         });
 
@@ -77,9 +77,9 @@ export class PasskeyAuthenticationPageComponent implements OnInit, OnDestroy {
 
     redirectToOriginalUrlOrHome() {
         if (this.returnUrl) {
-            this.router.navigateByUrl(this.returnUrl);
+            void this.router.navigateByUrl(this.returnUrl);
         } else {
-            this.router.navigate(['/sign-in']);
+            void this.router.navigate(['/sign-in']);
         }
     }
 }

--- a/src/main/webapp/app/core/auth/user-route-access-service.ts
+++ b/src/main/webapp/app/core/auth/user-route-access-service.ts
@@ -82,10 +82,10 @@ export class UserRouteAccessService implements CanActivate {
                 }
 
                 this.sessionStorageService.store('previousUrl', url);
-                this.router.navigate(['accessdenied']).then(() => {
+                void this.router.navigate(['accessdenied']).then(() => {
                     // only show the login dialog, if the user hasn't logged in yet
                     if (!account) {
-                        this.router.navigate(['/sign-in']);
+                        void this.router.navigate(['/sign-in']);
                     }
                 });
                 return false;

--- a/src/main/webapp/app/core/home/home.component.ts
+++ b/src/main/webapp/app/core/home/home.component.ts
@@ -82,7 +82,7 @@ export class HomeComponent implements OnInit, AfterViewChecked, OnDestroy {
 
     ngOnInit() {
         this.initializeWithProfileInfo();
-        this.accountService.identity().then((user) => {
+        void this.accountService.identity().then((user) => {
             this.currentUserCallback(user!);
 
             // Only start conditional mediation after confirming the user is NOT logged in.
@@ -91,7 +91,7 @@ export class HomeComponent implements OnInit, AfterViewChecked, OnDestroy {
             // challenge request, gets destroyed, and a new instance overwrites the cookie.
             if (!user) {
                 this.loading.set(false);
-                this.prefillPasskeysIfPossible();
+                void this.prefillPasskeysIfPossible();
             }
         });
         this.registerAuthenticationSuccess();
@@ -208,7 +208,7 @@ export class HomeComponent implements OnInit, AfterViewChecked, OnDestroy {
             // We only need to authenticate once, make sure we don't run this subscription multiple times
             this.eventManager.destroy(subscription);
 
-            this.accountService.identity().then((user) => {
+            void this.accountService.identity().then((user) => {
                 this.currentUserCallback(user!);
             });
         });
@@ -259,7 +259,7 @@ export class HomeComponent implements OnInit, AfterViewChecked, OnDestroy {
         this.authenticationError.set(false);
 
         if (this.router.url === '/register' || /^\/activate\//.test(this.router.url) || /^\/reset\//.test(this.router.url)) {
-            this.router.navigate(['']);
+            void this.router.navigate(['']);
         }
 
         this.eventManager.broadcast({
@@ -276,9 +276,9 @@ export class HomeComponent implements OnInit, AfterViewChecked, OnDestroy {
             const redirect = this.sessionStorageService.retrieve<string>('previousUrl');
             if (redirect && redirect !== '') {
                 this.sessionStorageService.store('previousUrl', '');
-                this.router.navigateByUrl(redirect);
+                void this.router.navigateByUrl(redirect);
             } else {
-                this.router.navigate(['courses']);
+                void this.router.navigate(['courses']);
             }
         }
     }

--- a/src/main/webapp/app/core/interceptor/artemis-version.interceptor.ts
+++ b/src/main/webapp/app/core/interceptor/artemis-version.interceptor.ts
@@ -78,7 +78,7 @@ export class ArtemisVersionInterceptor implements HttpInterceptor {
         const update = this.updates.isEnabled ? this.updates.checkForUpdate() : Promise.resolve(hasUpdate);
 
         // first update the service worker
-        update.then((updateAvailable: boolean) => {
+        void update.then((updateAvailable: boolean) => {
             if (this.hasSeenOutdatedInThisSession || updateAvailable) {
                 this.hasSeenOutdatedInThisSession = true;
 

--- a/src/main/webapp/app/core/landing/landing-footer.component.ts
+++ b/src/main/webapp/app/core/landing/landing-footer.component.ts
@@ -358,6 +358,6 @@ export class LandingFooterComponent {
     currentYear: number = new Date().getFullYear();
 
     navigateToLogin(): void {
-        this.router.navigateByUrl('/sign-in');
+        void this.router.navigateByUrl('/sign-in');
     }
 }

--- a/src/main/webapp/app/core/landing/landing-navbar.component.ts
+++ b/src/main/webapp/app/core/landing/landing-navbar.component.ts
@@ -244,7 +244,7 @@ export class LandingNavbarComponent {
     }
 
     navigateToLogin(): void {
-        this.router.navigateByUrl('/sign-in');
+        void this.router.navigateByUrl('/sign-in');
     }
 
     scrollToTop(): void {

--- a/src/main/webapp/app/core/login/login.service.ts
+++ b/src/main/webapp/app/core/login/login.service.ts
@@ -23,7 +23,7 @@ export class LoginService {
         return new Promise<void>((resolve, reject) => {
             this.authServerProvider.login(credentials).subscribe({
                 next: () => {
-                    this.accountService.identity(true).then(() => {
+                    void this.accountService.identity(true).then(() => {
                         resolve();
                     });
                 },
@@ -43,7 +43,7 @@ export class LoginService {
         return new Promise<void>((resolve, reject) => {
             this.authServerProvider.loginSAML2(rememberMe).subscribe({
                 next: () => {
-                    this.accountService.identity(true).then(() => {
+                    void this.accountService.identity(true).then(() => {
                         resolve();
                     });
                 },
@@ -80,7 +80,7 @@ export class LoginService {
     private onLogout(): void {
         this.accountService.authenticate(undefined);
         this.alertService.closeAll();
-        this.router.navigateByUrl('/sign-in');
+        void this.router.navigateByUrl('/sign-in');
         this.authServerProvider.clearCaches().subscribe();
     }
 

--- a/src/main/webapp/app/core/navbar/global-search/components/views/lecture-results/global-search-lecture-results.component.ts
+++ b/src/main/webapp/app/core/navbar/global-search/components/views/lecture-results/global-search-lecture-results.component.ts
@@ -81,7 +81,7 @@ export class GlobalSearchLectureResultsComponent extends SearchResultView {
         const result = this.lectureResults()[index];
         if (result) {
             event.preventDefault();
-            this.router.navigate([result.lectureUnit.link], { queryParams: result.lectureUnit.queryParams });
+            void this.router.navigate([result.lectureUnit.link], { queryParams: result.lectureUnit.queryParams });
         }
     }
 }

--- a/src/main/webapp/app/core/navbar/global-search/components/views/navigation-view/global-search-navigation-view.component.ts
+++ b/src/main/webapp/app/core/navbar/global-search/components/views/navigation-view/global-search-navigation-view.component.ts
@@ -268,7 +268,7 @@ export class GlobalSearchNavigationViewComponent extends SearchResultView {
 
         switch (result.type) {
             case 'course':
-                this.router.navigate(['/courses', courseId]);
+                void this.router.navigate(['/courses', courseId]);
                 break;
             case 'exercise':
                 if (result.id) this.navigateToExercise(result, courseId);
@@ -283,7 +283,7 @@ export class GlobalSearchNavigationViewComponent extends SearchResultView {
                 if (result.id) this.navigateToExam(result, courseId);
                 break;
             case 'faq':
-                this.router.navigate(['/courses', courseId, 'faq']);
+                void this.router.navigate(['/courses', courseId, 'faq']);
                 break;
             case 'channel':
                 if (result.id) this.navigateToChannel(courseId, result.id);
@@ -310,27 +310,27 @@ export class GlobalSearchNavigationViewComponent extends SearchResultView {
             this.navigateToExamExerciseDetailsPage(courseId, examId, exerciseGroupId, result);
         } else if (examId && isAtLeastTutor) {
             // Tutors: exam exercise assessment dashboard
-            this.router.navigate(['/course-management', courseId, 'exams', examId, 'assessment-dashboard', result.id]);
+            void this.router.navigate(['/course-management', courseId, 'exams', examId, 'assessment-dashboard', result.id]);
         } else if (examId) {
             // Students: student exam view
-            this.router.navigate(['/courses', courseId, 'exams', examId]);
+            void this.router.navigate(['/courses', courseId, 'exams', examId]);
         } else {
             // Students: student exercise view
-            this.router.navigate(['/courses', courseId, 'exercises', result.id]);
+            void this.router.navigate(['/courses', courseId, 'exercises', result.id]);
         }
     }
 
     private navigateToExamExerciseDetailsPage(courseId: string, examId: string, exerciseGroupId: string, result: GlobalSearchResult) {
         const typeSegment = (result.badge?.toLowerCase().replace(/ /g, '-') ?? 'text') + '-exercises';
-        this.router.navigate(['/course-management', courseId, 'exams', examId, 'exercise-groups', exerciseGroupId, typeSegment, result.id]);
+        void this.router.navigate(['/course-management', courseId, 'exams', examId, 'exercise-groups', exerciseGroupId, typeSegment, result.id]);
     }
 
     private navigateToStudentExamView(courseId: string, examId: string) {
-        this.router.navigate(['/courses', courseId, 'exams', examId]);
+        void this.router.navigate(['/courses', courseId, 'exams', examId]);
     }
 
     private navigateToLecture(courseId: string, lectureId: string) {
-        this.router.navigate(['/courses', courseId, 'lectures', lectureId]);
+        void this.router.navigate(['/courses', courseId, 'lectures', lectureId]);
     }
 
     private navigateToLectureUnit(result: GlobalSearchResult, courseId: string) {
@@ -344,22 +344,22 @@ export class GlobalSearchNavigationViewComponent extends SearchResultView {
         const isAtLeastEditor = !!result.metadata?.['isAtLeastEditor'];
         const isAtLeastTutor = !!result.metadata?.['isAtLeastTutor'];
         if (isAtLeastEditor) {
-            this.router.navigate(['/course-management', courseId, 'exams', result.id]);
+            void this.router.navigate(['/course-management', courseId, 'exams', result.id]);
         } else if (isAtLeastTutor) {
-            this.router.navigate(['/course-management', courseId, 'exams', result.id, 'assessment-dashboard']);
+            void this.router.navigate(['/course-management', courseId, 'exams', result.id, 'assessment-dashboard']);
         } else {
             this.navigateToStudentExamView(courseId, result.id!);
         }
     }
 
     private navigateToChannel(courseId: string, channelId: string) {
-        this.router.navigate(['/courses', courseId, 'communication'], { queryParams: { conversationId: channelId } });
+        void this.router.navigate(['/courses', courseId, 'communication'], { queryParams: { conversationId: channelId } });
     }
 
     private navigateToPost(result: GlobalSearchResult, courseId: string) {
         const channelId = result.metadata?.['channelId'];
         if (channelId) {
-            this.router.navigate(['/courses', courseId, 'communication'], { queryParams: { conversationId: channelId, focusPostId: result.id } });
+            void this.router.navigate(['/courses', courseId, 'communication'], { queryParams: { conversationId: channelId, focusPostId: result.id } });
         }
     }
 
@@ -367,7 +367,7 @@ export class GlobalSearchNavigationViewComponent extends SearchResultView {
         const channelId = result.metadata?.['channelId'];
         const postId = result.metadata?.['postId'];
         if (channelId && postId) {
-            this.router.navigate(['/courses', courseId, 'communication'], { queryParams: { conversationId: channelId, messageId: postId, focusReplyId: result.id } });
+            void this.router.navigate(['/courses', courseId, 'communication'], { queryParams: { conversationId: channelId, messageId: postId, focusReplyId: result.id } });
         }
     }
 

--- a/src/main/webapp/app/core/navbar/navbar.component.ts
+++ b/src/main/webapp/app/core/navbar/navbar.component.ts
@@ -818,7 +818,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
     logout() {
         this.collapseNavbar();
-        this.router.navigate(['/sign-in']).then((res) => {
+        void this.router.navigate(['/sign-in']).then((res) => {
             if (res) {
                 this.participationWebsocketService.resetLocalCache();
                 this.loginService.logout(true);

--- a/src/main/webapp/app/course/manage/course-lti-configuration/edit-course-lti-configuration.component.ts
+++ b/src/main/webapp/app/course/manage/course-lti-configuration/edit-course-lti-configuration.component.ts
@@ -114,7 +114,7 @@ export class EditCourseLtiConfigurationComponent implements OnInit {
     }
 
     transition(): void {
-        this.router.navigate(['/admin/lti-configuration'], {
+        void this.router.navigate(['/admin/lti-configuration'], {
             queryParams: {
                 page: this.page(),
                 sort: ['id', 'asc'],
@@ -171,7 +171,7 @@ export class EditCourseLtiConfigurationComponent implements OnInit {
      * Returns to the lti configuration page
      */
     navigateToLtiConfigurationPage() {
-        this.router.navigate(['course-management', this.course().id!.toString(), 'lti-configuration']);
+        void this.router.navigate(['course-management', this.course().id!.toString(), 'lti-configuration']);
     }
 
     setPlatform(platform: LtiPlatformConfiguration) {

--- a/src/main/webapp/app/course/manage/course-management-container/course-management-container.component.ts
+++ b/src/main/webapp/app/course/manage/course-management-container/course-management-container.component.ts
@@ -247,7 +247,7 @@ export class CourseManagementContainerComponent extends BaseCourseContainerCompo
         this.operationProgress.set(undefined);
         // Navigate to course list after closing a completed delete operation
         if (progress?.operationType === CourseOperationType.DELETE) {
-            this.router.navigate(['/course-management']);
+            void this.router.navigate(['/course-management']);
         }
     }
 

--- a/src/main/webapp/app/course/manage/course-material-import/course-material-import-dialog.component.ts
+++ b/src/main/webapp/app/course/manage/course-material-import/course-material-import-dialog.component.ts
@@ -115,7 +115,7 @@ export class CourseMaterialImportDialogComponent {
         // Load courses when dialog opens
         effect(() => {
             if (this.show()) {
-                untracked(() => this.loadCourses());
+                void untracked(() => this.loadCourses());
             }
         });
     }
@@ -193,7 +193,7 @@ export class CourseMaterialImportDialogComponent {
      */
     onSearchChange(): void {
         this.first.set(0);
-        this.loadCourses();
+        void this.loadCourses();
     }
 
     /**
@@ -202,7 +202,7 @@ export class CourseMaterialImportDialogComponent {
     onPageChange(event: PaginatorState): void {
         this.first.set(event.first ?? 0);
         this.rows.set(event.rows ?? 10);
-        this.loadCourses();
+        void this.loadCourses();
     }
 
     /**

--- a/src/main/webapp/app/course/manage/course-scores/course-scores.component.ts
+++ b/src/main/webapp/app/course/manage/course-scores/course-scores.component.ts
@@ -189,7 +189,7 @@ export class CourseScoresComponent implements OnInit {
         this.initializeExerciseTitles();
         this.includedExercises.set(this.determineExercisesIncludedInScore(course));
         this.numberOfReleasedExercises.set(this.determineReleasedExercises(course).length);
-        this.calculateCourseStatistics(course.id!);
+        void this.calculateCourseStatistics(course.id!);
     }
 
     /**

--- a/src/main/webapp/app/course/manage/detail/course-detail-doughnut-chart.component.ts
+++ b/src/main/webapp/app/course/manage/detail/course-detail-doughnut-chart.component.ts
@@ -137,7 +137,7 @@ export class CourseDetailDoughnutChartComponent {
         const course = this.course();
         const titleLink = this.titleLink();
         if (course.id && titleLink) {
-            this.router.navigate(['/course-management', course.id, titleLink]);
+            void this.router.navigate(['/course-management', course.id, titleLink]);
         }
     }
 

--- a/src/main/webapp/app/course/manage/detail/course-detail.component.ts
+++ b/src/main/webapp/app/course/manage/detail/course-detail.component.ts
@@ -130,14 +130,14 @@ export class CourseDetailComponent implements OnInit, OnDestroy, AfterViewInit {
         this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
             if (params['fromOnboarding'] === 'true') {
                 this.fromOnboarding.set(true);
-                this.router.navigate([], { queryParams: {}, replaceUrl: true });
+                void this.router.navigate([], { queryParams: {}, replaceUrl: true });
             }
         });
 
         this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(({ course }) => {
             if (course) {
                 if (course.onboardingDone !== true && course.isAtLeastInstructor && !this.accountService.isAdmin()) {
-                    this.router.navigate(['/course-management', course.id, 'onboarding'], { replaceUrl: true });
+                    void this.router.navigate(['/course-management', course.id, 'onboarding'], { replaceUrl: true });
                     return;
                 }
                 this.course.set(course);

--- a/src/main/webapp/app/course/manage/onboarding/course-onboarding.component.ts
+++ b/src/main/webapp/app/course/manage/onboarding/course-onboarding.component.ts
@@ -130,14 +130,14 @@ export class CourseOnboardingComponent implements OnInit {
         if (!current.onboardingDone) {
             current.onboardingDone = true;
             this.courseManagementService.update(current.id, current).subscribe({
-                next: () => this.router.navigate(['course-management', current.id], { queryParams: { fromOnboarding: true } }),
+                next: () => void this.router.navigate(['course-management', current.id], { queryParams: { fromOnboarding: true } }),
                 error: (error: HttpErrorResponse) => {
                     current.onboardingDone = false;
                     onError(this.alertService, error);
                 },
             });
         } else {
-            this.router.navigate(['course-management', current.id], { queryParams: { fromOnboarding: true } });
+            void this.router.navigate(['course-management', current.id], { queryParams: { fromOnboarding: true } });
         }
     }
 
@@ -259,6 +259,6 @@ export class CourseOnboardingComponent implements OnInit {
     }
 
     private updateStepUrl(step: number) {
-        this.router.navigate([], { queryParams: { step }, queryParamsHandling: 'merge', replaceUrl: true });
+        void this.router.navigate([], { queryParams: { step }, queryParamsHandling: 'merge', replaceUrl: true });
     }
 }

--- a/src/main/webapp/app/course/manage/update/course-update.component.ts
+++ b/src/main/webapp/app/course/manage/update/course-update.component.ts
@@ -454,7 +454,7 @@ export class CourseUpdateComponent implements OnInit {
             this.courseStorageService.updateCourse(updatedCourse!);
         }
 
-        this.router.navigate(['course-management', updatedCourse?.id?.toString()]);
+        void this.router.navigate(['course-management', updatedCourse?.id?.toString()]);
         scrollToTopOfPage();
     }
 

--- a/src/main/webapp/app/course/overview/course-card/course-card.component.ts
+++ b/src/main/webapp/app/course/overview/course-card/course-card.component.ts
@@ -134,6 +134,6 @@ export class CourseCardComponent {
      * Delegates the user to the corresponding course page when clicking on the chart
      */
     onSelect(): void {
-        this.router.navigate(['courses', this.course().id]);
+        void this.router.navigate(['courses', this.course().id]);
     }
 }

--- a/src/main/webapp/app/course/overview/course-dashboard/course-dashboard.component.ts
+++ b/src/main/webapp/app/course/overview/course-dashboard/course-dashboard.component.ts
@@ -274,6 +274,6 @@ export class CourseDashboardComponent implements OnDestroy {
     }
 
     navigateToLearningPaths() {
-        this.router.navigate(['courses', this._courseId(), 'learning-path']);
+        void this.router.navigate(['courses', this._courseId(), 'learning-path']);
     }
 }

--- a/src/main/webapp/app/course/overview/course-exercises/course-exercises.component.ts
+++ b/src/main/webapp/app/course/overview/course-exercises/course-exercises.component.ts
@@ -158,9 +158,9 @@ export class CourseExercisesComponent {
         }
 
         if (!exerciseId && lastSelectedExercise) {
-            this.router.navigate([lastSelectedExercise], { relativeTo: this.route, replaceUrl: true });
+            void this.router.navigate([lastSelectedExercise], { relativeTo: this.route, replaceUrl: true });
         } else if (!exerciseId && upcomingExercise) {
-            this.router.navigate([upcomingExercise.id], { relativeTo: this.route, replaceUrl: true });
+            void this.router.navigate([upcomingExercise.id], { relativeTo: this.route, replaceUrl: true });
         } else {
             this._exerciseSelected.set(!!exerciseId);
         }

--- a/src/main/webapp/app/course/overview/course-overview/course-overview-guard.ts
+++ b/src/main/webapp/app/course/overview/course-overview/course-overview-guard.ts
@@ -103,9 +103,9 @@ export class CourseOverviewGuard implements CanActivate {
         if (!hasAccess) {
             const hasOptedOutOfAI = user?.selectedLLMUsage === LLMSelectionDecision.NO_AI;
             if (type === CourseOverviewRoutePath.DASHBOARD && course?.irisEnabledInCourse && !hasOptedOutOfAI) {
-                this.router.navigate([`/courses/${course?.id}/iris`]);
+                void this.router.navigate([`/courses/${course?.id}/iris`]);
             } else {
-                this.router.navigate([`/courses/${course?.id}/exercises`]);
+                void this.router.navigate([`/courses/${course?.id}/exercises`]);
             }
         }
         return of(hasAccess);

--- a/src/main/webapp/app/course/overview/course-registration/course-registration-button/course-registration-button.component.ts
+++ b/src/main/webapp/app/course/overview/course-registration/course-registration-button/course-registration-button.component.ts
@@ -30,7 +30,7 @@ export class CourseRegistrationButtonComponent implements OnInit {
 
     loadUserIsAllowedToRegister() {
         this._loading.set(true);
-        this.accountService.identity().then((user) => {
+        void this.accountService.identity().then((user) => {
             const profileInfo = this.profileService.getProfileInfo();
             if (user?.login) {
                 this._userIsAllowedToRegister.set(matchesRegexFully(user.login, profileInfo.allowedCourseRegistrationUsernamePattern));

--- a/src/main/webapp/app/course/overview/course-registration/course-registration-detail/course-registration-detail.component.ts
+++ b/src/main/webapp/app/course/overview/course-registration/course-registration-detail/course-registration-detail.component.ts
@@ -40,7 +40,7 @@ export class CourseRegistrationDetailComponent implements OnInit, OnDestroy {
     }
 
     redirectToCoursePage(): void {
-        this.router.navigate(['courses', this.courseId]);
+        void this.router.navigate(['courses', this.courseId]);
     }
 
     /**

--- a/src/main/webapp/app/course/overview/course-registration/course-registration.component.ts
+++ b/src/main/webapp/app/course/overview/course-registration/course-registration.component.ts
@@ -81,7 +81,7 @@ export class CourseRegistrationComponent implements OnInit {
      * Triggers a route transition, updating the URL with the current sorting parameters.
      */
     transition(): void {
-        this.router.navigate(['/courses/enroll'], {
+        void this.router.navigate(['/courses/enroll'], {
             relativeTo: this.activatedRoute.parent,
             queryParams: {
                 sort: `${this.predicate},${this.ascending ? ASC : DESC}`,

--- a/src/main/webapp/app/course/overview/course-unenrollment-modal/course-unenrollment-modal.component.ts
+++ b/src/main/webapp/app/course/overview/course-unenrollment-modal/course-unenrollment-modal.component.ts
@@ -68,7 +68,7 @@ export class CourseUnenrollmentModalComponent implements OnInit {
         this.courseService.unenrollFromCourse(courseValue!.id!).subscribe({
             next: () => {
                 this.alertService.success('artemisApp.courseOverview.exerciseList.details.unenrollmentModal.unenrollmentSuccessful');
-                this.router.navigate(['/']);
+                void this.router.navigate(['/']);
             },
             error: (error: string) => {
                 this.alertService.error(error);

--- a/src/main/webapp/app/course/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/course/overview/exercise-details/course-exercise-details.component.ts
@@ -303,7 +303,7 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
 
         this.showIfExampleSolutionPresent(newExerciseDetails.exercise);
         this.subscribeForNewResults();
-        this.subscribeToTeamAssignmentUpdates();
+        void this.subscribeToTeamAssignmentUpdates();
 
         this._baseResource.set(`/course-management/${this.courseId}/${this.exercise?.type}-exercises/${this.exercise?.id}/`);
         if (this.exercise?.type) {
@@ -759,7 +759,7 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
         } else {
             return;
         }
-        this.router.navigate(['/courses', this.courseId, 'exercises', exerciseTypePath, this.exercise.id, 'participate', changedParticipation.id, 'submission', submissionId]);
+        void this.router.navigate(['/courses', this.courseId, 'exercises', exerciseTypePath, this.exercise.id, 'participate', changedParticipation.id, 'submission', submissionId]);
     }
 
     ngOnDestroy() {

--- a/src/main/webapp/app/course/overview/exercise-details/exercise-split-panel/exercise-split-panel.component.ts
+++ b/src/main/webapp/app/course/overview/exercise-details/exercise-split-panel/exercise-split-panel.component.ts
@@ -245,7 +245,7 @@ export class ExerciseSplitPanelComponent {
                     const targetSegment = mode === 'practice' ? 'practice' : 'live';
                     const currentSegment = this.route.firstChild?.snapshot.url[0]?.path;
                     if (currentSegment !== targetSegment) {
-                        this.router.navigate(['quiz-exercises', exercise.id, targetSegment], { relativeTo: this.route.parent });
+                        void this.router.navigate(['quiz-exercises', exercise.id, targetSegment], { relativeTo: this.route.parent });
                     }
                     return;
                 }
@@ -253,13 +253,13 @@ export class ExerciseSplitPanelComponent {
                 const currentParticipationId = this.route.firstChild?.snapshot.paramMap.get('participationId');
                 if (currentParticipationId === String(participation.id)) return;
                 if (type === ExerciseType.TEXT) {
-                    this.router.navigate(['text-exercises', exercise.id, 'participate', participation.id], { relativeTo: this.route.parent });
+                    void this.router.navigate(['text-exercises', exercise.id, 'participate', participation.id], { relativeTo: this.route.parent });
                 } else if (type === ExerciseType.PROGRAMMING && (exercise as ProgrammingExercise).allowOnlineEditor) {
-                    this.router.navigate(['programming-exercises', exercise.id, 'code-editor', participation.id], { relativeTo: this.route.parent });
+                    void this.router.navigate(['programming-exercises', exercise.id, 'code-editor', participation.id], { relativeTo: this.route.parent });
                 } else if (type === ExerciseType.MODELING) {
-                    this.router.navigate(['modeling-exercises', exercise.id, 'participate', participation.id], { relativeTo: this.route.parent });
+                    void this.router.navigate(['modeling-exercises', exercise.id, 'participate', participation.id], { relativeTo: this.route.parent });
                 } else if (type === ExerciseType.FILE_UPLOAD) {
-                    this.router.navigate(['file-upload-exercises', exercise.id, 'participate', participation.id], { relativeTo: this.route.parent });
+                    void this.router.navigate(['file-upload-exercises', exercise.id, 'participate', participation.id], { relativeTo: this.route.parent });
                 }
             });
         });
@@ -306,7 +306,7 @@ export class ExerciseSplitPanelComponent {
             } else if (component instanceof ModelingSubmissionComponent) {
                 component.submit();
             } else if (component instanceof FileUploadSubmissionComponent) {
-                component.submitExercise();
+                void component.submitExercise();
             } else if (component instanceof QuizParticipationComponent) {
                 component.onSubmit();
             }

--- a/src/main/webapp/app/course/overview/exercise-details/lti-initializer/lti-initializer-modal.component.ts
+++ b/src/main/webapp/app/course/overview/exercise-details/lti-initializer/lti-initializer-modal.component.ts
@@ -28,7 +28,7 @@ export class LtiInitializerModalComponent {
      */
     clear(): void {
         this.alertService.info('artemisApp.lti.startExercise');
-        this.router.navigate([], { relativeTo: this.activatedRoute, queryParams: { initialize: null }, queryParamsHandling: 'merge' });
+        void this.router.navigate([], { relativeTo: this.activatedRoute, queryParams: { initialize: null }, queryParamsHandling: 'merge' });
         this.visible.set(false);
     }
 }

--- a/src/main/webapp/app/course/overview/exercise-details/lti-initializer/lti-initializer.component.ts
+++ b/src/main/webapp/app/course/overview/exercise-details/lti-initializer/lti-initializer.component.ts
@@ -30,7 +30,7 @@ export class LtiInitializerComponent implements OnInit {
                     const password = res.body?.password;
                     if (!password) {
                         this.alertService.info('artemisApp.lti.initializationError');
-                        this.router.navigate([], {
+                        void this.router.navigate([], {
                             relativeTo: this.activatedRoute,
                             queryParams: { initialize: null },
                             queryParamsHandling: 'merge',

--- a/src/main/webapp/app/course/sidebar/sidebar-card-large/sidebar-card-large.component.ts
+++ b/src/main/webapp/app/course/sidebar/sidebar-card-large/sidebar-card-large.component.ts
@@ -29,11 +29,11 @@ export class SidebarCardLargeComponent {
     }
 
     refreshChildComponent(): void {
-        this.router.navigate(['../'], { skipLocationChange: true, relativeTo: this.route.firstChild }).then(() => {
+        void this.router.navigate(['../'], { skipLocationChange: true, relativeTo: this.route.firstChild }).then(() => {
             if (this.itemSelected()) {
-                this.router.navigate(['./' + this.sidebarItem()?.id], { relativeTo: this.route });
+                void this.router.navigate(['./' + this.sidebarItem()?.id], { relativeTo: this.route });
             } else {
-                this.router.navigate([this.location.path(), this.sidebarItem()?.id], { replaceUrl: true });
+                void this.router.navigate([this.location.path(), this.sidebarItem()?.id], { replaceUrl: true });
             }
         });
     }

--- a/src/main/webapp/app/course/sidebar/sidebar-card-medium/sidebar-card-medium.component.ts
+++ b/src/main/webapp/app/course/sidebar/sidebar-card-medium/sidebar-card-medium.component.ts
@@ -44,8 +44,8 @@ export class SidebarCardMediumComponent {
         const targetComponentSubRoute = this.sidebarItem()?.targetComponentSubRoute;
         const itemId = this.sidebarItem()?.id;
         const pathSegments = targetComponentSubRoute ? ['./', targetComponentSubRoute, itemId] : ['./', itemId];
-        this.router.navigate(['../'], { skipLocationChange: true, relativeTo: this.route.firstChild }).then(() => {
-            this.router.navigate(pathSegments, { relativeTo: this.route });
+        void this.router.navigate(['../'], { skipLocationChange: true, relativeTo: this.route.firstChild }).then(() => {
+            void this.router.navigate(pathSegments, { relativeTo: this.route });
         });
     }
 

--- a/src/main/webapp/app/course/sidebar/sidebar-card-small/sidebar-card-small.component.ts
+++ b/src/main/webapp/app/course/sidebar/sidebar-card-small/sidebar-card-small.component.ts
@@ -35,11 +35,11 @@ export class SidebarCardSmallComponent {
     }
 
     refreshChildComponent(): void {
-        this.router.navigate(['../'], { skipLocationChange: true, relativeTo: this.route.firstChild }).then(() => {
+        void this.router.navigate(['../'], { skipLocationChange: true, relativeTo: this.route.firstChild }).then(() => {
             if (this.itemSelected()) {
-                this.router.navigate(['./' + this.sidebarItem()?.id], { relativeTo: this.route });
+                void this.router.navigate(['./' + this.sidebarItem()?.id], { relativeTo: this.route });
             } else {
-                this.router.navigate([this.location.path(), this.sidebarItem()?.id], { replaceUrl: true });
+                void this.router.navigate([this.location.path(), this.sidebarItem()?.id], { replaceUrl: true });
             }
         });
     }

--- a/src/main/webapp/app/editor/markdown-editor/monaco/markdown-editor-monaco.component.ts
+++ b/src/main/webapp/app/editor/markdown-editor/monaco/markdown-editor-monaco.component.ts
@@ -964,13 +964,14 @@ export class MarkdownEditorMonacoComponent implements AfterContentInit, AfterVie
             return;
         }
         files.forEach((file) => {
-            (this.useCommunicationForFileUpload()
-                ? this.fileUploaderService.uploadMarkdownFileInCurrentMetisConversation(
-                      file,
-                      this.metisService?.getCourse()?.id,
-                      this.metisService?.getCurrentConversation()?.id ?? this.fallbackConversationId(),
-                  )
-                : this.fileUploaderService.uploadMarkdownFile(file)
+            void (
+                this.useCommunicationForFileUpload()
+                    ? this.fileUploaderService.uploadMarkdownFileInCurrentMetisConversation(
+                          file,
+                          this.metisService?.getCourse()?.id,
+                          this.metisService?.getCurrentConversation()?.id ?? this.fallbackConversationId(),
+                      )
+                    : this.fileUploaderService.uploadMarkdownFile(file)
             )
                 .then(
                     (response) => this.processFileUploadResponse(response, file),

--- a/src/main/webapp/app/editor/monaco-editor/model/actions/adapter/monaco-text-editor.adapter.ts
+++ b/src/main/webapp/app/editor/monaco-editor/model/actions/adapter/monaco-text-editor.adapter.ts
@@ -196,7 +196,7 @@ export class MonacoTextEditorAdapter implements TextEditor {
 
     addPasteListener(callback: (insertedText: string) => void | Promise<void>): Disposable {
         return this.editor.onDidPaste((pasteEvent) => {
-            callback(this.getTextAtRange(this.fromMonacoRange(pasteEvent.range)));
+            void callback(this.getTextAtRange(this.fromMonacoRange(pasteEvent.range)));
         });
     }
 

--- a/src/main/webapp/app/editor/monaco-editor/model/actions/communication/lecture-attachment-reference.action.ts
+++ b/src/main/webapp/app/editor/monaco-editor/model/actions/communication/lecture-attachment-reference.action.ts
@@ -44,7 +44,7 @@ export class LectureAttachmentReferenceAction extends TextEditorAction {
         private readonly fileService: FileService,
     ) {
         super(LectureAttachmentReferenceAction.ID, 'artemisApp.metis.editor.lecture');
-        firstValueFrom(this.lectureService.findAllByCourseIdWithSlides(this.metisService.getCourse().id!)).then((response) => {
+        void firstValueFrom(this.lectureService.findAllByCourseIdWithSlides(this.metisService.getCourse().id!)).then((response) => {
             const lectures = response.body;
             if (lectures) {
                 this.lecturesWithDetails = lectures

--- a/src/main/webapp/app/exam/manage/exam-management/exam-management.component.ts
+++ b/src/main/webapp/app/exam/manage/exam-management/exam-management.component.ts
@@ -186,7 +186,7 @@ export class ExamManagementComponent implements OnInit, OnDestroy {
         dialogRef?.onClose.subscribe((exam: Exam | undefined) => {
             if (exam) {
                 importBaseRoute.push(exam.id);
-                this.router.navigate(importBaseRoute);
+                void this.router.navigate(importBaseRoute);
             }
         });
     }

--- a/src/main/webapp/app/exam/manage/exams/detail/exam-detail.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/detail/exam-detail.component.ts
@@ -179,7 +179,7 @@ export class ExamDetailComponent implements OnInit, OnDestroy {
         this.examManagementService.delete(this.exam().course!.id!, examId).subscribe({
             next: () => {
                 this.dialogErrorSource.next('');
-                this.router.navigate(['/course-management', this.exam().course!.id!, 'exams']);
+                void this.router.navigate(['/course-management', this.exam().course!.id!, 'exams']);
             },
             error: (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),
         });

--- a/src/main/webapp/app/exam/manage/exams/update/exam-update.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/update/exam-update.component.ts
@@ -355,7 +355,7 @@ export class ExamUpdateComponent implements OnInit, OnDestroy, AfterViewInit {
             .then((response) => {
                 const importedExam = response.body?.exam;
                 if (importedExam) {
-                    this.onSaveSuccess(importedExam);
+                    void this.onSaveSuccess(importedExam);
                 } else {
                     this.isSaving.set(false);
                 }

--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.ts
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.ts
@@ -256,11 +256,11 @@ export class ExerciseGroupsComponent implements OnInit {
             if (result) {
                 if (result.id) {
                     importBaseRoute.push('import', result.id);
-                    this.router.navigate(importBaseRoute);
+                    void this.router.navigate(importBaseRoute);
                 } else {
                     // we know it must be a programming exercise, because only programming exercises can be imported from a file
                     importBaseRoute.push('import-from-file');
-                    this.router.navigate(importBaseRoute, {
+                    void this.router.navigate(importBaseRoute, {
                         state: {
                             programmingExerciseForImportFromFile: result,
                         },

--- a/src/main/webapp/app/exam/manage/exercise-groups/update/exercise-group-update.component.ts
+++ b/src/main/webapp/app/exam/manage/exercise-groups/update/exercise-group-update.component.ts
@@ -60,7 +60,7 @@ export class ExerciseGroupUpdateComponent implements OnInit {
     }
 
     previousState() {
-        this.router.navigate(['course-management', this.courseId, 'exams', this.route.snapshot.paramMap.get('examId'), 'exercise-groups']);
+        void this.router.navigate(['course-management', this.courseId, 'exams', this.route.snapshot.paramMap.get('examId'), 'exercise-groups']);
     }
 
     private subscribeToSaveResponse(result: Observable<HttpResponse<ExerciseGroup>>) {

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-timeline/programming-exam-diff/programming-exercise-exam-diff.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-timeline/programming-exam-diff/programming-exercise-exam-diff.component.ts
@@ -128,7 +128,7 @@ export class ProgrammingExerciseExamDiffComponent extends ExamSubmissionComponen
             if (left && right) {
                 this.cachedRepositoryFiles.set(this.leftKey, left);
                 this.cachedRepositoryFiles.set(this.rightKey, right);
-                this.processRepositoryDiff(left, right);
+                void this.processRepositoryDiff(left, right);
             } else {
                 this.alertService.error('artemisApp.programmingExercise.repositoryFilesError');
             }

--- a/src/main/webapp/app/exam/manage/students/exam-students.component.ts
+++ b/src/main/webapp/app/exam/manage/students/exam-students.component.ts
@@ -495,7 +495,7 @@ export class ExamStudentsComponent implements OnDestroy {
         if (!this.hasExamStarted() || !exam?.id) {
             return;
         }
-        this.router.navigate(['/course-management', this.courseId(), 'exams', exam.id, 'students', 'verify-attendance']);
+        void this.router.navigate(['/course-management', this.courseId(), 'exams', exam.id, 'students', 'verify-attendance']);
     }
 
     private openIndividualExamsStatusPopover(event?: Event, defer = false) {

--- a/src/main/webapp/app/exam/manage/suspicious-behavior/plagiarism-cases-overview/plagiarism-cases-overview.component.ts
+++ b/src/main/webapp/app/exam/manage/suspicious-behavior/plagiarism-cases-overview/plagiarism-cases-overview.component.ts
@@ -21,7 +21,7 @@ export class PlagiarismCasesOverviewComponent {
     goToPlagiarismDetection(exercise: Exercise) {
         const exerciseGroupId = exercise.exerciseGroup?.id;
         const exerciseType = exercise.type;
-        this.router.navigate([
+        void this.router.navigate([
             '/course-management',
             this.courseId(),
             'exams',
@@ -34,6 +34,6 @@ export class PlagiarismCasesOverviewComponent {
         ]);
     }
     goToPlagiarismCases() {
-        this.router.navigate(['/course-management', this.courseId(), 'exams', this.examId(), 'plagiarism-cases']);
+        void this.router.navigate(['/course-management', this.courseId(), 'exams', this.examId(), 'plagiarism-cases']);
     }
 }

--- a/src/main/webapp/app/exam/manage/suspicious-behavior/suspicious-behavior.component.ts
+++ b/src/main/webapp/app/exam/manage/suspicious-behavior/suspicious-behavior.component.ts
@@ -95,7 +95,7 @@ export class SuspiciousBehaviorComponent implements OnInit {
     };
 
     goToSuspiciousSessions() {
-        this.router.navigate(['/course-management', this.courseId(), 'exams', this.examId(), 'suspicious-behavior', 'suspicious-sessions'], {
+        void this.router.navigate(['/course-management', this.courseId(), 'exams', this.examId(), 'suspicious-behavior', 'suspicious-sessions'], {
             state: { suspiciousSessions: this.suspiciousSessions(), ipSubnet: this.ipSubnet() },
         });
     }

--- a/src/main/webapp/app/exam/manage/test-runs/test-run-management/test-run-management.component.ts
+++ b/src/main/webapp/app/exam/manage/test-runs/test-run-management/test-run-management.component.ts
@@ -93,7 +93,7 @@ export class TestRunManagementComponent implements OnInit {
             },
             error: (error: HttpErrorResponse) => onError(this.alertService, error),
         });
-        this.accountService.identity().then((user) => {
+        void this.accountService.identity().then((user) => {
             if (user) {
                 this.instructor.set(user);
             }

--- a/src/main/webapp/app/exam/overview/exam-cover/exam-participation-cover.component.ts
+++ b/src/main/webapp/app/exam/overview/exam-cover/exam-participation-cover.component.ts
@@ -98,7 +98,7 @@ export class ExamParticipationCoverComponent implements OnDestroy, OnInit {
                 this.formattedConfirmationText.set(this.artemisMarkdown.safeHtmlForMarkdown(exam.confirmationEndText));
             }
 
-            this.accountService.identity().then((user) => {
+            void this.accountService.identity().then((user) => {
                 if (user && user.name) {
                     this.accountName.set(user.name);
                 }

--- a/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.ts
@@ -458,12 +458,12 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
 
                     if (this.testRunId()) {
                         // If this is a test run, forward the user directly to the exam summary
-                        this.router.navigate(['course-management', this.courseId(), 'exams', this.examId(), 'test-runs', this.testRunId(), 'summary']);
+                        void this.router.navigate(['course-management', this.courseId(), 'exams', this.examId(), 'test-runs', this.testRunId(), 'summary']);
                     }
 
                     if (this.testExam()) {
                         this.examParticipationService.resetExamLayout();
-                        this.router.navigate(['courses', this.courseId(), 'exams', this.examId(), 'test-exam', this.studentExam().id]);
+                        void this.router.navigate(['courses', this.courseId(), 'exams', this.examId(), 'test-exam', this.studentExam().id]);
                         this.examParticipationService.setShouldUpdateTestExams(true);
                     }
 

--- a/src/main/webapp/app/exam/shared/course-exams/course-exams.component.ts
+++ b/src/main/webapp/app/exam/shared/course-exams/course-exams.component.ts
@@ -139,10 +139,10 @@ export class CourseExamsComponent implements OnInit, OnDestroy {
         const examId = this.route.firstChild?.snapshot.params.examId;
         if (!examId && lastSelectedExam) {
             // First, try to navigate to the last selected exam
-            this.router.navigate([lastSelectedExam], { relativeTo: this.route, replaceUrl: true });
+            void this.router.navigate([lastSelectedExam], { relativeTo: this.route, replaceUrl: true });
         } else if (!examId && upcomingExam) {
             // Second, try to navigate to the upcoming exam
-            this.router.navigate([upcomingExam.id], { relativeTo: this.route, replaceUrl: true });
+            void this.router.navigate([upcomingExam.id], { relativeTo: this.route, replaceUrl: true });
         } else {
             // If both is not defined, do not navigate and only set examSelected to true when the examId was found in the client URL
             this.examSelected.set(!!examId);
@@ -160,7 +160,7 @@ export class CourseExamsComponent implements OnInit, OnDestroy {
             this.realExamsOfCourse = exams.filter((exam) => !exam.testExam);
             this.testExamsOfCourse = exams.filter((exam) => exam.testExam);
             // get student exams for real exams
-            lastValueFrom(this.examParticipationService.getRealExamSidebarData(this.courseId())).then((studentExams) => {
+            void lastValueFrom(this.examParticipationService.getRealExamSidebarData(this.courseId())).then((studentExams) => {
                 studentExams.forEach((exam) => {
                     const studentExam = cloneDeep(exam) as StudentExam;
                     this.studentExamsForRealExams.set(studentExam.id!, studentExam);

--- a/src/main/webapp/app/exercise/dashboards/tutor-participation-graph/tutor-participation-graph.component.ts
+++ b/src/main/webapp/app/exercise/dashboards/tutor-participation-graph/tutor-participation-graph.component.ts
@@ -100,7 +100,7 @@ export class TutorParticipationGraphComponent {
     navigate() {
         const link = this.routerLink();
         if (link.length > 0) {
-            this.router.navigate([link]);
+            void this.router.navigate([link]);
         }
     }
 

--- a/src/main/webapp/app/exercise/exercise-create-buttons/exercise-create-button/exercise-create-button.component.ts
+++ b/src/main/webapp/app/exercise/exercise-create-buttons/exercise-create-button/exercise-create-button.component.ts
@@ -16,6 +16,6 @@ export class ExerciseCreateButtonComponent extends ExerciseManageButtonComponent
     linkToExerciseCreation() {
         this.beforeNavigate.emit();
         this.modalService.dismissAll();
-        this.router.navigate(['/course-management', this.course()?.id, this.exerciseType() + '-exercises', 'new']);
+        void this.router.navigate(['/course-management', this.course()?.id, this.exerciseType() + '-exercises', 'new']);
     }
 }

--- a/src/main/webapp/app/exercise/exercise-create-buttons/exercise-import-button/exercise-import-button.component.ts
+++ b/src/main/webapp/app/exercise/exercise-create-buttons/exercise-import-button/exercise-import-button.component.ts
@@ -48,7 +48,7 @@ export class ExerciseImportButtonComponent extends ExerciseManageButtonComponent
                 if (this.exerciseType() === ExerciseType.PROGRAMMING) {
                     this.handleProgrammingImport(result);
                 } else {
-                    this.router.navigate(['/course-management', this.course()?.id, this.exerciseType() + '-exercises', result.id, 'import']);
+                    void this.router.navigate(['/course-management', this.course()?.id, this.exerciseType() + '-exercises', result.id, 'import']);
                 }
             }
         });
@@ -57,13 +57,13 @@ export class ExerciseImportButtonComponent extends ExerciseManageButtonComponent
     handleProgrammingImport(result: Exercise) {
         //when the file is uploaded we set the id to undefined.
         if (result.id === undefined) {
-            this.router.navigate(['/course-management', this.course()?.id, 'programming-exercises', 'import-from-file'], {
+            void this.router.navigate(['/course-management', this.course()?.id, 'programming-exercises', 'import-from-file'], {
                 state: {
                     programmingExerciseForImportFromFile: result,
                 },
             });
         } else {
-            this.router.navigate(['/course-management', this.course()?.id, 'programming-exercises', 'import', result.id]);
+            void this.router.navigate(['/course-management', this.course()?.id, 'programming-exercises', 'import', result.id]);
         }
     }
 }

--- a/src/main/webapp/app/exercise/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.ts
+++ b/src/main/webapp/app/exercise/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.ts
@@ -149,9 +149,9 @@ export class NonProgrammingExerciseDetailCommonActionsComponent implements OnIni
         const course = this.course();
         const exercise = this.exercise();
         if (!this.isExamExercise()) {
-            this.router.navigateByUrl(`/course-management/${course.id}/exercises`);
+            void this.router.navigateByUrl(`/course-management/${course.id}/exercises`);
         } else {
-            this.router.navigateByUrl(`/course-management/${course.id}/exams/${exercise.exerciseGroup?.exam?.id}/exercise-groups`);
+            void this.router.navigateByUrl(`/course-management/${course.id}/exams/${exercise.exerciseGroup?.exam?.id}/exercise-groups`);
         }
     }
 

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header-actions/exercise-header-actions.component.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header-actions/exercise-header-actions.component.ts
@@ -498,7 +498,7 @@ export class ExerciseHeaderActionsComponent {
                 return;
             }
         }
-        this.router.navigate(['/courses', this.courseId(), 'exercises', 'quiz-exercises', this.exercise().id, quizMode]);
+        void this.router.navigate(['/courses', this.courseId(), 'exercises', 'quiz-exercises', this.exercise().id, quizMode]);
     }
 
     closeSubmitPopover() {

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-headers-information/result-history-dropdown/result-history-dropdown.component.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-headers-information/result-history-dropdown/result-history-dropdown.component.ts
@@ -124,15 +124,15 @@ export class ResultHistoryDropdownComponent {
 
         if (exercise.type === ExerciseType.QUIZ) {
             if (isPracticeMode(participation)) {
-                this.router.navigate(['/courses', courseId, 'exercises', 'quiz-exercises', exercise.id, 'practice', participation.id]);
+                void this.router.navigate(['/courses', courseId, 'exercises', 'quiz-exercises', exercise.id, 'practice', participation.id]);
             } else {
-                this.router.navigate(['/courses', courseId, 'exercises', 'quiz-exercises', exercise.id, 'live']);
+                void this.router.navigate(['/courses', courseId, 'exercises', 'quiz-exercises', exercise.id, 'live']);
             }
             return;
         }
 
         const exerciseTypePath = exercise.type === ExerciseType.TEXT ? 'text-exercises' : 'modeling-exercises';
-        this.router.navigate(['/courses', courseId, 'exercises', exerciseTypePath, exercise.id, 'participate', participation.id]);
+        void this.router.navigate(['/courses', courseId, 'exercises', exerciseTypePath, exercise.id, 'participate', participation.id]);
     }
 
     resultsPopover = viewChild<Popover>('resultsPopover');
@@ -242,16 +242,28 @@ export class ResultHistoryDropdownComponent {
         if (exercise.type === ExerciseType.QUIZ) {
             if (isPracticeMode(participation)) {
                 const submissionId = result.submission?.id;
-                this.router.navigate(['/courses', courseId, 'exercises', 'quiz-exercises', exercise.id, 'practice', participation.id, 'submission', submissionId]);
+                void this.router.navigate(['/courses', courseId, 'exercises', 'quiz-exercises', exercise.id, 'practice', participation.id, 'submission', submissionId]);
             } else {
-                this.router.navigate(['/courses', courseId, 'exercises', 'quiz-exercises', exercise.id, 'live']);
+                void this.router.navigate(['/courses', courseId, 'exercises', 'quiz-exercises', exercise.id, 'live']);
             }
             return;
         }
 
         const submissionId = result.submission?.id;
         const exerciseTypePath = exercise.type === ExerciseType.TEXT ? 'text-exercises' : 'modeling-exercises';
-        this.router.navigate(['/courses', courseId, 'exercises', exerciseTypePath, exercise.id, 'participate', participation.id, 'submission', submissionId, 'result', result.id]);
+        void this.router.navigate([
+            '/courses',
+            courseId,
+            'exercises',
+            exerciseTypePath,
+            exercise.id,
+            'participate',
+            participation.id,
+            'submission',
+            submissionId,
+            'result',
+            result.id,
+        ]);
     }
 
     showFeedback(result: Result, event: Event) {

--- a/src/main/webapp/app/exercise/result/result.component.ts
+++ b/src/main/webapp/app/exercise/result/result.component.ts
@@ -233,7 +233,7 @@ export class ResultComponent {
 
             const exerciseTypePath = exercise?.type === ExerciseType.TEXT ? 'text-exercises' : 'modeling-exercises';
 
-            this.router.navigate([
+            void this.router.navigate([
                 '/courses',
                 courseId,
                 'exercises',

--- a/src/main/webapp/app/exercise/statistics/doughnut-chart/doughnut-chart.component.ts
+++ b/src/main/webapp/app/exercise/statistics/doughnut-chart/doughnut-chart.component.ts
@@ -108,7 +108,7 @@ export class DoughnutChartComponent implements OnInit {
     openCorrespondingPage() {
         const titleLink = this.titleLink();
         if (this.course().id && this.exerciseId() && titleLink) {
-            this.router.navigate(titleLink);
+            void this.router.navigate(titleLink);
         }
     }
 

--- a/src/main/webapp/app/exercise/team-submission-sync/team-submission-sync.component.ts
+++ b/src/main/webapp/app/exercise/team-submission-sync/team-submission-sync.component.ts
@@ -42,7 +42,7 @@ export class TeamSubmissionSyncComponent implements OnInit, OnDestroy {
     websocketTopic: string;
 
     constructor() {
-        this.accountService.identity().then((user: User) => (this.currentUser = user));
+        void this.accountService.identity().then((user: User) => (this.currentUser = user));
     }
 
     /**

--- a/src/main/webapp/app/exercise/team/team-participate/team-students-online-list.component.ts
+++ b/src/main/webapp/app/exercise/team/team-participate/team-students-online-list.component.ts
@@ -49,7 +49,7 @@ export class TeamStudentsOnlineListComponent implements OnInit, OnDestroy {
      * client sometimes and thus the list is explicitly requested once more after a short timeout to cover those cases.
      */
     ngOnInit(): void {
-        this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User) => {
             this.currentUser = user;
             this.setupOnlineTeamStudentsReceiver();
             this.setupTypingIndicatorSender();

--- a/src/main/webapp/app/exercise/team/team.component.ts
+++ b/src/main/webapp/app/exercise/team/team.component.ts
@@ -69,7 +69,7 @@ export class TeamComponent implements OnInit {
     ];
 
     constructor() {
-        this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User) => {
             this.currentUser.set(user);
             this.isAdmin.set(this.accountService.isAdmin());
         });
@@ -129,6 +129,6 @@ export class TeamComponent implements OnInit {
      */
     onTeamDelete() {
         const exercise = this.exercise();
-        this.router.navigate(['/course-management', exercise?.course?.id, 'exercises', exercise?.id, 'teams']);
+        void this.router.navigate(['/course-management', exercise?.course?.id, 'exercises', exercise?.id, 'teams']);
     }
 }

--- a/src/main/webapp/app/exercise/team/teams/teams.component.ts
+++ b/src/main/webapp/app/exercise/team/teams/teams.component.ts
@@ -101,7 +101,7 @@ export class TeamsComponent implements OnInit, OnDestroy {
     ]);
 
     constructor() {
-        this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User) => {
             this.currentUser.set(user);
             this.isAdmin.set(this.accountService.isAdmin());
         });
@@ -159,7 +159,7 @@ export class TeamsComponent implements OnInit, OnDestroy {
      */
     updateTeamFilter(filter: FilterProp) {
         this.teamCriteria.filterProp = filter;
-        this.router.navigate([], { relativeTo: this.route, queryParams: { filter }, queryParamsHandling: 'merge', replaceUrl: true });
+        void this.router.navigate([], { relativeTo: this.route, queryParams: { filter }, queryParamsHandling: 'merge', replaceUrl: true });
         this.loadAll();
     }
 

--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
@@ -118,7 +118,7 @@ export class FileUploadAssessmentComponent implements OnInit {
         this.busy.set(true);
 
         // Used to check if the assessor is the current user
-        this.accountService.identity().then((user) => {
+        void this.accountService.identity().then((user) => {
             if (user?.id) {
                 this.userId = user.id;
             }
@@ -317,7 +317,7 @@ export class FileUploadAssessmentComponent implements OnInit {
                     this.examId,
                     this.exerciseGroupId,
                 );
-                this.router.navigate(url);
+                void this.router.navigate(url);
             },
             error: (error: HttpErrorResponse) => {
                 this.isLoading.set(false);

--- a/src/main/webapp/app/fileupload/overview/file-upload-submission/file-upload-submission.component.ts
+++ b/src/main/webapp/app/fileupload/overview/file-upload-submission/file-upload-submission.component.ts
@@ -192,7 +192,7 @@ export class FileUploadSubmissionComponent implements ComponentCanDeactivate {
         if (this.submission()?.submitted && this.result()?.completionDate) {
             const submissionId = this.submission()?.id;
             if (submissionId) {
-                firstValueFrom(this.fileUploadAssessmentService.getAssessment(submissionId)).then((assessmentResult: Result) => {
+                void firstValueFrom(this.fileUploadAssessmentService.getAssessment(submissionId)).then((assessmentResult: Result) => {
                     this.result.set(assessmentResult);
                 });
             }

--- a/src/main/webapp/app/foundation/util/download.util.ts
+++ b/src/main/webapp/app/foundation/util/download.util.ts
@@ -34,7 +34,7 @@ export function downloadStream(data: BlobPart | null, type: string, filename: st
 }
 
 export function downloadZipFromFilePromises(zip: ZipBuilder, filePromises: Promise<void | File>[], zipFileName: string) {
-    Promise.allSettled(filePromises).then(() => {
+    void Promise.allSettled(filePromises).then(() => {
         zip.generateBlob()
             .then((zipBlob) => {
                 downloadFile(zipBlob, `${zipFileName}.zip`);

--- a/src/main/webapp/app/foundation/util/fullscreen.util.ts
+++ b/src/main/webapp/app/foundation/util/fullscreen.util.ts
@@ -44,7 +44,7 @@ export function exitFullscreen() {
     const docElement = document as VendorPrefixedDocument;
     // exit fullscreen for different browser types
     if (document.exitFullscreen) {
-        document.exitFullscreen();
+        void document.exitFullscreen();
     } else if (docElement.mozCancelFullScreen) {
         docElement.mozCancelFullScreen();
     } else if (docElement.msRequestFullscreen) {
@@ -60,7 +60,7 @@ export function exitFullscreen() {
 export function enterFullscreen(element: VendorPrefixedElement) {
     // requestFullscreen for different browser types
     if (element.requestFullscreen) {
-        element.requestFullscreen();
+        void element.requestFullscreen();
     } else if (element.mozRequestFullScreen) {
         element.mozRequestFullScreen();
     } else if (element.msRequestFullscreen) {

--- a/src/main/webapp/app/foundation/util/navigate-back.util.ts
+++ b/src/main/webapp/app/foundation/util/navigate-back.util.ts
@@ -22,16 +22,16 @@ export function assessmentNavigateBack(location: Location, router: Router, exerc
 
         if (isTestRun) {
             const exam = exercise.exerciseGroup!.exam!;
-            router.navigateByUrl(`/course-management/${course?.id}/exams/${exam.id}/test-assessment-dashboard/${exercise.id}`);
+            void router.navigateByUrl(`/course-management/${course?.id}/exams/${exam.id}/test-assessment-dashboard/${exercise.id}`);
         } else {
             if (exercise.exerciseGroup) {
                 const exam = exercise.exerciseGroup.exam!;
-                router.navigateByUrl(`/course-management/${course?.id}/exams/${exam.id}/assessment-dashboard/${exercise.id}`);
+                void router.navigateByUrl(`/course-management/${course?.id}/exams/${exam.id}/assessment-dashboard/${exercise.id}`);
             } else if (exercise.teamMode && submission) {
                 const teamId = (submission.participation as StudentParticipation).team?.id;
-                router.navigateByUrl(`/courses/${course?.id}/exercises/${exercise.id}/teams/${teamId}`);
+                void router.navigateByUrl(`/courses/${course?.id}/exercises/${exercise.id}/teams/${teamId}`);
             } else {
-                router.navigateByUrl(`/course-management/${course?.id}/assessment-dashboard/${exercise.id}`);
+                void router.navigateByUrl(`/course-management/${course?.id}/assessment-dashboard/${exercise.id}`);
             }
         }
     } else {

--- a/src/main/webapp/app/foundation/util/navigation.utils.ts
+++ b/src/main/webapp/app/foundation/util/navigation.utils.ts
@@ -34,7 +34,7 @@ export class ArtemisNavigationUtilService {
         if (!this.onFirstPage) {
             this.location.back();
         } else if (fallbackUrl) {
-            this.router.navigate(fallbackUrl);
+            void this.router.navigate(fallbackUrl);
         }
     }
 
@@ -57,7 +57,7 @@ export class ArtemisNavigationUtilService {
     navigateForwardFromExerciseUpdateOrCreation(exercise?: Exercise) {
         if (exercise?.exerciseGroup?.exam?.course?.id) {
             // If an exercise group is set we are in exam mode
-            this.router.navigate([
+            void this.router.navigate([
                 'course-management',
                 exercise.exerciseGroup.exam.course.id,
                 'exams',
@@ -68,7 +68,7 @@ export class ArtemisNavigationUtilService {
                 exercise.id,
             ]);
         } else if (exercise?.course?.id) {
-            this.router.navigate(['course-management', exercise.course.id, exercise.type! + '-exercises', exercise.id]);
+            void this.router.navigate(['course-management', exercise.course.id, exercise.type! + '-exercises', exercise.id]);
         } else {
             // Fallback
             this.navigateBack();

--- a/src/main/webapp/app/iris/overview/citation-text/iris-citation-text.component.ts
+++ b/src/main/webapp/app/iris/overview/citation-text/iris-citation-text.component.ts
@@ -313,7 +313,7 @@ export class IrisCitationTextComponent {
             queryParams.page = page;
         }
 
-        this.router.navigate(['/courses', courseId, 'lectures', lectureId], { queryParams });
+        void this.router.navigate(['/courses', courseId, 'lectures', lectureId], { queryParams });
     }
 
     /**

--- a/src/main/webapp/app/iris/overview/course-iris/course-iris.component.ts
+++ b/src/main/webapp/app/iris/overview/course-iris/course-iris.component.ts
@@ -43,7 +43,7 @@ export class CourseIrisComponent {
         this.irisChatService.llmOptedOut$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
             const id = this.courseId();
             if (id !== undefined) {
-                this.router.navigate(['/courses', id, CourseOverviewRoutePath.EXERCISES]);
+                void this.router.navigate(['/courses', id, CourseOverviewRoutePath.EXERCISES]);
             }
         });
     }

--- a/src/main/webapp/app/iris/overview/services/iris-status.service.ts
+++ b/src/main/webapp/app/iris/overview/services/iris-status.service.ts
@@ -92,7 +92,7 @@ export class IrisStatusService implements OnDestroy {
      */
     private checkHeartbeat(): void {
         if (this.disconnected || !this.currentCourseId) return;
-        firstValueFrom(this.getIrisStatus(this.currentCourseId)).then((response: HttpResponse<IrisStatusDTO>) => {
+        void firstValueFrom(this.getIrisStatus(this.currentCourseId)).then((response: HttpResponse<IrisStatusDTO>) => {
             if (response.body) {
                 this.active = Boolean(response.body.active);
 

--- a/src/main/webapp/app/iris/shared/iris-guard.service.ts
+++ b/src/main/webapp/app/iris/shared/iris-guard.service.ts
@@ -17,7 +17,7 @@ export class IrisGuard implements CanActivate {
      */
     canActivate(): boolean {
         if (!this.profileService.isModuleFeatureActive(MODULE_FEATURE_IRIS)) {
-            this.router.navigate(['/']);
+            void this.router.navigate(['/']);
             return false;
         }
         return true;

--- a/src/main/webapp/app/lecture/manage/lecture-series-create/lecture-series-create.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-series-create/lecture-series-create.component.ts
@@ -119,7 +119,7 @@ export class LectureSeriesCreateComponent {
         const lecturesToSave = this.lectureDrafts().map((d) => d.dto);
         this.lectureService.createSeries(lecturesToSave, courseId).subscribe({
             next: () => {
-                this.router.navigate(['course-management', courseId, 'lectures']);
+                void this.router.navigate(['course-management', courseId, 'lectures']);
                 this.isLoading.set(false);
             },
             error: () => {

--- a/src/main/webapp/app/lecture/manage/lecture-units/attachment-video-units/attachment-video-units.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/attachment-video-units/attachment-video-units.component.ts
@@ -167,7 +167,7 @@ export class AttachmentVideoUnitsComponent implements OnInit {
 
             this.attachmentVideoUnitService.createUnits(this.lectureId, this.filename, lectureUnitInformation).subscribe({
                 next: () => {
-                    this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
+                    void this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
                     this.isLoading.set(false);
                 },
                 error: (res: HttpErrorResponse) => {
@@ -195,7 +195,7 @@ export class AttachmentVideoUnitsComponent implements OnInit {
      * Go back to the lecture page
      */
     cancelSplit() {
-        this.router.navigate(['course-management', this.courseId.toString(), 'lectures', this.lectureId.toString()]);
+        void this.router.navigate(['course-management', this.courseId.toString(), 'lectures', this.lectureId.toString()]);
     }
 
     addRow() {

--- a/src/main/webapp/app/lecture/manage/lecture-units/create-exercise-unit/create-exercise-unit.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/create-exercise-unit/create-exercise-unit.component.ts
@@ -94,7 +94,7 @@ export class CreateExerciseUnitComponent implements OnInit {
                 concatMap((unit) => this.exerciseUnitService.create(unit, this.resolvedLectureId()!)),
                 finalize(() => {
                     if (this.shouldNavigateOnSubmit()) {
-                        this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
+                        void this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
                     } else {
                         this.onExerciseUnitCreated.emit();
                     }

--- a/src/main/webapp/app/lecture/manage/lecture-units/create-online-unit/create-online-unit.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/create-online-unit/create-online-unit.component.ts
@@ -60,7 +60,7 @@ export class CreateOnlineUnitComponent implements OnInit {
             )
             .subscribe({
                 next: () => {
-                    this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
+                    void this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
                 },
                 error: (res: HttpErrorResponse) => onError(this.alertService, res),
             });

--- a/src/main/webapp/app/lecture/manage/lecture-units/create-text-unit/create-text-unit.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/create-text-unit/create-text-unit.component.ts
@@ -59,7 +59,7 @@ export class CreateTextUnitComponent implements OnInit {
             )
             .subscribe({
                 next: () => {
-                    this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
+                    void this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
                 },
                 error: (res: HttpErrorResponse) => onError(this.alertService, res),
             });

--- a/src/main/webapp/app/lecture/manage/lecture-units/edit-online-unit/edit-online-unit.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/edit-online-unit/edit-online-unit.component.ts
@@ -72,7 +72,7 @@ export class EditOnlineUnitComponent implements OnInit {
                 finalize(() => {
                     this.isLoading.set(false);
                     // navigate back to unit-management from :courseId/lectures/:lectureId/unit-management/online-units/:onlineUnitId/edit
-                    this.router.navigate(['../../../'], { relativeTo: this.activatedRoute });
+                    void this.router.navigate(['../../../'], { relativeTo: this.activatedRoute });
                 }),
             )
             .subscribe({

--- a/src/main/webapp/app/lecture/manage/lecture-units/edit-text-unit/edit-text-unit.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/edit-text-unit/edit-text-unit.component.ts
@@ -69,7 +69,7 @@ export class EditTextUnitComponent implements OnInit {
                 finalize(() => {
                     this.isLoading.set(false);
                     // navigate back to unit-management from :courseId/lectures/:lectureId/unit-management/text-units/:textUnitId/edit
-                    this.router.navigate(['../../../'], { relativeTo: this.activatedRoute });
+                    void this.router.navigate(['../../../'], { relativeTo: this.activatedRoute });
                 }),
             )
             .subscribe({

--- a/src/main/webapp/app/lecture/manage/lecture-units/management/lecture-unit-management.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/management/lecture-unit-management.component.ts
@@ -536,7 +536,7 @@ export class LectureUnitManagementComponent implements OnInit, OnDestroy {
                     // Navigate to edit page for the last created unit
                     const lectureValue = this.lecture();
                     if (lastCreatedUnit?.id && lectureValue?.course?.id) {
-                        this.router.navigate([
+                        void this.router.navigate([
                             '/course-management',
                             lectureValue.course.id,
                             'lectures',

--- a/src/main/webapp/app/lecture/manage/lecture-update/lecture-update.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-update/lecture-update.component.ts
@@ -322,11 +322,11 @@ export class LectureUpdateComponent implements OnInit, OnDestroy, LectureUnsaved
         if (this.processUnitMode()) {
             this.isProcessing.set(false);
             this.alertService.success(`Lecture with title ${lecture.title} was successfully ${this.lecture().id !== undefined ? 'updated' : 'created'}.`);
-            this.router.navigate(['course-management', lecture.course.id, 'lectures', lecture.id, 'unit-management', 'attachment-video-units', 'process'], {
+            void this.router.navigate(['course-management', lecture.course.id, 'lectures', lecture.id, 'unit-management', 'attachment-video-units', 'process'], {
                 state: { file: this.file, fileName: this.fileName() },
             });
         } else if (this.isEditMode()) {
-            this.router.navigate(['course-management', lecture.course.id, 'lectures', lecture.id]);
+            void this.router.navigate(['course-management', lecture.course.id, 'lectures', lecture.id]);
         } else {
             // after create we stay on the edit page, as now lecture units are available (we need the lecture id to save them)
             this.isNewlyCreatedExercise = true;
@@ -335,7 +335,7 @@ export class LectureUpdateComponent implements OnInit, OnDestroy, LectureUnsaved
             this.lecture.set(lecture);
             this.updateIsChangesMadeToTitleOrPeriodSection();
 
-            this.router.navigate(['course-management', lecture.course.id, 'lectures', lecture.id, 'edit']);
+            void this.router.navigate(['course-management', lecture.course.id, 'lectures', lecture.id, 'edit']);
             this.shouldDisplayDismissWarning = true;
         }
 

--- a/src/main/webapp/app/lecture/manage/lecture/lecture.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture/lecture.component.ts
@@ -135,7 +135,7 @@ export class LectureComponent implements OnInit, OnDestroy {
                     .subscribe({
                         next: (res: Lecture) => {
                             this.lectures.set([...this.lectures(), res]);
-                            this.router.navigate(['course-management', res.course!.id, 'lectures', res.id]);
+                            void this.router.navigate(['course-management', res.course!.id, 'lectures', res.id]);
                         },
                         error: (res: HttpErrorResponse) => onError(this.alertService, res),
                     });
@@ -236,7 +236,7 @@ export class LectureComponent implements OnInit, OnDestroy {
     }
 
     navigateToLectureCreationPage(): void {
-        this.router.navigate(['course-management', this.courseId, 'lectures', 'new'], {
+        void this.router.navigate(['course-management', this.courseId, 'lectures', 'new'], {
             state: { existingLectures: this.lectures() },
         });
     }
@@ -305,7 +305,7 @@ export class LectureComponent implements OnInit, OnDestroy {
                 next: (createdLecture: Lecture) => {
                     this.isUploadingPdfs.set(false);
                     this.alertService.success('artemisApp.lecture.pdfUpload.success');
-                    this.router.navigate(['course-management', this.courseId, 'lectures', createdLecture.id, 'edit']);
+                    void this.router.navigate(['course-management', this.courseId, 'lectures', createdLecture.id, 'edit']);
                 },
                 error: (error: HttpErrorResponse) => {
                     this.isUploadingPdfs.set(false);
@@ -333,7 +333,7 @@ export class LectureComponent implements OnInit, OnDestroy {
                 complete: () => {
                     this.isUploadingPdfs.set(false);
                     this.alertService.success('artemisApp.lecture.pdfUpload.success');
-                    this.router.navigate(['course-management', this.courseId, 'lectures', lectureId, 'edit']);
+                    void this.router.navigate(['course-management', this.courseId, 'lectures', lectureId, 'edit']);
                 },
             });
     }

--- a/src/main/webapp/app/lecture/manage/pdf-preview/pdf-preview-thumbnail-grid/pdf-preview-thumbnail-grid.component.ts
+++ b/src/main/webapp/app/lecture/manage/pdf-preview/pdf-preview-thumbnail-grid/pdf-preview-thumbnail-grid.component.ts
@@ -62,7 +62,7 @@ export class PdfPreviewThumbnailGridComponent implements OnChanges {
     ngOnChanges(changes: SimpleChanges): void {
         if (changes['orderedPages']) {
             if (!this.reordering()) {
-                this.renderPages();
+                void this.renderPages();
             }
             this.reordering.set(false);
         }

--- a/src/main/webapp/app/lecture/manage/pdf-preview/pdf-preview.component.ts
+++ b/src/main/webapp/app/lecture/manage/pdf-preview/pdf-preview.component.ts
@@ -256,7 +256,7 @@ export class PdfPreviewComponent implements OnInit, OnDestroy {
 
         blob.arrayBuffer()
             .then((arrayBuffer) => {
-                this.loadPdf(url, arrayBuffer, 'original', existingSlides);
+                void this.loadPdf(url, arrayBuffer, 'original', existingSlides);
             })
             .catch((error) => {
                 onError(this.alertService, error);
@@ -554,7 +554,7 @@ export class PdfPreviewComponent implements OnInit, OnDestroy {
             formData.append('attachment', objectToJsonBlob(this.attachmentToBeEdited()!));
             formData.append('attachmentVideoUnit', objectToJsonBlob(this.attachmentVideoUnit()!));
 
-            this.getFinalPageOrder().then((finalPageOrder) => {
+            void this.getFinalPageOrder().then((finalPageOrder) => {
                 formData.append(
                     'pageOrder',
                     new Blob(
@@ -898,9 +898,9 @@ export class PdfPreviewComponent implements OnInit, OnDestroy {
      */
     navigateToCourseManagement(): void {
         if (this.attachment()) {
-            this.router.navigate(['course-management', this.courseId(), 'lectures', this.attachment()!.lecture!.id, 'attachments']);
+            void this.router.navigate(['course-management', this.courseId(), 'lectures', this.attachment()!.lecture!.id, 'attachments']);
         } else {
-            this.router.navigate(['course-management', this.courseId(), 'lectures', this.attachmentVideoUnit()!.lecture!.id, 'unit-management']);
+            void this.router.navigate(['course-management', this.courseId(), 'lectures', this.attachmentVideoUnit()!.lecture!.id, 'unit-management']);
         }
     }
 }

--- a/src/main/webapp/app/lecture/shared/course-lectures/course-lectures.component.ts
+++ b/src/main/webapp/app/lecture/shared/course-lectures/course-lectures.component.ts
@@ -104,9 +104,9 @@ export class CourseLecturesComponent implements OnInit, OnDestroy {
         const lastSelectedLecture = this.getLastSelectedLecture();
         const lectureId = this.route.firstChild?.snapshot?.params?.lectureId;
         if (!lectureId && lastSelectedLecture) {
-            this.router.navigate([lastSelectedLecture], { relativeTo: this.route, replaceUrl: true });
+            void this.router.navigate([lastSelectedLecture], { relativeTo: this.route, replaceUrl: true });
         } else if (!lectureId && upcomingLecture) {
-            this.router.navigate([upcomingLecture.id], { relativeTo: this.route, replaceUrl: true });
+            void this.router.navigate([upcomingLecture.id], { relativeTo: this.route, replaceUrl: true });
         } else {
             this.lectureSelected.set(!!lectureId);
         }

--- a/src/main/webapp/app/lecture/shared/lecture-guard.service.ts
+++ b/src/main/webapp/app/lecture/shared/lecture-guard.service.ts
@@ -17,7 +17,7 @@ export class LectureGuard implements CanActivate {
      */
     canActivate(): boolean {
         if (!this.profileService.isModuleFeatureActive(MODULE_FEATURE_LECTURE)) {
-            this.router.navigate(['/']);
+            void this.router.navigate(['/']);
             return false;
         }
         return true;

--- a/src/main/webapp/app/localci/build-agent-details/build-agent-details.component.ts
+++ b/src/main/webapp/app/localci/build-agent-details/build-agent-details.component.ts
@@ -583,6 +583,6 @@ export class BuildAgentDetailsComponent implements OnInit, OnDestroy {
      * @param jobId The ID of the build job
      */
     navigateToJobDetail(jobId: string): void {
-        this.router.navigate(['/admin', 'build-overview', jobId, 'job-details']);
+        void this.router.navigate(['/admin', 'build-overview', jobId, 'job-details']);
     }
 }

--- a/src/main/webapp/app/localci/build-agent-summary/build-agent-summary.component.ts
+++ b/src/main/webapp/app/localci/build-agent-summary/build-agent-summary.component.ts
@@ -132,7 +132,7 @@ export class BuildAgentSummaryComponent implements OnInit, OnDestroy {
      */
     navigateToJobDetail(jobId?: string): void {
         if (jobId) {
-            this.router.navigate(['/admin/build-overview', jobId, 'job-details']);
+            void this.router.navigate(['/admin/build-overview', jobId, 'job-details']);
         }
     }
 

--- a/src/main/webapp/app/localci/build-queue/build-overview.component.ts
+++ b/src/main/webapp/app/localci/build-queue/build-overview.component.ts
@@ -597,9 +597,9 @@ export class BuildOverviewComponent implements OnInit, OnDestroy {
         if (!jobId) return;
         const courseId = this.courseId();
         if (courseId) {
-            this.router.navigate(['/course-management', courseId, 'build-overview', jobId, 'job-details']);
+            void this.router.navigate(['/course-management', courseId, 'build-overview', jobId, 'job-details']);
         } else {
-            this.router.navigate(['/admin', 'build-overview', jobId, 'job-details']);
+            void this.router.navigate(['/admin', 'build-overview', jobId, 'job-details']);
         }
     }
 

--- a/src/main/webapp/app/localci/shared/localci-guard.service.ts
+++ b/src/main/webapp/app/localci/shared/localci-guard.service.ts
@@ -13,7 +13,7 @@ export class LocalCIGuard implements CanActivate {
 
     canActivate(): boolean {
         if (!this.profileService.isProfileActive(PROFILE_LOCALCI)) {
-            this.router.navigate(['/course-management']);
+            void this.router.navigate(['/course-management']);
             return false;
         }
         return true;

--- a/src/main/webapp/app/localvc/repository-view/repository-view.component.ts
+++ b/src/main/webapp/app/localvc/repository-view/repository-view.component.ts
@@ -98,7 +98,7 @@ export class RepositoryViewComponent implements OnInit, OnDestroy {
      */
     ngOnInit(): void {
         // Used to check if the assessor is the current user
-        this.accountService.identity().then((user) => {
+        void this.accountService.identity().then((user) => {
             this.userId = user!.id!;
         });
         this.routeCommitHistory.set(this.router.url + '/commit-history');

--- a/src/main/webapp/app/logos/llm-selection-popup.component.ts
+++ b/src/main/webapp/app/logos/llm-selection-popup.component.ts
@@ -86,7 +86,7 @@ export class LLMSelectionModalComponent implements OnInit, OnDestroy {
     onLearnMoreClick(event: MouseEvent): void {
         event.preventDefault();
         this.modalService.emitChoice(LLM_MODAL_DISMISSED);
-        this.router.navigate(['/ai-experience-info']);
+        void this.router.navigate(['/ai-experience-info']);
         this.close();
     }
 

--- a/src/main/webapp/app/lti/manage/lti13-deep-linking/lti13-deep-linking.component.ts
+++ b/src/main/webapp/app/lti/manage/lti13-deep-linking/lti13-deep-linking.component.ts
@@ -89,7 +89,7 @@ export class Lti13DeepLinkingComponent implements OnInit {
                 return;
             }
 
-            this.accountService.identity().then((user) => {
+            void this.accountService.identity().then((user) => {
                 if (user) {
                     this.courseManagementService.findWithExercisesAndLecturesAndCompetencies(this.courseId).subscribe((findWithExercisesResult) => {
                         if (findWithExercisesResult?.body) {
@@ -116,7 +116,7 @@ export class Lti13DeepLinkingComponent implements OnInit {
      * @param currentLink The current URL to return to after login.
      */
     redirectUserToLoginThenTargetLink(currentLink: string): void {
-        this.router.navigate(['/sign-in']).then(() => {
+        void this.router.navigate(['/sign-in']).then(() => {
             this.accountService
                 .getAuthenticationState()
                 .pipe(filter(Boolean), take(1))

--- a/src/main/webapp/app/lti/overview/lti13-exercise-launch/lti13-exercise-launch.component.ts
+++ b/src/main/webapp/app/lti/overview/lti13-exercise-launch/lti13-exercise-launch.component.ts
@@ -77,7 +77,7 @@ export class Lti13ExerciseLaunchComponent implements OnInit {
 
     authenticateUserThenRedirect(error: HttpErrorResponse): void {
         const loginName = error.headers.get('ltiSuccessLoginRequired');
-        this.accountService.identity().then((user) => {
+        void this.accountService.identity().then((user) => {
             if (user) {
                 this.redirectUserToTargetLink(error);
             } else {
@@ -102,7 +102,7 @@ export class Lti13ExerciseLaunchComponent implements OnInit {
 
     redirectUserToLoginThenTargetLink(error: HttpErrorResponse): void {
         // Redirect the user to the login page
-        this.router.navigate(['/sign-in']).then(() => {
+        void this.router.navigate(['/sign-in']).then(() => {
             // After navigating to the login page, set up a listener for when the user logs in
             this.accountService
                 .getAuthenticationState()
@@ -174,6 +174,6 @@ export class Lti13ExerciseLaunchComponent implements OnInit {
             });
         }
 
-        this.router.navigate([path], { queryParams: queryParams, replaceUrl: true });
+        void this.router.navigate([path], { queryParams: queryParams, replaceUrl: true });
     }
 }

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -136,7 +136,7 @@ export class ModelingAssessmentEditorComponent implements OnInit {
 
     ngOnInit() {
         // Used to check if the assessor is the current user
-        this.accountService.identity().then((user) => {
+        void this.accountService.identity().then((user) => {
             this.userId = user!.id!;
         });
 
@@ -561,7 +561,7 @@ export class ModelingAssessmentEditorComponent implements OnInit {
                 this.isLoading.set(false);
 
                 const url = getLinkToSubmissionAssessment(ExerciseType.MODELING, this.courseId, this.exerciseId, undefined, submission.id!, this.examId, this.exerciseGroupId);
-                this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() } });
+                void this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() } });
             },
             error: (error: HttpErrorResponse) => {
                 this.nextSubmissionBusy.set(false);

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment.component.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment.component.ts
@@ -85,7 +85,7 @@ export class ModelingAssessmentComponent extends ModelingComponent implements Af
                 return;
             }
 
-            this.runHighlightUpdate();
+            void this.runHighlightUpdate();
         });
         effect(() => {
             const incoming = this.resultFeedbacks();
@@ -96,7 +96,7 @@ export class ModelingAssessmentComponent extends ModelingComponent implements Af
 
             this.referencedFeedbacks = incoming.filter((feedbackElement) => feedbackElement.reference != undefined);
             this.updateElementFeedbackMapping(this.referencedFeedbacks);
-            this.updateApollonAssessments(this.referencedFeedbacks);
+            void this.updateApollonAssessments(this.referencedFeedbacks);
         });
 
         effect(() => {
@@ -275,7 +275,7 @@ export class ModelingAssessmentComponent extends ModelingComponent implements Af
         if (feedbacks !== undefined) {
             this.referencedFeedbacks = filterInvalidFeedback(feedbacks, this.umlModel());
             this.updateElementFeedbackMapping(this.referencedFeedbacks);
-            this.updateApollonAssessments(this.referencedFeedbacks);
+            void this.updateApollonAssessments(this.referencedFeedbacks);
         }
     }
 

--- a/src/main/webapp/app/modeling/manage/example-modeling/example-modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling/manage/example-modeling/example-modeling-submission.component.ts
@@ -497,7 +497,7 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
     readAndUnderstood() {
         this.tutorParticipationService.assessExampleSubmission(this.exampleSubmission(), this.exerciseId).subscribe(() => {
             this.alertService.success('artemisApp.exampleSubmission.readSuccessfully');
-            this.back();
+            void this.back();
         });
     }
 

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
@@ -159,7 +159,7 @@ export class ModelingExerciseUpdateComponent implements AfterViewInit, OnDestroy
             titleComponent.titleChannelNameComponent().isValid(); // triggers effect on change
         }
 
-        void this.calculateFormSectionStatus().then();
+        void this.calculateFormSectionStatus();
     }
 
     /**

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
@@ -159,7 +159,7 @@ export class ModelingExerciseUpdateComponent implements AfterViewInit, OnDestroy
             titleComponent.titleChannelNameComponent().isValid(); // triggers effect on change
         }
 
-        this.calculateFormSectionStatus().then();
+        void this.calculateFormSectionStatus().then();
     }
 
     /**
@@ -281,7 +281,7 @@ export class ModelingExerciseUpdateComponent implements AfterViewInit, OnDestroy
      */
     validateDate(): void {
         this.exerciseService.validateDate(this.modelingExercise);
-        this.calculateFormSectionStatus();
+        void this.calculateFormSectionStatus();
     }
 
     onMarkdownEditorKeydown(event: KeyboardEvent): void {

--- a/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.component.ts
@@ -205,7 +205,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
     }
 
     private initializeApollonCollaborationUser(): void {
-        this.accountService.identity().then((user: User | undefined) => {
+        void this.accountService.identity().then((user: User | undefined) => {
             if (!user) {
                 // Without an identity the editor cannot mount its collaboration layer; surface it instead of failing silently.
                 captureException('Modeling team exercise: no user identity available for Apollon collaboration.');

--- a/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.ts
@@ -120,7 +120,7 @@ export class PlagiarismCaseInstructorDetailViewComponent implements OnInit, OnDe
                 this.metisService.getFilteredPosts({
                     plagiarismCaseId: plagiarismCase.id,
                 });
-                this.accountService.identity().then((user) => {
+                void this.accountService.identity().then((user) => {
                     this.currentAccount = user;
                     this.createEmptyPost();
                 });

--- a/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-container/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-container/code-editor-tutor-assessment-container.component.ts
@@ -175,7 +175,7 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
      */
     async ngOnInit(): Promise<void> {
         // Used to check if the assessor is the current user
-        this.accountService.identity().then((user) => {
+        void this.accountService.identity().then((user) => {
             this.userId = user!.id!;
         });
         this.route.queryParamMap.subscribe((queryParams) => {
@@ -494,7 +494,7 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
                     this.exerciseGroupId,
                     undefined,
                 );
-                this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() } });
+                void this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() } });
             },
             error: (error: HttpErrorResponse) => {
                 this.loadingParticipation.set(false);

--- a/src/main/webapp/app/programming/manage/code-editor/container/code-editor-container.component.ts
+++ b/src/main/webapp/app/programming/manage/code-editor/container/code-editor-container.component.ts
@@ -304,7 +304,7 @@ export class CodeEditorContainerComponent implements ComponentCanDeactivate, OnD
         if (_isEmpty(this.unsavedFiles) && this.editorState === EditorState.UNSAVED_CHANGES) {
             this.editorState = EditorState.CLEAN;
         }
-        this.monacoEditor()?.onFileChange(fileChange);
+        void this.monacoEditor()?.onFileChange(fileChange);
 
         this.onFileChanged.emit();
     }

--- a/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-and-editor-container.component.ts
+++ b/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-and-editor-container.component.ts
@@ -1832,19 +1832,19 @@ export class CodeEditorInstructorAndEditorContainerComponent extends CodeEditorI
             switch (location.targetType) {
                 case CommentThreadLocationType.TEMPLATE_REPO:
                     if (codeEditorContainer.selectedRepository() !== RepositoryType.TEMPLATE) {
-                        this.selectTemplateParticipation();
+                        void this.selectTemplateParticipation();
                         return;
                     }
                     break;
                 case CommentThreadLocationType.SOLUTION_REPO:
                     if (codeEditorContainer.selectedRepository() !== RepositoryType.SOLUTION) {
-                        this.selectSolutionParticipation();
+                        void this.selectSolutionParticipation();
                         return;
                     }
                     break;
                 case CommentThreadLocationType.TEST_REPO:
                     if (codeEditorContainer.selectedRepository() !== RepositoryType.TESTS) {
-                        this.selectTestRepository();
+                        void this.selectTestRepository();
                         return;
                     }
                     break;
@@ -1854,7 +1854,7 @@ export class CodeEditorInstructorAndEditorContainerComponent extends CodeEditorI
                         auxiliaryRepositoryId !== undefined &&
                         (codeEditorContainer.selectedRepository() !== RepositoryType.AUXILIARY || this.selectedRepositoryId !== auxiliaryRepositoryId)
                     ) {
-                        this.selectAuxiliaryRepository(auxiliaryRepositoryId);
+                        void this.selectAuxiliaryRepository(auxiliaryRepositoryId);
                         return;
                     }
                     break;

--- a/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-base-container.component.ts
+++ b/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-base-container.component.ts
@@ -400,7 +400,7 @@ export abstract class CodeEditorInstructorBaseContainerComponent implements OnIn
     deleteAssignmentParticipation() {
         this.loadingState.set(LOADING_STATE.DELETING_ASSIGNMENT_REPO);
         if (this.selectedRepository === RepositoryType.ASSIGNMENT) {
-            this.selectTemplateParticipation();
+            void this.selectTemplateParticipation();
         }
         const assignmentParticipationId = this.exercise.studentParticipations![0].id!;
         this.exercise.studentParticipations = [];

--- a/src/main/webapp/app/programming/manage/detail/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/programming/manage/detail/programming-exercise-detail.component.ts
@@ -776,9 +776,9 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
                 this.dialogErrorSource.next('');
 
                 if (!this.isExamExercise()) {
-                    this.router.navigateByUrl(`/course-management/${this.courseId}/exercises`);
+                    void this.router.navigateByUrl(`/course-management/${this.courseId}/exercises`);
                 } else {
-                    this.router.navigateByUrl(`/course-management/${this.courseId}/exams/${this.programmingExercise().exerciseGroup?.exam?.id}/exercise-groups`);
+                    void this.router.navigateByUrl(`/course-management/${this.courseId}/exams/${this.programmingExercise().exerciseGroup?.exam?.id}/exercise-groups`);
                 }
             },
             error: (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),

--- a/src/main/webapp/app/programming/manage/grading/feedback-analysis/feedback-analysis.component.ts
+++ b/src/main/webapp/app/programming/manage/grading/feedback-analysis/feedback-analysis.component.ts
@@ -100,7 +100,7 @@ export class FeedbackAnalysisComponent {
 
     constructor() {
         effect(() => {
-            untracked(async () => {
+            void untracked(async () => {
                 await this.loadData();
             });
         });
@@ -176,7 +176,7 @@ export class FeedbackAnalysisComponent {
 
     setPage(newPage: number): void {
         this.page.set(newPage);
-        this.loadData();
+        void this.loadData();
     }
 
     /** PrimeNG paginator page change (0-indexed) converted to the 1-indexed page used here. */
@@ -202,7 +202,7 @@ export class FeedbackAnalysisComponent {
             this.sortedColumn.set(column);
             this.sortingOrder.set(SortingOrder.ASCENDING);
         }
-        this.loadData();
+        void this.loadData();
     }
 
     getSortDirection(column: string): SortingOrder.ASCENDING | SortingOrder.DESCENDING | 'none' {
@@ -244,7 +244,7 @@ export class FeedbackAnalysisComponent {
 
     applyFilters(filters: FilterData): void {
         this.selectedFiltersCount.set(this.countAppliedFilters(filters));
-        this.loadData();
+        void this.loadData();
     }
 
     countAppliedFilters(filters: FilterData): number {
@@ -310,6 +310,6 @@ export class FeedbackAnalysisComponent {
 
     toggleGroupFeedback(): void {
         this.groupFeedback.update((current) => !current);
-        this.loadData();
+        void this.loadData();
     }
 }

--- a/src/main/webapp/app/programming/manage/grading/feedback-analysis/modal/feedback-affected-students/feedback-affected-students-modal.component.ts
+++ b/src/main/webapp/app/programming/manage/grading/feedback-analysis/modal/feedback-affected-students/feedback-affected-students-modal.component.ts
@@ -30,7 +30,7 @@ export class AffectedStudentsModalComponent {
 
     constructor() {
         effect(() => {
-            untracked(async () => {
+            void untracked(async () => {
                 await this.loadAffected();
             });
         });

--- a/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.ts
@@ -851,7 +851,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
             return;
         }
 
-        preUpdateModalRef.then((reference) => {
+        void preUpdateModalRef.then((reference) => {
             reference.componentInstance.confirmed.subscribe(() => onConfirmed());
             reference.componentInstance.reEvaluated.subscribe(() => onReEvaluated(reference));
         });
@@ -1039,7 +1039,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
         }
         const navigationExtras = { state: { [AUTO_START_CODE_GENERATION_ALL_REPOSITORIES_STATE]: true } };
         if (exercise.exerciseGroup?.exam?.id && exercise.exerciseGroup?.id) {
-            this.router.navigate(
+            void this.router.navigate(
                 [
                     'course-management',
                     courseId,
@@ -1056,7 +1056,7 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
                 navigationExtras,
             );
         } else {
-            this.router.navigate(
+            void this.router.navigate(
                 ['course-management', courseId, 'programming-exercises', exercise.id, 'code-editor', RepositoryType.TEMPLATE, exercise.templateParticipation.id],
                 navigationExtras,
             );

--- a/src/main/webapp/app/quiz/manage/apollon-diagrams/detail/apollon-diagram-detail.component.ts
+++ b/src/main/webapp/app/quiz/manage/apollon-diagrams/detail/apollon-diagram-detail.component.ts
@@ -224,7 +224,7 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
             this.autoSaveTimer++;
             if (this.autoSaveTimer >= AUTOSAVE_EXERCISE_INTERVAL) {
                 this.autoSaveTimer = 0;
-                this.saveDiagram();
+                void this.saveDiagram();
             }
         }, AUTOSAVE_CHECK_INTERVAL);
     }

--- a/src/main/webapp/app/quiz/manage/manage-buttons/quiz-exercise-manage-buttons.component.ts
+++ b/src/main/webapp/app/quiz/manage/manage-buttons/quiz-exercise-manage-buttons.component.ts
@@ -100,7 +100,7 @@ export class QuizExerciseManageButtonsComponent implements OnInit {
                 });
                 this.dialogErrorSource.next('');
                 if (this.isDetailPage()) {
-                    this.router.navigate(['course-management', this.courseId, 'exercises']);
+                    void this.router.navigate(['course-management', this.courseId, 'exercises']);
                 }
             },
             error: (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),

--- a/src/main/webapp/app/quiz/manage/re-evaluate/quiz-re-evaluate.component.ts
+++ b/src/main/webapp/app/quiz/manage/re-evaluate/quiz-re-evaluate.component.ts
@@ -119,7 +119,7 @@ export class QuizReEvaluateComponent extends QuizExerciseValidationDirective imp
                 files.set(filename, value.file);
             });
         }
-        this.popupService.open(QuizReEvaluateWarningComponent, this.quizExercise(), files).then((res) => {
+        void this.popupService.open(QuizReEvaluateWarningComponent, this.quizExercise(), files).then((res) => {
             res?.onClose.subscribe((confirmed) => {
                 if (confirmed) {
                     this.savedEntity = cloneDeep(this.quizExercise());

--- a/src/main/webapp/app/quiz/manage/service/quiz-exercise-popup.service.ts
+++ b/src/main/webapp/app/quiz/manage/service/quiz-exercise-popup.service.ts
@@ -49,9 +49,9 @@ export class QuizExercisePopupService {
         ref?.onClose.subscribe((result) => {
             this.dialogRef = undefined;
             if (result === 're-evaluate') {
-                this.router.navigate(['/course-management/' + quizExercise.course!.id + '/quiz-exercises']);
+                void this.router.navigate(['/course-management/' + quizExercise.course!.id + '/quiz-exercises']);
             } else {
-                this.router.navigate([{ outlets: { popup: null } }], { replaceUrl: true, queryParamsHandling: 'merge' });
+                void this.router.navigate([{ outlets: { popup: null } }], { replaceUrl: true, queryParamsHandling: 'merge' });
             }
         });
         return ref ?? undefined;

--- a/src/main/webapp/app/quiz/manage/statistics/question-statistic.component.ts
+++ b/src/main/webapp/app/quiz/manage/statistics/question-statistic.component.ts
@@ -137,14 +137,14 @@ export abstract class QuestionStatisticComponent extends AbstractQuizStatisticCo
         // if the Student finds a way to the Website
         //      -> the Student will be sent back to Courses
         if (!this.accountService.isAtLeastTutor()) {
-            this.router.navigateByUrl('courses');
+            void this.router.navigateByUrl('courses');
         }
         // search selected question in quizExercise based on questionId
         this.quizExercise = quiz;
         const updatedQuestion = this.quizExercise.quizQuestions?.filter((question) => this.questionIdParam === question.id)[0];
         // if anyone finds a way to the Website, with a wrong combination of QuizId and QuestionId, go back to Courses
         if (!updatedQuestion) {
-            this.router.navigateByUrl('courses');
+            void this.router.navigateByUrl('courses');
             return undefined;
         }
         this.question = updatedQuestion;

--- a/src/main/webapp/app/quiz/manage/statistics/quiz-point-statistic/quiz-point-statistic.component.ts
+++ b/src/main/webapp/app/quiz/manage/statistics/quiz-point-statistic/quiz-point-statistic.component.ts
@@ -149,7 +149,7 @@ export class QuizPointStatisticComponent extends AbstractQuizStatisticComponent 
         // if the Student finds a way to the Website
         //      -> the Student will be sent back to Courses
         if (!this.accountService.isAtLeastTutor()) {
-            this.router.navigate(['courses']);
+            void this.router.navigate(['courses']);
         }
         this.quizPointStatistic = statistic;
         this.loadData();
@@ -164,7 +164,7 @@ export class QuizPointStatisticComponent extends AbstractQuizStatisticComponent 
         // if the Student finds a way to the Website
         //      -> the Student will be sent back to Courses
         if (!this.accountService.isAtLeastTutor()) {
-            this.router.navigate(['courses']);
+            void this.router.navigate(['courses']);
         }
         this.quizExercise.set(quizExercise);
         this.waitingForQuizStart = !this.quizExercise().quizStarted;

--- a/src/main/webapp/app/quiz/manage/statistics/quiz-statistic/quiz-statistic.component.ts
+++ b/src/main/webapp/app/quiz/manage/statistics/quiz-statistic/quiz-statistic.component.ts
@@ -90,7 +90,7 @@ export class QuizStatisticComponent extends AbstractQuizStatisticComponent imple
     loadQuizSuccess(quiz: QuizExercise) {
         // if the Student finds a way to the Website -> the Student will be sent back to Courses
         if (!this.accountService.isAtLeastTutor()) {
-            this.router.navigate(['/courses']);
+            void this.router.navigate(['/courses']);
         }
         this.quizExercise.set(quiz);
         this.maxScore = calculateMaxScore(this.quizExercise());

--- a/src/main/webapp/app/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.ts
+++ b/src/main/webapp/app/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.ts
@@ -121,7 +121,7 @@ export class QuizStatisticsFooterComponent implements OnInit, OnDestroy {
     loadQuiz(quiz: QuizExercise) {
         // if the Student finds a way to the Website -> the Student will be sent back to Courses
         if (!this.accountService.isAtLeastTutor()) {
-            this.router.navigate(['/courses']);
+            void this.router.navigate(['/courses']);
         }
         this.quizExercise.set(quiz);
         const updatedQuestion = this.quizExercise().quizQuestions?.filter((question) => this.questionIdParam === question.id)[0];
@@ -138,10 +138,10 @@ export class QuizStatisticsFooterComponent implements OnInit, OnDestroy {
         const baseUrl = this.quizStatisticUtil.getBaseUrlForQuizExercise(quizExercise);
 
         if (this.isQuizStatistic()) {
-            this.router.navigateByUrl(baseUrl + `/quiz-point-statistic`);
+            void this.router.navigateByUrl(baseUrl + `/quiz-point-statistic`);
         } else if (this.isQuizPointStatistic()) {
             if (!quizExercise.quizQuestions || quizExercise.quizQuestions.length === 0) {
-                this.router.navigateByUrl(baseUrl + `/quiz-statistic`);
+                void this.router.navigateByUrl(baseUrl + `/quiz-statistic`);
             } else {
                 // go to previous question-statistic
                 this.quizStatisticUtil.navigateToStatisticOf(quizExercise, quizExercise.quizQuestions.last()!);
@@ -160,11 +160,11 @@ export class QuizStatisticsFooterComponent implements OnInit, OnDestroy {
         const baseUrl = this.quizStatisticUtil.getBaseUrlForQuizExercise(quizExercise);
 
         if (this.isQuizPointStatistic()) {
-            this.router.navigateByUrl(baseUrl + `/quiz-statistic`);
+            void this.router.navigateByUrl(baseUrl + `/quiz-statistic`);
         } else if (this.isQuizStatistic()) {
             // go to quiz-statistic if the position = last position
             if (!quizExercise.quizQuestions || quizExercise.quizQuestions.length === 0) {
-                this.router.navigateByUrl(baseUrl + `/quiz-point-statistic`);
+                void this.router.navigateByUrl(baseUrl + `/quiz-point-statistic`);
             } else {
                 // go to next question-statistic
                 this.quizStatisticUtil.navigateToStatisticOf(quizExercise, quizExercise.quizQuestions[0]);

--- a/src/main/webapp/app/quiz/overview/course-training/course-training-quiz/course-training-quiz.component.ts
+++ b/src/main/webapp/app/quiz/overview/course-training/course-training-quiz/course-training-quiz.component.ts
@@ -325,7 +325,7 @@ export class CourseTrainingQuizComponent {
      * navigates to the course practice page
      */
     navigateToTraining(): void {
-        this.router.navigate(['courses', this.courseId(), 'training']);
+        void this.router.navigate(['courses', this.courseId(), 'training']);
     }
 
     confirmUnratedPractice(): void {

--- a/src/main/webapp/app/quiz/overview/course-training/course-training.component.ts
+++ b/src/main/webapp/app/quiz/overview/course-training/course-training.component.ts
@@ -156,7 +156,7 @@ export class CourseTrainingComponent {
         effect(() => {
             const id = this.courseId();
             if (id) {
-                this.loadLeaderboard(Number(id));
+                void this.loadLeaderboard(Number(id));
             }
         });
     }
@@ -184,7 +184,7 @@ export class CourseTrainingComponent {
     public navigateToTraining(): void {
         const courseId = this.courseId();
         if (courseId !== undefined) {
-            this.router.navigate(['courses', courseId, 'training', 'quiz']);
+            void this.router.navigate(['courses', courseId, 'training', 'quiz']);
         }
     }
 
@@ -198,7 +198,7 @@ export class CourseTrainingComponent {
             this.isLoading.set(false);
             const courseId = this.courseId();
             if (courseId !== undefined) {
-                this.loadLeaderboard(courseId);
+                void this.loadLeaderboard(courseId);
             }
         } catch (error) {
             onError(this.alertService, error);
@@ -230,7 +230,7 @@ export class CourseTrainingComponent {
             this.displayInfoDialog = false;
             const courseId = this.courseId();
             if (courseId !== undefined) {
-                this.loadLeaderboard(courseId);
+                void this.loadLeaderboard(courseId);
             }
             this.isLoading.set(false);
         } catch (error) {

--- a/src/main/webapp/app/quiz/shared/service/quiz-statistic-util.service.ts
+++ b/src/main/webapp/app/quiz/shared/service/quiz-statistic-util.service.ts
@@ -45,7 +45,7 @@ export class QuizStatisticUtil {
         });
         // go to quiz-statistic if the position = 0
         if (index === 0) {
-            this.router.navigateByUrl(baseUrl + '/quiz-point-statistic');
+            void this.router.navigateByUrl(baseUrl + '/quiz-point-statistic');
         } else {
             // go to previous Question-statistic
             this.navigateToStatisticOf(quizExercise, quizExercise.quizQuestions![index - 1]);
@@ -68,7 +68,7 @@ export class QuizStatisticUtil {
         });
         // go to quiz-statistic if the position = last position
         if (index === quizExercise.quizQuestions!.length - 1) {
-            this.router.navigateByUrl(baseUrl + '/quiz-point-statistic');
+            void this.router.navigateByUrl(baseUrl + '/quiz-point-statistic');
         } else {
             // go to next Question-statistic
             this.navigateToStatisticOf(quizExercise, quizExercise.quizQuestions![index + 1]);
@@ -84,11 +84,11 @@ export class QuizStatisticUtil {
         const baseUrl = this.getBaseUrlForQuizExercise(quizExercise);
 
         if (question.type === QuizQuestionType.MULTIPLE_CHOICE) {
-            this.router.navigateByUrl(baseUrl + `/mc-question-statistic/${question.id}`);
+            void this.router.navigateByUrl(baseUrl + `/mc-question-statistic/${question.id}`);
         } else if (question.type === QuizQuestionType.DRAG_AND_DROP) {
-            this.router.navigateByUrl(baseUrl + `/dnd-question-statistic/${question.id}`);
+            void this.router.navigateByUrl(baseUrl + `/dnd-question-statistic/${question.id}`);
         } else if (question.type === QuizQuestionType.SHORT_ANSWER) {
-            this.router.navigateByUrl(baseUrl + `/sa-question-statistic/${question.id}`);
+            void this.router.navigateByUrl(baseUrl + `/sa-question-statistic/${question.id}`);
         }
     }
 }

--- a/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.ts
+++ b/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.ts
@@ -219,7 +219,7 @@ export class CodeButtonComponent implements OnInit {
         this.configureTooltips();
         this.initTheia(profileInfo);
 
-        this.ideSettingsService.loadIdePreferences().then((programmingLanguageToIde) => {
+        void this.ideSettingsService.loadIdePreferences().then((programmingLanguageToIde) => {
             if (programmingLanguageToIde.size) {
                 this.programmingLanguageToIde = programmingLanguageToIde;
             }

--- a/src/main/webapp/app/shared-ui/image-cropper/services/load-image.service.ts
+++ b/src/main/webapp/app/shared-ui/image-cropper/services/load-image.service.ts
@@ -47,7 +47,7 @@ export class LoadImageService {
                 canvas.width = img.width;
                 canvas.height = img.height;
                 context.drawImage(img, 0, 0);
-                this.loadBase64Image(canvas.toDataURL(), cropperSettings).then(resolve);
+                void this.loadBase64Image(canvas.toDataURL(), cropperSettings).then(resolve);
             };
             img.crossOrigin = 'anonymous';
             img.src = url;

--- a/src/main/webapp/app/shared-ui/virtual-scroll/virtual-scroll.component.ts
+++ b/src/main/webapp/app/shared-ui/virtual-scroll/virtual-scroll.component.ts
@@ -133,7 +133,7 @@ export class VirtualScrollComponent<T extends { id?: number }> implements OnInit
     ngOnInit() {
         this.focusInUnListener = this.renderer.listen(window, 'focusin', this.onFocusIn.bind(this));
         this.scrollUnListener = this.renderer.listen(window, 'scroll', this.onScroll.bind(this));
-        this.router.events.forEach((event) => {
+        void this.router.events.forEach((event) => {
             if (event instanceof NavigationStart) {
                 // invalidate item height cache in case user clicks to an item reference to solely display that item within the same page
                 this.forceReloadChange.emit(true);

--- a/src/main/webapp/app/sharing/sharing.component.ts
+++ b/src/main/webapp/app/sharing/sharing.component.ts
@@ -179,7 +179,7 @@ export class SharingComponent implements OnInit {
                 return;
             }
 
-            this.userRouteAccessService.checkLogin(IS_AT_LEAST_EDITOR, this.router.url).then((isLoggedIn) => {
+            void this.userRouteAccessService.checkLogin(IS_AT_LEAST_EDITOR, this.router.url).then((isLoggedIn) => {
                 if (!isLoggedIn) {
                     this.alertService.error('artemisApp.sharing.error.atLeastEditorNeeded');
                     return;

--- a/src/main/webapp/app/text/manage/example-text-submission/example-text-submission.component.ts
+++ b/src/main/webapp/app/text/manage/example-text-submission/example-text-submission.component.ts
@@ -335,9 +335,9 @@ export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent 
             }
         } else {
             if (this.readOnly() || this.toComplete()) {
-                this.router.navigate(['/course-management', courseId, 'assessment-dashboard', this.exerciseId]);
+                void this.router.navigate(['/course-management', courseId, 'assessment-dashboard', this.exerciseId]);
             } else {
-                this.router.navigate(['/course-management', courseId, 'text-exercises', this.exerciseId, 'example-submissions']);
+                void this.router.navigate(['/course-management', courseId, 'text-exercises', this.exerciseId, 'example-submissions']);
             }
         }
     }
@@ -416,7 +416,7 @@ export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent 
     readAndUnderstood(): void {
         this.tutorParticipationService.assessExampleSubmission(this.exampleSubmission, this.exerciseId).subscribe(() => {
             this.alertService.success('artemisApp.exampleSubmission.readSuccessfully');
-            this.back();
+            void this.back();
         });
     }
 

--- a/src/main/webapp/app/text/manage/text-exercise/exercise/text-exercise.component.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/exercise/text-exercise.component.ts
@@ -138,7 +138,7 @@ export class TextExerciseComponent extends ExerciseComponent {
 
         dialogRef?.onClose.subscribe((result: TextExercise | undefined) => {
             if (result?.id) {
-                this.router.navigate(['course-management', this.courseId(), 'text-exercises', result.id, 'import']);
+                void this.router.navigate(['course-management', this.courseId(), 'text-exercises', result.id, 'import']);
             }
         });
     }

--- a/src/main/webapp/app/text/manage/tutor-effort/tutor-effort-statistics.component.ts
+++ b/src/main/webapp/app/text/manage/tutor-effort/tutor-effort-statistics.component.ts
@@ -165,7 +165,7 @@ export class TutorEffortStatisticsComponent extends PlagiarismAndTutorEffortDire
      * Delegates the user to the assessment dashboard
      */
     onSelect() {
-        this.router.navigate(['/course-management', this.currentCourseId, 'assessment-dashboard', this.currentExerciseId]);
+        void this.router.navigate(['/course-management', this.currentCourseId, 'assessment-dashboard', this.currentExerciseId]);
     }
 
     /**

--- a/src/main/webapp/app/tutorialgroup/manage/management-tutorial-group-detail-container/management-tutorial-group-detail-container.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/management-tutorial-group-detail-container/management-tutorial-group-detail-container.component.ts
@@ -185,7 +185,7 @@ export class ManagementTutorialGroupDetailContainerComponent {
                 if (!response) {
                     return;
                 }
-                this.router.navigate(['../'], { relativeTo: this.route });
+                void this.router.navigate(['../'], { relativeTo: this.route });
                 this.isActionLoading.set(false);
             });
     }

--- a/src/main/webapp/app/tutorialgroup/manage/service/tutorial-group-management-course-resolver.service.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/service/tutorial-group-management-course-resolver.service.ts
@@ -25,7 +25,7 @@ export class TutorialGroupManagementCourseResolver implements Resolve<Course> {
                 }
                 // user has not completed all necessary configuration steps
                 if (!course.tutorialGroupsConfiguration || !course.timeZone) {
-                    this.router.navigate(['/course-management', course.id!, 'tutorial-groups-checklist']);
+                    void this.router.navigate(['/course-management', course.id!, 'tutorial-groups-checklist']);
                 }
             }),
         );

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-create-container/tutorial-create-container.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-create-container/tutorial-create-container.component.ts
@@ -47,7 +47,7 @@ export class TutorialCreateContainerComponent {
             .subscribe({
                 next: (newTutorialGroupId) => {
                     this.isTutorialGroupLoading.set(false);
-                    this.router.navigate(['..', newTutorialGroupId], { relativeTo: this.activatedRoute });
+                    void this.router.navigate(['..', newTutorialGroupId], { relativeTo: this.activatedRoute });
                 },
                 error: () => {
                     this.alertService.addErrorAlert('artemisApp.pages.createOrEditTutorialGroup.networkError.createGroup');

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-edit-container/tutorial-edit-container.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-edit-container/tutorial-edit-container.component.ts
@@ -64,7 +64,7 @@ export class TutorialEditContainerComponent {
                 next: () => {
                     this.isTutorialGroupLoading.set(false);
                     this.tutorialGroupCourseAndGroupService.fetchTutorialGroup(courseId, tutorialGroupId);
-                    this.router.navigate(['..'], { relativeTo: this.activatedRoute });
+                    void this.router.navigate(['..'], { relativeTo: this.activatedRoute });
                 },
                 error: () => {
                     this.alertService.addErrorAlert('artemisApp.pages.createOrEditTutorialGroup.networkError.updateGroup');

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/create-tutorial-groups-configuration/create-tutorial-groups-configuration.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/create-tutorial-groups-configuration/create-tutorial-groups-configuration.component.ts
@@ -75,7 +75,7 @@ export class CreateTutorialGroupsConfigurationComponent implements OnInit, OnDes
                 next: (resp) => {
                     this.course().tutorialGroupsConfiguration = tutorialGroupsConfigurationEntityFromDto(resp.body!);
                     this.courseStorageService.updateCourse(this.course());
-                    this.router.navigate(['/course-management', this.course().id!, 'tutorial-groups-checklist']);
+                    void this.router.navigate(['/course-management', this.course().id!, 'tutorial-groups-checklist']);
                 },
                 error: (res: HttpErrorResponse) => onError(this.alertService, res),
             });

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/edit-tutorial-groups-configuration/edit-tutorial-groups-configuration.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-configuration/crud/edit-tutorial-groups-configuration/edit-tutorial-groups-configuration.component.ts
@@ -82,7 +82,7 @@ export class EditTutorialGroupsConfigurationComponent implements OnInit, OnDestr
             .pipe(
                 finalize(() => {
                     this.isLoading.set(false);
-                    this.router.navigate(['/course-management', this.course().id!, 'tutorial-groups']);
+                    void this.router.navigate(['/course-management', this.course().id!, 'tutorial-groups']);
                 }),
                 takeUntil(this.ngUnsubscribe),
             )

--- a/src/main/webapp/app/tutorialgroup/overview/course-tutorial-groups/course-tutorial-groups.component.ts
+++ b/src/main/webapp/app/tutorialgroup/overview/course-tutorial-groups/course-tutorial-groups.component.ts
@@ -213,9 +213,9 @@ export class CourseTutorialGroupsComponent {
         const lastSelectedSubRoute = this.getLastSelectedSubRoute();
         const nothingSelected = !this.itemSelected();
         if (nothingSelected && lastSelectedSubRoute) {
-            this.router.navigate([lastSelectedSubRoute], { relativeTo: this.activatedRoute, replaceUrl: true });
+            void this.router.navigate([lastSelectedSubRoute], { relativeTo: this.activatedRoute, replaceUrl: true });
         } else if (nothingSelected && upcomingTutorialGroup) {
-            this.router.navigate([upcomingTutorialGroup.id], { relativeTo: this.activatedRoute, replaceUrl: true });
+            void this.router.navigate([upcomingTutorialGroup.id], { relativeTo: this.activatedRoute, replaceUrl: true });
         }
     }
 

--- a/src/main/webapp/app/tutorialgroup/shared/tutorial-group-detail/tutorial-group-detail.component.ts
+++ b/src/main/webapp/app/tutorialgroup/shared/tutorial-group-detail/tutorial-group-detail.component.ts
@@ -202,7 +202,7 @@ export class TutorialGroupDetailComponent {
                 next: (response) => {
                     const chatId = response.body?.id;
                     if (chatId) {
-                        this.router.navigate(['/courses', courseId, 'communication'], { queryParams: { conversationId: chatId } });
+                        void this.router.navigate(['/courses', courseId, 'communication'], { queryParams: { conversationId: chatId } });
                     } else {
                         this.alertService.addErrorAlert('artemisApp.pages.tutorialGroupDetail.networkError.createOneToOneChat');
                     }


### PR DESCRIPTION
### Summary
Enables `@typescript-eslint/no-floating-promises` at `error` for **all** production client code (`src/main/webapp`, specs excluded) and handles every resulting site (**318 across 194 files**). A floating Promise silently swallows rejections and hides ordering bugs, so this is a correctness rule. No user-facing behavior changes.

### Checklist
#### General
- [x] Non-user-facing change (lint enforcement + Promise handling), verified locally: 0 ESLint errors, tsc (app + spec) 0, AOT `webapp:build` clean, and the full client test suite (15,779 tests) passes.
- [x] I chose a title conforming to the naming conventions for pull requests.
#### Client
- [x] No REST calls / data-fetching added.
- [x] I strictly followed the client coding guidelines.
- [x] Existing specs cover the changed code; the full suite passes unchanged.

### Motivation and Context
A floating Promise (a Promise whose result is never awaited or `.catch`-ed) silently swallows rejections — unhandled errors that never surface — and can mask ordering assumptions. Enabling `no-floating-promises` makes every Promise explicitly handled, and prevents regressions going forward. This continues the client type-safety campaign after the strict-flags / `no-console` PR.

### Description
- **Rule**: `['error', { ignoreVoid: true, ignoreIIFE: true }]`, prod-only (specs excluded — tests float promises for brevity). Overrides the `'off'` default in the shared config for `src/main/webapp`.
- **318 sites / 194 files** handled. The overwhelming majority are behavior-preserving **`void` prefixes**: fire-and-forget navigation (`router.navigate`/`navigateByUrl` — the Angular convention), best-effort calls (`accountService.identity().then(...)`, `untracked(() => this.loadX())` inside effects, telemetry/version checks), and a few `firstValueFrom`/promise-executor cases. `void` marks the Promise as intentionally unhandled without changing runtime behavior.
- **No `await` was added inside non-async functions** (no signature/timing changes), no control-flow changes, and no `as any` / `as unknown` / `@ts-*` / `eslint-disable` escape hatches.

### Steps for Testing
Non-user-facing; verification is build + lint + tests.
1. `pnpm run lint` → 0 errors (no-floating-promises enforced at error).
2. `pnpm exec tsc -p tsconfig.app.json --noEmit` and `-p tsconfig.spec.json --noEmit` → 0 errors.
3. `pnpm run webapp:build` → succeeds.
4. `pnpm run vitest:run` → green.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list).

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2