### PR TITLE
`Iris`: Stream responses to the browser while the answer generates

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/iris/dto/IrisChatWebsocketDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/dto/IrisChatWebsocketDTO.java
@@ -22,10 +22,14 @@ import de.tum.cit.aet.artemis.iris.service.pyris.dto.status.PyrisStageDTO;
  * @param suggestions   the suggestions to send to the client
  * @param tokens        the token usage information for the response
  * @param citationInfo  metadata about citations referenced in the response
+ * @param runId         the id of the Pyris run that produced the payload
+ * @param partialResult the current accumulated partial response text
+ * @param partialSeq    the monotonic sequence number of the partial response
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record IrisChatWebsocketDTO(IrisWebsocketMessageType type, IrisMessageResponseDTO message, IrisRateLimitService.IrisRateLimitInformation rateLimitInfo,
-        List<PyrisStageDTO> stages, String sessionTitle, List<String> suggestions, List<LLMRequest> tokens, List<IrisCitationMetaDTO> citationInfo) {
+        List<PyrisStageDTO> stages, String sessionTitle, List<String> suggestions, List<LLMRequest> tokens, List<IrisCitationMetaDTO> citationInfo, @Nullable String runId,
+        @Nullable String partialResult, @Nullable Integer partialSeq) {
 
     /**
      * Creates a new IrisWebsocketDTO instance with the given parameters
@@ -41,19 +45,45 @@ public record IrisChatWebsocketDTO(IrisWebsocketMessageType type, IrisMessageRes
      */
     public IrisChatWebsocketDTO(@Nullable IrisMessageResponseDTO message, IrisRateLimitService.IrisRateLimitInformation rateLimitInfo, List<PyrisStageDTO> stages,
             String sessionTitle, List<String> suggestions, List<LLMRequest> tokens, List<IrisCitationMetaDTO> citationInfo) {
-        this(determineType(message), message, rateLimitInfo, stages, sessionTitle, suggestions, tokens, citationInfo);
+        this(message, rateLimitInfo, stages, sessionTitle, suggestions, tokens, citationInfo, null, null, null);
     }
 
     /**
-     * Determines the type of WebSocket message based on the presence of a message.
+     * Creates a new IrisWebsocketDTO instance with the given parameters
+     * Takes care of setting the type correctly.
+     *
+     * @param message       the IrisMessageResponseDTO (optional)
+     * @param rateLimitInfo the rate limit information
+     * @param stages        the stages of the Pyris pipeline
+     * @param sessionTitle  the session title to send
+     * @param suggestions   the suggestions to send
+     * @param tokens        the token usage information to send
+     * @param citationInfo  metadata about citations referenced in the response
+     * @param runId         the id of the Pyris run that produced the payload
+     * @param partialResult the current accumulated partial response text
+     * @param partialSeq    the monotonic sequence number of the partial response
+     */
+    public IrisChatWebsocketDTO(@Nullable IrisMessageResponseDTO message, IrisRateLimitService.IrisRateLimitInformation rateLimitInfo, List<PyrisStageDTO> stages,
+            String sessionTitle, List<String> suggestions, List<LLMRequest> tokens, List<IrisCitationMetaDTO> citationInfo, @Nullable String runId, @Nullable String partialResult,
+            @Nullable Integer partialSeq) {
+        this(determineType(message, partialResult), message, rateLimitInfo, stages, sessionTitle, suggestions, tokens, citationInfo, runId, partialResult, partialSeq);
+    }
+
+    /**
+     * Determines the type of WebSocket message based on the presence of a partial result or message.
      * <p>
-     * Returns {@link IrisWebsocketMessageType#MESSAGE} if the message is not null,
+     * Returns {@link IrisWebsocketMessageType#PARTIAL} if the partial result is not null,
+     * {@link IrisWebsocketMessageType#MESSAGE} if the message is not null,
      * {@link IrisWebsocketMessageType#STATUS} otherwise.
      *
-     * @param message The message DTO associated with the WebSocket, which may be null.
+     * @param message       The message DTO associated with the WebSocket, which may be null.
+     * @param partialResult The partial response text associated with the WebSocket, which may be null.
      * @return The {@link IrisWebsocketMessageType} indicating the type of the message based on the given parameters.
      */
-    private static IrisWebsocketMessageType determineType(@Nullable IrisMessageResponseDTO message) {
+    private static IrisWebsocketMessageType determineType(@Nullable IrisMessageResponseDTO message, @Nullable String partialResult) {
+        if (partialResult != null) {
+            return IrisWebsocketMessageType.PARTIAL;
+        }
         return message != null ? IrisWebsocketMessageType.MESSAGE : IrisWebsocketMessageType.STATUS;
     }
 
@@ -67,10 +97,12 @@ public record IrisChatWebsocketDTO(IrisWebsocketMessageType type, IrisMessageRes
         }
         IrisChatWebsocketDTO that = (IrisChatWebsocketDTO) o;
         return type == that.type && Objects.equals(message, that.message) && Objects.equals(rateLimitInfo, that.rateLimitInfo) && Objects.equals(stages, that.stages)
-                && Objects.equals(sessionTitle, that.sessionTitle) && Objects.equals(citationInfo, that.citationInfo);
+                && Objects.equals(sessionTitle, that.sessionTitle) && Objects.equals(suggestions, that.suggestions) && Objects.equals(tokens, that.tokens)
+                && Objects.equals(citationInfo, that.citationInfo) && Objects.equals(runId, that.runId) && Objects.equals(partialResult, that.partialResult)
+                && Objects.equals(partialSeq, that.partialSeq);
     }
 
     public enum IrisWebsocketMessageType {
-        MESSAGE, STATUS
+        MESSAGE, STATUS, PARTIAL
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineService.java
@@ -75,7 +75,7 @@ public class PyrisPipelineService {
     @Value("${server.url}")
     private String artemisBaseUrl;
 
-    @Value("${artemis.iris.response-streaming-enabled:false}")
+    @Value("${artemis.iris.response-streaming-enabled:true}")
     private boolean responseStreamingEnabled;
 
     public PyrisPipelineService(PyrisConnectorService pyrisConnectorService, PyrisJobService pyrisJobService, PyrisDTOService pyrisDTOService,

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineService.java
@@ -75,6 +75,9 @@ public class PyrisPipelineService {
     @Value("${server.url}")
     private String artemisBaseUrl;
 
+    @Value("${artemis.iris.response-streaming-enabled:false}")
+    private boolean responseStreamingEnabled;
+
     public PyrisPipelineService(PyrisConnectorService pyrisConnectorService, PyrisJobService pyrisJobService, PyrisDTOService pyrisDTOService,
             IrisChatWebsocketService irisChatWebsocketService, StudentParticipationRepository studentParticipationRepository, UserRepository userRepository,
             CourseLoadService courseLoadService, FeatureToggleService featureToggleService) {
@@ -116,7 +119,9 @@ public class PyrisPipelineService {
         // Send initial status update indicating that the preparation stage is in progress
         statusUpdater.accept(List.of(preparing.inProgress(), executing.notStarted()));
 
-        var baseDto = new PyrisPipelineExecutionDTO(new PyrisPipelineExecutionSettingsDTO(jobToken, aiSelection, artemisBaseUrl, variant, supportLevel), List.of(preparing.done()));
+        Boolean streamResponse = responseStreamingEnabled && "chat".equals(name) ? Boolean.TRUE : null;
+        var baseDto = new PyrisPipelineExecutionDTO(new PyrisPipelineExecutionSettingsDTO(jobToken, aiSelection, artemisBaseUrl, variant, supportLevel, streamResponse),
+                List.of(preparing.done()));
         long dtoBuildStart = System.nanoTime();
         var pipelineDto = dtoMapper.apply(baseDto);
         log.debug("Pyris {} pipeline DTO built in {} ms", name, (System.nanoTime() - dtoBuildStart) / 1_000_000);

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisStatusUpdateService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisStatusUpdateService.java
@@ -79,6 +79,11 @@ public class PyrisStatusUpdateService {
      * @param statusUpdate the status update
      */
     public void handleStatusUpdate(ChatJob job, PyrisChatStatusUpdateDTO statusUpdate) {
+        if (statusUpdate.partialResult() != null) {
+            irisChatSessionService.handlePartialStatusUpdate(job, statusUpdate);
+            return;
+        }
+
         var updatedJob = irisChatSessionService.handleStatusUpdate(job, statusUpdate);
 
         removeJobIfTerminatedElseUpdate(statusUpdate.stages(), updatedJob);

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/dto/PyrisPipelineExecutionSettingsDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/dto/PyrisPipelineExecutionSettingsDTO.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.iris.service.pyris.dto;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.core.domain.AiSelectionDecision;
@@ -12,7 +14,13 @@ import de.tum.cit.aet.artemis.core.domain.AiSelectionDecision;
  * @param artemisBaseUrl      the base URL of the Artemis instance
  * @param variant             the variant of the pipeline to execute
  * @param supportLevel        the instructional support level ("low" / "moderate" / "high")
+ * @param streamResponse      whether Pyris should send partial response updates during execution
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PyrisPipelineExecutionSettingsDTO(String authenticationToken, AiSelectionDecision selection, String artemisBaseUrl, String variant, String supportLevel) {
+public record PyrisPipelineExecutionSettingsDTO(String authenticationToken, AiSelectionDecision selection, String artemisBaseUrl, String variant, String supportLevel,
+        @Nullable Boolean streamResponse) {
+
+    public PyrisPipelineExecutionSettingsDTO(String authenticationToken, AiSelectionDecision selection, String artemisBaseUrl, String variant, String supportLevel) {
+        this(authenticationToken, selection, artemisBaseUrl, variant, supportLevel, null);
+    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/dto/chat/PyrisChatStatusUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/dto/chat/PyrisChatStatusUpdateDTO.java
@@ -12,5 +12,11 @@ import de.tum.cit.aet.artemis.iris.service.pyris.dto.status.PyrisStageDTO;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PyrisChatStatusUpdateDTO(@Nullable String result, List<PyrisStageDTO> stages, @Nullable String sessionTitle, @Nullable List<String> suggestions,
-        @Nullable List<LLMRequest> tokens, @Nullable List<MemirisMemoryDTO> accessedMemories, @Nullable List<MemirisMemoryDTO> createdMemories) {
+        @Nullable List<LLMRequest> tokens, @Nullable List<MemirisMemoryDTO> accessedMemories, @Nullable List<MemirisMemoryDTO> createdMemories, @Nullable String partialResult,
+        @Nullable Integer partialSeq) {
+
+    public PyrisChatStatusUpdateDTO(@Nullable String result, List<PyrisStageDTO> stages, @Nullable String sessionTitle, @Nullable List<String> suggestions,
+            @Nullable List<LLMRequest> tokens, @Nullable List<MemirisMemoryDTO> accessedMemories, @Nullable List<MemirisMemoryDTO> createdMemories) {
+        this(result, stages, sessionTitle, suggestions, tokens, accessedMemories, createdMemories, null, null);
+    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/session/AbstractIrisChatSessionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/session/AbstractIrisChatSessionService.java
@@ -185,7 +185,7 @@ public abstract class AbstractIrisChatSessionService<S extends IrisSession> impl
             message.setCreatedMemories(statusUpdate.createdMemories());
             savedMessage = irisMessageService.saveMessage(message, session, IrisMessageSender.LLM);
             updatedJob.getAndUpdate(j -> j.withAssistantMessageId(savedMessage.getId()));
-            irisChatWebsocketService.sendMessage(session, savedMessage, statusUpdate.stages(), sessionTitle, citationInfo);
+            irisChatWebsocketService.sendMessage(session, savedMessage, statusUpdate.stages(), sessionTitle, citationInfo, job.jobId());
         }
         else {
             savedMessage = null;
@@ -237,6 +237,19 @@ public abstract class AbstractIrisChatSessionService<S extends IrisSession> impl
         log.debug("Iris status update handled in {} ms (result present: {})", (System.nanoTime() - handlingStart) / 1_000_000, statusUpdate.result() != null);
 
         return updatedJob.get();
+    }
+
+    /**
+     * Handles a partial chat status update by relaying the partial response over the websocket.
+     * The partial response is ephemeral and is not persisted.
+     *
+     * @param job          The job that is currently executed
+     * @param statusUpdate The partial status update of the job
+     */
+    public void handlePartialStatusUpdate(TrackedSessionBasedPyrisJob job, PyrisChatStatusUpdateDTO statusUpdate) {
+        // noinspection unchecked
+        var session = (S) irisSessionRepository.findByIdElseThrow(job.sessionId());
+        irisChatWebsocketService.sendPartialUpdate(session, statusUpdate.partialResult(), statusUpdate.partialSeq(), job.jobId());
     }
 
     private static final String MALFORMED_MCQ_ERROR_MESSAGE = "Sorry, I tried to generate a quiz question but the response was malformed. Please try again.";

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/websocket/IrisChatWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/websocket/IrisChatWebsocketService.java
@@ -63,11 +63,29 @@ public class IrisChatWebsocketService {
      * @param citationInfo the citation metadata to send
      */
     public void sendMessage(IrisSession session, IrisMessage irisMessage, List<PyrisStageDTO> stages, String sessionTitle, List<IrisCitationMetaDTO> citationInfo) {
+        this.sendMessage(session, irisMessage, stages, sessionTitle, citationInfo, null);
+    }
+
+    /**
+     * Sends a message and/or a status update over the websocket to the user
+     * involved in the session. At least one of the message or the stages must be
+     * non-null, otherwise there is no need to send a message.
+     * This is currently used for both the exercise and course chat sessions, but
+     * this could be split up in the future.
+     *
+     * @param session      the session to send the message to
+     * @param irisMessage  that should be sent over the websocket
+     * @param stages       that should be sent over the websocket
+     * @param sessionTitle the session title to send
+     * @param citationInfo the citation metadata to send
+     * @param runId        the id of the Pyris run that produced the message
+     */
+    public void sendMessage(IrisSession session, IrisMessage irisMessage, List<PyrisStageDTO> stages, String sessionTitle, List<IrisCitationMetaDTO> citationInfo, String runId) {
         var messageDTO = irisMessage != null ? IrisMessageResponseDTO.of(irisMessage) : null;
         var user = userRepository.findByIdElseThrow(session.getUserId());
         var rateLimitInfo = rateLimitService.getRateLimitInformation(session, user);
         var topic = "" + session.getId(); // Todo: add more specific topic
-        var payload = new IrisChatWebsocketDTO(messageDTO, rateLimitInfo, stages, sessionTitle, null, null, citationInfo);
+        var payload = new IrisChatWebsocketDTO(messageDTO, rateLimitInfo, stages, sessionTitle, null, null, citationInfo, runId, null, null);
         websocketService.send(user.getLogin(), topic, payload);
     }
 
@@ -95,6 +113,22 @@ public class IrisChatWebsocketService {
         var rateLimitInfo = rateLimitService.getRateLimitInformation(session, user);
         var topic = "" + session.getId(); // Todo: add more specific topic
         var payload = new IrisChatWebsocketDTO(null, rateLimitInfo, stages, sessionTitle, suggestions, tokens, null);
+        websocketService.send(user.getLogin(), topic, payload);
+    }
+
+    /**
+     * Sends a partial response update over the websocket to a specific user.
+     *
+     * @param session       the session to send the partial update to
+     * @param partialResult the current accumulated partial response text
+     * @param partialSeq    the monotonic sequence number of the partial response
+     * @param runId         the id of the Pyris run that produced the partial response
+     */
+    public void sendPartialUpdate(IrisSession session, String partialResult, Integer partialSeq, String runId) {
+        var user = userRepository.findByIdElseThrow(session.getUserId());
+        var rateLimitInfo = rateLimitService.getRateLimitInformation(session, user);
+        var topic = "" + session.getId(); // Todo: add more specific topic
+        var payload = new IrisChatWebsocketDTO(null, rateLimitInfo, List.of(), null, null, null, null, runId, partialResult, partialSeq);
         websocketService.send(user.getLogin(), topic, payload);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/websocket/IrisChatWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/websocket/IrisChatWebsocketService.java
@@ -118,6 +118,10 @@ public class IrisChatWebsocketService {
 
     /**
      * Sends a partial response update over the websocket to a specific user.
+     * <p>
+     * Partial updates arrive many times per streamed answer and never change the user's quota, so we deliberately omit the rate limit information here: computing it can run
+     * the (potentially expensive) LLM-response-count query, and this streaming path must stay off that hot path. The rate limit information is refreshed by the final
+     * MESSAGE / status update instead.
      *
      * @param session       the session to send the partial update to
      * @param partialResult the current accumulated partial response text
@@ -126,9 +130,8 @@ public class IrisChatWebsocketService {
      */
     public void sendPartialUpdate(IrisSession session, String partialResult, Integer partialSeq, String runId) {
         var user = userRepository.findByIdElseThrow(session.getUserId());
-        var rateLimitInfo = rateLimitService.getRateLimitInformation(session, user);
         var topic = "" + session.getId(); // Todo: add more specific topic
-        var payload = new IrisChatWebsocketDTO(null, rateLimitInfo, List.of(), null, null, null, null, runId, partialResult, partialSeq);
+        var payload = new IrisChatWebsocketDTO(null, null, List.of(), null, null, null, null, runId, partialResult, partialSeq);
         websocketService.send(user.getLogin(), topic, payload);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/websocket/IrisWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/websocket/IrisWebsocketService.java
@@ -1,7 +1,5 @@
 package de.tum.cit.aet.artemis.iris.service.websocket;
 
-import java.util.concurrent.ExecutionException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Conditional;
@@ -38,13 +36,14 @@ public class IrisWebsocketService {
      */
     public void send(String userLogin, String topicSuffix, Object payload) {
         String topic = TOPIC_PREFIX + topicSuffix;
-        try {
-            websocketMessagingService.sendMessageToUser(userLogin, topic, payload).get();
-            log.debug("Sent message to Iris user {} on topic {}: {}", userLogin, topic, payload);
-        }
-        catch (InterruptedException | ExecutionException e) {
-            log.error("Error while sending message to Iris user {} on topic {}: {}", userLogin, topic, payload, e);
-        }
+        websocketMessagingService.sendMessageToUser(userLogin, topic, payload).whenComplete((ignored, throwable) -> {
+            if (throwable != null) {
+                log.warn("Error while sending message to Iris user {} on topic {}: {}", userLogin, topic, payload, throwable);
+            }
+            else {
+                log.debug("Sent message to Iris user {} on topic {}: {}", userLogin, topic, payload);
+            }
+        });
     }
 
 }

--- a/src/main/resources/config/application-artemis.yml
+++ b/src/main/resources/config/application-artemis.yml
@@ -139,6 +139,7 @@ artemis:
     enabled: false
     url: <your-pyris-url>
     secret-token: <your-secret>
+    response-streaming-enabled: false
     dashboard:
       max-query-window-days: 90
       stale-threshold-minutes: 5

--- a/src/main/resources/config/application-artemis.yml
+++ b/src/main/resources/config/application-artemis.yml
@@ -139,7 +139,7 @@ artemis:
     enabled: false
     url: <your-pyris-url>
     secret-token: <your-secret>
-    response-streaming-enabled: false
+    response-streaming-enabled: true
     dashboard:
       max-query-window-days: 90
       stale-threshold-minutes: 5

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -156,6 +156,7 @@ artemis:
         enabled: false # Set this to true in prod if you want to use Iris
         url: # Set this in production environment (e.g., https://pyris.example.com)
         secret-token: # Set this in production environment
+        response-streaming-enabled: false
         ratelimit:
             # Use -1 for both values to indicate unlimited (no rate limiting)
             # Otherwise: default-limit >= 0 (0 = no requests allowed), default-timeframe-hours >= 1

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -156,7 +156,7 @@ artemis:
         enabled: false # Set this to true in prod if you want to use Iris
         url: # Set this in production environment (e.g., https://pyris.example.com)
         secret-token: # Set this in production environment
-        response-streaming-enabled: false
+        response-streaming-enabled: true
         ratelimit:
             # Use -1 for both values to indicate unlimited (no rate limiting)
             # Otherwise: default-limit >= 0 (0 = no requests allowed), default-timeframe-hours >= 1

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.html
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.html
@@ -332,10 +332,10 @@
                                 }
                             </div>
                         }
-                        @if (liveAssistantDraft(); as draft) {
-                            <div class="llm-message-wrapper streaming-draft-wrapper">
+                        @if (liveAssistantDraft()) {
+                            <div #liveAssistantDraftElement class="llm-message-wrapper streaming-draft-wrapper">
                                 <div class="bubble-left streaming-draft-bubble">
-                                    <jhi-iris-citation-text [text]="draft.text" [citationInfo]="citationInfo()" />
+                                    <jhi-iris-citation-text [text]="displayedLiveAssistantDraftText()" [citationInfo]="citationInfo()" />
                                     <div class="streaming-draft-meta" aria-hidden="true">
                                         <fa-icon [icon]="faCircleNotch" animation="spin" />
                                     </div>

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.html
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.html
@@ -232,7 +232,7 @@
             </div>
         }
         <div class="chat-body" [class.empty-state]="isEmptyState()" #chatBody>
-            @if (messages()?.length) {
+            @if (messages()?.length || liveAssistantDraft()) {
                 <div class="messages" #messagesElement (scroll)="checkChatScroll()" (wheel)="onMessagesUserScroll($event)" (touchmove)="onMessagesUserScroll($event)">
                     <div class="messages-inner">
                         @for (message of messages(); track message.id ?? $index; let i = $index) {
@@ -332,6 +332,16 @@
                                 }
                             </div>
                         }
+                        @if (liveAssistantDraft(); as draft) {
+                            <div class="llm-message-wrapper streaming-draft-wrapper">
+                                <div class="bubble-left streaming-draft-bubble">
+                                    <jhi-iris-citation-text [text]="draft.text" [citationInfo]="citationInfo()" />
+                                    <div class="streaming-draft-meta" aria-hidden="true">
+                                        <fa-icon [icon]="faCircleNotch" animation="spin" />
+                                    </div>
+                                </div>
+                            </div>
+                        }
                         @if (canShowSuggestions()) {
                             <div animate.enter="suggestion-entering" animate.leave="suggestion-leaving">
                                 <div class="suggestions-container">
@@ -358,7 +368,7 @@
                     </div>
                 </div>
             }
-            @if (!messages()?.length && !isEmbeddedChat()) {
+            @if (!messages()?.length && !liveAssistantDraft() && !isEmbeddedChat()) {
                 <div class="empty-chat-message">
                     <jhi-iris-logo [size]="IrisLogoSize.SMALL" />
                     <h3 jhiTranslate="artemisApp.iris.chat.helpOffer"></h3>

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.html
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.html
@@ -233,10 +233,11 @@
         }
         <div class="chat-body" [class.empty-state]="isEmptyState()" #chatBody>
             @if (messages()?.length || liveAssistantDraft()) {
-                <div class="messages" #messagesElement (scroll)="checkChatScroll()" (wheel)="onMessagesUserScroll($event)" (touchmove)="onMessagesUserScroll($event)">
+                <div class="messages" #messagesElement (scroll)="checkChatScroll()">
                     <div class="messages-inner">
                         @for (message of messages(); track message.id ?? $index; let i = $index) {
                             <div
+                                [attr.data-message-id]="message.id"
                                 animate.enter="message-entering"
                                 [class.animate-enabled]="message.id !== undefined && animatingMessageIds().has(message.id)"
                                 [style.transform-origin]="message.sender === IrisSender.USER ? 'bottom right' : 'bottom left'"
@@ -333,7 +334,7 @@
                             </div>
                         }
                         @if (liveAssistantDraft()) {
-                            <div #liveAssistantDraftElement class="llm-message-wrapper streaming-draft-wrapper">
+                            <div class="llm-message-wrapper streaming-draft-wrapper">
                                 <div class="bubble-left streaming-draft-bubble">
                                     <jhi-iris-citation-text [text]="displayedLiveAssistantDraftText()" [citationInfo]="citationInfo()" />
                                     <div class="streaming-draft-meta" aria-hidden="true">
@@ -365,6 +366,7 @@
                         @if (shouldShowStatusBar()) {
                             <jhi-chat-status-bar [stages]="stages()" />
                         }
+                        <div class="stream-exchange-spacer" aria-hidden="true" [style.height.px]="exchangeSpacerPx()"></div>
                     </div>
                 </div>
             }

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.scss
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.scss
@@ -492,6 +492,11 @@ pre {
                 margin-inline: auto;
                 padding-bottom: 40px;
             }
+
+            .stream-exchange-spacer {
+                flex: 0 0 auto;
+                pointer-events: none;
+            }
         }
     }
 }

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.scss
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.scss
@@ -329,6 +329,19 @@ jhi-iris-mcq-question {
     gap: 8px;
 }
 
+.streaming-draft-wrapper {
+    max-width: 100%;
+}
+
+.streaming-draft-bubble {
+    opacity: 0.92;
+}
+
+.streaming-draft-meta {
+    color: var(--secondary);
+    font-size: 0.75rem;
+}
+
 .bubble-right {
     --_d: 100%;
 

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.scss
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.scss
@@ -331,6 +331,7 @@ jhi-iris-mcq-question {
 
 .streaming-draft-wrapper {
     max-width: 100%;
+    scroll-margin-top: 16px;
 }
 
 .streaming-draft-bubble {

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.spec.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.spec.ts
@@ -601,6 +601,27 @@ describe('IrisBaseChatbotComponent', () => {
 
             expect(bottomScrollSpy).not.toHaveBeenCalled();
         });
+
+        it('should not give the entrance animation to the message that finalizes the streamed draft', () => {
+            component['shouldAnimate'] = true;
+            pushDraft('run-1', 'Streaming answer');
+
+            // Same order as the service's MESSAGE handler: apply the final message first, then clear the draft.
+            chatService.messages.next([finalAssistantMessage('Streaming answer, finalized.')]);
+            chatService.liveAssistantDraft.next(undefined);
+            fixture.detectChanges();
+
+            expect(component.animatingMessageIds().has(9876)).toBe(false);
+        });
+
+        it('should still give the entrance animation to a new message when no draft was streaming', () => {
+            component['shouldAnimate'] = true;
+
+            chatService.messages.next([finalAssistantMessage('A fresh answer without streaming.')]);
+            fixture.detectChanges();
+
+            expect(component.animatingMessageIds().has(9876)).toBe(true);
+        });
     });
 
     it('should set the appropriate message styles based on the sender', async () => {

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.spec.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.spec.ts
@@ -553,6 +553,26 @@ describe('IrisBaseChatbotComponent', () => {
 
             expect(component.animatingMessageIds().has(9876)).toBe(true);
         });
+
+        it('should release the exchange anchor when a non-streamed answer completes without a live draft', () => {
+            vi.spyOn(component, 'scrollToBottom').mockImplementation(() => {});
+
+            const userMessage = mockUserMessageWithContent('Anchored question');
+            chatService.messages.next([userMessage]);
+            fixture.detectChanges();
+
+            // Simulate the state right after the sent user message was anchored to the top of the chat body.
+            component['anchoredMessageId'] = userMessage.id;
+            component['exchangeAnchorActive'] = true;
+
+            // The final assistant message lands with no live draft ever having existed (response streaming
+            // disabled, or a legacy Pyris that only sends the final MESSAGE), so the draft-finalization path
+            // never runs. The anchor/spacer must still be released to avoid blank space below the exchange.
+            chatService.messages.next([userMessage, finalAssistantMessage('A non-streamed answer.')]);
+            fixture.detectChanges();
+
+            expect(component['exchangeAnchorActive']).toBe(false);
+        });
     });
 
     it('should set the appropriate message styles based on the sender', async () => {

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.spec.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.spec.ts
@@ -579,6 +579,30 @@ describe('IrisBaseChatbotComponent', () => {
             expect(bottomScrollSpy).not.toHaveBeenCalled();
         });
 
+        it('should scroll only the chat body when bringing the draft into view, never ancestor scroll containers', () => {
+            vi.useFakeTimers();
+            // jsdom has no scrollIntoView; install a spy so a regression to it is caught.
+            const scrollIntoViewSpy = vi.fn();
+            (Element.prototype as any).scrollIntoView = scrollIntoViewSpy;
+            const containerScrollSpy = vi.fn();
+
+            try {
+                pushDraft('run-1', 'First partial');
+                // The .messages container only renders once a draft (or message) exists;
+                // the draft scroll is deferred via setTimeout, so spy before flushing it.
+                const messagesContainer: HTMLElement = fixture.nativeElement.querySelector('.messages');
+                messagesContainer.scrollTo = containerScrollSpy;
+                vi.advanceTimersByTime(0);
+
+                // scrollIntoView() also scrolls ancestor containers (the whole page in the
+                // full-page course chat) — the draft scroll must stay inside the chat body.
+                expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+                expect(containerScrollSpy).toHaveBeenCalled();
+            } finally {
+                delete (Element.prototype as any).scrollIntoView;
+            }
+        });
+
         it('should not bottom-scroll when thinking status updates while a draft is visible', () => {
             vi.useFakeTimers();
             const bottomScrollSpy = vi.spyOn(component, 'scrollToBottom').mockImplementation(() => {});

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.spec.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.spec.ts
@@ -128,6 +128,7 @@ describe('IrisBaseChatbotComponent', () => {
                 global.window ??= window;
                 window.scroll = vi.fn();
                 window.HTMLElement.prototype.scrollTo = vi.fn();
+                window.HTMLElement.prototype.scrollIntoView = vi.fn();
 
                 // Set up services BEFORE creating component
                 chatService = TestBed.inject(IrisChatService);
@@ -469,6 +470,137 @@ describe('IrisBaseChatbotComponent', () => {
         // then – the pin is released and the RAF loop is stopped
         expect(component['forcePinToBottom']).toBe(false);
         expect(component['pinScrollRafId']).toBeUndefined();
+    });
+
+    describe('live assistant draft streaming UX', () => {
+        const pushDraft = (runId: string, text: string) => {
+            chatService.liveAssistantDraft.next({ runId, text });
+            fixture.detectChanges();
+        };
+
+        const displayedDraftText = () => ((component as any).displayedLiveAssistantDraftText?.() ?? '') as string;
+
+        const finalAssistantMessage = (text: string): IrisAssistantMessage =>
+            ({
+                ...mockServerMessage,
+                id: 9876,
+                sender: IrisSender.LLM,
+                content: [new IrisTextMessageContent(text)],
+            }) as IrisAssistantMessage;
+
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it('should animate displayed draft text toward the latest partial and never shrink during the same run', () => {
+            vi.useFakeTimers();
+
+            const firstSnapshot = 'Hello streaming answer';
+            pushDraft('run-1', firstSnapshot);
+
+            expect(displayedDraftText()).toBe('');
+
+            vi.advanceTimersByTime(50);
+            const firstTickText = displayedDraftText();
+            expect(firstTickText.length).toBeGreaterThan(0);
+            expect(firstTickText.length).toBeLessThan(firstSnapshot.length);
+
+            const secondSnapshot = 'Hello streaming answer with a longer continuation';
+            pushDraft('run-1', secondSnapshot);
+            const beforeCatchUpLength = displayedDraftText().length;
+
+            vi.advanceTimersByTime(100);
+            expect(displayedDraftText().length).toBeGreaterThanOrEqual(beforeCatchUpLength);
+
+            vi.advanceTimersByTime(3000);
+            expect(displayedDraftText()).toBe(secondSnapshot);
+
+            pushDraft('run-1', 'Hello');
+            expect(displayedDraftText()).toBe(secondSnapshot);
+        });
+
+        it('should cancel draft animation and expose the final message immediately on finalization', () => {
+            vi.useFakeTimers();
+
+            pushDraft('run-1', 'This partial answer is intentionally much longer than one animation tick.');
+            vi.advanceTimersByTime(50);
+            expect(displayedDraftText().length).toBeGreaterThan(0);
+
+            const finalText = 'This final answer should be rendered in full.';
+            chatService.liveAssistantDraft.next(undefined);
+            chatService.messages.next([finalAssistantMessage(finalText)]);
+            fixture.detectChanges();
+
+            expect(displayedDraftText()).toBe('');
+            expect(component.messages().at(-1)?.content?.[0]).toMatchObject({ textContent: finalText });
+            expect(fixture.nativeElement.querySelector('.streaming-draft-wrapper')).toBeNull();
+
+            vi.advanceTimersByTime(1000);
+            expect(displayedDraftText()).toBe('');
+        });
+
+        it('should cancel the draft animation interval on destroy', () => {
+            vi.useFakeTimers();
+            const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+
+            pushDraft('run-1', 'This partial answer is long enough to keep the animation interval active.');
+
+            expect(component['liveDraftAnimationIntervalId']).toBeDefined();
+
+            fixture.destroy();
+
+            expect(clearIntervalSpy).toHaveBeenCalled();
+            expect(component['liveDraftAnimationIntervalId']).toBeUndefined();
+        });
+
+        it('should scroll the draft into view once on appearance without bottom scrolling on growth or finalization', () => {
+            vi.useFakeTimers();
+            const draftScrollSpy = vi.spyOn(component as any, 'scrollLiveAssistantDraftIntoView');
+            const bottomScrollSpy = vi.spyOn(component, 'scrollToBottom').mockImplementation(() => {});
+
+            pushDraft('run-1', 'First partial');
+            vi.advanceTimersByTime(0);
+
+            expect(draftScrollSpy).toHaveBeenCalledOnce();
+            expect(bottomScrollSpy).not.toHaveBeenCalled();
+
+            pushDraft('run-1', 'First partial with more text');
+            vi.advanceTimersByTime(0);
+
+            expect(draftScrollSpy).toHaveBeenCalledOnce();
+            expect(bottomScrollSpy).not.toHaveBeenCalled();
+
+            chatService.liveAssistantDraft.next(undefined);
+            chatService.messages.next([finalAssistantMessage('Final answer')]);
+            fixture.detectChanges();
+            vi.advanceTimersByTime(0);
+
+            expect(draftScrollSpy).toHaveBeenCalledOnce();
+            expect(bottomScrollSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not bottom-scroll when thinking status updates while a draft is visible', () => {
+            vi.useFakeTimers();
+            const bottomScrollSpy = vi.spyOn(component, 'scrollToBottom').mockImplementation(() => {});
+
+            pushDraft('run-1', 'Visible draft');
+            vi.advanceTimersByTime(0);
+            bottomScrollSpy.mockClear();
+
+            chatService.stages.next([
+                {
+                    name: 'Thinking',
+                    weight: 1,
+                    state: IrisStageStateDTO.IN_PROGRESS,
+                    message: 'Processing...',
+                    internal: false,
+                    chatMessage: 'Still thinking...',
+                },
+            ]);
+            fixture.detectChanges();
+
+            expect(bottomScrollSpy).not.toHaveBeenCalled();
+        });
     });
 
     it('should set the appropriate message styles based on the sender', async () => {

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.spec.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.spec.ts
@@ -34,7 +34,6 @@ import {
 import { By } from '@angular/platform-browser';
 import { HtmlForMarkdownPipe } from 'app/foundation/pipes/html-for-markdown.pipe';
 import { IrisAssistantMessage, IrisSender, IrisUserMessage } from 'app/iris/shared/entities/iris-message.model';
-import { IrisErrorMessageKey } from 'app/iris/shared/entities/iris-errors.model';
 import { IrisMessageResponseDTO } from 'app/iris/shared/entities/iris-message-response-dto.model';
 import { IrisJsonMessageContent, IrisMessageContentType, IrisTextMessageContent, getMcqData, isMcqContent } from 'app/iris/shared/entities/iris-content-type.model';
 import dayjs from 'dayjs/esm';
@@ -315,7 +314,8 @@ describe('IrisBaseChatbotComponent', () => {
         expect(component.newMessageTextContent()).toBe('');
     });
 
-    it('should scroll to bottom and pin to bottom when sending a non-empty message', async () => {
+    it('should anchor the sent user message at the top of the chat body without using ancestor scrolling', async () => {
+        vi.useFakeTimers();
         vi.spyOn(httpService, 'getCurrentSessionOrCreateIfNotExists').mockReturnValueOnce(of(mockServerSessionHttpResponse));
         vi.spyOn(wsMock, 'subscribeToSession').mockReturnValueOnce(of());
         vi.spyOn(httpService, 'getChatSessions').mockReturnValue(of([]));
@@ -323,153 +323,43 @@ describe('IrisBaseChatbotComponent', () => {
         const content = 'Hello';
         const createdMessage = mockUserMessageWithContent(content);
         vi.spyOn(httpService, 'createMessage').mockReturnValueOnce(of({ body: createdMessage } as HttpResponse<IrisMessageResponseDTO>));
+        const bottomScrollSpy = vi.spyOn(component, 'scrollToBottom').mockImplementation(() => {});
+        const scrollIntoViewSpy = vi.fn();
+        (Element.prototype as any).scrollIntoView = scrollIntoViewSpy;
+        (HTMLElement.prototype as any).scrollIntoView = scrollIntoViewSpy;
 
-        const scrollSpy = vi.spyOn(component, 'scrollToBottom').mockImplementation(() => {});
+        try {
+            component.newMessageTextContent.set(content);
+            chatService.switchTo(ChatServiceMode.COURSE, 123);
+            fixture.detectChanges();
+            bottomScrollSpy.mockClear();
 
-        component.newMessageTextContent.set(content);
-        chatService.switchTo(ChatServiceMode.COURSE, 123);
-        await fixture.whenStable();
+            component.onSend();
+            fixture.detectChanges();
 
-        // isolate scroll triggered by onSend from scrolls caused by session switch / effects
-        component.isScrolledToBottom.set(false);
-        scrollSpy.mockClear();
+            const messagesElement = fixture.nativeElement.querySelector('.messages') as HTMLElement;
+            const anchorElement = messagesElement.querySelector(`[data-message-id="${createdMessage.id}"]`) as HTMLElement;
+            const spacerElement = messagesElement.querySelector('.stream-exchange-spacer') as HTMLElement;
+            const containerScrollSpy = vi.fn();
+            messagesElement.scrollTo = containerScrollSpy;
+            messagesElement.scrollTop = 40;
+            Object.defineProperty(messagesElement, 'clientHeight', { value: 500, configurable: true });
+            Object.defineProperty(messagesElement, 'scrollHeight', { value: 600, configurable: true });
+            Object.defineProperty(spacerElement, 'offsetHeight', { value: 0, configurable: true });
+            messagesElement.getBoundingClientRect = vi.fn(() => ({ top: 10 }) as DOMRect);
+            anchorElement.getBoundingClientRect = vi.fn(() => ({ top: 210 }) as DOMRect);
 
-        // when – assert synchronously so async session effects don't interfere
-        component.onSend();
+            vi.advanceTimersByTime(0);
 
-        // then – instant scroll (no smooth-scroll race) and view pinned to the bottom
-        expect(scrollSpy).toHaveBeenCalledWith('auto');
-        expect(component.isScrolledToBottom()).toBe(true);
-    });
-
-    it('should keep the view pinned to the bottom after sending even when intermediate scroll events fire', async () => {
-        vi.spyOn(httpService, 'getCurrentSessionOrCreateIfNotExists').mockReturnValueOnce(of(mockServerSessionHttpResponse));
-        vi.spyOn(wsMock, 'subscribeToSession').mockReturnValueOnce(of());
-        vi.spyOn(httpService, 'getChatSessions').mockReturnValue(of([]));
-
-        const content = 'Hello';
-        const createdMessage = mockUserMessageWithContent(content);
-        vi.spyOn(httpService, 'createMessage').mockReturnValueOnce(of({ body: createdMessage } as HttpResponse<IrisMessageResponseDTO>));
-        vi.spyOn(component, 'scrollToBottom').mockImplementation(() => {});
-
-        component.newMessageTextContent.set(content);
-        chatService.switchTo(ChatServiceMode.COURSE, 123);
-        await fixture.whenStable();
-
-        // when – send, then simulate an intermediate (not-yet-at-bottom) scroll reading
-        component.onSend();
-        const messagesElement = fixture.nativeElement.querySelector('.messages') as HTMLElement | null;
-        if (messagesElement) {
-            Object.defineProperty(messagesElement, 'scrollTop', { value: 0, configurable: true });
-            Object.defineProperty(messagesElement, 'scrollHeight', { value: 1000, configurable: true });
-            Object.defineProperty(messagesElement, 'clientHeight', { value: 200, configurable: true });
+            expect(bottomScrollSpy).not.toHaveBeenCalled();
+            expect(containerScrollSpy).toHaveBeenCalledWith({ top: 240, behavior: 'smooth' });
+            expect(component.exchangeSpacerPx()).toBe(140);
+            expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+        } finally {
+            delete (Element.prototype as any).scrollIntoView;
+            delete (HTMLElement.prototype as any).scrollIntoView;
+            vi.useRealTimers();
         }
-        component.checkChatScroll();
-
-        // then – the intermediate reading must not un-pin the view
-        expect(component.isScrolledToBottom()).toBe(true);
-    });
-
-    it('should release the bottom pin on an upward wheel gesture', async () => {
-        vi.spyOn(httpService, 'getCurrentSessionOrCreateIfNotExists').mockReturnValueOnce(of(mockServerSessionHttpResponse));
-        vi.spyOn(wsMock, 'subscribeToSession').mockReturnValueOnce(of());
-        vi.spyOn(httpService, 'getChatSessions').mockReturnValue(of([]));
-
-        const content = 'Hello';
-        const createdMessage = mockUserMessageWithContent(content);
-        vi.spyOn(httpService, 'createMessage').mockReturnValueOnce(of({ body: createdMessage } as HttpResponse<IrisMessageResponseDTO>));
-        vi.spyOn(component, 'scrollToBottom').mockImplementation(() => {});
-
-        component.newMessageTextContent.set(content);
-        chatService.switchTo(ChatServiceMode.COURSE, 123);
-        await fixture.whenStable();
-
-        component.onSend();
-
-        // when – the user scrolls up while not at the bottom
-        const messagesElement = fixture.nativeElement.querySelector('.messages') as HTMLElement | null;
-        if (messagesElement) {
-            Object.defineProperty(messagesElement, 'scrollTop', { value: 0, configurable: true });
-            Object.defineProperty(messagesElement, 'scrollHeight', { value: 1000, configurable: true });
-            Object.defineProperty(messagesElement, 'clientHeight', { value: 200, configurable: true });
-        }
-        component.onMessagesUserScroll(new WheelEvent('wheel', { deltaY: -50 }));
-
-        // then – pin is released, so the scroll-to-bottom state reflects the real position
-        expect(component.isScrolledToBottom()).toBe(false);
-    });
-
-    it('should keep scrolling to the bottom frame-by-frame while pinned after a send', async () => {
-        vi.spyOn(httpService, 'getCurrentSessionOrCreateIfNotExists').mockReturnValueOnce(of(mockServerSessionHttpResponse));
-        vi.spyOn(wsMock, 'subscribeToSession').mockReturnValueOnce(of());
-        vi.spyOn(httpService, 'getChatSessions').mockReturnValue(of([]));
-
-        const content = 'Hello';
-        const createdMessage = mockUserMessageWithContent(content);
-        vi.spyOn(httpService, 'createMessage').mockReturnValueOnce(of({ body: createdMessage } as HttpResponse<IrisMessageResponseDTO>));
-
-        component.newMessageTextContent.set(content);
-        chatService.switchTo(ChatServiceMode.COURSE, 123);
-        await fixture.whenStable();
-
-        const messagesElement = fixture.nativeElement.querySelector('.messages') as HTMLElement;
-        Object.defineProperty(messagesElement, 'scrollHeight', { value: 1000, configurable: true });
-        messagesElement.scrollTop = 0;
-
-        // Queue rAF callbacks instead of running them synchronously. Invoking the callback inside
-        // requestAnimationFrame re-enters the component (which schedules from within an Angular
-        // effect) and trips the zoneless scheduler on teardown. We flush the queued frames
-        // explicitly, outside the current effect execution.
-        const rafQueue: FrameRequestCallback[] = [];
-        const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
-            rafQueue.push(cb);
-            return rafQueue.length;
-        });
-        vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
-
-        // when
-        component.onSend();
-
-        // flush a bounded number of frames outside Angular's effect execution
-        for (let i = 0; i < 3 && rafQueue.length > 0; i++) {
-            rafQueue.shift()!(0);
-        }
-
-        // then – the pin loop pushed scrollTop to the bottom (scrollHeight)
-        expect(messagesElement.scrollTop).toBe(1000);
-
-        rafSpy.mockRestore();
-    });
-
-    it('should release the bottom pin if an error arrives before the stream starts', async () => {
-        // given – the chat service surfaces an error before any stage goes active
-        const errorSubject = new Subject<IrisErrorMessageKey | undefined>();
-        vi.spyOn(chatService, 'currentError').mockReturnValue(errorSubject as any);
-
-        fixture = TestBed.createComponent(IrisBaseChatbotComponent);
-        component = fixture.componentInstance;
-        fixture.nativeElement.querySelector('.chat-body').scrollTo = vi.fn();
-        fixture.detectChanges();
-
-        vi.spyOn(httpService, 'getCurrentSessionOrCreateIfNotExists').mockReturnValueOnce(of(mockServerSessionHttpResponse));
-        vi.spyOn(wsMock, 'subscribeToSession').mockReturnValueOnce(of());
-        vi.spyOn(httpService, 'getChatSessions').mockReturnValue(of([]));
-        vi.spyOn(httpService, 'createMessage').mockReturnValueOnce(of({ body: mockUserMessageWithContent('Hello') } as HttpResponse<IrisMessageResponseDTO>));
-        vi.spyOn(component, 'scrollToBottom').mockImplementation(() => {});
-
-        component.newMessageTextContent.set('Hello');
-        chatService.switchTo(ChatServiceMode.COURSE, 123);
-        await fixture.whenStable();
-
-        // when – send pins to the bottom, then an error arrives without any stage starting
-        component.onSend();
-        expect(component['forcePinToBottom']).toBe(true);
-        errorSubject.next(IrisErrorMessageKey.SESSION_LOAD_FAILED);
-        fixture.detectChanges();
-
-        // then – the pin is released and the RAF loop is stopped
-        expect(component['forcePinToBottom']).toBe(false);
-        expect(component['pinScrollRafId']).toBeUndefined();
     });
 
     describe('live assistant draft streaming UX', () => {
@@ -553,54 +443,71 @@ describe('IrisBaseChatbotComponent', () => {
             expect(component['liveDraftAnimationIntervalId']).toBeUndefined();
         });
 
-        it('should scroll the draft into view once on appearance without bottom scrolling on growth or finalization', () => {
+        it('should not scroll at all when the draft appears', () => {
             vi.useFakeTimers();
-            const draftScrollSpy = vi.spyOn(component as any, 'scrollLiveAssistantDraftIntoView');
             const bottomScrollSpy = vi.spyOn(component, 'scrollToBottom').mockImplementation(() => {});
-
-            pushDraft('run-1', 'First partial');
-            vi.advanceTimersByTime(0);
-
-            expect(draftScrollSpy).toHaveBeenCalledOnce();
-            expect(bottomScrollSpy).not.toHaveBeenCalled();
-
-            pushDraft('run-1', 'First partial with more text');
-            vi.advanceTimersByTime(0);
-
-            expect(draftScrollSpy).toHaveBeenCalledOnce();
-            expect(bottomScrollSpy).not.toHaveBeenCalled();
-
-            chatService.liveAssistantDraft.next(undefined);
-            chatService.messages.next([finalAssistantMessage('Final answer')]);
-            fixture.detectChanges();
-            vi.advanceTimersByTime(0);
-
-            expect(draftScrollSpy).toHaveBeenCalledOnce();
-            expect(bottomScrollSpy).not.toHaveBeenCalled();
-        });
-
-        it('should scroll only the chat body when bringing the draft into view, never ancestor scroll containers', () => {
-            vi.useFakeTimers();
-            // jsdom has no scrollIntoView; install a spy so a regression to it is caught.
             const scrollIntoViewSpy = vi.fn();
             (Element.prototype as any).scrollIntoView = scrollIntoViewSpy;
-            const containerScrollSpy = vi.fn();
+            (HTMLElement.prototype as any).scrollIntoView = scrollIntoViewSpy;
 
             try {
                 pushDraft('run-1', 'First partial');
-                // The .messages container only renders once a draft (or message) exists;
-                // the draft scroll is deferred via setTimeout, so spy before flushing it.
                 const messagesContainer: HTMLElement = fixture.nativeElement.querySelector('.messages');
+                const containerScrollSpy = vi.fn();
                 messagesContainer.scrollTo = containerScrollSpy;
                 vi.advanceTimersByTime(0);
 
-                // scrollIntoView() also scrolls ancestor containers (the whole page in the
-                // full-page course chat) — the draft scroll must stay inside the chat body.
+                expect(containerScrollSpy).not.toHaveBeenCalled();
+                expect(bottomScrollSpy).not.toHaveBeenCalled();
                 expect(scrollIntoViewSpy).not.toHaveBeenCalled();
-                expect(containerScrollSpy).toHaveBeenCalled();
             } finally {
                 delete (Element.prototype as any).scrollIntoView;
+                delete (HTMLElement.prototype as any).scrollIntoView;
             }
+        });
+
+        it('should size the exchange spacer exactly while anchored and shrink only after finalization', () => {
+            const userMessage = mockUserMessageWithContent('Anchored question');
+            chatService.messages.next([userMessage]);
+            fixture.detectChanges();
+
+            const messagesElement = fixture.nativeElement.querySelector('.messages') as HTMLElement;
+            const anchorElement = messagesElement.querySelector(`[data-message-id="${userMessage.id}"]`) as HTMLElement;
+            const spacerElement = messagesElement.querySelector('.stream-exchange-spacer') as HTMLElement;
+            messagesElement.scrollTop = 40;
+            Object.defineProperty(messagesElement, 'clientHeight', { value: 500, configurable: true });
+            Object.defineProperty(messagesElement, 'scrollHeight', { value: 600, configurable: true });
+            messagesElement.getBoundingClientRect = vi.fn(() => ({ top: 10 }) as DOMRect);
+            anchorElement.getBoundingClientRect = vi.fn(() => ({ top: 210 }) as DOMRect);
+            Object.defineProperty(spacerElement, 'offsetHeight', { value: 0, configurable: true });
+            component['anchoredMessageId'] = userMessage.id;
+            component['exchangeAnchorActive'] = true;
+
+            component['updateExchangeSpacer']();
+
+            expect(component.exchangeSpacerPx()).toBe(140);
+
+            Object.defineProperty(messagesElement, 'scrollHeight', { value: 560, configurable: true });
+            Object.defineProperty(spacerElement, 'offsetHeight', { value: 140, configurable: true });
+
+            component['updateExchangeSpacer']();
+
+            expect(component.exchangeSpacerPx()).toBe(320);
+
+            component['exchangeAnchorActive'] = false;
+            Object.defineProperty(messagesElement, 'scrollHeight', { value: 760, configurable: true });
+            Object.defineProperty(spacerElement, 'offsetHeight', { value: 320, configurable: true });
+
+            component['updateExchangeSpacer']();
+
+            expect(component.exchangeSpacerPx()).toBe(300);
+
+            Object.defineProperty(messagesElement, 'scrollHeight', { value: 700, configurable: true });
+            Object.defineProperty(spacerElement, 'offsetHeight', { value: 300, configurable: true });
+
+            component['updateExchangeSpacer']();
+
+            expect(component.exchangeSpacerPx()).toBe(300);
         });
 
         it('should not bottom-scroll when thinking status updates while a draft is visible', () => {

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
@@ -1139,13 +1139,18 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
     }
 
     scrollLiveAssistantDraftIntoView(behavior: ScrollBehavior = 'smooth'): void {
-        const draftElement = this.liveAssistantDraftElement()?.nativeElement;
-        if (!draftElement) {
+        const container: HTMLElement | undefined = this.messagesElement()?.nativeElement;
+        const draftElement: HTMLElement | undefined = this.liveAssistantDraftElement()?.nativeElement;
+        if (!container || !draftElement) {
             return;
         }
-        draftElement.scrollIntoView({
-            block: 'start',
-            inline: 'nearest',
+        // Scroll only the chat body. scrollIntoView() would also scroll every scrollable
+        // ancestor — in the full-page course chat that drags the whole page along, shoving
+        // the input bar up and leaving dead space below it.
+        const containerRect = container.getBoundingClientRect();
+        const draftRect = draftElement.getBoundingClientRect();
+        container.scrollTo({
+            top: Math.max(0, container.scrollTop + (draftRect.top - containerRect.top)),
             behavior,
         });
     }

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
@@ -216,6 +216,7 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
     readonly suggestions = toSignal(this.chatService.currentSuggestions(), { initialValue: [] as string[] });
     readonly error = toSignal(this.chatService.currentError(), { initialValue: undefined });
     readonly numNewMessages = toSignal(this.chatService.currentNumNewMessages(), { initialValue: 0 });
+    readonly liveAssistantDraft = toSignal(this.chatService.currentLiveAssistantDraft(), { initialValue: undefined });
     readonly rateLimitInfo = toSignal(this.statusService.currentRatelimitInfo(), { requireSync: true });
     readonly active = toSignal(this.statusService.getActiveStatus(), { initialValue: true });
     readonly citationInfo = toSignal(this.chatService.currentCitationInfo(), { initialValue: [] as IrisCitationMetaDTO[] });
@@ -239,8 +240,8 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
         const active = stages.find((s) => s.state === IrisStageStateDTO.IN_PROGRESS && s.chatMessage);
         return active?.chatMessage;
     });
-    readonly isEmptyState = computed(() => !this.messages()?.length && !this.isEmbeddedChat());
-    readonly hasCurrentSessionContent = computed(() => (this.messages()?.length ?? 0) > 0);
+    readonly isEmptyState = computed(() => !this.messages()?.length && !this.liveAssistantDraft() && !this.isEmbeddedChat());
+    readonly hasCurrentSessionContent = computed(() => (this.messages()?.length ?? 0) > 0 || !!this.liveAssistantDraft());
     readonly hasSessionSwitcher = computed(
         () => (this.layout() === 'widget' || this.layout() === 'embedded') && this.showWidgetHeader() && (this.hasCurrentSessionContent() || this.hasPastSessions()),
     );
@@ -596,7 +597,7 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
         // initial gap between send and the first websocket update doesn't release early.
         // A genuine upward gesture also releases it (see onMessagesUserScroll).
         effect(() => {
-            const streaming = this.hasActiveStage() || !!this.activeChatMessage();
+            const streaming = this.hasActiveStage() || !!this.activeChatMessage() || !!this.liveAssistantDraft();
             if (this.forcePinToBottom) {
                 if (streaming) {
                     this.pinSawStreaming = true;
@@ -619,6 +620,13 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
         // Scroll when thinking bubble appears, if the user is at the bottom or just sent a message
         effect(() => {
             if (this.activeChatMessage() && (this.forcePinToBottom || this.isScrolledToBottom())) {
+                this.scrollToBottom(this.forcePinToBottom ? 'auto' : 'smooth');
+            }
+        });
+
+        // Scroll while a streamed assistant draft grows, if the user is at the bottom or just sent a message.
+        effect(() => {
+            if (this.liveAssistantDraft() && (this.forcePinToBottom || this.isScrolledToBottom())) {
                 this.scrollToBottom(this.forcePinToBottom ? 'auto' : 'smooth');
             }
         });

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
@@ -307,16 +307,10 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
             !this.hasActiveStage(),
     );
     readonly isScrolledToBottom = signal(true);
-    // While true, the view is force-kept at the bottom as new content (the echoed user
-    // message, the thinking bubble, the streamed response) arrives asynchronously after a
-    // send. It is set on send and cleared only by a genuine upward user gesture (wheel /
-    // touch) so the scroll handler's intermediate readings cannot un-pin us mid-stream.
-    private forcePinToBottom = false;
-    // Tracks whether the response stream has actually started since the last send, so the
-    // pin is not released during the initial gap before the first websocket update arrives.
-    private pinSawStreaming = false;
-    // requestAnimationFrame id for the active post-send pin scroll loop, if any.
-    private pinScrollRafId: number | undefined;
+    readonly exchangeSpacerPx = signal(0);
+    private pendingAnchorScroll = false;
+    private anchoredMessageId: number | undefined;
+    private exchangeAnchorActive = false;
     // requestAnimationFrame id and remaining-frame counter for the initial-load settle scroll.
     private settleScrollRafId: number | undefined;
     private settleScrollFrames = 0;
@@ -324,9 +318,7 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
     private liveAssistantDraftTargetText = '';
     private liveAssistantDraftRunId: string | undefined;
     private pendingFinalizedLiveAssistantDraftRunId: string | undefined;
-    private lastScrolledLiveAssistantDraftRunId: string | undefined;
     private liveDraftAnimationIntervalId: ReturnType<typeof setInterval> | undefined;
-    private liveDraftScrollTimeoutId: ReturnType<typeof setTimeout> | undefined;
     private draftSwapScrollRafId: number | undefined;
     readonly resendAnimationActive = signal(false);
     readonly clickedSuggestion = signal<string | undefined>(undefined);
@@ -367,7 +359,6 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
 
     // ViewChilds
     readonly messagesElement = viewChild<ElementRef>('messagesElement');
-    readonly liveAssistantDraftElement = viewChild<ElementRef<HTMLElement>>('liveAssistantDraftElement');
     readonly messageTextarea = viewChild<ElementRef<HTMLTextAreaElement>>('messageTextarea');
     readonly acceptButton = viewChild<ElementRef<HTMLButtonElement>>('acceptButton');
 
@@ -555,6 +546,10 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
                 this.animatingMessageIds.set(new Set<number>());
                 this.shouldAnimate = false;
                 this.isScrolledToBottom.set(true);
+                this.pendingAnchorScroll = false;
+                this.anchoredMessageId = undefined;
+                this.exchangeAnchorActive = false;
+                this.exchangeSpacerPx.set(0);
                 const timeoutId = setTimeout(() => (this.shouldAnimate = true));
                 onCleanup(() => clearTimeout(timeoutId));
             }
@@ -576,14 +571,18 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
                 // settling scroll to land exactly at the bottom instead of a tiny bit short.
                 const isInitialLoad = this.previousMessageCount === 0 && rawMessages.length > 0;
                 if (isDraftFinalization) {
-                    this.releasePinToBottom();
+                    this.exchangeAnchorActive = false;
                     this.pendingFinalizedLiveAssistantDraftRunId = undefined;
                     this.liveAssistantDraftRunId = undefined;
                     this.preserveScrollAcrossDraftSwap();
-                } else if (this.forcePinToBottom) {
-                    // Just sent a message: instant scroll so we stay glued to the bottom as
-                    // the echoed message / response grow the content (no smooth-scroll race).
-                    this.scrollToBottom('auto');
+                } else if (this.pendingAnchorScroll && rawMessages.length > this.previousMessageCount) {
+                    const lastMessage = rawMessages.at(-1);
+                    if (lastMessage?.sender === IrisSender.USER && lastMessage.id !== undefined) {
+                        this.pendingAnchorScroll = false;
+                        this.anchoredMessageId = lastMessage.id;
+                        this.exchangeAnchorActive = true;
+                        setTimeout(() => this.scrollAnchoredMessageToTop());
+                    }
                 } else if (isInitialLoad && this.isScrolledToBottom()) {
                     this.scrollToBottomSettled();
                 } else if (this.isScrolledToBottom() && !this.isSuggestionAnimating()) {
@@ -621,41 +620,26 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
             }
         });
 
-        // Release the post-send bottom pin once the response stream has settled. We only
-        // release after the exchange has actually started (a stage went active), so the
-        // initial gap between send and the first websocket update doesn't release early.
-        // A genuine upward gesture also releases it (see onMessagesUserScroll).
+        // Scroll when thinking bubble appears for flows that start without an explicit send.
         effect(() => {
-            const streaming = this.hasActiveStage() || !!this.activeChatMessage();
-            if (this.forcePinToBottom) {
-                if (streaming) {
-                    this.pinSawStreaming = true;
-                } else if (this.pinSawStreaming) {
-                    this.releasePinToBottom();
-                }
+            if (this.activeChatMessage() && !this.liveAssistantDraft() && this.isScrolledToBottom()) {
+                this.scrollToBottom('smooth');
             }
         });
 
-        // Release the pin (and stop the RAF loop) if the send fails before the stream ever
-        // starts. Without a stage going active, pinSawStreaming stays false, so the settle
-        // effect above can never release — the loop would otherwise spin forever. This path
-        // only fires on a genuine error signal, never during the normal pre-stream gap.
-        effect(() => {
-            if (this.error() && this.forcePinToBottom && !this.pinSawStreaming) {
-                this.releasePinToBottom();
-            }
-        });
-
-        // Scroll when thinking bubble appears, if the user is at the bottom or just sent a message
-        effect(() => {
-            if (this.activeChatMessage() && !this.liveAssistantDraft() && (this.forcePinToBottom || this.isScrolledToBottom())) {
-                this.scrollToBottom(this.forcePinToBottom ? 'auto' : 'smooth');
-            }
-        });
-
-        // Drive streamed assistant draft display and scroll only once when a new draft appears.
+        // Drive streamed assistant draft display.
         effect(() => {
             this.handleLiveAssistantDraftChange(this.liveAssistantDraft());
+        });
+
+        // Keep enough room below the anchored user message while streaming content changes height.
+        effect((onCleanup) => {
+            this.rawMessages();
+            this.displayedLiveAssistantDraftText();
+            this.activeChatMessage();
+            this.canShowSuggestions();
+            const rafId = window.requestAnimationFrame(() => this.updateExchangeSpacer());
+            onCleanup(() => window.cancelAnimationFrame(rafId));
         });
 
         // Reset clicked suggestion when new suggestions arrive and scroll to show them
@@ -684,7 +668,6 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
             }
         }, 150);
         this.destroyRef.onDestroy(() => clearTimeout(focusTimeoutId));
-        this.destroyRef.onDestroy(() => this.releasePinToBottom());
         this.destroyRef.onDestroy(() => this.resetLiveAssistantDraftState());
         this.destroyRef.onDestroy(() => {
             if (this.draftSwapScrollRafId !== undefined) {
@@ -860,28 +843,12 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
                         this.isLoading.set(false);
                     },
                     error: () => {
-                        // Send failed before any stage started: release the bottom pin and stop
-                        // the RAF loop here, since no stream will arrive to settle it (the
-                        // pinSawStreaming release path never runs). Done only on the send error,
-                        // not during the normal pre-stream gap.
                         this.isLoading.set(false);
-                        if (!this.pinSawStreaming) {
-                            this.releasePinToBottom();
-                        }
                     },
                 });
             this.newMessageTextContent.set('');
-            // User explicitly sent a message: follow it to the bottom and keep the view
-            // pinned there while the echoed message, thinking bubble and streamed response
-            // arrive asynchronously via WebSocket. Pinning is released by a real upward
-            // gesture (see onMessagesUserScroll).
-            this.forcePinToBottom = true;
-            this.pinSawStreaming = false;
-            this.isScrolledToBottom.set(true);
-            this.scrollToBottom('auto');
-            // Keep following the bottom frame-by-frame as the message, thinking bubble and
-            // response render asynchronously, so the user is taken down as soon as they appear.
-            this.startPinScrollLoop();
+            // The echoed user message renders asynchronously; anchor it after the DOM exists.
+            this.pendingAnchorScroll = true;
         }
         this.resetChatBodyHeight();
     }
@@ -1007,7 +974,7 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
      */
     private preserveScrollAcrossDraftSwap(): void {
         const container = this.messagesElement()?.nativeElement as HTMLElement | undefined;
-        if (!container || this.forcePinToBottom) {
+        if (!container) {
             return;
         }
         const scrollTopBeforeSwap = container.scrollTop;
@@ -1033,7 +1000,6 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
                 this.pendingFinalizedLiveAssistantDraftRunId = this.liveAssistantDraftRunId;
             }
             this.clearLiveAssistantDraftAnimation();
-            this.clearLiveAssistantDraftScrollTimeout();
             this.liveAssistantDraftRunId = undefined;
             return;
         }
@@ -1044,8 +1010,6 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
             this.pendingFinalizedLiveAssistantDraftRunId = undefined;
             this.liveAssistantDraftTargetText = '';
             this.displayedLiveAssistantDraftText.set('');
-            this.releasePinToBottom();
-            this.scheduleLiveAssistantDraftScroll(draft.runId);
         }
 
         this.updateLiveAssistantDraftTargetText(draft.text);
@@ -1113,46 +1077,54 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
 
     private resetLiveAssistantDraftState(): void {
         this.clearLiveAssistantDraftAnimation();
-        this.clearLiveAssistantDraftScrollTimeout();
         this.liveAssistantDraftRunId = undefined;
         this.pendingFinalizedLiveAssistantDraftRunId = undefined;
-        this.lastScrolledLiveAssistantDraftRunId = undefined;
     }
 
-    private scheduleLiveAssistantDraftScroll(runId: string): void {
-        if (this.lastScrolledLiveAssistantDraftRunId === runId) {
-            return;
-        }
-        this.lastScrolledLiveAssistantDraftRunId = runId;
-        this.clearLiveAssistantDraftScrollTimeout();
-        this.liveDraftScrollTimeoutId = setTimeout(() => {
-            this.liveDraftScrollTimeoutId = undefined;
-            this.scrollLiveAssistantDraftIntoView();
-        });
-    }
-
-    private clearLiveAssistantDraftScrollTimeout(): void {
-        if (this.liveDraftScrollTimeoutId !== undefined) {
-            clearTimeout(this.liveDraftScrollTimeoutId);
-            this.liveDraftScrollTimeoutId = undefined;
-        }
-    }
-
-    scrollLiveAssistantDraftIntoView(behavior: ScrollBehavior = 'smooth'): void {
+    private scrollAnchoredMessageToTop(): void {
         const container: HTMLElement | undefined = this.messagesElement()?.nativeElement;
-        const draftElement: HTMLElement | undefined = this.liveAssistantDraftElement()?.nativeElement;
-        if (!container || !draftElement) {
+        const anchorElement = container ? this.findAnchoredMessageElement(container) : undefined;
+        if (!container || !anchorElement) {
             return;
         }
-        // Scroll only the chat body. scrollIntoView() would also scroll every scrollable
-        // ancestor — in the full-page course chat that drags the whole page along, shoving
-        // the input bar up and leaving dead space below it.
-        const containerRect = container.getBoundingClientRect();
-        const draftRect = draftElement.getBoundingClientRect();
+        this.updateExchangeSpacer();
         container.scrollTo({
-            top: Math.max(0, container.scrollTop + (draftRect.top - containerRect.top)),
-            behavior,
+            top: this.getAnchorTop(container, anchorElement),
+            behavior: 'smooth',
         });
+    }
+
+    private updateExchangeSpacer(): void {
+        const container: HTMLElement | undefined = this.messagesElement()?.nativeElement;
+        const spacerElement = container?.querySelector<HTMLElement>('.stream-exchange-spacer');
+        const anchorElement = container ? this.findAnchoredMessageElement(container) : undefined;
+        if (!container || !spacerElement || !anchorElement) {
+            return;
+        }
+
+        const contentSansSpacer = container.scrollHeight - spacerElement.offsetHeight;
+        const needed = Math.max(0, this.getAnchorTop(container, anchorElement) + container.clientHeight - contentSansSpacer);
+        const nextHeight = this.exchangeAnchorActive ? needed : Math.min(spacerElement.offsetHeight, needed);
+        this.setExchangeSpacerHeight(spacerElement, nextHeight);
+    }
+
+    private findAnchoredMessageElement(container: HTMLElement): HTMLElement | undefined {
+        if (this.anchoredMessageId === undefined) {
+            return undefined;
+        }
+        return container.querySelector<HTMLElement>(`[data-message-id="${this.anchoredMessageId}"]`) ?? undefined;
+    }
+
+    private getAnchorTop(container: HTMLElement, anchorElement: HTMLElement): number {
+        const containerRect = container.getBoundingClientRect();
+        const anchorRect = anchorElement.getBoundingClientRect();
+        return anchorRect.top - containerRect.top + container.scrollTop;
+    }
+
+    private setExchangeSpacerHeight(spacerElement: HTMLElement, height: number): void {
+        const normalizedHeight = Math.max(0, height);
+        this.exchangeSpacerPx.set(normalizedHeight);
+        spacerElement.style.height = `${normalizedHeight}px`;
     }
 
     /**
@@ -1195,38 +1167,6 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
             }
         };
         this.settleScrollRafId = window.requestAnimationFrame(settle);
-    }
-
-    /**
-     * While the post-send pin is active, keep the view glued to the bottom on every animation
-     * frame. The user message, thinking bubble and streamed response all render asynchronously
-     * after onSend(); a single scroll call would run before they exist, so we follow the growing
-     * content frame-by-frame until the pin is released (gesture or stream settled).
-     */
-    private startPinScrollLoop() {
-        if (this.pinScrollRafId !== undefined) return;
-        const step = () => {
-            if (!this.forcePinToBottom) {
-                this.pinScrollRafId = undefined;
-                return;
-            }
-            const messagesElement: HTMLElement | undefined = this.messagesElement()?.nativeElement;
-            if (messagesElement) {
-                messagesElement.scrollTop = messagesElement.scrollHeight;
-            }
-            this.pinScrollRafId = window.requestAnimationFrame(step);
-        };
-        this.pinScrollRafId = window.requestAnimationFrame(step);
-    }
-
-    /** Releases the post-send bottom pin and stops the frame-by-frame scroll loop. */
-    private releasePinToBottom() {
-        this.forcePinToBottom = false;
-        this.pinSawStreaming = false;
-        if (this.pinScrollRafId !== undefined) {
-            window.cancelAnimationFrame(this.pinScrollRafId);
-            this.pinScrollRafId = undefined;
-        }
     }
 
     /**
@@ -1332,26 +1272,8 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
     checkChatScroll() {
         const messagesElement = this.messagesElement()?.nativeElement;
         if (!messagesElement) return;
-        // While pinned (just after a send), ignore intermediate scroll readings produced by
-        // programmatic scrolling and async content growth so they cannot un-pin the view.
-        if (this.forcePinToBottom) {
-            this.isScrolledToBottom.set(true);
-            return;
-        }
         const { scrollTop, scrollHeight, clientHeight } = messagesElement;
         this.isScrolledToBottom.set(scrollTop >= scrollHeight - clientHeight - 50);
-    }
-
-    /**
-     * Handles a genuine upward scroll gesture (wheel up or touch drag) from the user.
-     * Releases the post-send bottom pin so the user can freely scroll the history.
-     */
-    onMessagesUserScroll(event: WheelEvent | TouchEvent) {
-        if (!this.forcePinToBottom) return;
-        // Wheel up (deltaY < 0) or any touch drag means the user wants to leave the bottom.
-        if (event instanceof WheelEvent && event.deltaY >= 0) return;
-        this.releasePinToBottom();
-        this.checkChatScroll();
     }
 
     onSuggestionClick(suggestion: string) {

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
@@ -62,7 +62,7 @@ import {
 import { IrisMcqQuestionComponent } from 'app/iris/overview/mcq-question/iris-mcq-question.component';
 import { IrisMcqCarouselComponent } from 'app/iris/overview/mcq-question/iris-mcq-carousel.component';
 import { AccountService } from 'app/core/auth/account.service';
-import { ChatServiceMode, IrisChatService } from 'app/iris/overview/services/iris-chat.service';
+import { ChatServiceMode, IrisChatService, IrisLiveAssistantDraft } from 'app/iris/overview/services/iris-chat.service';
 import { IrisChatHttpService } from 'app/iris/overview/services/iris-chat-http.service';
 import * as _ from 'lodash-es';
 import { IrisCitationMetaDTO } from 'app/iris/shared/entities/iris-citation-meta-dto.model';
@@ -110,6 +110,10 @@ const COPY_FEEDBACK_DURATION_MS = 1500;
 // Interval (in ms) between placeholder label cycling
 const PLACEHOLDER_CYCLE_INTERVAL_MS = 5000;
 const PLACEHOLDER_FADE_DURATION_MS = 300;
+
+// Interval (in ms) for client-side streamed draft reveal.
+const LIVE_DRAFT_ANIMATION_TICK_MS = 50;
+const LIVE_DRAFT_CATCH_UP_MS = 400;
 
 @Component({
     selector: 'jhi-iris-base-chatbot',
@@ -316,6 +320,13 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
     // requestAnimationFrame id and remaining-frame counter for the initial-load settle scroll.
     private settleScrollRafId: number | undefined;
     private settleScrollFrames = 0;
+    readonly displayedLiveAssistantDraftText = signal('');
+    private liveAssistantDraftTargetText = '';
+    private liveAssistantDraftRunId: string | undefined;
+    private pendingFinalizedLiveAssistantDraftRunId: string | undefined;
+    private lastScrolledLiveAssistantDraftRunId: string | undefined;
+    private liveDraftAnimationIntervalId: ReturnType<typeof setInterval> | undefined;
+    private liveDraftScrollTimeoutId: ReturnType<typeof setTimeout> | undefined;
     readonly resendAnimationActive = signal(false);
     readonly clickedSuggestion = signal<string | undefined>(undefined);
     private readonly isSuggestionAnimating = signal(false);
@@ -355,6 +366,7 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
 
     // ViewChilds
     readonly messagesElement = viewChild<ElementRef>('messagesElement');
+    readonly liveAssistantDraftElement = viewChild<ElementRef<HTMLElement>>('liveAssistantDraftElement');
     readonly messageTextarea = viewChild<ElementRef<HTMLTextAreaElement>>('messageTextarea');
     readonly acceptButton = viewChild<ElementRef<HTMLButtonElement>>('acceptButton');
 
@@ -538,6 +550,7 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
         effect((onCleanup) => {
             const sessionId = this.currentSessionId();
             if (this.previousSessionId !== sessionId) {
+                this.resetLiveAssistantDraftState();
                 this.animatingMessageIds.set(new Set<number>());
                 this.shouldAnimate = false;
                 this.isScrolledToBottom.set(true);
@@ -551,11 +564,19 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
         effect((onCleanup) => {
             const rawMessages = this.rawMessages();
             if (rawMessages.length !== this.previousMessageCount) {
+                const isDraftFinalization =
+                    rawMessages.length > this.previousMessageCount &&
+                    !this.liveAssistantDraft() &&
+                    (this.liveAssistantDraftRunId !== undefined || this.pendingFinalizedLiveAssistantDraftRunId !== undefined);
                 // Initial history load (e.g. after a page refresh): the batch lands at once and
                 // its content keeps growing the scroll height for several frames, so use the
                 // settling scroll to land exactly at the bottom instead of a tiny bit short.
                 const isInitialLoad = this.previousMessageCount === 0 && rawMessages.length > 0;
-                if (this.forcePinToBottom) {
+                if (isDraftFinalization) {
+                    this.releasePinToBottom();
+                    this.pendingFinalizedLiveAssistantDraftRunId = undefined;
+                    this.liveAssistantDraftRunId = undefined;
+                } else if (this.forcePinToBottom) {
                     // Just sent a message: instant scroll so we stay glued to the bottom as
                     // the echoed message / response grow the content (no smooth-scroll race).
                     this.scrollToBottom('auto');
@@ -597,7 +618,7 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
         // initial gap between send and the first websocket update doesn't release early.
         // A genuine upward gesture also releases it (see onMessagesUserScroll).
         effect(() => {
-            const streaming = this.hasActiveStage() || !!this.activeChatMessage() || !!this.liveAssistantDraft();
+            const streaming = this.hasActiveStage() || !!this.activeChatMessage();
             if (this.forcePinToBottom) {
                 if (streaming) {
                     this.pinSawStreaming = true;
@@ -619,16 +640,14 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
 
         // Scroll when thinking bubble appears, if the user is at the bottom or just sent a message
         effect(() => {
-            if (this.activeChatMessage() && (this.forcePinToBottom || this.isScrolledToBottom())) {
+            if (this.activeChatMessage() && !this.liveAssistantDraft() && (this.forcePinToBottom || this.isScrolledToBottom())) {
                 this.scrollToBottom(this.forcePinToBottom ? 'auto' : 'smooth');
             }
         });
 
-        // Scroll while a streamed assistant draft grows, if the user is at the bottom or just sent a message.
+        // Drive streamed assistant draft display and scroll only once when a new draft appears.
         effect(() => {
-            if (this.liveAssistantDraft() && (this.forcePinToBottom || this.isScrolledToBottom())) {
-                this.scrollToBottom(this.forcePinToBottom ? 'auto' : 'smooth');
-            }
+            this.handleLiveAssistantDraftChange(this.liveAssistantDraft());
         });
 
         // Reset clicked suggestion when new suggestions arrive and scroll to show them
@@ -658,6 +677,7 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
         }, 150);
         this.destroyRef.onDestroy(() => clearTimeout(focusTimeoutId));
         this.destroyRef.onDestroy(() => this.releasePinToBottom());
+        this.destroyRef.onDestroy(() => this.resetLiveAssistantDraftState());
         this.destroyRef.onDestroy(() => {
             if (this.settleScrollRafId !== undefined) {
                 window.cancelAnimationFrame(this.settleScrollRafId);
@@ -964,6 +984,129 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
         this.copyResetTimeoutId = setTimeout(() => {
             this.copiedMessageKey.set(undefined);
         }, COPY_FEEDBACK_DURATION_MS);
+    }
+
+    private handleLiveAssistantDraftChange(draft: IrisLiveAssistantDraft | undefined): void {
+        if (!draft) {
+            if (this.liveAssistantDraftRunId !== undefined) {
+                this.pendingFinalizedLiveAssistantDraftRunId = this.liveAssistantDraftRunId;
+            }
+            this.clearLiveAssistantDraftAnimation();
+            this.clearLiveAssistantDraftScrollTimeout();
+            this.liveAssistantDraftRunId = undefined;
+            return;
+        }
+
+        const isNewRun = draft.runId !== this.liveAssistantDraftRunId;
+        if (isNewRun) {
+            this.liveAssistantDraftRunId = draft.runId;
+            this.pendingFinalizedLiveAssistantDraftRunId = undefined;
+            this.liveAssistantDraftTargetText = '';
+            this.displayedLiveAssistantDraftText.set('');
+            this.releasePinToBottom();
+            this.scheduleLiveAssistantDraftScroll(draft.runId);
+        }
+
+        this.updateLiveAssistantDraftTargetText(draft.text);
+    }
+
+    private updateLiveAssistantDraftTargetText(text: string): void {
+        const displayedText = this.displayedLiveAssistantDraftText();
+        const displayedLength = Array.from(displayedText).length;
+        const targetLength = Array.from(text).length;
+
+        if (targetLength < displayedLength) {
+            this.liveAssistantDraftTargetText = displayedText;
+        } else {
+            this.liveAssistantDraftTargetText = text;
+            if (targetLength === displayedLength && text !== displayedText) {
+                this.displayedLiveAssistantDraftText.set(text);
+            }
+        }
+
+        if (Array.from(this.liveAssistantDraftTargetText).length > Array.from(this.displayedLiveAssistantDraftText()).length) {
+            this.ensureLiveAssistantDraftAnimationLoop();
+        } else {
+            this.stopLiveAssistantDraftAnimationLoop();
+        }
+    }
+
+    private ensureLiveAssistantDraftAnimationLoop(): void {
+        if (this.liveDraftAnimationIntervalId !== undefined) {
+            return;
+        }
+        this.liveDraftAnimationIntervalId = setInterval(() => this.advanceLiveAssistantDraftAnimation(), LIVE_DRAFT_ANIMATION_TICK_MS);
+    }
+
+    private advanceLiveAssistantDraftAnimation(): void {
+        const displayedCodePoints = Array.from(this.displayedLiveAssistantDraftText());
+        const targetCodePoints = Array.from(this.liveAssistantDraftTargetText);
+        const remainingCharacters = targetCodePoints.length - displayedCodePoints.length;
+        if (remainingCharacters <= 0) {
+            this.stopLiveAssistantDraftAnimationLoop();
+            return;
+        }
+
+        const ticksPerSnapshot = LIVE_DRAFT_CATCH_UP_MS / LIVE_DRAFT_ANIMATION_TICK_MS;
+        const charactersToReveal = Math.max(1, Math.ceil(remainingCharacters / ticksPerSnapshot));
+        const nextLength = Math.min(targetCodePoints.length, displayedCodePoints.length + charactersToReveal);
+        this.displayedLiveAssistantDraftText.set(targetCodePoints.slice(0, nextLength).join(''));
+
+        if (nextLength >= targetCodePoints.length) {
+            this.stopLiveAssistantDraftAnimationLoop();
+        }
+    }
+
+    private clearLiveAssistantDraftAnimation(): void {
+        this.stopLiveAssistantDraftAnimationLoop();
+        this.liveAssistantDraftTargetText = '';
+        this.displayedLiveAssistantDraftText.set('');
+    }
+
+    private stopLiveAssistantDraftAnimationLoop(): void {
+        if (this.liveDraftAnimationIntervalId !== undefined) {
+            clearInterval(this.liveDraftAnimationIntervalId);
+            this.liveDraftAnimationIntervalId = undefined;
+        }
+    }
+
+    private resetLiveAssistantDraftState(): void {
+        this.clearLiveAssistantDraftAnimation();
+        this.clearLiveAssistantDraftScrollTimeout();
+        this.liveAssistantDraftRunId = undefined;
+        this.pendingFinalizedLiveAssistantDraftRunId = undefined;
+        this.lastScrolledLiveAssistantDraftRunId = undefined;
+    }
+
+    private scheduleLiveAssistantDraftScroll(runId: string): void {
+        if (this.lastScrolledLiveAssistantDraftRunId === runId) {
+            return;
+        }
+        this.lastScrolledLiveAssistantDraftRunId = runId;
+        this.clearLiveAssistantDraftScrollTimeout();
+        this.liveDraftScrollTimeoutId = setTimeout(() => {
+            this.liveDraftScrollTimeoutId = undefined;
+            this.scrollLiveAssistantDraftIntoView();
+        });
+    }
+
+    private clearLiveAssistantDraftScrollTimeout(): void {
+        if (this.liveDraftScrollTimeoutId !== undefined) {
+            clearTimeout(this.liveDraftScrollTimeoutId);
+            this.liveDraftScrollTimeoutId = undefined;
+        }
+    }
+
+    scrollLiveAssistantDraftIntoView(behavior: ScrollBehavior = 'smooth'): void {
+        const draftElement = this.liveAssistantDraftElement()?.nativeElement;
+        if (!draftElement) {
+            return;
+        }
+        draftElement.scrollIntoView({
+            block: 'start',
+            inline: 'nearest',
+            behavior,
+        });
     }
 
     /**

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
@@ -583,6 +583,17 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
                         this.exchangeAnchorActive = true;
                         setTimeout(() => this.scrollAnchoredMessageToTop());
                     }
+                } else if (
+                    this.exchangeAnchorActive &&
+                    rawMessages.length > this.previousMessageCount &&
+                    !this.liveAssistantDraft() &&
+                    rawMessages.at(-1)?.sender === IrisSender.LLM
+                ) {
+                    // A non-streamed answer (response streaming disabled, or an older Pyris that only
+                    // sends the final MESSAGE) completes without a live draft ever existing, so the
+                    // draft-finalization branch above never runs. Release the anchor here so the
+                    // exchange spacer collapses instead of leaving blank space below the finished exchange.
+                    this.exchangeAnchorActive = false;
                 } else if (isInitialLoad && this.isScrolledToBottom()) {
                     this.scrollToBottomSettled();
                 } else if (this.isScrolledToBottom() && !this.isSuggestionAnimating()) {

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
@@ -564,11 +564,13 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
         // Handle message scroll on new messages
         effect((onCleanup) => {
             const rawMessages = this.rawMessages();
+            // A count increase landing exactly as the streamed draft disappeared is the
+            // draft's own finalization: the persisted message replacing the live bubble.
+            const isDraftFinalization =
+                rawMessages.length > this.previousMessageCount &&
+                !this.liveAssistantDraft() &&
+                (this.liveAssistantDraftRunId !== undefined || this.pendingFinalizedLiveAssistantDraftRunId !== undefined);
             if (rawMessages.length !== this.previousMessageCount) {
-                const isDraftFinalization =
-                    rawMessages.length > this.previousMessageCount &&
-                    !this.liveAssistantDraft() &&
-                    (this.liveAssistantDraftRunId !== undefined || this.pendingFinalizedLiveAssistantDraftRunId !== undefined);
                 // Initial history load (e.g. after a page refresh): the batch lands at once and
                 // its content keeps growing the scroll height for several frames, so use the
                 // settling scroll to land exactly at the bottom instead of a tiny bit short.
@@ -590,8 +592,12 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
                 const timeoutId = setTimeout(() => this.messageTextarea()?.nativeElement?.focus(), 10);
                 onCleanup(() => clearTimeout(timeoutId));
             }
-            // Track new messages for animation (compare against previous IDs, not current)
-            if (this.shouldAnimate) {
+            // Track new messages for animation (compare against previous IDs, not current).
+            // A message that finalizes a streamed draft must NOT get the entrance
+            // animation: its content is already fully visible in the draft bubble, and
+            // the animation renders it at height 0 (grid-template-rows: 0fr) growing to
+            // full size — collapsing the scroll content and snapping the viewport.
+            if (this.shouldAnimate && !isDraftFinalization) {
                 // Use untracked to read current value without creating a dependency
                 // (otherwise updating animatingMessageIds would retrigger this effect infinitely)
                 const newAnimatingIds = new Set(untracked(() => this.animatingMessageIds()));

--- a/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
+++ b/src/main/webapp/app/iris/overview/base-chatbot/iris-base-chatbot.component.ts
@@ -327,6 +327,7 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
     private lastScrolledLiveAssistantDraftRunId: string | undefined;
     private liveDraftAnimationIntervalId: ReturnType<typeof setInterval> | undefined;
     private liveDraftScrollTimeoutId: ReturnType<typeof setTimeout> | undefined;
+    private draftSwapScrollRafId: number | undefined;
     readonly resendAnimationActive = signal(false);
     readonly clickedSuggestion = signal<string | undefined>(undefined);
     private readonly isSuggestionAnimating = signal(false);
@@ -576,6 +577,7 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
                     this.releasePinToBottom();
                     this.pendingFinalizedLiveAssistantDraftRunId = undefined;
                     this.liveAssistantDraftRunId = undefined;
+                    this.preserveScrollAcrossDraftSwap();
                 } else if (this.forcePinToBottom) {
                     // Just sent a message: instant scroll so we stay glued to the bottom as
                     // the echoed message / response grow the content (no smooth-scroll race).
@@ -678,6 +680,11 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
         this.destroyRef.onDestroy(() => clearTimeout(focusTimeoutId));
         this.destroyRef.onDestroy(() => this.releasePinToBottom());
         this.destroyRef.onDestroy(() => this.resetLiveAssistantDraftState());
+        this.destroyRef.onDestroy(() => {
+            if (this.draftSwapScrollRafId !== undefined) {
+                window.cancelAnimationFrame(this.draftSwapScrollRafId);
+            }
+        });
         this.destroyRef.onDestroy(() => {
             if (this.settleScrollRafId !== undefined) {
                 window.cancelAnimationFrame(this.settleScrollRafId);
@@ -984,6 +991,34 @@ export class IrisBaseChatbotComponent implements AfterViewInit {
         this.copyResetTimeoutId = setTimeout(() => {
             this.copiedMessageKey.set(undefined);
         }, COPY_FEEDBACK_DURATION_MS);
+    }
+
+    /**
+     * Keeps the user's reading position stable while the ephemeral draft bubble is
+     * replaced by the persisted final message. The swap spans two render frames
+     * (message added, draft removed); restoring the captured scrollTop on the frames
+     * after the swap prevents the browser from clamping/shifting the viewport.
+     */
+    private preserveScrollAcrossDraftSwap(): void {
+        const container = this.messagesElement()?.nativeElement as HTMLElement | undefined;
+        if (!container || this.forcePinToBottom) {
+            return;
+        }
+        const scrollTopBeforeSwap = container.scrollTop;
+        let remainingFrames = 3;
+        const restore = () => {
+            container.scrollTop = scrollTopBeforeSwap;
+            remainingFrames -= 1;
+            if (remainingFrames > 0) {
+                this.draftSwapScrollRafId = window.requestAnimationFrame(restore);
+            } else {
+                this.draftSwapScrollRafId = undefined;
+            }
+        };
+        if (this.draftSwapScrollRafId !== undefined) {
+            window.cancelAnimationFrame(this.draftSwapScrollRafId);
+        }
+        this.draftSwapScrollRafId = window.requestAnimationFrame(restore);
     }
 
     private handleLiveAssistantDraftChange(draft: IrisLiveAssistantDraft | undefined): void {

--- a/src/main/webapp/app/iris/overview/services/iris-chat.service.spec.ts
+++ b/src/main/webapp/app/iris/overview/services/iris-chat.service.spec.ts
@@ -30,7 +30,7 @@ import 'app/foundation/util/array.extension';
 import { Router } from '@angular/router';
 import { IrisSessionDTO } from 'app/iris/shared/entities/iris-session-dto.model';
 import { IrisSession } from 'app/iris/shared/entities/iris-session.model';
-import { IrisChatWebsocketPayloadType } from 'app/iris/shared/entities/iris-chat-websocket-dto.model';
+import { IrisChatWebsocketDTO, IrisChatWebsocketPayloadType } from 'app/iris/shared/entities/iris-chat-websocket-dto.model';
 import { IrisStageDTO } from 'app/iris/shared/entities/iris-stage-dto.model';
 import { MockAccountService } from 'test/helpers/mocks/service/mock-account.service';
 import { User } from 'app/account/user/user.model';
@@ -64,6 +64,14 @@ describe('IrisChatService', () => {
     const waitForSessionIdValue = (expectedId: number) => firstValueFrom(service.currentSessionId().pipe(filter((value): value is number => value === expectedId)));
     const waitForCurrentChatMode = () => firstValueFrom(service.currentChatMode().pipe(filter((value): value is ChatServiceMode => value !== undefined)));
     const waitForCurrentRelatedEntityId = () => firstValueFrom(service.currentRelatedEntityId().pipe(filter((value): value is number => value !== undefined)));
+    const startSessionWithWebsocket = async (websocketSubject: Subject<IrisChatWebsocketDTO>) => {
+        vi.spyOn(httpService, 'getCurrentSessionOrCreateIfNotExists').mockReturnValue(of(mockServerSessionHttpResponseWithId(id)));
+        vi.spyOn(httpService, 'getChatSessions').mockReturnValue(of([]));
+        vi.spyOn(wsMock, 'subscribeToSession').mockReturnValue(websocketSubject.asObservable());
+
+        service.switchTo(ChatServiceMode.COURSE, id);
+        await waitForSessionId();
+    };
 
     beforeEach(() => {
         routerMock = { url: '' };
@@ -371,6 +379,49 @@ describe('IrisChatService', () => {
         expect(messages).toHaveLength(mockConversation.messages!.length + 1);
         const lastMessage = messages.last();
         expect(lastMessage).toMatchObject({ sender: message.sender, id: message.id, content: message.content });
+    });
+
+    it('should set live assistant draft from websocket partial without incrementing new message counter', async () => {
+        const websocketSubject = new Subject<IrisChatWebsocketDTO>();
+        await startSessionWithWebsocket(websocketSubject);
+
+        websocketSubject.next({ type: IrisChatWebsocketPayloadType.PARTIAL, runId: 'run-1', partialResult: 'Hel', partialSeq: 1 });
+
+        const draft = await firstValueFrom(service.currentLiveAssistantDraft());
+        expect(draft).toEqual({ runId: 'run-1', text: 'Hel' });
+        expect(await firstValueFrom(service.currentNumNewMessages())).toBe(0);
+    });
+
+    it('should ignore stale websocket partial sequence numbers', async () => {
+        const websocketSubject = new Subject<IrisChatWebsocketDTO>();
+        await startSessionWithWebsocket(websocketSubject);
+
+        websocketSubject.next({ type: IrisChatWebsocketPayloadType.PARTIAL, runId: 'run-1', partialResult: 'Hello', partialSeq: 2 });
+        websocketSubject.next({ type: IrisChatWebsocketPayloadType.PARTIAL, runId: 'run-1', partialResult: 'Hel', partialSeq: 1 });
+
+        expect(await firstValueFrom(service.currentLiveAssistantDraft())).toEqual({ runId: 'run-1', text: 'Hello' });
+    });
+
+    it('should clear live assistant draft on final websocket message and ignore later partials for the same run', async () => {
+        const websocketSubject = new Subject<IrisChatWebsocketDTO>();
+        await startSessionWithWebsocket(websocketSubject);
+
+        websocketSubject.next({ type: IrisChatWebsocketPayloadType.PARTIAL, runId: 'run-1', partialResult: 'Hello', partialSeq: 2 });
+        websocketSubject.next({ ...mockWebsocketServerMessage, runId: 'run-1' });
+        websocketSubject.next({ type: IrisChatWebsocketPayloadType.PARTIAL, runId: 'run-1', partialResult: 'late', partialSeq: 3 });
+
+        expect(await firstValueFrom(service.currentLiveAssistantDraft())).toBeUndefined();
+    });
+
+    it('should clear live assistant draft on session switch', async () => {
+        const websocketSubject = new Subject<IrisChatWebsocketDTO>();
+        await startSessionWithWebsocket(websocketSubject);
+        websocketSubject.next({ type: IrisChatWebsocketPayloadType.PARTIAL, runId: 'run-1', partialResult: 'Hello', partialSeq: 2 });
+
+        vi.spyOn(httpService, 'getCurrentSessionOrCreateIfNotExists').mockReturnValue(of(mockServerSessionHttpResponseWithId(id + 1)));
+        service.switchTo(ChatServiceMode.PROGRAMMING_EXERCISE, id + 1);
+
+        expect(await firstValueFrom(service.currentLiveAssistantDraft())).toBeUndefined();
     });
 
     it('should emit sessionId when set', async () => {

--- a/src/main/webapp/app/iris/overview/services/iris-chat.service.ts
+++ b/src/main/webapp/app/iris/overview/services/iris-chat.service.ts
@@ -38,6 +38,11 @@ interface SessionContext {
     entityId: number;
 }
 
+export interface IrisLiveAssistantDraft {
+    runId: string;
+    text: string;
+}
+
 /**
  * The IrisSessionService is responsible for managing Iris sessions and retrieving their associated messages.
  */
@@ -79,6 +84,7 @@ export class IrisChatService implements OnDestroy {
     stages: BehaviorSubject<IrisStageDTO[]> = new BehaviorSubject<IrisStageDTO[]>([]);
     suggestions: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([]);
     citationInfo: BehaviorSubject<IrisCitationMetaDTO[]> = new BehaviorSubject<IrisCitationMetaDTO[]>([]);
+    liveAssistantDraft: BehaviorSubject<IrisLiveAssistantDraft | undefined> = new BehaviorSubject<IrisLiveAssistantDraft | undefined>(undefined);
     error: BehaviorSubject<IrisErrorMessageKey | undefined> = new BehaviorSubject<IrisErrorMessageKey | undefined>(undefined);
     chatSessions: BehaviorSubject<IrisSessionDTO[]> = new BehaviorSubject<IrisSessionDTO[]>([]);
 
@@ -108,6 +114,10 @@ export class IrisChatService implements OnDestroy {
     private stateGeneration = 0;
 
     private sessionContext?: SessionContext;
+
+    private lastSeenPartialSeqByRunId = new Map<string, number>();
+
+    private finalizedRunIds = new Set<string>();
 
     private shouldReopenChatSubject = new BehaviorSubject<boolean>(false);
     public shouldReopenChat$ = this.shouldReopenChatSubject.asObservable();
@@ -182,6 +192,7 @@ export class IrisChatService implements OnDestroy {
         this.stages.next([]);
         this.suggestions.next([]);
         this.citationInfo.next([]);
+        this.resetLiveAssistantDraftTracking();
         this.numNewMessages.next(0);
         this.newIrisMessage.next(undefined);
         this.error.next(undefined);
@@ -510,6 +521,7 @@ export class IrisChatService implements OnDestroy {
                 this.citationInfo.next(newIrisSession.citationInfo || []);
                 this.messages.next(newIrisSession.messages || []);
                 this.parseLatestSuggestions(newIrisSession.latestSuggestions);
+                this.resetLiveAssistantDraftTracking();
                 // Flip the gate before subscribing to the websocket: the load itself has
                 // succeeded, so consumers waiting on "messages have settled" are unblocked
                 // even if the websocket layer throws synchronously (e.g. mocked-out in tests).
@@ -570,6 +582,11 @@ export class IrisChatService implements OnDestroy {
         }
         switch (payload.type) {
             case IrisChatWebsocketPayloadType.MESSAGE:
+                this.liveAssistantDraft.next(undefined);
+                if (payload.runId) {
+                    this.finalizedRunIds.add(payload.runId);
+                    this.lastSeenPartialSeqByRunId.delete(payload.runId);
+                }
                 if (payload.message?.sender === IrisSender.LLM) {
                     this.numNewMessages.next(this.numNewMessages.getValue() + 1);
                 }
@@ -580,6 +597,9 @@ export class IrisChatService implements OnDestroy {
                     this.stages.next(this.filterStages(payload.stages));
                 }
                 break;
+            case IrisChatWebsocketPayloadType.PARTIAL:
+                this.handlePartialWebsocketMessage(payload);
+                break;
             case IrisChatWebsocketPayloadType.STATUS:
                 this.stages.next(this.filterStages(payload.stages || []));
                 if (payload.suggestions) {
@@ -587,6 +607,27 @@ export class IrisChatService implements OnDestroy {
                 }
                 break;
         }
+    }
+
+    private handlePartialWebsocketMessage(payload: IrisChatWebsocketDTO): void {
+        if (!payload.runId || payload.partialResult === undefined || payload.partialSeq === undefined) {
+            return;
+        }
+        if (this.finalizedRunIds.has(payload.runId)) {
+            return;
+        }
+        const lastSeenSeq = this.lastSeenPartialSeqByRunId.get(payload.runId);
+        if (lastSeenSeq !== undefined && payload.partialSeq <= lastSeenSeq) {
+            return;
+        }
+        this.lastSeenPartialSeqByRunId.set(payload.runId, payload.partialSeq);
+        this.liveAssistantDraft.next({ runId: payload.runId, text: payload.partialResult });
+    }
+
+    private resetLiveAssistantDraftTracking(): void {
+        this.liveAssistantDraft.next(undefined);
+        this.lastSeenPartialSeqByRunId.clear();
+        this.finalizedRunIds.clear();
     }
 
     private mapMessageDTO(dto: IrisMessageResponseDTO): IrisMessage {
@@ -611,6 +652,7 @@ export class IrisChatService implements OnDestroy {
             this.stages.next([]);
             this.suggestions.next([]);
             this.citationInfo.next([]);
+            this.resetLiveAssistantDraftTracking();
             this.numNewMessages.next(0);
             this.newIrisMessage.next(undefined);
             this.initialLoadCompleteSubject.next(false);
@@ -768,6 +810,10 @@ export class IrisChatService implements OnDestroy {
 
     public currentCitationInfo(): Observable<IrisCitationMetaDTO[]> {
         return this.citationInfo.asObservable();
+    }
+
+    public currentLiveAssistantDraft(): Observable<IrisLiveAssistantDraft | undefined> {
+        return this.liveAssistantDraft.asObservable();
     }
 
     public currentError(): Observable<IrisErrorMessageKey | undefined> {

--- a/src/main/webapp/app/iris/overview/services/iris-chat.service.ts
+++ b/src/main/webapp/app/iris/overview/services/iris-chat.service.ts
@@ -582,7 +582,6 @@ export class IrisChatService implements OnDestroy {
         }
         switch (payload.type) {
             case IrisChatWebsocketPayloadType.MESSAGE:
-                this.liveAssistantDraft.next(undefined);
                 if (payload.runId) {
                     this.finalizedRunIds.add(payload.runId);
                     this.lastSeenPartialSeqByRunId.delete(payload.runId);
@@ -593,6 +592,10 @@ export class IrisChatService implements OnDestroy {
                 if (payload.message?.id) {
                     this.replaceOrAddMessage(this.mapMessageDTO(payload.message));
                 }
+                // Clear the draft only AFTER the final message was applied: removing the
+                // draft first shrinks the scroll content for one frame, which clamps
+                // scrollTop and visually snaps the viewport to the top of the answer.
+                this.liveAssistantDraft.next(undefined);
                 if (payload.stages) {
                     this.stages.next(this.filterStages(payload.stages));
                 }

--- a/src/main/webapp/app/iris/shared/entities/iris-chat-websocket-dto.model.ts
+++ b/src/main/webapp/app/iris/shared/entities/iris-chat-websocket-dto.model.ts
@@ -15,9 +15,13 @@ export class IrisChatWebsocketDTO {
     suggestions?: string[];
     sessionTitle?: string;
     citationInfo?: IrisCitationMetaDTO[];
+    runId?: string;
+    partialResult?: string;
+    partialSeq?: number;
 }
 
 export enum IrisChatWebsocketPayloadType {
     MESSAGE = 'MESSAGE',
     STATUS = 'STATUS',
+    PARTIAL = 'PARTIAL',
 }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisChatStatusUpdateDTOTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisChatStatusUpdateDTOTest.java
@@ -1,0 +1,46 @@
+package de.tum.cit.aet.artemis.iris.service.pyris;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.tum.cit.aet.artemis.core.util.JsonObjectMapper;
+import de.tum.cit.aet.artemis.iris.service.pyris.dto.chat.PyrisChatStatusUpdateDTO;
+
+class PyrisChatStatusUpdateDTOTest {
+
+    private final ObjectMapper objectMapper = JsonObjectMapper.get();
+
+    @Test
+    void deserializesPartialFields() throws JsonProcessingException {
+        String json = """
+                {
+                    "stages": [],
+                    "partialResult": "Hello",
+                    "partialSeq": 7
+                }
+                """;
+
+        var dto = objectMapper.readValue(json, PyrisChatStatusUpdateDTO.class);
+
+        assertThat(dto.partialResult()).isEqualTo("Hello");
+        assertThat(dto.partialSeq()).isEqualTo(7);
+    }
+
+    @Test
+    void deserializesWithoutPartialFields() throws JsonProcessingException {
+        String json = """
+                {
+                    "stages": []
+                }
+                """;
+
+        var dto = objectMapper.readValue(json, PyrisChatStatusUpdateDTO.class);
+
+        assertThat(dto.partialResult()).isNull();
+        assertThat(dto.partialSeq()).isNull();
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineExecutionSettingsDTOTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineExecutionSettingsDTOTest.java
@@ -29,4 +29,22 @@ class PyrisPipelineExecutionSettingsDTOTest {
 
         assertThat(serialized).contains("\"supportLevel\":\"low\"");
     }
+
+    @Test
+    void serializesStreamResponseWhenEnabled() throws JsonProcessingException {
+        var dto = new PyrisPipelineExecutionSettingsDTO("token", null, "https://artemis.example", "default", "low", true);
+
+        String serialized = objectMapper.writeValueAsString(dto);
+
+        assertThat(serialized).contains("\"streamResponse\":true");
+    }
+
+    @Test
+    void omitsStreamResponseWhenUnset() throws JsonProcessingException {
+        var dto = new PyrisPipelineExecutionSettingsDTO("token", null, "https://artemis.example", "default", "low");
+
+        String serialized = objectMapper.writeValueAsString(dto);
+
+        assertThat(serialized).doesNotContain("streamResponse");
+    }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisPipelineServiceTest.java
@@ -1,0 +1,72 @@
+package de.tum.cit.aet.artemis.iris.service.pyris;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import de.tum.cit.aet.artemis.account.domain.User;
+import de.tum.cit.aet.artemis.account.repository.UserRepository;
+import de.tum.cit.aet.artemis.core.domain.AiSelectionDecision;
+import de.tum.cit.aet.artemis.core.service.feature.FeatureToggleService;
+import de.tum.cit.aet.artemis.course.service.CourseLoadService;
+import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
+import de.tum.cit.aet.artemis.iris.domain.session.IrisChatSession;
+import de.tum.cit.aet.artemis.iris.service.pyris.dto.PyrisPipelineExecutionSettingsDTO;
+import de.tum.cit.aet.artemis.iris.service.pyris.dto.chat.PyrisChatPipelineExecutionDTO;
+import de.tum.cit.aet.artemis.iris.service.websocket.IrisChatWebsocketService;
+
+class PyrisPipelineServiceTest {
+
+    @Test
+    void chatPipelineSettingsOmitStreamResponseWhenDisabled() {
+        var settings = executeChatPipelineAndCaptureSettings(false);
+
+        assertThat(settings.streamResponse()).isNull();
+    }
+
+    @Test
+    void chatPipelineSettingsEnableStreamResponseWhenEnabled() {
+        var settings = executeChatPipelineAndCaptureSettings(true);
+
+        assertThat(settings.streamResponse()).isTrue();
+    }
+
+    private PyrisPipelineExecutionSettingsDTO executeChatPipelineAndCaptureSettings(boolean responseStreamingEnabled) {
+        var pyrisConnectorService = mock(PyrisConnectorService.class);
+        var pyrisJobService = mock(PyrisJobService.class);
+        var userRepository = mock(UserRepository.class);
+        var user = new User();
+        user.setId(7L);
+        user.setLogin("student");
+        user.setSelectedLLMUsage(AiSelectionDecision.CLOUD_AI);
+        when(userRepository.findByIdElseThrow(7L)).thenReturn(user);
+        when(pyrisJobService.addChatJob(1L, 2L, 3L, null)).thenReturn("run-1");
+
+        var service = new PyrisPipelineService(pyrisConnectorService, pyrisJobService, mock(PyrisDTOService.class), mock(IrisChatWebsocketService.class),
+                mock(StudentParticipationRepository.class), userRepository, mock(CourseLoadService.class), mock(FeatureToggleService.class));
+        ReflectionTestUtils.setField(service, "artemisBaseUrl", "https://artemis.example");
+        ReflectionTestUtils.setField(service, "responseStreamingEnabled", responseStreamingEnabled);
+
+        var session = new IrisChatSession();
+        session.setCourseId(1L);
+        session.setId(2L);
+        session.setEntityId(3L);
+        session.setUserId(7L);
+
+        var capturedSettings = new AtomicReference<PyrisPipelineExecutionSettingsDTO>();
+        service.executeChatPipeline("default", "moderate", session, Optional.empty(), (executionDto, ignoredUser, ignoredPyrisUser) -> {
+            capturedSettings.set(executionDto.settings());
+            return new PyrisChatPipelineExecutionDTO(null, List.of(), executionDto.settings(), null, ignoredPyrisUser, executionDto.initialStages(), null, null, null, null, null,
+                    null, null, null, null, null);
+        });
+
+        return capturedSettings.get();
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisStatusUpdateServiceChatTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisStatusUpdateServiceChatTest.java
@@ -1,0 +1,69 @@
+package de.tum.cit.aet.artemis.iris.service.pyris;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.tum.cit.aet.artemis.iris.service.AutonomousTutorService;
+import de.tum.cit.aet.artemis.iris.service.IrisCompetencyGenerationService;
+import de.tum.cit.aet.artemis.iris.service.pyris.dto.chat.PyrisChatStatusUpdateDTO;
+import de.tum.cit.aet.artemis.iris.service.pyris.dto.status.PyrisStageDTO;
+import de.tum.cit.aet.artemis.iris.service.pyris.dto.status.PyrisStageState;
+import de.tum.cit.aet.artemis.iris.service.pyris.job.ChatJob;
+import de.tum.cit.aet.artemis.iris.service.session.IrisChatSessionService;
+import de.tum.cit.aet.artemis.iris.service.session.IrisTutorSuggestionSessionService;
+import de.tum.cit.aet.artemis.iris.service.websocket.IrisWebsocketService;
+
+class PyrisStatusUpdateServiceChatTest {
+
+    private PyrisJobService pyrisJobService;
+
+    private IrisChatSessionService irisChatSessionService;
+
+    private PyrisStatusUpdateService service;
+
+    @BeforeEach
+    void setUp() {
+        pyrisJobService = mock(PyrisJobService.class);
+        irisChatSessionService = mock(IrisChatSessionService.class);
+        service = new PyrisStatusUpdateService(pyrisJobService, irisChatSessionService, mock(IrisCompetencyGenerationService.class), mock(IrisTutorSuggestionSessionService.class),
+                mock(AutonomousTutorService.class), Optional.empty(), mock(IrisWebsocketService.class));
+    }
+
+    @Test
+    void partialChatStatusUpdateIsRelayedWithoutUpdatingJob() {
+        var job = new ChatJob("run-1", 1L, 2L, 3L, null, null, null);
+        var statusUpdate = new PyrisChatStatusUpdateDTO(null, List.of(stage(PyrisStageState.IN_PROGRESS)), null, null, null, null, null, "partial", 4);
+
+        service.handleStatusUpdate(job, statusUpdate);
+
+        verify(irisChatSessionService).handlePartialStatusUpdate(job, statusUpdate);
+        verify(irisChatSessionService, never()).handleStatusUpdate(job, statusUpdate);
+        verifyNoInteractions(pyrisJobService);
+    }
+
+    @Test
+    void nonPartialChatStatusUpdateUsesNormalResultPath() {
+        var job = new ChatJob("run-1", 1L, 2L, 3L, null, null, null);
+        var statusUpdate = new PyrisChatStatusUpdateDTO("result", List.of(stage(PyrisStageState.DONE)), null, null, null, null, null, null, null);
+        when(irisChatSessionService.handleStatusUpdate(job, statusUpdate)).thenReturn(job);
+
+        service.handleStatusUpdate(job, statusUpdate);
+
+        verify(irisChatSessionService).handleStatusUpdate(job, statusUpdate);
+        verify(irisChatSessionService, never()).handlePartialStatusUpdate(job, statusUpdate);
+        verify(pyrisJobService).removeJob(job);
+    }
+
+    private PyrisStageDTO stage(PyrisStageState state) {
+        return new PyrisStageDTO("stage", 1, state, null, false, null);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/iris/service/session/IrisChatSessionServicePartialUpdateTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/service/session/IrisChatSessionServicePartialUpdateTest.java
@@ -1,0 +1,77 @@
+package de.tum.cit.aet.artemis.iris.service.session;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.MessageSource;
+
+import de.tum.cit.aet.artemis.admin.service.LLMTokenUsageService;
+import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
+import de.tum.cit.aet.artemis.core.util.JsonObjectMapper;
+import de.tum.cit.aet.artemis.course.repository.CourseRepository;
+import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
+import de.tum.cit.aet.artemis.exercise.repository.SubmissionRepository;
+import de.tum.cit.aet.artemis.iris.domain.session.IrisChatSession;
+import de.tum.cit.aet.artemis.iris.repository.IrisChatSessionRepository;
+import de.tum.cit.aet.artemis.iris.repository.IrisMessageRepository;
+import de.tum.cit.aet.artemis.iris.repository.IrisSessionRepository;
+import de.tum.cit.aet.artemis.iris.service.IrisCitationService;
+import de.tum.cit.aet.artemis.iris.service.IrisMessageService;
+import de.tum.cit.aet.artemis.iris.service.IrisRateLimitService;
+import de.tum.cit.aet.artemis.iris.service.pyris.dto.chat.PyrisChatStatusUpdateDTO;
+import de.tum.cit.aet.artemis.iris.service.pyris.job.ChatJob;
+import de.tum.cit.aet.artemis.iris.service.settings.IrisSettingsService;
+import de.tum.cit.aet.artemis.iris.service.websocket.IrisChatWebsocketService;
+import de.tum.cit.aet.artemis.lecture.api.LectureRepositoryApi;
+import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseStudentParticipationRepository;
+import de.tum.cit.aet.artemis.programming.repository.ProgrammingSubmissionRepository;
+
+class IrisChatSessionServicePartialUpdateTest {
+
+    private IrisSessionRepository irisSessionRepository;
+
+    private IrisMessageService irisMessageService;
+
+    private IrisMessageRepository irisMessageRepository;
+
+    private IrisChatWebsocketService irisChatWebsocketService;
+
+    private IrisChatSessionService irisChatSessionService;
+
+    @BeforeEach
+    void setUp() {
+        irisSessionRepository = mock(IrisSessionRepository.class);
+        irisMessageService = mock(IrisMessageService.class);
+        irisMessageRepository = mock(IrisMessageRepository.class);
+        irisChatWebsocketService = mock(IrisChatWebsocketService.class);
+
+        irisChatSessionService = new IrisChatSessionService(irisMessageService, irisMessageRepository, mock(LLMTokenUsageService.class), mock(IrisSettingsService.class),
+                irisChatWebsocketService, mock(AuthorizationCheckService.class), irisSessionRepository, mock(IrisChatSessionRepository.class),
+                mock(ProgrammingExerciseStudentParticipationRepository.class), mock(ProgrammingSubmissionRepository.class), mock(IrisRateLimitService.class),
+                JsonObjectMapper.get(), mock(ExerciseRepository.class), mock(SubmissionRepository.class), mock(CourseRepository.class), Optional.<LectureRepositoryApi>empty(),
+                mock(IrisCitationService.class), mock(MessageSource.class), mock(IrisChatPipelineExecutionService.class));
+    }
+
+    @Test
+    void partialStatusUpdateRelaysDraftWithoutPersistingMessage() {
+        var job = new ChatJob("run-1", 1L, 2L, 3L, null, null, null);
+        var statusUpdate = new PyrisChatStatusUpdateDTO(null, List.of(), null, null, null, null, null, "partial", 4);
+        var session = new IrisChatSession();
+        session.setId(2L);
+        session.setUserId(5L);
+        when(irisSessionRepository.findByIdElseThrow(2L)).thenReturn(session);
+
+        irisChatSessionService.handlePartialStatusUpdate(job, statusUpdate);
+
+        verify(irisSessionRepository).findByIdElseThrow(2L);
+        verify(irisChatWebsocketService).sendPartialUpdate(session, "partial", 4, "run-1");
+        verifyNoInteractions(irisMessageService, irisMessageRepository);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/iris/service/websocket/IrisChatWebsocketServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/service/websocket/IrisChatWebsocketServiceTest.java
@@ -1,0 +1,65 @@
+package de.tum.cit.aet.artemis.iris.service.websocket;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import de.tum.cit.aet.artemis.account.domain.User;
+import de.tum.cit.aet.artemis.account.repository.UserRepository;
+import de.tum.cit.aet.artemis.iris.domain.session.IrisChatSession;
+import de.tum.cit.aet.artemis.iris.dto.IrisChatWebsocketDTO;
+import de.tum.cit.aet.artemis.iris.service.IrisRateLimitService;
+
+class IrisChatWebsocketServiceTest {
+
+    private IrisWebsocketService websocketService;
+
+    private IrisRateLimitService rateLimitService;
+
+    private UserRepository userRepository;
+
+    private IrisChatWebsocketService irisChatWebsocketService;
+
+    @BeforeEach
+    void setUp() {
+        websocketService = mock(IrisWebsocketService.class);
+        rateLimitService = mock(IrisRateLimitService.class);
+        userRepository = mock(UserRepository.class);
+        irisChatWebsocketService = new IrisChatWebsocketService(websocketService, rateLimitService, userRepository);
+    }
+
+    /**
+     * Partial updates are emitted many times per streamed answer and never change the user's quota. Resolving the rate limit information can run the (potentially expensive)
+     * LLM-response-count query, so the streaming hot path must not touch {@link IrisRateLimitService}. The final MESSAGE / status update is responsible for refreshing it.
+     */
+    @Test
+    void partialUpdateDoesNotComputeRateLimitInformation() {
+        var user = new User();
+        user.setLogin("iris-student");
+        var session = new IrisChatSession();
+        session.setId(42L);
+        session.setUserId(7L);
+        when(userRepository.findByIdElseThrow(anyLong())).thenReturn(user);
+
+        irisChatWebsocketService.sendPartialUpdate(session, "partial text", 3, "run-1");
+
+        verifyNoInteractions(rateLimitService);
+
+        var payloadCaptor = ArgumentCaptor.forClass(IrisChatWebsocketDTO.class);
+        verify(websocketService).send(eq("iris-student"), eq("42"), payloadCaptor.capture());
+        var payload = payloadCaptor.getValue();
+        assertThat(payload.type()).isEqualTo(IrisChatWebsocketDTO.IrisWebsocketMessageType.PARTIAL);
+        assertThat(payload.rateLimitInfo()).isNull();
+        assertThat(payload.partialResult()).isEqualTo("partial text");
+        assertThat(payload.partialSeq()).isEqualTo(3);
+        assertThat(payload.runId()).isEqualTo("run-1");
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/iris/service/websocket/IrisChatWebsocketServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/service/websocket/IrisChatWebsocketServiceTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import de.tum.cit.aet.artemis.account.domain.User;
-import de.tum.cit.aet.artemis.account.repository.UserRepository;
+import de.tum.cit.aet.artemis.account.test_repository.UserTestRepository;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisChatSession;
 import de.tum.cit.aet.artemis.iris.dto.IrisChatWebsocketDTO;
 import de.tum.cit.aet.artemis.iris.service.IrisRateLimitService;
@@ -24,7 +24,7 @@ class IrisChatWebsocketServiceTest {
 
     private IrisRateLimitService rateLimitService;
 
-    private UserRepository userRepository;
+    private UserTestRepository userRepository;
 
     private IrisChatWebsocketService irisChatWebsocketService;
 
@@ -32,7 +32,7 @@ class IrisChatWebsocketServiceTest {
     void setUp() {
         websocketService = mock(IrisWebsocketService.class);
         rateLimitService = mock(IrisRateLimitService.class);
-        userRepository = mock(UserRepository.class);
+        userRepository = mock(UserTestRepository.class);
         irisChatWebsocketService = new IrisChatWebsocketService(websocketService, rateLimitService, userRepository);
     }
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #13093 (`feature/iris/reduce-chat-callback-and-dto-overhead`); base retargets to `develop` as the stack merges. Review only the last commit. Pyris counterpart: ls1intum/edutelligence#658.

## Summary

Users currently wait for the entire Iris pipeline (agent loop + citations + post-processing) before seeing anything. This PR adds the Artemis half of response streaming: while Pyris generates the final answer, it POSTs periodic partial-text callbacks that Artemis relays to the browser as an ephemeral draft bubble — perceived time-to-first-token drops to roughly when the model starts writing the answer. Off by default (`artemis.iris.response-streaming-enabled`), fully backwards compatible in both directions.

## Description

**Design principle: partials are ephemeral — nothing is persisted for them.**

- Pyris opts in per run via a new optional `streamResponse` field in the execution settings (sent only for chat pipelines when the property is enabled; old Pyris ignores it, old Artemis never sends it).
- Partial callbacks carry `partialResult` (accumulated provisional text) + `partialSeq` (monotonic). `PyrisStatusUpdateService` short-circuits them to a relay path: light session load (`findByIdElseThrow`), websocket send, early return — **no message insert, no heavy session reload, no Hazelcast job update**. The final result callback keeps today's exact single-insert path on any node version, so rolling deploys / mixed clusters cannot duplicate messages: an old node receiving a partial deserializes unknown fields to null and treats it as a status-only update.
- Websocket payloads gain a `PARTIAL` type and a `runId` correlation field (also set on the final `MESSAGE` of the same run).
- Client: partials update a dedicated `liveAssistantDraft` signal — never injected into the persisted message list, no new-message bell — rendered as an assistant-style draft bubble; guarded by `partialSeq` monotonicity and a finalized-run set; cleared on the final MESSAGE, session switch, and reload.
- Bonus latency fix: `IrisWebsocketService` no longer blocks on `sendMessageToUser(...).get()` — browser fan-out latency previously extended the HTTP thread that Pyris synchronously blocks on for every callback. Failures now log via `whenComplete`.

## Test Coverage

Server (all green, focused Iris suite via Gradle + embedded Postgres):
- `PyrisChatStatusUpdateDTOTest` — Jackson round-trip with/without the new fields
- `PyrisStatusUpdateServiceChatTest` — partial path relays and returns early (no persistence, no job update); null-partial path unchanged
- `IrisChatSessionServicePartialUpdateTest` — light session load + relay arguments
- `PyrisPipelineServiceTest` / `PyrisPipelineExecutionSettingsDTOTest` — flag sent iff property enabled; serialization omits null
- Existing Iris integration tests unaffected (full focused suite green)

Client: `iris-chat.service.spec.ts` — **53/53 vitest tests pass** (new: PARTIAL sets draft, stale seq ignored, MESSAGE finalizes and blocks late partials, session switch clears, no bell for partials). No measured line-coverage table: server verification is the focused integration suite; client is the service spec suite (`npm run coverage` not run — out of scope for this stacked PR, CI reports it).

**Viewport behaviour.** The draft bubble does not pin the viewport to the bottom — it scrolls into view once when the answer starts and the user reads top-down while text streams in below; finalization no longer moves the viewport. Partial snapshots are smoothed by a client-side typewriter (adaptive catch-up ≤400ms per snapshot, code-point-safe, markdown re-render capped at the 50ms tick, draft-only binding). vitest: 223 passed across the service + new component specs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live streaming draft messages in chat, so responses can appear progressively before the final answer.
  * Enabled optional response streaming for chat conversations.

* **Bug Fixes**
  * Improved chat updates so partial responses no longer replace completed messages or cause duplicate/out-of-order updates.
  * Refined scrolling behavior to keep the chat view stable while streaming content is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->