### PR TITLE
`Development`: Fix multi-node e2e tests failing to start node-2

### DIFF
--- a/docker/artemis/config/node2-fast.env
+++ b/docker/artemis/config/node2-fast.env
@@ -1,5 +1,8 @@
 # node-2: Hazelcast member + build agent. Hosts LocalVC. HTTP :8081, Hazelcast :5702.
-SPRING_PROFILES_ACTIVE="prod,localvc,localci,buildagent,core,docker"
+# `prod` must stay AFTER `buildagent`: buildagent sets `spring.jpa.database: default` and prod disables
+# the JDBC metadata probe. prod must win the `database` key (POSTGRESQL) or Hibernate cannot determine
+# the dialect on this combined member+build-agent node and it fails to start. See node2.env.
+SPRING_PROFILES_ACTIVE="localvc,localci,buildagent,core,prod,docker"
 EUREKA_INSTANCE_INSTANCEID="Artemis:2"
 SERVER_PORT="8081"
 SPRING_HAZELCAST_PORT="5702"

--- a/docker/artemis/config/node2.env
+++ b/docker/artemis/config/node2.env
@@ -1,4 +1,8 @@
-SPRING_PROFILES_ACTIVE='prod,localvc,localci,buildagent,core,docker'
+# `prod` must stay AFTER `buildagent`: application-buildagent.yml sets `spring.jpa.database: default`,
+# and prod disables the JDBC metadata probe (allow_jdbc_metadata_access=false). On this combined
+# member+build-agent node (which needs JPA via core/localvc/localci), prod must win the `database`
+# key with POSTGRESQL, otherwise Hibernate cannot determine the dialect and the node fails to start.
+SPRING_PROFILES_ACTIVE='localvc,localci,buildagent,core,prod,docker'
 EUREKA_INSTANCE_INSTANCEID='Artemis:2'
 EUREKA_INSTANCE_HOSTNAME='artemis-app-node-2'
 SPRING_HAZELCAST_INTERFACE='artemis-app-node-2'

--- a/docker/artemis/config/node2.env
+++ b/docker/artemis/config/node2.env
@@ -1,5 +1,5 @@
 # `prod` must stay AFTER `buildagent`: application-buildagent.yml sets `spring.jpa.database: default`,
-# and prod disables the JDBC metadata probe (allow_jdbc_metadata_access=false). On this combined
+# and prod disables the JDBC metadata probe (hibernate.boot.allow_jdbc_metadata_access: false). On this combined
 # member+build-agent node (which needs JPA via core/localvc/localci), prod must win the `database`
 # key with POSTGRESQL, otherwise Hibernate cannot determine the dialect and the node fails to start.
 SPRING_PROFILES_ACTIVE='localvc,localci,buildagent,core,prod,docker'


### PR DESCRIPTION
### Summary

Since #13013, **every push to `develop` reports the E2E tests as failed.** This is deterministic (not flaky, not a timeout): the multi-node E2E stack cannot start `artemis-app-node-2`, which aborts the whole run before any test results are produced.

`node-2` runs with `SPRING_PROFILES_ACTIVE` listing `prod` **before** `buildagent`. `application-buildagent.yml` sets `spring.jpa.database: default` (to keep pure build agents off the database), and #13013 disabled Hibernate's JDBC metadata probe in `prod` (`allow_jdbc_metadata_access: false`) to speed up production startup. Because Spring applies a last-profile-wins strategy, `buildagent`'s `default` overrode `prod`'s `POSTGRESQL`. With neither an explicit dialect nor a metadata probe, node-2 (the only node that combines `buildagent` with `core`/`localvc`/`localci`, which require JPA) fails to build the `EntityManagerFactory` and crashes:

```
org.hibernate.HibernateException: Unable to determine Dialect without JDBC metadata
```

Because `docker compose` runs with `--abort-on-container-exit`, node-2's crash immediately kills the Playwright container (exit 137), so no `test-reports/*.xml` is produced and the job fails at teardown.

The fix moves `prod` to **last** in `node2.env` and `node2-fast.env`, so its `POSTGRESQL` wins. This matches the ordering every other combined `buildagent`+`prod` env file already uses (e.g. `playwright-local.env`), which is why single-node and local runs were unaffected. `node3.env` is intentionally left unchanged: node-3 is a pure build agent that excludes the Hibernate/DataSource auto-configuration, so it never builds an `EntityManagerFactory`.

The bug was latent since #7958 (2024); the pre-#13013 metadata probe hid it by determining the dialect from a live JDBC connection.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

The E2E "End-to-End (E2E) Tests" commit status has been red on every push to `develop` since 2026-06-28. This restores a green, trustworthy E2E signal on `develop` without weakening any timeout or check.

### Description

- `docker/artemis/config/node2.env`: reorder `SPRING_PROFILES_ACTIVE` to `localvc,localci,buildagent,core,prod,docker` (was `prod,localvc,localci,buildagent,core,docker`) so the `prod` profile's `spring.jpa.database: POSTGRESQL` is not overridden by the `buildagent` profile's `default`. Added a comment explaining the ordering constraint.
- `docker/artemis/config/node2-fast.env`: same reorder for the host-JVM multi-node-fast variant.

### Steps for Testing

This only affects the multi-node E2E topology (pushes to `develop` and the local multi-node runners); PR CI runs single-node and is unaffected.

1. `./run-e2e-tests-local-multinode-fast.sh --filter "SystemHealth"`
2. Confirm node-2 becomes ready (previously it crashed with the dialect error).
3. Confirm the Hazelcast cluster forms with size 2 and the SystemHealth tests pass.

Verified locally: node-2 ready in ~35s, cluster size 2, 7/7 SystemHealth tests passed.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-04 08:16:49 UTC_

