### PR TITLE
`Development`: Fix eslint cleanup lint warnings

### DIFF
--- a/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.spec.ts
+++ b/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.spec.ts
@@ -279,6 +279,25 @@ examples.forEach((activeConversation) => {
             expect(component.activeConversation()).toEqual(activeConversation);
         });
 
+        it('should store the highlight observers and disconnect them in ngOnDestroy', () => {
+            // Trigger both highlight helpers for elements that do not exist yet, so each creates and stores a MutationObserver.
+            component['scrollToAndHighlightPost'](999999);
+            component['scrollToAndHighlightReply'](999998);
+
+            const postObserver = component['highlightPostObserver'];
+            const replyObserver = component['highlightReplyObserver'];
+            expect(postObserver).toBeDefined();
+            expect(replyObserver).toBeDefined();
+
+            const postDisconnectSpy = vi.spyOn(postObserver!, 'disconnect');
+            const replyDisconnectSpy = vi.spyOn(replyObserver!, 'disconnect');
+
+            component.ngOnDestroy();
+
+            expect(postDisconnectSpy).toHaveBeenCalled();
+            expect(replyDisconnectSpy).toHaveBeenCalled();
+        });
+
         describe('Dialog Opening', () => {
             setupTestBed({ zoneless: true });
 

--- a/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
+++ b/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
@@ -174,6 +174,11 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
     private openSidebarEventSubscription: Subscription;
     private toggleSidebarEventSubscription: Subscription;
     private reloadSidebarEventSubscription: Subscription;
+    // Transient observers that watch for a post/reply to appear in the DOM. They self-disconnect on
+    // success and via a 5s timeout, but are stored here so ngOnDestroy can disconnect them if the
+    // component is torn down within that window.
+    private highlightPostObserver?: MutationObserver;
+    private highlightReplyObserver?: MutationObserver;
     course = signal<Course | undefined>(undefined);
     readonly isLoading = signal(false);
     readonly isServiceSetUp = signal(false);
@@ -454,6 +459,8 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
         this.closeSidebarEventSubscription?.unsubscribe();
         this.toggleSidebarEventSubscription?.unsubscribe();
         this.reloadSidebarEventSubscription?.unsubscribe();
+        this.highlightPostObserver?.disconnect();
+        this.highlightReplyObserver?.disconnect();
     }
 
     private subscribeToActiveConversation() {
@@ -789,11 +796,13 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
 
         if (tryHighlight()) return;
 
+        this.highlightPostObserver?.disconnect();
         const observer = new MutationObserver(() => {
             if (tryHighlight()) {
                 observer.disconnect();
             }
         });
+        this.highlightPostObserver = observer;
         observer.observe(document.body, { childList: true, subtree: true });
         setTimeout(() => observer.disconnect(), 5000);
     }
@@ -809,6 +818,7 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
         }
 
         // Watch for the element to appear in the DOM
+        this.highlightReplyObserver?.disconnect();
         const observer = new MutationObserver(() => {
             const element = document.getElementById(elementId);
             if (element) {
@@ -816,6 +826,7 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
                 this.highlightElement(element);
             }
         });
+        this.highlightReplyObserver = observer;
 
         observer.observe(document.body, { childList: true, subtree: true });
 

--- a/src/main/webapp/app/quiz/overview/participation/quiz-participation.component.ts
+++ b/src/main/webapp/app/quiz/overview/participation/quiz-participation.component.ts
@@ -214,6 +214,7 @@ export class QuizParticipationComponent implements OnInit, OnDestroy {
             if (!root) {
                 return;
             }
+            // eslint-disable-next-line localRules/enforce-cleanup-on-destroy -- the observer is disconnected via the effect's onCleanup below, which runs on every effect re-run and on component destroy. The rule only scans ngOnDestroy, so it cannot see this teardown.
             const observer = new ResizeObserver(() => {
                 const rect = root.getBoundingClientRect();
                 root.style.setProperty('--quiz-overlay-center-x', `${rect.left + rect.width / 2}px`);


### PR DESCRIPTION
### Summary

Resolves the 3 remaining `localRules/enforce-cleanup-on-destroy` client lint warnings (all real observer-lifecycle warnings). After this PR, `pnpm run lint` reports only the pre-existing `@typescript-eslint/no-deprecated` warnings.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

The two components created DOM observers that the `enforce-cleanup-on-destroy` rule flagged as never disconnected. In `course-conversations`, the two highlight `MutationObserver`s self-disconnect on success and via a 5s `setTimeout`, but they leak if the component is destroyed within that window. Storing them and disconnecting in `ngOnDestroy` closes that gap.

### Description

- **`course-conversations.component.ts`**: store the `scrollToAndHighlightPost` and `scrollToAndHighlightReply` `MutationObserver`s in `highlightPostObserver` / `highlightReplyObserver` fields (disconnecting any previous instance before reassigning) and disconnect both in `ngOnDestroy`.
- **`quiz-participation.component.ts`**: the `ResizeObserver` is created inside an `effect()` and is already disconnected via that effect's `onCleanup` (which runs on every effect re-run **and** on component destroy). The lint rule only scans the `ngOnDestroy` body, so this is a false positive. Hoisting the observer out of the effect to satisfy the rule would leak on every effect re-run, so this instead adds a justified `eslint-disable-next-line` with an explanation.

### Steps for Testing

1. Run `pnpm exec eslint src/main/webapp` and confirm no `localRules/enforce-cleanup-on-destroy` warnings remain (only `@typescript-eslint/no-deprecated`).
2. Run the affected specs: `pnpm exec vitest run src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.spec.ts src/main/webapp/app/quiz/overview/participation/quiz-participation.component.spec.ts` (297 tests pass).

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| course-conversations.component.ts | 84.10% | 765 | 113 | 14.8 |
| quiz-participation.component.ts | 79.05% | 936 | 97 | 10.4 |

_Last updated: 2026-07-04 06:48:44 UTC_

