### PR TITLE
`Development`: Enable `strictFunctionTypes` to improve client type safety

### DIFF
--- a/src/main/webapp/app/account/user/settings/passkey-settings/passkey-settings.component.ts
+++ b/src/main/webapp/app/account/user/settings/passkey-settings/passkey-settings.component.ts
@@ -111,7 +111,7 @@ export class PasskeySettingsComponent implements OnDestroy {
         this.authStateSubscription = this.accountService
             .getAuthenticationState()
             .pipe(
-                tap((user: User) => {
+                tap((user: User | undefined) => {
                     this.currentUser.set(user);
                     return this.currentUser;
                 }),

--- a/src/main/webapp/app/account/user/settings/passkey-settings/util/credential.util.ts
+++ b/src/main/webapp/app/account/user/settings/passkey-settings/util/credential.util.ts
@@ -76,11 +76,15 @@ function handleMalformedLoginCredential<T>(
  * @returns The processed credential
  * @throws {@link InvalidCredentialError} if the credential cannot be processed.
  */
-function getCredentialWithGracefullyHandlingAuthenticatorIssues<T extends SerializableRegistrationCredential | SerializableLoginCredential>(
+function getCredentialWithGracefullyHandlingAuthenticatorIssues<
+    T extends SerializableRegistrationCredential | SerializableLoginCredential,
+    B extends MalformedBitwardenRegistrationCredential | MalformedBitwardenLoginCredential,
+    P extends Malformed1Password8RegistrationCredential | Malformed1Password8LoginCredential,
+>(
     credential: Credential | undefined,
     credentialType: 'registration' | 'login',
-    bitwardenConverter: (malformedBitwardenCredential: MalformedBitwardenRegistrationCredential | MalformedBitwardenLoginCredential | undefined) => T | undefined,
-    onePassword8Converter: (malformed1Password8Credential: Malformed1Password8RegistrationCredential | Malformed1Password8LoginCredential | undefined) => T | undefined,
+    bitwardenConverter: (malformedBitwardenCredential: B | undefined) => T | undefined,
+    onePassword8Converter: (malformed1Password8Credential: P | undefined) => T | undefined,
     malformedHandler: <U>(credential: Credential | undefined, converterFunction: (credential: U | undefined) => T | undefined) => T,
 ): Credential | T {
     try {
@@ -96,13 +100,13 @@ function getCredentialWithGracefullyHandlingAuthenticatorIssues<T extends Serial
         captureException(new Error(`Authenticator returned a malformed ${credentialType} credential, attempting to fix it`, { cause: error }));
 
         // Authenticators, such as bitwarden, do not handle the credential generation properly; this is a workaround for it
-        let fixedCredential = malformedHandler<MalformedBitwardenRegistrationCredential>(credential, bitwardenConverter);
+        let fixedCredential = malformedHandler<B>(credential, bitwardenConverter);
 
         // 1Password8 returns empty string for authenticatorData when the Bitwarden workaround is applied
         const is1Password8Credential = fixedCredential.response?.authenticatorData === '';
         if (is1Password8Credential) {
             captureException(new Error('Bitwarden workaround did not succeed, attempting 1password8 workaround', { cause: error }));
-            fixedCredential = malformedHandler<Malformed1Password8RegistrationCredential>(credential, onePassword8Converter);
+            fixedCredential = malformedHandler<P>(credential, onePassword8Converter);
         }
 
         return fixedCredential;
@@ -122,7 +126,11 @@ function getCredentialWithGracefullyHandlingAuthenticatorIssues<T extends Serial
  * @throws {@link InvalidCredentialError} if the credential cannot be processed.
  */
 export function getRegistrationCredentialWithGracefullyHandlingAuthenticatorIssues(credential: Credential | undefined): Credential | SerializableRegistrationCredential {
-    return getCredentialWithGracefullyHandlingAuthenticatorIssues<SerializableRegistrationCredential>(
+    return getCredentialWithGracefullyHandlingAuthenticatorIssues<
+        SerializableRegistrationCredential,
+        MalformedBitwardenRegistrationCredential,
+        Malformed1Password8RegistrationCredential
+    >(
         credential,
         'registration',
         getRegistrationCredentialFromMalformedBitwardenObject,
@@ -144,7 +152,7 @@ export function getRegistrationCredentialWithGracefullyHandlingAuthenticatorIssu
  * @throws {@link InvalidCredentialError} if the credential cannot be processed.
  */
 export function getLoginCredentialWithGracefullyHandlingAuthenticatorIssues(credential: Credential | undefined): Credential | SerializableLoginCredential {
-    return getCredentialWithGracefullyHandlingAuthenticatorIssues<SerializableLoginCredential>(
+    return getCredentialWithGracefullyHandlingAuthenticatorIssues<SerializableLoginCredential, MalformedBitwardenLoginCredential, Malformed1Password8LoginCredential>(
         credential,
         'login',
         getLoginCredentialFromMalformedBitwardenObject,

--- a/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.ts
+++ b/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.ts
@@ -39,7 +39,7 @@ export class UserSettingsContainerComponent implements OnInit {
         this.accountService
             .getAuthenticationState()
             .pipe(
-                tap((user: User) => {
+                tap((user: User | undefined) => {
                     this.currentUser.set(user);
                     this.isAtLeastTutor.set(this.accountService.isAtLeastTutor());
                 }),

--- a/src/main/webapp/app/account/user/settings/vcs-access-tokens-settings/vcs-access-tokens-settings.component.ts
+++ b/src/main/webapp/app/account/user/settings/vcs-access-tokens-settings/vcs-access-tokens-settings.component.ts
@@ -57,7 +57,7 @@ export class VcsAccessTokensSettingsComponent implements OnInit, OnDestroy {
         this.authStateSubscription = this.accountService
             .getAuthenticationState()
             .pipe(
-                tap((user: User) => {
+                tap((user: User | undefined) => {
                     this.currentUser.set(user);
                     return user;
                 }),

--- a/src/main/webapp/app/admin/standardized-competencies/knowledge-area-edit.component.ts
+++ b/src/main/webapp/app/admin/standardized-competencies/knowledge-area-edit.component.ts
@@ -2,7 +2,7 @@ import { Component, effect, inject, input, model, output } from '@angular/core';
 import { faBan, faPencil, faPlus, faSave, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { KnowledgeArea, KnowledgeAreaDTO, KnowledgeAreaValidators } from 'app/atlas/shared/entities/standardized-competency.model';
 import { ButtonSize, ButtonType } from 'app/shared-ui/components/buttons/button/button.component';
-import { FormBuilder, FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AbstractControl, FormBuilder, FormControl, FormGroup, FormsModule, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { ButtonComponent } from 'app/shared-ui/components/buttons/button/button.component';
@@ -195,12 +195,12 @@ export class KnowledgeAreaEditComponent {
      * (I.e. the new parent of a knowledge area must not be itself or one of its current descendants)
      * @param knowledgeArea - The knowledge area being validated
      */
-    private createNoCircularDependencyValidator(knowledgeArea: KnowledgeAreaDTO) {
+    private createNoCircularDependencyValidator(knowledgeArea: KnowledgeAreaDTO): ValidatorFn {
         // If the knowledgeArea is new, no validator is needed
         if (knowledgeArea.id === undefined) {
-            return (_parentIdControl: FormControl<number | undefined>) => null;
+            return (_parentIdControl: AbstractControl): ValidationErrors | null => null;
         }
-        return (parentIdControl: FormControl<number | undefined>) => {
+        return (parentIdControl: AbstractControl): ValidationErrors | null => {
             if (parentIdControl.value === undefined) {
                 return null;
             }

--- a/src/main/webapp/app/admin/standardized-competencies/standardized-competency-management.spec.ts
+++ b/src/main/webapp/app/admin/standardized-competencies/standardized-competency-management.spec.ts
@@ -122,7 +122,7 @@ describe('StandardizedCompetencyManagementComponent', () => {
         const knowledgeArea2: KnowledgeAreaDTO = { id: 2 };
         const expectedCompetency: StandardizedCompetencyDTO = { knowledgeAreaId: 1 };
         const expectedCompetency2: StandardizedCompetencyDTO = { knowledgeAreaId: 2 };
-        const cancelModalSpy = vi.spyOn(component as any, 'openCancelModal').mockImplementation((title, entityType, callback: () => void) => callback());
+        const cancelModalSpy = vi.spyOn(component as any, 'openCancelModal').mockImplementation((...args: unknown[]) => (args[2] as () => void)());
 
         component['isEditing'].set(false);
         component.openNewCompetency(knowledgeArea.id!);
@@ -139,7 +139,7 @@ describe('StandardizedCompetencyManagementComponent', () => {
     it('should select competency', () => {
         const expectedCompetency = createCompetencyDTO(1, 'title1', 'description1');
         const expectedCompetency2 = createCompetencyDTO(2, 'title2', 'description2');
-        const cancelModalSpy = vi.spyOn(component as any, 'openCancelModal').mockImplementation((title, entityType, callback: () => void) => callback());
+        const cancelModalSpy = vi.spyOn(component as any, 'openCancelModal').mockImplementation((...args: unknown[]) => (args[2] as () => void)());
 
         component['isEditing'].set(false);
         component.selectCompetency(expectedCompetency);
@@ -158,7 +158,7 @@ describe('StandardizedCompetencyManagementComponent', () => {
     });
 
     it('should close competency', () => {
-        const cancelModalSpy = vi.spyOn(component as any, 'openCancelModal').mockImplementation((title, entityType, callback: () => void) => callback());
+        const cancelModalSpy = vi.spyOn(component as any, 'openCancelModal').mockImplementation((...args: unknown[]) => (args[2] as () => void)());
         const expectedCompetency = createCompetencyDTO(1, 'title1', 'description1');
         component['selectedCompetency'].set(expectedCompetency);
         component['isEditing'].set(false);
@@ -277,7 +277,7 @@ describe('StandardizedCompetencyManagementComponent', () => {
     it('should open new knowledgeArea', () => {
         const expectedKnowledgeArea1: KnowledgeAreaDTO = { parentId: 1 };
         const expectedKnowledgeArea2: KnowledgeAreaDTO = { parentId: 2 };
-        const cancelModalSpy = vi.spyOn(component as any, 'openCancelModal').mockImplementation((title, entityType, callback: () => void) => callback());
+        const cancelModalSpy = vi.spyOn(component as any, 'openCancelModal').mockImplementation((...args: unknown[]) => (args[2] as () => void)());
 
         component['isEditing'].set(false);
         component.openNewKnowledgeArea(expectedKnowledgeArea1.parentId);
@@ -294,7 +294,7 @@ describe('StandardizedCompetencyManagementComponent', () => {
     it('should select knowledgeArea', () => {
         const expectedKnowledgeArea = createKnowledgeAreaDTO(1, 'title1', 't1');
         const expectedKnowledgeArea2 = createKnowledgeAreaDTO(2, 'title2', 't2');
-        const cancelModalSpy = vi.spyOn(component as any, 'openCancelModal').mockImplementation((title, entityType, callback: () => void) => callback());
+        const cancelModalSpy = vi.spyOn(component as any, 'openCancelModal').mockImplementation((...args: unknown[]) => (args[2] as () => void)());
 
         component['isEditing'].set(false);
         component.selectKnowledgeArea(expectedKnowledgeArea);
@@ -312,7 +312,7 @@ describe('StandardizedCompetencyManagementComponent', () => {
     });
 
     it('should close knowledgeArea', () => {
-        const cancelModalSpy = vi.spyOn(component as any, 'openCancelModal').mockImplementation((title, entityType, callback: () => void) => callback());
+        const cancelModalSpy = vi.spyOn(component as any, 'openCancelModal').mockImplementation((...args: unknown[]) => (args[2] as () => void)());
         const expectedKnowledgeArea = createKnowledgeAreaDTO(1, 'title1', 't1');
         component['selectedKnowledgeArea'].set(expectedKnowledgeArea);
         component['isEditing'].set(false);

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
@@ -130,7 +130,7 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
      * Initializes current account and loads system notifications.
      */
     ngOnInit(): void {
-        void this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User | undefined) => {
             this.currentAccount.set(user);
             this.loadAll();
             this.registerChangeInNotifications();

--- a/src/main/webapp/app/admin/user-management/user-management.component.ts
+++ b/src/main/webapp/app/admin/user-management/user-management.component.ts
@@ -294,7 +294,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
         const tempInStorage = temp
             ? temp
                   .split(',')
-                  .map((filter: keyof Filter) => type[filter] as E) // type assertion
+                  .map((filter: string) => type[filter as keyof Filter] as E) // type assertion
                   .filter(Boolean)
             : [];
         return new Set<E>(tempInStorage);

--- a/src/main/webapp/app/assessment/manage/grading/bonus/bonus.component.spec.ts
+++ b/src/main/webapp/app/assessment/manage/grading/bonus/bonus.component.spec.ts
@@ -246,7 +246,7 @@ describe('BonusComponent', () => {
         },
     ];
 
-    const bonusStrategyToOptionAndDiscretenessMappings = [
+    const bonusStrategyToOptionAndDiscretenessMappings: [BonusStrategy | undefined, BonusStrategyOption | undefined, BonusStrategyDiscreteness | undefined][] = [
         [BonusStrategy.GRADES_CONTINUOUS, BonusStrategyOption.GRADES, BonusStrategyDiscreteness.CONTINUOUS],
         [BonusStrategy.GRADES_DISCRETE, BonusStrategyOption.GRADES, BonusStrategyDiscreteness.DISCRETE],
         [BonusStrategy.POINTS, BonusStrategyOption.POINTS, undefined],
@@ -351,7 +351,7 @@ describe('BonusComponent', () => {
 
     it.each(bonusStrategyToOptionAndDiscretenessMappings.slice(0, -1))(
         'should set bonus strategy and discreteness for [%p, %p, %p]',
-        (bonusStrategy: BonusStrategy, bonusStrategyOption: BonusStrategyOption, bonusStrategyDiscreteness: BonusStrategyDiscreteness) => {
+        (bonusStrategy: BonusStrategy | undefined, bonusStrategyOption: BonusStrategyOption | undefined, bonusStrategyDiscreteness: BonusStrategyDiscreteness | undefined) => {
             const bonusSpy = findBonusForExamSpy.mockReturnValue(of({ body: { bonusStrategy } } as EntityResponseType));
             component.ngOnInit();
             expect(bonusSpy).toHaveBeenCalledTimes(1);
@@ -362,7 +362,7 @@ describe('BonusComponent', () => {
 
     it.each(bonusStrategyToOptionAndDiscretenessMappings)(
         'should convert from inputs to BonusStrategy for [%p, %p, %p]',
-        (bonusStrategy: BonusStrategy, bonusStrategyOption: BonusStrategyOption, bonusStrategyDiscreteness: BonusStrategyDiscreteness) => {
+        (bonusStrategy: BonusStrategy | undefined, bonusStrategyOption: BonusStrategyOption | undefined, bonusStrategyDiscreteness: BonusStrategyDiscreteness | undefined) => {
             const actualBonusStrategy = component.convertFromInputsToBonusStrategy(bonusStrategyOption, bonusStrategyDiscreteness);
             expect(actualBonusStrategy).toBe(bonusStrategy);
         },

--- a/src/main/webapp/app/assessment/manage/grading/bonus/bonus.service.spec.ts
+++ b/src/main/webapp/app/assessment/manage/grading/bonus/bonus.service.spec.ts
@@ -205,7 +205,7 @@ describe('Bonus Service', () => {
             100,
             undefined,
         ],
-    ])('should get included boundary points [%p, %p, %p, %p]', (gradeStep: GradeStep, maxPoints: number, expected: number) => {
+    ])('should get included boundary points [%p, %p, %p, %p]', (gradeStep: GradeStep, maxPoints: number, expected: number | undefined) => {
         const result = service.getIncludedBoundaryPoints(gradeStep, maxPoints);
         expect(result).toBe(expected);
     });

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
@@ -24,7 +24,7 @@ import {
 } from 'app/exercise/shared/entities/submission/submission.model';
 import { ModelingSubmissionService } from 'app/modeling/overview/modeling-submission/modeling-submission.service';
 import { Observable, of } from 'rxjs';
-import { finalize, map } from 'rxjs/operators';
+import { filter, finalize, map } from 'rxjs/operators';
 import { StatsForDashboard } from 'app/assessment/shared/assessment-dashboard/stats-for-dashboard.model';
 import { TranslateService } from '@ngx-translate/core';
 import { FileUploadSubmissionService } from 'app/fileupload/overview/file-upload-submission.service';
@@ -554,6 +554,7 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
         submissionsObservable
             .pipe(
                 map((res) => res.body),
+                filter((body): body is Submission[] => body != undefined),
                 map(this.reconnectEntities),
             )
             .subscribe((submissions: Submission[]) => {

--- a/src/main/webapp/app/atlas/manage/forms/course-competency-form.component.ts
+++ b/src/main/webapp/app/atlas/manage/forms/course-competency-form.component.ts
@@ -1,5 +1,5 @@
 import { Component, InputSignal, inject, input, output } from '@angular/core';
-import { AsyncValidatorFn, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { AbstractControl, AsyncValidatorFn, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { of } from 'rxjs';
 import { catchError, delay, map, switchMap } from 'rxjs/operators';
 import { CompetencyTaxonomy, DEFAULT_MASTERY_THRESHOLD } from 'app/atlas/shared/entities/competency.model';
@@ -11,7 +11,7 @@ import { CourseCompetencyService } from 'app/atlas/shared/services/course-compet
  * Async validator to make sure that a competency title is unique within a course.
  */
 export const titleUniqueValidator = (courseCompetencyService: CourseCompetencyService, courseId: number, excludeCompetencyId?: number): AsyncValidatorFn => {
-    return (competencyTitleControl: FormControl<string | undefined>) => {
+    return (competencyTitleControl: AbstractControl<string | undefined>) => {
         return of(competencyTitleControl.value).pipe(
             delay(250),
             switchMap((title) => {

--- a/src/main/webapp/app/atlas/shared/competencies-popover/competencies-popover.component.spec.ts
+++ b/src/main/webapp/app/atlas/shared/competencies-popover/competencies-popover.component.spec.ts
@@ -62,7 +62,7 @@ describe('CompetencyPopoverComponent', () => {
         expect(competencyPopoverComponent).toBeDefined();
     });
 
-    it.each([
+    it.each<['competencyManagement' | 'courseCompetencies', string[]]>([
         ['courseCompetencies', ['/courses', '1', 'competencies']],
         ['competencyManagement', ['/course-management', '1', 'competency-management']],
     ])('should navigate', (navigateTo: 'competencyManagement' | 'courseCompetencies', expectedNavigation: string[]) => {

--- a/src/main/webapp/app/calendar/shared/calendar-overview/calendar-overview-component.directive.ts
+++ b/src/main/webapp/app/calendar/shared/calendar-overview/calendar-overview-component.directive.ts
@@ -58,7 +58,7 @@ export abstract class CalendarOverviewComponent {
                     const courseIdParameter = parameterMap.get('courseId');
                     return courseIdParameter !== null ? Number(courseIdParameter) : undefined;
                 }),
-                distinctUntilChanged(),
+                distinctUntilChanged<number | undefined>(),
             ),
             { initialValue: undefined },
         );

--- a/src/main/webapp/app/communication/course-conversations-components/dialogs/channels-overview-dialog/channels-overview-dialog.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/dialogs/channels-overview-dialog/channels-overview-dialog.component.ts
@@ -111,7 +111,7 @@ export class ChannelsOverviewDialogComponent extends AbstractDialogComponent imp
         this.channelService
             .getChannelsOfCourse(this.course()!.id!)
             .pipe(
-                map((res: HttpResponse<ChannelDTO[]>) => res.body),
+                map((res: HttpResponse<ChannelDTO[]>) => res.body ?? []),
                 finalize(() => {
                     this.isLoading.set(false);
                 }),

--- a/src/main/webapp/app/communication/course-conversations-components/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/dialogs/conversation-detail-dialog/tabs/conversation-info/conversation-info.component.ts
@@ -209,8 +209,10 @@ export class ConversationInfoComponent implements OnInit, OnDestroy {
                 takeUntil(this.ngUnsubscribe),
             )
             .subscribe({
-                next: (updatedGroupChat: GroupChatDTO) => {
-                    groupChat[propertyName] = updatedGroupChat[propertyName];
+                next: (updatedGroupChat: GroupChatDTO | null) => {
+                    if (updatedGroupChat) {
+                        groupChat[propertyName] = updatedGroupChat[propertyName];
+                    }
                     this.markSaved();
                     this.onChangePerformed();
                 },
@@ -235,8 +237,10 @@ export class ConversationInfoComponent implements OnInit, OnDestroy {
                 takeUntil(this.ngUnsubscribe),
             )
             .subscribe({
-                next: (updatedChannel: ChannelDTO) => {
-                    channel[propertyName] = updatedChannel[propertyName];
+                next: (updatedChannel: ChannelDTO | null) => {
+                    if (updatedChannel) {
+                        channel[propertyName] = updatedChannel[propertyName];
+                    }
                     this.markSaved();
                     this.onChangePerformed();
                 },

--- a/src/main/webapp/app/communication/course-conversations-components/dialogs/conversation-detail-dialog/tabs/conversation-members/conversation-member-row/conversation-member-row.component.spec.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/dialogs/conversation-detail-dialog/tabs/conversation-members/conversation-member-row/conversation-member-row.component.spec.ts
@@ -110,7 +110,7 @@ examples.forEach((activeConversation) => {
             component.canGrantChannelModeratorRole = canGrantChannelModeratorRole;
             component.canRemoveUsersFromConversation = canRemoveUsersFromConversation;
             translateService = TestBed.inject(TranslateService) as TranslateService;
-            vi.spyOn(translateService, 'instant').mockImplementation((key: string) => key);
+            vi.spyOn(translateService, 'instant').mockImplementation((key: string | string[]) => key);
         });
 
         afterEach(() => {

--- a/src/main/webapp/app/communication/course-conversations-components/dialogs/conversation-detail-dialog/tabs/conversation-members/conversation-member-row/conversation-member-row.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/dialogs/conversation-detail-dialog/tabs/conversation-members/conversation-member-row/conversation-member-row.component.ts
@@ -99,7 +99,10 @@ export class ConversationMemberRowComponent implements OnInit, OnDestroy {
 
     ngOnInit(): void {
         if (this.conversationMember() && this.activeConversation()) {
-            void this.accountService.identity().then((loggedInUser: User) => {
+            void this.accountService.identity().then((loggedInUser: User | undefined) => {
+                if (!loggedInUser) {
+                    return;
+                }
                 this.idOfLoggedInUser = loggedInUser.id!;
                 if (this.conversationMember()?.id === this.idOfLoggedInUser) {
                     this.isCurrentUser.set(true);

--- a/src/main/webapp/app/communication/course-conversations-components/layout/conversation-header/conversation-header.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/layout/conversation-header/conversation-header.component.ts
@@ -119,7 +119,7 @@ export class ConversationHeaderComponent implements OnInit, OnDestroy {
     }
 
     private subscribeToActiveConversation() {
-        this.metisConversationService.activeConversation$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((conversation: ConversationDTO) => {
+        this.metisConversationService.activeConversation$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((conversation: ConversationDTO | undefined) => {
             this.activeConversation.set(conversation);
             const activeConversationAsChannel = getAsChannelDTO(conversation);
             this.activeConversationAsChannel.set(activeConversationAsChannel);

--- a/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.spec.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.spec.ts
@@ -671,10 +671,10 @@ examples.forEach((activeConversation) => {
         });
 
         it('should return true if at least one unread post is visible', () => {
-            const mockPostId = 1;
+            const mockPostId: number = 1;
             component.unreadPosts = [{ id: mockPostId } as any];
 
-            vi.spyOn(component as any, 'isPostVisible').mockImplementation((id: number) => id === mockPostId);
+            vi.spyOn(component as any, 'isPostVisible').mockImplementation((...args: unknown[]) => args[0] === mockPostId);
 
             const result = (component as any).isAnyUnreadPostVisible();
             expect(result).toBe(true);

--- a/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.ts
@@ -213,7 +213,7 @@ export class ConversationMessagesComponent implements OnInit, AfterViewInit, OnD
                 this.pinnedCount.emit(pinnedPosts.length);
             });
 
-        void this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User | undefined) => {
             this.currentUser = user!;
         });
 
@@ -223,7 +223,7 @@ export class ConversationMessagesComponent implements OnInit, AfterViewInit, OnD
     }
 
     private subscribeToActiveConversation() {
-        this.metisConversationService.activeConversation$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((conversation: ConversationDTO) => {
+        this.metisConversationService.activeConversation$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((conversation: ConversationDTO | undefined) => {
             // This statement avoids a bug that reloads the messages when the conversation is already displayed
             if (conversation && this._activeConversation()?.id === conversation.id) {
                 return;

--- a/src/main/webapp/app/communication/course-faq/course-faq.component.ts
+++ b/src/main/webapp/app/communication/course-faq/course-faq.component.ts
@@ -82,7 +82,7 @@ export class CourseFaqComponent implements OnInit, OnDestroy {
     private loadFaqs() {
         this.faqService
             .findAllByCourseIdAndState(this.courseId, this.faqState)
-            .pipe(map((res: HttpResponse<Faq[]>) => res.body))
+            .pipe(map((res: HttpResponse<Faq[]>) => res.body ?? []))
             .subscribe({
                 next: (res: Faq[]) => {
                     this.faqs.set(res);

--- a/src/main/webapp/app/communication/emoji/emoji.utils.spec.ts
+++ b/src/main/webapp/app/communication/emoji/emoji.utils.spec.ts
@@ -11,7 +11,10 @@ describe('EmojiUtils', () => {
         expect(EmojiUtils.singleDarkModeEmojiUrlFn({ unified: emojiId } as EmojiData)).toBe('public/emoji/' + emojiId.toLowerCase() + '.png');
     });
 
-    it.each([{ unified: 'foo' }, { unified: '' }, { unified: undefined }, undefined])('should return nothing for emojis that are not be replaced', (emoji: EmojiData) => {
-        expect(EmojiUtils.singleDarkModeEmojiUrlFn(emoji)).toBe('');
-    });
+    it.each([{ unified: 'foo' }, { unified: '' }, { unified: undefined }, undefined])(
+        'should return nothing for emojis that are not be replaced',
+        (emoji: Partial<EmojiData> | undefined) => {
+            expect(EmojiUtils.singleDarkModeEmojiUrlFn((emoji ?? null) as EmojiData | null)).toBe('');
+        },
+    );
 });

--- a/src/main/webapp/app/communication/emoji/emoji.utils.ts
+++ b/src/main/webapp/app/communication/emoji/emoji.utils.ts
@@ -32,7 +32,7 @@ export class EmojiUtils {
      *
      * @param emoji the emoji that is to be rendered
      */
-    public static readonly singleDarkModeEmojiUrlFn: (emoji: EmojiData | null) => string = (emoji: EmojiData) => {
+    public static readonly singleDarkModeEmojiUrlFn: (emoji: EmojiData | null) => string = (emoji: EmojiData | null) => {
         if (emoji?.unified && EMOJIS_TO_REPLACE.includes(emoji.unified)) {
             return EMOJI_URL + emoji.unified.toLowerCase() + '.png';
         }

--- a/src/main/webapp/app/communication/faq/faq.component.ts
+++ b/src/main/webapp/app/communication/faq/faq.component.ts
@@ -153,7 +153,7 @@ export class FaqComponent implements OnInit, OnDestroy {
     private loadAll() {
         this.faqService
             .findAllByCourseId(this.courseId())
-            .pipe(map((res: HttpResponse<Faq[]>) => res.body))
+            .pipe(map((res: HttpResponse<Faq[]>) => res.body ?? []))
             .subscribe({
                 next: (res: Faq[]) => {
                     this.faqs = res;

--- a/src/main/webapp/app/communication/faq/faq.service.ts
+++ b/src/main/webapp/app/communication/faq/faq.service.ts
@@ -92,9 +92,9 @@ export class FaqService {
      * Converts the faq category json strings into FaqCategory objects (if it exists).
      * @param res the response
      */
-    static convertFaqCategoryArrayFromServer<E extends Faq, EART extends EntityArrayResponseType>(res: EART): EART {
+    static convertFaqCategoryArrayFromServer<EART extends EntityArrayResponseType>(res: EART): EART {
         if (res.body) {
-            res.body.forEach((faq: E) => FaqService.parseFaqCategories(faq));
+            res.body.forEach((faq: Faq) => FaqService.parseFaqCategories(faq));
         }
         return res;
     }

--- a/src/main/webapp/app/communication/posting-header/posting-header.component.ts
+++ b/src/main/webapp/app/communication/posting-header/posting-header.component.ts
@@ -90,7 +90,7 @@ export class PostingHeaderComponent implements OnInit {
         this.accountService
             .getAuthenticationState()
             .pipe(
-                tap((user: User) => {
+                tap((user: User | undefined) => {
                     this.currentUser.set(user);
                     this.setUserProperties();
                 }),

--- a/src/main/webapp/app/communication/service/metis-conversation.service.ts
+++ b/src/main/webapp/app/communication/service/metis-conversation.service.ts
@@ -63,7 +63,10 @@ export class MetisConversationService implements OnDestroy {
     private _isServiceSetup$: ReplaySubject<boolean> = new ReplaySubject<boolean>(1);
 
     constructor() {
-        void this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User | undefined) => {
+            if (!user) {
+                return;
+            }
             this.userId = user.id!;
             const conversationTopic = `/topic/user/${this.userId}/notifications/conversations`;
             this.activeConversationSubscription = this.websocketService.subscribe<MetisPostDTO>(conversationTopic).subscribe((postDTO: MetisPostDTO) => {

--- a/src/main/webapp/app/communication/service/metis.service.ts
+++ b/src/main/webapp/app/communication/service/metis.service.ts
@@ -25,7 +25,7 @@ import { Conversation, ConversationDTO } from 'app/communication/shared/entities
 import { getAsGroupChatDTO } from 'app/communication/shared/entities/conversation/group-chat.model';
 import { getAsOneToOneChatDTO } from 'app/communication/shared/entities/conversation/one-to-one-chat.model';
 import { Faq } from 'app/communication/shared/entities/faq.model';
-import { ForwardedMessage, ForwardedMessagesGroupDTO } from 'app/communication/shared/entities/forwarded-message.model';
+import { ForwardedMessage, ForwardedMessageDTO, ForwardedMessagesGroupDTO } from 'app/communication/shared/entities/forwarded-message.model';
 import { MetisPostDTO } from 'app/communication/shared/entities/metis-post-dto.model';
 import { Post } from 'app/communication/shared/entities/post.model';
 import { Posting, PostingType, SavedPostStatus } from 'app/communication/shared/entities/posting.model';
@@ -76,7 +76,7 @@ export class MetisService implements OnDestroy {
     private faqs$: BehaviorSubject<Faq[]> = new BehaviorSubject<Faq[]>([]);
 
     constructor() {
-        void this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User | undefined) => {
             this.user = user!;
 
             const conversationTopic = `/topic/user/${this.user.id}/notifications/conversations`;
@@ -956,7 +956,15 @@ export class MetisService implements OnDestroy {
 
                 // Send a creation request for each ForwardedMessage
                 const createForwardedMessageObservables = forwardedMessages.map((message) =>
-                    this.forwardedMessageService.createForwardedMessage(message).pipe(map((res: HttpResponse<ForwardedMessage>) => res.body!)),
+                    this.forwardedMessageService.createForwardedMessage(message).pipe(
+                        // Return the locally-built ForwardedMessage entity (which carries `destinationPost`, used by the
+                        // cache-marking logic below) updated with the server-assigned id, rather than casting the response
+                        // DTO — which only exposes `destinationPostId` — to the entity type.
+                        map((res: HttpResponse<ForwardedMessageDTO>) => {
+                            message.id = res.body?.id;
+                            return message;
+                        }),
+                    ),
                 );
 
                 return forkJoin(createForwardedMessageObservables).pipe(

--- a/src/main/webapp/app/communication/service/saved-post.service.ts
+++ b/src/main/webapp/app/communication/service/saved-post.service.ts
@@ -57,7 +57,7 @@ export class SavedPostService {
      */
     public fetchSavedPosts(courseId: number, status: SavedPostStatus): Observable<HttpResponse<Posting[]>> {
         const params = new HttpParams().set('status', status.toString().toLowerCase()).set('courseId', courseId.toString());
-        return this.http.get(`${this.resourceUrl}`, { observe: 'response', params }).pipe(map(this.convertPostResponseFromServer));
+        return this.http.get<Posting[]>(`${this.resourceUrl}`, { observe: 'response', params }).pipe(map(this.convertPostResponseFromServer));
     }
 
     /**

--- a/src/main/webapp/app/communication/shared/conversation-global-search/conversation-global-search.component.ts
+++ b/src/main/webapp/app/communication/shared/conversation-global-search/conversation-global-search.component.ts
@@ -100,8 +100,8 @@ export class ConversationGlobalSearchComponent implements OnInit, OnDestroy {
     readonly ButtonType = ButtonType;
 
     ngOnInit(): void {
-        void this.accountService.identity().then((user: User) => {
-            this.user = user!;
+        void this.accountService.identity().then((user: User | undefined) => {
+            this.user = user;
         });
     }
 

--- a/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.spec.ts
+++ b/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.spec.ts
@@ -99,7 +99,7 @@ examples.forEach((activeConversation) => {
                 breakpoints: { [Breakpoints.Handset]: false },
             });
 
-            queryParamsSubject = new BehaviorSubject(convertToParamMap({}));
+            queryParamsSubject = new BehaviorSubject<Params>({});
 
             TestBed.configureTestingModule({
                 imports: [
@@ -223,7 +223,7 @@ examples.forEach((activeConversation) => {
             fixture = TestBed.createComponent(CourseConversationsComponent);
             component = fixture.componentInstance;
 
-            postsSubject = new BehaviorSubject([]);
+            postsSubject = new BehaviorSubject<Post[]>([]);
             vi.spyOn(metisConversationService, 'course', 'get').mockReturnValue(course);
             vi.spyOn(metisConversationService, 'activeConversation$', 'get').mockReturnValue(new BehaviorSubject(activeConversation).asObservable());
             setActiveConversationSpy = vi.spyOn(metisConversationService, 'setActiveConversation');

--- a/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
+++ b/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
@@ -464,7 +464,7 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
     }
 
     private subscribeToActiveConversation() {
-        this.metisConversationService.activeConversation$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((conversation: ConversationDTO) => {
+        this.metisConversationService.activeConversation$.pipe(takeUntil(this.ngUnsubscribe)).subscribe((conversation: ConversationDTO | undefined) => {
             const previousConversation = this.activeConversation();
             this.activeConversation.set(conversation);
 

--- a/src/main/webapp/app/communication/shared/discussion-section/discussion-section.component.ts
+++ b/src/main/webapp/app/communication/shared/discussion-section/discussion-section.component.ts
@@ -142,7 +142,7 @@ export class DiscussionSectionComponent extends CourseDiscussionDirective implem
                 this.currentPost.set(this.posts().find((post) => post.id === this.currentPostId));
             }
         });
-        void this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User | undefined) => {
             this.currentUser = user!;
         });
         this.metisService.totalNumberOfPosts.pipe(takeUntil(this.ngUnsubscribe)).subscribe((totalNumberOfPosts: number) => {
@@ -174,7 +174,7 @@ export class DiscussionSectionComponent extends CourseDiscussionDirective implem
     setChannel(courseId: number): void {
         const getChannel = () => {
             return {
-                next: (channel: ChannelDTO) => {
+                next: (channel: ChannelDTO | null) => {
                     this.channel.set(channel ?? undefined);
                     this.resetFormGroup();
                     this.setFilterAndSort();

--- a/src/main/webapp/app/core/auth/passkey-authentication-page/passkey-authentication-page.component.spec.ts
+++ b/src/main/webapp/app/core/auth/passkey-authentication-page/passkey-authentication-page.component.spec.ts
@@ -265,9 +265,9 @@ describe('PasskeyAuthenticationPageComponent', () => {
         const instructionSpans = fixture.nativeElement.querySelectorAll('p.text-wrap span[jhiTranslate]');
         expect(instructionSpans.length).toBeGreaterThanOrEqual(3);
 
-        const startSpan = Array.from(instructionSpans).find((span: HTMLElement) => span.getAttribute('jhiTranslate') === 'global.menu.admin.passkeyApprovalInstructions.start') as
-            | HTMLElement
-            | undefined;
+        const startSpan = Array.from<HTMLElement>(instructionSpans).find(
+            (span: HTMLElement) => span.getAttribute('jhiTranslate') === 'global.menu.admin.passkeyApprovalInstructions.start',
+        );
         expect(startSpan).toBeTruthy();
 
         const link = fixture.nativeElement.querySelector('a[routerLink="/user-settings/passkeys"]');
@@ -276,9 +276,9 @@ describe('PasskeyAuthenticationPageComponent', () => {
         const linkSpan = link.querySelector('span[jhiTranslate="global.menu.admin.passkeyApprovalInstructions.link"]');
         expect(linkSpan).toBeTruthy();
 
-        const endSpan = Array.from(instructionSpans).find((span: HTMLElement) => span.getAttribute('jhiTranslate') === 'global.menu.admin.passkeyApprovalInstructions.end') as
-            | HTMLElement
-            | undefined;
+        const endSpan = Array.from<HTMLElement>(instructionSpans).find(
+            (span: HTMLElement) => span.getAttribute('jhiTranslate') === 'global.menu.admin.passkeyApprovalInstructions.end',
+        );
         expect(endSpan).toBeTruthy();
     });
 

--- a/src/main/webapp/app/core/navbar/navbar.component.ts
+++ b/src/main/webapp/app/core/navbar/navbar.component.ts
@@ -215,7 +215,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
         this.authStateSubscription = this.accountService
             .getAuthenticationState()
             .pipe(
-                tap((user: User) => {
+                tap((user: User | undefined) => {
                     this.currAccount.set(user);
                     this.passwordResetEnabled.set(user?.internal || false);
                     this.onResize();

--- a/src/main/webapp/app/core/notification/system-notification/system-notification.component.ts
+++ b/src/main/webapp/app/core/notification/system-notification/system-notification.component.ts
@@ -126,7 +126,7 @@ export class SystemNotificationComponent implements OnInit, OnDestroy, AfterView
             .flatMap((notification) => [notification.expireDate, notification.notificationDate])
             .filter((date) => date?.isAfter(now))
             .map((date) => date!)
-            .reduce((previous, current) => (previous ? dayjs.min(previous, current) : current), undefined);
+            .reduce<dayjs.Dayjs | undefined>((previous, current) => (previous ? dayjs.min(previous, current) : current), undefined);
 
         if (nextRelevantTimestamp) {
             this.nextUpdateFuture = setTimeout(() => {

--- a/src/main/webapp/app/course/manage/course-management-container/course-management-container.component.ts
+++ b/src/main/webapp/app/course/manage/course-management-container/course-management-container.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewInit, Component, DestroyRef, ElementRef, OnDestroy, OnInit, inject, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { NavigationEnd, RouterOutlet } from '@angular/router';
+import { NavigationEnd, Params, RouterOutlet } from '@angular/router';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { Observable, Subject, of } from 'rxjs';
 import { distinctUntilChanged, filter, map, startWith } from 'rxjs/operators';
@@ -163,7 +163,7 @@ export class CourseManagementContainerComponent extends BaseCourseContainerCompo
     >(undefined);
 
     override async ngOnInit() {
-        this.route.firstChild?.params.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params: { courseId: string }) => {
+        this.route.firstChild?.params.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params: Params) => {
             const id = Number(params.courseId);
             this.handleCourseIdChange(id);
             this.checkIfSettingsPage();

--- a/src/main/webapp/app/course/manage/update/course-update.component.ts
+++ b/src/main/webapp/app/course/manage/update/course-update.component.ts
@@ -1,7 +1,7 @@
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Component, DestroyRef, ElementRef, OnInit, inject, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
+import { AbstractControl, FormControl, FormGroup, FormsModule, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { AlertService, AlertType } from 'app/foundation/service/alert.service';
 import { HasAnyAuthorityDirective } from 'app/foundation/auth/has-any-authority.directive';
@@ -804,7 +804,8 @@ export class CourseUpdateComponent implements OnInit {
     }
 }
 
-const CourseValidator: ValidatorFn = (formGroup: FormGroup) => {
+const CourseValidator: ValidatorFn = (control: AbstractControl) => {
+    const formGroup = control as FormGroup;
     const onlineCourse = formGroup.controls['onlineCourse'].value;
     const enrollmentEnabled = formGroup.controls['enrollmentEnabled'].value;
     // it cannot be the case that both values are true

--- a/src/main/webapp/app/course/overview/course-exercises/course-exercise-row/course-exercise-row.component.ts
+++ b/src/main/webapp/app/course/overview/course-exercises/course-exercise-row/course-exercise-row.component.ts
@@ -6,6 +6,7 @@ import dayjs from 'dayjs/esm';
 import { Course } from 'app/course/shared/entities/course.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { StudentParticipation, isPracticeMode } from 'app/exercise/shared/entities/participation/student-participation.model';
+import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 import { QuizExercise } from 'app/quiz/shared/entities/quiz-exercise.model';
 import { Exercise, ExerciseType, IncludedInOverallScore, getIcon, getIconTooltip } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { ExerciseService } from 'app/exercise/services/exercise.service';
@@ -110,13 +111,14 @@ export class CourseExerciseRowComponent implements OnInit {
         this.participationWebsocketService
             .subscribeForParticipationChanges()
             .pipe(takeUntilDestroyed(this.destroyRef))
-            .subscribe((changedParticipation: StudentParticipation) => {
+            .subscribe((changedParticipation: Participation | undefined) => {
                 const exerciseValue = this.exercise();
                 if (changedParticipation && exerciseValue?.id && changedParticipation.exercise?.id === exerciseValue.id) {
+                    const studentParticipation = changedParticipation as StudentParticipation;
                     const currentParticipations = this._studentParticipations();
                     const updatedParticipations = currentParticipations.length
-                        ? currentParticipations.map((el) => (el.id === changedParticipation.id ? changedParticipation : el))
-                        : [changedParticipation];
+                        ? currentParticipations.map((el) => (el.id === studentParticipation.id ? studentParticipation : el))
+                        : [studentParticipation];
                     this._studentParticipations.set(updatedParticipations);
                     const participation = this.participationService.getSpecificStudentParticipation(updatedParticipations, false);
                     this._gradedStudentParticipation.set(participation);

--- a/src/main/webapp/app/course/overview/course-overview/course-overview.component.ts
+++ b/src/main/webapp/app/course/overview/course-overview/course-overview.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, OnDestroy, OnInit, computed, inject, signal } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { Params, RouterOutlet } from '@angular/router';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { Observable, Subscription, of, throwError } from 'rxjs';
 import { AccountService } from 'app/core/auth/account.service';
@@ -111,7 +111,7 @@ export class CourseOverviewComponent extends BaseCourseContainerComponent implem
             });
         });
 
-        this.subscription = this.route?.params.subscribe((params: { courseId: string }) => {
+        this.subscription = this.route?.params.subscribe((params: Params) => {
             const id = Number(params.courseId);
             const previousCourseId = this.courseId();
             this.courseId.set(id);

--- a/src/main/webapp/app/course/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/course/overview/exercise-details/course-exercise-details.component.ts
@@ -12,6 +12,16 @@ import { ParticipationWebsocketService } from 'app/course/shared/services/partic
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { Exercise, ExerciseType, getIcon } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
+import { Participation, ParticipationType } from 'app/exercise/shared/entities/participation/participation.model';
+
+/**
+ * Type guard mirroring the domain rule that a student participation is any participation that is neither a
+ * template nor a solution participation. Used to soundly narrow the app-wide participation stream (which is
+ * only ever fed student participations for this view) from Participation to StudentParticipation.
+ */
+function isStudentParticipationChange(participation: Participation | undefined): participation is StudentParticipation {
+    return !!participation && participation.type !== ParticipationType.TEMPLATE && participation.type !== ParticipationType.SOLUTION;
+}
 import { ExampleSolutionInfo, ExerciseDetailsType, ExerciseService } from 'app/exercise/services/exercise.service';
 import { AssessmentType } from 'app/assessment/shared/entities/assessment-type.model';
 import { hasExerciseDueDatePassed } from 'app/exercise/util/exercise.utils';
@@ -356,9 +366,12 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
             this._sortedHistoryResults.set(sorted);
         }
     }
-    private resultSortFunction = (a: Result, b: Result) => {
-        const aValue = dayjs(a.completionDate).valueOf();
-        const bValue = dayjs(b.completionDate).valueOf();
+    private resultSortFunction = (a: Result | undefined, b: Result | undefined) => {
+        // Missing/undefined completion dates sort last (treated as the max timestamp). This keeps the prior
+        // ordering (`dayjs(undefined)` evaluated to "now", placing undated results after real dates) but is
+        // deterministic and avoids the "now" footgun — and two undated results compare equal (0) rather than NaN.
+        const aValue = a?.completionDate ? dayjs(a.completionDate).valueOf() : Number.MAX_SAFE_INTEGER;
+        const bValue = b?.completionDate ? dayjs(b.completionDate).valueOf() : Number.MAX_SAFE_INTEGER;
         return aValue - bValue;
     };
 
@@ -390,8 +403,9 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
             .subscribeForParticipationChanges()
             // Skip the first event, as it is the initial state. All data should already be loaded.
             .pipe(skip(1), takeUntilDestroyed(this.destroyRef))
-            .subscribe((changedParticipation: StudentParticipation) => {
-                if (changedParticipation && this.exercise && changedParticipation.exercise?.id === this.exercise.id) {
+            .subscribe((changedParticipation: Participation | undefined) => {
+                // The app-wide participation subject only ever emits (structurally plain) student participations for this view.
+                if (isStudentParticipationChange(changedParticipation) && this.exercise && changedParticipation.exercise?.id === this.exercise.id) {
                     const currentGraded = this.gradedStudentParticipation();
                     // Notify student about late submission result
                     if (

--- a/src/main/webapp/app/course/shared/services/course-for-import-dto-paging-service.ts
+++ b/src/main/webapp/app/course/shared/services/course-for-import-dto-paging-service.ts
@@ -20,6 +20,8 @@ export class CourseForImportDTOPagingService extends PagingService<CourseForImpo
 
     override search(pageable: SearchTermPageableSearch): Observable<EntityResponseType> {
         const params = this.createHttpParams(pageable);
-        return this.http.get(`${this.RESOURCE_URL}/for-import`, { params, observe: 'response' }).pipe(map((resp: HttpResponse<EntityResponseType>) => resp && resp.body!));
+        return this.http
+            .get<EntityResponseType>(`${this.RESOURCE_URL}/for-import`, { params, observe: 'response' })
+            .pipe(map((resp: HttpResponse<EntityResponseType>) => resp && resp.body!));
     }
 }

--- a/src/main/webapp/app/course/shared/services/participation-websocket.service.spec.ts
+++ b/src/main/webapp/app/course/shared/services/participation-websocket.service.spec.ts
@@ -122,7 +122,7 @@ describe('ParticipationWebsocketService', () => {
 
     it('should emit rated result when received through websocket', () => {
         participationWebsocketService.subscribeForLatestResultOfParticipation(participation.id!, true);
-        const resultObservable = new BehaviorSubject(undefined);
+        const resultObservable = new BehaviorSubject<undefined | Result>(undefined);
         const resultSpy = vi.spyOn(resultObservable, 'next');
         participationWebsocketService.resultObservables.set(participation.id!, resultObservable);
 

--- a/src/main/webapp/app/course/shared/services/participation-websocket.service.ts
+++ b/src/main/webapp/app/course/shared/services/participation-websocket.service.ts
@@ -150,7 +150,7 @@ export class ParticipationWebsocketService implements IParticipationWebsocketSer
     /**
      * BehaviorSubjects that emit the latest result per participationId.
      */
-    resultObservables: Map<number, BehaviorSubject<Result | undefined>> = new Map<number, BehaviorSubject<Result>>();
+    resultObservables: Map<number, BehaviorSubject<Result | undefined>> = new Map<number, BehaviorSubject<Result | undefined>>();
 
     /**
      * BehaviorSubject that emits the latest updated participation.
@@ -206,7 +206,7 @@ export class ParticipationWebsocketService implements IParticipationWebsocketSer
             this.removeParticipation(participation.id!, participation.exercise?.id);
         });
         this.cachedParticipations = new Map<number, StudentParticipation>();
-        this.resultObservables = new Map<number, BehaviorSubject<Result>>();
+        this.resultObservables = new Map<number, BehaviorSubject<Result | undefined>>();
         this.participationObservable = undefined;
         this.subscribedExercises = new Map<number, Set<number>>();
         this.participationSubscriptionTypes = new Map<number, boolean>();
@@ -217,9 +217,9 @@ export class ParticipationWebsocketService implements IParticipationWebsocketSer
      *
      * @param participation Updated participation object
      */
-    private notifyParticipationSubscribers = (participation: Participation): void => {
+    private notifyParticipationSubscribers = (participation: Participation | undefined): void => {
         if (!this.participationObservable) {
-            this.participationObservable = new BehaviorSubject(participation);
+            this.participationObservable = new BehaviorSubject<Participation | undefined>(participation);
         } else {
             this.participationObservable.next(participation);
         }
@@ -235,7 +235,7 @@ export class ParticipationWebsocketService implements IParticipationWebsocketSer
         // TODO: We never convert the date strings of the result (e.g. completionDate) to a Dayjs object
         //  this could be an issue in some parts of app when a formatted date is needed.
         if (!resultObservable) {
-            this.resultObservables.set(result.submission!.participation!.id!, new BehaviorSubject(result));
+            this.resultObservables.set(result.submission!.participation!.id!, new BehaviorSubject<Result | undefined>(result));
         } else {
             resultObservable.next(result);
         }

--- a/src/main/webapp/app/editor/monaco-editor/model/actions/communication/user-mention.action.ts
+++ b/src/main/webapp/app/editor/monaco-editor/model/actions/communication/user-mention.action.ts
@@ -59,7 +59,7 @@ export class UserMentionAction extends TextEditorAction {
         this.disposableCompletionProvider?.dispose();
     }
 
-    async loadUsersForSearchTerm(searchTerm: string): Promise<UserNameAndLoginDTO[]> {
+    async loadUsersForSearchTerm(searchTerm: string = ''): Promise<UserNameAndLoginDTO[]> {
         const response = await firstValueFrom(this.courseManagementService.searchMembersForUserMentions(this.metisService.getCourse().id!, searchTerm));
         return response.body ?? [];
     }

--- a/src/main/webapp/app/editor/monaco-editor/monaco-editor.component.spec.ts
+++ b/src/main/webapp/app/editor/monaco-editor/monaco-editor.component.spec.ts
@@ -291,7 +291,7 @@ describe('MonacoEditorComponent', () => {
         fixture.detectChanges();
         const updateOptionsSpy = vi.spyOn((comp as any)._editor, 'updateOptions');
         const originalGetOption = (comp as any)._editor.getOption.bind((comp as any)._editor);
-        const getOptionSpy = vi.spyOn((comp as any)._editor, 'getOption').mockImplementation((option: monaco.editor.EditorOption) => {
+        const getOptionSpy = vi.spyOn((comp as any)._editor, 'getOption').mockImplementation((option: unknown) => {
             if (option === monaco.editor.EditorOption.folding) {
                 return false;
             }

--- a/src/main/webapp/app/exam/manage/exams/exam-import/exam-import-paging.service.ts
+++ b/src/main/webapp/app/exam/manage/exams/exam-import/exam-import-paging.service.ts
@@ -22,7 +22,7 @@ export class ExamImportPagingService extends PagingService<Exam> {
     override search(pageable: SearchTermPageableSearch, options: { withExercises: boolean }): Observable<EntityResponseType> {
         const params = this.createHttpParams(pageable);
         return this.http
-            .get(`${ExamImportPagingService.RESOURCE_URL}?withExercises=${options.withExercises}`, { params, observe: 'response' })
+            .get<EntityResponseType>(`${ExamImportPagingService.RESOURCE_URL}?withExercises=${options.withExercises}`, { params, observe: 'response' })
             .pipe(map((resp: HttpResponse<EntityResponseType>) => resp && resp.body!));
     }
 }

--- a/src/main/webapp/app/exam/manage/students/verify-attendance-check/exam-students-attendance-check.component.ts
+++ b/src/main/webapp/app/exam/manage/students/verify-attendance-check/exam-students-attendance-check.component.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { ExamUserAttendanceCheckDTO } from 'app/exam/shared/entities/exam-users-attendance-check-dto.model';
 import { SortService } from 'app/foundation/service/sort.service';
 import { Subject, Subscription } from 'rxjs';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Data } from '@angular/router';
 import { ActionType } from 'app/shared-ui/delete-dialog/delete-dialog.model';
 import { Exam } from 'app/exam/shared/entities/exam.model';
 import { ExamManagementService } from 'app/exam/manage/services/exam-management.service';
@@ -67,7 +67,8 @@ export class ExamStudentsAttendanceCheckComponent implements OnInit, OnDestroy {
     ngOnInit() {
         this.isLoading.set(true);
         this.courseId = Number(this.route.snapshot.paramMap.get('courseId'));
-        this.route.data.subscribe(({ exam }: { exam: Exam }) => {
+        this.route.data.subscribe((data: Data) => {
+            const exam: Exam = data.exam;
             this.exam = exam;
             this.hasExamStarted.set(exam.startDate?.isBefore(dayjs()) || false);
             this.hasExamEnded.set(exam.endDate?.isBefore(dayjs()) || false);

--- a/src/main/webapp/app/exam/overview/exam-cover/exam-participation-cover.component.ts
+++ b/src/main/webapp/app/exam/overview/exam-cover/exam-participation-cover.component.ts
@@ -167,8 +167,13 @@ export class ExamParticipationCoverComponent implements OnDestroy, OnInit {
             this.isFetching.set(true);
             this.loadExamSubscription = this.examParticipationService
                 .loadStudentExamWithExercisesForConduction(this.exam().course!.id!, this.exam().id!, this.studentExam().id!)
-                .subscribe((studentExam: StudentExam) => {
+                .subscribe((studentExam: StudentExam | undefined) => {
+                    // Always clear the loading state so the start action recovers even when the load falls back to
+                    // local storage and yields no exam — otherwise `isFetching` would stay true and the button spins.
                     this.isFetching.set(false);
+                    if (!studentExam) {
+                        return;
+                    }
                     this.examParticipationService.saveStudentExamToLocalStorage(this.exam().course!.id!, this.exam().id!, studentExam);
                     if (this.hasStarted()) {
                         this.onExamStarted.emit(studentExam);

--- a/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.ts
@@ -195,7 +195,7 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
     readonly isAtLeastTutor = signal<boolean | undefined>(undefined);
     readonly isAtLeastInstructor = signal<boolean | undefined>(undefined);
 
-    generateParticipationStatus: BehaviorSubject<GenerateParticipationStatus> = new BehaviorSubject('success');
+    generateParticipationStatus: BehaviorSubject<GenerateParticipationStatus> = new BehaviorSubject<GenerateParticipationStatus>('success');
 
     constructor() {
         // show only one synchronization error every 5s
@@ -282,8 +282,10 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
 
     loadAndDisplaySummary() {
         this.examParticipationService.loadStudentExamWithExercisesForSummary(this.courseId(), this.examId(), this.studentExam().id!).subscribe({
-            next: (studentExamWithExercises: StudentExam) => {
-                this.studentExam.set(studentExamWithExercises);
+            next: (studentExamWithExercises: StudentExam | undefined) => {
+                if (studentExamWithExercises) {
+                    this.studentExam.set(studentExamWithExercises);
+                }
                 this.showExamSummary.set(true);
                 this.loadingExam.set(false);
             },
@@ -691,19 +693,21 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
         } else {
             // Directly start the exam when we continue from a failed save
             if (this.examParticipationService.lastSaveFailed(this.courseId(), this.examId())) {
-                this.examParticipationService.loadStudentExamWithExercisesForConductionFromLocalStorage(this.courseId(), this.examId()).subscribe((localExam: StudentExam) => {
-                    if (localExam) {
-                        // Keep the working time from the server
-                        localExam.workingTime = this.studentExam().workingTime ?? localExam.workingTime;
-                        this.studentExam.set(localExam);
-                        this.loadingExam.set(false);
-                        // Resume from the locally cached exam: keep not-yet-saved answers (isSynced=false) and re-send them.
-                        this.examStarted(this.studentExam(), true);
-                        // Inform the student that their previously entered answers were restored and are being saved,
-                        // so it is clear that nothing was lost when the page was reloaded.
-                        this.alertService.info('artemisApp.examParticipation.answersRestoredFromLocalStorage');
-                    }
-                });
+                this.examParticipationService
+                    .loadStudentExamWithExercisesForConductionFromLocalStorage(this.courseId(), this.examId())
+                    .subscribe((localExam: StudentExam | undefined) => {
+                        if (localExam) {
+                            // Keep the working time from the server
+                            localExam.workingTime = this.studentExam().workingTime ?? localExam.workingTime;
+                            this.studentExam.set(localExam);
+                            this.loadingExam.set(false);
+                            // Resume from the locally cached exam: keep not-yet-saved answers (isSynced=false) and re-send them.
+                            this.examStarted(this.studentExam(), true);
+                            // Inform the student that their previously entered answers were restored and are being saved,
+                            // so it is clear that nothing was lost when the page was reloaded.
+                            this.alertService.info('artemisApp.examParticipation.answersRestoredFromLocalStorage');
+                        }
+                    });
             } else {
                 this.loadingExam.set(false);
             }
@@ -743,28 +747,33 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
         if (this.workingTimeUpdateEventsSubscription) {
             this.workingTimeUpdateEventsSubscription.unsubscribe();
         }
-        this.workingTimeUpdateEventsSubscription = this.liveEventsService
-            .observeNewEventsAsSystem([ExamLiveEventType.WORKING_TIME_UPDATE])
-            .subscribe((event: WorkingTimeUpdateEvent) => {
-                // Create new object to make change detection work, otherwise the date will not update
-                this.studentExam.set({ ...this.studentExam(), workingTime: event.newWorkingTime });
-                this.examParticipationService.currentlyLoadedStudentExam.next(this.studentExam());
-                this.individualStudentEndDate.set(dayjs(startDate).add(this.studentExam().workingTime!, 'seconds'));
-                this.individualStudentEndDateWithGracePeriod.set(this.individualStudentEndDate().clone().add(this.exam().gracePeriod!, 'seconds'));
-                this.liveEventsService.acknowledgeEvent(event, false);
-            });
+        // observeNewEventsAsSystem already filters by the requested event type, so the emitted events are
+        // WorkingTimeUpdateEvent at runtime; the cast keeps the callback param typed without an extra `filter`
+        // (which would incorrectly drop events lacking an explicit `eventType`, e.g. in tests).
+        this.workingTimeUpdateEventsSubscription = (
+            this.liveEventsService.observeNewEventsAsSystem([ExamLiveEventType.WORKING_TIME_UPDATE]) as Observable<WorkingTimeUpdateEvent>
+        ).subscribe((event: WorkingTimeUpdateEvent) => {
+            // Create new object to make change detection work, otherwise the date will not update
+            this.studentExam.set({ ...this.studentExam(), workingTime: event.newWorkingTime });
+            this.examParticipationService.currentlyLoadedStudentExam.next(this.studentExam());
+            this.individualStudentEndDate.set(dayjs(startDate).add(this.studentExam().workingTime!, 'seconds'));
+            this.individualStudentEndDateWithGracePeriod.set(this.individualStudentEndDate().clone().add(this.exam().gracePeriod!, 'seconds'));
+            this.liveEventsService.acknowledgeEvent(event, false);
+        });
     }
 
     private subscribeToProblemStatementUpdates() {
         if (this.problemStatementUpdateEventsSubscription) {
             this.problemStatementUpdateEventsSubscription.unsubscribe();
         }
-        this.problemStatementUpdateEventsSubscription = this.liveEventsService
-            .observeNewEventsAsSystem([ExamLiveEventType.PROBLEM_STATEMENT_UPDATE])
-            .subscribe((event: ProblemStatementUpdateEvent) => {
-                this.updateProblemStatement(event);
-                this.liveEventsService.acknowledgeEvent(event, false);
-            });
+        // See subscribeToWorkingTimeUpdates: the events are already type-filtered by observeNewEventsAsSystem,
+        // so we cast rather than add a `filter` that would drop events without an explicit `eventType`.
+        this.problemStatementUpdateEventsSubscription = (
+            this.liveEventsService.observeNewEventsAsSystem([ExamLiveEventType.PROBLEM_STATEMENT_UPDATE]) as Observable<ProblemStatementUpdateEvent>
+        ).subscribe((event: ProblemStatementUpdateEvent) => {
+            this.updateProblemStatement(event);
+            this.liveEventsService.acknowledgeEvent(event, false);
+        });
     }
 
     /**

--- a/src/main/webapp/app/exam/overview/services/exam-participation.service.spec.ts
+++ b/src/main/webapp/app/exam/overview/services/exam-participation.service.spec.ts
@@ -245,7 +245,7 @@ describe('ExamParticipationService', () => {
         studentExam.exercises = [];
         service.saveStudentExamToLocalStorage(1, 1, studentExam);
 
-        service.loadStudentExamWithExercisesForConductionFromLocalStorage(1, 1).subscribe((localExam: StudentExam) => {
+        service.loadStudentExamWithExercisesForConductionFromLocalStorage(1, 1).subscribe((localExam: StudentExam | undefined) => {
             expect(localExam).toBeDefined();
             expect(localExam).toEqual(studentExam);
         });

--- a/src/main/webapp/app/exercise/example-submission/example-submission-import/example-submission-import-paging.service.ts
+++ b/src/main/webapp/app/exercise/example-submission/example-submission-import/example-submission-import-paging.service.ts
@@ -26,7 +26,7 @@ export class ExampleSubmissionImportPagingService extends PagingService<Submissi
     override search(pageable: SearchTermPageableSearch, options: { exerciseId: number }): Observable<EntityResponseType> {
         const params = this.createHttpParams(pageable);
         return this.http
-            .get(`${ExampleSubmissionImportPagingService.RESOURCE_URL}/${options.exerciseId}/submissions-for-import`, { params, observe: 'response' })
+            .get<EntityResponseType>(`${ExampleSubmissionImportPagingService.RESOURCE_URL}/${options.exerciseId}/submissions-for-import`, { params, observe: 'response' })
             .pipe(map((resp: HttpResponse<EntityResponseType>) => resp && resp.body!));
     }
 }

--- a/src/main/webapp/app/exercise/exercise-info/exercise-info.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-info/exercise-info.component.spec.ts
@@ -35,7 +35,7 @@ describe('Exercise Info Component', () => {
         [{ dueDate: dateOne } as Exercise, undefined, dateOne],
         [{ dueDate: dateOne } as Exercise, {}, dateOne],
         [{ dueDate: dateOne } as Exercise, { individualDueDate: dateTwo }, dateTwo],
-    ])('should determine due date', (exercise: Exercise, studentParticipation: StudentParticipation | undefined, expectedDueDate: dayjs.Dayjs) => {
+    ])('should determine due date', (exercise: Partial<Exercise>, studentParticipation: Partial<StudentParticipation> | undefined, expectedDueDate: dayjs.Dayjs | undefined) => {
         fixture.componentRef.setInput('exercise', exercise);
         fixture.componentRef.setInput('studentParticipation', studentParticipation);
 

--- a/src/main/webapp/app/exercise/exercise-scores/exercise-scores.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-scores/exercise-scores.component.spec.ts
@@ -251,11 +251,14 @@ describe('Exercise Scores Component', () => {
             [FilterProp.LOCKED, { type: ExerciseType.PROGRAMMING, isAtLeastInstructor: true }, true, true],
             [FilterProp.LOCKED, { type: ExerciseType.PROGRAMMING, isAtLeastInstructor: false }, false, false],
             [FilterProp.LOCKED, { type: ExerciseType.TEXT }, true, false],
-        ])('should determine if filter is relevant for exercise configuration', (filter: FilterProp, ex: Exercise, newManualResultsAllowed: boolean, expected: boolean) => {
-            component.exercise.set(ex);
-            component.newManualResultAllowed.set(newManualResultsAllowed);
-            expect(component.relevantFilters().includes(filter)).toBe(expected);
-        });
+        ])(
+            'should determine if filter is relevant for exercise configuration',
+            (filter: FilterProp, ex: Partial<Exercise>, newManualResultsAllowed: boolean, expected: boolean) => {
+                component.exercise.set(ex as Exercise);
+                component.newManualResultAllowed.set(newManualResultsAllowed);
+                expect(component.relevantFilters().includes(filter)).toBe(expected);
+            },
+        );
     });
 
     describe('getBuildPlanUrl', () => {

--- a/src/main/webapp/app/exercise/feedback/feedback.component.ts
+++ b/src/main/webapp/app/exercise/feedback/feedback.component.ts
@@ -143,7 +143,7 @@ export class FeedbackComponent implements OnInit, OnChanges {
             horizontal: true,
             stacked: true,
             maxBarThickness: 25,
-            xAxis: { max: this.chartData().xScaleMax, tickFormatter: this.xAxisFormatting },
+            xAxis: { max: this.chartData().xScaleMax, tickFormatter: (value) => this.xAxisFormatting(String(value)) },
             yAxis: { display: false },
             legend: { position: 'bottom' },
             tooltip: false,

--- a/src/main/webapp/app/exercise/review/review-comment-thread-widget/review-comment-thread-widget.component.spec.ts
+++ b/src/main/webapp/app/exercise/review/review-comment-thread-widget/review-comment-thread-widget.component.spec.ts
@@ -8,7 +8,7 @@ import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { ExerciseReviewCommentService } from 'app/exercise/review/exercise-review-comment.service';
-import { ConfirmationService } from 'primeng/api';
+import { Confirmation, ConfirmationService } from 'primeng/api';
 import { signal } from '@angular/core';
 
 describe('ReviewCommentThreadWidgetComponent', () => {
@@ -63,8 +63,8 @@ describe('ReviewCommentThreadWidgetComponent', () => {
 
     it('should delete comment when deletion is confirmed', () => {
         let acceptCallback: (() => void) | undefined;
-        vi.spyOn(confirmationService, 'confirm').mockImplementation((confirmation: { accept?: () => void }) => {
-            acceptCallback = confirmation.accept;
+        vi.spyOn(confirmationService, 'confirm').mockImplementation((confirmation: Confirmation) => {
+            acceptCallback = confirmation.accept as (() => void) | undefined;
             return confirmationService;
         });
 
@@ -78,8 +78,8 @@ describe('ReviewCommentThreadWidgetComponent', () => {
 
     it('should not delete comment when deletion is dismissed', () => {
         let rejectCallback: (() => void) | undefined;
-        vi.spyOn(confirmationService, 'confirm').mockImplementation((confirmation: { reject?: () => void }) => {
-            rejectCallback = confirmation.reject;
+        vi.spyOn(confirmationService, 'confirm').mockImplementation((confirmation: Confirmation) => {
+            rejectCallback = confirmation.reject as (() => void) | undefined;
             return confirmationService;
         });
 

--- a/src/main/webapp/app/exercise/services/exercise-paging.service.ts
+++ b/src/main/webapp/app/exercise/services/exercise-paging.service.ts
@@ -30,6 +30,6 @@ export abstract class ExercisePagingService<T extends Exercise> extends PagingSe
         if (options.programmingLanguage) {
             params = params.set('programmingLanguage', options.programmingLanguage);
         }
-        return this.http.get(`${this.resourceUrl}`, { params, observe: 'response' }).pipe(map((resp: HttpResponse<SearchResult<T>>) => resp && resp.body!));
+        return this.http.get<SearchResult<T>>(`${this.resourceUrl}`, { params, observe: 'response' }).pipe(map((resp: HttpResponse<SearchResult<T>>) => resp && resp.body!));
     }
 }

--- a/src/main/webapp/app/exercise/services/exercise.service.ts
+++ b/src/main/webapp/app/exercise/services/exercise.service.ts
@@ -370,9 +370,9 @@ export class ExerciseService {
      * Replace dates in http-response including an array of exercises with the corresponding client time
      * @param res - Response from server including an array of exercise
      */
-    static convertExerciseArrayDatesFromServer<E extends Exercise, EART extends EntityArrayResponseType>(res: EART): EART {
+    static convertExerciseArrayDatesFromServer<EART extends EntityArrayResponseType>(res: EART): EART {
         if (res.body) {
-            res.body.forEach((exercise: E) => {
+            res.body.forEach((exercise: Exercise) => {
                 ExerciseService.convertExerciseDatesFromServer(exercise);
             });
         }
@@ -407,9 +407,9 @@ export class ExerciseService {
      * Converts the exercise category json strings into ExerciseCategory objects (if it exists).
      * @param res the response
      */
-    static convertExerciseCategoryArrayFromServer<E extends Exercise, EART extends EntityArrayResponseType>(res: EART): EART {
+    static convertExerciseCategoryArrayFromServer<EART extends EntityArrayResponseType>(res: EART): EART {
         if (res.body) {
-            res.body.forEach((exercise: E) => ExerciseService.parseExerciseCategories(exercise));
+            res.body.forEach((exercise: Exercise) => ExerciseService.parseExerciseCategories(exercise));
         }
         return res;
     }

--- a/src/main/webapp/app/exercise/synchronization/metadata/exercise-metadata-handlers.ts
+++ b/src/main/webapp/app/exercise/synchronization/metadata/exercise-metadata-handlers.ts
@@ -23,10 +23,14 @@ import { toAuxiliaryRepositories, toBuildConfig } from 'app/exercise/synchroniza
 export interface ExerciseMetadataFieldHandler<T extends Exercise, V = unknown> {
     key: string;
     labelKey: string;
-    getCurrentValue: (exercise: T) => V;
-    getBaselineValue: (exercise: T) => V;
-    getIncomingValue: (snapshot: ExerciseSnapshotDTO) => V;
-    applyValue: (exercise: T, value: V) => void;
+    // Method syntax (not `prop: (…) => V`) is intentional: it makes the members bivariant, so a concrete
+    // `…FieldHandler<Exercise, string | undefined>` remains assignable to the erased `…FieldHandler<Exercise, unknown>`
+    // element type of the handler arrays. Each value round-trips through its own handler (getters ↔ applyValue),
+    // so the variance is safe by construction. Without this, strictFunctionTypes rejects `applyValue`'s `V` parameter.
+    getCurrentValue(exercise: T): V;
+    getBaselineValue(exercise: T): V;
+    getIncomingValue(snapshot: ExerciseSnapshotDTO): V;
+    applyValue(exercise: T, value: V): void;
 }
 
 type ExerciseResolver = () => Exercise;

--- a/src/main/webapp/app/exercise/synchronization/services/exercise-metadata-sync.service.ts
+++ b/src/main/webapp/app/exercise/synchronization/services/exercise-metadata-sync.service.ts
@@ -29,9 +29,13 @@ import { ExerciseSnapshotDTO } from 'app/exercise/synchronization/metadata/exerc
 export interface ExerciseMetadataSyncContext<T extends Exercise> {
     exerciseId: number;
     exerciseType: ExerciseType;
-    getCurrentExercise: () => T;
-    getBaselineExercise: () => T;
-    setBaselineExercise: (exercise: T) => void;
+    // Method syntax (not `prop: (…) => …`) makes these members bivariant, so a subtype-specific context
+    // (e.g. <ProgrammingExercise>) stays assignable to the erased <Exercise> context the service stores.
+    // Safe by construction: setBaselineExercise only ever receives values read from this same context's
+    // getters (see applySnapshotToBaseline). Without this, strictFunctionTypes rejects the assignment.
+    getCurrentExercise(): T;
+    getBaselineExercise(): T;
+    setBaselineExercise(exercise: T): void;
 }
 
 interface ConflictCandidate {
@@ -192,6 +196,8 @@ export class ExerciseMetadataSyncService {
         if (this.subscriptionActive && this.context?.exerciseId !== context.exerciseId) {
             this.destroy();
         }
+        // The generic <T> lets callers pass a subtype-specific context; the interface's method-syntax members
+        // (see its note) keep that assignable to the erased <Exercise> context stored here — no cast needed.
         this.context = context;
         this.cachedHandlers = this.buildHandlers(this.context);
         if (this.subscriptionActive) {

--- a/src/main/webapp/app/exercise/team-submission-sync/team-submission-sync.component.ts
+++ b/src/main/webapp/app/exercise/team-submission-sync/team-submission-sync.component.ts
@@ -42,7 +42,7 @@ export class TeamSubmissionSyncComponent implements OnInit, OnDestroy {
     websocketTopic: string;
 
     constructor() {
-        void this.accountService.identity().then((user: User) => (this.currentUser = user));
+        void this.accountService.identity().then((user: User | undefined) => (this.currentUser = user!));
     }
 
     /**

--- a/src/main/webapp/app/exercise/team/team-participate/team-students-online-list.component.ts
+++ b/src/main/webapp/app/exercise/team/team-participate/team-students-online-list.component.ts
@@ -31,7 +31,7 @@ export class TeamStudentsOnlineListComponent implements OnInit, OnDestroy {
     readonly typing$ = input<Observable<string> | undefined>(undefined);
     readonly participation = input.required<StudentParticipation>();
 
-    currentUser: User;
+    currentUser?: User;
     onlineTeamStudents: OnlineTeamStudent[] = [];
     typingTeamStudents: OnlineTeamStudent[] = [];
     websocketTopic: string;
@@ -49,7 +49,7 @@ export class TeamStudentsOnlineListComponent implements OnInit, OnDestroy {
      * client sometimes and thus the list is explicitly requested once more after a short timeout to cover those cases.
      */
     ngOnInit(): void {
-        void this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User | undefined) => {
             this.currentUser = user;
             this.setupOnlineTeamStudentsReceiver();
             this.setupTypingIndicatorSender();
@@ -153,13 +153,14 @@ export class TeamStudentsOnlineListComponent implements OnInit, OnDestroy {
     }
 
     private convertOnlineTeamStudentsFromServer(students: OnlineTeamStudent[]) {
-        return students.map((student) => {
-            return {
-                ...student,
-                lastTypingDate: student.lastTypingDate !== null ? dayjs(student.lastTypingDate) : null,
-                lastActionDate: student.lastActionDate !== null ? dayjs(student.lastActionDate) : null,
-            };
-        });
+        // The server may send null dates (never typed/acted); the accessors and templates handle that. The array
+        // cast (on the map result, not an object literal — so it satisfies consistent-type-assertions) keeps the
+        // stream typed as OnlineTeamStudent[] the way it was before strictFunctionTypes enforced the callback variance.
+        return students.map((student) => ({
+            ...student,
+            lastTypingDate: student.lastTypingDate !== null ? dayjs(student.lastTypingDate) : null,
+            lastActionDate: student.lastActionDate !== null ? dayjs(student.lastActionDate) : null,
+        })) as OnlineTeamStudent[];
     }
 
     /**

--- a/src/main/webapp/app/exercise/team/team-participation-table/team-participation-table.component.ts
+++ b/src/main/webapp/app/exercise/team/team-participation-table/team-participation-table.component.ts
@@ -177,7 +177,7 @@ export class TeamParticipationTableComponent implements OnInit {
      * @param exercises Exercises from the server which to transform
      */
     transformExercisesFromServer(exercises: Exercise[]): ExerciseForTeam[] {
-        return ExerciseService.convertExercisesDateFromServer(exercises).map((exercise: ExerciseForTeam) => {
+        return (ExerciseService.convertExercisesDateFromServer(exercises) as ExerciseForTeam[]).map((exercise: ExerciseForTeam) => {
             exercise.team = exercise.teams![0];
             const participation = get(exercise, 'studentParticipations[0]', undefined);
             exercise.participation = participation;

--- a/src/main/webapp/app/exercise/team/team.component.ts
+++ b/src/main/webapp/app/exercise/team/team.component.ts
@@ -69,7 +69,7 @@ export class TeamComponent implements OnInit {
     ];
 
     constructor() {
-        void this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User | undefined) => {
             this.currentUser.set(user);
             this.isAdmin.set(this.accountService.isAdmin());
         });

--- a/src/main/webapp/app/exercise/team/team.service.ts
+++ b/src/main/webapp/app/exercise/team/team.service.ts
@@ -11,7 +11,6 @@ import { downloadFile } from 'app/foundation/util/download.util';
 import { createRequestOption } from 'app/foundation/util/request.util';
 import { Observable, Subscription } from 'rxjs';
 import { filter, map, shareReplay } from 'rxjs/operators';
-import { EntityResponseType } from 'app/exercise/services/exercise.service';
 import { convertDateFromServer } from 'app/foundation/util/date.utils';
 
 /**
@@ -266,7 +265,7 @@ export class TeamService implements ITeamService, OnDestroy {
     findCourseWithExercisesAndParticipationsForTeam(course: Course, team: Team): Observable<HttpResponse<Course>> {
         return this.http
             .get<Course>(`api/exercise/courses/${course.id}/teams/${team.shortName}/with-exercises-and-participations`, { observe: 'response' })
-            .pipe(map((res: EntityResponseType) => this.setAccessRightsCourseEntityResponseType(res)));
+            .pipe(map((res: HttpResponse<Course>) => this.setAccessRightsCourseEntityResponseType(res)));
     }
 
     /**
@@ -364,7 +363,7 @@ export class TeamService implements ITeamService, OnDestroy {
         return team;
     }
 
-    private setAccessRightsCourseEntityResponseType(res: EntityResponseType): EntityResponseType {
+    private setAccessRightsCourseEntityResponseType(res: HttpResponse<Course>): HttpResponse<Course> {
         if (res.body) {
             this.accountService.setAccessRightsForCourse(res.body);
         }

--- a/src/main/webapp/app/exercise/team/teams/teams.component.ts
+++ b/src/main/webapp/app/exercise/team/teams/teams.component.ts
@@ -101,7 +101,7 @@ export class TeamsComponent implements OnInit, OnDestroy {
     ]);
 
     constructor() {
-        void this.accountService.identity().then((user: User) => {
+        void this.accountService.identity().then((user: User | undefined) => {
             this.currentUser.set(user);
             this.isAdmin.set(this.accountService.isAdmin());
         });

--- a/src/main/webapp/app/exercise/util/exercise.utils.ts
+++ b/src/main/webapp/app/exercise/util/exercise.utils.ts
@@ -242,6 +242,7 @@ export const countSubmissions = (participation?: StudentParticipation): number =
     participation?.submissions
         ?.filter((submission) => submission.type === SubmissionType.MANUAL)
         .map((submission) => (submission as ProgrammingSubmission).commitHash)
-        .forEach((commitHash: string) => commitHashSet.add(commitHash));
+        .filter((commitHash): commitHash is string => commitHash !== undefined)
+        .forEach((commitHash) => commitHashSet.add(commitHash));
     return commitHashSet.size;
 };

--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.spec.ts
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.spec.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { ActivatedRoute, Params, Router, convertToParamMap, provideRouter } from '@angular/router';
+import { ActivatedRoute, ParamMap, Params, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { BehaviorSubject, of, throwError } from 'rxjs';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { TranslateModule } from '@ngx-translate/core';
@@ -126,10 +126,10 @@ describe('FileUploadAssessmentComponent', () => {
     };
 
     let routeParams$: BehaviorSubject<Params>;
-    let routeQueryParams$: BehaviorSubject<Params>;
+    let routeQueryParams$: BehaviorSubject<ParamMap>;
 
     beforeEach(async () => {
-        routeParams$ = new BehaviorSubject({ exerciseId: 20, courseId: 123, submissionId: 7 });
+        routeParams$ = new BehaviorSubject<Params>({ exerciseId: 20, courseId: 123, submissionId: 7 });
         routeQueryParams$ = new BehaviorSubject(
             convertToParamMap({
                 testRun: 'false',

--- a/src/main/webapp/app/fileupload/manage/exercise-details/file-upload-exercise-detail.component.spec.ts
+++ b/src/main/webapp/app/fileupload/manage/exercise-details/file-upload-exercise-detail.component.spec.ts
@@ -23,7 +23,7 @@ import { Exam } from 'app/exam/shared/entities/exam.model';
 import { ExerciseManagementStatisticsDto } from 'app/exercise/statistics/exercise-management-statistics-dto';
 import { StatisticsService } from 'app/exercise/statistics-graph/service/statistics.service';
 import { AlertService } from 'app/foundation/service/alert.service';
-import { EventManager } from 'app/foundation/service/event-manager.service';
+import { EventManager, EventWithContent } from 'app/foundation/service/event-manager.service';
 
 import { NonProgrammingExerciseDetailCommonActionsComponent } from 'app/exercise/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component';
 import { ExerciseDetailStatisticsComponent } from 'app/exercise/statistics/exercise-detail-statistic/exercise-detail-statistics.component';
@@ -76,7 +76,7 @@ describe('FileUploadExerciseDetailComponent', () => {
     });
 
     beforeEach(async () => {
-        routeParams$ = new BehaviorSubject({ exerciseId: 456 });
+        routeParams$ = new BehaviorSubject<Params>({ exerciseId: 456 });
 
         await TestBed.configureTestingModule({
             imports: [FileUploadExerciseDetailComponent, TranslateModule.forRoot()],
@@ -275,8 +275,8 @@ describe('FileUploadExerciseDetailComponent', () => {
             const exercise = createExercise(course);
             const findSpy = vi.spyOn(fileUploadExerciseService, 'find').mockReturnValue(of(new HttpResponse({ body: exercise })));
             const eventManager = TestBed.inject(EventManager);
-            let subscribedCallback: (() => void) | undefined;
-            vi.spyOn(eventManager, 'subscribe').mockImplementation((name: string, callback: () => void) => {
+            let subscribedCallback: ((event: string | EventWithContent<unknown>) => void) | undefined;
+            vi.spyOn(eventManager, 'subscribe').mockImplementation((name: string | string[], callback: (event: string | EventWithContent<unknown>) => void) => {
                 subscribedCallback = callback;
                 return new Subscription();
             });

--- a/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.spec.ts
@@ -180,9 +180,9 @@ describe('FileUploadExerciseUpdateComponent', () => {
     };
 
     beforeEach(async () => {
-        routeData$ = new BehaviorSubject({ fileUploadExercise: createExercise(createCourse()) });
+        routeData$ = new BehaviorSubject<Data>({ fileUploadExercise: createExercise(createCourse()) });
         routeUrl$ = new BehaviorSubject([{ path: 'new' }] as UrlSegment[]);
-        routeParams$ = new BehaviorSubject({ courseId: 123 });
+        routeParams$ = new BehaviorSubject<Params>({ courseId: 123 });
 
         await TestBed.configureTestingModule({
             imports: [FileUploadExerciseUpdateComponent, TranslateModule.forRoot()],

--- a/src/main/webapp/app/fileupload/overview/file-upload-submission/file-upload-submission.component.spec.ts
+++ b/src/main/webapp/app/fileupload/overview/file-upload-submission/file-upload-submission.component.spec.ts
@@ -118,7 +118,7 @@ describe('FileUploadSubmissionComponent', () => {
     };
 
     beforeEach(async () => {
-        routeParams$ = new BehaviorSubject({ participationId: 111 });
+        routeParams$ = new BehaviorSubject<Params>({ participationId: 111 });
 
         await TestBed.configureTestingModule({
             imports: [FileUploadSubmissionComponent, TranslateModule.forRoot()],

--- a/src/main/webapp/app/iris/overview/services/iris-chat.service.ts
+++ b/src/main/webapp/app/iris/overview/services/iris-chat.service.ts
@@ -73,14 +73,14 @@ export class IrisChatService implements OnDestroy {
         this.currentSessionIdSubject.next(id);
     }
 
-    messages: BehaviorSubject<IrisMessage[]> = new BehaviorSubject([]);
-    newIrisMessage: BehaviorSubject<IrisMessage | undefined> = new BehaviorSubject(undefined);
+    messages: BehaviorSubject<IrisMessage[]> = new BehaviorSubject<IrisMessage[]>([]);
+    newIrisMessage: BehaviorSubject<IrisMessage | undefined> = new BehaviorSubject<IrisMessage | undefined>(undefined);
     numNewMessages: BehaviorSubject<number> = new BehaviorSubject(0);
-    stages: BehaviorSubject<IrisStageDTO[]> = new BehaviorSubject([]);
-    suggestions: BehaviorSubject<string[]> = new BehaviorSubject([]);
-    citationInfo: BehaviorSubject<IrisCitationMetaDTO[]> = new BehaviorSubject([]);
-    error: BehaviorSubject<IrisErrorMessageKey | undefined> = new BehaviorSubject(undefined);
-    chatSessions: BehaviorSubject<IrisSessionDTO[]> = new BehaviorSubject([]);
+    stages: BehaviorSubject<IrisStageDTO[]> = new BehaviorSubject<IrisStageDTO[]>([]);
+    suggestions: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([]);
+    citationInfo: BehaviorSubject<IrisCitationMetaDTO[]> = new BehaviorSubject<IrisCitationMetaDTO[]>([]);
+    error: BehaviorSubject<IrisErrorMessageKey | undefined> = new BehaviorSubject<IrisErrorMessageKey | undefined>(undefined);
+    chatSessions: BehaviorSubject<IrisSessionDTO[]> = new BehaviorSubject<IrisSessionDTO[]>([]);
 
     // Flips to true once the first session-load attempt has produced a result (success OR
     // error). Until then, `messages` still holds its empty initial value, so subscribers

--- a/src/main/webapp/app/lecture/manage/lecture/lecture.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture/lecture.component.ts
@@ -131,6 +131,7 @@ export class LectureComponent implements OnInit, OnDestroy {
                     .pipe(
                         filter((res: HttpResponse<Lecture>) => res.ok),
                         map((res: HttpResponse<Lecture>) => res.body),
+                        filter((body): body is Lecture => body != undefined),
                     )
                     .subscribe({
                         next: (res: Lecture) => {
@@ -181,6 +182,7 @@ export class LectureComponent implements OnInit, OnDestroy {
             .pipe(
                 filter((res: HttpResponse<Lecture[]>) => res.ok),
                 map((res: HttpResponse<Lecture[]>) => res.body),
+                filter((body): body is Lecture[] => body != undefined),
             )
             .subscribe({
                 next: (res: Lecture[]) => {

--- a/src/main/webapp/app/lecture/manage/pdf-preview/pdf-preview-thumbnail-grid/pdf-preview-thumbnail-grid.component.ts
+++ b/src/main/webapp/app/lecture/manage/pdf-preview/pdf-preview-thumbnail-grid/pdf-preview-thumbnail-grid.component.ts
@@ -80,7 +80,7 @@ export class PdfPreviewThumbnailGridComponent implements OnChanges {
         try {
             const engine = await this.pdfEngineService.getEngine();
             const containerEl = this.pdfContainer().nativeElement;
-            const canvases = containerEl.querySelectorAll('.pdf-canvas-container canvas');
+            const canvases = containerEl.querySelectorAll<HTMLCanvasElement>('.pdf-canvas-container canvas');
             canvases.forEach((canvas: HTMLCanvasElement) => {
                 if (canvas.parentNode) {
                     this.renderer.removeChild(canvas.parentNode, canvas);
@@ -249,7 +249,7 @@ export class PdfPreviewThumbnailGridComponent implements OnChanges {
      * Updates checkbox states to match the current selection model
      */
     private updateCheckboxStates(): void {
-        const checkboxes = this.pdfContainer()?.nativeElement.querySelectorAll('input[type="checkbox"]');
+        const checkboxes = this.pdfContainer()?.nativeElement.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
 
         checkboxes.forEach((checkbox: HTMLInputElement) => {
             const match = checkbox.id.match(/checkbox-(.+)/);

--- a/src/main/webapp/app/lecture/manage/services/lecture-paging.service.ts
+++ b/src/main/webapp/app/lecture/manage/services/lecture-paging.service.ts
@@ -20,6 +20,8 @@ export class LecturePagingService extends PagingService<Lecture> {
 
     override search(pageable: SearchTermPageableSearch): Observable<EntityResponseType> {
         const params = this.createHttpParams(pageable);
-        return this.http.get(`${LecturePagingService.RESOURCE_URL}`, { params, observe: 'response' }).pipe(map((resp: HttpResponse<EntityResponseType>) => resp && resp.body!));
+        return this.http
+            .get<EntityResponseType>(`${LecturePagingService.RESOURCE_URL}`, { params, observe: 'response' })
+            .pipe(map((resp: HttpResponse<EntityResponseType>) => resp && resp.body!));
     }
 }

--- a/src/main/webapp/app/localci/shared/entities/build-log.model.ts
+++ b/src/main/webapp/app/localci/shared/entities/build-log.model.ts
@@ -69,13 +69,14 @@ export class BuildLogEntryArray extends Array<BuildLogEntry> {
                 // Parse build logs
                 .map(({ log, time }) => ({ log: log.split('\n', 1)[0].trim().match(errorLogRegex), time }))
                 // Remove entries that could not be parsed, are too short or not errors
-                .filter(({ log }: { log: ParsedLogEntry | null; time: string }) => {
+                .filter((entry: { log: RegExpMatchArray | null; time: string }): entry is { log: ParsedLogEntry; time: string } => {
+                    const { log } = entry;
                     // Java logs do not always contain "ERROR"
-                    return log && log.length === 6 && (log[0]?.includes(':[') || log[1] === 'ERROR' || log[4] === 'error:');
+                    return !!log && log.length === 6 && (log[0]?.includes(':[') || log[1] === 'ERROR' || log[4] === 'error:');
                 })
                 // Sort entries to fit a standard format
                 .map(({ log, time }) => {
-                    const sortedLog = [...log!];
+                    const sortedLog = [...log];
                     if (programmingLanguage === ProgrammingLanguage.SWIFT || projectType === ProjectType.PLAIN_GRADLE || projectType === ProjectType.GRADLE_GRADLE) {
                         const errorIndicator = sortedLog.splice(sortedLog.indexOf('error:'), 1)[0];
                         sortedLog.unshift(errorIndicator);
@@ -83,7 +84,7 @@ export class BuildLogEntryArray extends Array<BuildLogEntry> {
                     return { log: sortedLog, time };
                 })
                 // Map buildLogEntries into annotation format
-                .map(({ log: [, , fileName, row, column, text], time }: { log: ParsedLogEntry; time: string }) => ({
+                .map(({ log: [, , fileName, row, column, text], time }: { log: string[]; time: string }) => ({
                     type: 'error',
                     fileName,
                     row: Math.max(parseInt(row, 10) - 1, 0),

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment.component.spec.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment.component.spec.ts
@@ -349,11 +349,12 @@ describe('ModelingAssessmentComponent', () => {
         ];
 
         // Mock translatePipe to return a meaningful value so assessmentNote gets set
-        const spy = vi.spyOn(translatePipe, 'transform').mockImplementation((key: string, params?: any) => {
-            if (key === 'artemisApp.modelingAssessment.impactWarning' && params?.affectedSubmissionsCount) {
-                return `Warning: ${params.affectedSubmissionsCount} other submissions`;
+        const spy = vi.spyOn(translatePipe, 'transform').mockImplementation((key: string | undefined | null, params?: object) => {
+            const affectedSubmissionsCount = (params as { affectedSubmissionsCount?: number } | undefined)?.affectedSubmissionsCount;
+            if (key === 'artemisApp.modelingAssessment.impactWarning' && affectedSubmissionsCount) {
+                return `Warning: ${affectedSubmissionsCount} other submissions`;
             }
-            return key;
+            return key ?? '';
         });
 
         fixture.componentRef.setInput('umlModel', mockModel);

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.spec.ts
@@ -151,9 +151,9 @@ describe('ModelingExerciseUpdateComponent', () => {
         const modelingExercise = createModelingExercise(course);
         modelingExercise.id = 123;
 
-        routeData$ = new BehaviorSubject({ modelingExercise });
+        routeData$ = new BehaviorSubject<Data>({ modelingExercise });
         routeUrl$ = new BehaviorSubject([{ path: 'new' }] as UrlSegment[]);
-        routeParams$ = new BehaviorSubject({ courseId: 1 });
+        routeParams$ = new BehaviorSubject<Params>({ courseId: 1 });
 
         await TestBed.configureTestingModule({
             imports: [ModelingExerciseUpdateComponent, TranslateModule.forRoot()],

--- a/src/main/webapp/app/programming/manage/code-editor/build-output/code-editor-build-output.component.ts
+++ b/src/main/webapp/app/programming/manage/code-editor/build-output/code-editor-build-output.component.ts
@@ -169,6 +169,7 @@ export class CodeEditorBuildOutputComponent implements OnInit, OnDestroy {
                     this.result.set(result);
                 }),
                 switchMap((result) => this.fetchBuildResults(result)),
+                map((buildLogsFromServer) => buildLogsFromServer ?? []),
                 tap((buildLogsFromServer: BuildLogEntry[]) => {
                     this.rawBuildLogs.set(BuildLogEntryArray.fromBuildLogs(buildLogsFromServer));
                 }),
@@ -188,8 +189,8 @@ export class CodeEditorBuildOutputComponent implements OnInit, OnDestroy {
      */
     loadAndAttachResultDetails(participation: Participation, result: Result): Observable<Result> {
         return this.resultService.getFeedbackDetailsForResult(participation.id, result).pipe(
-            map((res) => res?.body),
-            map((feedbacks: Feedback[]) => {
+            map((res) => res?.body ?? undefined),
+            map((feedbacks: Feedback[] | undefined) => {
                 result.feedbacks = feedbacks;
                 return result;
             }),

--- a/src/main/webapp/app/programming/manage/code-editor/file-browser/code-editor-file-browser.component.ts
+++ b/src/main/webapp/app/programming/manage/code-editor/file-browser/code-editor-file-browser.component.ts
@@ -497,7 +497,7 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnDestroy, IFileD
         }
         // If the node has children, we cannot compress it. However, we can try to compress its children.
         else if (node.children) {
-            return { ...node, children: node.children.map(this.compressTree.bind(this)) };
+            return { ...node, children: (node.children as FileTreeItem[]).map(this.compressTree.bind(this)) };
         }
         // If the node has no children, there is nothing to compress.
         else {

--- a/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-base-container.component.ts
+++ b/src/main/webapp/app/programming/manage/code-editor/instructor-and-editor-container/code-editor-instructor-base-container.component.ts
@@ -216,13 +216,18 @@ export abstract class CodeEditorInstructorBaseContainerComponent implements OnIn
      * @param preferredParticipationId
      */
     private getNextAvailableParticipation(preferredParticipationId: number): Participation | undefined {
+        type ProgrammingParticipation = TemplateProgrammingExerciseParticipation | SolutionProgrammingExerciseParticipation | ProgrammingExerciseStudentParticipation;
         const availableParticipations = [
             this.exercise.templateParticipation,
             this.exercise.solutionParticipation,
-            this.exercise.studentParticipations && this.exercise.studentParticipations.length ? this.exercise.studentParticipations[0] : undefined,
-        ].filter(Boolean);
-        const selectedParticipation = availableParticipations.find(({ id }: ProgrammingExerciseStudentParticipation) => id === preferredParticipationId);
-        return [selectedParticipation, ...availableParticipations].filter(Boolean).find(({ repositoryUri }: ProgrammingExerciseStudentParticipation) => !!repositoryUri);
+            this.exercise.studentParticipations && this.exercise.studentParticipations.length
+                ? (this.exercise.studentParticipations[0] as ProgrammingExerciseStudentParticipation)
+                : undefined,
+        ].filter((participation): participation is ProgrammingParticipation => participation != undefined);
+        const selectedParticipation = availableParticipations.find(({ id }: ProgrammingParticipation) => id === preferredParticipationId);
+        return [selectedParticipation, ...availableParticipations]
+            .filter((participation): participation is ProgrammingParticipation => participation != undefined)
+            .find(({ repositoryUri }: ProgrammingParticipation) => !!repositoryUri);
     }
 
     /**

--- a/src/main/webapp/app/programming/manage/grading/charts/sca-category-distribution-chart.component.ts
+++ b/src/main/webapp/app/programming/manage/grading/charts/sca-category-distribution-chart.component.ts
@@ -61,7 +61,7 @@ export class ScaCategoryDistributionChartComponent extends ProgrammingGradingCha
             horizontal: true,
             stacked: true,
             percentScale: true,
-            xAxis: { tickFormatter: this.xAxisFormatting },
+            xAxis: { tickFormatter: (value) => this.xAxisFormatting(String(value)) },
             tooltip: {
                 title: (items) => items[0]?.dataset.label ?? '',
                 label: (item) => {

--- a/src/main/webapp/app/programming/manage/grading/charts/test-case-distribution-chart.component.ts
+++ b/src/main/webapp/app/programming/manage/grading/charts/test-case-distribution-chart.component.ts
@@ -63,7 +63,7 @@ export class TestCaseDistributionChartComponent extends ProgrammingGradingCharts
             horizontal: true,
             stacked: true,
             percentScale: true,
-            xAxis: { tickFormatter: this.xAxisFormatting },
+            xAxis: { tickFormatter: (value) => this.xAxisFormatting(String(value)) },
             tooltip: {
                 title: (items) => items[0]?.dataset.label ?? '',
                 label: (item) => {
@@ -89,7 +89,7 @@ export class TestCaseDistributionChartComponent extends ProgrammingGradingCharts
         barChartOptions({
             horizontal: true,
             stacked: true,
-            xAxis: { max: 100, tickFormatter: this.xAxisFormatting },
+            xAxis: { max: 100, tickFormatter: (value) => this.xAxisFormatting(String(value)) },
             tooltip: {
                 title: (items) => items[0]?.dataset.label ?? '',
                 label: (item) => {

--- a/src/main/webapp/app/programming/manage/grading/configure/programming-exercise-configure-grading.component.ts
+++ b/src/main/webapp/app/programming/manage/grading/configure/programming-exercise-configure-grading.component.ts
@@ -363,8 +363,8 @@ export class ProgrammingExerciseConfigureGradingComponent implements OnInit, OnD
         this.testCaseSubscription = this.gradingService
             .subscribeForTestCases(this.programmingExercise.id!)
             .pipe(
-                tap((testCases: ProgrammingExerciseTestCase[]) => {
-                    this.testCases = testCases;
+                tap((testCases: ProgrammingExerciseTestCase[] | undefined) => {
+                    this.testCases = testCases ?? [];
                 }),
                 tap(() => this.loadStatistics(this.programmingExercise.id!)),
             )
@@ -464,7 +464,7 @@ export class ProgrammingExerciseConfigureGradingComponent implements OnInit, OnD
         const categoriesToUpdate = _intersectionWith(
             this.backupStaticCodeAnalysisCategories,
             this.changedCategoryIds(),
-            (codeAnalysisCategory: StaticCodeAnalysisCategory, id: number) => codeAnalysisCategory.id === id,
+            (codeAnalysisCategory: StaticCodeAnalysisCategory, id: number | StaticCodeAnalysisCategory) => codeAnalysisCategory.id === id,
         );
         const categoryUpdates = categoriesToUpdate.map((category) => StaticCodeAnalysisCategoryUpdate.from(category));
 

--- a/src/main/webapp/app/programming/manage/grading/tasks/programming-exercise-grading-tasks-table/programming-exercise-grading-tasks-table.component.ts
+++ b/src/main/webapp/app/programming/manage/grading/tasks/programming-exercise-grading-tasks-table/programming-exercise-grading-tasks-table.component.ts
@@ -138,8 +138,8 @@ export class ProgrammingExerciseGradingTasksTableComponent implements OnInit {
 
         // the objects task and test have their name attribute named differently, making this necessary
         if (this.currentSort?.by === 'name') {
-            comparator = (a: ProgrammingExerciseTask, b: ProgrammingExerciseTask) => {
-                const order = this.compareStringForAttribute('testName')(a, b);
+            comparator = (a: ProgrammingExerciseTask | ProgrammingExerciseTestCase, b: ProgrammingExerciseTask | ProgrammingExerciseTestCase) => {
+                const order = this.compareStringForAttribute<ProgrammingExerciseTestCase>('testName')(a, b);
                 return this.currentSort?.descending ? order : -order;
             };
         }
@@ -148,8 +148,8 @@ export class ProgrammingExerciseGradingTasksTableComponent implements OnInit {
     };
 
     private compareNumForAttribute = <T extends ProgrammingExerciseTask | ProgrammingExerciseTestCase>(attributeKey: keyof T): TaskComparator => {
-        return (a: T, b: T) => {
-            return ((a[attributeKey] as number) ?? 0) - ((b[attributeKey] as number) ?? 0);
+        return (a: ProgrammingExerciseTask | ProgrammingExerciseTestCase, b: ProgrammingExerciseTask | ProgrammingExerciseTestCase) => {
+            return (((a as T)[attributeKey] as number) ?? 0) - (((b as T)[attributeKey] as number) ?? 0);
         };
     };
 
@@ -160,9 +160,9 @@ export class ProgrammingExerciseGradingTasksTableComponent implements OnInit {
     private compareStringForAttribute = <T extends ProgrammingExerciseTask | ProgrammingExerciseServerSideTask | ProgrammingExerciseTestCase>(
         attributeKey: keyof T,
     ): TaskComparator => {
-        return (a: T, b: T) => {
-            const aType = a[attributeKey] ?? '';
-            const bType = b[attributeKey] ?? '';
+        return (a: ProgrammingExerciseTask | ProgrammingExerciseTestCase, b: ProgrammingExerciseTask | ProgrammingExerciseTestCase) => {
+            const aType = (a as T)[attributeKey] ?? '';
+            const bType = (b as T)[attributeKey] ?? '';
 
             if (aType < bType) return -1;
             if (aType > bType) return 1;

--- a/src/main/webapp/app/programming/manage/instructions-editor/analysis/programming-exercise-instruction-analysis.service.ts
+++ b/src/main/webapp/app/programming/manage/instructions-editor/analysis/programming-exercise-instruction-analysis.service.ts
@@ -98,12 +98,14 @@ export class ProgrammingExerciseInstructionAnalysisService {
 
         return analysis
             .flat()
-            .map(([lineNumber, values, issueType]: AnalysisItem) => [
-                lineNumber,
-                values.map((id) => this.translateService.instant(this.getTranslationByIssueType(issueType), { id })),
-                issueType,
-            ])
-            .reduce(reducer, new Map());
+            .map(
+                ([lineNumber, values, issueType]: AnalysisItem): AnalysisItem => [
+                    lineNumber,
+                    values.map((id) => this.translateService.instant(this.getTranslationByIssueType(issueType), { id })),
+                    issueType,
+                ],
+            )
+            .reduce<ProblemStatementAnalysis>(reducer, new Map());
     };
 
     /**
@@ -133,11 +135,11 @@ export class ProgrammingExerciseInstructionAnalysisService {
 
         return tasks
             .filter(([, task]) => !!task)
-            .map(([lineNumber, task]) => {
+            .map(([lineNumber, task]): [number, string | undefined] => {
                 const extractedValue = task.match(regex);
                 return extractedValue && extractedValue.length > 1 ? [lineNumber, extractedValue[1]] : [lineNumber, undefined];
             })
-            .filter(([, testCases]) => !!testCases)
+            .filter((entry): entry is [number, string] => !!entry[1])
             .map(([lineNumber, match]: [number, string]) => {
                 const cleanedMatches = cleanMatches(match.split(/,(?![^(]*?\))/).map((m: string) => m.trim()));
                 return [lineNumber, cleanedMatches];

--- a/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewInit, Component, HostListener, OnDestroy, ViewEncapsulation, computed, effect, inject, input, output, signal, viewChild } from '@angular/core';
 import { AlertService } from 'app/foundation/service/alert.service';
-import { EMPTY, Observable, Subject, Subscription, of, throwError } from 'rxjs';
+import { EMPTY, Observable, Subject, Subscription, of } from 'rxjs';
 import { catchError, finalize, map, switchMap, tap } from 'rxjs/operators';
 import { ProgrammingExerciseTestCase } from 'app/programming/shared/entities/programming-exercise-test-case.model';
 import { ProblemStatementAnalysis } from 'app/programming/manage/instructions-editor/analysis/programming-exercise-instruction-analysis.model';
@@ -362,12 +362,22 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
      * This is the fallback for older programming exercises without test cases in the database.
      * @param templateParticipationId
      */
-    loadTestCasesFromTemplateParticipationResult = (templateParticipationId: number): Observable<Array<string | undefined>> => {
+    loadTestCasesFromTemplateParticipationResult = (templateParticipationId: number): Observable<string[]> => {
         // Fallback for exercises that don't have test cases yet.
         return this.programmingExerciseParticipationService.getLatestResultWithFeedback(templateParticipationId).pipe(
-            map((result) => (!result?.feedbacks ? throwError(() => new Error('no result available')) : result)),
+            map((result) => {
+                if (!result?.feedbacks) {
+                    throw new Error('no result available');
+                }
+                return result;
+            }),
             // use the text (legacy case) or the name of the provided test case attribute
-            map(({ feedbacks }: Result) => feedbacks!.map((feedback) => feedback.text ?? feedback.testCase?.testName).sort()),
+            map(({ feedbacks }: Result) =>
+                feedbacks!
+                    .map((feedback) => feedback.text ?? feedback.testCase?.testName)
+                    .filter((name): name is string => name != undefined)
+                    .sort(),
+            ),
             catchError(() => of([])),
         );
     };

--- a/src/main/webapp/app/programming/manage/services/programming-exercise-websocket.service.ts
+++ b/src/main/webapp/app/programming/manage/services/programming-exercise-websocket.service.ts
@@ -75,7 +75,7 @@ export class ProgrammingExerciseWebsocketService implements OnDestroy, IProgramm
      */
     private initTestCaseStateSubscription(programmingExerciseId: number) {
         const testCaseTopic = `/topic/programming-exercises/${programmingExerciseId}/test-cases-changed`;
-        this.subjects[programmingExerciseId] = new BehaviorSubject(undefined);
+        this.subjects[programmingExerciseId] = new BehaviorSubject<boolean | undefined>(undefined);
         this.connections[programmingExerciseId] = this.websocketService
             .subscribe<boolean>(testCaseTopic)
             .pipe(tap((testCasesChanged) => this.notifySubscribers(programmingExerciseId, testCasesChanged)))

--- a/src/main/webapp/app/programming/overview/code-editor-student-container/code-editor-student-container.component.spec.ts
+++ b/src/main/webapp/app/programming/overview/code-editor-student-container/code-editor-student-container.component.spec.ts
@@ -66,7 +66,7 @@ describe('CodeEditorStudentContainerComponent', () => {
 
     it.each([undefined, { active: false } as SubmissionPolicy])(
         'should not calculate the number of submissions for no or inactive submission policy',
-        (submissionPolicy: SubmissionPolicy) => {
+        (submissionPolicy: SubmissionPolicy | undefined) => {
             vi.spyOn(programmingExerciseParticipationService, 'getStudentParticipationWithLatestResult').mockReturnValue(of(studentParticipation));
             vi.spyOn(submissionPolicyService, 'getSubmissionPolicyOfProgrammingExercise').mockReturnValue(of(submissionPolicy));
             const getParticipationSubmissionCountSpy = vi.spyOn(submissionPolicyService, 'getParticipationSubmissionCount');

--- a/src/main/webapp/app/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -20,7 +20,7 @@ import { getLocalRepositoryLink } from 'app/foundation/util/navigation.utils';
 import { CodeEditorRepositoryFileService, CodeEditorRepositoryService, ConnectionError } from 'app/programming/shared/code-editor/services/code-editor-repository.service';
 import { CodeEditorConflictStateService } from 'app/programming/shared/code-editor/services/code-editor-conflict-state.service';
 import { CodeEditorSubmissionService } from 'app/programming/shared/code-editor/services/code-editor-submission.service';
-import { CommitState, EditorState, FileSubmission, GitConflictState } from '../model/code-editor.model';
+import { CommitState, EditorState, FileSubmission, FileSubmissionError, GitConflictState } from '../model/code-editor.model';
 import { CodeEditorConfirmRefreshModalComponent } from 'app/programming/shared/code-editor/actions/refresh-modal/code-editor-confirm-refresh-modal.component';
 import { CodeEditorResolveConflictModalComponent } from 'app/programming/shared/code-editor/actions/conflict-modal/code-editor-resolve-conflict-modal.component';
 
@@ -218,14 +218,16 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
             .subscribe();
     }
 
-    saveChangedFiles(andCommit = false): Observable<FileSubmission | undefined> {
+    saveChangedFiles(andCommit = false): Observable<FileSubmission | FileSubmissionError | undefined> {
         const unsavedFilesValue = this.unsavedFiles();
         if (!_isEmpty(unsavedFilesValue)) {
             this.editorState.set(EditorState.SAVING);
             const unsavedFiles = Object.entries(unsavedFilesValue).map(([fileName, fileContent]) => ({ fileName, fileContent }));
             return this.repositoryFileService.updateFiles(unsavedFiles, andCommit).pipe(
-                tap((fileSubmission: FileSubmission) => {
-                    this.onSavedFiles.emit(fileSubmission);
+                tap((fileSubmission: FileSubmission | FileSubmissionError) => {
+                    if (!('error' in fileSubmission)) {
+                        this.onSavedFiles.emit(fileSubmission);
+                    }
                 }),
                 catchError((error: Error) => {
                     this.editorState.set(EditorState.UNSAVED_CHANGES);

--- a/src/main/webapp/app/programming/shared/code-editor/services/code-editor-repository.service.ts
+++ b/src/main/webapp/app/programming/shared/code-editor/services/code-editor-repository.service.ts
@@ -229,7 +229,7 @@ export class CodeEditorRepositoryFileService extends DomainDependentEndpointServ
 
     getFilesWithContent = (domain?: DomainChange) => {
         const restResourceUrl = domain ? this.calculateRestResourceURL(domain) : this.restResourceUrl;
-        return this.http.get(`${restResourceUrl}/files-content`).pipe(handleErrorResponse<{ [fileName: string]: string }>(this.conflictService));
+        return this.http.get<{ [fileName: string]: string }>(`${restResourceUrl}/files-content`).pipe(handleErrorResponse<{ [fileName: string]: string }>(this.conflictService));
     };
 
     createFile = (fileName: string) => {

--- a/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/programming-exercise-instruction.component.ts
@@ -391,7 +391,7 @@ export class ProgrammingExerciseInstructionComponent implements OnInit, OnDestro
     loadLatestResult(): Observable<Result | undefined> {
         return this.programmingExerciseParticipationService.getLatestResultWithFeedback(this.participation()!.id!).pipe(
             catchError(() => of(undefined)),
-            mergeMap((latestResult: Result) => (latestResult && !latestResult.feedbacks ? this.loadAndAttachResultDetails(latestResult) : of(latestResult))),
+            mergeMap((latestResult: Result | undefined) => (latestResult && !latestResult.feedbacks ? this.loadAndAttachResultDetails(latestResult) : of(latestResult))),
         );
     }
 
@@ -404,8 +404,8 @@ export class ProgrammingExerciseInstructionComponent implements OnInit, OnDestro
         const currentParticipation = this.participation();
         return this.resultService.getFeedbackDetailsForResult(currentParticipation!.id, result).pipe(
             map((res) => res && res.body),
-            map((feedbacks: Feedback[]) => {
-                result.feedbacks = feedbacks;
+            map((feedbacks: Feedback[] | null) => {
+                result.feedbacks = feedbacks ?? undefined;
                 return result;
             }),
             catchError(() => of(result)),

--- a/src/main/webapp/app/programming/shared/instructions-render/services/programming-exercise-instruction.service.ts
+++ b/src/main/webapp/app/programming/shared/instructions-render/services/programming-exercise-instruction.service.ts
@@ -58,7 +58,7 @@ export class ProgrammingExerciseInstructionService {
     };
 
     private separateTests(tests: number[], latestResult: Result) {
-        return tests.reduce(
+        return tests.reduce<{ failed: number[]; successful: number[]; notExecuted: number[] }>(
             (acc, testId) => {
                 const feedback = latestResult?.feedbacks?.find((feedback) => feedback.testCase?.id === testId);
 

--- a/src/main/webapp/app/programming/shared/services/programming-submission.service.spec.ts
+++ b/src/main/webapp/app/programming/shared/services/programming-submission.service.spec.ts
@@ -159,7 +159,7 @@ describe('ProgrammingSubmissionService', () => {
     });
 
     it('should return cached subject as Observable for provided participation if exists', () => {
-        const cachedSubject = new BehaviorSubject(undefined);
+        const cachedSubject = new BehaviorSubject<ProgrammingSubmissionStateObj | undefined>(undefined);
         const fetchLatestPendingSubmissionSpy = vi.spyOn(priv(submissionService), 'fetchLatestPendingSubmissionByParticipationId');
         const setupWebsocketSubscriptionSpy = vi.spyOn(priv(submissionService), 'setupWebsocketSubscriptionForLatestPendingSubmission');
         const subscribeForNewResultSpy = vi.spyOn(priv(submissionService), 'subscribeForNewResult');
@@ -527,7 +527,10 @@ describe('ProgrammingSubmissionService', () => {
     it('should recalculate the result eta based on the number of open submissions', () => {
         const exerciseId = 10;
         // Simulate 340 participations with one pending submission each.
-        const submissionState = _range(340).reduce((acc, n) => ({ ...acc, [n]: { submissionDate: dayjs().subtract(1, 'minutes') } as ProgrammingSubmission }), {});
+        const submissionState = _range(340).reduce<Record<string, ProgrammingSubmission>>(
+            (acc, n) => ({ ...acc, [n]: { submissionDate: dayjs().subtract(1, 'minutes') } as ProgrammingSubmission }),
+            {},
+        );
         const expectedSubmissionState = Object.entries(submissionState).reduce(
             (acc, [participationID, submission]: [string, ProgrammingSubmission]) => ({
                 ...acc,

--- a/src/main/webapp/app/programming/shared/services/programming-submission.service.ts
+++ b/src/main/webapp/app/programming/shared/services/programming-submission.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy, inject } from '@angular/core';
 import { HttpClient, HttpParams, HttpResponse } from '@angular/common/http';
-import { BehaviorSubject, Observable, Subject, Subscription, from, merge, of, timer } from 'rxjs';
+import { BehaviorSubject, EMPTY, Observable, Subject, Subscription, from, merge, of, timer } from 'rxjs';
 import { catchError, distinctUntilChanged, filter, map, reduce, switchMap, tap } from 'rxjs/operators';
 import { ParticipationWebsocketService } from 'app/course/shared/services/participation-websocket.service';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
@@ -465,7 +465,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
         const timerObservable = this.resultTimerSubjects.get(participationId)!.pipe(
             // Fallback: Try to fetch the latest result from the server as the websocket connection might have failed
             switchMap(() => this.participationService.getLatestResultWithFeedback(participationId)),
-            tap((result: Result) => {
+            tap((result: Result | undefined) => {
                 if (this.isResultOfLatestSubmission(result, exerciseId, participationId)) {
                     // Notify all result subscribers with the latest result if it belongs to the latest submission
                     // This will also trigger the resultObservable above, which emits that the submission is no longer pending
@@ -493,7 +493,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
             .subscribe();
     }
 
-    private isResultOfLatestSubmission(result: Result | undefined, exerciseId: number, participationId: number): boolean {
+    private isResultOfLatestSubmission(result: Result | undefined, exerciseId: number, participationId: number): result is Result {
         if (!result || !result.submission) {
             return false;
         }
@@ -717,8 +717,10 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
                 map(this.mapParticipationIdToNumber),
                 switchMap((submissions: Array<[number, ProgrammingSubmission]>) => {
                     if (!submissions.length) {
-                        // This needs to be done as from([]) would stop the stream.
-                        return of([]);
+                        // No pending submissions: emit nothing so the downstream reduce emits its `{}` seed
+                        // (an empty ExerciseSubmissionState). EMPTY completes without a value and keeps the
+                        // switchMap's output typed as Observable<ProgrammingSubmissionStateObj>.
+                        return EMPTY;
                     }
                     return from(submissions).pipe(
                         switchMap(([participationId, submission]): Observable<ProgrammingSubmissionStateObj> => {
@@ -854,8 +856,8 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
         );
     }
 
-    private mapParticipationIdToNumber(submissions: Array<[string, ProgrammingSubmission | undefined]>) {
-        return submissions.map(([participationId, submission]) => [parseInt(participationId, 10), submission]);
+    private mapParticipationIdToNumber(submissions: Array<[string, ProgrammingSubmission]>): Array<[number, ProgrammingSubmission]> {
+        return submissions.map(([participationId, submission]): [number, ProgrammingSubmission] => [parseInt(participationId, 10), submission]);
     }
 
     private mapToExerciseBuildState(exerciseSubmissionState: ExerciseSubmissionState, programmingSubmissionState: ProgrammingSubmissionStateObj) {

--- a/src/main/webapp/app/quiz/manage/apollon-diagrams/exercise-generation/svg-renderer.ts
+++ b/src/main/webapp/app/quiz/manage/apollon-diagrams/exercise-generation/svg-renderer.ts
@@ -166,9 +166,7 @@ export function cropRenderedSVGToElement(renderedSVG: SVG, elementId: string): S
 // Some browsers (such as IE or Edge) don't support the HTMLCanvasElement.toBlob() method,
 // so we use the (much more inefficient) toDataURL() method as a fallback
 function toPNGBlob(canvas: HTMLCanvasElement, callback: (blob: Blob) => void) {
-    if (typeof canvas.toBlob === 'function') {
-        canvas.toBlob(callback);
-    } else {
+    const fallbackViaDataUrl = () =>
         setTimeout(() => {
             const binaryRepresentation = window.atob(canvas.toDataURL().split(',')[1]);
             const length = binaryRepresentation.length;
@@ -180,5 +178,11 @@ function toPNGBlob(canvas: HTMLCanvasElement, callback: (blob: Blob) => void) {
 
             callback(new Blob([buffer], { type: 'image/png' }));
         });
+    if (typeof canvas.toBlob === 'function') {
+        // toBlob may invoke its callback with null (e.g. an empty canvas); fall back to the toDataURL path so
+        // the callback is always invoked and callers awaiting the PNG blob never hang.
+        canvas.toBlob((blob) => (blob ? callback(blob) : fallbackViaDataUrl()));
+    } else {
+        fallbackViaDataUrl();
     }
 }

--- a/src/main/webapp/app/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.spec.ts
+++ b/src/main/webapp/app/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.spec.ts
@@ -146,8 +146,9 @@ describe('DragAndDropQuestionEditComponent', () => {
         fixture.componentRef.setInput('questionIndex', 1);
         fixture.componentRef.setInput('reEvaluationInProgress', false);
         questionUpdatedSpy = vi.spyOn(component.questionUpdated, 'emit');
-        createObjectURLStub = vi.spyOn(window.URL, 'createObjectURL').mockImplementation((file: File) => {
-            return 'some/client/dependent/path/' + file.name;
+        createObjectURLStub = vi.spyOn(window.URL, 'createObjectURL').mockImplementation((obj: Blob | MediaSource) => {
+            const fileName = obj instanceof File ? obj.name : '';
+            return 'some/client/dependent/path/' + fileName;
         });
         addFileSpy = vi.spyOn(component.addNewFile, 'emit');
         removeFileSpy = vi.spyOn(component.removeFile, 'emit');

--- a/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.spec.ts
@@ -167,9 +167,9 @@ describe('TextExercise Management Update Component', () => {
     };
 
     beforeEach(async () => {
-        routeData$ = new BehaviorSubject({ textExercise: createExercise(createCourse()) });
+        routeData$ = new BehaviorSubject<Data>({ textExercise: createExercise(createCourse()) });
         routeUrl$ = new BehaviorSubject([{ path: 'new' }] as UrlSegment[]);
-        routeParams$ = new BehaviorSubject({ courseId: 1 });
+        routeParams$ = new BehaviorSubject<Params>({ courseId: 1 });
 
         await TestBed.configureTestingModule({
             imports: [TextExerciseUpdateComponent, TranslateModule.forRoot()],

--- a/src/main/webapp/app/text/overview/text-editor/text-editor.component.ts
+++ b/src/main/webapp/app/text/overview/text-editor/text-editor.component.ts
@@ -11,6 +11,7 @@ import { TextEditorService } from 'app/text/overview/service/text-editor.service
 import dayjs from 'dayjs/esm';
 import { Subject, Subscription, merge } from 'rxjs';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
+import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 import { debounceTime, distinctUntilChanged, map, skip } from 'rxjs/operators';
 import { TextSubmissionService } from 'app/text/overview/service/text-submission.service';
 import { ComponentCanDeactivate } from 'app/foundation/guard/can-deactivate.model';
@@ -183,16 +184,20 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
         this.participationUpdateListener = this.participationWebsocketService
             .subscribeForParticipationChanges()
             .pipe(skip(1))
-            .subscribe((changedParticipation: StudentParticipation) => {
+            .subscribe((updatedParticipation: Participation | undefined) => {
+                if (!updatedParticipation) {
+                    return;
+                }
                 // subscribeForParticipationChanges() is backed by a single app-wide BehaviorSubject, so every
                 // text-editor instance receives every participation change (including the ones emitted by other
                 // instances when they call addParticipation()). Without this guard, multiple editors rendered
                 // together - e.g. several text exercises in the exam result summary - would all overwrite their
                 // own exercise/submission state with whichever participation was added last, making every text
                 // summary display the last exercise. Only react to changes for our own participation.
-                if (changedParticipation?.id !== this.participation()?.id) {
+                if (updatedParticipation?.id !== this.participation()?.id) {
                     return;
                 }
+                const changedParticipation = updatedParticipation as StudentParticipation;
                 const results = changedParticipation.submissions?.flatMap((submission) => submission.results ?? []) || [];
                 const oldResults = this.participation().submissions?.flatMap((submission) => submission.results ?? []) || [];
                 const lastResult = results?.last();

--- a/src/main/webapp/app/text/overview/text-result/text-result.component.ts
+++ b/src/main/webapp/app/text/overview/text-result/text-result.component.ts
@@ -42,7 +42,7 @@ export class TextResultComponent {
 
     private convertTextToResultBlocks(feedbacks: Feedback[] = []): void {
         checkSubsequentFeedbackInAssessment(feedbacks);
-        const [referenceBasedFeedback, blockBasedFeedback]: [Feedback[], Feedback[]] = feedbacks.reduce(
+        const [referenceBasedFeedback, blockBasedFeedback] = feedbacks.reduce<[Feedback[], Feedback[]]>(
             ([refBased, blockBased], elem) => (this.SHA1_REGEX.test(elem.reference!) ? [refBased, [...blockBased, elem]] : [[...refBased, elem], blockBased]),
             [[], []],
         );

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-create-or-edit/tutorial-create-or-edit.component.spec.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-create-or-edit/tutorial-create-or-edit.component.spec.ts
@@ -6,7 +6,7 @@ import { MockComponent, MockDirective } from 'ng-mocks';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { Observable, of, throwError } from 'rxjs';
 import dayjs from 'dayjs/esm';
-import { ConfirmationService } from 'primeng/api';
+import { Confirmation, ConfirmationService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { AlertService } from 'app/foundation/service/alert.service';
@@ -465,7 +465,7 @@ describe('TutorialCreateOrEditComponent', () => {
         await fixture.whenStable();
 
         const confirmationService = fixture.debugElement.injector.get(ConfirmationService);
-        const confirmSpy = vi.spyOn(confirmationService, 'confirm').mockImplementation((confirmation: { accept?: () => void }) => {
+        const confirmSpy = vi.spyOn(confirmationService, 'confirm').mockImplementation((confirmation: Confirmation) => {
             confirmation.accept?.();
             return confirmationService;
         });

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-registrations-import-modal/tutorial-registrations-import-modal.component.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-registrations-import-modal/tutorial-registrations-import-modal.component.ts
@@ -15,6 +15,7 @@ import { TutorialGroupRegisterStudentRequest } from 'app/tutorialgroup/shared/en
 import { LoadingIndicatorOverlayComponent } from 'app/shared-ui/loading-indicator-overlay/loading-indicator-overlay.component';
 import { TutorialGroupRegisteredStudentsService } from 'app/tutorialgroup/manage/service/tutorial-group-registered-students.service';
 import { TutorialGroupApiService } from 'app/openapi/api/tutorialGroupApi.service';
+import { TutorialGroupStudentImportData } from 'app/openapi/model/tutorialGroupStudentImportData';
 
 export enum ImportFlowStep {
     EXPLANATION = 'EXPLANATION',
@@ -107,7 +108,7 @@ export class TutorialRegistrationsImportModalComponent {
     importParsedStudents() {
         this.isLoading.set(true);
         this.tutorialGroupApiService.importRegistrations(this.courseId(), this.tutorialGroupId(), this.parsedStudents(), 'response').subscribe({
-            next: (response: HttpResponse<Array<TutorialGroupRegisterStudentRequest>>) => {
+            next: (response: HttpResponse<Array<TutorialGroupStudentImportData>>) => {
                 const nonExistingStudents = response.body || [];
                 const studentResults: ImportResult[] = this.parsedStudents().map((parsedStudent) => {
                     return {

--- a/src/main/webapp/app/tutorialgroup/overview/course-tutorial-groups/course-tutorial-groups.component.ts
+++ b/src/main/webapp/app/tutorialgroup/overview/course-tutorial-groups/course-tutorial-groups.component.ts
@@ -242,11 +242,11 @@ export class CourseTutorialGroupsComponent {
     private getCurrentCourseIdSignal(): Signal<number | undefined> {
         return toSignal(
             this.activatedRoute.parent!.paramMap.pipe(
-                map((parameterMap) => {
+                map((parameterMap): number | undefined => {
                     const courseIdParameter = parameterMap.get('courseId');
                     return courseIdParameter !== null ? Number(courseIdParameter) : undefined;
                 }),
-                distinctUntilChanged(),
+                distinctUntilChanged<number | undefined>(),
             ),
             { initialValue: undefined },
         );

--- a/src/main/webapp/app/tutorialgroup/shared/tutorial-group-detail/tutorial-group-detail.component.spec.ts
+++ b/src/main/webapp/app/tutorialgroup/shared/tutorial-group-detail/tutorial-group-detail.component.spec.ts
@@ -24,7 +24,7 @@ import { LectureService } from 'app/lecture/manage/services/lecture.service';
 import { TutorialGroupDetailData as RawTutorialGroupDetailData } from 'app/openapi/model/tutorialGroupDetailData';
 import { TutorialGroupSession as RawTutorialGroupSession } from 'app/openapi/model/tutorialGroupSession';
 import { CreateOrUpdateTutorialGroupSessionRequest } from 'app/openapi/model/createOrUpdateTutorialGroupSessionRequest';
-import { ConfirmationService } from 'primeng/api';
+import { Confirmation, ConfirmationService } from 'primeng/api';
 import {
     TutorialSessionCreateOrEditModalComponent,
     UpdateTutorialGroupSessionData,
@@ -823,7 +823,7 @@ describe('TutorialGroupDetailComponent', () => {
         fixture.detectChanges();
 
         const confirmationService = fixture.debugElement.injector.get(ConfirmationService);
-        const confirmSpy = vi.spyOn(confirmationService, 'confirm').mockImplementation((confirmation: { accept?: () => void }) => {
+        const confirmSpy = vi.spyOn(confirmationService, 'confirm').mockImplementation((confirmation: Confirmation) => {
             confirmation.accept?.();
             return confirmationService;
         });
@@ -843,7 +843,7 @@ describe('TutorialGroupDetailComponent', () => {
         fixture.detectChanges();
 
         const confirmationService = fixture.debugElement.injector.get(ConfirmationService);
-        const confirmSpy = vi.spyOn(confirmationService, 'confirm').mockImplementation((confirmation: { accept?: () => void }) => {
+        const confirmSpy = vi.spyOn(confirmationService, 'confirm').mockImplementation((confirmation: Confirmation) => {
             confirmation.accept?.();
             return confirmationService;
         });

--- a/src/test/javascript/spec/helpers/mocks/service/mock-account.service.ts
+++ b/src/test/javascript/spec/helpers/mocks/service/mock-account.service.ts
@@ -5,6 +5,7 @@ import { User } from 'app/account/user/user.model';
 import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { signal } from '@angular/core';
 import { LLMSelectionDecision } from 'app/account/user/shared/dto/updateLLMSelectionDecision.dto';
+import { Authority } from 'app/foundation/constants/authority.constants';
 
 export class MockAccountService implements IAccountService {
     userIdentity = signal<User | undefined>(undefined);
@@ -12,15 +13,15 @@ export class MockAccountService implements IAccountService {
     identity = () => Promise.resolve({ id: 99, login: 'admin' } as User);
     getAndClearPrefilledUsername = () => 'prefilledUsername';
     setPrefilledUsername = (username: string) => ({});
-    hasAnyAuthority = (authorities: any[]) => Promise.resolve(true);
-    hasAnyAuthorityDirect = (authorities: any[]) => authorities.length !== 0;
+    hasAnyAuthority = (authorities: readonly Authority[]) => Promise.resolve(true);
+    hasAnyAuthorityDirect = (authorities: readonly Authority[]) => authorities.length !== 0;
     getAuthenticationState: () => Observable<User | undefined> = () => of({ id: 99 } as User);
     authenticate = (identity: User | undefined) => {};
     fetch = () => of({ body: { id: 99 } as User } as any);
     updateLanguage = (languageKey: string) => of({});
     getImageUrl = () => 'blob';
     hasAuthority = (authority: string) => Promise.resolve(true);
-    isAtLeastTutor = () => this.hasAnyAuthorityDirect(['ROLE_TUTOR']);
+    isAtLeastTutor = () => this.hasAnyAuthorityDirect([Authority.TUTOR]);
     isAtLeastTutorInCourse = (course: Course) => true;
     isAtLeastEditorInCourse = (course?: Course) => course?.isAtLeastEditor ?? false;
     isAtLeastInstructorInCourse = (course?: Course) => course?.isAtLeastInstructor ?? false;

--- a/src/test/javascript/spec/helpers/mocks/service/mock-programming-exercise-grading.service.ts
+++ b/src/test/javascript/spec/helpers/mocks/service/mock-programming-exercise-grading.service.ts
@@ -20,7 +20,7 @@ export class MockProgrammingExerciseGradingService implements IProgrammingExerci
         if (this.testCaseSubject) {
             this.testCaseSubject.complete();
         }
-        this.testCaseSubject = new BehaviorSubject(initialValue);
+        this.testCaseSubject = new BehaviorSubject<ProgrammingExerciseTestCase[] | undefined>(initialValue);
     }
 
     nextTestCases(value: ProgrammingExerciseTestCase[] | undefined) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
         "strict": false,
         "noImplicitReturns": true,
         "noImplicitOverride": true,
+        "strictFunctionTypes": true,
         "noUnusedLocals": true,
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,


### PR DESCRIPTION
### Summary
Enables the TypeScript **`strictFunctionTypes`** compiler flag for the client and fixes every resulting violation (~193 sites across ~107 files). `strictFunctionTypes` checks function-type parameters **contravariantly**, catching unsound function/callback assignments the current `strict: false` baseline lets through. All changes are behavior-preserving.

### Checklist
#### General
- [x] Non-user-facing change (compiler-flag enforcement). Verified locally: **0 ESLint errors**, `tsc` app + spec **0**, AOT `webapp:build` clean, and the **full client test suite passes**.
- [x] I chose a title conforming to the naming conventions for pull requests.
#### Client
- [x] No REST/data-fetching changes.
- [x] No `any` / `as any` / `as unknown` / `@ts-*` / `eslint-disable` introduced in production code.

### Motivation and Context
`strict: false` is still the master switch in `tsconfig.json`; the strict sub-flags are being enabled one at a time. `strictFunctionTypes` is the next low-count, high-signal flag — it catches a real bug class: a function/callback assigned where its parameter types are checked unsoundly (e.g. a subscriber typed for a narrower value than the stream actually emits). This continues the client type-safety campaign (after `noImplicitReturns`/`noImplicitOverride` + `restrict-plus-operands`/`no-base-to-string` in #13100).

### Description
- **Dominant fix (most sites):** widen a too-narrow callback parameter to match its source type — e.g. a Promise `.then`, RxJS operator, or array callback typed `(user: User)` where the source emits `User | undefined`. Widening a parameter type is behavior-preserving; the callback still runs identically.
- **RxJS:** operator/overload corrections and nullable-map `filter` type guards.
- **Two safe-by-construction registries** (`ExerciseMetadataFieldHandler`, `ExerciseMetadataSyncContext`) switch to **method syntax**, which is bivariant, so their invariant value type stays assignable to the erased element/field type — no casts.
- A few Angular Forms typings, and test-mock signature alignments.

### Steps for Testing
Non-user-facing; verification is build + lint + tests.
1. `pnpm run lint` → 0 errors.
2. `pnpm exec tsc -p tsconfig.app.json --noEmit` and `-p tsconfig.spec.json --noEmit` → 0 errors.
3. `pnpm run webapp:build` → succeeds.
4. `pnpm run vitest:run` → green.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list).

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for missing or empty data across several screens, reducing crashes and blank states when user, course, conversation, FAQ, or result data is unavailable.
  * Fixed several live update flows to ignore empty websocket or response payloads instead of passing invalid values through the UI.
  * Added safer fallbacks in editors, grading, and course/exam views so saved state and results load more reliably.

* **Tests**
  * Updated test coverage to match the new optional-value behavior and stricter typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->