### PR TITLE
`Development`: Fix nightly iris e2e overlay width probe after dynamic dialog migration

### DIFF
--- a/src/test/playwright/support/pageobjects/iris/IrisChatbotWidget.ts
+++ b/src/test/playwright/support/pageobjects/iris/IrisChatbotWidget.ts
@@ -6,8 +6,9 @@ import { Locator, Page, expect } from '@playwright/test';
  * The floating FAB is `jhi-exercise-chatbot-button .chatbot-button jhi-iris-logo`; clicking it
  * opens the widget overlay `.chat-widget`. The widget header `.chat-header` exposes
  * `button.header-control` controls whose fa icons are `circle-info` (info), `expand`/`compress`
- * (maximize/restore), and `xmark` (close). Maximizing resizes `.chat-widget` to ~93% of the
- * `.cdk-overlay-container` width via an inline pixel `style.width`.
+ * (maximize/restore), and `xmark` (close). The widget is rendered in a PrimeNG DynamicDialog, whose
+ * mask wrapper `.p-dialog-mask` covers the viewport; maximizing resizes `.chat-widget` to ~93% of
+ * that mask's width via an inline pixel `style.width`.
  */
 export class IrisChatbotWidget {
     private readonly page: Page;
@@ -105,10 +106,10 @@ export class IrisChatbotWidget {
         await expect(messageInput).toBeVisible();
     }
 
-    /** Returns the width of the CDK overlay container (the widget's positioning context). */
+    /** Returns the width of the PrimeNG dialog mask (the widget's positioning context). */
     async getOverlayWidth(): Promise<number> {
-        const box = await this.page.locator('.cdk-overlay-container').boundingBox();
-        expect(box, { message: 'cdk-overlay-container should have a bounding box' }).not.toBeNull();
+        const box = await this.page.locator('.p-dialog-mask').boundingBox();
+        expect(box, { message: 'p-dialog-mask should have a bounding box' }).not.toBeNull();
         return box!.width;
     }
 


### PR DESCRIPTION
### Summary
The nightly Iris e2e monitor (`nightly-iris / real-pyris`) started failing on `develop`. This PR fixes a stale Playwright selector in the Iris chatbot widget page object. It is a test-only change; no production code is touched.

### Motivation and Context
Fixes #13105.

The `IrisChatbotWidget.getOverlayWidth()` page object still queried `.cdk-overlay-container` to measure the widget's positioning context. In #13015 the Iris chatbot widget was migrated from an Angular CDK overlay to a PrimeNG `DynamicDialog`, so that element no longer exists in the DOM. Its container is now the dialog mask wrapper `.p-dialog-mask` (see the component's own `getContainerRect()` at `chatbot-widget.component.ts:305`).

Because the selector matched zero elements, `locator('.cdk-overlay-container').boundingBox()` polled a never-attached node and timed out after 45s, failing the test on both the initial run and the retry (deterministic, not flaky). Failing run: https://github.com/ls1intum/Artemis/actions/runs/28692911767/job/85097341503

Only the `maximizes to ~full overlay width` test hit this path. The wire-contract test (`sends a message and renders the assistant reply streamed back from real Pyris`) kept passing, confirming the widget itself works and only the layout probe was broken.

### Description
Point `getOverlayWidth()` at `.p-dialog-mask` instead of `.cdk-overlay-container`, and update the related doc comments. The mask covers the viewport exactly like the old CDK overlay did, so the existing maximize geometry assertions (start narrower than the container, grow to ~93% of it) remain valid without further changes.

### Steps for Testing
This is an e2e-only change verified against the current widget implementation. To exercise it, run the Iris e2e against the real-Pyris (mock-LLM) stack:

```
RUN_IRIS=true ./run-e2e-tests-local-fast.sh --filter "Iris"
```

Both tests in `IrisChatbotWidget.spec.ts` should pass. The nightly monitor will confirm on the next scheduled run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget size checks so maximized chatbot dialogs are measured using the actual dialog wrapper, making the width assertion more reliable.

* **Documentation**
  * Updated chatbot widget guidance to reflect the current maximization behavior and sizing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->