### PR TITLE
`Development`: Migrate submission REST endpoints and services to DTOs

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationCourseContextDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationCourseContextDTO.java
@@ -1,0 +1,29 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.course.domain.Course;
+
+/**
+ * Minimal course context required by participation clients.
+ *
+ * @param id               the unique identifier of the course
+ * @param title            the course title, if available
+ * @param shortName        the course short name, if available
+ * @param accuracyOfScores the configured number of decimal places for scores, if available
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ParticipationCourseContextDTO(Long id, @Nullable String title, @Nullable String shortName, @Nullable Integer accuracyOfScores) {
+
+    /**
+     * Creates a minimal course context response.
+     *
+     * @param course the course to map
+     * @return the minimal course context
+     */
+    public static ParticipationCourseContextDTO of(Course course) {
+        return new ParticipationCourseContextDTO(course.getId(), course.getTitle(), course.getShortName(), course.getAccuracyOfScores());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationDueDateUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationDueDateUpdateDTO.java
@@ -4,6 +4,8 @@ import java.time.ZonedDateTime;
 
 import jakarta.validation.constraints.NotNull;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -18,7 +20,7 @@ import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record ParticipationDueDateUpdateDTO(@NotNull Long id, @NotNull Long exerciseId, ZonedDateTime individualDueDate) {
+public record ParticipationDueDateUpdateDTO(@NotNull Long id, @NotNull Long exerciseId, @Nullable ZonedDateTime individualDueDate) {
 
     /**
      * Creates a ParticipationDueDateUpdateDTO from a StudentParticipation.

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationExerciseContextDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationExerciseContextDTO.java
@@ -1,0 +1,88 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.time.ZonedDateTime;
+
+import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
+import de.tum.cit.aet.artemis.course.domain.Course;
+import de.tum.cit.aet.artemis.course.dto.CourseWithIdDTO;
+import de.tum.cit.aet.artemis.exam.domain.Exam;
+import de.tum.cit.aet.artemis.exam.domain.ExerciseGroup;
+import de.tum.cit.aet.artemis.exam.dto.ExamWithIdAndCourseDTO;
+import de.tum.cit.aet.artemis.exercise.domain.Exercise;
+import de.tum.cit.aet.artemis.exercise.domain.ExerciseType;
+
+/**
+ * Minimal exercise context included in participation responses.
+ *
+ * @param id                the unique identifier of the exercise
+ * @param title             the exercise title, if available
+ * @param type              the polymorphic exercise discriminator
+ * @param exerciseType      the exercise category
+ * @param assessmentType    the configured assessment type, if available
+ * @param releaseDate       the release date, if configured
+ * @param startDate         the start date, if configured
+ * @param dueDate           the due date, if configured
+ * @param assessmentDueDate the assessment due date, if configured
+ * @param maxPoints         the maximum achievable points, if configured
+ * @param course            the minimal course context, if initialized
+ * @param exerciseGroup     the minimal exam exercise-group context, if initialized
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ParticipationExerciseContextDTO(Long id, @Nullable String title, String type, ExerciseType exerciseType, @Nullable AssessmentType assessmentType,
+        @Nullable ZonedDateTime releaseDate, @Nullable ZonedDateTime startDate, @Nullable ZonedDateTime dueDate, @Nullable ZonedDateTime assessmentDueDate,
+        @Nullable Double maxPoints, @Nullable ParticipationCourseContextDTO course, @Nullable ExerciseGroupWithIdAndExamDTO exerciseGroup) {
+
+    /**
+     * Creates a minimal exercise context after the caller has applied sensitive-information filtering.
+     *
+     * @param exercise the exercise to map
+     * @return the minimal exercise context
+     */
+    public static ParticipationExerciseContextDTO of(Exercise exercise) {
+        ParticipationCourseContextDTO courseDTO = mapCourse(exercise);
+        ExerciseGroupWithIdAndExamDTO exerciseGroupDTO = mapExerciseGroup(exercise.getExerciseGroup());
+        return new ParticipationExerciseContextDTO(exercise.getId(), exercise.getTitle(), exercise.getType(), exercise.getExerciseType(), exercise.getAssessmentType(),
+                exercise.getReleaseDate(), exercise.getStartDate(), exercise.getDueDate(), exercise.getAssessmentDueDate(), exercise.getMaxPoints(), courseDTO, exerciseGroupDTO);
+    }
+
+    @Nullable
+    private static ParticipationCourseContextDTO mapCourse(Exercise exercise) {
+        Course course;
+        if (exercise.isCourseExercise()) {
+            course = exercise.getCourseViaExerciseGroupOrCourseMember();
+        }
+        else {
+            ExerciseGroup exerciseGroup = exercise.getExerciseGroup();
+            if (exerciseGroup == null || !Hibernate.isInitialized(exerciseGroup)) {
+                return null;
+            }
+            Exam exam = exerciseGroup.getExam();
+            if (exam == null || !Hibernate.isInitialized(exam)) {
+                return null;
+            }
+            course = exam.getCourse();
+        }
+        return course != null && Hibernate.isInitialized(course) ? ParticipationCourseContextDTO.of(course) : null;
+    }
+
+    @Nullable
+    private static ExerciseGroupWithIdAndExamDTO mapExerciseGroup(@Nullable ExerciseGroup exerciseGroup) {
+        if (exerciseGroup == null || !Hibernate.isInitialized(exerciseGroup)) {
+            return null;
+        }
+        Exam exam = exerciseGroup.getExam();
+        if (exam == null || !Hibernate.isInitialized(exam)) {
+            return null;
+        }
+        Course course = exam.getCourse();
+        if (course == null || !Hibernate.isInitialized(course)) {
+            return null;
+        }
+        return new ExerciseGroupWithIdAndExamDTO(exerciseGroup.getId(), new ExamWithIdAndCourseDTO(exam.getId(), new CourseWithIdDTO(course.getId())));
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationSubmissionDTO.java
@@ -1,0 +1,44 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Objects;
+
+import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.exercise.domain.Submission;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
+
+/**
+ * Lean submission information nested in a participation response.
+ *
+ * @param id                     the unique identifier of the submission
+ * @param submitted              whether the submission was submitted, if known
+ * @param submissionDate         the submission time, if available
+ * @param submissionExerciseType the exercise-type discriminator of the submission
+ * @param commitHash             the programming commit hash, if this is a programming submission
+ * @param results                initialized lean results, or absent when results were not loaded
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ParticipationSubmissionDTO(Long id, @Nullable Boolean submitted, @Nullable ZonedDateTime submissionDate, String submissionExerciseType, @Nullable String commitHash,
+        @Nullable List<ParticipationSubmissionResultDTO> results) {
+
+    /**
+     * Creates a lean response DTO from a submission without initializing lazy results.
+     *
+     * @param submission the submission to map
+     * @return the lean submission response
+     */
+    public static ParticipationSubmissionDTO of(Submission submission) {
+        List<ParticipationSubmissionResultDTO> resultDTOs = null;
+        if (Hibernate.isInitialized(submission.getResults())) {
+            resultDTOs = submission.getResults().stream().filter(Objects::nonNull).map(ParticipationSubmissionResultDTO::of).toList();
+        }
+        String commitHash = submission instanceof ProgrammingSubmission programmingSubmission ? programmingSubmission.getCommitHash() : null;
+        return new ParticipationSubmissionDTO(submission.getId(), submission.isSubmitted(), submission.getSubmissionDate(), submission.getSubmissionExerciseType(), commitHash,
+                resultDTOs);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationSubmissionResultDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationSubmissionResultDTO.java
@@ -1,0 +1,36 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.time.ZonedDateTime;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
+import de.tum.cit.aet.artemis.assessment.domain.Result;
+
+/**
+ * Lean result information nested in a participation submission response.
+ *
+ * @param id             the unique identifier of the result
+ * @param completionDate the time at which the result was completed, if available
+ * @param successful     whether the result was successful, if determined
+ * @param score          the achieved score in percent, if calculated
+ * @param rated          whether the result contributes to the exercise score
+ * @param assessmentType the type of assessment that produced the result, if known
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ParticipationSubmissionResultDTO(Long id, @Nullable ZonedDateTime completionDate, @Nullable Boolean successful, @Nullable Double score, boolean rated,
+        @Nullable AssessmentType assessmentType) {
+
+    /**
+     * Creates a lean response DTO from a result.
+     *
+     * @param result the result to map
+     * @return the lean result response
+     */
+    public static ParticipationSubmissionResultDTO of(Result result) {
+        return new ParticipationSubmissionResultDTO(result.getId(), result.getCompletionDate(), result.isSuccessful(), result.getScore(), result.isRated(),
+                result.getAssessmentType());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationTeamDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationTeamDTO.java
@@ -1,0 +1,38 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.util.List;
+
+import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.core.dto.UserPublicInfoDTO;
+import de.tum.cit.aet.artemis.exercise.domain.Team;
+
+/**
+ * Safe team information included in a participation response.
+ *
+ * @param id        the unique identifier of the team
+ * @param name      the display name of the team, if available
+ * @param shortName the short name used to identify the team, if available
+ * @param image     the team image path, if available
+ * @param students  public information for initialized team members, or absent when members were not loaded
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record ParticipationTeamDTO(Long id, @Nullable String name, @Nullable String shortName, @Nullable String image, @Nullable List<UserPublicInfoDTO> students) {
+
+    /**
+     * Creates a safe team response without initializing the team's students.
+     *
+     * @param team the team to map after participant visibility has been checked
+     * @return the safe team response
+     */
+    public static ParticipationTeamDTO of(Team team) {
+        List<UserPublicInfoDTO> students = null;
+        if (team.getStudents() != null && Hibernate.isInitialized(team.getStudents())) {
+            students = team.getStudents().stream().map(UserPublicInfoDTO::new).toList();
+        }
+        return new ParticipationTeamDTO(team.getId(), team.getName(), team.getShortName(), team.getImage(), students);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationUpdateDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationUpdateDTO.java
@@ -2,6 +2,8 @@ package de.tum.cit.aet.artemis.exercise.dto;
 
 import jakarta.validation.constraints.NotNull;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -14,5 +16,5 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record ParticipationUpdateDTO(@NotNull Long id, @NotNull Long exerciseId, Double presentationScore) {
+public record ParticipationUpdateDTO(@NotNull Long id, @NotNull Long exerciseId, @Nullable Double presentationScore) {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/StudentParticipationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/StudentParticipationDTO.java
@@ -2,53 +2,165 @@ package de.tum.cit.aet.artemis.exercise.dto;
 
 import java.io.Serializable;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tum.cit.aet.artemis.core.dto.UserNameDTO;
+import de.tum.cit.aet.artemis.account.domain.User;
+import de.tum.cit.aet.artemis.core.dto.UserPublicInfoDTO;
+import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
+import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParticipation;
 
 /**
- * DTO containing {@link StudentParticipation} information.
- * This does not include large reference attributes in order to send minimal data to the client.
+ * DTO representing the REST response for a student participation.
+ *
+ * @param id                    the unique identifier of the participation
+ * @param initializationState   the current initialization state, if available
+ * @param initializationDate    the time at which initialization started, if available
+ * @param individualDueDate     the individual due date, if configured
+ * @param presentationScore     the presentation score, if assigned
+ * @param testRun               whether this is an exam test run or course practice participation
+ * @param type                  the polymorphic participation discriminator
+ * @param submissionCount       the transient number of submissions, if calculated
+ * @param participantName       the visible participant name, if authorized
+ * @param participantIdentifier the visible participant identifier, if authorized
+ * @param student               safe public student information, if authorized and initialized
+ * @param team                  safe team information, if authorized and initialized
+ * @param exercise              the minimal exercise context, if requested and initialized
+ * @param submissions           initialized lean submissions, or absent when submissions were not loaded
+ * @param repositoryUri         the programming repository URI, if applicable
+ * @param buildPlanId           the programming build-plan identifier, if applicable
+ * @param branch                the programming repository branch, if applicable
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record StudentParticipationDTO(Long id, String type, boolean testRun, InitializationState initializationState, ZonedDateTime initializationDate,
-        ZonedDateTime individualDueDate, Double presentationScore, UserNameDTO student, TeamDTO team, ParticipationDTO.ParticipationExerciseDTO exercise) implements Serializable {
+public record StudentParticipationDTO(Long id, @Nullable InitializationState initializationState, @Nullable ZonedDateTime initializationDate,
+        @Nullable ZonedDateTime individualDueDate, @Nullable Double presentationScore, boolean testRun, String type, @Nullable Integer submissionCount,
+        @Nullable String participantName, @Nullable String participantIdentifier, @Nullable UserPublicInfoDTO student, @Nullable ParticipationTeamDTO team,
+        @Nullable ParticipationExerciseContextDTO exercise, @Nullable List<ParticipationSubmissionDTO> submissions, @Nullable String repositoryUri, @Nullable String buildPlanId,
+        @Nullable String branch) implements Serializable {
 
-    public static StudentParticipationDTO of(StudentParticipation participation) {
+    /**
+     * Maps a participation for an enclosing response without exposing its participant.
+     *
+     * @param participation the participation to map
+     * @return the participation response, or {@code null} when the input is {@code null}
+     */
+    public static @Nullable StudentParticipationDTO of(@Nullable StudentParticipation participation) {
         return of(participation, false);
     }
 
     /**
-     * Converts a {@link StudentParticipation} into a {@link StudentParticipationDTO}.
+     * Maps a participation for an enclosing response, optionally including its visible participant.
      *
-     * @param participation  the participation to convert
-     * @param includeStudent whether the student should be included; when {@code false} the student is omitted (e.g. for tutors)
-     * @return the converted DTO, or {@code null} if the participation is {@code null}
+     * @param participation  the participation to map
+     * @param includeStudent whether initialized participant information should be included
+     * @return the participation response, or {@code null} when the input is {@code null}
      */
-    public static StudentParticipationDTO of(StudentParticipation participation, boolean includeStudent) {
-        if (participation == null) {
-            return null;
+    public static @Nullable StudentParticipationDTO of(@Nullable StudentParticipation participation, boolean includeStudent) {
+        return participation != null ? of(participation, includeStudent, true, false) : null;
+    }
+
+    /**
+     * Maps a newly started participation including its visible participant, exercise, and initialized submissions.
+     *
+     * @param participation the newly started participation after sensitive-information filtering
+     * @return the participation response
+     */
+    public static StudentParticipationDTO ofAfterStart(StudentParticipation participation) {
+        return of(participation, true, true, true);
+    }
+
+    /**
+     * Maps a resumed programming participation including its filtered exercise context.
+     *
+     * @param participation the resumed programming participation after sensitive-information filtering
+     * @return the participation response
+     */
+    public static StudentParticipationDTO ofAfterResume(ProgrammingExerciseStudentParticipation participation) {
+        return of(participation, false, true, true);
+    }
+
+    /**
+     * Maps a participation for latest-result polling with initialized lean submissions and results.
+     *
+     * @param participation the participation loaded with its latest result
+     * @return the polling response
+     */
+    public static StudentParticipationDTO ofWithLatestResult(StudentParticipation participation) {
+        return of(participation, false, false, true);
+    }
+
+    /**
+     * Maps a participation for its current owner, including safe participant and exercise information.
+     *
+     * @param participation the authorized participation loaded with team students when applicable
+     * @return the current-user participation response
+     */
+    public static StudentParticipationDTO ofForCurrentUser(StudentParticipation participation) {
+        return of(participation, true, true, false);
+    }
+
+    /**
+     * Maps a participation after a scalar management update without initializing unrelated associations.
+     *
+     * @param participation the updated participation
+     * @return the lean update response
+     */
+    public static StudentParticipationDTO ofAfterUpdate(StudentParticipation participation) {
+        return of(participation, false, false, false);
+    }
+
+    /**
+     * Maps a programming participation after its build plan was cleaned up.
+     *
+     * @param participation the updated programming participation
+     * @return the lean cleanup response
+     */
+    public static StudentParticipationDTO ofAfterBuildPlanCleanup(ProgrammingExerciseStudentParticipation participation) {
+        return of(participation, false, false, false);
+    }
+
+    private static StudentParticipationDTO of(StudentParticipation participation, boolean includeParticipant, boolean includeExercise, boolean includeSubmissions) {
+        UserPublicInfoDTO studentDTO = null;
+        ParticipationTeamDTO teamDTO = null;
+        if (includeParticipant) {
+            User student = participation.getStudent().filter(Hibernate::isInitialized).orElse(null);
+            Team team = participation.getTeam().filter(Hibernate::isInitialized).orElse(null);
+            studentDTO = student != null ? new UserPublicInfoDTO(student) : null;
+            teamDTO = team != null ? ParticipationTeamDTO.of(team) : null;
         }
-        UserNameDTO student = null;
-        TeamDTO team = null;
-        if (includeStudent) {
-            if (Hibernate.isInitialized(participation.getStudent().orElse(null))) {
-                student = UserNameDTO.of(participation.getStudent().orElse(null));
-            }
-            if (Hibernate.isInitialized(participation.getTeam().orElse(null))) {
-                team = TeamDTO.of(participation.getTeam().orElse(null));
-            }
+
+        String participantName = studentDTO != null || teamDTO != null ? participation.getParticipantName() : null;
+        String participantIdentifier = studentDTO != null || teamDTO != null ? participation.getParticipantIdentifier() : null;
+
+        ParticipationExerciseContextDTO exerciseDTO = null;
+        Exercise exercise = participation.getExercise();
+        if (includeExercise && exercise != null && Hibernate.isInitialized(exercise)) {
+            exerciseDTO = ParticipationExerciseContextDTO.of(exercise);
         }
-        ParticipationDTO.ParticipationExerciseDTO exercise = null;
-        if (Hibernate.isInitialized(participation.getExercise())) {
-            exercise = ParticipationDTO.ParticipationExerciseDTO.of(participation.getExercise());
+
+        List<ParticipationSubmissionDTO> submissionDTOs = null;
+        if (includeSubmissions && Hibernate.isInitialized(participation.getSubmissions())) {
+            submissionDTOs = participation.getSubmissions().stream().map(ParticipationSubmissionDTO::of).toList();
         }
-        return new StudentParticipationDTO(participation.getId(), participation.getType(), participation.isTestRun(), participation.getInitializationState(),
-                participation.getInitializationDate(), participation.getIndividualDueDate(), participation.getPresentationScore(), student, team, exercise);
+
+        String repositoryUri = null;
+        String buildPlanId = null;
+        String branch = null;
+        if (participation instanceof ProgrammingExerciseStudentParticipation programmingParticipation) {
+            repositoryUri = programmingParticipation.getRepositoryUri();
+            buildPlanId = programmingParticipation.getBuildPlanId();
+            branch = programmingParticipation.getBranch();
+        }
+
+        return new StudentParticipationDTO(participation.getId(), participation.getInitializationState(), participation.getInitializationDate(),
+                participation.getIndividualDueDate(), participation.getPresentationScore(), participation.isTestRun(), participation.getType(), participation.getSubmissionCount(),
+                participantName, participantIdentifier, studentDTO, teamDTO, exerciseDTO, submissionDTOs, repositoryUri, buildPlanId, branch);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/StudentParticipationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/StudentParticipationDTO.java
@@ -63,7 +63,18 @@ public record StudentParticipationDTO(Long id, @Nullable InitializationState ini
      * @return the participation response, or {@code null} when the input is {@code null}
      */
     public static @Nullable StudentParticipationDTO of(@Nullable StudentParticipation participation, boolean includeStudent) {
-        return participation != null ? of(participation, includeStudent, true, false) : null;
+        return participation != null ? of(participation, includeStudent, true, false, true) : null;
+    }
+
+    /**
+     * Maps a participation without participant-derived programming repository details.
+     *
+     * @param participation  the participation to map
+     * @param includeStudent whether initialized participant information should be included
+     * @return the participation response, or {@code null} when the input is {@code null}
+     */
+    public static @Nullable StudentParticipationDTO ofWithoutProgrammingDetails(@Nullable StudentParticipation participation, boolean includeStudent) {
+        return participation != null ? of(participation, includeStudent, true, false, false) : null;
     }
 
     /**
@@ -73,7 +84,7 @@ public record StudentParticipationDTO(Long id, @Nullable InitializationState ini
      * @return the participation response
      */
     public static StudentParticipationDTO ofAfterStart(StudentParticipation participation) {
-        return of(participation, true, true, true);
+        return of(participation, true, true, true, true);
     }
 
     /**
@@ -83,7 +94,7 @@ public record StudentParticipationDTO(Long id, @Nullable InitializationState ini
      * @return the participation response
      */
     public static StudentParticipationDTO ofAfterResume(ProgrammingExerciseStudentParticipation participation) {
-        return of(participation, false, true, true);
+        return of(participation, false, true, true, true);
     }
 
     /**
@@ -93,7 +104,7 @@ public record StudentParticipationDTO(Long id, @Nullable InitializationState ini
      * @return the polling response
      */
     public static StudentParticipationDTO ofWithLatestResult(StudentParticipation participation) {
-        return of(participation, false, false, true);
+        return of(participation, false, false, true, true);
     }
 
     /**
@@ -103,7 +114,7 @@ public record StudentParticipationDTO(Long id, @Nullable InitializationState ini
      * @return the current-user participation response
      */
     public static StudentParticipationDTO ofForCurrentUser(StudentParticipation participation) {
-        return of(participation, true, true, false);
+        return of(participation, true, true, false, true);
     }
 
     /**
@@ -113,7 +124,7 @@ public record StudentParticipationDTO(Long id, @Nullable InitializationState ini
      * @return the lean update response
      */
     public static StudentParticipationDTO ofAfterUpdate(StudentParticipation participation) {
-        return of(participation, false, false, false);
+        return of(participation, false, false, false, true);
     }
 
     /**
@@ -123,10 +134,11 @@ public record StudentParticipationDTO(Long id, @Nullable InitializationState ini
      * @return the lean cleanup response
      */
     public static StudentParticipationDTO ofAfterBuildPlanCleanup(ProgrammingExerciseStudentParticipation participation) {
-        return of(participation, false, false, false);
+        return of(participation, false, false, false, true);
     }
 
-    private static StudentParticipationDTO of(StudentParticipation participation, boolean includeParticipant, boolean includeExercise, boolean includeSubmissions) {
+    private static StudentParticipationDTO of(StudentParticipation participation, boolean includeParticipant, boolean includeExercise, boolean includeSubmissions,
+            boolean includeProgrammingDetails) {
         UserPublicInfoDTO studentDTO = null;
         ParticipationTeamDTO teamDTO = null;
         if (includeParticipant) {
@@ -153,7 +165,7 @@ public record StudentParticipationDTO(Long id, @Nullable InitializationState ini
         String repositoryUri = null;
         String buildPlanId = null;
         String branch = null;
-        if (participation instanceof ProgrammingExerciseStudentParticipation programmingParticipation) {
+        if (includeProgrammingDetails && participation instanceof ProgrammingExerciseStudentParticipation programmingParticipation) {
             repositoryUri = programmingParticipation.getRepositoryUri();
             buildPlanId = programmingParticipation.getBuildPlanId();
             branch = programmingParticipation.getBranch();

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/SubmissionAssessmentNoteDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/SubmissionAssessmentNoteDTO.java
@@ -1,0 +1,36 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.AssessmentNote;
+import de.tum.cit.aet.artemis.core.dto.UserPublicInfoDTO;
+
+/**
+ * DTO representing an internal assessment note nested in a submission result.
+ *
+ * @param id      the assessment-note identifier
+ * @param note    the note text, if available
+ * @param creator safe public information about the initialized creator, if available
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record SubmissionAssessmentNoteDTO(Long id, @Nullable String note, @Nullable UserPublicInfoDTO creator) implements Serializable {
+
+    /**
+     * Maps an assessment note without initializing its creator association.
+     *
+     * @param assessmentNote the assessment note to map
+     * @return the submission assessment-note DTO
+     */
+    public static SubmissionAssessmentNoteDTO of(AssessmentNote assessmentNote) {
+        Objects.requireNonNull(assessmentNote, "The assessment note must be set");
+        UserPublicInfoDTO creator = assessmentNote.getCreator() != null && Hibernate.isInitialized(assessmentNote.getCreator()) ? new UserPublicInfoDTO(assessmentNote.getCreator())
+                : null;
+        return new SubmissionAssessmentNoteDTO(assessmentNote.getId(), assessmentNote.getNote(), creator);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/SubmissionFeedbackDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/SubmissionFeedbackDTO.java
@@ -1,0 +1,53 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.Feedback;
+import de.tum.cit.aet.artemis.assessment.domain.FeedbackType;
+import de.tum.cit.aet.artemis.assessment.domain.Visibility;
+import de.tum.cit.aet.artemis.assessment.dto.GradingInstructionDTO;
+
+/**
+ * DTO representing feedback nested in a submission response.
+ *
+ * @param id                  the feedback identifier
+ * @param text                the short feedback text, if available
+ * @param detailText          the detailed feedback text, if available
+ * @param hasLongFeedbackText whether the complete detail text is stored separately
+ * @param reference           the assessed element reference, if available
+ * @param credits             the awarded credits, if available
+ * @param positive            whether the feedback is positive, if specified
+ * @param type                the feedback type, if available
+ * @param visibility          the feedback visibility, if available
+ * @param testCaseName        the initialized programming test-case name, if available
+ * @param gradingInstruction  the initialized grading instruction, if available
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record SubmissionFeedbackDTO(Long id, @Nullable String text, @Nullable String detailText, boolean hasLongFeedbackText, @Nullable String reference, @Nullable Double credits,
+        @Nullable Boolean positive, @Nullable FeedbackType type, @Nullable Visibility visibility, @Nullable String testCaseName, @Nullable GradingInstructionDTO gradingInstruction)
+        implements Serializable {
+
+    /**
+     * Maps initialized feedback data without exposing entity back-references.
+     *
+     * @param feedback the feedback to map
+     * @return the submission feedback DTO
+     */
+    public static SubmissionFeedbackDTO of(Feedback feedback) {
+        Objects.requireNonNull(feedback, "The feedback must be set");
+
+        String testCaseName = feedback.getTestCase() != null && Hibernate.isInitialized(feedback.getTestCase()) ? feedback.getTestCase().getTestName() : null;
+        GradingInstructionDTO gradingInstruction = feedback.getGradingInstruction() != null && Hibernate.isInitialized(feedback.getGradingInstruction())
+                ? GradingInstructionDTO.of(feedback.getGradingInstruction())
+                : null;
+
+        return new SubmissionFeedbackDTO(feedback.getId(), feedback.getText(), feedback.getDetailText(), feedback.getHasLongFeedbackText(), feedback.getReference(),
+                feedback.getCredits(), feedback.isPositive(), feedback.getType(), feedback.getVisibility(), testCaseName, gradingInstruction);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/SubmissionResponseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/SubmissionResponseDTO.java
@@ -1,0 +1,146 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Objects;
+
+import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.core.domain.Language;
+import de.tum.cit.aet.artemis.exercise.domain.Submission;
+import de.tum.cit.aet.artemis.exercise.domain.SubmissionType;
+import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.fileupload.domain.FileUploadSubmission;
+import de.tum.cit.aet.artemis.modeling.domain.ModelingSubmission;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
+import de.tum.cit.aet.artemis.quiz.domain.AbstractQuizSubmission;
+import de.tum.cit.aet.artemis.quiz.domain.QuizSubmission;
+import de.tum.cit.aet.artemis.text.domain.TextSubmission;
+
+/**
+ * DTO representing a polymorphic submission REST response.
+ *
+ * @param id                     the submission identifier
+ * @param submitted              whether the submission was submitted
+ * @param type                   the submission trigger type, if available
+ * @param exampleSubmission      whether this is an example submission, if specified
+ * @param submissionDate         the submission date, if available
+ * @param durationInMinutes      the duration between participation start and submission, if available
+ * @param submissionExerciseType the polymorphic exercise-type discriminator
+ * @param participation          a DTO-safe participation reference without submissions, if available
+ * @param results                initialized result DTOs, or absent if results were not loaded
+ * @param commitHash             the programming commit hash, if applicable
+ * @param buildFailed            whether the programming build failed, if applicable
+ * @param text                   the submitted text, if applicable
+ * @param language               the text language, if applicable
+ * @param model                  the submitted model, if applicable
+ * @param explanationText        the modeling explanation, if applicable
+ * @param filePath               the uploaded file path, if applicable
+ * @param quizBatch              the quiz batch identifier, if applicable
+ * @param scoreInPoints          the quiz score in points, if applicable
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record SubmissionResponseDTO(Long id, Boolean submitted, @Nullable SubmissionType type, @Nullable Boolean exampleSubmission, @Nullable ZonedDateTime submissionDate,
+        @Nullable Long durationInMinutes, String submissionExerciseType, @Nullable StudentParticipationDTO participation, @Nullable List<SubmissionResultDTO> results,
+        @Nullable String commitHash, @Nullable Boolean buildFailed, @Nullable String text, @Nullable Language language, @Nullable String model, @Nullable String explanationText,
+        @Nullable String filePath, @Nullable Long quizBatch, @Nullable Double scoreInPoints) implements Serializable {
+
+    /**
+     * Maps a submission for participation history, retaining visible participant data and initialized assessors.
+     *
+     * @param submission the authorized history submission to map
+     * @return the submission response DTO
+     */
+    public static SubmissionResponseDTO ofForParticipationHistory(Submission submission) {
+        return of(submission, true, false, false);
+    }
+
+    /**
+     * Maps the final prepared test-run submission, retaining initialized feedback and test-run context.
+     *
+     * @param submission the prepared test-run submission to map
+     * @return the submission response DTO
+     */
+    public static SubmissionResponseDTO ofForTestRunAssessment(Submission submission) {
+        return of(submission, true, true, false);
+    }
+
+    /**
+     * Maps a submission for example-submission import, retaining participant display data and content used for the size preview.
+     *
+     * @param submission the import candidate to map
+     * @return the submission response DTO
+     */
+    public static SubmissionResponseDTO ofForImport(Submission submission) {
+        return of(submission, true, false, true);
+    }
+
+    /**
+     * Maps an already anonymized submission for the complaint assessment dashboard.
+     *
+     * @param submission the filtered complaint submission to map
+     * @return the submission response DTO
+     */
+    public static SubmissionResponseDTO ofForComplaintDashboard(Submission submission) {
+        return of(submission, false, false, false);
+    }
+
+    private static SubmissionResponseDTO of(Submission submission, boolean includeParticipant, boolean includeFeedback, boolean latestResultOnly) {
+        Objects.requireNonNull(submission, "The submission must be set");
+
+        StudentParticipationDTO participation = Hibernate.isInitialized(submission.getParticipation())
+                && submission.getParticipation() instanceof StudentParticipation studentParticipation ? StudentParticipationDTO.of(studentParticipation, includeParticipant) : null;
+        List<SubmissionResultDTO> results = null;
+        if (Hibernate.isInitialized(submission.getResults())) {
+            if (latestResultOnly) {
+                var latestResult = submission.getLatestResult();
+                results = latestResult != null ? List.of(SubmissionResultDTO.of(latestResult, includeFeedback)) : List.of();
+            }
+            else {
+                results = submission.getResults().stream().filter(Objects::nonNull).map(result -> SubmissionResultDTO.of(result, includeFeedback)).toList();
+            }
+        }
+
+        String commitHash = null;
+        Boolean buildFailed = null;
+        String text = null;
+        Language language = null;
+        String model = null;
+        String explanationText = null;
+        String filePath = null;
+        Long quizBatch = null;
+        Double scoreInPoints = null;
+
+        if (submission instanceof ProgrammingSubmission programmingSubmission) {
+            commitHash = programmingSubmission.getCommitHash();
+            buildFailed = programmingSubmission.isBuildFailed();
+        }
+        else if (submission instanceof TextSubmission textSubmission) {
+            text = textSubmission.getText();
+            language = textSubmission.getLanguage();
+        }
+        else if (submission instanceof ModelingSubmission modelingSubmission) {
+            model = modelingSubmission.getModel();
+            explanationText = modelingSubmission.getExplanationText();
+        }
+        else if (submission instanceof FileUploadSubmission fileUploadSubmission) {
+            filePath = fileUploadSubmission.getFilePath();
+        }
+        else if (submission instanceof QuizSubmission quizSubmission) {
+            quizBatch = quizSubmission.getQuizBatch();
+            scoreInPoints = quizSubmission.getScoreInPoints();
+        }
+        else if (submission instanceof AbstractQuizSubmission quizSubmission) {
+            scoreInPoints = quizSubmission.getScoreInPoints();
+        }
+
+        Long durationInMinutes = submission.getParticipation() == null || Hibernate.isInitialized(submission.getParticipation()) ? submission.getDurationInMinutes() : null;
+        return new SubmissionResponseDTO(submission.getId(), submission.isSubmitted(), submission.getType(), submission.isExampleSubmission(), submission.getSubmissionDate(),
+                durationInMinutes, submission.getSubmissionExerciseType(), participation, results, commitHash, buildFailed, text, language, model, explanationText, filePath,
+                quizBatch, scoreInPoints);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/SubmissionResponseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/SubmissionResponseDTO.java
@@ -17,7 +17,6 @@ import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation
 import de.tum.cit.aet.artemis.fileupload.domain.FileUploadSubmission;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingSubmission;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
-import de.tum.cit.aet.artemis.quiz.domain.AbstractQuizSubmission;
 import de.tum.cit.aet.artemis.quiz.domain.QuizSubmission;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 
@@ -56,7 +55,7 @@ public record SubmissionResponseDTO(Long id, Boolean submitted, @Nullable Submis
      * @return the submission response DTO
      */
     public static SubmissionResponseDTO ofForParticipationHistory(Submission submission) {
-        return of(submission, true, false, false);
+        return of(submission, true, false, false, true);
     }
 
     /**
@@ -66,7 +65,7 @@ public record SubmissionResponseDTO(Long id, Boolean submitted, @Nullable Submis
      * @return the submission response DTO
      */
     public static SubmissionResponseDTO ofForTestRunAssessment(Submission submission) {
-        return of(submission, true, true, false);
+        return of(submission, true, true, false, true);
     }
 
     /**
@@ -76,7 +75,7 @@ public record SubmissionResponseDTO(Long id, Boolean submitted, @Nullable Submis
      * @return the submission response DTO
      */
     public static SubmissionResponseDTO ofForImport(Submission submission) {
-        return of(submission, true, false, true);
+        return of(submission, true, false, true, true);
     }
 
     /**
@@ -86,14 +85,18 @@ public record SubmissionResponseDTO(Long id, Boolean submitted, @Nullable Submis
      * @return the submission response DTO
      */
     public static SubmissionResponseDTO ofForComplaintDashboard(Submission submission) {
-        return of(submission, false, false, false);
+        return of(submission, false, false, false, false);
     }
 
-    private static SubmissionResponseDTO of(Submission submission, boolean includeParticipant, boolean includeFeedback, boolean latestResultOnly) {
+    private static SubmissionResponseDTO of(Submission submission, boolean includeParticipant, boolean includeFeedback, boolean latestResultOnly,
+            boolean includeProgrammingDetails) {
         Objects.requireNonNull(submission, "The submission must be set");
 
-        StudentParticipationDTO participation = Hibernate.isInitialized(submission.getParticipation())
-                && submission.getParticipation() instanceof StudentParticipation studentParticipation ? StudentParticipationDTO.of(studentParticipation, includeParticipant) : null;
+        StudentParticipationDTO participation = null;
+        if (Hibernate.isInitialized(submission.getParticipation()) && submission.getParticipation() instanceof StudentParticipation studentParticipation) {
+            participation = includeProgrammingDetails ? StudentParticipationDTO.of(studentParticipation, includeParticipant)
+                    : StudentParticipationDTO.ofWithoutProgrammingDetails(studentParticipation, includeParticipant);
+        }
         List<SubmissionResultDTO> results = null;
         if (Hibernate.isInitialized(submission.getResults())) {
             if (latestResultOnly) {
@@ -132,9 +135,6 @@ public record SubmissionResponseDTO(Long id, Boolean submitted, @Nullable Submis
         }
         else if (submission instanceof QuizSubmission quizSubmission) {
             quizBatch = quizSubmission.getQuizBatch();
-            scoreInPoints = quizSubmission.getScoreInPoints();
-        }
-        else if (submission instanceof AbstractQuizSubmission quizSubmission) {
             scoreInPoints = quizSubmission.getScoreInPoints();
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/SubmissionResultDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/SubmissionResultDTO.java
@@ -1,0 +1,72 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Objects;
+
+import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.AssessmentNote;
+import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
+import de.tum.cit.aet.artemis.assessment.domain.Result;
+import de.tum.cit.aet.artemis.core.dto.UserPublicInfoDTO;
+
+/**
+ * DTO representing a result nested in a submission response.
+ *
+ * @param id                  the result identifier
+ * @param completionDate      the completion date, if the assessment is complete
+ * @param successful          whether the result is successful, if known
+ * @param score               the score in percent, if available
+ * @param rated               whether the result counts toward the exercise score
+ * @param assessmentType      the assessment type, if available
+ * @param hasComplaint        whether a complaint exists, if known
+ * @param exampleResult       whether this is an example result, if known
+ * @param testCaseCount       the number of programming test cases, if available
+ * @param passedTestCaseCount the number of passed programming test cases, if available
+ * @param codeIssueCount      the number of programming code issues, if available
+ * @param assessor            safe public assessor information, if initialized
+ * @param feedbacks           initialized feedback, when requested by the enclosing response
+ * @param assessmentNote      the initialized internal assessment note, if available
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record SubmissionResultDTO(Long id, @Nullable ZonedDateTime completionDate, @Nullable Boolean successful, @Nullable Double score, boolean rated,
+        @Nullable AssessmentType assessmentType, @Nullable Boolean hasComplaint, @Nullable Boolean exampleResult, @Nullable Integer testCaseCount,
+        @Nullable Integer passedTestCaseCount, @Nullable Integer codeIssueCount, @Nullable UserPublicInfoDTO assessor, @Nullable List<SubmissionFeedbackDTO> feedbacks,
+        @Nullable SubmissionAssessmentNoteDTO assessmentNote) implements Serializable {
+
+    /**
+     * Maps a result including initialized feedback.
+     *
+     * @param result the result to map
+     * @return the submission result DTO
+     */
+    public static SubmissionResultDTO of(Result result) {
+        return of(result, true);
+    }
+
+    /**
+     * Maps a result without initializing lazy associations.
+     *
+     * @param result          the result to map
+     * @param includeFeedback whether initialized feedback should be included
+     * @return the submission result DTO
+     */
+    public static SubmissionResultDTO of(Result result, boolean includeFeedback) {
+        Objects.requireNonNull(result, "The result must be set");
+
+        UserPublicInfoDTO assessor = result.getAssessor() != null && Hibernate.isInitialized(result.getAssessor()) ? new UserPublicInfoDTO(result.getAssessor()) : null;
+        List<SubmissionFeedbackDTO> feedbacks = includeFeedback && Hibernate.isInitialized(result.getFeedbacks())
+                ? result.getFeedbacks().stream().filter(Objects::nonNull).map(SubmissionFeedbackDTO::of).toList()
+                : null;
+        AssessmentNote assessmentNote = result.getAssessmentNote();
+
+        return new SubmissionResultDTO(result.getId(), result.getCompletionDate(), result.isSuccessful(), result.getScore(), result.isRated(), result.getAssessmentType(),
+                result.hasComplaint(), result.isExampleResult(), result.getTestCaseCount(), result.getPassedTestCaseCount(), result.getCodeIssueCount(), assessor, feedbacks,
+                assessmentNote != null ? SubmissionAssessmentNoteDTO.of(assessmentNote) : null);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/SubmissionWithComplaintDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/SubmissionWithComplaintDTO.java
@@ -3,11 +3,26 @@ package de.tum.cit.aet.artemis.exercise.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.assessment.domain.Complaint;
+import de.tum.cit.aet.artemis.assessment.dto.ComplaintDTO;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 
 /**
- * Wrapper Class to send achieved points and achieved scores of a student to the client for courses / exam
+ * DTO combining an anonymized submission with its complaint for the assessment dashboard.
+ *
+ * @param submission the DTO-safe, already-filtered submission
+ * @param complaint  the DTO-safe, already-filtered complaint
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record SubmissionWithComplaintDTO(Submission submission, Complaint complaint) {
+public record SubmissionWithComplaintDTO(SubmissionResponseDTO submission, ComplaintDTO complaint) {
+
+    /**
+     * Maps an already-filtered submission and complaint without reloading participant information.
+     *
+     * @param submission the filtered submission
+     * @param complaint  the filtered complaint
+     * @return the complaint dashboard wrapper DTO
+     */
+    public static SubmissionWithComplaintDTO of(Submission submission, Complaint complaint) {
+        return new SubmissionWithComplaintDTO(SubmissionResponseDTO.ofForComplaintDashboard(submission), ComplaintDTO.of(complaint));
+    }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Service;
 
 import de.tum.cit.aet.artemis.account.domain.User;
@@ -901,8 +900,7 @@ public class SubmissionService {
         Page<StudentParticipation> studentParticipationPage = studentParticipationRepository.findAllWithEagerSubmissionsAndResultsByExerciseId(exerciseId, searchTerm, pageable);
 
         var latestSubmissions = studentParticipationPage.getContent().stream().map(Participation::findLatestSubmission).filter(Optional::isPresent).map(Optional::get).toList();
-        final Page<SubmissionResponseDTO> submissionPage = new PageImpl<>(latestSubmissions.stream().map(SubmissionResponseDTO::ofForImport).toList(), pageable,
-                latestSubmissions.size());
-        return new SearchResultPageDTO<>(submissionPage.getContent(), studentParticipationPage.getTotalPages());
+        final List<SubmissionResponseDTO> submissionDTOs = latestSubmissions.stream().map(SubmissionResponseDTO::ofForImport).toList();
+        return new SearchResultPageDTO<>(submissionDTOs, studentParticipationPage.getTotalPages());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
@@ -51,6 +51,7 @@ import de.tum.cit.aet.artemis.exercise.domain.SubmissionType;
 import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionResponseDTO;
 import de.tum.cit.aet.artemis.exercise.dto.SubmissionWithComplaintDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
@@ -813,7 +814,7 @@ public class SubmissionService {
                 submission.setResults(submission.getNonAthenaResults());
                 Complaint complaintOfSubmission = complaintMap.get(submission.getResultWithComplaint().getId());
                 prepareComplaintAndSubmission(complaintOfSubmission, submission);
-                submissionWithComplaintDTOs.add(new SubmissionWithComplaintDTO(submission, complaintOfSubmission));
+                submissionWithComplaintDTOs.add(SubmissionWithComplaintDTO.of(submission, complaintOfSubmission));
             });
         }
 
@@ -845,13 +846,14 @@ public class SubmissionService {
      * @param exerciseId Id of the exercise the submissions belongs to
      * @return A wrapper object containing a list of all found submissions and the total number of pages
      */
-    public SearchResultPageDTO<Submission> getSubmissionsOnPageWithSize(SearchTermPageableSearchDTO<String> search, Long exerciseId) {
+    public SearchResultPageDTO<SubmissionResponseDTO> getSubmissionsOnPageWithSize(SearchTermPageableSearchDTO<String> search, Long exerciseId) {
         final var pageable = PageUtil.createDefaultPageRequest(search, PageUtil.ColumnMapping.STUDENT_PARTICIPATION);
         String searchTerm = search.getSearchTerm();
         Page<StudentParticipation> studentParticipationPage = studentParticipationRepository.findAllWithEagerSubmissionsAndResultsByExerciseId(exerciseId, searchTerm, pageable);
 
         var latestSubmissions = studentParticipationPage.getContent().stream().map(Participation::findLatestSubmission).filter(Optional::isPresent).map(Optional::get).toList();
-        final Page<Submission> submissionPage = new PageImpl<>(latestSubmissions, pageable, latestSubmissions.size());
+        final Page<SubmissionResponseDTO> submissionPage = new PageImpl<>(latestSubmissions.stream().map(SubmissionResponseDTO::ofForImport).toList(), pageable,
+                latestSubmissions.size());
         return new SearchResultPageDTO<>(submissionPage.getContent(), studentParticipationPage.getTotalPages());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
@@ -53,6 +53,7 @@ import de.tum.cit.aet.artemis.exercise.domain.SubmissionType;
 import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionResponseDTO;
 import de.tum.cit.aet.artemis.exercise.dto.SubmissionWithComplaintDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
@@ -862,7 +863,7 @@ public class SubmissionService {
                 submission.setResults(submission.getNonAthenaResults());
                 Complaint complaintOfSubmission = complaintMap.get(submission.getResultWithComplaint().getId());
                 prepareComplaintAndSubmission(complaintOfSubmission, submission);
-                submissionWithComplaintDTOs.add(new SubmissionWithComplaintDTO(submission, complaintOfSubmission));
+                submissionWithComplaintDTOs.add(SubmissionWithComplaintDTO.of(submission, complaintOfSubmission));
             });
         }
 
@@ -894,13 +895,14 @@ public class SubmissionService {
      * @param exerciseId Id of the exercise the submissions belongs to
      * @return A wrapper object containing a list of all found submissions and the total number of pages
      */
-    public SearchResultPageDTO<Submission> getSubmissionsOnPageWithSize(SearchTermPageableSearchDTO<String> search, Long exerciseId) {
+    public SearchResultPageDTO<SubmissionResponseDTO> getSubmissionsOnPageWithSize(SearchTermPageableSearchDTO<String> search, Long exerciseId) {
         final var pageable = PageUtil.createDefaultPageRequest(search, PageUtil.ColumnMapping.STUDENT_PARTICIPATION);
         String searchTerm = search.getSearchTerm();
         Page<StudentParticipation> studentParticipationPage = studentParticipationRepository.findAllWithEagerSubmissionsAndResultsByExerciseId(exerciseId, searchTerm, pageable);
 
         var latestSubmissions = studentParticipationPage.getContent().stream().map(Participation::findLatestSubmission).filter(Optional::isPresent).map(Optional::get).toList();
-        final Page<Submission> submissionPage = new PageImpl<>(latestSubmissions, pageable, latestSubmissions.size());
+        final Page<SubmissionResponseDTO> submissionPage = new PageImpl<>(latestSubmissions.stream().map(SubmissionResponseDTO::ofForImport).toList(), pageable,
+                latestSubmissions.size());
         return new SearchResultPageDTO<>(submissionPage.getContent(), studentParticipationPage.getTotalPages());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationDeletionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationDeletionResource.java
@@ -28,8 +28,8 @@ import de.tum.cit.aet.artemis.core.service.feature.Feature;
 import de.tum.cit.aet.artemis.core.service.feature.FeatureToggle;
 import de.tum.cit.aet.artemis.core.service.feature.FeatureToggleService;
 import de.tum.cit.aet.artemis.core.util.HeaderUtil;
-import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.service.ParticipationAuthorizationService;
 import de.tum.cit.aet.artemis.exercise.service.ParticipationDeletionService;
@@ -121,13 +121,13 @@ public class ParticipationDeletionResource {
     @PutMapping("participations/{participationId}/cleanup-build-plan")
     @EnforceAtLeastInstructor
     @FeatureToggle(Feature.ProgrammingExercises)
-    public ResponseEntity<Participation> cleanupBuildPlan(@PathVariable Long participationId, Principal principal) {
+    public ResponseEntity<StudentParticipationDTO> cleanupBuildPlan(@PathVariable Long participationId, Principal principal) {
         ProgrammingExerciseStudentParticipation participation = (ProgrammingExerciseStudentParticipation) studentParticipationRepository.findByIdElseThrow(participationId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
         participationAuthorizationService.checkAccessPermissionAtLeastInstructor(participation, user);
         log.info("Clean up participation with build plan {} by {}", participation.getBuildPlanId(), principal.getName());
         participationDeletionService.cleanupBuildPlan(participation);
-        return ResponseEntity.ok().body(participation);
+        return ResponseEntity.ok().body(StudentParticipationDTO.ofAfterBuildPlanCleanup(participation));
     }
 
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationDeletionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationDeletionResource.java
@@ -28,8 +28,8 @@ import de.tum.cit.aet.artemis.core.service.feature.Feature;
 import de.tum.cit.aet.artemis.core.service.feature.FeatureToggle;
 import de.tum.cit.aet.artemis.core.service.feature.FeatureToggleService;
 import de.tum.cit.aet.artemis.core.util.HeaderUtil;
-import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.service.ParticipationAuthorizationService;
 import de.tum.cit.aet.artemis.exercise.service.ParticipationDeletionService;
@@ -121,13 +121,13 @@ public class ParticipationDeletionResource {
     @PutMapping("participations/{participationId}/cleanup-build-plan")
     @EnforceAtLeastInstructor
     @FeatureToggle(Feature.ProgrammingExercises)
-    public ResponseEntity<Participation> cleanupBuildPlan(@PathVariable Long participationId, Principal principal) {
+    public ResponseEntity<StudentParticipationDTO> cleanupBuildPlan(@PathVariable Long participationId, Principal principal) {
         ProgrammingExerciseStudentParticipation participation = (ProgrammingExerciseStudentParticipation) studentParticipationRepository.findByIdElseThrow(participationId);
         User user = userRepository.getUserWithAuthorities();
         participationAuthorizationService.checkAccessPermissionAtLeastInstructor(participation, user);
         log.info("Clean up participation with build plan {} by {}", participation.getBuildPlanId(), principal.getName());
         participationDeletionService.cleanupBuildPlan(participation);
-        return ResponseEntity.ok().body(participation);
+        return ResponseEntity.ok().body(StudentParticipationDTO.ofAfterBuildPlanCleanup(participation));
     }
 
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationResource.java
@@ -46,8 +46,8 @@ import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participant;
-import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.repository.SubmissionRepository;
@@ -59,7 +59,6 @@ import de.tum.cit.aet.artemis.exercise.service.ParticipationService;
 import de.tum.cit.aet.artemis.fileupload.domain.FileUploadExercise;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
-import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParticipation;
 import de.tum.cit.aet.artemis.programming.exception.VersionControlException;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseRepository;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseStudentParticipationRepository;
@@ -141,7 +140,7 @@ public class ParticipationResource {
     @PostMapping("exercises/{exerciseId}/participations")
     @EnforceAtLeastStudentInExercise
     @AllowedTools(ToolTokenType.SCORPIO)
-    public ResponseEntity<Participation> startParticipation(@PathVariable Long exerciseId) throws URISyntaxException {
+    public ResponseEntity<StudentParticipationDTO> startParticipation(@PathVariable Long exerciseId) throws URISyntaxException {
         log.debug("REST request to start Exercise : {}", exerciseId);
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
@@ -175,7 +174,7 @@ public class ParticipationResource {
 
         // remove sensitive information before sending participation to the client
         participation.getExercise().filterSensitiveInformation();
-        return ResponseEntity.created(new URI("/api/exercise/participations/" + participation.getId())).body(participation);
+        return ResponseEntity.created(new URI("/api/exercise/participations/" + participation.getId())).body(StudentParticipationDTO.ofAfterStart(participation));
     }
 
     /**
@@ -189,7 +188,7 @@ public class ParticipationResource {
     @PostMapping("exercises/{exerciseId}/participations/practice")
     @EnforceAtLeastStudent
     @AllowedTools(ToolTokenType.SCORPIO)
-    public ResponseEntity<Participation> startPracticeParticipation(@PathVariable Long exerciseId,
+    public ResponseEntity<StudentParticipationDTO> startPracticeParticipation(@PathVariable Long exerciseId,
             @RequestParam(value = "useGradedParticipation", defaultValue = "false") boolean useGradedParticipation) throws URISyntaxException {
         log.debug("REST request to practice Exercise : {}", exerciseId);
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
@@ -226,7 +225,7 @@ public class ParticipationResource {
 
         // remove sensitive information before sending participation to the client
         participation.getExercise().filterSensitiveInformation();
-        return ResponseEntity.created(new URI("/api/participations/" + participation.getId())).body(participation);
+        return ResponseEntity.created(new URI("/api/participations/" + participation.getId())).body(StudentParticipationDTO.ofAfterStart(participation));
     }
 
     /**
@@ -240,7 +239,7 @@ public class ParticipationResource {
             "exercises/{exerciseId}/resume-programming-participation/{participationId}" })
     @EnforceAtLeastStudent
     @FeatureToggle(Feature.ProgrammingExercises)
-    public ResponseEntity<ProgrammingExerciseStudentParticipation> resumeParticipation(@PathVariable Long exerciseId, @PathVariable Long participationId) {
+    public ResponseEntity<StudentParticipationDTO> resumeParticipation(@PathVariable Long exerciseId, @PathVariable Long participationId) {
         log.debug("REST request to resume Exercise : {}", exerciseId);
         var programmingExercise = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationElseThrow(exerciseId);
         var participation = programmingExerciseStudentParticipationRepository.findWithTeamStudentsByIdElseThrow(participationId);
@@ -270,7 +269,7 @@ public class ParticipationResource {
 
         participation = participationService.resumeProgrammingExercise(participation);
         participation.getExercise().filterSensitiveInformation();
-        return ResponseEntity.ok().body(participation);
+        return ResponseEntity.ok().body(StudentParticipationDTO.ofAfterResume(participation));
     }
 
     /**
@@ -282,7 +281,7 @@ public class ParticipationResource {
      */
     @PutMapping("exercises/{exerciseId}/participations/{participationId}/request-feedback")
     @EnforceAtLeastStudent
-    public ResponseEntity<StudentParticipation> requestFeedback(@PathVariable Long exerciseId, @PathVariable Long participationId) {
+    public ResponseEntity<StudentParticipationDTO> requestFeedback(@PathVariable Long exerciseId, @PathVariable Long participationId) {
         log.debug("REST request to request feedback for exercise {} and participation {}", exerciseId, participationId);
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
@@ -340,7 +339,7 @@ public class ParticipationResource {
         }
 
         StudentParticipation updatedParticipation = feedbackRequestService.processFeedbackRequest(exercise, participation);
-        return ResponseEntity.ok().body(updatedParticipation);
+        return ResponseEntity.ok().body(StudentParticipationDTO.ofWithLatestResult(updatedParticipation));
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationResource.java
@@ -46,8 +46,8 @@ import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participant;
-import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.repository.SubmissionRepository;
@@ -59,7 +59,6 @@ import de.tum.cit.aet.artemis.exercise.service.ParticipationService;
 import de.tum.cit.aet.artemis.fileupload.domain.FileUploadExercise;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
-import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParticipation;
 import de.tum.cit.aet.artemis.programming.exception.VersionControlException;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseRepository;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseStudentParticipationRepository;
@@ -141,7 +140,7 @@ public class ParticipationResource {
     @PostMapping("exercises/{exerciseId}/participations")
     @EnforceAtLeastStudentInExercise
     @AllowedTools(ToolTokenType.SCORPIO)
-    public ResponseEntity<Participation> startParticipation(@PathVariable Long exerciseId) throws URISyntaxException {
+    public ResponseEntity<StudentParticipationDTO> startParticipation(@PathVariable Long exerciseId) throws URISyntaxException {
         log.debug("REST request to start Exercise : {}", exerciseId);
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
         User user = userRepository.getUserWithAuthorities();
@@ -180,7 +179,7 @@ public class ParticipationResource {
 
         // remove sensitive information before sending participation to the client
         participation.getExercise().filterSensitiveInformation();
-        return ResponseEntity.created(new URI("/api/exercise/participations/" + participation.getId())).body(participation);
+        return ResponseEntity.created(new URI("/api/exercise/participations/" + participation.getId())).body(StudentParticipationDTO.ofAfterStart(participation));
     }
 
     /**
@@ -194,7 +193,7 @@ public class ParticipationResource {
     @PostMapping("exercises/{exerciseId}/participations/practice")
     @EnforceAtLeastStudent
     @AllowedTools(ToolTokenType.SCORPIO)
-    public ResponseEntity<Participation> startPracticeParticipation(@PathVariable Long exerciseId,
+    public ResponseEntity<StudentParticipationDTO> startPracticeParticipation(@PathVariable Long exerciseId,
             @RequestParam(value = "useGradedParticipation", defaultValue = "false") boolean useGradedParticipation) throws URISyntaxException {
         log.debug("REST request to practice Exercise : {}", exerciseId);
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
@@ -231,7 +230,7 @@ public class ParticipationResource {
 
         // remove sensitive information before sending participation to the client
         participation.getExercise().filterSensitiveInformation();
-        return ResponseEntity.created(new URI("/api/participations/" + participation.getId())).body(participation);
+        return ResponseEntity.created(new URI("/api/participations/" + participation.getId())).body(StudentParticipationDTO.ofAfterStart(participation));
     }
 
     /**
@@ -245,7 +244,7 @@ public class ParticipationResource {
             "exercises/{exerciseId}/resume-programming-participation/{participationId}" })
     @EnforceAtLeastStudent
     @FeatureToggle(Feature.ProgrammingExercises)
-    public ResponseEntity<ProgrammingExerciseStudentParticipation> resumeParticipation(@PathVariable Long exerciseId, @PathVariable Long participationId) {
+    public ResponseEntity<StudentParticipationDTO> resumeParticipation(@PathVariable Long exerciseId, @PathVariable Long participationId) {
         log.debug("REST request to resume Exercise : {}", exerciseId);
         var programmingExercise = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationElseThrow(exerciseId);
         var participation = programmingExerciseStudentParticipationRepository.findWithTeamStudentsByIdElseThrow(participationId);
@@ -275,7 +274,7 @@ public class ParticipationResource {
 
         participation = participationService.resumeProgrammingExercise(participation);
         participation.getExercise().filterSensitiveInformation();
-        return ResponseEntity.ok().body(participation);
+        return ResponseEntity.ok().body(StudentParticipationDTO.ofAfterResume(participation));
     }
 
     /**
@@ -287,7 +286,7 @@ public class ParticipationResource {
      */
     @PutMapping("exercises/{exerciseId}/participations/{participationId}/request-feedback")
     @EnforceAtLeastStudent
-    public ResponseEntity<StudentParticipation> requestFeedback(@PathVariable Long exerciseId, @PathVariable Long participationId) {
+    public ResponseEntity<StudentParticipationDTO> requestFeedback(@PathVariable Long exerciseId, @PathVariable Long participationId) {
         log.debug("REST request to request feedback for exercise {} and participation {}", exerciseId, participationId);
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
         User user = userRepository.getUserWithAuthorities();
@@ -340,7 +339,7 @@ public class ParticipationResource {
         }
 
         StudentParticipation updatedParticipation = feedbackRequestService.processFeedbackRequest(exercise, participation);
-        return ResponseEntity.ok().body(updatedParticipation);
+        return ResponseEntity.ok().body(StudentParticipationDTO.ofWithLatestResult(updatedParticipation));
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationRetrievalResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationRetrievalResource.java
@@ -38,6 +38,7 @@ import de.tum.cit.aet.artemis.exercise.dto.ParticipationScoreDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationScoreSearchDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationSearchDTO;
 import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionResponseDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.repository.SubmissionRepository;
@@ -141,12 +142,12 @@ public class ParticipationRetrievalResource {
      */
     @GetMapping("participations/{participationId}/submissions")
     @EnforceAtLeastInstructor
-    public ResponseEntity<List<Submission>> getSubmissionsOfParticipation(@PathVariable Long participationId) {
+    public ResponseEntity<List<SubmissionResponseDTO>> getSubmissionsOfParticipation(@PathVariable Long participationId) {
         StudentParticipation participation = studentParticipationRepository.findByIdElseThrow(participationId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
         checkAccessPermissionAtLeastInstructor(participation, user);
         List<Submission> submissions = submissionRepository.findAllWithResultsAndAssessorByParticipationId(participationId);
-        return ResponseEntity.ok(submissions);
+        return ResponseEntity.ok(submissions.stream().map(SubmissionResponseDTO::ofForParticipationHistory).toList());
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationRetrievalResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationRetrievalResource.java
@@ -37,6 +37,7 @@ import de.tum.cit.aet.artemis.exercise.dto.ParticipationNameExportDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationScoreDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationScoreSearchDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationSearchDTO;
+import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.repository.SubmissionRepository;
@@ -88,12 +89,12 @@ public class ParticipationRetrievalResource {
      */
     @GetMapping("participations/{participationId}/with-latest-result")
     @EnforceAtLeastStudent
-    public ResponseEntity<StudentParticipation> getParticipationWithLatestResult(@PathVariable Long participationId) {
+    public ResponseEntity<StudentParticipationDTO> getParticipationWithLatestResult(@PathVariable Long participationId) {
         log.debug("REST request to get Participation : {}", participationId);
         StudentParticipation participation = studentParticipationRepository.findByIdWithResultsElseThrow(participationId);
         participationAuthCheckService.checkCanAccessParticipationElseThrow(participation);
 
-        return new ResponseEntity<>(participation, HttpStatus.OK);
+        return new ResponseEntity<>(StudentParticipationDTO.ofWithLatestResult(participation), HttpStatus.OK);
     }
 
     /**
@@ -104,12 +105,12 @@ public class ParticipationRetrievalResource {
      */
     @GetMapping("participations/{participationId}")
     @EnforceAtLeastStudent
-    public ResponseEntity<StudentParticipation> getParticipationForCurrentUser(@PathVariable Long participationId) {
+    public ResponseEntity<StudentParticipationDTO> getParticipationForCurrentUser(@PathVariable Long participationId) {
         log.debug("REST request to get participation : {}", participationId);
         StudentParticipation participation = studentParticipationRepository.findByIdWithEagerTeamStudentsElseThrow(participationId);
         User user = userRepository.getUserWithAuthorities();
         checkAccessPermissionOwner(participation, user);
-        return new ResponseEntity<>(participation, HttpStatus.OK);
+        return new ResponseEntity<>(StudentParticipationDTO.ofForCurrentUser(participation), HttpStatus.OK);
     }
 
     private void checkAccessPermissionAtLeastInstructor(StudentParticipation participation, User user) {

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationRetrievalResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationRetrievalResource.java
@@ -38,6 +38,7 @@ import de.tum.cit.aet.artemis.exercise.dto.ParticipationScoreDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationScoreSearchDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationSearchDTO;
 import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionResponseDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.repository.SubmissionRepository;
@@ -141,12 +142,12 @@ public class ParticipationRetrievalResource {
      */
     @GetMapping("participations/{participationId}/submissions")
     @EnforceAtLeastInstructor
-    public ResponseEntity<List<Submission>> getSubmissionsOfParticipation(@PathVariable Long participationId) {
+    public ResponseEntity<List<SubmissionResponseDTO>> getSubmissionsOfParticipation(@PathVariable Long participationId) {
         StudentParticipation participation = studentParticipationRepository.findByIdElseThrow(participationId);
         User user = userRepository.getUserWithAuthorities();
         checkAccessPermissionAtLeastInstructor(participation, user);
         List<Submission> submissions = submissionRepository.findAllWithResultsAndAssessorByParticipationId(participationId);
-        return ResponseEntity.ok(submissions);
+        return ResponseEntity.ok(submissions.stream().map(SubmissionResponseDTO::ofForParticipationHistory).toList());
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationRetrievalResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationRetrievalResource.java
@@ -37,6 +37,7 @@ import de.tum.cit.aet.artemis.exercise.dto.ParticipationNameExportDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationScoreDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationScoreSearchDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationSearchDTO;
+import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.repository.SubmissionRepository;
@@ -88,12 +89,12 @@ public class ParticipationRetrievalResource {
      */
     @GetMapping("participations/{participationId}/with-latest-result")
     @EnforceAtLeastStudent
-    public ResponseEntity<StudentParticipation> getParticipationWithLatestResult(@PathVariable Long participationId) {
+    public ResponseEntity<StudentParticipationDTO> getParticipationWithLatestResult(@PathVariable Long participationId) {
         log.debug("REST request to get Participation : {}", participationId);
         StudentParticipation participation = studentParticipationRepository.findByIdWithResultsElseThrow(participationId);
         participationAuthCheckService.checkCanAccessParticipationElseThrow(participation);
 
-        return new ResponseEntity<>(participation, HttpStatus.OK);
+        return new ResponseEntity<>(StudentParticipationDTO.ofWithLatestResult(participation), HttpStatus.OK);
     }
 
     /**
@@ -104,12 +105,12 @@ public class ParticipationRetrievalResource {
      */
     @GetMapping("participations/{participationId}")
     @EnforceAtLeastStudent
-    public ResponseEntity<StudentParticipation> getParticipationForCurrentUser(@PathVariable Long participationId) {
+    public ResponseEntity<StudentParticipationDTO> getParticipationForCurrentUser(@PathVariable Long participationId) {
         log.debug("REST request to get participation : {}", participationId);
         StudentParticipation participation = studentParticipationRepository.findByIdWithEagerTeamStudentsElseThrow(participationId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
         checkAccessPermissionOwner(participation, user);
-        return new ResponseEntity<>(participation, HttpStatus.OK);
+        return new ResponseEntity<>(StudentParticipationDTO.ofForCurrentUser(participation), HttpStatus.OK);
     }
 
     private void checkAccessPermissionAtLeastInstructor(StudentParticipation participation, User user) {

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/ParticipationUpdateResource.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import jakarta.validation.Valid;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,10 +33,10 @@ import de.tum.cit.aet.artemis.core.service.messaging.InstanceMessageSendService;
 import de.tum.cit.aet.artemis.core.util.HeaderUtil;
 import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
-import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationDueDateUpdateDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationUpdateDTO;
+import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.exercise.repository.StudentParticipationRepository;
 import de.tum.cit.aet.artemis.exercise.service.ExerciseDateService;
@@ -97,7 +99,7 @@ public class ParticipationUpdateResource {
      */
     @PutMapping("exercises/{exerciseId}/participations")
     @EnforceAtLeastTutor
-    public ResponseEntity<Participation> updateParticipation(@PathVariable long exerciseId, @RequestBody ParticipationUpdateDTO dto) {
+    public ResponseEntity<StudentParticipationDTO> updateParticipation(@PathVariable long exerciseId, @Valid @RequestBody ParticipationUpdateDTO dto) {
         log.debug("REST request to update Participation : {}", dto);
         if (dto.exerciseId() != exerciseId) {
             throw new ConflictException("The exercise of the participation does not match the exercise id in the URL", ENTITY_NAME, "noidmatch");
@@ -163,9 +165,9 @@ public class ParticipationUpdateResource {
         // Apply the update to the managed entity
         existingParticipation.setPresentationScore(newPresentationScore);
 
-        Participation updatedParticipation = studentParticipationRepository.saveAndFlush(existingParticipation);
+        StudentParticipation updatedParticipation = studentParticipationRepository.saveAndFlush(existingParticipation);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, existingParticipation.getParticipant().getName()))
-                .body(updatedParticipation);
+                .body(StudentParticipationDTO.ofAfterUpdate(updatedParticipation));
     }
 
     /**
@@ -180,8 +182,8 @@ public class ParticipationUpdateResource {
      */
     @PutMapping("exercises/{exerciseId}/participations/update-individual-due-date")
     @EnforceAtLeastInstructor
-    public ResponseEntity<List<StudentParticipation>> updateParticipationDueDates(@PathVariable long exerciseId,
-            @RequestBody List<ParticipationDueDateUpdateDTO> dueDateUpdateDTOs) {
+    public ResponseEntity<List<StudentParticipationDTO>> updateParticipationDueDates(@PathVariable long exerciseId,
+            @Valid @RequestBody List<@Valid ParticipationDueDateUpdateDTO> dueDateUpdateDTOs) {
         final boolean anyInvalidExerciseId = dueDateUpdateDTOs.stream().anyMatch(dto -> dto.exerciseId() != exerciseId);
         if (anyInvalidExerciseId) {
             throw new BadRequestAlertException("The participation needs to be connected to the specified exercise", ENTITY_NAME, "exerciseidmismatch");
@@ -212,7 +214,7 @@ public class ParticipationUpdateResource {
             }
         }
 
-        return ResponseEntity.ok().body(updatedParticipations);
+        return ResponseEntity.ok().body(updatedParticipations.stream().map(StudentParticipationDTO::ofAfterUpdate).toList());
     }
 
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/SubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/SubmissionResource.java
@@ -35,6 +35,7 @@ import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.SubmissionVersion;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionResponseDTO;
 import de.tum.cit.aet.artemis.exercise.dto.SubmissionVersionDTO;
 import de.tum.cit.aet.artemis.exercise.dto.SubmissionWithComplaintDTO;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
@@ -137,7 +138,7 @@ public class SubmissionResource {
      */
     @GetMapping("exercises/{exerciseId}/test-run-submissions")
     @EnforceAtLeastEditor
-    public ResponseEntity<List<Submission>> getTestRunSubmissionsForAssessment(@PathVariable Long exerciseId) {
+    public ResponseEntity<List<SubmissionResponseDTO>> getTestRunSubmissionsForAssessment(@PathVariable Long exerciseId) {
         log.debug("REST request to get all test run submissions for exercise {}", exerciseId);
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
         if (!exercise.isExamExercise()) {
@@ -156,7 +157,7 @@ public class SubmissionResource {
                 latestSubmission.addResult(submissionService.prepareTestRunSubmissionForAssessment(latestSubmission));
             }
             latestSubmission.removeAutomaticResults();
-            return ResponseEntity.ok().body(List.of(latestSubmission));
+            return ResponseEntity.ok().body(List.of(SubmissionResponseDTO.ofForTestRunAssessment(latestSubmission)));
         }
         else {
             return ResponseEntity.ok(List.of());
@@ -215,7 +216,7 @@ public class SubmissionResource {
      */
     @GetMapping("exercises/{exerciseId}/submissions-for-import")
     @EnforceAtLeastInstructor
-    public ResponseEntity<SearchResultPageDTO<Submission>> getSubmissionsOnPageWithSize(@PathVariable Long exerciseId, SearchTermPageableSearchDTO<String> search) {
+    public ResponseEntity<SearchResultPageDTO<SubmissionResponseDTO>> getSubmissionsOnPageWithSize(@PathVariable Long exerciseId, SearchTermPageableSearchDTO<String> search) {
         log.debug("REST request to get all Submissions for import : {}", exerciseId);
 
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);

--- a/src/main/webapp/app/exercise/course-exercises/course-exercise.service.spec.ts
+++ b/src/main/webapp/app/exercise/course-exercises/course-exercise.service.spec.ts
@@ -5,10 +5,13 @@ import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { Course } from 'app/course/shared/entities/course.model';
-import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { Exercise, ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { FileUploadExercise } from 'app/fileupload/shared/entities/file-upload-exercise.model';
 import { ModelingExercise } from 'app/modeling/shared/entities/modeling-exercise.model';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
+import { ProgrammingExerciseStudentParticipation } from 'app/exercise/shared/entities/participation/programming-exercise-student-participation.model';
+import { StudentParticipationDTO } from 'app/exercise/shared/entities/participation/student-participation.dto';
+import { ParticipationType } from 'app/exercise/shared/entities/participation/participation.model';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { LocalStorageService } from 'app/foundation/service/local-storage.service';
 import { SessionStorageService } from 'app/foundation/service/session-storage.service';
@@ -171,83 +174,101 @@ describe('Course Management Service', () => {
 
     it('should start exercise', () => {
         const participationId = 12345;
-        const participation = new StudentParticipation();
-        participation.id = participationId;
-        participation.exercise = programmingExercise;
-        returnedFromService = { ...participation };
-        const expected = Object.assign(
-            {
-                initializationDate: undefined,
-            },
-            participation,
-        );
+        const participationDTO = createProgrammingParticipationDTO(participationId, false);
+        let participation: StudentParticipation | undefined;
         vi.spyOn(TestBed.inject(ProfileService), 'getProfileInfo').mockReturnValue({ buildPlanURLTemplate: 'testci.fake' } as ProfileInfo);
 
         service
             .startExercise(exerciseId)
             .pipe(take(1))
-            .subscribe((res) => expect(res).toEqual(expected));
+            .subscribe((res) => (participation = res));
 
-        requestAndExpectDateConversion('POST', `api/exercise/exercises/${exerciseId}/participations`, returnedFromService, participation.exercise, true);
-        expect(programmingExercise.studentParticipations?.[0]?.id).toBe(participationId);
+        const req = httpMock.expectOne({ method: 'POST', url: `api/exercise/exercises/${exerciseId}/participations` });
+        req.flush(participationDTO);
+        expect(participation).toBeInstanceOf(ProgrammingExerciseStudentParticipation);
+        expect(participation?.id).toBe(participationId);
+        expectDateConversionToBeDone(participation!.exercise!, true);
+        expect(participation?.exercise?.studentParticipations?.[0]).toBe(participation);
     });
 
     it.each([true, false])('should start practice', (useGradedParticipation: boolean) => {
         const participationId = 12345;
-        const participation = new StudentParticipation();
-        participation.id = participationId;
-        participation.exercise = programmingExercise;
-        returnedFromService = { ...participation };
-        const expected = Object.assign(
-            {
-                initializationDate: undefined,
-            },
-            participation,
-        );
+        const participationDTO = createProgrammingParticipationDTO(participationId, true);
+        let participation: StudentParticipation | undefined;
         vi.spyOn(TestBed.inject(ProfileService), 'getProfileInfo').mockReturnValue({ buildPlanURLTemplate: 'testci.fake' } as ProfileInfo);
 
         service
             .startPractice(exerciseId, useGradedParticipation)
             .pipe(take(1))
-            .subscribe((res) => expect(res).toEqual(expected));
+            .subscribe((res) => (participation = res));
 
-        requestAndExpectDateConversion(
-            'POST',
-            `api/exercise/exercises/${exerciseId}/participations/practice?useGradedParticipation=${useGradedParticipation}`,
-            returnedFromService,
-            participation.exercise,
-            true,
-        );
-        expect(programmingExercise.studentParticipations?.[0]?.id).toBe(participationId);
+        const req = httpMock.expectOne({
+            method: 'POST',
+            url: `api/exercise/exercises/${exerciseId}/participations/practice?useGradedParticipation=${useGradedParticipation}`,
+        });
+        req.flush(participationDTO);
+        expect(participation).toBeInstanceOf(ProgrammingExerciseStudentParticipation);
+        expect(participation?.testRun).toBe(true);
+        expectDateConversionToBeDone(participation!.exercise!, true);
+        expect(participation?.exercise?.studentParticipations?.[0]).toBe(participation);
     });
 
     it('should resume programming exercise', () => {
         const participationId = 12345;
-        const participation = new StudentParticipation();
-        participation.id = participationId;
-        participation.exercise = programmingExercise;
-        returnedFromService = { ...participation };
-        const expected = Object.assign(
-            {
-                initializationDate: undefined,
-            },
-            participation,
-        );
+        const participationDTO = createProgrammingParticipationDTO(participationId, false);
+        let participation: StudentParticipation | undefined;
         vi.spyOn(TestBed.inject(ProfileService), 'getProfileInfo').mockReturnValue({ buildPlanURLTemplate: 'testci.fake' } as ProfileInfo);
 
         service
             .resumeProgrammingExercise(exerciseId, participationId)
             .pipe(take(1))
-            .subscribe((res) => expect(res).toEqual(expected));
+            .subscribe((res) => (participation = res));
 
-        requestAndExpectDateConversion(
-            'PUT',
-            `api/exercise/exercises/${exerciseId}/participations/${participationId}/resume-programming-participation`,
-            returnedFromService,
-            participation.exercise,
-            true,
-        );
-        expect(programmingExercise.studentParticipations?.[0]?.id).toBe(participationId);
+        const req = httpMock.expectOne({
+            method: 'PUT',
+            url: `api/exercise/exercises/${exerciseId}/participations/${participationId}/resume-programming-participation`,
+        });
+        req.flush(participationDTO);
+        expect(participation).toBeInstanceOf(ProgrammingExerciseStudentParticipation);
+        expect((participation as ProgrammingExerciseStudentParticipation).repositoryUri).toBe('repository-uri');
+        expectDateConversionToBeDone(participation!.exercise!, true);
+        expect(participation?.exercise?.studentParticipations?.[0]).toBe(participation);
+    });
+
+    it('should adapt a request-feedback response', () => {
+        const participationId = 12345;
+        let participation: StudentParticipation | undefined;
+
+        service
+            .requestFeedback(exerciseId, participationId)
+            .pipe(take(1))
+            .subscribe((res) => (participation = res));
+
+        const req = httpMock.expectOne({
+            method: 'PUT',
+            url: `api/exercise/exercises/${exerciseId}/participations/${participationId}/request-feedback`,
+        });
+        req.flush(createProgrammingParticipationDTO(participationId, false));
+        expect(participation).toBeInstanceOf(ProgrammingExerciseStudentParticipation);
+        expect((participation as ProgrammingExerciseStudentParticipation).repositoryUri).toBe('repository-uri');
+    });
+
+    const createProgrammingParticipationDTO = (participationId: number, testRun: boolean): StudentParticipationDTO => ({
+        id: participationId,
+        testRun,
+        type: ParticipationType.PROGRAMMING,
+        repositoryUri: 'repository-uri',
+        buildPlanId: 'build-plan-id',
+        branch: 'main',
+        exercise: {
+            id: exerciseId,
+            title: 'Programming exercise',
+            type: ExerciseType.PROGRAMMING,
+            exerciseType: ExerciseType.PROGRAMMING,
+            releaseDate: releaseDateString,
+            dueDate: dueDateString,
+            assessmentDueDate: assessmentDueDateString,
+        },
     });
 
     afterEach(() => {

--- a/src/main/webapp/app/exercise/course-exercises/course-exercise.service.spec.ts
+++ b/src/main/webapp/app/exercise/course-exercises/course-exercise.service.spec.ts
@@ -4,10 +4,13 @@ import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { Course } from 'app/course/shared/entities/course.model';
-import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { Exercise, ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { FileUploadExercise } from 'app/fileupload/shared/entities/file-upload-exercise.model';
 import { ModelingExercise } from 'app/modeling/shared/entities/modeling-exercise.model';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
+import { ProgrammingExerciseStudentParticipation } from 'app/exercise/shared/entities/participation/programming-exercise-student-participation.model';
+import { StudentParticipationDTO } from 'app/exercise/shared/entities/participation/student-participation.dto';
+import { ParticipationType } from 'app/exercise/shared/entities/participation/participation.model';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { LocalStorageService } from 'app/foundation/service/local-storage.service';
 import { SessionStorageService } from 'app/foundation/service/session-storage.service';
@@ -168,83 +171,101 @@ describe('Course Management Service', () => {
 
     it('should start exercise', () => {
         const participationId = 12345;
-        const participation = new StudentParticipation();
-        participation.id = participationId;
-        participation.exercise = programmingExercise;
-        returnedFromService = { ...participation };
-        const expected = Object.assign(
-            {
-                initializationDate: undefined,
-            },
-            participation,
-        );
+        const participationDTO = createProgrammingParticipationDTO(participationId, false);
+        let participation: StudentParticipation | undefined;
         vi.spyOn(TestBed.inject(ProfileService), 'getProfileInfo').mockReturnValue({ buildPlanURLTemplate: 'testci.fake' } as ProfileInfo);
 
         service
             .startExercise(exerciseId)
             .pipe(take(1))
-            .subscribe((res) => expect(res).toEqual(expected));
+            .subscribe((res) => (participation = res));
 
-        requestAndExpectDateConversion('POST', `api/exercise/exercises/${exerciseId}/participations`, returnedFromService, participation.exercise, true);
-        expect(programmingExercise.studentParticipations?.[0]?.id).toBe(participationId);
+        const req = httpMock.expectOne({ method: 'POST', url: `api/exercise/exercises/${exerciseId}/participations` });
+        req.flush(participationDTO);
+        expect(participation).toBeInstanceOf(ProgrammingExerciseStudentParticipation);
+        expect(participation?.id).toBe(participationId);
+        expectDateConversionToBeDone(participation!.exercise!, true);
+        expect(participation?.exercise?.studentParticipations?.[0]).toBe(participation);
     });
 
     it.each([true, false])('should start practice', (useGradedParticipation: boolean) => {
         const participationId = 12345;
-        const participation = new StudentParticipation();
-        participation.id = participationId;
-        participation.exercise = programmingExercise;
-        returnedFromService = { ...participation };
-        const expected = Object.assign(
-            {
-                initializationDate: undefined,
-            },
-            participation,
-        );
+        const participationDTO = createProgrammingParticipationDTO(participationId, true);
+        let participation: StudentParticipation | undefined;
         vi.spyOn(TestBed.inject(ProfileService), 'getProfileInfo').mockReturnValue({ buildPlanURLTemplate: 'testci.fake' } as ProfileInfo);
 
         service
             .startPractice(exerciseId, useGradedParticipation)
             .pipe(take(1))
-            .subscribe((res) => expect(res).toEqual(expected));
+            .subscribe((res) => (participation = res));
 
-        requestAndExpectDateConversion(
-            'POST',
-            `api/exercise/exercises/${exerciseId}/participations/practice?useGradedParticipation=${useGradedParticipation}`,
-            returnedFromService,
-            participation.exercise,
-            true,
-        );
-        expect(programmingExercise.studentParticipations?.[0]?.id).toBe(participationId);
+        const req = httpMock.expectOne({
+            method: 'POST',
+            url: `api/exercise/exercises/${exerciseId}/participations/practice?useGradedParticipation=${useGradedParticipation}`,
+        });
+        req.flush(participationDTO);
+        expect(participation).toBeInstanceOf(ProgrammingExerciseStudentParticipation);
+        expect(participation?.testRun).toBe(true);
+        expectDateConversionToBeDone(participation!.exercise!, true);
+        expect(participation?.exercise?.studentParticipations?.[0]).toBe(participation);
     });
 
     it('should resume programming exercise', () => {
         const participationId = 12345;
-        const participation = new StudentParticipation();
-        participation.id = participationId;
-        participation.exercise = programmingExercise;
-        returnedFromService = { ...participation };
-        const expected = Object.assign(
-            {
-                initializationDate: undefined,
-            },
-            participation,
-        );
+        const participationDTO = createProgrammingParticipationDTO(participationId, false);
+        let participation: StudentParticipation | undefined;
         vi.spyOn(TestBed.inject(ProfileService), 'getProfileInfo').mockReturnValue({ buildPlanURLTemplate: 'testci.fake' } as ProfileInfo);
 
         service
             .resumeProgrammingExercise(exerciseId, participationId)
             .pipe(take(1))
-            .subscribe((res) => expect(res).toEqual(expected));
+            .subscribe((res) => (participation = res));
 
-        requestAndExpectDateConversion(
-            'PUT',
-            `api/exercise/exercises/${exerciseId}/participations/${participationId}/resume-programming-participation`,
-            returnedFromService,
-            participation.exercise,
-            true,
-        );
-        expect(programmingExercise.studentParticipations?.[0]?.id).toBe(participationId);
+        const req = httpMock.expectOne({
+            method: 'PUT',
+            url: `api/exercise/exercises/${exerciseId}/participations/${participationId}/resume-programming-participation`,
+        });
+        req.flush(participationDTO);
+        expect(participation).toBeInstanceOf(ProgrammingExerciseStudentParticipation);
+        expect((participation as ProgrammingExerciseStudentParticipation).repositoryUri).toBe('repository-uri');
+        expectDateConversionToBeDone(participation!.exercise!, true);
+        expect(participation?.exercise?.studentParticipations?.[0]).toBe(participation);
+    });
+
+    it('should adapt a request-feedback response', () => {
+        const participationId = 12345;
+        let participation: StudentParticipation | undefined;
+
+        service
+            .requestFeedback(exerciseId, participationId)
+            .pipe(take(1))
+            .subscribe((res) => (participation = res));
+
+        const req = httpMock.expectOne({
+            method: 'PUT',
+            url: `api/exercise/exercises/${exerciseId}/participations/${participationId}/request-feedback`,
+        });
+        req.flush(createProgrammingParticipationDTO(participationId, false));
+        expect(participation).toBeInstanceOf(ProgrammingExerciseStudentParticipation);
+        expect((participation as ProgrammingExerciseStudentParticipation).repositoryUri).toBe('repository-uri');
+    });
+
+    const createProgrammingParticipationDTO = (participationId: number, testRun: boolean): StudentParticipationDTO => ({
+        id: participationId,
+        testRun,
+        type: ParticipationType.PROGRAMMING,
+        repositoryUri: 'repository-uri',
+        buildPlanId: 'build-plan-id',
+        branch: 'main',
+        exercise: {
+            id: exerciseId,
+            title: 'Programming exercise',
+            type: ExerciseType.PROGRAMMING,
+            exerciseType: ExerciseType.PROGRAMMING,
+            releaseDate: releaseDateString,
+            dueDate: dueDateString,
+            assessmentDueDate: assessmentDueDateString,
+        },
     });
 
     afterEach(() => {

--- a/src/main/webapp/app/exercise/course-exercises/course-exercise.service.ts
+++ b/src/main/webapp/app/exercise/course-exercises/course-exercise.service.ts
@@ -11,6 +11,7 @@ import { Observable, map } from 'rxjs';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { convertDateFromServer } from 'app/foundation/util/date.utils';
+import { StudentParticipationDTO, fromStudentParticipationDTO } from 'app/exercise/shared/entities/participation/student-participation.dto';
 
 @Injectable({ providedIn: 'root' })
 export class CourseExerciseService {
@@ -80,9 +81,9 @@ export class CourseExerciseService {
      * @param exerciseId - the unique identifier of the exercise
      */
     startExercise(exerciseId: number): Observable<StudentParticipation> {
-        return this.http.post<StudentParticipation>(`api/exercise/exercises/${exerciseId}/participations`, {}).pipe(
-            map((participation: StudentParticipation) => {
-                return this.handleParticipation(participation);
+        return this.http.post<StudentParticipationDTO>(`api/exercise/exercises/${exerciseId}/participations`, {}).pipe(
+            map((participationDTO) => {
+                return this.handleParticipation(fromStudentParticipationDTO(participationDTO));
             }),
         );
     }
@@ -93,9 +94,9 @@ export class CourseExerciseService {
      * @param useGradedParticipation - flag indicating if the student wants to continue from their graded participation
      */
     startPractice(exerciseId: number, useGradedParticipation: boolean): Observable<StudentParticipation> {
-        return this.http.post<StudentParticipation>(`api/exercise/exercises/${exerciseId}/participations/practice?useGradedParticipation=${useGradedParticipation}`, {}).pipe(
-            map((participation: StudentParticipation) => {
-                return this.handleParticipation(participation);
+        return this.http.post<StudentParticipationDTO>(`api/exercise/exercises/${exerciseId}/participations/practice?useGradedParticipation=${useGradedParticipation}`, {}).pipe(
+            map((participationDTO) => {
+                return this.handleParticipation(fromStudentParticipationDTO(participationDTO));
             }),
         );
     }
@@ -106,17 +107,17 @@ export class CourseExerciseService {
      * @param participationId - the unique identifier of the participation to continue
      */
     resumeProgrammingExercise(exerciseId: number, participationId: number): Observable<StudentParticipation> {
-        return this.http.put<StudentParticipation>(`api/exercise/exercises/${exerciseId}/participations/${participationId}/resume-programming-participation`, {}).pipe(
-            map((participation: StudentParticipation) => {
-                return this.handleParticipation(participation);
+        return this.http.put<StudentParticipationDTO>(`api/exercise/exercises/${exerciseId}/participations/${participationId}/resume-programming-participation`, {}).pipe(
+            map((participationDTO) => {
+                return this.handleParticipation(fromStudentParticipationDTO(participationDTO));
             }),
         );
     }
 
     requestFeedback(exerciseId: number, participationId: number): Observable<StudentParticipation> {
         return this.http
-            .put<StudentParticipation>(`api/exercise/exercises/${exerciseId}/participations/${participationId}/request-feedback`, {})
-            .pipe(map((participation: StudentParticipation) => participation));
+            .put<StudentParticipationDTO>(`api/exercise/exercises/${exerciseId}/participations/${participationId}/request-feedback`, {})
+            .pipe(map(fromStudentParticipationDTO));
     }
 
     /**

--- a/src/main/webapp/app/exercise/example-submission/example-submission-import/example-submission-import-paging.service.spec.ts
+++ b/src/main/webapp/app/exercise/example-submission/example-submission-import/example-submission-import-paging.service.spec.ts
@@ -12,6 +12,7 @@ import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
 import { provideHttpClient } from '@angular/common/http';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+import { SubmissionExerciseType } from 'app/exercise/shared/entities/submission/submission.model';
 
 describe('Example Submission Import Paging Service', () => {
     setupTestBed({ zoneless: true });
@@ -35,12 +36,20 @@ describe('Example Submission Import Paging Service', () => {
         const exercise = {
             id: 1,
         } as Exercise;
-        const searchResult = { resultsOnPage: [new TextSubmission()], numberOfPages: 4 };
+        const searchResult = {
+            resultsOnPage: [{ id: 10, submitted: true, submissionExerciseType: SubmissionExerciseType.TEXT, text: 'example submission' }],
+            numberOfPages: 4,
+        };
         const pageable = { pageSize: 2, page: 3, sortingOrder: SortingOrder.DESCENDING, searchTerm: 'testSearchTerm', sortedColumn: 'testSortedColumn' };
         service
             .search(pageable, { exerciseId: exercise.id! })
             .pipe(take(1))
-            .subscribe((resp) => expect(resp).toEqual(searchResult));
+            .subscribe((resp) => {
+                expect(resp.numberOfPages).toBe(4);
+                expect(resp.resultsOnPage).toHaveLength(1);
+                expect(resp.resultsOnPage[0]).toBeInstanceOf(TextSubmission);
+                expect(resp.resultsOnPage[0]).toMatchObject({ id: 10, text: 'example submission' });
+            });
         const req = httpMock.expectOne({ method: 'GET' });
         expect(req.request.params.get('pageSize')).toBe('2');
         expect(req.request.params.get('page')).toBe('3');

--- a/src/main/webapp/app/exercise/example-submission/example-submission-import/example-submission-import-paging.service.spec.ts
+++ b/src/main/webapp/app/exercise/example-submission/example-submission-import/example-submission-import-paging.service.spec.ts
@@ -11,6 +11,7 @@ import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
 import { provideHttpClient } from '@angular/common/http';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SubmissionExerciseType } from 'app/exercise/shared/entities/submission/submission.model';
 
 describe('Example Submission Import Paging Service', () => {
     let service: ExampleSubmissionImportPagingService;
@@ -32,12 +33,20 @@ describe('Example Submission Import Paging Service', () => {
         const exercise = {
             id: 1,
         } as Exercise;
-        const searchResult = { resultsOnPage: [new TextSubmission()], numberOfPages: 4 };
+        const searchResult = {
+            resultsOnPage: [{ id: 10, submitted: true, submissionExerciseType: SubmissionExerciseType.TEXT, text: 'example submission' }],
+            numberOfPages: 4,
+        };
         const pageable = { pageSize: 2, page: 3, sortingOrder: SortingOrder.DESCENDING, searchTerm: 'testSearchTerm', sortedColumn: 'testSortedColumn' };
         service
             .search(pageable, { exerciseId: exercise.id! })
             .pipe(take(1))
-            .subscribe((resp) => expect(resp).toEqual(searchResult));
+            .subscribe((resp) => {
+                expect(resp.numberOfPages).toBe(4);
+                expect(resp.resultsOnPage).toHaveLength(1);
+                expect(resp.resultsOnPage[0]).toBeInstanceOf(TextSubmission);
+                expect(resp.resultsOnPage[0]).toMatchObject({ id: 10, text: 'example submission' });
+            });
         const req = httpMock.expectOne({ method: 'GET' });
         expect(req.request.params.get('pageSize')).toBe('2');
         expect(req.request.params.get('page')).toBe('3');

--- a/src/main/webapp/app/exercise/example-submission/example-submission-import/example-submission-import-paging.service.ts
+++ b/src/main/webapp/app/exercise/example-submission/example-submission-import/example-submission-import-paging.service.ts
@@ -5,8 +5,10 @@ import { PagingService } from 'app/exercise/services/paging.service';
 import { SearchResult, SearchTermPageableSearch } from 'app/foundation/pagination/pageable-table';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { SubmissionResponseDTO, fromSubmissionResponseDTO } from 'app/exercise/shared/entities/submission/submission-response.dto';
 
 type EntityResponseType = SearchResult<Submission>;
+type SubmissionSearchResponseDTO = SearchResult<SubmissionResponseDTO>;
 
 @Injectable({ providedIn: 'root' })
 export class ExampleSubmissionImportPagingService extends PagingService<Submission> {
@@ -26,7 +28,12 @@ export class ExampleSubmissionImportPagingService extends PagingService<Submissi
     override search(pageable: SearchTermPageableSearch, options: { exerciseId: number }): Observable<EntityResponseType> {
         const params = this.createHttpParams(pageable);
         return this.http
-            .get<EntityResponseType>(`${ExampleSubmissionImportPagingService.RESOURCE_URL}/${options.exerciseId}/submissions-for-import`, { params, observe: 'response' })
-            .pipe(map((resp: HttpResponse<EntityResponseType>) => resp && resp.body!));
+            .get<SubmissionSearchResponseDTO>(`${ExampleSubmissionImportPagingService.RESOURCE_URL}/${options.exerciseId}/submissions-for-import`, { params, observe: 'response' })
+            .pipe(
+                map((resp: HttpResponse<SubmissionSearchResponseDTO>) => ({
+                    resultsOnPage: resp.body?.resultsOnPage.map(fromSubmissionResponseDTO) ?? [],
+                    numberOfPages: resp.body?.numberOfPages ?? 0,
+                })),
+            );
     }
 }

--- a/src/main/webapp/app/exercise/example-submission/example-submission-import/example-submission-import-paging.service.ts
+++ b/src/main/webapp/app/exercise/example-submission/example-submission-import/example-submission-import-paging.service.ts
@@ -31,7 +31,7 @@ export class ExampleSubmissionImportPagingService extends PagingService<Submissi
             .get<SubmissionSearchResponseDTO>(`${ExampleSubmissionImportPagingService.RESOURCE_URL}/${options.exerciseId}/submissions-for-import`, { params, observe: 'response' })
             .pipe(
                 map((resp: HttpResponse<SubmissionSearchResponseDTO>) => ({
-                    resultsOnPage: resp.body?.resultsOnPage.map(fromSubmissionResponseDTO) ?? [],
+                    resultsOnPage: resp.body?.resultsOnPage?.map(fromSubmissionResponseDTO) ?? [],
                     numberOfPages: resp.body?.numberOfPages ?? 0,
                 })),
             );

--- a/src/main/webapp/app/exercise/participation/participation.service.spec.ts
+++ b/src/main/webapp/app/exercise/participation/participation.service.spec.ts
@@ -8,7 +8,7 @@ import { SessionStorageService } from 'app/foundation/service/session-storage.se
 import { take } from 'rxjs/operators';
 import dayjs from 'dayjs/esm';
 import { ParticipationService } from 'app/exercise/participation/participation.service';
-import { Participation, ParticipationType } from 'app/exercise/shared/entities/participation/participation.model';
+import { InitializationState, ParticipationType } from 'app/exercise/shared/entities/participation/participation.model';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { ProgrammingExerciseStudentParticipation } from 'app/exercise/shared/entities/participation/programming-exercise-student-participation.model';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
@@ -19,12 +19,13 @@ import { Course } from 'app/course/shared/entities/course.model';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { SortingOrder } from 'app/foundation/pagination/pageable-table';
 import { Exercise, ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { StudentParticipationDTO } from 'app/exercise/shared/entities/participation/student-participation.dto';
+import { SubmissionExerciseType } from 'app/exercise/shared/entities/submission/submission.model';
 
 describe('Participation Service', () => {
     setupTestBed({ zoneless: true });
     let service: ParticipationService;
     let httpMock: HttpTestingController;
-    let participationDefault: Participation;
     let currentDate: dayjs.Dayjs;
 
     beforeEach(() => {
@@ -41,29 +42,46 @@ describe('Participation Service', () => {
         service = TestBed.inject(ParticipationService);
         httpMock = TestBed.inject(HttpTestingController);
         currentDate = dayjs();
-
-        participationDefault = { type: 'student' } as unknown as StudentParticipation;
     });
 
     it('should find an element', () => {
-        const returnedFromService = Object.assign(
-            {
-                initializationDate: currentDate.toDate(),
-            },
-            participationDefault,
-        );
+        const returnedFromService: StudentParticipationDTO = {
+            id: 123,
+            initializationDate: currentDate.toISOString(),
+            testRun: false,
+            type: ParticipationType.STUDENT,
+            submissions: [
+                {
+                    id: 456,
+                    submissionExerciseType: SubmissionExerciseType.TEXT,
+                    results: [{ id: 789, rated: true }],
+                },
+            ],
+        };
         service
             .find(123)
             .pipe(take(1))
-            .subscribe((resp) => expect(resp).toMatchObject({ body: participationDefault }));
+            .subscribe((resp) => {
+                expect(resp.body).toBeInstanceOf(StudentParticipation);
+                expect(dayjs.isDayjs(resp.body?.initializationDate)).toBe(true);
+                expect(resp.body?.submissions?.[0].participation).toBe(resp.body);
+                expect(resp.body?.submissions?.[0].results?.[0].submission).toBe(resp.body?.submissions?.[0]);
+            });
 
         const req = httpMock.expectOne({ method: 'GET' });
         req.flush(returnedFromService);
     });
 
     it('should cleanup build plan', () => {
-        service.cleanupBuildPlan(participationDefault).subscribe((resp) => expect(resp).toMatchObject(participationDefault));
-        httpMock.expectOne({ method: 'PUT' });
+        const participation = new ProgrammingExerciseStudentParticipation();
+        participation.id = 123;
+        service.cleanupBuildPlan(participation).subscribe((resp) => {
+            expect(resp.body).toBeInstanceOf(ProgrammingExerciseStudentParticipation);
+            expect(resp.body?.initializationState).toBe(InitializationState.INACTIVE);
+            expect((resp.body as ProgrammingExerciseStudentParticipation).buildPlanId).toBeUndefined();
+        });
+        const req = httpMock.expectOne({ method: 'PUT' });
+        req.flush({ id: 123, initializationState: InitializationState.INACTIVE, testRun: false, type: ParticipationType.PROGRAMMING });
     });
 
     it('should merge student participations for programming exercises', () => {
@@ -156,30 +174,30 @@ describe('Participation Service', () => {
     it('should update a Participation', () => {
         const exercise = new ProgrammingExercise(new Course(), undefined);
         exercise.id = 1;
-        exercise.categories = undefined;
-        exercise.exampleSolutionPublicationDate = undefined;
+        const participation = new ProgrammingExerciseStudentParticipation();
+        participation.id = 2;
+        participation.presentationScore = 1;
 
-        const returnedFromService = {
-            ...participationDefault,
-            repositoryUri: 'BBBBBB',
-            buildPlanId: 'BBBBBB',
-            initializationState: 'BBBBBB',
-            initializationDate: currentDate,
+        const returnedFromService: StudentParticipationDTO = {
+            id: participation.id,
+            repositoryUri: 'repository-uri',
+            buildPlanId: 'build-plan-id',
+            initializationState: InitializationState.INITIALIZED,
+            initializationDate: currentDate.toISOString(),
             presentationScore: 1,
-            exercise,
-            // the update service will make the participation results and submissions
-            // empty arrays instead of undefined, so we need to adapt our expected
-            // values accordingly
-            results: [],
-            submissions: [],
+            testRun: false,
+            type: ParticipationType.PROGRAMMING,
         };
 
-        const expected = Object.assign({}, returnedFromService) as StudentParticipation;
-
         service
-            .update(exercise, expected)
+            .update(exercise, participation)
             .pipe(take(1))
-            .subscribe((resp) => expect(resp.body).toMatchObject({ ...expected }));
+            .subscribe((resp) => {
+                expect(resp.body).toBeInstanceOf(ProgrammingExerciseStudentParticipation);
+                expect(resp.body?.presentationScore).toBe(1);
+                expect((resp.body as ProgrammingExerciseStudentParticipation).repositoryUri).toBe('repository-uri');
+                expect(dayjs.isDayjs(resp.body?.initializationDate)).toBe(true);
+            });
         const req = httpMock.expectOne({ method: 'PUT' });
         req.flush(returnedFromService);
     });

--- a/src/main/webapp/app/exercise/participation/participation.service.spec.ts
+++ b/src/main/webapp/app/exercise/participation/participation.service.spec.ts
@@ -7,7 +7,7 @@ import { SessionStorageService } from 'app/foundation/service/session-storage.se
 import { take } from 'rxjs/operators';
 import dayjs from 'dayjs/esm';
 import { ParticipationService } from 'app/exercise/participation/participation.service';
-import { Participation, ParticipationType } from 'app/exercise/shared/entities/participation/participation.model';
+import { InitializationState, ParticipationType } from 'app/exercise/shared/entities/participation/participation.model';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { ProgrammingExerciseStudentParticipation } from 'app/exercise/shared/entities/participation/programming-exercise-student-participation.model';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
@@ -18,11 +18,12 @@ import { Course } from 'app/course/shared/entities/course.model';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { SortingOrder } from 'app/foundation/pagination/pageable-table';
 import { Exercise, ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { StudentParticipationDTO } from 'app/exercise/shared/entities/participation/student-participation.dto';
+import { SubmissionExerciseType } from 'app/exercise/shared/entities/submission/submission.model';
 
 describe('Participation Service', () => {
     let service: ParticipationService;
     let httpMock: HttpTestingController;
-    let participationDefault: Participation;
     let currentDate: dayjs.Dayjs;
 
     beforeEach(() => {
@@ -39,29 +40,46 @@ describe('Participation Service', () => {
         service = TestBed.inject(ParticipationService);
         httpMock = TestBed.inject(HttpTestingController);
         currentDate = dayjs();
-
-        participationDefault = { type: 'student' } as unknown as StudentParticipation;
     });
 
     it('should find an element', () => {
-        const returnedFromService = Object.assign(
-            {
-                initializationDate: currentDate.toDate(),
-            },
-            participationDefault,
-        );
+        const returnedFromService: StudentParticipationDTO = {
+            id: 123,
+            initializationDate: currentDate.toISOString(),
+            testRun: false,
+            type: ParticipationType.STUDENT,
+            submissions: [
+                {
+                    id: 456,
+                    submissionExerciseType: SubmissionExerciseType.TEXT,
+                    results: [{ id: 789, rated: true }],
+                },
+            ],
+        };
         service
             .find(123)
             .pipe(take(1))
-            .subscribe((resp) => expect(resp).toMatchObject({ body: participationDefault }));
+            .subscribe((resp) => {
+                expect(resp.body).toBeInstanceOf(StudentParticipation);
+                expect(dayjs.isDayjs(resp.body?.initializationDate)).toBe(true);
+                expect(resp.body?.submissions?.[0].participation).toBe(resp.body);
+                expect(resp.body?.submissions?.[0].results?.[0].submission).toBe(resp.body?.submissions?.[0]);
+            });
 
         const req = httpMock.expectOne({ method: 'GET' });
         req.flush(returnedFromService);
     });
 
     it('should cleanup build plan', () => {
-        service.cleanupBuildPlan(participationDefault).subscribe((resp) => expect(resp).toMatchObject(participationDefault));
-        httpMock.expectOne({ method: 'PUT' });
+        const participation = new ProgrammingExerciseStudentParticipation();
+        participation.id = 123;
+        service.cleanupBuildPlan(participation).subscribe((resp) => {
+            expect(resp.body).toBeInstanceOf(ProgrammingExerciseStudentParticipation);
+            expect(resp.body?.initializationState).toBe(InitializationState.INACTIVE);
+            expect((resp.body as ProgrammingExerciseStudentParticipation).buildPlanId).toBeUndefined();
+        });
+        const req = httpMock.expectOne({ method: 'PUT' });
+        req.flush({ id: 123, initializationState: InitializationState.INACTIVE, testRun: false, type: ParticipationType.PROGRAMMING });
     });
 
     it('should merge student participations for programming exercises', () => {
@@ -154,30 +172,30 @@ describe('Participation Service', () => {
     it('should update a Participation', () => {
         const exercise = new ProgrammingExercise(new Course(), undefined);
         exercise.id = 1;
-        exercise.categories = undefined;
-        exercise.exampleSolutionPublicationDate = undefined;
+        const participation = new ProgrammingExerciseStudentParticipation();
+        participation.id = 2;
+        participation.presentationScore = 1;
 
-        const returnedFromService = {
-            ...participationDefault,
-            repositoryUri: 'BBBBBB',
-            buildPlanId: 'BBBBBB',
-            initializationState: 'BBBBBB',
-            initializationDate: currentDate,
+        const returnedFromService: StudentParticipationDTO = {
+            id: participation.id,
+            repositoryUri: 'repository-uri',
+            buildPlanId: 'build-plan-id',
+            initializationState: InitializationState.INITIALIZED,
+            initializationDate: currentDate.toISOString(),
             presentationScore: 1,
-            exercise,
-            // the update service will make the participation results and submissions
-            // empty arrays instead of undefined, so we need to adapt our expected
-            // values accordingly
-            results: [],
-            submissions: [],
+            testRun: false,
+            type: ParticipationType.PROGRAMMING,
         };
 
-        const expected = Object.assign({}, returnedFromService) as StudentParticipation;
-
         service
-            .update(exercise, expected)
+            .update(exercise, participation)
             .pipe(take(1))
-            .subscribe((resp) => expect(resp.body).toMatchObject({ ...expected }));
+            .subscribe((resp) => {
+                expect(resp.body).toBeInstanceOf(ProgrammingExerciseStudentParticipation);
+                expect(resp.body?.presentationScore).toBe(1);
+                expect((resp.body as ProgrammingExerciseStudentParticipation).repositoryUri).toBe('repository-uri');
+                expect(dayjs.isDayjs(resp.body?.initializationDate)).toBe(true);
+            });
         const req = httpMock.expectOne({ method: 'PUT' });
         req.flush(returnedFromService);
     });

--- a/src/main/webapp/app/exercise/participation/participation.service.ts
+++ b/src/main/webapp/app/exercise/participation/participation.service.ts
@@ -16,6 +16,7 @@ import { ExerciseService } from 'app/exercise/services/exercise.service';
 import { AccountService } from 'app/core/auth/account.service';
 import { convertDateFromClient, convertDateFromServer } from 'app/foundation/util/date.utils';
 import dayjs from 'dayjs/esm';
+import { StudentParticipationDTO, fromStudentParticipationDTO } from 'app/exercise/shared/entities/participation/student-participation.dto';
 
 export type EntityResponseType = HttpResponse<StudentParticipation>;
 export type EntityArrayResponseType = HttpResponse<StudentParticipation[]>;
@@ -62,15 +63,15 @@ export class ParticipationService {
             presentationScore: participation.presentationScore,
         };
         return this.http
-            .put<StudentParticipation>(`api/exercise/exercises/${exercise.id}/participations`, dto, { observe: 'response' })
-            .pipe(map((res: EntityResponseType) => this.processParticipationEntityResponseType(res)));
+            .put<StudentParticipationDTO>(`api/exercise/exercises/${exercise.id}/participations`, dto, { observe: 'response' })
+            .pipe(map((res) => this.processParticipationDTOResponseType(res)));
     }
 
     updateIndividualDueDates(exercise: Exercise, participations: StudentParticipation[]): Observable<EntityArrayResponseType> {
         const dtos = participations.map((participation) => this.toDueDateUpdateDTO(participation, exercise.id!));
         return this.http
-            .put<StudentParticipation[]>(`api/exercise/exercises/${exercise.id}/participations/update-individual-due-date`, dtos, { observe: 'response' })
-            .pipe(map((res: EntityArrayResponseType) => this.processParticipationEntityArrayResponseType(res)));
+            .put<StudentParticipationDTO[]>(`api/exercise/exercises/${exercise.id}/participations/update-individual-due-date`, dtos, { observe: 'response' })
+            .pipe(map((res) => this.processParticipationDTOArrayResponseType(res)));
     }
 
     private toDueDateUpdateDTO(participation: StudentParticipation, exerciseId: number): ParticipationDueDateUpdateDTO {
@@ -83,8 +84,8 @@ export class ParticipationService {
 
     find(participationId: number): Observable<EntityResponseType> {
         return this.http
-            .get<StudentParticipation>(`${this.resourceUrl}/${participationId}`, { observe: 'response' })
-            .pipe(map((res: EntityResponseType) => this.processParticipationEntityResponseType(res)));
+            .get<StudentParticipationDTO>(`${this.resourceUrl}/${participationId}`, { observe: 'response' })
+            .pipe(map((res) => this.processParticipationDTOResponseType(res)));
     }
 
     /**
@@ -178,8 +179,8 @@ export class ParticipationService {
     cleanupBuildPlan(participation: StudentParticipation): Observable<EntityResponseType> {
         const copy = this.convertParticipationDatesFromClient(participation);
         return this.http
-            .put<StudentParticipation>(`${this.resourceUrl}/${participation.id}/cleanup-build-plan`, copy, { observe: 'response' })
-            .pipe(map((res: EntityResponseType) => this.convertParticipationResponseDatesFromServer(res)));
+            .put<StudentParticipationDTO>(`${this.resourceUrl}/${participation.id}/cleanup-build-plan`, copy, { observe: 'response' })
+            .pipe(map((res) => this.processParticipationDTOResponseType(res)));
     }
 
     shouldPreferPractice(exercise?: Exercise): boolean {
@@ -333,10 +334,10 @@ export class ParticipationService {
      * This method bundles recurring conversion steps for Participation EntityArrayResponses.
      * @param participationRes
      */
-    private processParticipationEntityArrayResponseType(participationRes: EntityArrayResponseType): EntityArrayResponseType {
-        this.convertParticipationResponseArrayDatesFromServer(participationRes);
-        this.setAccessRightsParticipationEntityArrayResponseType(participationRes);
-        return participationRes;
+    private processParticipationDTOArrayResponseType(participationRes: HttpResponse<StudentParticipationDTO[]>): EntityArrayResponseType {
+        const convertedResponse = participationRes.clone({ body: participationRes.body?.map(fromStudentParticipationDTO) ?? null });
+        this.setAccessRightsParticipationEntityArrayResponseType(convertedResponse);
+        return convertedResponse;
     }
 
     /**
@@ -347,6 +348,12 @@ export class ParticipationService {
         this.convertParticipationResponseDatesFromServer(participationRes);
         this.setAccessRightsParticipationEntityResponseType(participationRes);
         return participationRes;
+    }
+
+    private processParticipationDTOResponseType(participationRes: HttpResponse<StudentParticipationDTO>): EntityResponseType {
+        const convertedResponse = participationRes.clone({ body: participationRes.body ? fromStudentParticipationDTO(participationRes.body) : null });
+        this.setAccessRightsParticipationEntityResponseType(convertedResponse);
+        return convertedResponse;
     }
 
     private setAccessRightsParticipationEntityResponseType(res: EntityResponseType): EntityResponseType {

--- a/src/main/webapp/app/exercise/shared/entities/participation/student-participation.dto.ts
+++ b/src/main/webapp/app/exercise/shared/entities/participation/student-participation.dto.ts
@@ -111,7 +111,7 @@ export function fromStudentParticipationDTO(dto: StudentParticipationDTO): Stude
     participation.submissionCount = dto.submissionCount;
     participation.participantName = dto.participantName;
     participation.participantIdentifier = dto.participantIdentifier;
-    participation.student = dto.student ? Object.assign(new User(), dto.student) : undefined;
+    participation.student = dto.student ? fromUserPublicInfoDTO(dto.student) : undefined;
     participation.team = dto.team ? fromParticipationTeamDTO(dto.team) : undefined;
     participation.exercise = dto.exercise ? fromParticipationExerciseContextDTO(dto.exercise) : undefined;
 
@@ -135,7 +135,7 @@ function fromParticipationTeamDTO(dto: ParticipationTeamDTO): Team {
     team.name = dto.name;
     team.shortName = dto.shortName;
     team.image = dto.image;
-    team.students = dto.students?.map((student) => Object.assign(new User(), student));
+    team.students = dto.students?.map(fromUserPublicInfoDTO);
     return team;
 }
 
@@ -150,7 +150,7 @@ function fromParticipationExerciseContextDTO(dto: ParticipationExerciseContextDT
     exercise.dueDate = convertDateStringFromServer(dto.dueDate);
     exercise.assessmentDueDate = convertDateStringFromServer(dto.assessmentDueDate);
     exercise.maxPoints = dto.maxPoints;
-    exercise.course = dto.course ? Object.assign(new Course(), dto.course) : undefined;
+    exercise.course = dto.course ? fromCourseContextDTO(dto.course) : undefined;
     exercise.exerciseGroup = dto.exerciseGroup ? fromExerciseGroupDTO(dto.exerciseGroup, exercise.course) : undefined;
     return exercise;
 }
@@ -160,8 +160,29 @@ function fromExerciseGroupDTO(dto: NonNullable<ParticipationExerciseContextDTO['
     exerciseGroup.id = dto.id;
     exerciseGroup.exam = new Exam();
     exerciseGroup.exam.id = dto.exam.id;
-    exerciseGroup.exam.course = course ?? Object.assign(new Course(), dto.exam.course);
+    exerciseGroup.exam.course = course ?? fromCourseContextDTO(dto.exam.course);
     return exerciseGroup;
+}
+
+function fromUserPublicInfoDTO(dto: UserPublicInfoDTO): User {
+    const user = new User();
+    user.id = dto.id;
+    user.login = dto.login;
+    user.name = dto.name;
+    user.firstName = dto.firstName;
+    user.lastName = dto.lastName;
+    user.email = dto.email;
+    user.imageUrl = dto.imageUrl;
+    return user;
+}
+
+function fromCourseContextDTO(dto: Partial<ParticipationCourseContextDTO> & { id: number }): Course {
+    const course = new Course();
+    course.id = dto.id;
+    course.title = dto.title;
+    course.shortName = dto.shortName;
+    course.accuracyOfScores = dto.accuracyOfScores;
+    return course;
 }
 
 function fromParticipationSubmissionDTO(dto: ParticipationSubmissionDTO): Submission {

--- a/src/main/webapp/app/exercise/shared/entities/participation/student-participation.dto.ts
+++ b/src/main/webapp/app/exercise/shared/entities/participation/student-participation.dto.ts
@@ -1,0 +1,203 @@
+import { User, UserPublicInfoDTO } from 'app/account/user/user.model';
+import { AssessmentType } from 'app/assessment/shared/entities/assessment-type.model';
+import { Course } from 'app/course/shared/entities/course.model';
+import { Exam } from 'app/exam/shared/entities/exam.model';
+import { ExerciseGroup } from 'app/exam/shared/entities/exercise-group.model';
+import { Exercise, ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { InitializationState, ParticipationType } from 'app/exercise/shared/entities/participation/participation.model';
+import { ProgrammingExerciseStudentParticipation } from 'app/exercise/shared/entities/participation/programming-exercise-student-participation.model';
+import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
+import { Result } from 'app/exercise/shared/entities/result/result.model';
+import { Submission, SubmissionExerciseType } from 'app/exercise/shared/entities/submission/submission.model';
+import { Team } from 'app/exercise/shared/entities/team/team.model';
+import { convertDateStringFromServer } from 'app/foundation/util/date.utils';
+import { FileUploadSubmission } from 'app/fileupload/shared/entities/file-upload-submission.model';
+import { ModelingSubmission } from 'app/modeling/shared/entities/modeling-submission.model';
+import { ProgrammingSubmission } from 'app/programming/shared/entities/programming-submission.model';
+import { QuizSubmission } from 'app/quiz/shared/entities/quiz-submission.model';
+import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
+
+export interface ParticipationSubmissionResultDTO {
+    id: number;
+    completionDate?: string;
+    successful?: boolean;
+    score?: number;
+    rated: boolean;
+    assessmentType?: AssessmentType;
+}
+
+export interface ParticipationSubmissionDTO {
+    id: number;
+    submitted?: boolean;
+    submissionDate?: string;
+    submissionExerciseType: SubmissionExerciseType;
+    commitHash?: string;
+    results?: ParticipationSubmissionResultDTO[];
+}
+
+export interface ParticipationTeamDTO {
+    id: number;
+    name?: string;
+    shortName?: string;
+    image?: string;
+    students?: UserPublicInfoDTO[];
+}
+
+export interface ParticipationCourseContextDTO {
+    id: number;
+    title?: string;
+    shortName?: string;
+    accuracyOfScores?: number;
+}
+
+export interface ParticipationExerciseContextDTO {
+    id: number;
+    title?: string;
+    type: ExerciseType;
+    exerciseType: ExerciseType;
+    assessmentType?: AssessmentType;
+    releaseDate?: string;
+    startDate?: string;
+    dueDate?: string;
+    assessmentDueDate?: string;
+    maxPoints?: number;
+    course?: ParticipationCourseContextDTO;
+    exerciseGroup?: {
+        id: number;
+        exam: {
+            id: number;
+            course: { id: number };
+        };
+    };
+}
+
+export interface StudentParticipationDTO {
+    id: number;
+    initializationState?: InitializationState;
+    initializationDate?: string;
+    individualDueDate?: string;
+    presentationScore?: number;
+    testRun: boolean;
+    type: ParticipationType.STUDENT | ParticipationType.PROGRAMMING;
+    submissionCount?: number;
+    participantName?: string;
+    participantIdentifier?: string;
+    student?: UserPublicInfoDTO;
+    team?: ParticipationTeamDTO;
+    exercise?: ParticipationExerciseContextDTO;
+    submissions?: ParticipationSubmissionDTO[];
+    repositoryUri?: string;
+    buildPlanId?: string;
+    branch?: string;
+}
+
+class ParticipationExerciseContext extends Exercise {
+    constructor(type: ExerciseType) {
+        super(type);
+    }
+}
+
+/**
+ * Converts a participation wire DTO into the existing component-facing model and reconnects its nested relationships.
+ */
+export function fromStudentParticipationDTO(dto: StudentParticipationDTO): StudentParticipation {
+    const participation = dto.type === ParticipationType.PROGRAMMING ? new ProgrammingExerciseStudentParticipation() : new StudentParticipation(ParticipationType.STUDENT);
+    participation.id = dto.id;
+    participation.initializationState = dto.initializationState;
+    participation.initializationDate = convertDateStringFromServer(dto.initializationDate);
+    participation.individualDueDate = convertDateStringFromServer(dto.individualDueDate);
+    participation.presentationScore = dto.presentationScore;
+    participation.testRun = dto.testRun;
+    participation.submissionCount = dto.submissionCount;
+    participation.participantName = dto.participantName;
+    participation.participantIdentifier = dto.participantIdentifier;
+    participation.student = dto.student ? Object.assign(new User(), dto.student) : undefined;
+    participation.team = dto.team ? fromParticipationTeamDTO(dto.team) : undefined;
+    participation.exercise = dto.exercise ? fromParticipationExerciseContextDTO(dto.exercise) : undefined;
+
+    if (participation instanceof ProgrammingExerciseStudentParticipation) {
+        participation.repositoryUri = dto.repositoryUri;
+        participation.buildPlanId = dto.buildPlanId;
+        participation.branch = dto.branch;
+    }
+
+    participation.submissions = dto.submissions?.map(fromParticipationSubmissionDTO);
+    participation.submissions?.forEach((submission) => {
+        submission.participation = participation;
+        submission.results?.forEach((result) => (result.submission = submission));
+    });
+    return participation;
+}
+
+function fromParticipationTeamDTO(dto: ParticipationTeamDTO): Team {
+    const team = new Team();
+    team.id = dto.id;
+    team.name = dto.name;
+    team.shortName = dto.shortName;
+    team.image = dto.image;
+    team.students = dto.students?.map((student) => Object.assign(new User(), student));
+    return team;
+}
+
+function fromParticipationExerciseContextDTO(dto: ParticipationExerciseContextDTO): Exercise {
+    const exercise = new ParticipationExerciseContext(dto.exerciseType);
+    exercise.id = dto.id;
+    exercise.title = dto.title;
+    exercise.type = dto.type;
+    exercise.assessmentType = dto.assessmentType;
+    exercise.releaseDate = convertDateStringFromServer(dto.releaseDate);
+    exercise.startDate = convertDateStringFromServer(dto.startDate);
+    exercise.dueDate = convertDateStringFromServer(dto.dueDate);
+    exercise.assessmentDueDate = convertDateStringFromServer(dto.assessmentDueDate);
+    exercise.maxPoints = dto.maxPoints;
+    exercise.course = dto.course ? Object.assign(new Course(), dto.course) : undefined;
+    exercise.exerciseGroup = dto.exerciseGroup ? fromExerciseGroupDTO(dto.exerciseGroup, exercise.course) : undefined;
+    return exercise;
+}
+
+function fromExerciseGroupDTO(dto: NonNullable<ParticipationExerciseContextDTO['exerciseGroup']>, course: Course | undefined): ExerciseGroup {
+    const exerciseGroup = new ExerciseGroup();
+    exerciseGroup.id = dto.id;
+    exerciseGroup.exam = new Exam();
+    exerciseGroup.exam.id = dto.exam.id;
+    exerciseGroup.exam.course = course ?? Object.assign(new Course(), dto.exam.course);
+    return exerciseGroup;
+}
+
+function fromParticipationSubmissionDTO(dto: ParticipationSubmissionDTO): Submission {
+    const submission = createSubmission(dto.submissionExerciseType);
+    submission.id = dto.id;
+    submission.submitted = dto.submitted;
+    submission.submissionDate = convertDateStringFromServer(dto.submissionDate);
+    submission.results = dto.results?.map(fromParticipationSubmissionResultDTO);
+    if (submission instanceof ProgrammingSubmission) {
+        submission.commitHash = dto.commitHash;
+    }
+    return submission;
+}
+
+function createSubmission(type: SubmissionExerciseType): Submission {
+    switch (type) {
+        case SubmissionExerciseType.PROGRAMMING:
+            return new ProgrammingSubmission();
+        case SubmissionExerciseType.MODELING:
+            return new ModelingSubmission();
+        case SubmissionExerciseType.QUIZ:
+            return new QuizSubmission();
+        case SubmissionExerciseType.TEXT:
+            return new TextSubmission();
+        case SubmissionExerciseType.FILE_UPLOAD:
+            return new FileUploadSubmission();
+    }
+}
+
+function fromParticipationSubmissionResultDTO(dto: ParticipationSubmissionResultDTO): Result {
+    const result = new Result();
+    result.id = dto.id;
+    result.completionDate = convertDateStringFromServer(dto.completionDate);
+    result.successful = dto.successful;
+    result.score = dto.score;
+    result.rated = dto.rated;
+    result.assessmentType = dto.assessmentType;
+    return result;
+}

--- a/src/main/webapp/app/exercise/shared/entities/submission/submission-response.dto.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission-response.dto.ts
@@ -5,7 +5,7 @@ import { Feedback, FeedbackDTO, convertFeedbackFromServer } from 'app/assessment
 import { Language } from 'app/course/shared/entities/course.model';
 import { StudentParticipationDTO, fromStudentParticipationDTO } from 'app/exercise/shared/entities/participation/student-participation.dto';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
-import { Submission, SubmissionExerciseType, SubmissionType, setLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
+import { Submission, SubmissionExerciseType, SubmissionType } from 'app/exercise/shared/entities/submission/submission.model';
 import { convertDateStringFromServer } from 'app/foundation/util/date.utils';
 import { FileUploadSubmission } from 'app/fileupload/shared/entities/file-upload-submission.model';
 import { ModelingSubmission } from 'app/modeling/shared/entities/modeling-submission.model';
@@ -88,7 +88,7 @@ export function fromSubmissionResponseDTO(dto: SubmissionResponseDTO): Submissio
     }
 
     submission.results?.forEach((result) => (result.submission = submission));
-    setLatestSubmissionResult(submission, submission.results?.last());
+    submission.latestResult = findLatestSubmissionResult(submission.results);
     return submission;
 }
 
@@ -120,7 +120,7 @@ function fromSubmissionResultDTO(dto: SubmissionResultDTO): Result {
     result.testCaseCount = dto.testCaseCount;
     result.passedTestCaseCount = dto.passedTestCaseCount;
     result.codeIssueCount = dto.codeIssueCount;
-    result.assessor = dto.assessor ? Object.assign(new User(), dto.assessor) : undefined;
+    result.assessor = dto.assessor ? fromUserPublicInfoDTO(dto.assessor) : undefined;
     result.feedbacks = dto.feedbacks?.map((feedback) => reconnectFeedback(convertFeedbackFromServer(feedback), result));
     result.assessmentNote = dto.assessmentNote ? fromSubmissionAssessmentNoteDTO(dto.assessmentNote) : undefined;
     return result;
@@ -135,6 +135,33 @@ function fromSubmissionAssessmentNoteDTO(dto: SubmissionAssessmentNoteDTO): Asse
     const assessmentNote = new AssessmentNote();
     assessmentNote.id = dto.id;
     assessmentNote.note = dto.note;
-    assessmentNote.creator = dto.creator ? Object.assign(new User(), dto.creator) : undefined;
+    assessmentNote.creator = dto.creator ? fromUserPublicInfoDTO(dto.creator) : undefined;
     return assessmentNote;
+}
+
+function findLatestSubmissionResult(results: Result[] | undefined): Result | undefined {
+    return results?.reduce<Result | undefined>((latestResult, result) => {
+        if (!latestResult) {
+            return result;
+        }
+        if (result.id === undefined) {
+            return latestResult;
+        }
+        if (latestResult.id === undefined) {
+            return result;
+        }
+        return result.id > latestResult.id ? result : latestResult;
+    }, undefined);
+}
+
+function fromUserPublicInfoDTO(dto: UserPublicInfoDTO): User {
+    const user = new User();
+    user.id = dto.id;
+    user.login = dto.login;
+    user.name = dto.name;
+    user.firstName = dto.firstName;
+    user.lastName = dto.lastName;
+    user.email = dto.email;
+    user.imageUrl = dto.imageUrl;
+    return user;
 }

--- a/src/main/webapp/app/exercise/shared/entities/submission/submission-response.dto.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission-response.dto.ts
@@ -1,0 +1,140 @@
+import { User, UserPublicInfoDTO } from 'app/account/user/user.model';
+import { AssessmentNote } from 'app/assessment/shared/entities/assessment-note.model';
+import { AssessmentType } from 'app/assessment/shared/entities/assessment-type.model';
+import { Feedback, FeedbackDTO, convertFeedbackFromServer } from 'app/assessment/shared/entities/feedback.model';
+import { Language } from 'app/course/shared/entities/course.model';
+import { StudentParticipationDTO, fromStudentParticipationDTO } from 'app/exercise/shared/entities/participation/student-participation.dto';
+import { Result } from 'app/exercise/shared/entities/result/result.model';
+import { Submission, SubmissionExerciseType, SubmissionType, setLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
+import { convertDateStringFromServer } from 'app/foundation/util/date.utils';
+import { FileUploadSubmission } from 'app/fileupload/shared/entities/file-upload-submission.model';
+import { ModelingSubmission } from 'app/modeling/shared/entities/modeling-submission.model';
+import { ProgrammingSubmission } from 'app/programming/shared/entities/programming-submission.model';
+import { QuizSubmission } from 'app/quiz/shared/entities/quiz-submission.model';
+import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
+
+export interface SubmissionAssessmentNoteDTO {
+    id: number;
+    note?: string;
+    creator?: UserPublicInfoDTO;
+}
+
+export interface SubmissionResultDTO {
+    id: number;
+    completionDate?: string;
+    successful?: boolean;
+    score?: number;
+    rated: boolean;
+    assessmentType?: AssessmentType;
+    hasComplaint?: boolean;
+    exampleResult?: boolean;
+    testCaseCount?: number;
+    passedTestCaseCount?: number;
+    codeIssueCount?: number;
+    assessor?: UserPublicInfoDTO;
+    feedbacks?: FeedbackDTO[];
+    assessmentNote?: SubmissionAssessmentNoteDTO;
+}
+
+export interface SubmissionResponseDTO {
+    id: number;
+    submitted: boolean;
+    type?: SubmissionType;
+    exampleSubmission?: boolean;
+    submissionDate?: string;
+    durationInMinutes?: number;
+    submissionExerciseType: SubmissionExerciseType;
+    participation?: StudentParticipationDTO;
+    results?: SubmissionResultDTO[];
+    commitHash?: string;
+    buildFailed?: boolean;
+    text?: string;
+    language?: Language;
+    model?: string;
+    explanationText?: string;
+    filePath?: string;
+    quizBatch?: number;
+    scoreInPoints?: number;
+}
+
+/**
+ * Converts a submission wire DTO into the existing component-facing subtype and reconnects its relationships.
+ */
+export function fromSubmissionResponseDTO(dto: SubmissionResponseDTO): Submission {
+    const submission = createSubmission(dto.submissionExerciseType);
+    submission.id = dto.id;
+    submission.submitted = dto.submitted;
+    submission.type = dto.type;
+    submission.exampleSubmission = dto.exampleSubmission;
+    submission.submissionDate = convertDateStringFromServer(dto.submissionDate);
+    submission.durationInMinutes = dto.durationInMinutes;
+    submission.participation = dto.participation ? fromStudentParticipationDTO(dto.participation) : undefined;
+    submission.results = dto.results?.map(fromSubmissionResultDTO);
+
+    if (submission instanceof ProgrammingSubmission) {
+        submission.commitHash = dto.commitHash;
+        submission.buildFailed = dto.buildFailed;
+    } else if (submission instanceof TextSubmission) {
+        submission.text = dto.text;
+        submission.language = dto.language;
+    } else if (submission instanceof ModelingSubmission) {
+        submission.model = dto.model;
+        submission.explanationText = dto.explanationText;
+    } else if (submission instanceof FileUploadSubmission) {
+        submission.filePath = dto.filePath;
+    } else if (submission instanceof QuizSubmission) {
+        submission.quizBatch = dto.quizBatch;
+        submission.scoreInPoints = dto.scoreInPoints;
+    }
+
+    submission.results?.forEach((result) => (result.submission = submission));
+    setLatestSubmissionResult(submission, submission.results?.last());
+    return submission;
+}
+
+function createSubmission(type: SubmissionExerciseType): Submission {
+    switch (type) {
+        case SubmissionExerciseType.PROGRAMMING:
+            return new ProgrammingSubmission();
+        case SubmissionExerciseType.MODELING:
+            return new ModelingSubmission();
+        case SubmissionExerciseType.QUIZ:
+            return new QuizSubmission();
+        case SubmissionExerciseType.TEXT:
+            return new TextSubmission();
+        case SubmissionExerciseType.FILE_UPLOAD:
+            return new FileUploadSubmission();
+    }
+}
+
+function fromSubmissionResultDTO(dto: SubmissionResultDTO): Result {
+    const result = new Result();
+    result.id = dto.id;
+    result.completionDate = convertDateStringFromServer(dto.completionDate);
+    result.successful = dto.successful;
+    result.score = dto.score;
+    result.rated = dto.rated;
+    result.assessmentType = dto.assessmentType;
+    result.hasComplaint = dto.hasComplaint;
+    result.exampleResult = dto.exampleResult;
+    result.testCaseCount = dto.testCaseCount;
+    result.passedTestCaseCount = dto.passedTestCaseCount;
+    result.codeIssueCount = dto.codeIssueCount;
+    result.assessor = dto.assessor ? Object.assign(new User(), dto.assessor) : undefined;
+    result.feedbacks = dto.feedbacks?.map((feedback) => reconnectFeedback(convertFeedbackFromServer(feedback), result));
+    result.assessmentNote = dto.assessmentNote ? fromSubmissionAssessmentNoteDTO(dto.assessmentNote) : undefined;
+    return result;
+}
+
+function reconnectFeedback(feedback: Feedback, result: Result): Feedback {
+    feedback.result = result;
+    return feedback;
+}
+
+function fromSubmissionAssessmentNoteDTO(dto: SubmissionAssessmentNoteDTO): AssessmentNote {
+    const assessmentNote = new AssessmentNote();
+    assessmentNote.id = dto.id;
+    assessmentNote.note = dto.note;
+    assessmentNote.creator = dto.creator ? Object.assign(new User(), dto.creator) : undefined;
+    return assessmentNote;
+}

--- a/src/main/webapp/app/exercise/submission/submission.service.spec.ts
+++ b/src/main/webapp/app/exercise/submission/submission.service.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
-import { SubmissionService, SubmissionWithComplaintDTO } from 'app/exercise/submission/submission.service';
+import { SubmissionService } from 'app/exercise/submission/submission.service';
 import { TestBed } from '@angular/core/testing';
 import { LocalStorageService } from 'app/foundation/service/local-storage.service';
 import { SessionStorageService } from 'app/foundation/service/session-storage.service';
@@ -12,9 +12,9 @@ import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { Feedback, FeedbackType } from 'app/assessment/shared/entities/feedback.model';
 import { HttpResponse, provideHttpClient } from '@angular/common/http';
-import { Submission, SubmissionType, getLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
+import { Submission, SubmissionExerciseType, SubmissionType, getLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
 import dayjs from 'dayjs/esm';
-import { Complaint } from 'app/assessment/shared/entities/complaint.model';
+import { SubmissionResponseDTO } from 'app/exercise/shared/entities/submission/submission-response.dto';
 
 describe('Submission Service', () => {
     setupTestBed({ zoneless: true });
@@ -23,6 +23,7 @@ describe('Submission Service', () => {
     let httpMock: HttpTestingController;
     let expectedResult: any;
     let submission: TextSubmission;
+    let submissionResponseDTO: SubmissionResponseDTO;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -55,6 +56,20 @@ describe('Submission Service', () => {
                 credits: 1,
             },
         ];
+        submissionResponseDTO = {
+            id: submission.id!,
+            submitted: submission.submitted!,
+            type: submission.type,
+            text: submission.text,
+            submissionExerciseType: SubmissionExerciseType.TEXT,
+            results: submission.results!.map((result) => ({
+                id: result.id!,
+                score: result.score,
+                rated: result.rated!,
+                hasComplaint: result.hasComplaint,
+                feedbacks: result.feedbacks,
+            })),
+        };
     });
 
     afterEach(() => {
@@ -72,32 +87,32 @@ describe('Submission Service', () => {
 
     it('should find all submissions of a given participation', () => {
         const participationId = 1;
-        const returnedFromService = [...[submission]];
-        const expected = [...[submission]];
         service
             .findAllSubmissionsOfParticipation(participationId)
             .pipe(take(1))
-            .subscribe((resp) => expect(resp.body).toEqual(expected));
+            .subscribe((resp) => {
+                expect(resp.body).toHaveLength(1);
+                expect(resp.body![0]).toBeInstanceOf(TextSubmission);
+                expect(resp.body![0].id).toBe(submission.id);
+                expect(resp.body![0].results![0].submission).toBe(resp.body![0]);
+            });
         const req = httpMock.expectOne({ url: `api/exercise/participations/${participationId}/submissions`, method: 'GET' });
-        req.flush(returnedFromService);
+        req.flush([submissionResponseDTO]);
     });
 
     it('should get test run submission for a given exercise', () => {
         const exerciseId = 1;
 
-        const returnedFromService = [submission];
-        const expected = [
-            {
-                ...submission,
-                latestResult: getLatestSubmissionResult(submission),
-            },
-        ];
         service
             .getTestRunSubmissionsForExercise(exerciseId)
             .pipe(take(1))
-            .subscribe((resp) => expect(resp.body).toEqual(expected));
+            .subscribe((resp) => {
+                expect(resp.body).toHaveLength(1);
+                expect(resp.body![0]).toBeInstanceOf(TextSubmission);
+                expect(resp.body![0].latestResult).toBe(resp.body![0].results![0]);
+            });
         const req = httpMock.expectOne({ url: `api/exercise/exercises/${exerciseId}/test-run-submissions`, method: 'GET' });
-        req.flush(returnedFromService);
+        req.flush([submissionResponseDTO]);
     });
 
     it('should handle feedback correction round tag', () => {
@@ -162,16 +177,12 @@ describe('Submission Service', () => {
         const submissionDateStr = '2022-02-02T12:34:56.789Z';
         const complaintSubmittedTimeStr = '2022-02-03T22:11:33.444Z';
 
-        const complaint: Complaint = {
-            submittedTime: complaintSubmittedTimeStr as any, // String should be converted to proper type by the tested service.
-        };
-        const returnedFromService: SubmissionWithComplaintDTO[] = [
+        const returnedFromService = [
             {
-                submission,
-                complaint,
+                submission: { ...submissionResponseDTO, submissionDate: submissionDateStr },
+                complaint: { id: 2, submittedTime: complaintSubmittedTimeStr, complaintIsAccepted: true },
             },
         ];
-        submission.submissionDate = submissionDateStr as any; // String should be converted to proper type by the tested service.
 
         service
             .getSubmissionsWithComplaintsForTutor(exerciseId)
@@ -181,6 +192,7 @@ describe('Submission Service', () => {
                 const submissionWithComplaint = resp.body![0];
                 expect(submissionWithComplaint.submission.submissionDate).toEqual(dayjs(submissionDateStr));
                 expect(submissionWithComplaint.complaint.submittedTime).toEqual(dayjs(complaintSubmittedTimeStr));
+                expect(submissionWithComplaint.complaint.accepted).toBe(true);
             });
         const req = httpMock.expectOne({ url: `api/exercise/exercises/${exerciseId}/submissions-with-complaints`, method: 'GET' });
         req.flush(returnedFromService);

--- a/src/main/webapp/app/exercise/submission/submission.service.spec.ts
+++ b/src/main/webapp/app/exercise/submission/submission.service.spec.ts
@@ -11,15 +11,16 @@ import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { Feedback, FeedbackType } from 'app/assessment/shared/entities/feedback.model';
 import { HttpResponse, provideHttpClient } from '@angular/common/http';
-import { Submission, SubmissionType, getLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
+import { Submission, SubmissionExerciseType, SubmissionType, getLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
 import dayjs from 'dayjs/esm';
-import { Complaint } from 'app/assessment/shared/entities/complaint.model';
+import { SubmissionResponseDTO } from 'app/exercise/shared/entities/submission/submission-response.dto';
 
 describe('Submission Service', () => {
     let service: SubmissionService;
     let httpMock: HttpTestingController;
     let expectedResult: any;
     let submission: TextSubmission;
+    let submissionResponseDTO: SubmissionResponseDTO;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -52,6 +53,20 @@ describe('Submission Service', () => {
                 credits: 1,
             },
         ];
+        submissionResponseDTO = {
+            id: submission.id!,
+            submitted: submission.submitted!,
+            type: submission.type,
+            text: submission.text,
+            submissionExerciseType: SubmissionExerciseType.TEXT,
+            results: submission.results!.map((result) => ({
+                id: result.id!,
+                score: result.score,
+                rated: result.rated!,
+                hasComplaint: result.hasComplaint,
+                feedbacks: result.feedbacks,
+            })),
+        };
     });
 
     afterEach(() => {
@@ -69,32 +84,32 @@ describe('Submission Service', () => {
 
     it('should find all submissions of a given participation', () => {
         const participationId = 1;
-        const returnedFromService = [...[submission]];
-        const expected = [...[submission]];
         service
             .findAllSubmissionsOfParticipation(participationId)
             .pipe(take(1))
-            .subscribe((resp) => expect(resp.body).toEqual(expected));
+            .subscribe((resp) => {
+                expect(resp.body).toHaveLength(1);
+                expect(resp.body![0]).toBeInstanceOf(TextSubmission);
+                expect(resp.body![0].id).toBe(submission.id);
+                expect(resp.body![0].results![0].submission).toBe(resp.body![0]);
+            });
         const req = httpMock.expectOne({ url: `api/exercise/participations/${participationId}/submissions`, method: 'GET' });
-        req.flush(returnedFromService);
+        req.flush([submissionResponseDTO]);
     });
 
     it('should get test run submission for a given exercise', () => {
         const exerciseId = 1;
 
-        const returnedFromService = [submission];
-        const expected = [
-            {
-                ...submission,
-                latestResult: getLatestSubmissionResult(submission),
-            },
-        ];
         service
             .getTestRunSubmissionsForExercise(exerciseId)
             .pipe(take(1))
-            .subscribe((resp) => expect(resp.body).toEqual(expected));
+            .subscribe((resp) => {
+                expect(resp.body).toHaveLength(1);
+                expect(resp.body![0]).toBeInstanceOf(TextSubmission);
+                expect(resp.body![0].latestResult).toBe(resp.body![0].results![0]);
+            });
         const req = httpMock.expectOne({ url: `api/exercise/exercises/${exerciseId}/test-run-submissions`, method: 'GET' });
-        req.flush(returnedFromService);
+        req.flush([submissionResponseDTO]);
     });
 
     it('should handle feedback correction round tag', () => {
@@ -159,16 +174,12 @@ describe('Submission Service', () => {
         const submissionDateStr = '2022-02-02T12:34:56.789Z';
         const complaintSubmittedTimeStr = '2022-02-03T22:11:33.444Z';
 
-        const complaint: Complaint = {
-            submittedTime: complaintSubmittedTimeStr as any, // String should be converted to proper type by the tested service.
-        };
-        const returnedFromService: SubmissionWithComplaintDTO[] = [
+        const returnedFromService = [
             {
-                submission,
-                complaint,
+                submission: { ...submissionResponseDTO, submissionDate: submissionDateStr },
+                complaint: { id: 2, submittedTime: complaintSubmittedTimeStr, complaintIsAccepted: true },
             },
         ];
-        submission.submissionDate = submissionDateStr as any; // String should be converted to proper type by the tested service.
 
         service
             .getSubmissionsWithComplaintsForTutor(exerciseId)
@@ -178,6 +189,7 @@ describe('Submission Service', () => {
                 const submissionWithComplaint = resp.body![0];
                 expect(submissionWithComplaint.submission.submissionDate).toEqual(dayjs(submissionDateStr));
                 expect(submissionWithComplaint.complaint.submittedTime).toEqual(dayjs(complaintSubmittedTimeStr));
+                expect(submissionWithComplaint.complaint.accepted).toBe(true);
             });
         const req = httpMock.expectOne({ url: `api/exercise/exercises/${exerciseId}/submissions-with-complaints`, method: 'GET' });
         req.flush(returnedFromService);

--- a/src/main/webapp/app/exercise/submission/submission.service.spec.ts
+++ b/src/main/webapp/app/exercise/submission/submission.service.spec.ts
@@ -14,6 +14,7 @@ import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { Submission, SubmissionExerciseType, SubmissionType, getLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
 import dayjs from 'dayjs/esm';
 import { SubmissionResponseDTO } from 'app/exercise/shared/entities/submission/submission-response.dto';
+import { deepClone } from 'app/foundation/util/deep-clone.util';
 
 describe('Submission Service', () => {
     let service: SubmissionService;
@@ -173,10 +174,12 @@ describe('Submission Service', () => {
         const exerciseId = 1;
         const submissionDateStr = '2022-02-02T12:34:56.789Z';
         const complaintSubmittedTimeStr = '2022-02-03T22:11:33.444Z';
+        const returnedSubmission = deepClone(submissionResponseDTO);
+        returnedSubmission.submissionDate = submissionDateStr;
 
         const returnedFromService = [
             {
-                submission: { ...submissionResponseDTO, submissionDate: submissionDateStr },
+                submission: returnedSubmission,
                 complaint: { id: 2, submittedTime: complaintSubmittedTimeStr, complaintIsAccepted: true },
             },
         ];

--- a/src/main/webapp/app/exercise/submission/submission.service.ts
+++ b/src/main/webapp/app/exercise/submission/submission.service.ts
@@ -5,14 +5,15 @@ import { createRequestOption } from 'app/foundation/util/request.util';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { Submission, getLatestSubmissionResult, setLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
 import { filter, map, tap } from 'rxjs/operators';
-import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
 import { Feedback } from 'app/assessment/shared/entities/feedback.model';
 import { Complaint } from 'app/assessment/shared/entities/complaint.model';
-import { ComplaintResponseService } from 'app/assessment/manage/services/complaint-response.service';
 import { AccountService } from 'app/core/auth/account.service';
 import { ParticipationService } from 'app/exercise/participation/participation.service';
 import { convertDateFromServer } from 'app/foundation/util/date.utils';
 import { ExerciseService } from 'app/exercise/services/exercise.service';
+import { SubmissionResponseDTO, fromSubmissionResponseDTO } from 'app/exercise/shared/entities/submission/submission-response.dto';
+import { ComplaintDTO } from 'app/assessment/shared/entities/complaint-dto.model';
+import { ComplaintService } from 'app/assessment/shared/services/complaint.service';
 
 export type EntityResponseType = HttpResponse<Submission>;
 export type EntityArrayResponseType = HttpResponse<Submission[]>;
@@ -22,10 +23,15 @@ export class SubmissionWithComplaintDTO {
     public complaint: Complaint;
 }
 
+export interface SubmissionWithComplaintResponseDTO {
+    submission: SubmissionResponseDTO;
+    complaint: ComplaintDTO;
+}
+
 @Injectable({ providedIn: 'root' })
 export class SubmissionService {
     private http = inject(HttpClient);
-    private complaintResponseService = inject(ComplaintResponseService);
+    private complaintService = inject(ComplaintService);
     private accountService = inject(AccountService);
 
     public resourceUrl = 'api/exercise/submissions';
@@ -46,15 +52,10 @@ export class SubmissionService {
      * @param {number} participationId - The id of the participation to be searched for
      */
     findAllSubmissionsOfParticipation(participationId: number): Observable<EntityArrayResponseType> {
-        return this.http.get<Submission[]>(`${this.resourceUrlParticipation}/${participationId}/submissions`, { observe: 'response' }).pipe(
-            map((res) => this.convertSubmissionArrayResponseDatesFromServer(res)),
+        return this.http.get<SubmissionResponseDTO[]>(`${this.resourceUrlParticipation}/${participationId}/submissions`, { observe: 'response' }).pipe(
+            map((res) => res.clone({ body: res.body?.map(fromSubmissionResponseDTO) })),
             filter((res) => !!res.body),
-            tap((res) =>
-                res.body!.forEach((submission) => {
-                    SubmissionService.reconnectSubmissionAndResult(submission);
-                    this.setSubmissionAccessRights(submission);
-                }),
-            ),
+            tap((res) => res.body!.forEach((submission) => this.setSubmissionAccessRights(submission))),
         );
     }
 
@@ -64,7 +65,7 @@ export class SubmissionService {
      */
     getSubmissionsWithComplaintsForTutor(exerciseId: number): Observable<HttpResponse<SubmissionWithComplaintDTO[]>> {
         return this.http
-            .get<SubmissionWithComplaintDTO[]>(`api/exercise/exercises/${exerciseId}/submissions-with-complaints`, { observe: 'response' })
+            .get<SubmissionWithComplaintResponseDTO[]>(`api/exercise/exercises/${exerciseId}/submissions-with-complaints`, { observe: 'response' })
             .pipe(map((res) => this.convertDTOsFromServer(res)));
     }
 
@@ -74,19 +75,19 @@ export class SubmissionService {
      */
     getSubmissionsWithMoreFeedbackRequestsForTutor(exerciseId: number): Observable<HttpResponse<SubmissionWithComplaintDTO[]>> {
         return this.http
-            .get<SubmissionWithComplaintDTO[]>(`api/exercise/exercises/${exerciseId}/more-feedback-requests-with-complaints`, { observe: 'response' })
+            .get<SubmissionWithComplaintResponseDTO[]>(`api/exercise/exercises/${exerciseId}/more-feedback-requests-with-complaints`, { observe: 'response' })
             .pipe(map((res) => this.convertDTOsFromServer(res)));
     }
 
-    protected convertDTOsFromServer(res: HttpResponse<SubmissionWithComplaintDTO[]>) {
-        if (res.body) {
-            res.body.forEach((dto) => {
-                dto.submission = SubmissionService.convertSubmissionDateFromServer(dto.submission)!;
-                dto.complaint = this.convertComplaintDatesFromServer(dto.complaint);
-                this.setSubmissionAccessRights(dto.submission);
-            });
-        }
-        return res;
+    protected convertDTOsFromServer(res: HttpResponse<SubmissionWithComplaintResponseDTO[]>): HttpResponse<SubmissionWithComplaintDTO[]> {
+        const body = res.body?.map((dto) => {
+            const submission = fromSubmissionResponseDTO(dto.submission);
+            const complaint = this.complaintService.convertComplaintFromServerInList(dto.complaint);
+            complaint.result = submission.results?.find((result) => result.id === dto.complaint.result?.id) ?? complaint.result;
+            this.setSubmissionAccessRights(submission);
+            return { submission, complaint };
+        });
+        return res.clone({ body });
     }
 
     public static convertSubmissionDateFromServer(submission: Submission | undefined) {
@@ -95,14 +96,6 @@ export class SubmissionService {
             this.reconnectSubmissionAndResult(submission);
         }
         return submission;
-    }
-
-    convertComplaintDatesFromServer(complaint: Complaint) {
-        complaint.submittedTime = convertDateFromServer(complaint.submittedTime);
-        if (complaint.complaintResponse) {
-            this.complaintResponseService.convertComplaintResponseDatesFromServer(complaint.complaintResponse);
-        }
-        return complaint;
     }
 
     /**
@@ -151,10 +144,10 @@ export class SubmissionService {
 
     getTestRunSubmissionsForExercise(exerciseId: number): Observable<HttpResponse<Submission[]>> {
         return this.http
-            .get<TextSubmission[]>(`api/exercise/exercises/${exerciseId}/test-run-submissions`, {
+            .get<SubmissionResponseDTO[]>(`api/exercise/exercises/${exerciseId}/test-run-submissions`, {
                 observe: 'response',
             })
-            .pipe(map((res: HttpResponse<TextSubmission[]>) => this.convertArrayResponse(res)));
+            .pipe(map((res) => res.clone({ body: res.body?.map(fromSubmissionResponseDTO) })));
     }
 
     public convertResponse(res: EntityResponseType): EntityResponseType {

--- a/src/main/webapp/app/exercise/submission/submission.service.ts
+++ b/src/main/webapp/app/exercise/submission/submission.service.ts
@@ -5,14 +5,15 @@ import { createRequestOption } from 'app/foundation/util/request.util';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { Submission, getLatestSubmissionResult, setLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
 import { filter, map, tap } from 'rxjs/operators';
-import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
 import { Feedback } from 'app/assessment/shared/entities/feedback.model';
 import { Complaint } from 'app/assessment/shared/entities/complaint.model';
-import { ComplaintResponseService } from 'app/assessment/manage/services/complaint-response.service';
 import { AccountService } from 'app/core/auth/account.service';
 import { ParticipationService } from 'app/exercise/participation/participation.service';
 import { convertDateFromServer } from 'app/foundation/util/date.utils';
 import { ExerciseService } from 'app/exercise/services/exercise.service';
+import { SubmissionResponseDTO, fromSubmissionResponseDTO } from 'app/exercise/shared/entities/submission/submission-response.dto';
+import { ComplaintDTO } from 'app/assessment/shared/entities/complaint-dto.model';
+import { ComplaintService } from 'app/assessment/shared/services/complaint.service';
 
 export type EntityResponseType = HttpResponse<Submission>;
 export type EntityArrayResponseType = HttpResponse<Submission[]>;
@@ -22,10 +23,15 @@ export interface SubmissionWithComplaintDTO {
     complaint: Complaint;
 }
 
+export interface SubmissionWithComplaintResponseDTO {
+    submission: SubmissionResponseDTO;
+    complaint: ComplaintDTO;
+}
+
 @Injectable({ providedIn: 'root' })
 export class SubmissionService {
     private http = inject(HttpClient);
-    private complaintResponseService = inject(ComplaintResponseService);
+    private complaintService = inject(ComplaintService);
     private accountService = inject(AccountService);
 
     public resourceUrl = 'api/exercise/submissions';
@@ -46,15 +52,10 @@ export class SubmissionService {
      * @param {number} participationId - The id of the participation to be searched for
      */
     findAllSubmissionsOfParticipation(participationId: number): Observable<EntityArrayResponseType> {
-        return this.http.get<Submission[]>(`${this.resourceUrlParticipation}/${participationId}/submissions`, { observe: 'response' }).pipe(
-            map((res) => this.convertSubmissionArrayResponseDatesFromServer(res)),
+        return this.http.get<SubmissionResponseDTO[]>(`${this.resourceUrlParticipation}/${participationId}/submissions`, { observe: 'response' }).pipe(
+            map((res) => res.clone({ body: res.body?.map(fromSubmissionResponseDTO) })),
             filter((res) => !!res.body),
-            tap((res) =>
-                res.body!.forEach((submission) => {
-                    SubmissionService.reconnectSubmissionAndResult(submission);
-                    this.setSubmissionAccessRights(submission);
-                }),
-            ),
+            tap((res) => res.body!.forEach((submission) => this.setSubmissionAccessRights(submission))),
         );
     }
 
@@ -64,7 +65,7 @@ export class SubmissionService {
      */
     getSubmissionsWithComplaintsForTutor(exerciseId: number): Observable<HttpResponse<SubmissionWithComplaintDTO[]>> {
         return this.http
-            .get<SubmissionWithComplaintDTO[]>(`api/exercise/exercises/${exerciseId}/submissions-with-complaints`, { observe: 'response' })
+            .get<SubmissionWithComplaintResponseDTO[]>(`api/exercise/exercises/${exerciseId}/submissions-with-complaints`, { observe: 'response' })
             .pipe(map((res) => this.convertDTOsFromServer(res)));
     }
 
@@ -74,19 +75,19 @@ export class SubmissionService {
      */
     getSubmissionsWithMoreFeedbackRequestsForTutor(exerciseId: number): Observable<HttpResponse<SubmissionWithComplaintDTO[]>> {
         return this.http
-            .get<SubmissionWithComplaintDTO[]>(`api/exercise/exercises/${exerciseId}/more-feedback-requests-with-complaints`, { observe: 'response' })
+            .get<SubmissionWithComplaintResponseDTO[]>(`api/exercise/exercises/${exerciseId}/more-feedback-requests-with-complaints`, { observe: 'response' })
             .pipe(map((res) => this.convertDTOsFromServer(res)));
     }
 
-    protected convertDTOsFromServer(res: HttpResponse<SubmissionWithComplaintDTO[]>) {
-        if (res.body) {
-            res.body.forEach((dto) => {
-                dto.submission = SubmissionService.convertSubmissionDateFromServer(dto.submission)!;
-                dto.complaint = this.convertComplaintDatesFromServer(dto.complaint);
-                this.setSubmissionAccessRights(dto.submission);
-            });
-        }
-        return res;
+    protected convertDTOsFromServer(res: HttpResponse<SubmissionWithComplaintResponseDTO[]>): HttpResponse<SubmissionWithComplaintDTO[]> {
+        const body = res.body?.map((dto) => {
+            const submission = fromSubmissionResponseDTO(dto.submission);
+            const complaint = this.complaintService.convertComplaintFromServerInList(dto.complaint);
+            complaint.result = submission.results?.find((result) => result.id === dto.complaint.result?.id) ?? complaint.result;
+            this.setSubmissionAccessRights(submission);
+            return { submission, complaint };
+        });
+        return res.clone({ body });
     }
 
     public static convertSubmissionDateFromServer(submission: Submission | undefined) {
@@ -95,14 +96,6 @@ export class SubmissionService {
             this.reconnectSubmissionAndResult(submission);
         }
         return submission;
-    }
-
-    convertComplaintDatesFromServer(complaint: Complaint) {
-        complaint.submittedTime = convertDateFromServer(complaint.submittedTime);
-        if (complaint.complaintResponse) {
-            this.complaintResponseService.convertComplaintResponseDatesFromServer(complaint.complaintResponse);
-        }
-        return complaint;
     }
 
     /**
@@ -151,10 +144,10 @@ export class SubmissionService {
 
     getTestRunSubmissionsForExercise(exerciseId: number): Observable<HttpResponse<Submission[]>> {
         return this.http
-            .get<TextSubmission[]>(`api/exercise/exercises/${exerciseId}/test-run-submissions`, {
+            .get<SubmissionResponseDTO[]>(`api/exercise/exercises/${exerciseId}/test-run-submissions`, {
                 observe: 'response',
             })
-            .pipe(map((res: HttpResponse<TextSubmission[]>) => this.convertArrayResponse(res)));
+            .pipe(map((res) => res.clone({ body: res.body?.map(fromSubmissionResponseDTO) })));
     }
 
     public convertResponse(res: EntityResponseType): EntityResponseType {

--- a/src/main/webapp/app/quiz/shared/entities/quiz-submission.model.ts
+++ b/src/main/webapp/app/quiz/shared/entities/quiz-submission.model.ts
@@ -4,6 +4,7 @@ import type { SubmittedAnswer } from 'app/quiz/shared/entities/submitted-answer.
 export class QuizSubmission extends Submission {
     public scoreInPoints?: number;
     public submittedAnswers?: SubmittedAnswer[];
+    public quizBatch?: number;
 
     constructor() {
         super(SubmissionExerciseType.QUIZ);

--- a/src/main/webapp/app/quiz/shared/entities/quiz-submission.model.ts
+++ b/src/main/webapp/app/quiz/shared/entities/quiz-submission.model.ts
@@ -2,6 +2,8 @@ import { SubmissionExerciseType } from 'app/exercise/shared/entities/submission/
 import { AbstractQuizSubmission } from 'app/quiz/shared/entities/abstract-quiz-exam-submission.model';
 
 export class QuizSubmission extends AbstractQuizSubmission {
+    public quizBatch?: number;
+
     constructor() {
         super(SubmissionExerciseType.QUIZ);
     }

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/AssessmentComplaintIntegrationTest.java
@@ -545,12 +545,11 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
                 SubmissionWithComplaintDTO.class, params);
 
         submissionWithComplaintDTOs.forEach(dto -> {
-            final var participation = (StudentParticipation) dto.complaint().getResult().getSubmission().getParticipation();
-            assertThat(participation.getStudent()).as("No student information").isEmpty();
-            assertThat(dto.complaint().getParticipant()).as("No student information").isNull();
-            assertThat(participation.getExercise()).as("No additional exercise information").isNull();
-            assertThat(((StudentParticipation) dto.submission().getParticipation()).getParticipant()).as("No student information in participation").isNull();
-            assertThat(dto.submission().getParticipation().getExercise()).as("No additional exercise information").isNull();
+            assertThat(dto.complaint().participant()).as("No student information").isNull();
+            assertThat(dto.complaint().result().submission().participation().exercise()).as("No additional exercise information").isNull();
+            assertThat(dto.submission().participation().student()).as("No student information in participation").isNull();
+            assertThat(dto.submission().participation().team()).as("No team information in participation").isNull();
+            assertThat(dto.submission().participation().exercise()).as("No additional exercise information").isNull();
 
         });
     }

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/AssessmentComplaintIntegrationTest.java
@@ -542,12 +542,11 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
                 SubmissionWithComplaintDTO.class, params);
 
         submissionWithComplaintDTOs.forEach(dto -> {
-            final var participation = (StudentParticipation) dto.complaint().getResult().getSubmission().getParticipation();
-            assertThat(participation.getStudent()).as("No student information").isEmpty();
-            assertThat(dto.complaint().getParticipant()).as("No student information").isNull();
-            assertThat(participation.getExercise()).as("No additional exercise information").isNull();
-            assertThat(((StudentParticipation) dto.submission().getParticipation()).getParticipant()).as("No student information in participation").isNull();
-            assertThat(dto.submission().getParticipation().getExercise()).as("No additional exercise information").isNull();
+            assertThat(dto.complaint().participant()).as("No student information").isNull();
+            assertThat(dto.complaint().result().submission().participation().exercise()).as("No additional exercise information").isNull();
+            assertThat(dto.submission().participation().student()).as("No student information in participation").isNull();
+            assertThat(dto.submission().participation().team()).as("No team information in participation").isNull();
+            assertThat(dto.submission().participation().exercise()).as("No additional exercise information").isNull();
 
         });
     }

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
@@ -99,6 +99,7 @@ import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionResponseDTO;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
 import de.tum.cit.aet.artemis.exercise.repository.SubmissionVersionRepository;
@@ -675,10 +676,11 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         exam2 = examUtilService.addExam(course2, examVisibleDate, examStartDate, examEndDate);
         var exam = examUtilService.addTextModelingProgrammingExercisesToExam(exam2, false, false);
         var testRun = examUtilService.setupTestRunForExamWithExerciseGroupsForInstructor(exam, instructor, exam.getExerciseGroups());
-        List<Submission> response = request.getList("/api/exercise/exercises/" + testRun.getExercises().getFirst().getId() + "/test-run-submissions", HttpStatus.OK,
-                Submission.class);
+        List<SubmissionResponseDTO> response = request.getList("/api/exercise/exercises/" + testRun.getExercises().getFirst().getId() + "/test-run-submissions", HttpStatus.OK,
+                SubmissionResponseDTO.class);
         assertThat(response).isNotEmpty();
-        assertThat((response.getFirst().getParticipation()).isTestRun()).isTrue();
+        assertThat(response.getFirst().participation().testRun()).isTrue();
+        assertThat(response.getFirst().participation().submissions()).isNull();
     }
 
     @Test
@@ -686,7 +688,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
     void testGetAllTestRunSubmissionsForExercise_notExamExercise() throws Exception {
         course2 = courseUtilService.addEnrolledEmptyCourse(TEST_PREFIX);
         var exercise = programmingExerciseUtilService.addProgrammingExerciseToCourse(course2, false);
-        request.getList("/api/exercise/exercises/" + exercise.getId() + "/test-run-submissions", HttpStatus.FORBIDDEN, Submission.class);
+        request.getList("/api/exercise/exercises/" + exercise.getId() + "/test-run-submissions", HttpStatus.FORBIDDEN, SubmissionResponseDTO.class);
     }
 
     @Test
@@ -701,7 +703,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         var exam = examUtilService.addTextModelingProgrammingExercisesToExam(exam2, false, false);
         var testRun = examUtilService.setupTestRunForExamWithExerciseGroupsForInstructor(exam, instructor, exam.getExerciseGroups());
         userUtilService.changeUser(TEST_PREFIX + "student2");
-        request.getList("/api/exercise/exercises/" + testRun.getExercises().getFirst().getId() + "/test-run-submissions", HttpStatus.FORBIDDEN, Submission.class);
+        request.getList("/api/exercise/exercises/" + testRun.getExercises().getFirst().getId() + "/test-run-submissions", HttpStatus.FORBIDDEN, SubmissionResponseDTO.class);
     }
 
     @Test
@@ -715,7 +717,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         var exam = examUtilService.addTextModelingProgrammingExercisesToExam(exam2, false, false);
         final var latestSubmissions = request.getList(
                 "/api/exercise/exercises/" + exam.getExerciseGroups().getFirst().getExercises().iterator().next().getId() + "/test-run-submissions", HttpStatus.OK,
-                Submission.class);
+                SubmissionResponseDTO.class);
         assertThat(latestSubmissions).isEmpty();
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
@@ -97,6 +97,7 @@ import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionResponseDTO;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
 import de.tum.cit.aet.artemis.exercise.repository.SubmissionVersionRepository;
@@ -671,10 +672,11 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         exam2 = examUtilService.addExam(course2, examVisibleDate, examStartDate, examEndDate);
         var exam = examUtilService.addTextModelingProgrammingExercisesToExam(exam2, false, false);
         var testRun = examUtilService.setupTestRunForExamWithExerciseGroupsForInstructor(exam, instructor, exam.getExerciseGroups());
-        List<Submission> response = request.getList("/api/exercise/exercises/" + testRun.getExercises().getFirst().getId() + "/test-run-submissions", HttpStatus.OK,
-                Submission.class);
+        List<SubmissionResponseDTO> response = request.getList("/api/exercise/exercises/" + testRun.getExercises().getFirst().getId() + "/test-run-submissions", HttpStatus.OK,
+                SubmissionResponseDTO.class);
         assertThat(response).isNotEmpty();
-        assertThat((response.getFirst().getParticipation()).isTestRun()).isTrue();
+        assertThat(response.getFirst().participation().testRun()).isTrue();
+        assertThat(response.getFirst().participation().submissions()).isNull();
     }
 
     @Test
@@ -682,7 +684,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
     void testGetAllTestRunSubmissionsForExercise_notExamExercise() throws Exception {
         course2 = courseUtilService.addEmptyCourse();
         var exercise = programmingExerciseUtilService.addProgrammingExerciseToCourse(course2, false);
-        request.getList("/api/exercise/exercises/" + exercise.getId() + "/test-run-submissions", HttpStatus.FORBIDDEN, Submission.class);
+        request.getList("/api/exercise/exercises/" + exercise.getId() + "/test-run-submissions", HttpStatus.FORBIDDEN, SubmissionResponseDTO.class);
     }
 
     @Test
@@ -697,7 +699,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         var exam = examUtilService.addTextModelingProgrammingExercisesToExam(exam2, false, false);
         var testRun = examUtilService.setupTestRunForExamWithExerciseGroupsForInstructor(exam, instructor, exam.getExerciseGroups());
         userUtilService.changeUser(TEST_PREFIX + "student2");
-        request.getList("/api/exercise/exercises/" + testRun.getExercises().getFirst().getId() + "/test-run-submissions", HttpStatus.FORBIDDEN, Submission.class);
+        request.getList("/api/exercise/exercises/" + testRun.getExercises().getFirst().getId() + "/test-run-submissions", HttpStatus.FORBIDDEN, SubmissionResponseDTO.class);
     }
 
     @Test
@@ -711,7 +713,7 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         var exam = examUtilService.addTextModelingProgrammingExercisesToExam(exam2, false, false);
         final var latestSubmissions = request.getList(
                 "/api/exercise/exercises/" + exam.getExerciseGroups().getFirst().getExercises().iterator().next().getId() + "/test-run-submissions", HttpStatus.OK,
-                Submission.class);
+                SubmissionResponseDTO.class);
         assertThat(latestSubmissions).isEmpty();
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/architecture/ExerciseEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/architecture/ExerciseEntityUsageArchitectureTest.java
@@ -18,7 +18,7 @@ class ExerciseEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchi
     // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getExpectedEntityReturnViolations() {
-        return 23;
+        return 14;
     }
 
     // This module is already compliant for input violations

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/architecture/ExerciseEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/architecture/ExerciseEntityUsageArchitectureTest.java
@@ -18,7 +18,7 @@ class ExerciseEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchi
     // TODO: Reduce this to 0 by returning DTOs instead of entities
     @Override
     protected int getExpectedEntityReturnViolations() {
-        return 14;
+        return 11;
     }
 
     // This module is already compliant for input violations
@@ -30,6 +30,6 @@ class ExerciseEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchi
     // TODO: Reduce this to 0 by removing entity references from DTOs
     @Override
     protected int getExpectedDtoEntityFieldViolations() {
-        return 3;
+        return 1;
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
@@ -76,6 +76,7 @@ import de.tum.cit.aet.artemis.exercise.dto.ParticipationSubmissionDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationSubmissionResultDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationUpdateDTO;
 import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionResponseDTO;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
 import de.tum.cit.aet.artemis.exercise.repository.TeamRepository;
@@ -1594,8 +1595,12 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         var participation = participationUtilService.createAndSaveParticipationForExercise(textExercise, TEST_PREFIX + "student1");
         var submission1 = participationUtilService.addSubmission(participation, ParticipationFactory.generateTextSubmission("text", Language.ENGLISH, true));
         var submission2 = participationUtilService.addSubmission(participation, ParticipationFactory.generateTextSubmission("text2", Language.ENGLISH, true));
-        var submissions = request.getList("/api/exercise/participations/" + participation.getId() + "/submissions", HttpStatus.OK, Submission.class);
-        assertThat(submissions).contains(submission1, submission2);
+        var submissions = request.getList("/api/exercise/participations/" + participation.getId() + "/submissions", HttpStatus.OK, SubmissionResponseDTO.class);
+        assertThat(submissions).extracting(SubmissionResponseDTO::id).containsExactlyInAnyOrder(submission1.getId(), submission2.getId());
+        assertThat(submissions).allSatisfy(submission -> {
+            assertThat(submission.submissionExerciseType()).isEqualTo("text");
+            assertThat(submission.participation().submissions()).isNull();
+        });
     }
 
     @ParameterizedTest

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
@@ -72,7 +72,10 @@ import de.tum.cit.aet.artemis.exercise.dto.ParticipationManagementDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationScoreDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationScoreSearchDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationSearchDTO;
+import de.tum.cit.aet.artemis.exercise.dto.ParticipationSubmissionDTO;
+import de.tum.cit.aet.artemis.exercise.dto.ParticipationSubmissionResultDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationUpdateDTO;
+import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
 import de.tum.cit.aet.artemis.exercise.repository.TeamRepository;
@@ -265,10 +268,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void participateInModelingExercise() throws Exception {
         URI location = request.post("/api/exercise/exercises/" + modelingExercise.getId() + "/participations", null, HttpStatus.CREATED);
 
-        StudentParticipation participation = request.get(location.getPath(), HttpStatus.OK, StudentParticipation.class);
-        assertThat(participation.getExercise()).as("participated in correct exercise").isEqualTo(modelingExercise);
-        assertThat(participation.getStudent()).as("Student got set").isNotNull();
-        assertThat(participation.getParticipantIdentifier()).as("Correct student got set").isEqualTo(TEST_PREFIX + "student1");
+        StudentParticipationDTO participation = request.get(location.getPath(), HttpStatus.OK, StudentParticipationDTO.class);
+        assertThat(participation.exercise().id()).as("participated in correct exercise").isEqualTo(modelingExercise.getId());
+        assertThat(participation.student()).as("Student got set").isNotNull();
+        assertThat(participation.participantIdentifier()).as("Correct student got set").isEqualTo(TEST_PREFIX + "student1");
         Participation storedParticipation = participationRepo
                 .findWithEagerSubmissionsByExerciseIdAndStudentLoginAndTestRun(modelingExercise.getId(), TEST_PREFIX + "student1", false).orElseThrow();
         assertThat(storedParticipation.getSubmissions()).as("submission was initialized").hasSize(1);
@@ -280,10 +283,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void participateInTextExercise() throws Exception {
         URI location = request.post("/api/exercise/exercises/" + textExercise.getId() + "/participations", null, HttpStatus.CREATED);
 
-        StudentParticipation participation = request.get(location.getPath(), HttpStatus.OK, StudentParticipation.class);
-        assertThat(participation.getExercise()).as("participated in correct exercise").isEqualTo(textExercise);
-        assertThat(participation.getStudent()).as("Student got set").isNotNull();
-        assertThat(participation.getParticipantIdentifier()).as("Correct student got set").isEqualTo(TEST_PREFIX + "student2");
+        StudentParticipationDTO participation = request.get(location.getPath(), HttpStatus.OK, StudentParticipationDTO.class);
+        assertThat(participation.exercise().id()).as("participated in correct exercise").isEqualTo(textExercise.getId());
+        assertThat(participation.student()).as("Student got set").isNotNull();
+        assertThat(participation.participantIdentifier()).as("Correct student got set").isEqualTo(TEST_PREFIX + "student2");
         Participation storedParticipation = participationRepo.findWithEagerSubmissionsByExerciseIdAndStudentLoginAndTestRun(textExercise.getId(), TEST_PREFIX + "student2", false)
                 .orElseThrow();
         assertThat(storedParticipation.getSubmissions()).as("submission was initialized").hasSize(1);
@@ -362,13 +365,12 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         textExercise.setDueDate(ZonedDateTime.now().plusHours(2));
         exerciseRepository.save(textExercise);
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", null, StudentParticipation.class,
-                HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
 
         assertThat(participation).isNotNull();
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
-        Set<User> participationUsers = participation.getStudents();
-        assertThat(participationUsers).contains(user);
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
     }
 
     @Test
@@ -391,12 +393,11 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         examTextExercise.getExam().setEndDate(ZonedDateTime.now().plusHours(1));
         examTestRepository.save(examTextExercise.getExam());
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + examTextExercise.getId() + "/participations", null,
-                StudentParticipation.class, HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + examTextExercise.getId() + "/participations", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
         assertThat(participation).isNotNull();
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
-        Set<User> participationUsers = participation.getStudents();
-        assertThat(participationUsers).contains(user);
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
     }
 
     /**
@@ -445,13 +446,12 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         studentExam.setWorkingTime(threeHours);
         studentExamRepository.save(studentExam);
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + examTextExercise.getId() + "/participations", null,
-                StudentParticipation.class, HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + examTextExercise.getId() + "/participations", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
 
         assertThat(participation).isNotNull();
         User user = userUtilService.getUserByLogin(studentLogin);
-        Set<User> participationUsers = participation.getStudents();
-        assertThat(participationUsers).contains(user);
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
     }
 
     /**
@@ -555,11 +555,12 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         mockConnectorRequestsForStartPractice(programmingExercise, TEST_PREFIX + "student1");
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations/practice", null,
-                StudentParticipation.class, HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations/practice", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
         assertThat(participation).isNotNull();
-        assertThat(participation.isPracticeMode()).isTrue();
-        assertThat(participation.getStudent()).contains(user);
+        assertThat(participation.testRun()).isTrue();
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
+        assertThat(participation.repositoryUri()).isNotBlank();
     }
 
     @Test
@@ -570,11 +571,12 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         prepareMocksForProgrammingExercise();
         mockConnectorRequestsForStartParticipation(programmingExercise, TEST_PREFIX + "student1", Set.of(user), true);
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations", null,
-                StudentParticipation.class, HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
         assertThat(participation).isNotNull();
-        assertThat(participation.isPracticeMode()).isFalse();
-        assertThat(participation.getStudent()).contains(user);
+        assertThat(participation.testRun()).isFalse();
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
+        assertThat(participation.repositoryUri()).isNotBlank();
     }
 
     @Test
@@ -591,19 +593,19 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         textExercise.setDueDate(ZonedDateTime.now().minusHours(1));
         exerciseRepository.save(textExercise);
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
-                StudentParticipation.class, HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
         assertThat(participation).isNotNull();
-        assertThat(participation.isPracticeMode()).isTrue();
-        assertThat(participation.getAttempt()).isEqualTo(1);
+        assertThat(participation.testRun()).isTrue();
+        assertThat(participationRepo.findByIdElseThrow(participation.id()).getAttempt()).isEqualTo(1);
 
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
-        assertThat(participation.getStudent()).contains(user);
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
 
-        List<Submission> submissions = submissionRepository.findAllByParticipationId(participation.getId());
+        List<Submission> submissions = submissionRepository.findAllByParticipationId(participation.id());
         assertThat(submissions).hasSize(1);
         Submission submission = submissions.getFirst();
-        assertThat(submission.getParticipation().getId()).isEqualTo(participation.getId());
+        assertThat(submission.getParticipation().getId()).isEqualTo(participation.id());
         assertThat(submission).isInstanceOf(TextSubmission.class);
         assertThat(((TextSubmission) submission).getText()).isNull();
     }
@@ -614,19 +616,19 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         modelingExercise.setDueDate(ZonedDateTime.now().minusHours(1));
         exerciseRepository.save(modelingExercise);
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + modelingExercise.getId() + "/participations/practice", null,
-                StudentParticipation.class, HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + modelingExercise.getId() + "/participations/practice", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
         assertThat(participation).isNotNull();
-        assertThat(participation.isPracticeMode()).isTrue();
-        assertThat(participation.getAttempt()).isEqualTo(1);
+        assertThat(participation.testRun()).isTrue();
+        assertThat(participationRepo.findByIdElseThrow(participation.id()).getAttempt()).isEqualTo(1);
 
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
-        assertThat(participation.getStudent()).contains(user);
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
 
-        List<Submission> submissions = submissionRepository.findAllByParticipationId(participation.getId());
+        List<Submission> submissions = submissionRepository.findAllByParticipationId(participation.id());
         assertThat(submissions).hasSize(1);
         Submission submission = submissions.getFirst();
-        assertThat(submission.getParticipation().getId()).isEqualTo(participation.getId());
+        assertThat(submission.getParticipation().getId()).isEqualTo(participation.id());
         assertThat(submission).isInstanceOf(ModelingSubmission.class);
         assertThat(((ModelingSubmission) submission).getModel()).isNull();
     }
@@ -656,9 +658,9 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         textExercise.setDueDate(ZonedDateTime.now().minusHours(1));
         exerciseRepository.save(textExercise);
 
-        StudentParticipation practiceParticipation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
-                StudentParticipation.class, HttpStatus.CREATED);
-        assertThat(practiceParticipation.isPracticeMode()).isTrue();
+        StudentParticipationDTO practiceParticipation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
+        assertThat(practiceParticipation.testRun()).isTrue();
 
         // Now reset due date and start a graded participation — should not return the
         // practice one
@@ -666,11 +668,11 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         exerciseRepository.save(textExercise);
 
         URI location = request.post("/api/exercise/exercises/" + textExercise.getId() + "/participations", null, HttpStatus.CREATED);
-        StudentParticipation gradedParticipation = request.get(location.getPath(), HttpStatus.OK, StudentParticipation.class);
+        StudentParticipationDTO gradedParticipation = request.get(location.getPath(), HttpStatus.OK, StudentParticipationDTO.class);
 
         assertThat(gradedParticipation).isNotNull();
-        assertThat(gradedParticipation.isPracticeMode()).isFalse();
-        assertThat(gradedParticipation.getId()).isNotEqualTo(practiceParticipation.getId());
+        assertThat(gradedParticipation.testRun()).isFalse();
+        assertThat(gradedParticipation.id()).isNotEqualTo(practiceParticipation.id());
     }
 
     @Test
@@ -687,14 +689,14 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         textExercise.setDueDate(ZonedDateTime.now().minusHours(1));
         exerciseRepository.save(textExercise);
 
-        StudentParticipation firstParticipation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
-                StudentParticipation.class, HttpStatus.CREATED);
-        assertThat(firstParticipation.isPracticeMode()).isTrue();
+        StudentParticipationDTO firstParticipation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
+        assertThat(firstParticipation.testRun()).isTrue();
 
         // Starting practice mode again should return the same participation
-        StudentParticipation secondParticipation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
-                StudentParticipation.class, HttpStatus.CREATED);
-        assertThat(secondParticipation.getId()).isEqualTo(firstParticipation.getId());
+        StudentParticipationDTO secondParticipation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
+        assertThat(secondParticipation.id()).isEqualTo(firstParticipation.id());
     }
 
     @Test
@@ -852,7 +854,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(result2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations/" + participation.getId() + "/request-feedback", null,
-                ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(programmingMessagingService, timeout(2000).times(2)).notifyUserAboutNewResult(resultCaptor.capture(), any());
 
@@ -912,7 +914,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(result2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations/" + participation.getId() + "/request-feedback", null,
-                ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(programmingMessagingService, timeout(2000).times(2)).notifyUserAboutNewResult(resultCaptor.capture(), any());
 
@@ -983,7 +985,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(resultText2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/" + textParticipation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(resultWebsocketService, timeout(2000).times(2)).broadcastNewResult(any(), resultCaptor.capture());
 
@@ -1028,7 +1030,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         participationUtilService.addResultToSubmission(AssessmentType.MANUAL, ZonedDateTime.now(), submission);
 
         request.putWithResponseBody("/api/exercise/exercises/" + teamExercise.getId() + "/participations/" + participation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(resultWebsocketService, timeout(2000).times(2)).broadcastNewResult(any(), resultCaptor.capture());
 
@@ -1077,7 +1079,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(result2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + teamExercise.getId() + "/participations/" + participation.getId() + "/request-feedback", null,
-                ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(programmingMessagingService, timeout(2000).times(2)).notifyUserAboutNewResult(resultCaptor.capture(), any());
 
@@ -1118,7 +1120,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(resultModeling2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + modelingExercise.getId() + "/participations/" + modelingParticipation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(resultWebsocketService, timeout(2000).times(2)).broadcastNewResult(any(), resultCaptor.capture());
 
@@ -1164,7 +1166,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         participationUtilService.addResultToSubmission(AssessmentType.MANUAL, ZonedDateTime.now(), submission);
 
         request.putWithResponseBody("/api/exercise/exercises/" + teamExercise.getId() + "/participations/" + participation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(resultWebsocketService, timeout(2000).times(2)).broadcastNewResult(any(), resultCaptor.capture());
 
@@ -1200,7 +1202,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(result2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations/" + participation.getId() + "/request-feedback", null,
-                ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(programmingMessagingService, timeout(2000).times(2)).notifyUserAboutNewResult(resultCaptor.capture(), any());
 
@@ -1241,7 +1243,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(resultText2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/" + textParticipation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(resultWebsocketService, timeout(2000).times(2)).broadcastNewResult(any(), resultCaptor.capture());
 
@@ -1279,7 +1281,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(resultModeling2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + modelingExercise.getId() + "/participations/" + modelingParticipation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(resultWebsocketService, timeout(2000).times(2)).broadcastNewResult(any(), resultCaptor.capture());
 
@@ -1299,8 +1301,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         var updatedParticipation = request.putWithResponseBody(
                 "/api/exercise/exercises/" + programmingExercise.getId() + "/participations/" + participation.getId() + "/resume-programming-participation", null,
-                ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
-        assertThat(updatedParticipation.getInitializationState()).isEqualTo(InitializationState.INITIALIZED);
+                StudentParticipationDTO.class, HttpStatus.OK);
+        assertThat(updatedParticipation.initializationState()).isEqualTo(InitializationState.INITIALIZED);
+        assertThat(updatedParticipation.repositoryUri()).isEqualTo(participation.getRepositoryUri());
+        assertThat(updatedParticipation.exercise().id()).isEqualTo(programmingExercise.getId());
     }
 
     @Test
@@ -1334,10 +1338,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         participation.setPresentationScore(1.);
         participation = participationRepo.save(participation);
         var dto = new ParticipationUpdateDTO(participation.getId(), textExercise.getId(), null);
-        var actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto, StudentParticipation.class,
+        var actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto, StudentParticipationDTO.class,
                 HttpStatus.OK);
         assertThat(actualParticipation).as("The participation was updated").isNotNull();
-        assertThat(actualParticipation.getPresentationScore()).as("Presentation score was set to null").isNull();
+        assertThat(actualParticipation.presentationScore()).as("Presentation score was set to null").isNull();
     }
 
     @Test
@@ -1359,10 +1363,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         participation = participationRepo.save(participation);
         var dto = new ParticipationUpdateDTO(participation.getId(), textExercise.getId(), 2.);
-        var actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto, StudentParticipation.class,
+        var actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto, StudentParticipationDTO.class,
                 HttpStatus.OK);
         assertThat(actualParticipation).as("The participation was updated").isNotNull();
-        assertThat(actualParticipation.getPresentationScore()).as("Presentation score was set to 1").isEqualTo(1.);
+        assertThat(actualParticipation.presentationScore()).as("Presentation score was set to 1").isEqualTo(1.);
     }
 
     @ParameterizedTest
@@ -1388,10 +1392,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
             assertThat(actualParticipation).as("The participation was not updated").isNull();
         }
         else {
-            StudentParticipation actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto,
-                    StudentParticipation.class, HttpStatus.OK);
+            StudentParticipationDTO actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto,
+                    StudentParticipationDTO.class, HttpStatus.OK);
             assertThat(actualParticipation).as("The participation was updated").isNotNull();
-            assertThat(actualParticipation.getPresentationScore()).as("Presentation score was set to " + input).isEqualTo(input);
+            assertThat(actualParticipation.presentationScore()).as("Presentation score was set to " + input).isEqualTo(input);
         }
     }
 
@@ -1413,18 +1417,18 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         // SHOULD ADD FIRST PRESENTATION GRADE
         var dto1 = new ParticipationUpdateDTO(participation1.getId(), textExercise.getId(), 100.0);
 
-        var actualParticipation1 = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto1, StudentParticipation.class,
+        var actualParticipation1 = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto1, StudentParticipationDTO.class,
                 HttpStatus.OK);
         assertThat(actualParticipation1).as("The participation was updated").isNotNull();
-        assertThat(actualParticipation1.getPresentationScore()).as("Presentation score was set to 100").isEqualTo(100.0);
+        assertThat(actualParticipation1.presentationScore()).as("Presentation score was set to 100").isEqualTo(100.0);
 
         // SHOULD UPDATE FIRST PRESENTATION GRADE
         var dto1Update = new ParticipationUpdateDTO(participation1.getId(), textExercise.getId(), 80.0);
 
-        actualParticipation1 = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto1Update, StudentParticipation.class,
+        actualParticipation1 = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto1Update, StudentParticipationDTO.class,
                 HttpStatus.OK);
         assertThat(actualParticipation1).as("The participation was updated").isNotNull();
-        assertThat(actualParticipation1.getPresentationScore()).as("Presentation score was set to 80").isEqualTo(80.0);
+        assertThat(actualParticipation1.presentationScore()).as("Presentation score was set to 80").isEqualTo(80.0);
 
         // SHOULD NOT ADD SECOND PRESENTATION GRADE
         StudentParticipation participation2 = ParticipationFactory.generateStudentParticipation(InitializationState.INITIALIZED, modelingExercise,
@@ -1488,10 +1492,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         final var participationsToUpdate = new DueDateUpdateDTOList((StudentParticipation) submission.getParticipation());
         final var response = request.putWithResponseBodyList("/api/exercise/exercises/%d/participations/update-individual-due-date".formatted(exercise.getId()),
-                participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
+                participationsToUpdate, StudentParticipationDTO.class, HttpStatus.OK);
 
         assertThat(response).hasSize(1);
-        assertThat(response.getFirst().getIndividualDueDate()).isCloseTo(submission.getParticipation().getIndividualDueDate(), HalfSecond());
+        assertThat(response.getFirst().individualDueDate()).isCloseTo(submission.getParticipation().getIndividualDueDate(), HalfSecond());
 
         verify(programmingExerciseScheduleService, never()).updateScheduling(any());
     }
@@ -1513,10 +1517,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         final var participationsToUpdate = new DueDateUpdateDTOList(participation, participation2);
         final var response = request.putWithResponseBodyList("/api/exercise/exercises/%d/participations/update-individual-due-date".formatted(exercise.getId()),
-                participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
+                participationsToUpdate, StudentParticipationDTO.class, HttpStatus.OK);
 
         assertThat(response).hasSize(1);
-        assertThat(response.getFirst().getIndividualDueDate()).isCloseTo(participation.getIndividualDueDate(), HalfSecond());
+        assertThat(response.getFirst().individualDueDate()).isCloseTo(participation.getIndividualDueDate(), HalfSecond());
 
         verify(programmingExerciseScheduleService).updateScheduling(exercise);
     }
@@ -1532,7 +1536,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         final var participation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
         final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         final var response = request.putWithResponseBodyList("/api/exercise/exercises/%d/participations/update-individual-due-date".formatted(exercise.getId()),
-                participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
+                participationsToUpdate, StudentParticipationDTO.class, HttpStatus.OK);
 
         assertThat(response).isEmpty();
         verify(programmingExerciseScheduleService, never()).updateScheduling(exercise);
@@ -1551,7 +1555,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         final var response = request.putWithResponseBodyList("/api/exercise/exercises/%d/participations/update-individual-due-date".formatted(exercise.getId()),
-                participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
+                participationsToUpdate, StudentParticipationDTO.class, HttpStatus.OK);
 
         assertThat(response).isEmpty(); // individual due date should remain null
         verify(programmingExerciseScheduleService, never()).updateScheduling(exercise);
@@ -1573,7 +1577,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         final var response = request.putWithResponseBodyList("/api/exercise/exercises/%d/participations/update-individual-due-date".formatted(exercise.getId()),
-                participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
+                participationsToUpdate, StudentParticipationDTO.class, HttpStatus.OK);
 
         assertThat(response).hasSize(1);
         verify(programmingExerciseScheduleService).updateScheduling(exercise);
@@ -1596,7 +1600,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         final var response = request.putWithResponseBodyList("/api/exercise/exercises/%d/participations/update-individual-due-date".formatted(exercise.getId()),
-                participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
+                participationsToUpdate, StudentParticipationDTO.class, HttpStatus.OK);
 
         assertThat(response).hasSize(1);
         verify(programmingExerciseScheduleService).updateScheduling(exercise);
@@ -1632,12 +1636,12 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         submission.addResult(latestResult);
         submissionRepository.save(submission);
 
-        var actualParticipation = request.get("/api/exercise/participations/" + participation.getId() + "/with-latest-result", HttpStatus.OK, StudentParticipation.class);
+        var actualParticipation = request.get("/api/exercise/participations/" + participation.getId() + "/with-latest-result", HttpStatus.OK, StudentParticipationDTO.class);
 
         assertThat(actualParticipation).isNotNull();
-        assertThat(actualParticipation.getSubmissions()).as("Only latest submission is returned").containsExactly(submission);
-        assertThat(participationUtilService.getResultsForParticipation(actualParticipation)).as("All results of the latest submission are returned")
-                .containsExactlyInAnyOrder(firstResult, latestResult);
+        assertThat(actualParticipation.submissions()).as("Only latest submission is returned").extracting(ParticipationSubmissionDTO::id).containsExactly(submission.getId());
+        assertThat(actualParticipation.submissions().getFirst().results()).as("All results of the latest submission are returned").extracting(ParticipationSubmissionResultDTO::id)
+                .containsExactlyInAnyOrder(firstResult.getId(), latestResult.getId());
     }
 
     @Test
@@ -1663,11 +1667,11 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         }
         jenkinsRequestMockProvider.enableMockingOfRequests();
         mockDeleteBuildPlan(programmingExercise.getProjectKey(), participation.getBuildPlanId(), false);
-        var actualParticipation = request.putWithResponseBody("/api/exercise/participations/" + participation.getId() + "/cleanup-build-plan", null, Participation.class,
+        var actualParticipation = request.putWithResponseBody("/api/exercise/participations/" + participation.getId() + "/cleanup-build-plan", null, StudentParticipationDTO.class,
                 HttpStatus.OK);
-        assertThat(actualParticipation).isEqualTo(participation);
-        assertThat(actualParticipation.getInitializationState()).isEqualTo(!practiceMode && afterDueDate ? InitializationState.FINISHED : InitializationState.INACTIVE);
-        assertThat(((ProgrammingExerciseStudentParticipation) actualParticipation).getBuildPlanId()).isNull();
+        assertThat(actualParticipation.id()).isEqualTo(participation.getId());
+        assertThat(actualParticipation.initializationState()).isEqualTo(!practiceMode && afterDueDate ? InitializationState.FINISHED : InitializationState.INACTIVE);
+        assertThat(actualParticipation.buildPlanId()).isNull();
     }
 
     @Test
@@ -2010,7 +2014,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("text");
 
         request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/" + practiceParticipation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
     }
 
     @Test
@@ -2030,7 +2034,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("modeling");
 
         request.putWithResponseBody("/api/exercise/exercises/" + modelingExercise.getId() + "/participations/" + practiceParticipation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
@@ -76,6 +76,7 @@ import de.tum.cit.aet.artemis.exercise.dto.ParticipationSubmissionDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationSubmissionResultDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationUpdateDTO;
 import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionResponseDTO;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
 import de.tum.cit.aet.artemis.exercise.repository.TeamRepository;
@@ -1650,8 +1651,12 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         var participation = participationUtilService.createAndSaveParticipationForExercise(textExercise, TEST_PREFIX + "student1");
         var submission1 = participationUtilService.addSubmission(participation, ParticipationFactory.generateTextSubmission("text", Language.ENGLISH, true));
         var submission2 = participationUtilService.addSubmission(participation, ParticipationFactory.generateTextSubmission("text2", Language.ENGLISH, true));
-        var submissions = request.getList("/api/exercise/participations/" + participation.getId() + "/submissions", HttpStatus.OK, Submission.class);
-        assertThat(submissions).contains(submission1, submission2);
+        var submissions = request.getList("/api/exercise/participations/" + participation.getId() + "/submissions", HttpStatus.OK, SubmissionResponseDTO.class);
+        assertThat(submissions).extracting(SubmissionResponseDTO::id).containsExactlyInAnyOrder(submission1.getId(), submission2.getId());
+        assertThat(submissions).allSatisfy(submission -> {
+            assertThat(submission.submissionExerciseType()).isEqualTo("text");
+            assertThat(submission.participation().submissions()).isNull();
+        });
     }
 
     @ParameterizedTest

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
@@ -72,7 +72,10 @@ import de.tum.cit.aet.artemis.exercise.dto.ParticipationManagementDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationScoreDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationScoreSearchDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationSearchDTO;
+import de.tum.cit.aet.artemis.exercise.dto.ParticipationSubmissionDTO;
+import de.tum.cit.aet.artemis.exercise.dto.ParticipationSubmissionResultDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationUpdateDTO;
+import de.tum.cit.aet.artemis.exercise.dto.StudentParticipationDTO;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
 import de.tum.cit.aet.artemis.exercise.repository.TeamRepository;
@@ -257,10 +260,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void participateInModelingExercise() throws Exception {
         URI location = request.post("/api/exercise/exercises/" + modelingExercise.getId() + "/participations", null, HttpStatus.CREATED);
 
-        StudentParticipation participation = request.get(location.getPath(), HttpStatus.OK, StudentParticipation.class);
-        assertThat(participation.getExercise()).as("participated in correct exercise").isEqualTo(modelingExercise);
-        assertThat(participation.getStudent()).as("Student got set").isNotNull();
-        assertThat(participation.getParticipantIdentifier()).as("Correct student got set").isEqualTo(TEST_PREFIX + "student1");
+        StudentParticipationDTO participation = request.get(location.getPath(), HttpStatus.OK, StudentParticipationDTO.class);
+        assertThat(participation.exercise().id()).as("participated in correct exercise").isEqualTo(modelingExercise.getId());
+        assertThat(participation.student()).as("Student got set").isNotNull();
+        assertThat(participation.participantIdentifier()).as("Correct student got set").isEqualTo(TEST_PREFIX + "student1");
         Participation storedParticipation = participationRepo
                 .findWithEagerSubmissionsByExerciseIdAndStudentLoginAndTestRun(modelingExercise.getId(), TEST_PREFIX + "student1", false).orElseThrow();
         assertThat(storedParticipation.getSubmissions()).as("submission was initialized").hasSize(1);
@@ -272,10 +275,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void participateInTextExercise() throws Exception {
         URI location = request.post("/api/exercise/exercises/" + textExercise.getId() + "/participations", null, HttpStatus.CREATED);
 
-        StudentParticipation participation = request.get(location.getPath(), HttpStatus.OK, StudentParticipation.class);
-        assertThat(participation.getExercise()).as("participated in correct exercise").isEqualTo(textExercise);
-        assertThat(participation.getStudent()).as("Student got set").isNotNull();
-        assertThat(participation.getParticipantIdentifier()).as("Correct student got set").isEqualTo(TEST_PREFIX + "student2");
+        StudentParticipationDTO participation = request.get(location.getPath(), HttpStatus.OK, StudentParticipationDTO.class);
+        assertThat(participation.exercise().id()).as("participated in correct exercise").isEqualTo(textExercise.getId());
+        assertThat(participation.student()).as("Student got set").isNotNull();
+        assertThat(participation.participantIdentifier()).as("Correct student got set").isEqualTo(TEST_PREFIX + "student2");
         Participation storedParticipation = participationRepo.findWithEagerSubmissionsByExerciseIdAndStudentLoginAndTestRun(textExercise.getId(), TEST_PREFIX + "student2", false)
                 .orElseThrow();
         assertThat(storedParticipation.getSubmissions()).as("submission was initialized").hasSize(1);
@@ -354,13 +357,12 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         textExercise.setDueDate(ZonedDateTime.now().plusHours(2));
         exerciseRepository.save(textExercise);
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", null, StudentParticipation.class,
-                HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
 
         assertThat(participation).isNotNull();
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
-        Set<User> participationUsers = participation.getStudents();
-        assertThat(participationUsers).contains(user);
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
     }
 
     @Test
@@ -383,12 +385,11 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         examTextExercise.getExam().setEndDate(ZonedDateTime.now().plusHours(1));
         examTestRepository.save(examTextExercise.getExam());
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + examTextExercise.getId() + "/participations", null,
-                StudentParticipation.class, HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + examTextExercise.getId() + "/participations", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
         assertThat(participation).isNotNull();
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
-        Set<User> participationUsers = participation.getStudents();
-        assertThat(participationUsers).contains(user);
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
     }
 
     /**
@@ -437,13 +438,12 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         studentExam.setWorkingTime(threeHours);
         studentExamRepository.save(studentExam);
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + examTextExercise.getId() + "/participations", null,
-                StudentParticipation.class, HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + examTextExercise.getId() + "/participations", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
 
         assertThat(participation).isNotNull();
         User user = userUtilService.getUserByLogin(studentLogin);
-        Set<User> participationUsers = participation.getStudents();
-        assertThat(participationUsers).contains(user);
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
     }
 
     /**
@@ -547,11 +547,12 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         mockConnectorRequestsForStartPractice(programmingExercise, TEST_PREFIX + "student1");
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations/practice", null,
-                StudentParticipation.class, HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations/practice", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
         assertThat(participation).isNotNull();
-        assertThat(participation.isPracticeMode()).isTrue();
-        assertThat(participation.getStudent()).contains(user);
+        assertThat(participation.testRun()).isTrue();
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
+        assertThat(participation.repositoryUri()).isNotBlank();
     }
 
     @Test
@@ -562,11 +563,12 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         prepareMocksForProgrammingExercise();
         mockConnectorRequestsForStartParticipation(programmingExercise, TEST_PREFIX + "student1", Set.of(user), true);
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations", null,
-                StudentParticipation.class, HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
         assertThat(participation).isNotNull();
-        assertThat(participation.isPracticeMode()).isFalse();
-        assertThat(participation.getStudent()).contains(user);
+        assertThat(participation.testRun()).isFalse();
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
+        assertThat(participation.repositoryUri()).isNotBlank();
     }
 
     @Test
@@ -583,19 +585,19 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         textExercise.setDueDate(ZonedDateTime.now().minusHours(1));
         exerciseRepository.save(textExercise);
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
-                StudentParticipation.class, HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
         assertThat(participation).isNotNull();
-        assertThat(participation.isPracticeMode()).isTrue();
-        assertThat(participation.getAttempt()).isEqualTo(1);
+        assertThat(participation.testRun()).isTrue();
+        assertThat(participationRepo.findByIdElseThrow(participation.id()).getAttempt()).isEqualTo(1);
 
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
-        assertThat(participation.getStudent()).contains(user);
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
 
-        List<Submission> submissions = submissionRepository.findAllByParticipationId(participation.getId());
+        List<Submission> submissions = submissionRepository.findAllByParticipationId(participation.id());
         assertThat(submissions).hasSize(1);
         Submission submission = submissions.getFirst();
-        assertThat(submission.getParticipation().getId()).isEqualTo(participation.getId());
+        assertThat(submission.getParticipation().getId()).isEqualTo(participation.id());
         assertThat(submission).isInstanceOf(TextSubmission.class);
         assertThat(((TextSubmission) submission).getText()).isNull();
     }
@@ -606,19 +608,19 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         modelingExercise.setDueDate(ZonedDateTime.now().minusHours(1));
         exerciseRepository.save(modelingExercise);
 
-        StudentParticipation participation = request.postWithResponseBody("/api/exercise/exercises/" + modelingExercise.getId() + "/participations/practice", null,
-                StudentParticipation.class, HttpStatus.CREATED);
+        StudentParticipationDTO participation = request.postWithResponseBody("/api/exercise/exercises/" + modelingExercise.getId() + "/participations/practice", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
         assertThat(participation).isNotNull();
-        assertThat(participation.isPracticeMode()).isTrue();
-        assertThat(participation.getAttempt()).isEqualTo(1);
+        assertThat(participation.testRun()).isTrue();
+        assertThat(participationRepo.findByIdElseThrow(participation.id()).getAttempt()).isEqualTo(1);
 
         User user = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
-        assertThat(participation.getStudent()).contains(user);
+        assertThat(participation.student().getId()).isEqualTo(user.getId());
 
-        List<Submission> submissions = submissionRepository.findAllByParticipationId(participation.getId());
+        List<Submission> submissions = submissionRepository.findAllByParticipationId(participation.id());
         assertThat(submissions).hasSize(1);
         Submission submission = submissions.getFirst();
-        assertThat(submission.getParticipation().getId()).isEqualTo(participation.getId());
+        assertThat(submission.getParticipation().getId()).isEqualTo(participation.id());
         assertThat(submission).isInstanceOf(ModelingSubmission.class);
         assertThat(((ModelingSubmission) submission).getModel()).isNull();
     }
@@ -648,9 +650,9 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         textExercise.setDueDate(ZonedDateTime.now().minusHours(1));
         exerciseRepository.save(textExercise);
 
-        StudentParticipation practiceParticipation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
-                StudentParticipation.class, HttpStatus.CREATED);
-        assertThat(practiceParticipation.isPracticeMode()).isTrue();
+        StudentParticipationDTO practiceParticipation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
+        assertThat(practiceParticipation.testRun()).isTrue();
 
         // Now reset due date and start a graded participation — should not return the
         // practice one
@@ -658,11 +660,11 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         exerciseRepository.save(textExercise);
 
         URI location = request.post("/api/exercise/exercises/" + textExercise.getId() + "/participations", null, HttpStatus.CREATED);
-        StudentParticipation gradedParticipation = request.get(location.getPath(), HttpStatus.OK, StudentParticipation.class);
+        StudentParticipationDTO gradedParticipation = request.get(location.getPath(), HttpStatus.OK, StudentParticipationDTO.class);
 
         assertThat(gradedParticipation).isNotNull();
-        assertThat(gradedParticipation.isPracticeMode()).isFalse();
-        assertThat(gradedParticipation.getId()).isNotEqualTo(practiceParticipation.getId());
+        assertThat(gradedParticipation.testRun()).isFalse();
+        assertThat(gradedParticipation.id()).isNotEqualTo(practiceParticipation.id());
     }
 
     @Test
@@ -679,14 +681,14 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         textExercise.setDueDate(ZonedDateTime.now().minusHours(1));
         exerciseRepository.save(textExercise);
 
-        StudentParticipation firstParticipation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
-                StudentParticipation.class, HttpStatus.CREATED);
-        assertThat(firstParticipation.isPracticeMode()).isTrue();
+        StudentParticipationDTO firstParticipation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
+        assertThat(firstParticipation.testRun()).isTrue();
 
         // Starting practice mode again should return the same participation
-        StudentParticipation secondParticipation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
-                StudentParticipation.class, HttpStatus.CREATED);
-        assertThat(secondParticipation.getId()).isEqualTo(firstParticipation.getId());
+        StudentParticipationDTO secondParticipation = request.postWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/practice", null,
+                StudentParticipationDTO.class, HttpStatus.CREATED);
+        assertThat(secondParticipation.id()).isEqualTo(firstParticipation.id());
     }
 
     @Test
@@ -842,7 +844,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(result2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations/" + participation.getId() + "/request-feedback", null,
-                ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(programmingMessagingService, timeout(2000).times(2)).notifyUserAboutNewResult(resultCaptor.capture(), any());
 
@@ -897,7 +899,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(result2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations/" + participation.getId() + "/request-feedback", null,
-                ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(programmingMessagingService, timeout(2000).times(2)).notifyUserAboutNewResult(resultCaptor.capture(), any());
 
@@ -939,7 +941,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(resultText2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/" + textParticipation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(resultWebsocketService, timeout(2000).times(2)).broadcastNewResult(any(), resultCaptor.capture());
 
@@ -984,7 +986,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         participationUtilService.addResultToSubmission(AssessmentType.MANUAL, ZonedDateTime.now(), submission);
 
         request.putWithResponseBody("/api/exercise/exercises/" + teamExercise.getId() + "/participations/" + participation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(resultWebsocketService, timeout(2000).times(2)).broadcastNewResult(any(), resultCaptor.capture());
 
@@ -1031,7 +1033,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(result2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + teamExercise.getId() + "/participations/" + participation.getId() + "/request-feedback", null,
-                ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(programmingMessagingService, timeout(2000).times(2)).notifyUserAboutNewResult(resultCaptor.capture(), any());
 
@@ -1072,7 +1074,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(resultModeling2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + modelingExercise.getId() + "/participations/" + modelingParticipation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(resultWebsocketService, timeout(2000).times(2)).broadcastNewResult(any(), resultCaptor.capture());
 
@@ -1118,7 +1120,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         participationUtilService.addResultToSubmission(AssessmentType.MANUAL, ZonedDateTime.now(), submission);
 
         request.putWithResponseBody("/api/exercise/exercises/" + teamExercise.getId() + "/participations/" + participation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(resultWebsocketService, timeout(2000).times(2)).broadcastNewResult(any(), resultCaptor.capture());
 
@@ -1152,7 +1154,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(result2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + programmingExercise.getId() + "/participations/" + participation.getId() + "/request-feedback", null,
-                ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(programmingMessagingService, timeout(2000).times(2)).notifyUserAboutNewResult(resultCaptor.capture(), any());
 
@@ -1193,7 +1195,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(resultText2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/" + textParticipation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(resultWebsocketService, timeout(2000).times(2)).broadcastNewResult(any(), resultCaptor.capture());
 
@@ -1231,7 +1233,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         resultRepository.save(resultModeling2);
 
         request.putWithResponseBody("/api/exercise/exercises/" + modelingExercise.getId() + "/participations/" + modelingParticipation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
 
         verify(resultWebsocketService, timeout(2000).times(2)).broadcastNewResult(any(), resultCaptor.capture());
 
@@ -1251,8 +1253,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         var updatedParticipation = request.putWithResponseBody(
                 "/api/exercise/exercises/" + programmingExercise.getId() + "/participations/" + participation.getId() + "/resume-programming-participation", null,
-                ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
-        assertThat(updatedParticipation.getInitializationState()).isEqualTo(InitializationState.INITIALIZED);
+                StudentParticipationDTO.class, HttpStatus.OK);
+        assertThat(updatedParticipation.initializationState()).isEqualTo(InitializationState.INITIALIZED);
+        assertThat(updatedParticipation.repositoryUri()).isEqualTo(participation.getRepositoryUri());
+        assertThat(updatedParticipation.exercise().id()).isEqualTo(programmingExercise.getId());
     }
 
     @Test
@@ -1286,10 +1290,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         participation.setPresentationScore(1.);
         participation = participationRepo.save(participation);
         var dto = new ParticipationUpdateDTO(participation.getId(), textExercise.getId(), null);
-        var actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto, StudentParticipation.class,
+        var actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto, StudentParticipationDTO.class,
                 HttpStatus.OK);
         assertThat(actualParticipation).as("The participation was updated").isNotNull();
-        assertThat(actualParticipation.getPresentationScore()).as("Presentation score was set to null").isNull();
+        assertThat(actualParticipation.presentationScore()).as("Presentation score was set to null").isNull();
     }
 
     @Test
@@ -1311,10 +1315,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
                 userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
         participation = participationRepo.save(participation);
         var dto = new ParticipationUpdateDTO(participation.getId(), textExercise.getId(), 2.);
-        var actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto, StudentParticipation.class,
+        var actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto, StudentParticipationDTO.class,
                 HttpStatus.OK);
         assertThat(actualParticipation).as("The participation was updated").isNotNull();
-        assertThat(actualParticipation.getPresentationScore()).as("Presentation score was set to 1").isEqualTo(1.);
+        assertThat(actualParticipation.presentationScore()).as("Presentation score was set to 1").isEqualTo(1.);
     }
 
     @ParameterizedTest
@@ -1340,10 +1344,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
             assertThat(actualParticipation).as("The participation was not updated").isNull();
         }
         else {
-            StudentParticipation actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto,
-                    StudentParticipation.class, HttpStatus.OK);
+            StudentParticipationDTO actualParticipation = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto,
+                    StudentParticipationDTO.class, HttpStatus.OK);
             assertThat(actualParticipation).as("The participation was updated").isNotNull();
-            assertThat(actualParticipation.getPresentationScore()).as("Presentation score was set to " + input).isEqualTo(input);
+            assertThat(actualParticipation.presentationScore()).as("Presentation score was set to " + input).isEqualTo(input);
         }
     }
 
@@ -1365,18 +1369,18 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         // SHOULD ADD FIRST PRESENTATION GRADE
         var dto1 = new ParticipationUpdateDTO(participation1.getId(), textExercise.getId(), 100.0);
 
-        var actualParticipation1 = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto1, StudentParticipation.class,
+        var actualParticipation1 = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto1, StudentParticipationDTO.class,
                 HttpStatus.OK);
         assertThat(actualParticipation1).as("The participation was updated").isNotNull();
-        assertThat(actualParticipation1.getPresentationScore()).as("Presentation score was set to 100").isEqualTo(100.0);
+        assertThat(actualParticipation1.presentationScore()).as("Presentation score was set to 100").isEqualTo(100.0);
 
         // SHOULD UPDATE FIRST PRESENTATION GRADE
         var dto1Update = new ParticipationUpdateDTO(participation1.getId(), textExercise.getId(), 80.0);
 
-        actualParticipation1 = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto1Update, StudentParticipation.class,
+        actualParticipation1 = request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations", dto1Update, StudentParticipationDTO.class,
                 HttpStatus.OK);
         assertThat(actualParticipation1).as("The participation was updated").isNotNull();
-        assertThat(actualParticipation1.getPresentationScore()).as("Presentation score was set to 80").isEqualTo(80.0);
+        assertThat(actualParticipation1.presentationScore()).as("Presentation score was set to 80").isEqualTo(80.0);
 
         // SHOULD NOT ADD SECOND PRESENTATION GRADE
         StudentParticipation participation2 = ParticipationFactory.generateStudentParticipation(InitializationState.INITIALIZED, modelingExercise,
@@ -1440,10 +1444,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         final var participationsToUpdate = new DueDateUpdateDTOList((StudentParticipation) submission.getParticipation());
         final var response = request.putWithResponseBodyList("/api/exercise/exercises/%d/participations/update-individual-due-date".formatted(exercise.getId()),
-                participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
+                participationsToUpdate, StudentParticipationDTO.class, HttpStatus.OK);
 
         assertThat(response).hasSize(1);
-        assertThat(response.getFirst().getIndividualDueDate()).isCloseTo(submission.getParticipation().getIndividualDueDate(), HalfSecond());
+        assertThat(response.getFirst().individualDueDate()).isCloseTo(submission.getParticipation().getIndividualDueDate(), HalfSecond());
 
         verify(programmingExerciseScheduleService, never()).updateScheduling(any());
     }
@@ -1465,10 +1469,10 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         final var participationsToUpdate = new DueDateUpdateDTOList(participation, participation2);
         final var response = request.putWithResponseBodyList("/api/exercise/exercises/%d/participations/update-individual-due-date".formatted(exercise.getId()),
-                participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
+                participationsToUpdate, StudentParticipationDTO.class, HttpStatus.OK);
 
         assertThat(response).hasSize(1);
-        assertThat(response.getFirst().getIndividualDueDate()).isCloseTo(participation.getIndividualDueDate(), HalfSecond());
+        assertThat(response.getFirst().individualDueDate()).isCloseTo(participation.getIndividualDueDate(), HalfSecond());
 
         verify(programmingExerciseScheduleService).updateScheduling(exercise);
     }
@@ -1484,7 +1488,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         final var participation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
         final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         final var response = request.putWithResponseBodyList("/api/exercise/exercises/%d/participations/update-individual-due-date".formatted(exercise.getId()),
-                participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
+                participationsToUpdate, StudentParticipationDTO.class, HttpStatus.OK);
 
         assertThat(response).isEmpty();
         verify(programmingExerciseScheduleService, never()).updateScheduling(exercise);
@@ -1503,7 +1507,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         final var response = request.putWithResponseBodyList("/api/exercise/exercises/%d/participations/update-individual-due-date".formatted(exercise.getId()),
-                participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
+                participationsToUpdate, StudentParticipationDTO.class, HttpStatus.OK);
 
         assertThat(response).isEmpty(); // individual due date should remain null
         verify(programmingExerciseScheduleService, never()).updateScheduling(exercise);
@@ -1525,7 +1529,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         final var response = request.putWithResponseBodyList("/api/exercise/exercises/%d/participations/update-individual-due-date".formatted(exercise.getId()),
-                participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
+                participationsToUpdate, StudentParticipationDTO.class, HttpStatus.OK);
 
         assertThat(response).hasSize(1);
         verify(programmingExerciseScheduleService).updateScheduling(exercise);
@@ -1548,7 +1552,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
 
         final var participationsToUpdate = new DueDateUpdateDTOList(participation);
         final var response = request.putWithResponseBodyList("/api/exercise/exercises/%d/participations/update-individual-due-date".formatted(exercise.getId()),
-                participationsToUpdate, StudentParticipation.class, HttpStatus.OK);
+                participationsToUpdate, StudentParticipationDTO.class, HttpStatus.OK);
 
         assertThat(response).hasSize(1);
         verify(programmingExerciseScheduleService).updateScheduling(exercise);
@@ -1576,11 +1580,12 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         result.submission(submission).setCompletionDate(ZonedDateTime.now().minusHours(2));
         result.setExerciseId(textExercise.getId());
         resultRepository.save(result);
-        var actualParticipation = request.get("/api/exercise/participations/" + participation.getId() + "/with-latest-result", HttpStatus.OK, StudentParticipation.class);
+        var actualParticipation = request.get("/api/exercise/participations/" + participation.getId() + "/with-latest-result", HttpStatus.OK, StudentParticipationDTO.class);
 
         assertThat(actualParticipation).isNotNull();
-        assertThat(actualParticipation.getSubmissions()).as("Only latest submission is returned").containsExactly(submission);
-        assertThat(participationUtilService.getResultsForParticipation(actualParticipation)).as("Only latest result is returned").containsExactly(result);
+        assertThat(actualParticipation.submissions()).as("Only latest submission is returned").extracting(ParticipationSubmissionDTO::id).containsExactly(submission.getId());
+        assertThat(actualParticipation.submissions().getFirst().results()).as("Only latest result is returned").extracting(ParticipationSubmissionResultDTO::id)
+                .containsExactly(result.getId());
     }
 
     @Test
@@ -1606,11 +1611,11 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         }
         jenkinsRequestMockProvider.enableMockingOfRequests();
         mockDeleteBuildPlan(programmingExercise.getProjectKey(), participation.getBuildPlanId(), false);
-        var actualParticipation = request.putWithResponseBody("/api/exercise/participations/" + participation.getId() + "/cleanup-build-plan", null, Participation.class,
+        var actualParticipation = request.putWithResponseBody("/api/exercise/participations/" + participation.getId() + "/cleanup-build-plan", null, StudentParticipationDTO.class,
                 HttpStatus.OK);
-        assertThat(actualParticipation).isEqualTo(participation);
-        assertThat(actualParticipation.getInitializationState()).isEqualTo(!practiceMode && afterDueDate ? InitializationState.FINISHED : InitializationState.INACTIVE);
-        assertThat(((ProgrammingExerciseStudentParticipation) actualParticipation).getBuildPlanId()).isNull();
+        assertThat(actualParticipation.id()).isEqualTo(participation.getId());
+        assertThat(actualParticipation.initializationState()).isEqualTo(!practiceMode && afterDueDate ? InitializationState.FINISHED : InitializationState.INACTIVE);
+        assertThat(actualParticipation.buildPlanId()).isNull();
     }
 
     @Test
@@ -1953,7 +1958,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("text");
 
         request.putWithResponseBody("/api/exercise/exercises/" + textExercise.getId() + "/participations/" + practiceParticipation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
     }
 
     @Test
@@ -1973,7 +1978,7 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         athenaRequestMockProvider.mockGetFeedbackSuggestionsAndExpect("modeling");
 
         request.putWithResponseBody("/api/exercise/exercises/" + modelingExercise.getId() + "/participations/" + practiceParticipation.getId() + "/request-feedback", null,
-                StudentParticipation.class, HttpStatus.OK);
+                StudentParticipationDTO.class, HttpStatus.OK);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/SubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/SubmissionIntegrationTest.java
@@ -21,6 +21,7 @@ import de.tum.cit.aet.artemis.core.util.PageableSearchUtilService;
 import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.SubmissionVersion;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionResponseDTO;
 import de.tum.cit.aet.artemis.exercise.dto.SubmissionVersionDTO;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
@@ -165,9 +166,14 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentBatc
         participationUtilService.addResultToSubmission(submission, AssessmentType.MANUAL, userUtilService.getUserByLogin(TEST_PREFIX + "instructor1"));
         SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureStudentParticipationSearch("");
 
-        var resultPage = request.getSearchResult("/api/exercise/exercises/" + textExercise.getId() + "/submissions-for-import", HttpStatus.OK, Submission.class,
+        var resultPage = request.getSearchResult("/api/exercise/exercises/" + textExercise.getId() + "/submissions-for-import", HttpStatus.OK, SubmissionResponseDTO.class,
                 pageableSearchUtilService.searchMapping(search));
         assertThat(resultPage.getResultsOnPage()).hasSize(1);
+        assertThat(resultPage.getNumberOfPages()).isEqualTo(1);
+        assertThat(resultPage.getResultsOnPage().getFirst().id()).isEqualTo(submission.getId());
+        assertThat(resultPage.getResultsOnPage().getFirst().text()).isEqualTo("submissionText");
+        assertThat(resultPage.getResultsOnPage().getFirst().participation().participantName()).isNotBlank();
+        assertThat(resultPage.getResultsOnPage().getFirst().results()).extracting(result -> result.id()).containsExactly(submission.getLatestResult().getId());
     }
 
     @Test
@@ -175,7 +181,7 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentBatc
     void testGetSubmissionsOnPageWithSize_exerciseNotFound() throws Exception {
         long randomExerciseId = UUID.nameUUIDFromBytes("test".getBytes()).getMostSignificantBits();
         SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureStudentParticipationSearch("");
-        request.getSearchResult("/api/exercise/exercises/" + randomExerciseId + "/submissions-for-import", HttpStatus.NOT_FOUND, Submission.class,
+        request.getSearchResult("/api/exercise/exercises/" + randomExerciseId + "/submissions-for-import", HttpStatus.NOT_FOUND, SubmissionResponseDTO.class,
                 pageableSearchUtilService.searchMapping(search));
     }
 
@@ -188,7 +194,7 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentBatc
         SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureStudentParticipationSearch("");
         User instructor = userUtilService.getUserByLogin(TEST_PREFIX + "instructor1");
         userUtilService.unenrollUserFromCourseByRole(instructor, course, CourseRole.INSTRUCTOR);
-        request.getSearchResult("/api/exercise/exercises/" + textExercise.getId() + "/submissions-for-import", HttpStatus.FORBIDDEN, Submission.class,
+        request.getSearchResult("/api/exercise/exercises/" + textExercise.getId() + "/submissions-for-import", HttpStatus.FORBIDDEN, SubmissionResponseDTO.class,
                 pageableSearchUtilService.searchMapping(search));
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/SubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/SubmissionIntegrationTest.java
@@ -20,6 +20,7 @@ import de.tum.cit.aet.artemis.core.util.PageableSearchUtilService;
 import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.SubmissionVersion;
+import de.tum.cit.aet.artemis.exercise.dto.SubmissionResponseDTO;
 import de.tum.cit.aet.artemis.exercise.dto.SubmissionVersionDTO;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
@@ -164,9 +165,14 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentBatc
         participationUtilService.addResultToSubmission(submission, AssessmentType.MANUAL, userUtilService.getUserByLogin(TEST_PREFIX + "instructor1"));
         SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureStudentParticipationSearch("");
 
-        var resultPage = request.getSearchResult("/api/exercise/exercises/" + textExercise.getId() + "/submissions-for-import", HttpStatus.OK, Submission.class,
+        var resultPage = request.getSearchResult("/api/exercise/exercises/" + textExercise.getId() + "/submissions-for-import", HttpStatus.OK, SubmissionResponseDTO.class,
                 pageableSearchUtilService.searchMapping(search));
         assertThat(resultPage.getResultsOnPage()).hasSize(1);
+        assertThat(resultPage.getNumberOfPages()).isEqualTo(1);
+        assertThat(resultPage.getResultsOnPage().getFirst().id()).isEqualTo(submission.getId());
+        assertThat(resultPage.getResultsOnPage().getFirst().text()).isEqualTo("submissionText");
+        assertThat(resultPage.getResultsOnPage().getFirst().participation().participantName()).isNotBlank();
+        assertThat(resultPage.getResultsOnPage().getFirst().results()).extracting(result -> result.id()).containsExactly(submission.getLatestResult().getId());
     }
 
     @Test
@@ -174,7 +180,7 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentBatc
     void testGetSubmissionsOnPageWithSize_exerciseNotFound() throws Exception {
         long randomExerciseId = UUID.nameUUIDFromBytes("test".getBytes()).getMostSignificantBits();
         SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureStudentParticipationSearch("");
-        request.getSearchResult("/api/exercise/exercises/" + randomExerciseId + "/submissions-for-import", HttpStatus.NOT_FOUND, Submission.class,
+        request.getSearchResult("/api/exercise/exercises/" + randomExerciseId + "/submissions-for-import", HttpStatus.NOT_FOUND, SubmissionResponseDTO.class,
                 pageableSearchUtilService.searchMapping(search));
     }
 
@@ -187,7 +193,7 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentBatc
         course.setInstructorGroupName("test");
         courseRepository.save(course);
         SearchTermPageableSearchDTO<String> search = pageableSearchUtilService.configureStudentParticipationSearch("");
-        request.getSearchResult("/api/exercise/exercises/" + textExercise.getId() + "/submissions-for-import", HttpStatus.FORBIDDEN, Submission.class,
+        request.getSearchResult("/api/exercise/exercises/" + textExercise.getId() + "/submissions-for-import", HttpStatus.FORBIDDEN, SubmissionResponseDTO.class,
                 pageableSearchUtilService.searchMapping(search));
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/SubmissionServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/SubmissionServiceTest.java
@@ -19,7 +19,6 @@ import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.test_repository.UserTestRepository;
 import de.tum.cit.aet.artemis.account.util.UserUtilService;
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
-import de.tum.cit.aet.artemis.assessment.domain.Complaint;
 import de.tum.cit.aet.artemis.assessment.domain.ComplaintType;
 import de.tum.cit.aet.artemis.assessment.domain.Feedback;
 import de.tum.cit.aet.artemis.assessment.domain.FeedbackType;
@@ -599,19 +598,18 @@ class SubmissionServiceTest extends AbstractSpringIntegrationIndependentBatchTes
 
         List<SubmissionWithComplaintDTO> dtoList = submissionService.getSubmissionsWithComplaintsForExercise(examTextExercise.getId(), true);
 
-        List<Submission> submissionsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::submission).filter(Objects::nonNull).toList();
-        List<Complaint> complaintsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::complaint).filter(Objects::nonNull).toList();
+        List<Long> submissionIdsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::submission).filter(Objects::nonNull).map(submission -> submission.id()).toList();
 
         assertThat(dtoList).hasSize(2);
-        assertThat(complaintsFromDTO).hasSize(2);
-        assertThat(submissionsFromDTO).isEqualTo(List.of(submissionWithComplaintSameTutor, submissionWithComplaintOtherTutor));
+        assertThat(dtoList).allSatisfy(dto -> assertThat(dto.complaint()).isNotNull());
+        assertThat(submissionIdsFromDTO).containsExactly(submissionWithComplaintSameTutor.getId(), submissionWithComplaintOtherTutor.getId());
 
         dtoList.forEach(dto -> {
-            if (dto.submission().equals(submissionWithComplaintSameTutor)) {
-                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().getId()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student2");
+            if (dto.submission().id().equals(submissionWithComplaintSameTutor.getId())) {
+                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().id()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student2");
             }
-            else if (dto.submission().equals(submissionWithComplaintOtherTutor)) {
-                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().getId()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student3");
+            else if (dto.submission().id().equals(submissionWithComplaintOtherTutor.getId())) {
+                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().id()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student3");
             }
             else {
                 fail("Unreachable statement");
@@ -634,15 +632,14 @@ class SubmissionServiceTest extends AbstractSpringIntegrationIndependentBatchTes
 
         List<SubmissionWithComplaintDTO> dtoList = submissionService.getSubmissionsWithComplaintsForExercise(examTextExercise.getId(), false);
 
-        List<Submission> submissionsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::submission).filter(Objects::nonNull).toList();
-        List<Complaint> complaintsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::complaint).filter(Objects::nonNull).toList();
+        List<Long> submissionIdsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::submission).filter(Objects::nonNull).map(submission -> submission.id()).toList();
 
         assertThat(dtoList).hasSize(1);
-        assertThat(complaintsFromDTO).hasSize(1);
-        assertThat(submissionsFromDTO).isEqualTo(List.of(submissionWithComplaintOtherTutor));
+        assertThat(dtoList).allSatisfy(dto -> assertThat(dto.complaint()).isNotNull());
+        assertThat(submissionIdsFromDTO).containsExactly(submissionWithComplaintOtherTutor.getId());
         dtoList.forEach(dto -> {
-            if (dto.submission().equals(submissionWithComplaintOtherTutor)) {
-                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().getId()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student3");
+            if (dto.submission().id().equals(submissionWithComplaintOtherTutor.getId())) {
+                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().id()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student3");
             }
             else {
                 fail("Unreachable statement");
@@ -665,15 +662,14 @@ class SubmissionServiceTest extends AbstractSpringIntegrationIndependentBatchTes
 
         List<SubmissionWithComplaintDTO> dtoList = submissionService.getSubmissionsWithMoreFeedbackRequestsForExercise(examTextExercise.getId());
 
-        List<Submission> submissionsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::submission).filter(Objects::nonNull).toList();
-        List<Complaint> requestsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::complaint).filter(Objects::nonNull).toList();
+        List<Long> submissionIdsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::submission).filter(Objects::nonNull).map(submission -> submission.id()).toList();
 
         assertThat(dtoList).hasSize(1);
-        assertThat(requestsFromDTO).hasSize(1);
-        assertThat(submissionsFromDTO).isEqualTo(List.of(submissionWithRequestSameTutor));
+        assertThat(dtoList).allSatisfy(dto -> assertThat(dto.complaint()).isNotNull());
+        assertThat(submissionIdsFromDTO).containsExactly(submissionWithRequestSameTutor.getId());
         dtoList.forEach(dto -> {
-            if (dto.submission().equals(submissionWithRequestSameTutor)) {
-                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().getId()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student2");
+            if (dto.submission().id().equals(submissionWithRequestSameTutor.getId())) {
+                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().id()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student2");
             }
             else {
                 fail("Unreachable statement");

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/SubmissionServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/SubmissionServiceTest.java
@@ -19,7 +19,6 @@ import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.test_repository.UserTestRepository;
 import de.tum.cit.aet.artemis.account.util.UserUtilService;
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
-import de.tum.cit.aet.artemis.assessment.domain.Complaint;
 import de.tum.cit.aet.artemis.assessment.domain.ComplaintType;
 import de.tum.cit.aet.artemis.assessment.domain.Feedback;
 import de.tum.cit.aet.artemis.assessment.domain.FeedbackType;
@@ -601,19 +600,18 @@ class SubmissionServiceTest extends AbstractSpringIntegrationIndependentBatchTes
 
         List<SubmissionWithComplaintDTO> dtoList = submissionService.getSubmissionsWithComplaintsForExercise(examTextExercise.getId(), true);
 
-        List<Submission> submissionsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::submission).filter(Objects::nonNull).toList();
-        List<Complaint> complaintsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::complaint).filter(Objects::nonNull).toList();
+        List<Long> submissionIdsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::submission).filter(Objects::nonNull).map(submission -> submission.id()).toList();
 
         assertThat(dtoList).hasSize(2);
-        assertThat(complaintsFromDTO).hasSize(2);
-        assertThat(submissionsFromDTO).isEqualTo(List.of(submissionWithComplaintSameTutor, submissionWithComplaintOtherTutor));
+        assertThat(dtoList).allSatisfy(dto -> assertThat(dto.complaint()).isNotNull());
+        assertThat(submissionIdsFromDTO).containsExactly(submissionWithComplaintSameTutor.getId(), submissionWithComplaintOtherTutor.getId());
 
         dtoList.forEach(dto -> {
-            if (dto.submission().equals(submissionWithComplaintSameTutor)) {
-                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().getId()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student2");
+            if (dto.submission().id().equals(submissionWithComplaintSameTutor.getId())) {
+                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().id()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student2");
             }
-            else if (dto.submission().equals(submissionWithComplaintOtherTutor)) {
-                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().getId()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student3");
+            else if (dto.submission().id().equals(submissionWithComplaintOtherTutor.getId())) {
+                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().id()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student3");
             }
             else {
                 fail("Unreachable statement");
@@ -636,15 +634,14 @@ class SubmissionServiceTest extends AbstractSpringIntegrationIndependentBatchTes
 
         List<SubmissionWithComplaintDTO> dtoList = submissionService.getSubmissionsWithComplaintsForExercise(examTextExercise.getId(), false);
 
-        List<Submission> submissionsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::submission).filter(Objects::nonNull).toList();
-        List<Complaint> complaintsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::complaint).filter(Objects::nonNull).toList();
+        List<Long> submissionIdsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::submission).filter(Objects::nonNull).map(submission -> submission.id()).toList();
 
         assertThat(dtoList).hasSize(1);
-        assertThat(complaintsFromDTO).hasSize(1);
-        assertThat(submissionsFromDTO).isEqualTo(List.of(submissionWithComplaintOtherTutor));
+        assertThat(dtoList).allSatisfy(dto -> assertThat(dto.complaint()).isNotNull());
+        assertThat(submissionIdsFromDTO).containsExactly(submissionWithComplaintOtherTutor.getId());
         dtoList.forEach(dto -> {
-            if (dto.submission().equals(submissionWithComplaintOtherTutor)) {
-                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().getId()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student3");
+            if (dto.submission().id().equals(submissionWithComplaintOtherTutor.getId())) {
+                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().id()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student3");
             }
             else {
                 fail("Unreachable statement");
@@ -667,15 +664,14 @@ class SubmissionServiceTest extends AbstractSpringIntegrationIndependentBatchTes
 
         List<SubmissionWithComplaintDTO> dtoList = submissionService.getSubmissionsWithMoreFeedbackRequestsForExercise(examTextExercise.getId());
 
-        List<Submission> submissionsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::submission).filter(Objects::nonNull).toList();
-        List<Complaint> requestsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::complaint).filter(Objects::nonNull).toList();
+        List<Long> submissionIdsFromDTO = dtoList.stream().map(SubmissionWithComplaintDTO::submission).filter(Objects::nonNull).map(submission -> submission.id()).toList();
 
         assertThat(dtoList).hasSize(1);
-        assertThat(requestsFromDTO).hasSize(1);
-        assertThat(submissionsFromDTO).isEqualTo(List.of(submissionWithRequestSameTutor));
+        assertThat(dtoList).allSatisfy(dto -> assertThat(dto.complaint()).isNotNull());
+        assertThat(submissionIdsFromDTO).containsExactly(submissionWithRequestSameTutor.getId());
         dtoList.forEach(dto -> {
-            if (dto.submission().equals(submissionWithRequestSameTutor)) {
-                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().getId()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student2");
+            if (dto.submission().id().equals(submissionWithRequestSameTutor.getId())) {
+                assertThat(complaintRepository.findByResultSubmissionId(dto.submission().id()).orElseThrow().getStudent().getLogin()).isEqualTo(TEST_PREFIX + "student2");
             }
             else {
                 fail("Unreachable statement");

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextSubmissionIntegrationTest.java
@@ -468,7 +468,7 @@ class TextSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
         assertThat(submission.participation().initializationState()).isEqualTo(InitializationState.FINISHED);
         // The save/submit response must carry the (owning) student so the client can verify participation ownership.
         assertThat(submission.participation().student()).as("submit response includes the owning student").isNotNull();
-        assertThat(submission.participation().student().login()).isEqualTo(TEST_PREFIX + "student1");
+        assertThat(submission.participation().student().getLogin()).isEqualTo(TEST_PREFIX + "student1");
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextSubmissionIntegrationTest.java
@@ -466,7 +466,7 @@ class TextSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
         assertThat(submission.participation().initializationState()).isEqualTo(InitializationState.FINISHED);
         // The save/submit response must carry the (owning) student so the client can verify participation ownership.
         assertThat(submission.participation().student()).as("submit response includes the owning student").isNotNull();
-        assertThat(submission.participation().student().login()).isEqualTo(TEST_PREFIX + "student1");
+        assertThat(submission.participation().student().getLogin()).isEqualTo(TEST_PREFIX + "student1");
     }
 
     @Test

--- a/src/test/playwright/support/commands.ts
+++ b/src/test/playwright/support/commands.ts
@@ -1,6 +1,6 @@
 import { UserCredentials } from './users';
 import { Locator, Page, expect } from '@playwright/test';
-import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
+import { StudentParticipationDTO } from 'app/exercise/shared/entities/participation/student-participation.dto';
 import { ExerciseAPIRequests } from './requests/ExerciseAPIRequests';
 import { BUILD_FINISH_TIMEOUT, POLLING_INTERVAL } from './timeouts';
 
@@ -342,7 +342,7 @@ export class Commands {
         timeout: number = BUILD_FINISH_TIMEOUT,
         minResults?: number,
     ) => {
-        let exerciseParticipation: StudentParticipation | undefined;
+        let exerciseParticipation: StudentParticipationDTO | undefined;
         let participationId: number | undefined;
         const startTime = Date.now();
 
@@ -362,7 +362,7 @@ export class Commands {
             throw new Error(`Timed out waiting for participation for exercise ${exerciseId}`);
         }
 
-        const countResults = (participation: StudentParticipation | undefined): number => {
+        const countResults = (participation: StudentParticipationDTO | undefined): number => {
             return participation?.submissions ? participation.submissions.reduce((sum, submission) => sum + (submission.results?.length ?? 0), 0) : 0;
         };
 
@@ -411,7 +411,7 @@ export class Commands {
         }
         const startTime = Date.now();
 
-        const getLatestResultId = (participation: StudentParticipation): number | undefined => {
+        const getLatestResultId = (participation: StudentParticipationDTO): number | undefined => {
             const ids = (participation.submissions ?? [])
                 .flatMap((s) => s.results ?? [])
                 .map((r) => r.id)

--- a/src/test/playwright/support/requests/ExerciseAPIRequests.ts
+++ b/src/test/playwright/support/requests/ExerciseAPIRequests.ts
@@ -34,7 +34,7 @@ import { ProgrammingExercise } from 'app/programming/shared/entities/programming
 import { FileUploadExercise } from 'app/fileupload/shared/entities/file-upload-exercise.model';
 import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 import { Exam } from 'app/exam/shared/entities/exam.model';
-import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
+import { StudentParticipationDTO } from 'app/exercise/shared/entities/participation/student-participation.dto';
 import { TeamAssignmentConfig } from 'app/exercise/shared/entities/team/team-assignment-config.model';
 import { ProgrammingExerciseSubmission } from '../pageobjects/exercises/programming/OnlineEditorPage';
 import { Fixtures } from '../../fixtures/fixtures';
@@ -722,7 +722,7 @@ export class ExerciseAPIRequests {
      * participation data (with latest result) via the per-participation endpoint.
      *
      * @param exerciseId - The ID of the exercise for which to retrieve the participation data.
-     * @returns A Promise<StudentParticipation> representing the student participation with latest result.
+     * @returns A Promise<StudentParticipationDTO> representing the student participation with latest result.
      * @throws Error if no participations are found for the exercise.
      */
     /**
@@ -774,7 +774,7 @@ export class ExerciseAPIRequests {
         }
     }
 
-    async getProgrammingExerciseParticipation(exerciseId: number): Promise<StudentParticipation> {
+    async getProgrammingExerciseParticipation(exerciseId: number): Promise<StudentParticipationDTO> {
         const pageResponse = await this.page.request.get(
             `api/exercise/exercises/${exerciseId}/participations/page?page=0&pageSize=1&sortingOrder=ASCENDING&sortedColumn=participantName&searchTerm=&filterProp=`,
         );
@@ -793,14 +793,14 @@ export class ExerciseAPIRequests {
      * who own the participation.
      *
      * @param participationId - The ID of the participation to retrieve.
-     * @returns A Promise<StudentParticipation> representing the student participation with latest results.
+     * @returns A Promise<StudentParticipationDTO> representing the student participation with latest results.
      */
-    async getParticipationWithLatestResult(participationId: number): Promise<StudentParticipation> {
+    async getParticipationWithLatestResult(participationId: number): Promise<StudentParticipationDTO> {
         const response = await this.page.request.get(`api/exercise/participations/${participationId}/with-latest-result`);
         if (!response.ok()) {
             throw new Error(`Failed to get participation ${participationId}: ${response.status()}`);
         }
-        return (await response.json()) as StudentParticipation;
+        return (await response.json()) as StudentParticipationDTO;
     }
 
     /**

--- a/src/test/playwright/support/requests/ExerciseAPIRequests.ts
+++ b/src/test/playwright/support/requests/ExerciseAPIRequests.ts
@@ -35,7 +35,7 @@ import { FileUploadExercise } from 'app/fileupload/shared/entities/file-upload-e
 import { FileUploadSubmission } from 'app/fileupload/shared/entities/file-upload-submission.model';
 import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 import { Exam } from 'app/exam/shared/entities/exam.model';
-import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
+import { StudentParticipationDTO } from 'app/exercise/shared/entities/participation/student-participation.dto';
 import { TeamAssignmentConfig } from 'app/exercise/shared/entities/team/team-assignment-config.model';
 import { ProgrammingExerciseSubmission } from '../pageobjects/exercises/programming/OnlineEditorPage';
 import { Fixtures } from '../../fixtures/fixtures';
@@ -779,7 +779,7 @@ export class ExerciseAPIRequests {
      * participation data (with latest result) via the per-participation endpoint.
      *
      * @param exerciseId - The ID of the exercise for which to retrieve the participation data.
-     * @returns A Promise<StudentParticipation> representing the student participation with latest result.
+     * @returns A Promise<StudentParticipationDTO> representing the student participation with latest result.
      * @throws Error if no participations are found for the exercise.
      */
     /**
@@ -831,7 +831,7 @@ export class ExerciseAPIRequests {
         }
     }
 
-    async getProgrammingExerciseParticipation(exerciseId: number): Promise<StudentParticipation> {
+    async getProgrammingExerciseParticipation(exerciseId: number): Promise<StudentParticipationDTO> {
         const pageResponse = await this.page.request.get(
             `api/exercise/exercises/${exerciseId}/participations/page?page=0&pageSize=1&sortingOrder=ASCENDING&sortedColumn=participantName&searchTerm=&filterProp=`,
         );
@@ -850,14 +850,14 @@ export class ExerciseAPIRequests {
      * who own the participation.
      *
      * @param participationId - The ID of the participation to retrieve.
-     * @returns A Promise<StudentParticipation> representing the student participation with latest results.
+     * @returns A Promise<StudentParticipationDTO> representing the student participation with latest results.
      */
-    async getParticipationWithLatestResult(participationId: number): Promise<StudentParticipation> {
+    async getParticipationWithLatestResult(participationId: number): Promise<StudentParticipationDTO> {
         const response = await this.page.request.get(`api/exercise/participations/${participationId}/with-latest-result`);
         if (!response.ok()) {
             throw new Error(`Failed to get participation ${participationId}: ${response.status()}`);
         }
-        return (await response.json()) as StudentParticipation;
+        return (await response.json()) as StudentParticipationDTO;
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

> [!IMPORTANT]  
> Needs [#13103](https://github.com/ls1intum/Artemis/pull/13103) to be merged first!

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 

Migrate participation and submission REST endpoints from returning raw JPA entities to structured DTO records. Introduces `StudentParticipationDTO`, `SubmissionResponseDTO`, and supporting DTOs on the server, updates all affected REST resources and services, and adds corresponding TypeScript DTO interfaces with mapper functions on the client.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions)..


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.


#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.


#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **LocalVC** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Part of the ongoing DTO migration effort to enforce data economy at the REST boundary. Previously, participation and submission endpoints returned full JPA entity graphs, leaking internal persistence details and exposing unnecessary data. Explicit DTO records ensure only the required data is serialized per endpoint, improving security, performance, and API stability.


### Description
<!-- Describe your changes in detail -->

**Server-side changes:**
- New DTO records: `StudentParticipationDTO`, `SubmissionResponseDTO`, `SubmissionResultDTO`, `SubmissionFeedbackDTO`, `SubmissionAssessmentNoteDTO`, `ParticipationExerciseContextDTO`, `ParticipationCourseContextDTO`, `ParticipationTeamDTO`, `ParticipationSubmissionDTO`, `ParticipationSubmissionResultDTO` — each with context-specific factory methods (e.g. `ofAfterStart`, `ofWithLatestResult`, `ofForCurrentUser`).
- Updated `ParticipationResource`, `ParticipationRetrievalResource`, `ParticipationUpdateResource`, `ParticipationDeletionResource`, and `SubmissionResource` to return DTOs instead of entities.
- Updated `SubmissionService` and `SubmissionWithComplaintDTO` to use `SubmissionResponseDTO`.

**Client-side changes:**
- New TypeScript DTO interfaces: `StudentParticipationDTO` with `fromStudentParticipationDTO()` mapper, `SubmissionResponseDTO` with `fromSubmissionResponseDTO()` mapper.
- Updated `ParticipationService`, `CourseExerciseService`, `SubmissionService`, and `ExampleSubmissionImportPagingService` to consume and map the new DTOs.
- Added `quizBatch` property to `QuizSubmission` model.

**Test changes:**
- Updated server integration tests (`ParticipationIntegrationTest`, `SubmissionIntegrationTest`, `SubmissionServiceTest`, `StudentExamIntegrationTest`, `AssessmentComplaintIntegrationTest`, `TextSubmissionIntegrationTest`) to assert against DTO shapes.
- Updated `ExerciseEntityUsageArchitectureTest` for the new DTO-based REST boundary.
- Updated Playwright e2e tests and Vitest specs for affected services.


### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Tutor
- 2 Students
- 1 Course with complaints and more-feedback requests enabled
- 1 Text Exercise in the course
- 1 Programming Exercise in the course

1. Course Participation and Submission DTOs
Create or use the Text Exercise, then log in as Student 1 and Student 2, start the exercise, and submit one solution per student.

As the Tutor, assess both submissions and submit the assessments.

As the Instructor, open the exercise participation management page.
Verify: Participations load correctly, participant names are visible where expected, and no page fails because of missing entity fields.

Open one participation from the management page and inspect `GET /api/exercise/participations/{participationId}/with-latest-result` in the Network tab.
Verify: The response uses the participation DTO shape, contains the latest submission/result data needed by the UI, and does not contain circular entity references such as nested `result.submission` or repeated `participation.submissions`.

Open the participation submission history and inspect `GET /api/exercise/participations/{participationId}/submissions`.
Verify: The submissions render with their results and assessor information. The response contains `SubmissionResponseDTO` entries and does not contain nested entity cycles such as `submission.participation.submissions` or `result.submission`.

2. Example Submission Import
As the Instructor, open the Text Exercise example-submission import flow and search for existing student submissions.

Inspect `GET /api/exercise/exercises/{exerciseId}/submissions-for-import`.
Verify: The submission search result renders even when the result list is empty, pagination still shows the correct number of pages, and each non-empty row contains the submission text, participant display data, and latest result without circular entity references.

Import one submission as an example submission.
Verify: The imported example submission opens correctly and the preview/content still match the original submission.

3. Complaint and More-Feedback Dashboard Responses
As Student 1, open the assessed exercise result and submit a complaint.

As the Tutor or Instructor, open the assessment dashboard complaint view and inspect `GET /api/exercise/exercises/{exerciseId}/submissions-with-complaints`.
Verify: The complaint row loads with the submission and complaint data. The response does not expose circular entity references, and anonymized rows do not expose participant-derived programming details such as `repositoryUri`, `buildPlanId`, or `branch`.

As the Instructor, accept or reject the complaint, update feedback or score if needed, enter a response, and submit it.
Verify: The updated score, feedback, and complaint response are visible to the student, and the latest result shown in the UI is the updated result rather than an older result.

If the request-more-feedback button is available for the assessed result, log in as Student 2 and request more feedback.

As the Tutor or Instructor, open the assessment dashboard more-feedback request view and inspect `GET /api/exercise/exercises/{exerciseId}/more-feedback-requests-with-complaints`.
Verify: The request appears with the expected submission and complaint data, uses the same DTO-safe response shape, and does not expose nested entity cycles.

4. Programming Participation DTOs
As Student 1, start the Programming Exercise, submit a solution, and wait until a build result is available.

As the Student, reopen the exercise page.
Verify: The participation state, repository/build-plan related UI, latest result, score, and build status render correctly after the DTO conversion.

As the Instructor or Tutor, open the Programming Exercise participation/submission views.
Verify: Programming submissions, commit hash, build status, and results render correctly, and complaint-dashboard responses still keep anonymized programming details hidden as described above.


#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 1 Tutor assigned to the course
- 2 Students registered for the exam
- 1 Exam with a Programming Exercise or Text Exercise

1. Student Exam Submission Flow
As the Instructor, conduct the exam with both registered students.

As Student 1 and Student 2, participate in the exam and submit solutions.
Verify: Submissions are saved during conduction and after final exam submission, and the student-facing submission/result state renders correctly.

As the Tutor, assess the exam submissions and submit the assessments.
Verify: The assessment editor, saved feedback, submitted result, score, and assessor display still work with DTO-backed submission responses.

Publish the exam results and open the exam review as each Student.
Verify: The submitted solution, score, and feedback are displayed correctly, without circular entity references or internal persistence fields in the inspected responses.

2. Exam Test Run Submission Flow
As the Instructor, create an exam test run, participate in the test run, and submit a solution.

Open the test-run assessment/submission view and inspect `GET /api/exercise/exercises/{exerciseId}/test-run-submissions`.
Verify: Test-run submissions are listed correctly, the response uses `SubmissionResponseDTO`, the nested participation is marked as a test run, and no nested submission/result cycles are present.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/31346333046) did not pass (`failure`). Coverage below may be partial.

#### Client

Coverage data not found. Run tests first or check if coverage-summary.json exists.
#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| ParticipationCourseContextDTO.java | 100.00% | 10 |
| ParticipationDueDateUpdateDTO.java | 100.00% | 15 |
| ParticipationExerciseContextDTO.java | 83.33% | 58 |
| ParticipationSubmissionDTO.java | 100.00% | 22 |
| ParticipationSubmissionResultDTO.java | 100.00% | 14 |
| ParticipationTeamDTO.java | 100.00% | 17 |
| ParticipationUpdateDTO.java | 100.00% | 9 |
| StudentParticipationDTO.java | 97.14% | 81 |
| SubmissionAssessmentNoteDTO.java | 0.00% | 17 |
| SubmissionFeedbackDTO.java | 0.00% | 24 |
| SubmissionResponseDTO.java | 76.74% | 86 |
| SubmissionResultDTO.java | 90.91% | 32 |
| SubmissionWithComplaintDTO.java | 100.00% | 11 |
| SubmissionService.java | 94.86% | 501 |
| ParticipationDeletionResource.java | 96.43% | 90 |
| ParticipationResource.java | 85.40% | 299 |
| ParticipationRetrievalResource.java | 78.95% | 147 |
| ParticipationUpdateResource.java | 89.71% | 155 |
| SubmissionResource.java | 88.57% | 170 |

_Last updated: 2026-08-10 01:48:49 UTC_

