### PR TITLE
`Usability`: Keep the filter dropdown from jumping when toggling options

### DIFF
--- a/src/main/webapp/app/calendar/desktop/overview/calendar-desktop-overview.component.scss
+++ b/src/main/webapp/app/calendar/desktop/overview/calendar-desktop-overview.component.scss
@@ -18,6 +18,13 @@
             height: 100%;
         }
 
+        // Reserve enough width for all localized filter chips (German is the widest, ~29rem including
+        // the dropdown) so the trigger keeps a constant width. Without this, removing a chip shrinks the
+        // right-aligned trigger, moves its left edge, and makes the inline overlay panel jump.
+        p-multiselect {
+            min-width: 30rem;
+        }
+
         .chips-section {
             display: flex;
             gap: 0.375rem;

--- a/src/main/webapp/app/calendar/desktop/overview/calendar-desktop-overview.component.scss
+++ b/src/main/webapp/app/calendar/desktop/overview/calendar-desktop-overview.component.scss
@@ -18,9 +18,9 @@
             height: 100%;
         }
 
-        // Reserve enough width for all localized filter chips (German is the widest, ~29rem including
-        // the dropdown) so the trigger keeps a constant width. Without this, removing a chip shrinks the
-        // right-aligned trigger, moves its left edge, and makes the inline overlay panel jump.
+        /* Reserve enough width for all localized filter chips (German is the widest, ~29rem including
+           the dropdown) so the trigger keeps a constant width. Without this, removing a chip shrinks the
+           right-aligned trigger, moves its left edge, and makes the inline overlay panel jump. */
         p-multiselect {
             min-width: 30rem;
         }


### PR DESCRIPTION
### Summary

In the calendar, the filter dropdown jumped / repositioned every time an option was selected or deselected, making it hard to toggle several options in a row. The filter is a PrimeNG multiselect that is right-aligned in the header (after a flex `spacer`) and sized to its selected chips. Removing a chip shrank the trigger, which — because it is right-aligned — moved its left edge; the inline overlay panel is positioned relative to that edge, so it jumped. This PR reserves a stable width for the trigger so it (and the panel) stay in place.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.

### Motivation and Context

Closes #13076.

A control that repositions on every click is a poor experience and makes multi-toggling error-prone. The dropdown should stay in place while options are selected/deselected.

### Description

- Added a `min-width: 30rem` to the calendar filter `p-multiselect` (scoped to the calendar desktop overview header) so the trigger keeps a constant width regardless of how many chips are selected. With a stable trigger the inline overlay panel no longer jumps.
- The value was chosen by measuring the all-selected chip rows for both locales — English ≈ 26.5rem and German ≈ 28.8rem (widest) including the dropdown chevron — so all four localized filter chips (`Lectures / Exams / Exercises / Tutorials`, `Vorlesungen / Klausuren / Übungen / Tutorien`) fit without clipping and without forcing the trigger wider than the reserved width.
- No colors/theming variables were changed; the only change is a layout `min-width`.

### Steps for Testing

Prerequisites:
- 1 User with access to a course calendar that has several event categories (lectures, exams, exercises, tutorials)

1. Open the calendar (desktop) and open the filter dropdown.
2. Select and deselect several options in a row (including removing chips via their ✕).
3. Confirm the dropdown panel stays in place and no longer jumps/repositions.
4. Switch the UI language to German and repeat — confirm the chips still fit and the panel stays put.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in the calendar header when removing localized filter chips.
  * Prevented layout jitter by keeping the filter control at a consistent width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->