### PR TITLE
`Programming exercises`: Fix the ssh settings documentation link

### DIFF
--- a/src/main/webapp/app/shared-ui/components/documentation-link/documentation-link.component.ts
+++ b/src/main/webapp/app/shared-ui/components/documentation-link/documentation-link.component.ts
@@ -5,7 +5,7 @@ import { TranslateDirective } from 'app/foundation/language/translate.directive'
 // Therefore, it's important that they exactly match the url to the subpage of the documentation.
 // Additionally, the case names must match the keys in documentationLinks.json for the tooltip.
 const DocumentationLinks: { [key: string]: string } = {
-    SshSetup: 'student/integrated-code-lifecycle',
+    SshSetup: 'student/tools-reference/integrated-code-lifecycle',
 };
 
 export type DocumentationType = keyof typeof DocumentationLinks;


### PR DESCRIPTION
### Summary

The **"Learn more about fingerprints"** link on the **Settings → SSH Fingerprints** page (and the other "Learn more" links in the SSH settings) opened a non-existent documentation page (404). The `documentation-link` component mapped `SshSetup` to `student/integrated-code-lifecycle`, which is missing the `tools-reference/` path segment. The actual page lives at `student/tools-reference/integrated-code-lifecycle`. This PR corrects the URL.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes #13138.

A "Learn more" link that opens a 404 is broken and confusing. All three SSH-settings "Learn more" links use this `SshSetup` entry, so they were all affected.

### Description

- Changed `SshSetup` in `documentation-link.component.ts` from `student/integrated-code-lifecycle` to `student/tools-reference/integrated-code-lifecycle`, so the link opens the existing page `https://docs.artemis.tum.de/student/tools-reference/integrated-code-lifecycle`.
- The doc page source exists at `documentation/docs/student/tools-reference/integrated-code-lifecycle.mdx`; there is no page (and no redirect) at the previous path, which is why it 404'd.

> Note: `documentation-link.component.ts` and `documentation-button.component.ts` each keep their **own** `DocumentationLinks` map — the button map already had the correct `SshSetup` path, which is how they drifted apart. De-duplicating the two maps would prevent this class of bug but is left out of this focused fix.

### Steps for Testing

Prerequisites:
- A user account with access to the SSH settings

1. Open **Settings → SSH** and go to the **SSH Fingerprints** section.
2. Click **"Learn more about fingerprints"**.
3. Confirm it opens the correct documentation page (Integrated Code Lifecycle under *tools-reference*) and no longer a 404.
4. Confirm the other "Learn more about SSH keys" links (SSH overview and key details pages) also open the correct page.

### Screenshots

_To be added._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the SSH setup documentation link to point to the correct location.
  * Improved navigation to the integrated code lifecycle docs from the documentation area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->