### PR TITLE
`Iris`: Fix an issue in the proactive chat when a build failed or progress is stalled

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/session/IrisChatPipelineExecutionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/session/IrisChatPipelineExecutionService.java
@@ -191,7 +191,11 @@ public class IrisChatPipelineExecutionService {
             case PROGRAMMING_EXERCISE_CHAT -> {
                 var progExercise = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationElseThrow(session.getEntityId());
                 programmingExercise = pyrisDTOService.toPyrisProgrammingExerciseDTO(progExercise);
-                var actualSubmission = latestSubmission.or(() -> getLatestSubmissionIfExists(progExercise, user));
+                // Reload via the eager graph instead of trusting the caller-supplied entity: latestSubmission may be an event
+                // payload handed off across a thread boundary (e.g. CompletableFuture.runAsync) with no Hibernate session,
+                // so its lazy buildLogEntries/results associations would throw LazyInitializationException otherwise.
+                var actualSubmission = latestSubmission.flatMap(s -> programmingSubmissionRepository.findWithEagerResultsAndFeedbacksAndBuildLogsById(s.getId()))
+                        .or(() -> getLatestSubmissionIfExists(progExercise, user));
                 progSubmission = actualSubmission.map(s -> pyrisDTOService.toPyrisSubmissionDTO(s, uncommittedFiles)).orElse(null);
             }
             case TEXT_EXERCISE_CHAT -> {

--- a/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +47,8 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
 import de.tum.cit.aet.artemis.programming.domain.ProjectType;
 import de.tum.cit.aet.artemis.programming.domain.SolutionProgrammingExerciseParticipation;
 import de.tum.cit.aet.artemis.programming.domain.TemplateProgrammingExerciseParticipation;
+import de.tum.cit.aet.artemis.programming.domain.build.BuildLogEntry;
+import de.tum.cit.aet.artemis.programming.test_repository.ProgrammingSubmissionTestRepository;
 import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseUtilService;
 
 class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
@@ -69,6 +72,9 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
 
     @Autowired
     private IrisChatSessionUtilService irisChatSessionUtilService;
+
+    @Autowired
+    private ProgrammingSubmissionTestRepository programmingSubmissionRepository;
 
     private ProgrammingExercise exercise;
 
@@ -165,6 +171,39 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         return createSubmission(studentParticipation, 0, true);
     }
 
+    /**
+     * Creates a failing submission with real build log entries, then reloads it the same way the event thread would see
+     * it: {@code results} eagerly fetched, but {@code buildLogEntries} left as an uninitialized lazy proxy, detached from
+     * any Hibernate session. Reproduces the off-session state that {@link NewResultEvent}s carry across the
+     * {@code CompletableFuture.runAsync} boundary in {@code IrisChatSessionService}.
+     */
+    private Result createFailingSubmissionWithLazyBuildLogEntries(ProgrammingExerciseStudentParticipation studentParticipation) {
+        ProgrammingSubmission submission = new ProgrammingSubmission();
+        submission.setBuildFailed(true);
+        submission.setType(SubmissionType.MANUAL);
+        submission.setParticipation(studentParticipation);
+        submission.setSubmissionDate(ZonedDateTime.now());
+        submission = submissionRepository.saveAndFlush(submission);
+
+        List<BuildLogEntry> logs = new ArrayList<>();
+        logs.add(new BuildLogEntry(ZonedDateTime.now(), "compilation failed: cannot find symbol", submission));
+        submission.setBuildLogEntries(logs);
+        submission = submissionRepository.saveAndFlush(submission);
+
+        Result result = ParticipationFactory.generateResult(true, 0);
+        result.setSubmission(submission);
+        result.setExerciseId(studentParticipation.getExercise().getId());
+        result.completionDate(ZonedDateTime.now());
+        result.setAssessmentType(AssessmentType.AUTOMATIC);
+        submission.addResult(result);
+        submissionRepository.saveAndFlush(submission);
+        result = resultRepository.save(result);
+
+        ProgrammingSubmission detachedSubmission = programmingSubmissionRepository.findProgrammingSubmissionById(submission.getId()).orElseThrow();
+        result.setSubmission(detachedSubmission);
+        return result;
+    }
+
     private ProgrammingExerciseStudentParticipation createTeamParticipation(User owner) {
         var team = teamUtilService.addTeamForExercise(exercise, owner);
         var teamParticipation = participationUtilService.addTeamParticipationForProgrammingExercise(exercise, team);
@@ -206,6 +245,29 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         Result result = createFailingSubmission(studentParticipation);
         irisRequestMockProvider.mockBuildFailedRunResponse((dto) -> {
             assertThat(dto.settings().authenticationToken()).isNotNull();
+            pipelineDone.set(true);
+        });
+
+        var event = new NewResultEvent(result);
+        pyrisEventService.trigger(event);
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> verify(irisChatSessionService, times(1)).handleNewResultEvent(eq(event)));
+
+        await().atMost(2, TimeUnit.SECONDS).until(() -> pipelineDone.get());
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(
+                () -> verify(pyrisPipelineService, times(1)).executeChatPipeline(eq("default"), eq("moderate"), eq(irisSession), eq(Optional.of("build_failed")), any()));
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testShouldFireBuildFailedEventWhenBuildLogEntriesAreNotEagerlyFetched() {
+        IrisChatSession irisSession = irisChatSessionUtilService.createAndSaveProgrammingExerciseChatSessionForUser(exercise,
+                userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        Result result = createFailingSubmissionWithLazyBuildLogEntries(studentParticipation);
+        irisRequestMockProvider.mockBuildFailedRunResponse((dto) -> {
+            assertThat(dto.programmingExerciseSubmission()).isNotNull();
+            assertThat(dto.programmingExerciseSubmission().buildLogEntries()).extracting("message").containsExactly("compilation failed: cannot find symbol");
             pipelineDone.set(true);
         });
 

--- a/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
@@ -39,6 +39,7 @@ import de.tum.cit.aet.artemis.exercise.test_repository.SubmissionTestRepository;
 import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
 import de.tum.cit.aet.artemis.iris.domain.session.IrisChatSession;
 import de.tum.cit.aet.artemis.iris.domain.settings.IrisPipelineVariant;
+import de.tum.cit.aet.artemis.iris.service.pyris.dto.data.PyrisBuildLogEntryDTO;
 import de.tum.cit.aet.artemis.iris.service.pyris.event.NewResultEvent;
 import de.tum.cit.aet.artemis.iris.util.IrisChatSessionUtilService;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
@@ -267,7 +268,7 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         Result result = createFailingSubmissionWithLazyBuildLogEntries(studentParticipation);
         irisRequestMockProvider.mockBuildFailedRunResponse((dto) -> {
             assertThat(dto.programmingExerciseSubmission()).isNotNull();
-            assertThat(dto.programmingExerciseSubmission().buildLogEntries()).extracting("message").containsExactly("compilation failed: cannot find symbol");
+            assertThat(dto.programmingExerciseSubmission().buildLogEntries()).extracting(PyrisBuildLogEntryDTO::message).containsExactly("compilation failed: cannot find symbol");
             pipelineDone.set(true);
         });
 


### PR DESCRIPTION
### Summary
The Iris proactive-chat triggers (`build_failed` and `progress_stalled`) crashed with `org.hibernate.LazyInitializationException` before the request ever reached Pyris, so the proactive message was silently dropped. This fixes the root cause by always reloading the programming submission through the existing eager-fetch repository method before building the Pyris DTO, instead of trusting the entity handed in from the async event thread.

### Checklist
#### General
- [x] This is a small issue that I tested locally (deterministic integration test reproducing the exact reported stack trace).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
Fixes #13148.

`IrisChatSessionService.onBuildFailure` / `onNewResult` hand a `ProgrammingSubmission` taken from a `NewResultEvent` to `IrisChatPipelineExecutionService.execute(...)` on a `CompletableFuture.runAsync` (ForkJoinPool) thread. `PyrisDTOService.toPyrisSubmissionDTO` dereferences the lazy `submission.buildLogEntries` collection as its first statement. With no Hibernate session on that thread (`open-in-view: false`), the access throws `LazyInitializationException`, which is only logged via `.exceptionally(...)`, so the proactive intervention (build failure hint / "you seem stuck" nudge) never reaches the student.

### Description
`IrisChatPipelineExecutionService.buildChatDTO` used `latestSubmission.or(() -> getLatestSubmissionIfExists(progExercise, user))` for the `PROGRAMMING_EXERCISE_CHAT` case. Because `latestSubmission` was present (supplied by the event), the eager fallback (`getLatestSubmissionIfExists`, which already loads via `findWithEagerResultsAndFeedbacksAndBuildLogsById`) was skipped, so the under-fetched event submission was used directly and its lazy `buildLogEntries`/`results` collections threw once accessed off-session.

The fix reloads `latestSubmission` through the same eager-fetch repository method (`findWithEagerResultsAndFeedbacksAndBuildLogsById`) before use, falling back to `getLatestSubmissionIfExists` only if that submission can no longer be found (e.g. deleted in the meantime). This makes every code path that reaches `toPyrisSubmissionDTO` session-safe, regardless of which thread it runs on.

### Steps for Testing
No manual/UI testing is needed; this is a server-only fix with no user-facing surface beyond the (previously broken) proactive Iris message delivery. Verified via a new deterministic integration test:

```
./gradlew test --tests "de.tum.cit.aet.artemis.iris.PyrisEventSystemIntegrationTest" -x webapp -Dzonky.test.database.type=H2
```

The new test (`testShouldFireBuildFailedEventWhenBuildLogEntriesAreNotEagerlyFetched`) creates a failing submission with real build log entries, reloads it the same way the async event thread would see it (results eager, `buildLogEntries` an uninitialized lazy proxy detached from any Hibernate session), fires the `build_failed` event through the real event pipeline, and asserts the DTO is built (and the build log content is present) without throwing. Confirmed this test fails with the exact reported `LazyInitializationException` stack trace when the fix is reverted, and passes with the fix applied. The full `de.tum.cit.aet.artemis.iris` package (611 tests) and `checkstyleMain`/`spotlessCheck` pass.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/28786399186) did not pass (`failure`). Coverage below may be partial.

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| IrisChatPipelineExecutionService.java | not found (modified) | 204 |

_Last updated: 2026-07-06 12:18:18 UTC_

