### PR TITLE
`Programming exercises`: Fix an issue with special characters in problem statement tasks

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseTaskService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseTaskService.java
@@ -429,7 +429,7 @@ public class ProgrammingExerciseTaskService {
             String testIds = replacer.apply(testNames, testCases);
 
             // construct a new task using the testids
-            return "[task][%s](%s)".formatted(taskName, testIds);
+            return Matcher.quoteReplacement("[task][%s](%s)".formatted(taskName, testIds));
         });
     }
 
@@ -451,15 +451,15 @@ public class ProgrammingExerciseTaskService {
             // matchResult: Full UML diagram (everything between @startuml and @enduml)
             String diagram = matchResult.group();
             Matcher tests = TESTSCOLOR_PATTERN.matcher(diagram);
-            return tests.replaceAll(testsMatchResult -> {
+            return Matcher.quoteReplacement(tests.replaceAll(testsMatchResult -> {
                 // testsMatchResult: one testscolor instance, e.g. testsColor(testAttributes[BubbleSort])
                 String fullMatch = testsMatchResult.group();
                 // group 1: test name, e.g, testAttributes[BubbleSort]
                 String testName = testsMatchResult.group(1);
                 // id to insert, e.g., <testid>15</testid>
                 String testId = replacer.apply(testName, testCases);
-                return fullMatch.replace(testName, testId);
-            });
+                return Matcher.quoteReplacement(fullMatch.replace(testName, testId));
+            }));
         });
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseTaskServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseTaskServiceTest.java
@@ -1,0 +1,85 @@
+package de.tum.cit.aet.artemis.programming.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.tum.cit.aet.artemis.programming.AbstractProgrammingIntegrationIndependentTest;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseTestCase;
+import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseTaskRepository;
+import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseTestCaseRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class ProgrammingExerciseTaskServiceTest extends AbstractProgrammingIntegrationIndependentTest {
+
+    ProgrammingExerciseTaskService programmingExerciseTaskService;
+
+    @Mock
+    ProgrammingExerciseTaskRepository programmingExerciseTaskRepository;
+
+    @Mock
+    ProgrammingExerciseTestCaseRepository programmingExerciseTestCaseRepository;
+
+    @BeforeEach
+    void setUp() {
+        programmingExerciseTaskService = new ProgrammingExerciseTaskService(programmingExerciseTaskRepository, programmingExerciseTestCaseRepository);
+    }
+
+    @Test
+    void verifyTaskReplacementInProblemStatementTest() {
+        ProgrammingExerciseTestCase testCase1 = mock(ProgrammingExerciseTestCase.class);
+        when(testCase1.getId()).thenReturn(1L);
+        when(testCase1.getTestName()).thenReturn("TestTask");
+
+        doReturn((Set.of(testCase1))).when(programmingExerciseTestCaseRepository).findByExerciseIdAndActive(1L, true);
+
+        ProgrammingExercise exercise = new ProgrammingExercise();
+        exercise.setProblemStatement("Some Problem Statement Text infront [task][Placeholder in Problem Statement](TestTask) More Text at the end"
+                + "Only Problem Statement Text infront [task][Placeholder in Problem Statement](TestTask)"
+                + "[task][Placeholder in Problem Statement](TestTask) Only Problem Statement Text at the end");
+        exercise.setId(1L);
+
+        final String problemStatement = String.format(
+                "Some Problem Statement Text infront [task][Placeholder in Problem Statement](<testid>%d</testid>) More Text at the end"
+                        + "Only Problem Statement Text infront [task][Placeholder in Problem Statement](<testid>%d</testid>)"
+                        + "[task][Placeholder in Problem Statement](<testid>%d</testid>) Only Problem Statement Text at the end",
+                testCase1.getId(), testCase1.getId(), testCase1.getId());
+        programmingExerciseTaskService.replaceTestNamesWithIds(exercise);
+        assertEquals(problemStatement, exercise.getProblemStatement());
+    }
+
+    @Test
+    void verifyRegexCharacterEscapeForTaskReplacementTest() {
+        ProgrammingExerciseTestCase testCase1 = mock(ProgrammingExerciseTestCase.class);
+        when(testCase1.getId()).thenReturn(1L);
+        when(testCase1.getTestName()).thenReturn("Outerclass$Innerclass#method");
+
+        ProgrammingExerciseTestCase testCase2 = mock(ProgrammingExerciseTestCase.class);
+        when(testCase2.getId()).thenReturn(2L);
+        when(testCase2.getTestName()).thenReturn("someTestNameThatContains\\\\");
+
+        doReturn((Set.of(testCase1, testCase2))).when(programmingExerciseTestCaseRepository).findByExerciseIdAndActive(1L, true);
+
+        ProgrammingExercise exercise = new ProgrammingExercise();
+        exercise.setProblemStatement(
+                "[task][Placeholder in Problem Statement](Outerclass$Innerclass#method)" + "[task][Placeholder2 in Problem Statement](someTestNameThatContains\\\\)");
+        exercise.setId(1L);
+
+        final String problemStatement = String.format(
+                "[task][Placeholder in Problem Statement](<testid>%d</testid>)" + "[task][Placeholder2 in Problem Statement](<testid>%d</testid>)", testCase1.getId(),
+                testCase2.getId());
+        programmingExerciseTaskService.replaceTestNamesWithIds(exercise);
+        assertEquals(problemStatement, exercise.getProblemStatement());
+    }
+
+}


### PR DESCRIPTION
### Summary 
This fix adress the usage of special characters in the problem statement of any exercise which lead to internal corruption due to errors in the replacement process of task names.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Server
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context
The user should not be able to corrupt an exercise by changing the problem statement. User input should either be sanatized and accepted or the user should be prevented to do so. This fix aims to keep the freedom of text to the user.


### Description
Added the qouteEscape implemented from Matcher to remove Problems with $ and \ symbols in replaceAll from Matcher used to replace task names with task ids.


### Steps for Testing
1.Run `./gradlew test --tests ProgrammingExerciseTaskServiceTest -x webapp`

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/28786195819) did not pass (`failure`). Coverage below may be partial.

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| ProgrammingExerciseTaskService.java | not found (modified) | 260 |

_Last updated: 2026-07-06 11:31:30 UTC_

