### PR TITLE
`Development`: Disable theia module feature on build agents

### DIFF
--- a/src/main/resources/config/application-buildagent.yml
+++ b/src/main/resources/config/application-buildagent.yml
@@ -47,6 +47,8 @@ artemis:
         enabled: false
     iris:
         enabled: false
+    theia:
+        enabled: false # the online IDE is served by core nodes only, never by build agents
 
     checked-out-repos-path: ./checked-out-repos # The directory to which repositories temporarily get cloned for the build job execution
     repo-clone-path: ./repos


### PR DESCRIPTION
## Problem

Build agents (`buildagent` profile) never serve the Theia online IDE, yet nothing enforced `artemis.theia.enabled=false` on them. The value fell back to the base default, and an externally rendered configuration file could flip it on, so a build agent could load Theia config it has no use for.

## Solution

Set `artemis.theia.enabled: false` explicitly in `application-buildagent.yml`, alongside the other modules that are already disabled for build agents. This makes the WAR the authoritative source for build-agent module toggles.

The complementary configuration change, which gates the Theia block to core nodes so an external `application-prod.yml` never enables it on build agents, is tracked in the Ansible collection.

## Context

This came out of investigating a deployment in which the build agents crash-looped after a Spring Boot 4 WAR was rolled out; the root cause was a stale `spring.autoconfigure.exclude` list in the configuration template. The Theia cleanup was a related hardening request.

## Testing

Config-only change. Build agents already start cleanly with `application-buildagent.yml`; this adds one module toggle consistent with the existing disabled set.