### PR TITLE
`Notifications`: Stop the popup overlay from blocking clicks in the bottom-right corner

### DIFF
--- a/src/main/webapp/app/notification/course-notification/course-notification-popup-overlay/course-notification-popup-overlay.component.scss
+++ b/src/main/webapp/app/notification/course-notification/course-notification-popup-overlay/course-notification-popup-overlay.component.scss
@@ -81,14 +81,21 @@
     overflow: visible;
     pointer-events: none;
 
-    // Allow clicks on children
-    > * {
+    // Only the notification cards should catch clicks. Do not use `> *` here: under emulated view
+    // encapsulation it outranks `.course-notification-popup-overlay-collapse { pointer-events: none }`,
+    // so the invisible (opacity: 0) collapse controls would swallow clicks on the page underneath.
+    > .notification-animation-wrapper {
         pointer-events: auto;
     }
 
     transition:
         max-height 0.2s 0.2s ease-in-out,
         height 0.2s 0.2s ease-in-out;
+}
+
+// No notifications: remove the overlay entirely so it never sits on top of the page and blocks clicks.
+.course-notification-popup-overlay.hidden {
+    display: none;
 }
 
 .course-notification-popup-overlay::-webkit-scrollbar {


### PR DESCRIPTION
### Summary

The global **course-notification popup overlay** (`jhi-course-notification-popup-overlay`, rendered once in `app.component.html`) is `position: fixed` at the bottom-right on every page. It **silently blocks clicks** on whatever sits in that corner — most visibly the **"Generate" / save button** when creating a programming exercise: the button is enabled, but clicking does nothing (no request, no error), because an invisible overlay element intercepts the click.

### Regression origin

This is a **regression introduced on 2026-07-07 by #12963** (admin Tailwind/PrimeNG migration), which changed the overlay's hide-class:

```diff
- [ngClass]="{ 'is-expanded': isExpanded(), 'd-none': notifications().length === 0 }"
+ [ngClass]="{ 'is-expanded': isExpanded(), hidden: notifications().length === 0 }"
```

- Bootstrap's `.d-none` is `display: none !important`, so the empty overlay was genuinely removed from layout/hit-testing — the (pre-existing, latent) `pointer-events` issue below never mattered.
- Tailwind's `.hidden` has **no `!important`**. The component sets `.course-notification-popup-overlay { display: flex }`, and under Angular's emulated view encapsulation that rule (`…[_ngcontent]`, specificity 0-2-0) **outranks** the bare `.hidden` utility (0-1-0). So `hidden` does nothing, the empty overlay stays on top of the page, and its invisible child swallows clicks.

The latent contributor: `.course-notification-popup-overlay-collapse` is meant to be non-interactive until expanded (`pointer-events: none`, `opacity: 0`), but the blanket `.course-notification-popup-overlay > * { pointer-events: auto }` rule overrides it — under emulated encapsulation `> *` compiles to `> *[_ngcontent…]`, whose specificity is higher than the `.…-collapse` class, so the collapse element ends up `pointer-events: auto`.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).

### Motivation and Context

An enabled button that does nothing on click is confusing and hard to diagnose, and it affects any interactive element in the bottom-right of the viewport (not just exercise creation) on every page where no notification popup is shown.

Reverting the class to `d-none` is not an option — #12963 also added a `no-bootstrap-classes` lint rule — so the fix keeps the `hidden` class and makes it actually work.

### Description

`course-notification-popup-overlay.component.scss`:
- Add `.course-notification-popup-overlay.hidden { display: none; }` — a component-scoped rule (specificity 0-2-0) that beats the component's own `display: flex`, so the overlay is truly removed from layout/hit-testing when there are no notifications. This restores the behavior Bootstrap's `d-none !important` used to provide, without a Bootstrap class.
- Scope the interactive `pointer-events: auto` to the notification cards (`> .notification-animation-wrapper`) instead of the blanket `> *`, so the collapse controls keep their intended `pointer-events` (`none` until expanded) and never intercept clicks — hardening the latent issue as well.

No behavior change when notifications are shown: the cards remain clickable, and the collapse controls still become interactive in the expanded state (`.is-expanded … { pointer-events: all }`).

This is a CSS-only fix, so no unit test is added (a DOM/style assertion would be low value here).

### Steps for Testing

Prerequisites:
- Instructor access; a course with an exam (or any page with a bottom-right action button)

1. With **no** active notification popup, go to **Course Management → Exercises/Exam → add a programming exercise** (or any exercise create form).
2. Fill the form and click **Generate** — it now saves (previously the click was swallowed and nothing happened).
3. Trigger a course notification popup (bottom-right) and confirm the notification card and its close/expand/clear controls still work as before.

### Screenshots

_To be added._
