### PR TITLE
`General`: Fix an issue in the science tab in the user settings

### DIFF
--- a/src/main/webapp/app/account/user/settings/directive/user-settings.directive.ts
+++ b/src/main/webapp/app/account/user/settings/directive/user-settings.directive.ts
@@ -8,15 +8,9 @@ import { Setting, UserSettingsStructure } from 'app/account/user/settings/user-s
 
 /**
  * Is used as the abstract user-settings "parent" with all the necessary basic logic for other "child" components to implement/inherit from.
- *
- * The concrete setting type is a generic parameter so subclasses (e.g. science settings) get the narrowed type without
- * re-declaring the {@link userSettings}/{@link settings} signals. Re-declaring an inherited, initialized field in a
- * subclass MUST be avoided: under `useDefineForClassFields` (target es2024) the Angular build emits the subclass field
- * as an uninitialized property that shadows the base signal with `undefined`, which crashed the science settings page
- * (issue #13173). Parameterizing here keeps the signals defined on every subclass instance.
  */
 @Directive()
-export abstract class UserSettingsDirective<T extends Setting = Setting> implements OnInit {
+export abstract class UserSettingsDirective implements OnInit {
     protected userSettingsService = inject(UserSettingsService);
     private alertService = inject(AlertService);
 
@@ -27,8 +21,8 @@ export abstract class UserSettingsDirective<T extends Setting = Setting> impleme
     // userSettings logic related
     userSettingsCategory!: UserSettingsCategory; // set in the overriding ngOnInit() of each child-settings component before loadSetting() reads it
     changeEventMessage!: string; // set in the ngOnInit() of each child-settings component before createApplyChangesEvent() reads it
-    readonly userSettings = signal<UserSettingsStructure<T>>(undefined!);
-    readonly settings = signal<Array<T>>(undefined!);
+    readonly userSettings = signal<UserSettingsStructure<Setting>>(undefined!);
+    readonly settings = signal<Array<Setting>>(undefined!);
     page = 0;
     error?: string;
 
@@ -45,8 +39,8 @@ export abstract class UserSettingsDirective<T extends Setting = Setting> impleme
     protected loadSetting(): void {
         this.userSettingsService.loadSettings(this.userSettingsCategory)?.subscribe({
             next: (res: HttpResponse<Setting[]>) => {
-                this.userSettings.set(this.userSettingsService.loadSettingsSuccessAsSettingsStructure(res.body!, this.userSettingsCategory) as UserSettingsStructure<T>);
-                this.settings.set(this.userSettingsService.extractIndividualSettingsFromSettingsStructure(this.userSettings()) as T[]);
+                this.userSettings.set(this.userSettingsService.loadSettingsSuccessAsSettingsStructure(res.body!, this.userSettingsCategory));
+                this.settings.set(this.userSettingsService.extractIndividualSettingsFromSettingsStructure(this.userSettings()));
                 this.alertService.closeAll();
             },
             error: (res: HttpErrorResponse) => this.onError(res),
@@ -62,8 +56,8 @@ export abstract class UserSettingsDirective<T extends Setting = Setting> impleme
     public saveSettings() {
         this.userSettingsService.saveSettings(this.settings(), this.userSettingsCategory).subscribe({
             next: (res: HttpResponse<Setting[]>) => {
-                this.userSettings.set(this.userSettingsService.saveSettingsSuccess(this.userSettings(), res.body!) as UserSettingsStructure<T>);
-                this.settings.set(this.userSettingsService.extractIndividualSettingsFromSettingsStructure(this.userSettings()) as T[]);
+                this.userSettings.set(this.userSettingsService.saveSettingsSuccess(this.userSettings(), res.body!));
+                this.settings.set(this.userSettingsService.extractIndividualSettingsFromSettingsStructure(this.userSettings()));
                 this.finishSaving();
             },
             error: (res: HttpErrorResponse) => this.onError(res),

--- a/src/main/webapp/app/account/user/settings/directive/user-settings.directive.ts
+++ b/src/main/webapp/app/account/user/settings/directive/user-settings.directive.ts
@@ -8,9 +8,15 @@ import { Setting, UserSettingsStructure } from 'app/account/user/settings/user-s
 
 /**
  * Is used as the abstract user-settings "parent" with all the necessary basic logic for other "child" components to implement/inherit from.
+ *
+ * The concrete setting type is a generic parameter so subclasses (e.g. science settings) get the narrowed type without
+ * re-declaring the {@link userSettings}/{@link settings} signals. Re-declaring an inherited, initialized field in a
+ * subclass MUST be avoided: under `useDefineForClassFields` (target es2024) the Angular build emits the subclass field
+ * as an uninitialized property that shadows the base signal with `undefined`, which crashed the science settings page
+ * (issue #13173). Parameterizing here keeps the signals defined on every subclass instance.
  */
 @Directive()
-export abstract class UserSettingsDirective implements OnInit {
+export abstract class UserSettingsDirective<T extends Setting = Setting> implements OnInit {
     protected userSettingsService = inject(UserSettingsService);
     private alertService = inject(AlertService);
 
@@ -21,8 +27,8 @@ export abstract class UserSettingsDirective implements OnInit {
     // userSettings logic related
     userSettingsCategory!: UserSettingsCategory; // set in the overriding ngOnInit() of each child-settings component before loadSetting() reads it
     changeEventMessage!: string; // set in the ngOnInit() of each child-settings component before createApplyChangesEvent() reads it
-    readonly userSettings = signal<UserSettingsStructure<Setting>>(undefined!);
-    readonly settings = signal<Array<Setting>>(undefined!);
+    readonly userSettings = signal<UserSettingsStructure<T>>(undefined!);
+    readonly settings = signal<Array<T>>(undefined!);
     page = 0;
     error?: string;
 
@@ -39,8 +45,8 @@ export abstract class UserSettingsDirective implements OnInit {
     protected loadSetting(): void {
         this.userSettingsService.loadSettings(this.userSettingsCategory)?.subscribe({
             next: (res: HttpResponse<Setting[]>) => {
-                this.userSettings.set(this.userSettingsService.loadSettingsSuccessAsSettingsStructure(res.body!, this.userSettingsCategory));
-                this.settings.set(this.userSettingsService.extractIndividualSettingsFromSettingsStructure(this.userSettings()));
+                this.userSettings.set(this.userSettingsService.loadSettingsSuccessAsSettingsStructure(res.body!, this.userSettingsCategory) as UserSettingsStructure<T>);
+                this.settings.set(this.userSettingsService.extractIndividualSettingsFromSettingsStructure(this.userSettings()) as T[]);
                 this.alertService.closeAll();
             },
             error: (res: HttpErrorResponse) => this.onError(res),
@@ -56,8 +62,8 @@ export abstract class UserSettingsDirective implements OnInit {
     public saveSettings() {
         this.userSettingsService.saveSettings(this.settings(), this.userSettingsCategory).subscribe({
             next: (res: HttpResponse<Setting[]>) => {
-                this.userSettings.set(this.userSettingsService.saveSettingsSuccess(this.userSettings(), res.body!));
-                this.settings.set(this.userSettingsService.extractIndividualSettingsFromSettingsStructure(this.userSettings()));
+                this.userSettings.set(this.userSettingsService.saveSettingsSuccess(this.userSettings(), res.body!) as UserSettingsStructure<T>);
+                this.settings.set(this.userSettingsService.extractIndividualSettingsFromSettingsStructure(this.userSettings()) as T[]);
                 this.finishSaving();
             },
             error: (res: HttpErrorResponse) => this.onError(res),

--- a/src/main/webapp/app/account/user/settings/science-settings/science-settings-structure.ts
+++ b/src/main/webapp/app/account/user/settings/science-settings/science-settings-structure.ts
@@ -2,9 +2,8 @@ import { IS_AT_LEAST_STUDENT } from 'app/foundation/constants/authority.constant
 import { SettingId, UserSettingsCategory } from 'app/foundation/constants/user-settings.constants';
 import { Setting, UserSettingsStructure } from '../user-settings.model';
 
-export interface ScienceSetting extends Setting {
-    active?: boolean;
-}
+// Science settings are plain user settings; the on/off state (`active`) lives on the base `Setting`.
+export type ScienceSetting = Setting;
 
 export const scienceSettingsStructure: UserSettingsStructure<ScienceSetting> = {
     category: UserSettingsCategory.SCIENCE_SETTINGS,

--- a/src/main/webapp/app/account/user/settings/science-settings/science-settings.component.spec.ts
+++ b/src/main/webapp/app/account/user/settings/science-settings/science-settings.component.spec.ts
@@ -109,4 +109,25 @@ describe('ScienceSettingsComponent', () => {
         // check if current settings are not empty
         expect(comp.userSettings()).toEqual(scienceSettingsStructure);
     });
+
+    // Regression test for issue #13173: the inherited userSettings/settings signals must exist on the instance so the
+    // component actually renders. The previous spec never called detectChanges(), so a fully blank render slipped through.
+    it('should inherit the userSettings/settings signals from the base and render the settings content (issue #13173)', () => {
+        // The inherited fields must be callable signals, not undefined (a subclass field re-declaration would shadow them).
+        expect(typeof comp.userSettings).toBe('function');
+        expect(typeof comp.settings).toBe('function');
+
+        vi.spyOn(scienceSettingsServiceMock, 'getScienceSettings').mockReturnValue([scienceSetting]);
+        comp.ngOnInit();
+        fixture.detectChanges();
+
+        // The settings signal is populated (proving the inherited signal works, not undefined).
+        expect(comp.userSettings()).toBeTruthy();
+
+        const element: HTMLElement = fixture.nativeElement;
+        // The heading AND the unconditional info line below it must render. In the bug the component threw right after
+        // the heading, so only the <h2> showed and this info line (a plain sibling) was missing.
+        expect(element.querySelector('h2')).toBeTruthy();
+        expect(element.querySelector('.userSettings-info')).toBeTruthy();
+    });
 });

--- a/src/main/webapp/app/account/user/settings/science-settings/science-settings.component.ts
+++ b/src/main/webapp/app/account/user/settings/science-settings/science-settings.component.ts
@@ -23,7 +23,7 @@ import { ScienceSetting } from 'app/account/user/settings/science-settings/scien
         ArtemisTranslatePipe,
     ],
 })
-export class ScienceSettingsComponent extends UserSettingsDirective<ScienceSetting> implements OnInit, OnDestroy {
+export class ScienceSettingsComponent extends UserSettingsDirective implements OnInit, OnDestroy {
     private scienceSettingsService = inject(ScienceSettingsService);
     private featureToggleService = inject(FeatureToggleService);
 

--- a/src/main/webapp/app/account/user/settings/science-settings/science-settings.component.ts
+++ b/src/main/webapp/app/account/user/settings/science-settings/science-settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, WritableSignal, inject, signal } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
 import { UserSettingsCategory } from 'app/foundation/constants/user-settings.constants';
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { FeatureToggle, FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
@@ -9,7 +9,6 @@ import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pip
 import { HasAnyAuthorityDirective } from 'app/foundation/auth/has-any-authority.directive';
 import { UserSettingsDirective } from 'app/account/user/settings/directive/user-settings.directive';
 import { ScienceSettingsService } from 'app/account/user/settings/science-settings/science-settings.service';
-import { UserSettingsStructure } from 'app/account/user/settings/user-settings.model';
 import { ScienceSetting } from 'app/account/user/settings/science-settings/science-settings-structure';
 
 @Component({
@@ -24,7 +23,7 @@ import { ScienceSetting } from 'app/account/user/settings/science-settings/scien
         ArtemisTranslatePipe,
     ],
 })
-export class ScienceSettingsComponent extends UserSettingsDirective implements OnInit, OnDestroy {
+export class ScienceSettingsComponent extends UserSettingsDirective<ScienceSetting> implements OnInit, OnDestroy {
     private scienceSettingsService = inject(ScienceSettingsService);
     private featureToggleService = inject(FeatureToggleService);
 
@@ -34,9 +33,6 @@ export class ScienceSettingsComponent extends UserSettingsDirective implements O
     private saveSubscription?: Subscription;
     readonly featureToggleActive = signal(false);
     private lastConfirmedValues = new Map<string, boolean>();
-
-    declare userSettings: WritableSignal<UserSettingsStructure<ScienceSetting>>;
-    declare settings: WritableSignal<Array<ScienceSetting>>;
 
     override ngOnInit(): void {
         this.userSettingsCategory = UserSettingsCategory.SCIENCE_SETTINGS;

--- a/src/main/webapp/app/account/user/settings/science-settings/science-settings.guard.spec.ts
+++ b/src/main/webapp/app/account/user/settings/science-settings/science-settings.guard.spec.ts
@@ -1,0 +1,55 @@
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+import { MockRouter } from 'test/helpers/mocks/mock-router';
+import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
+import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
+import { MODULE_FEATURE_ATLAS } from 'app/app.constants';
+import { scienceSettingsGuard } from 'app/account/user/settings/science-settings/science-settings.guard';
+
+describe('scienceSettingsGuard', () => {
+    setupTestBed({ zoneless: true });
+
+    let profileService: ProfileService;
+    let router: MockRouter;
+
+    // The guard ignores its arguments, so empty snapshots are sufficient.
+    const route = {} as ActivatedRouteSnapshot;
+    const state = {} as RouterStateSnapshot;
+
+    beforeEach(() => {
+        router = new MockRouter();
+        TestBed.configureTestingModule({
+            providers: [
+                { provide: ProfileService, useClass: MockProfileService },
+                { provide: Router, useValue: router },
+            ],
+        });
+        profileService = TestBed.inject(ProfileService);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should allow activation when the atlas module is active', () => {
+        vi.spyOn(profileService, 'isModuleFeatureActive').mockImplementation((feature) => feature === MODULE_FEATURE_ATLAS);
+
+        const result = TestBed.runInInjectionContext(() => scienceSettingsGuard(route, state));
+
+        expect(result).toBe(true);
+        expect(router.createUrlTree).not.toHaveBeenCalled();
+    });
+
+    it('should redirect to the user-settings root when the atlas module is inactive (issue #13173)', () => {
+        vi.spyOn(profileService, 'isModuleFeatureActive').mockReturnValue(false);
+        const redirect = new UrlTree();
+        router.createUrlTree.mockReturnValue(redirect);
+
+        const result = TestBed.runInInjectionContext(() => scienceSettingsGuard(route, state));
+
+        expect(router.createUrlTree).toHaveBeenCalledWith(['/user-settings']);
+        expect(result).toBe(redirect);
+    });
+});

--- a/src/main/webapp/app/account/user/settings/science-settings/science-settings.guard.ts
+++ b/src/main/webapp/app/account/user/settings/science-settings/science-settings.guard.ts
@@ -1,0 +1,23 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+import { MODULE_FEATURE_ATLAS } from 'app/app.constants';
+import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
+
+/**
+ * Guards the "/user-settings/science" route. The science settings endpoint lives in the atlas module (the server-side
+ * {@link https://github.com/ls1intum/Artemis ScienceSettingsResource} is annotated with {@code @Conditional(AtlasEnabled.class)}),
+ * so when the atlas module is disabled the endpoint returns 404 and the page would render empty (issue #13173).
+ *
+ * The sidebar already hides the tab in that case; this guard additionally prevents direct navigation (e.g. via a
+ * bookmark or URL) from opening the empty page by redirecting back to the user-settings root.
+ *
+ * @returns true if the atlas module is active, otherwise a redirect to the user-settings root.
+ */
+export const scienceSettingsGuard: CanActivateFn = (): boolean | UrlTree => {
+    const profileService = inject(ProfileService);
+    const router = inject(Router);
+    if (profileService.isModuleFeatureActive(MODULE_FEATURE_ATLAS)) {
+        return true;
+    }
+    return router.createUrlTree(['/user-settings']);
+};

--- a/src/main/webapp/app/account/user/settings/science-settings/science-settings.service.ts
+++ b/src/main/webapp/app/account/user/settings/science-settings/science-settings.service.ts
@@ -56,10 +56,7 @@ export class ScienceSettingsService {
 
         this.userSettingsService.loadSettings(UserSettingsCategory.SCIENCE_SETTINGS).subscribe({
             next: (res: HttpResponse<Setting[]>) => {
-                const currentScienceSettings = this.userSettingsService.loadSettingsSuccessAsIndividualSettings(
-                    res.body!,
-                    UserSettingsCategory.SCIENCE_SETTINGS,
-                ) as ScienceSetting[];
+                const currentScienceSettings = this.userSettingsService.loadSettingsSuccessAsIndividualSettings(res.body!, UserSettingsCategory.SCIENCE_SETTINGS);
 
                 this.storeScienceSettings(currentScienceSettings);
                 this.currentScienceSettingsSubject.next(currentScienceSettings);

--- a/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.html
+++ b/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.html
@@ -26,7 +26,9 @@
                     <a class="list-group-item btn btn-outline-primary" routerLink="ai-experience" routerLinkActive="active" jhiTranslate="artemisApp.userSettings.aiExperience"></a>
                 }
                 <a class="list-group-item btn btn-outline-primary" routerLink="profile" routerLinkActive="active" jhiTranslate="artemisApp.userSettings.learnerProfile"></a>
-                <a class="list-group-item btn btn-outline-primary" routerLink="science" routerLinkActive="active" jhiTranslate="artemisApp.userSettings.scienceSettings"></a>
+                @if (isScienceEnabled()) {
+                    <a class="list-group-item btn btn-outline-primary" routerLink="science" routerLinkActive="active" jhiTranslate="artemisApp.userSettings.scienceSettings"></a>
+                }
                 <a class="list-group-item btn btn-outline-primary" routerLink="ssh" routerLinkActive="active" jhiTranslate="artemisApp.userSettings.sshSettings"></a>
                 @if (isAtLeastTutor()) {
                     <a

--- a/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.spec.ts
+++ b/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.spec.ts
@@ -11,7 +11,7 @@ import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from 'test/helpers/mocks/service/mock-account.service';
 import { MockActivatedRoute } from 'test/helpers/mocks/activated-route/mock-activated-route';
 import { UserSettingsContainerComponent } from 'app/account/user/settings/user-settings-container/user-settings-container.component';
-import { MODULE_FEATURE_ATHENA, MODULE_FEATURE_IRIS } from 'app/app.constants';
+import { MODULE_FEATURE_ATHENA, MODULE_FEATURE_ATLAS, MODULE_FEATURE_IRIS } from 'app/app.constants';
 
 describe('UserSettingsContainerComponent', () => {
     setupTestBed({ zoneless: true });
@@ -55,6 +55,29 @@ describe('UserSettingsContainerComponent', () => {
         vi.spyOn(component['profileService'], 'isModuleFeatureActive').mockReturnValue(false);
         component.ngOnInit();
         expect(component.isPasskeyEnabled()).toBe(false);
+    });
+
+    describe('science tab visibility', () => {
+        const queryScienceLink = (): HTMLElement | null => {
+            fixture.detectChanges();
+            return fixture.nativeElement.querySelector('a[routerLink="science"]');
+        };
+
+        it('should hide the science tab when the atlas module is inactive (issue #13173)', () => {
+            vi.spyOn(component['profileService'], 'isModuleFeatureActive').mockImplementation((feature) => feature !== MODULE_FEATURE_ATLAS);
+            component.ngOnInit();
+            expect(component.isScienceEnabled()).toBe(false);
+            expect(queryScienceLink()).toBeFalsy();
+        });
+
+        it('should show the science tab when the atlas module is active', () => {
+            vi.spyOn(component['profileService'], 'isModuleFeatureActive').mockImplementation((feature) => feature === MODULE_FEATURE_ATLAS);
+            component.ngOnInit();
+            expect(component.isScienceEnabled()).toBe(true);
+            const scienceLink = queryScienceLink();
+            expect(scienceLink).toBeTruthy();
+            expect(scienceLink?.getAttribute('jhiTranslate')).toBe('artemisApp.userSettings.scienceSettings');
+        });
     });
 
     describe('isAiEnabled behavior', () => {

--- a/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.ts
+++ b/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { faUser } from '@fortawesome/free-solid-svg-icons';
-import { MODULE_FEATURE_PASSKEY, addPublicFilePrefix } from 'app/app.constants';
+import { MODULE_FEATURE_ATLAS, MODULE_FEATURE_PASSKEY, addPublicFilePrefix } from 'app/app.constants';
 import { User } from 'app/account/user/user.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
@@ -31,9 +31,14 @@ export class UserSettingsContainerComponent implements OnInit {
     readonly isPasskeyEnabled = signal(false);
     readonly isAtLeastTutor = signal(false);
     readonly isAiEnabled = signal(false);
+    // The science settings live in the atlas module (server-side ScienceSettingsResource is @Conditional(AtlasEnabled)).
+    // When atlas is disabled the science-settings endpoint does not exist, so the tab must be hidden instead of opening
+    // an empty page (issue #13173).
+    readonly isScienceEnabled = signal(false);
 
     ngOnInit() {
         this.isPasskeyEnabled.set(this.profileService.isModuleFeatureActive(MODULE_FEATURE_PASSKEY));
+        this.isScienceEnabled.set(this.profileService.isModuleFeatureActive(MODULE_FEATURE_ATLAS));
 
         this.isAiEnabled.set(this.dataGuard.isUsingLLM());
         this.accountService

--- a/src/main/webapp/app/account/user/settings/user-settings.model.ts
+++ b/src/main/webapp/app/account/user/settings/user-settings.model.ts
@@ -39,4 +39,7 @@ export abstract class Setting {
     descriptionKey?: string;
     settingId!: SettingId;
     changed?: boolean;
+    // The on/off state of the setting (see the class doc: settings hold changeable on/off properties). Kept on the base
+    // so concrete settings components can read it via the inherited signals without re-declaring (shadowing) them.
+    active?: boolean;
 }

--- a/src/main/webapp/app/account/user/settings/user-settings.route.ts
+++ b/src/main/webapp/app/account/user/settings/user-settings.route.ts
@@ -3,6 +3,7 @@ import { Routes } from '@angular/router';
 import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
 import { IS_AT_LEAST_STUDENT, IS_AT_LEAST_TUTOR } from 'app/foundation/constants/authority.constants';
 import { DataGuard } from 'app/account/user/settings/data-guard.service';
+import { scienceSettingsGuard } from 'app/account/user/settings/science-settings/science-settings.guard';
 
 export const routes: Routes = [
     {
@@ -45,6 +46,7 @@ export const routes: Routes = [
                 data: {
                     pageTitle: 'artemisApp.userSettings.categories.SCIENCE_SETTINGS',
                 },
+                canActivate: [scienceSettingsGuard],
             },
             {
                 path: 'ssh',


### PR DESCRIPTION
### Summary
The **Science** tab in the user account settings opened a blank page. This PR makes the page render again and hides the tab when the underlying feature is unavailable.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Client
- [x] I strictly followed the client coding guidelines.
- [x] I added Vitest tests related to the fix (with a high test coverage).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
Fixes #13173.

The Science settings page rendered only its heading and then stayed blank. Two independent problems were behind this:

1. **Blank page (runtime crash).** `ScienceSettingsComponent` extends the abstract `UserSettingsDirective`, which initializes the `userSettings` / `settings` signals. The subclass re-declared those inherited fields via `declare userSettings: WritableSignal<…>`. Under `useDefineForClassFields` (TypeScript target `es2024`), the Angular production build emits these `declare` re-declarations as **uninitialized** class fields that shadow the base signals with `undefined`. At runtime this threw `Cannot read properties of undefined (reading 'set')` and, in the template, `userSettings is not a function` — so only the `<h2>` rendered and the rest of the page stayed blank. Plain `tsc`/`esbuild` and the Vitest transform strip `declare`, which is why unit tests and local repros did not reproduce it.
2. **Tab shown when the feature is unavailable.** The Science settings endpoint lives in the atlas module (`ScienceSettingsResource` is `@Conditional(AtlasEnabled.class)`), but the settings sidebar always showed the tab, so it opened a non-functional page when the atlas module is disabled.

### Description
- Removed the field shadowing: `ScienceSettingsComponent` no longer re-declares the inherited `userSettings`/`settings` signals. The on/off state (`active`) is moved onto the base `Setting` (its class doc already describes settings as on/off changeable properties), and `ScienceSetting` becomes a type alias for `Setting`. The component now reads the inherited, correctly-typed signals directly — no re-declaration, no generic, no casts. Verified against a production webapp build: the emitted `ScienceSettingsComponent` no longer declares the shadowing fields, so `this.userSettings` is the inherited signal and the page renders.
- Gated the Science tab in the user-settings sidebar on `MODULE_FEATURE_ATLAS`, and added a `scienceSettingsGuard` route guard that redirects `/user-settings/science` to the settings root when the atlas module is disabled (so direct navigation cannot open the empty page either).
- Added a render regression test — the previous spec never called `detectChanges()`, which is how the blank render slipped through — plus container and guard tests.

No new user-facing strings were added (the translation keys already existed), and no server changes are required.

### Steps for Testing
Prerequisites: 1 user; an instance with the **atlas module enabled**.
1. Log in and open **Settings** → **Science**.
2. Verify the page renders: the heading, the "Help Artemis to get better!" info line, and the activity-tracking toggle.
3. Toggle the setting and verify it is saved (a success alert appears).
4. On an instance with the **atlas module disabled**: verify the Science tab is **not** shown in the sidebar, and that navigating directly to `/user-settings/science` redirects to the settings root instead of showing a blank page.

### Screenshots
- **Before** (see #13173): only the "Science Settings" heading renders; the rest of the panel is blank.
- **After**: the info line and the activity-tracking toggle render normally.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/28959733097) did not pass (`failure`). Coverage below may be partial.

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| science-settings-structure.ts | 100.00% | 21 | ? | ? |
| science-settings.component.ts | 92.30% | 85 | 14 | 16.5 |
| science-settings.guard.ts | 100.00% | 12 | 4 | 33.3 |
| science-settings.service.ts | 93.54% | 72 | 17 | 23.6 |
| user-settings-container.component.ts | 100.00% | 43 | 15 | 34.9 |
| user-settings.model.ts | not found (modified) | 18 | ? | ? |

_Last updated: 2026-07-08 17:22:22 UTC_

