### PR TITLE
`Exam mode`: Force sending restored answer on resume

### DIFF
--- a/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.spec.ts
+++ b/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.spec.ts
@@ -801,23 +801,24 @@ describe('ExamParticipationComponent', () => {
             expect(quizSpy).toHaveBeenCalledWith(11, quizSubmission);
         });
 
-        it('should keep answers unsynced and not send them when offline at resume so the autosave retries later', () => {
+        it('should force the recovery re-send even when the websocket is not (re)connected yet at resume', () => {
             const { studentExam, quizSubmission, textSubmission, modelingSubmission } = buildResumeStudentExam();
             comp.exam.set(studentExam.exam!);
-            comp.connected.set(false); // the websocket is not (re)connected yet at resume time
+            // Right after a reload the websocket often has not re-established yet (especially in a multi-node cluster),
+            // so `connected()` is false. The recovery re-send is a plain HTTP request that does not need the websocket,
+            // and it must fire regardless — otherwise the restored answers are silently deferred to the next autosave
+            // cycle, the answer-loss window this recovery path exists to close (regression: ExamSubmissionRecovery E2E).
+            comp.connected.set(false);
             const quizSpy = vi.spyOn(examParticipationService, 'updateQuizSubmission').mockReturnValue(of(quizSubmission));
             const textSpy = vi.spyOn(textSubmissionService, 'update').mockReturnValue(of(new HttpResponse({ body: textSubmission })));
             const modelingSpy = vi.spyOn(modelingSubmissionService, 'update').mockReturnValue(of(new HttpResponse({ body: modelingSubmission })));
 
             comp.examStarted(studentExam, true);
 
-            // Nothing is sent while offline, but the answers stay unsynced so the autosave re-sends them once reconnected.
-            expect(quizSpy).not.toHaveBeenCalled();
-            expect(textSpy).not.toHaveBeenCalled();
-            expect(modelingSpy).not.toHaveBeenCalled();
-            expect(quizSubmission.isSynced).toBe(false);
-            expect(textSubmission.isSynced).toBe(false);
-            expect(modelingSubmission.isSynced).toBe(false);
+            // All three restored answers are re-sent immediately, not deferred, despite the websocket being down.
+            expect(quizSpy).toHaveBeenCalledWith(11, quizSubmission);
+            expect(textSpy).toHaveBeenCalledWith(textSubmission, 12);
+            expect(modelingSpy).toHaveBeenCalledWith(modelingSubmission, 13);
         });
 
         it('should not show the restore notification on a normal (not failed) start', () => {

--- a/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.ts
@@ -401,7 +401,11 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
             // Immediately re-send any answers that were restored from local storage but not yet saved to the server,
             // instead of waiting for the next autosave cycle. Submissions that fail again stay isSynced=false and are
             // retried by the autosave timer. Guarded by studentExam because triggerSave dereferences the current exam.
-            this.triggerSave(false);
+            // Force the save (forceSave=true): the recovery re-send is a plain HTTP request and must NOT be gated on the
+            // WebSocket `connected()` state, which right after a reload has often not re-established yet (especially in a
+            // multi-node cluster). Gating it there would silently defer the recovery to the next autosave cycle, which is
+            // exactly the answer-loss window this recovery path exists to close.
+            this.triggerSave(true);
         }
     }
 


### PR DESCRIPTION
### Summary
Fixes a flaky exam-submission-recovery path (and the multi-node-flaky `ExamSubmissionRecovery` E2E test): after a failed save, a restored quiz/text/modeling answer was sometimes not re-sent on reload until the next autosave cycle, because the recovery re-send was gated on the WebSocket connection being up.

### Checklist
#### General
- [x] I chose a title conforming to the naming conventions for pull requests.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.

#### Client
- [x] I followed the client coding and design guidelines.
- [x] Covered by the existing `exam-participation.component.spec.ts` resume tests, one of which is updated to assert the corrected behavior.

### Motivation and Context
When a submission save fails (e.g. a network/power outage), the answer is written to local storage and, on reload, restored and re-sent to the server. The recovery re-send used `triggerSave(false)`, which only sends when `forceSave || connected()`. `connected()` reflects the **WebSocket** status, which right after a reload has usually not re-established yet — especially in a multi-node cluster. So the plain-HTTP recovery re-send was skipped and deferred to the next autosave cycle: exactly the answer-loss window this recovery path exists to close. It also made the `ExamSubmissionRecovery` E2E test flaky under multi-node load (the re-send `PUT` missed the test's 30s window; it passes single-node, where the WebSocket reconnects quickly).

### Description
- `exam-participation.component.ts`: the resume-after-failed-save re-send now uses `triggerSave(true)`. The recovery send is a plain HTTP request that must not depend on the transient WebSocket state. If the client is genuinely offline, the forced attempt fails gracefully and stays unsynced for the autosave to retry (unchanged). Safe because `activePageComponent` is `undefined` on the overview/resume page, so the `forceSave` active-component branch is skipped.
- `exam-participation.component.spec.ts`: updated the resume test that previously asserted the buggy "skip the re-send while the WebSocket is down" behavior to assert the forced send instead.

### Steps for Testing
Prerequisites: 1 Student, 1 Exam with a quiz exercise.

1. Start the exam as a student, open the quiz, tick an answer.
2. Simulate a failed save (block the quiz exam-save endpoint), then reload the page while the WebSocket is still reconnecting.
3. The restored answer is re-sent immediately (successful `PUT .../submissions/exam`) rather than waiting for the next autosave cycle.

Automated: `pnpm run vitest:run -- src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.spec.ts` (validated locally, all pass), and the `ExamSubmissionRecovery` E2E test.

### Testserver States
You can manage test servers using Helios. This is a small client-only change; no special server state is required.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after a page reload so unsaved exam answers are re-sent immediately.
  * Fixed an issue where restored submissions could wait for a reconnect before being saved, reducing the risk of lost answers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->