### PR TITLE
`Text exercises`: Fix an issue for exercises without fetched categories

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/text/dto/TextExerciseListItemDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/dto/TextExerciseListItemDTO.java
@@ -77,9 +77,14 @@ public record TextExerciseListItemDTO(Long id, String title, String shortName, S
         // the cross-course import search; resolves the course for both course and exam exercises.
         CourseRefDTO course = CourseRefDTO.from(exercise.getCourseViaExerciseGroupOrCourseMember());
 
+        // categories is a LAZY @ElementCollection: never store the live Hibernate collection in the record. The
+        // dev-profile LoggingAspect calls toString() on the DTO after the loading session closed, which throws
+        // LazyInitializationException (500) for load paths that do not fetch categories.
+        Set<String> categories = exercise.getCategories() != null && Hibernate.isInitialized(exercise.getCategories()) ? Set.copyOf(exercise.getCategories()) : null;
+
         return new TextExerciseListItemDTO(exercise.getId(), exercise.getTitle(), exercise.getShortName(), exercise.getType(), exercise.getExerciseType(),
                 exercise.getReleaseDate(), exercise.getDueDate(), exercise.getAssessmentDueDate(), exercise.getMaxPoints(), exercise.getBonusPoints(),
-                exercise.getIncludedInOverallScore(), exercise.getPresentationScoreEnabled(), exercise.getMode() == ExerciseMode.TEAM, exercise.getCategories(),
-                gradingCriterionDTOs, courseId, course, examId, examTitle, exerciseGroup);
+                exercise.getIncludedInOverallScore(), exercise.getPresentationScoreEnabled(), exercise.getMode() == ExerciseMode.TEAM, categories, gradingCriterionDTOs, courseId,
+                course, examId, examTitle, exerciseGroup);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/text/dto/TextExerciseResponseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/dto/TextExerciseResponseDTO.java
@@ -114,11 +114,16 @@ public record TextExerciseResponseDTO(Long id, String title, String shortName, S
                 ? exercise.getExampleSubmissions().stream().map(ExampleSubmissionDTO::of).collect(Collectors.toSet())
                 : null;
 
+        // categories is a LAZY @ElementCollection: never store the live Hibernate collection in the record. The
+        // dev-profile LoggingAspect calls toString() on the DTO after the loading session closed, which throws
+        // LazyInitializationException (500) for load paths that do not fetch categories, e.g. the text editor endpoint.
+        Set<String> categories = exercise.getCategories() != null && Hibernate.isInitialized(exercise.getCategories()) ? Set.copyOf(exercise.getCategories()) : null;
+
         return new TextExerciseResponseDTO(exercise.getId(), exercise.getTitle(), exercise.getShortName(), exercise.getType(), exercise.getExerciseType(), exercise.getDifficulty(),
                 exercise.getMode(), exercise.getMaxPoints(), exercise.getBonusPoints(), exercise.getIncludedInOverallScore(), exercise.getReleaseDate(), exercise.getStartDate(),
                 exercise.getDueDate(), exercise.getAssessmentDueDate(), exercise.getExampleSolutionPublicationDate(), exercise.getAssessmentType(),
                 exercise.getSecondCorrectionEnabled(), exercise.getPresentationScoreEnabled(), exercise.getProblemStatement(), exercise.getExampleSolution(),
-                exercise.getGradingInstructions(), exercise.getCategories(), exercise.getChannelName(), exercise.getFeedbackSuggestionModule(),
+                exercise.getGradingInstructions(), categories, exercise.getChannelName(), exercise.getFeedbackSuggestionModule(),
                 exercise.getAllowComplaintsForAutomaticAssessments(), exercise.getAllowFeedbackRequests(), courseId, courseAccuracyOfScores, course, exerciseGroupId, examId,
                 examPublishResultsDate, teamAssignmentConfigDTO, gradingCriterionDTOs, competencyLinkDTOs, plagiarismDetectionConfigDTO,
                 exercise.isGradingInstructionFeedbackUsed(), exampleSubmissionDTOs, exercise.getMode() == ExerciseMode.TEAM, exerciseGroup);

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextExerciseIntegrationTest.java
@@ -7,6 +7,7 @@ import static de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus.CONFIRME
 import static de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus.DENIED;
 import static de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismStatus.NONE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -181,6 +182,26 @@ class TextExerciseIntegrationTest extends AbstractSpringIntegrationIndependentTe
         course = textExerciseUtilService.addCourseWithOneReleasedTextExercise();
         textExercise = textExerciseRepository.findByCourseIdWithCategories(course.getId()).getFirst();
         competency = competencyUtilService.createCompetency(course);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void responseDtosMustNotHoldLiveLazyCategoriesCollection() {
+        // Load through a query that does NOT fetch the LAZY categories @ElementCollection: the repository transaction
+        // is closed when the factory runs, exactly like in a REST call (OSIV is off). Pre-fix, the record stored the
+        // live Hibernate collection and the dev-profile LoggingAspect's toString() threw LazyInitializationException.
+        TextExercise detached = textExerciseRepository.findById(textExercise.getId()).orElseThrow();
+
+        TextExerciseResponseDTO responseDTO = TextExerciseResponseDTO.of(detached);
+        assertThatNoException().as("toString on a DTO built from an exercise without fetched categories").isThrownBy(responseDTO::toString);
+        assertThat(responseDTO.categories()).as("uninitialized categories map to null instead of a live collection").isNull();
+
+        TextExerciseListItemDTO listItemDTO = TextExerciseListItemDTO.of(detached);
+        assertThatNoException().as("toString on a list-item DTO built from an exercise without fetched categories").isThrownBy(listItemDTO::toString);
+        assertThat(listItemDTO.categories()).as("uninitialized categories map to null instead of a live collection").isNull();
+
+        // The initialized path still carries the categories (setup loads via findByCourseIdWithCategories).
+        assertThat(TextExerciseResponseDTO.of(textExercise).categories()).isEqualTo(textExercise.getCategories());
     }
 
     @Test


### PR DESCRIPTION
### Checklist

#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://confluence.aet.cit.tum.de/spaces/IPD/pages/25252197/Artemis+Language+Guidelines).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.cit.tum.de/dev/development-process/development-process.html#naming-conventions-for-github-pull-requests).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.cit.tum.de/dev/guidelines/performance/) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added an integration regression test (Spring) that reproduces the crash before the fix and passes after.

### Motivation and Context

`TextExerciseResponseDTO.of` and `TextExerciseListItemDTO.of` (introduced in #12922) store the **live Hibernate collection** returned by `exercise.getCategories()` (a LAZY `@ElementCollection`) directly in the record. For any load path that does not fetch categories — e.g. `GET /api/text/text-exercises/{id}/text-editor/{participationId}` — the collection is uninitialized, the loading session is closed when the record is used (open-in-view is off), and the dev-profile `LoggingAspect` `toString()` call throws `LazyInitializationException`, turning the request into a 500.

This currently breaks text-exercise participation flows (including exam conduction with text exercises) on dev-profile deployments and is visible as consistent failures in the exam Playwright E2E suites.

### Description

Both factories now map `categories` through the same guard every other lazy association in these DTOs already uses: `Hibernate.isInitialized(...) ? Set.copyOf(...) : null`. Uninitialized categories serialize as omitted (unchanged wire behavior — Jackson's Hibernate module already replaced them before); initialized categories are copied so no live persistent collection ever ends up in a record.

### Steps for Testing

Prerequisites: 1 course with a text exercise, 1 student participation.

1. Log in as a student.
2. Open the text exercise (text editor) and submit a text.
3. Verify the editor loads and the submission succeeds without error notifications.
4. As an instructor, open the exam-mode test run flow with a text exercise and verify the text editor loads.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/29010791635) did not pass (`failure`). Coverage below may be partial.

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| TextExerciseListItemDTO.java | not found (modified) | 59 |
| TextExerciseResponseDTO.java | not found (modified) | 95 |

_Last updated: 2026-07-09 19:27:14 UTC_

