### PR TITLE
`Usability`: Fix broken table layout in import dialog

### DIFF
--- a/src/main/webapp/app/exercise/import/exercise-import.component.html
+++ b/src/main/webapp/app/exercise/import/exercise-import.component.html
@@ -14,9 +14,9 @@
             <span class="ms-3" jhiTranslate="artemisApp.exercise.import.loading"></span>
         }
     </div>
-    <table class="table table-striped flex">
+    <table class="table table-striped">
         <thead class="thead-dark">
-            <tr jhiSort [(predicate)]="sortedColumn" [(ascending)]="listSorting" (sortChange)="sortRows()" class="flex-row">
+            <tr jhiSort [(predicate)]="sortedColumn" [(ascending)]="listSorting" (sortChange)="sortRows()">
                 <th jhiSortBy="ID" class="col-1">
                     <span>#</span>
                     <fa-icon [icon]="faSort" />
@@ -47,7 +47,7 @@
         </thead>
         <tbody>
             @for (exercise of content().resultsOnPage; track trackId($index, exercise)) {
-                <tr [class]="'flex-row exercise-' + exercise.id">
+                <tr [class]="'exercise-' + exercise.id">
                     <td class="col-1">
                         <span [class.ngb-highlight]="'' + exercise.id === searchTerm"> {{ exercise.id }}</span>
                     </td>

--- a/src/main/webapp/app/exercise/import/exercise-import.component.spec.ts
+++ b/src/main/webapp/app/exercise/import/exercise-import.component.spec.ts
@@ -21,6 +21,10 @@ import { SortService } from 'app/foundation/service/sort.service';
 import { SearchResult, SearchTermPageableSearch, SortingOrder } from 'app/foundation/pagination/pageable-table';
 import { TextExercisePagingService } from 'app/text/manage/text-exercise/service/text-exercise-paging.service';
 import { TextExercise } from 'app/text/shared/entities/text-exercise.model';
+import { TranslateService } from '@ngx-translate/core';
+import { TranslateDirective } from 'app/foundation/language/translate.directive';
+import { MockJhiTranslateDirective } from 'test/helpers/mocks/directive/mock-jhi-translate-directive.directive';
+import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 
 describe('ExerciseImportComponent', () => {
     setupTestBed({ zoneless: true });
@@ -325,5 +329,59 @@ describe('ExerciseImportComponent', () => {
         comp.sortedColumn = 'COURSE_TITLE';
 
         expect(comp.sortedColumn).toBe('EXAM_TITLE');
+    });
+});
+
+describe('ExerciseImportComponent template', () => {
+    setupTestBed({ zoneless: true });
+
+    let fixture: ComponentFixture<ExerciseImportComponent>;
+    let comp: ExerciseImportComponent;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            providers: [
+                { provide: DynamicDialogRef, useValue: { close: vi.fn(), onClose: new Subject<Exercise | undefined>() } },
+                { provide: Router, useValue: { navigate: vi.fn() } },
+                { provide: TranslateService, useClass: MockTranslateService },
+                provideHttpClient(),
+                provideHttpClientTesting(),
+            ],
+        })
+            // Render the real template but stub the translate directive so no TranslateService is required.
+            .overrideComponent(ExerciseImportComponent, {
+                remove: { imports: [TranslateDirective] },
+                add: { imports: [MockJhiTranslateDirective] },
+            })
+            .compileComponents();
+
+        fixture = TestBed.createComponent(ExerciseImportComponent);
+        comp = fixture.componentInstance;
+        fixture.componentRef.setInput('exerciseType', ExerciseType.QUIZ);
+        vi.spyOn(TestBed.inject(QuizExercisePagingService), 'search').mockReturnValue(of({ numberOfPages: 0, resultsOnPage: [] }));
+    });
+
+    it('should render the results as a normal table with the header aligned above the rows', () => {
+        const exercise = new QuizExercise(undefined, undefined);
+        exercise.id = 1;
+        exercise.title = 'Some exercise';
+
+        // detect changes first so that ngOnInit runs (it resets the content), then populate the table
+        fixture.detectChanges();
+        comp.content.set({ resultsOnPage: [exercise], numberOfPages: 1 });
+        fixture.detectChanges();
+
+        const table: HTMLTableElement = fixture.nativeElement.querySelector('table');
+        // Regression guard: a bare `flex` class turned the table into a flex row, so the browser
+        // laid out <thead> and <tbody> as side-by-side items (header next to the rows) instead of
+        // stacking them. The table (and its rows) must not carry the flex classes.
+        expect(table.classList.contains('flex')).toBe(false);
+        expect(table.querySelector('thead tr')?.classList.contains('flex-row')).toBe(false);
+        expect(table.querySelector('tbody tr')?.classList.contains('flex-row')).toBe(false);
+
+        // In a normal table every row has the same number of columns as the header, so they align.
+        const headerColumns = table.querySelectorAll('thead tr th').length;
+        const firstRowColumns = table.querySelectorAll('tbody tr:first-child td').length;
+        expect(firstRowColumns).toBe(headerColumns);
     });
 });


### PR DESCRIPTION
### Summary

The exercise import dialog (e.g. **Import Programming Exercise** → *From instance*) rendered its results table incorrectly: the column header row appeared as a narrow column on the left while the result rows were pushed to the right, misaligned with the header. The results `<table>` carried a bare `flex` class; since the client migrated to **Tailwind CSS v4**, `.flex` now resolves to `display: flex`, turning the table into a flex row container and laying out `<thead>` and `<tbody>` as side-by-side items. This PR removes the obsolete `flex` / `flex-row` classes so the results render as a normal, aligned table again.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).

### Motivation and Context

Closes #13193.

After the Bootstrap → Tailwind CSS v4 migration, the bare `flex` class on the import results `<table>` changed meaning from a no-op (Bootstrap only defines `.d-flex`) to `display: flex` (Tailwind). With the default `flex-direction: row`, the `<thead>` and `<tbody>` became side-by-side flex items, so the column header rendered to the left of the result rows instead of above them — making the import dialog's table unreadable.

### Description

In `exercise-import.component.html`:
- Removed the `flex` class from the `<table>` element.
- Removed the now-obsolete `flex-row` class from the header row and the data rows.

The table now renders with its normal `display: table` layout, so `<thead>` stacks above `<tbody>` and every column lines up under its heading. The existing `col-*` width hints continue to size the columns. No colors, REST calls, or component logic changed — the fix is purely presentational.

Added a Vitest test that renders the real template and asserts the table (and its rows) no longer carry the flex classes and that each result row has the same number of columns as the header. The test fails on the previous markup and passes with the fix.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Course with at least one programming exercise

1. Log in to Artemis as an instructor.
2. Navigate to a course's exercise management page.
3. Next to *Programming Exercises*, click **Import** to open the **Import Programming Exercise** dialog (*From instance* tab).
4. Verify the results table renders normally: the header row (`#`, `Title`, `Language`, `Course | Exam`, `Exam Question`) sits above the result rows, and every column lines up under its heading — no header column on the left with the rows pushed to the right.
5. Repeat for other exercise types (e.g. **Import Quiz**) to confirm the shared import dialog is consistent.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-10 19:17:52 UTC_


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the exercise import results table layout by removing incorrect flex styling.
  * Improved table rendering to ensure rows align consistently with their headers.

* **Tests**
  * Added coverage verifying table structure, styling, and matching column counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->