### PR TITLE
`Exam mode`: Fix file upload submission now showing in exam summaries

### DIFF
--- a/src/main/webapp/app/fileupload/overview/file-upload-submission/file-upload-submission.component.ts
+++ b/src/main/webapp/app/fileupload/overview/file-upload-submission/file-upload-submission.component.ts
@@ -8,6 +8,7 @@ import { RatingComponent } from 'app/exercise/rating/rating.component';
 import dayjs from 'dayjs/esm';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { FileUploadSubmissionService } from 'app/fileupload/overview/file-upload-submission.service';
+import { addPublicFilePrefix } from 'app/app.constants';
 import { MAX_SUBMISSION_FILE_SIZE } from 'app/foundation/constants/input.constants';
 import { FileUploadAssessmentService } from 'app/fileupload/manage/assess/file-upload-assessment.service';
 import { omit } from 'lodash-es';
@@ -212,6 +213,9 @@ export class FileUploadSubmissionComponent implements ComponentCanDeactivate {
         }
         const submission = this.inputSubmission();
         if (submission) {
+            if (submission.filePath && !submission.filePathUrl) {
+                submission.filePathUrl = addPublicFilePrefix(submission.filePath);
+            }
             this.submission.set(submission);
         }
         const participation = this.inputParticipation();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
When looking at an exam summary the file upload submission does not show the uploaded file.
This fixes that.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes a bug. Students may think their submission was not saved properly.

### Description
<!-- Describe your changes in detail -->
Populate the submission.filePathUrl so the client can show it.

### Steps for Testing

#### Exam Mode Testing
Prerequisites:
- 1 Instructor
- 1 Student

1. Create an exam with a file upload exercise and convenient timing so that you dont have to wait long to start as a student
2. As a student participate in the exam and upload a file. Hand the exam in.
3. Check out your exam summary by going on the exam paga again. You should be able to view your uploaded file.



### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Exam Mode Test
- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| file-upload-submission.component.ts | 94.77% | 281 | 45 | 16.0 |

_Last updated: 2026-07-11 11:21:08 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
As you can see the file can be seen and downloaded:
<img width="958" height="653" alt="image" src="https://github.com/user-attachments/assets/a98dde72-d6b9-424d-8011-b944e0ee4859" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File submission entries now correctly display file links when only a file path is provided.
  * Improved file URL handling during submission initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->