### PR TITLE
`Exam mode`: Use a DTO for the student exam submit endpoint

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/FileUploadExamSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/FileUploadExamSubmissionDTO.java
@@ -1,0 +1,17 @@
+package de.tum.cit.aet.artemis.exam.dto.submit;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * The file-upload-submission variant of {@link SubmitExamSubmissionDTO}. File-upload submissions are persisted
+ * exclusively through the file-upload submission page, never through the exam hand-in, so this record carries only
+ * the id and is accepted-and-ignored. It exists so a legacy full-entity {@code StudentExam} body that still includes
+ * file-upload submissions deserializes without error.
+ *
+ * @param id the id of the file-upload submission (ignored by the submit path)
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FileUploadExamSubmissionDTO(Long id) implements SubmitExamSubmissionDTO {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/ModelingExamSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/ModelingExamSubmissionDTO.java
@@ -1,0 +1,17 @@
+package de.tum.cit.aet.artemis.exam.dto.submit;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * The modeling-submission variant of {@link SubmitExamSubmissionDTO}: carries the existing submission id and the
+ * student's latest UML model and explanation.
+ *
+ * @param id              the id of the existing modeling submission the answer belongs to
+ * @param model           the submitted UML model as JSON string (may be {@code null})
+ * @param explanationText the submitted explanation text (may be {@code null})
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ModelingExamSubmissionDTO(Long id, String model, String explanationText) implements SubmitExamSubmissionDTO {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/ModelingExamSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/ModelingExamSubmissionDTO.java
@@ -6,6 +6,10 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 /**
  * The modeling-submission variant of {@link SubmitExamSubmissionDTO}: carries the existing submission id and the
  * student's latest UML model and explanation.
+ * <p>
+ * Unlike {@link TextExamSubmissionDTO} (which also carries {@code language}), a modeling submission has no type-specific
+ * metadata beyond {@code model} and {@code explanationText}; the only other merge-overwritten columns are the base
+ * {@code type} and {@code exampleSubmission}, which are always {@code null} for exam submissions, so this DTO is complete.
  *
  * @param id              the id of the existing modeling submission the answer belongs to
  * @param model           the submitted UML model as JSON string (may be {@code null})

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/ProgrammingExamSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/ProgrammingExamSubmissionDTO.java
@@ -1,0 +1,17 @@
+package de.tum.cit.aet.artemis.exam.dto.submit;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * The programming-submission variant of {@link SubmitExamSubmissionDTO}. Programming submissions are persisted
+ * exclusively through git pushes / the programming submission page, never through the exam hand-in, so this record
+ * carries only the id and is accepted-and-ignored. It exists so a legacy full-entity {@code StudentExam} body that
+ * still includes programming submissions deserializes without error.
+ *
+ * @param id the id of the programming submission (ignored by the submit path)
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ProgrammingExamSubmissionDTO(Long id) implements SubmitExamSubmissionDTO {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/QuizExamSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/QuizExamSubmissionDTO.java
@@ -1,0 +1,29 @@
+package de.tum.cit.aet.artemis.exam.dto.submit;
+
+import java.util.Set;
+
+import jakarta.validation.Valid;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.quiz.dto.submittedanswer.SubmittedAnswerFromLiveClientDTO;
+
+/**
+ * The quiz-submission variant of {@link SubmitExamSubmissionDTO}: carries the existing submission id and the
+ * student's submitted answers.
+ * <p>
+ * The answer set reuses the {@link SubmittedAnswerFromLiveClientDTO} family shipped for the live and exam quiz
+ * auto-save endpoints (#12832): the server rebuilds the {@link de.tum.cit.aet.artemis.quiz.domain.QuizSubmission}
+ * via {@link de.tum.cit.aet.artemis.quiz.service.QuizSubmissionService#buildSubmissionFromLiveClientDTO}, which
+ * re-resolves every answer's ids against the loaded quiz exercise and leniently drops answers whose ids no longer
+ * exist. This is intentionally stricter than the previous exam-submit path (which persisted client-supplied ids
+ * verbatim) and keeps the exam hand-in consistent with the quiz live-save behavior.
+ *
+ * @param id               the id of the existing quiz submission the answers belong to
+ * @param submittedAnswers the student's submitted answers (may be {@code null} or empty)
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record QuizExamSubmissionDTO(Long id, Set<@Valid SubmittedAnswerFromLiveClientDTO> submittedAnswers) implements SubmitExamSubmissionDTO {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/QuizExamSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/QuizExamSubmissionDTO.java
@@ -2,8 +2,6 @@ package de.tum.cit.aet.artemis.exam.dto.submit;
 
 import java.util.Set;
 
-import jakarta.validation.Valid;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -25,5 +23,5 @@ import de.tum.cit.aet.artemis.quiz.dto.submittedanswer.SubmittedAnswerFromLiveCl
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record QuizExamSubmissionDTO(Long id, Set<@Valid SubmittedAnswerFromLiveClientDTO> submittedAnswers) implements SubmitExamSubmissionDTO {
+public record QuizExamSubmissionDTO(Long id, Set<SubmittedAnswerFromLiveClientDTO> submittedAnswers) implements SubmitExamSubmissionDTO {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/SubmitExamExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/SubmitExamExerciseDTO.java
@@ -1,0 +1,22 @@
+package de.tum.cit.aet.artemis.exam.dto.submit;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * A single exercise as sent by the exam hand-in. Only the database id (matched against the exercise instance loaded
+ * from the DB, which continues to drive the {@code instanceof} type switch server-side) and the student participations
+ * are bound.
+ * <p>
+ * {@code studentParticipations} is kept as a {@link List} (never a {@code Set}) so the server's exact
+ * {@code studentParticipations.size() != 1 -> skip} semantics are preserved by construction.
+ *
+ * @param id                    the id of the exercise
+ * @param studentParticipations the student's participations for this exercise (the server only acts when exactly one is present)
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SubmitExamExerciseDTO(Long id, List<SubmitExamParticipationDTO> studentParticipations) {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/SubmitExamParticipationDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/SubmitExamParticipationDTO.java
@@ -1,0 +1,22 @@
+package de.tum.cit.aet.artemis.exam.dto.submit;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * A single student participation as sent by the exam hand-in. Only the database id (matched against the existing
+ * participation loaded from the DB) and the submissions are bound; the participant is deliberately dropped and
+ * re-derived server-side from the authenticated user.
+ * <p>
+ * {@code submissions} is kept as a {@link List} (never a {@code Set}) so the server's exact
+ * {@code submissions.size() != 1 -> skip} semantics are preserved by construction.
+ *
+ * @param id          the id of the existing student participation
+ * @param submissions the participation's submissions (the server only acts when exactly one is present)
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SubmitExamParticipationDTO(Long id, List<SubmitExamSubmissionDTO> submissions) {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/SubmitExamSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/SubmitExamSubmissionDTO.java
@@ -1,0 +1,37 @@
+package de.tum.cit.aet.artemis.exam.dto.submit;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Polymorphic request DTO for a single submission sent as part of the exam hand-in
+ * ({@code POST courses/{courseId}/exams/{examId}/student-exams/submit}).
+ * <p>
+ * The discriminator property and subtype names deliberately match the {@code submissionExerciseType}
+ * {@link com.fasterxml.jackson.annotation.JsonTypeInfo}/{@link com.fasterxml.jackson.annotation.JsonSubTypes}
+ * on the {@link de.tum.cit.aet.artemis.exercise.domain.Submission} entity, so that a full-entity
+ * {@code StudentExam} body posted by a stale client tab opened before the DTO rollout still binds
+ * losslessly (every record additionally sets {@code @JsonIgnoreProperties(ignoreUnknown = true)}).
+ * <p>
+ * Only the fields the server actually persists are bound: the database id (matched against the existing
+ * submission) plus the per-type content. Programming and file-upload submissions carry no content and are
+ * accepted-and-ignored (the server saves those only through their dedicated submission pages), but they are
+ * still modelled so a legacy body that includes them deserializes.
+ */
+@Schema(discriminatorProperty = "submissionExerciseType", discriminatorMapping = { @DiscriminatorMapping(value = "text", schema = TextExamSubmissionDTO.class),
+        @DiscriminatorMapping(value = "modeling", schema = ModelingExamSubmissionDTO.class), @DiscriminatorMapping(value = "quiz", schema = QuizExamSubmissionDTO.class),
+        @DiscriminatorMapping(value = "programming", schema = ProgrammingExamSubmissionDTO.class),
+        @DiscriminatorMapping(value = "file-upload", schema = FileUploadExamSubmissionDTO.class) }, oneOf = { TextExamSubmissionDTO.class, ModelingExamSubmissionDTO.class,
+                QuizExamSubmissionDTO.class, ProgrammingExamSubmissionDTO.class, FileUploadExamSubmissionDTO.class })
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "submissionExerciseType")
+@JsonSubTypes({ @JsonSubTypes.Type(value = TextExamSubmissionDTO.class, name = "text"), @JsonSubTypes.Type(value = ModelingExamSubmissionDTO.class, name = "modeling"),
+        @JsonSubTypes.Type(value = QuizExamSubmissionDTO.class, name = "quiz"), @JsonSubTypes.Type(value = ProgrammingExamSubmissionDTO.class, name = "programming"),
+        @JsonSubTypes.Type(value = FileUploadExamSubmissionDTO.class, name = "file-upload") })
+public sealed interface SubmitExamSubmissionDTO
+        permits TextExamSubmissionDTO, ModelingExamSubmissionDTO, QuizExamSubmissionDTO, ProgrammingExamSubmissionDTO, FileUploadExamSubmissionDTO {
+
+    Long id();
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/SubmitStudentExamDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/SubmitStudentExamDTO.java
@@ -1,0 +1,29 @@
+package de.tum.cit.aet.artemis.exam.dto.submit;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Request body for the exam hand-in ({@code POST courses/{courseId}/exams/{examId}/student-exams/submit}).
+ * <p>
+ * It carries only the id of the student exam and the last-second submission changes to persist. Everything else the
+ * old full-entity {@code StudentExam} body used to carry ({@code user}, {@code exam}, {@code submitted}, dates,
+ * {@code workingTime}, {@code examSessions}, {@code testRun}/{@code testExam}) is deliberately dropped: the server
+ * loads the authoritative student exam from the database by {@link #id()} and derives ownership, exam/course
+ * validation, the submitted flag, the submission date and the test-run/test-exam gating from that DB truth rather than
+ * from the client. Dropping the client-supplied {@code user} in particular removes the previous anti-manipulation
+ * gate's reliance on a client claim: ownership is now checked against the persisted student exam's owner.
+ * <p>
+ * Every record in this package is {@code @JsonIgnoreProperties(ignoreUnknown = true)} and mirrors the discriminator
+ * property names of the underlying entities, so a stale client tab that still posts the full-entity body deserializes
+ * losslessly across the DTO rollout.
+ *
+ * @param id        the id of the student exam being submitted
+ * @param exercises the exercises with their participations and submissions carrying the last-second changes
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SubmitStudentExamDTO(Long id, List<SubmitExamExerciseDTO> exercises) {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/TextExamSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/TextExamSubmissionDTO.java
@@ -1,0 +1,16 @@
+package de.tum.cit.aet.artemis.exam.dto.submit;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * The text-submission variant of {@link SubmitExamSubmissionDTO}: carries the existing submission id and the
+ * student's latest answer text.
+ *
+ * @param id   the id of the existing text submission the answer belongs to
+ * @param text the submitted answer text (may be {@code null} if the student left it empty)
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TextExamSubmissionDTO(Long id, String text) implements SubmitExamSubmissionDTO {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/TextExamSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/submit/TextExamSubmissionDTO.java
@@ -3,14 +3,26 @@ package de.tum.cit.aet.artemis.exam.dto.submit;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import de.tum.cit.aet.artemis.core.domain.Language;
+
 /**
- * The text-submission variant of {@link SubmitExamSubmissionDTO}: carries the existing submission id and the
- * student's latest answer text.
+ * The text-submission variant of {@link SubmitExamSubmissionDTO}: carries the existing submission id, the student's
+ * latest answer text and the client-detected {@link Language}.
+ * <p>
+ * The language is part of the wire contract on purpose. The downstream save
+ * ({@code StudentExamService.saveSubmissionTextExercise}) persists the client submission through a JPA merge, which
+ * overwrites <i>every</i> mapped column of the existing row from the posted entity. Omitting the language here would
+ * therefore null it out on every hand-in text edit — a regression against the legacy full-entity body, which round-tripped
+ * the language the client detects in {@code text-exam-submission.component.ts}. The submission {@code type} and
+ * {@code exampleSubmission} columns are the other merge-overwritten fields, but they are always {@code null} for exam
+ * submissions (initialized with a {@code null} type in {@code ParticipationService}, never example submissions), so
+ * dropping them is a no-op and they are intentionally not part of this DTO.
  *
- * @param id   the id of the existing text submission the answer belongs to
- * @param text the submitted answer text (may be {@code null} if the student left it empty)
+ * @param id       the id of the existing text submission the answer belongs to
+ * @param text     the submitted answer text (may be {@code null} if the student left it empty)
+ * @param language the client-detected language of the answer text (may be {@code null})
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record TextExamSubmissionDTO(Long id, String text) implements SubmitExamSubmissionDTO {
+public record TextExamSubmissionDTO(Long id, String text, Language language) implements SubmitExamSubmissionDTO {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamService.java
@@ -44,6 +44,7 @@ import de.tum.cit.aet.artemis.exam.domain.Exam;
 import de.tum.cit.aet.artemis.exam.domain.StudentExam;
 import de.tum.cit.aet.artemis.exam.dto.AthenaFeedbackUsageDTO;
 import de.tum.cit.aet.artemis.exam.dto.StudentExamWithGradeDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.SubmitStudentExamDTO;
 import de.tum.cit.aet.artemis.exam.repository.ExamRepository;
 import de.tum.cit.aet.artemis.exam.repository.StudentExamRepository;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
@@ -134,6 +135,8 @@ public class StudentExamService {
 
     private final TaskScheduler scheduler;
 
+    private final StudentExamSubmitMapper studentExamSubmitMapper;
+
     /**
      * Maximum number of Athena feedback requests a student may accumulate across all of their submitted test-exam
      * attempts for a given exam. Reuses the course-exercise cap so the two stay in sync.
@@ -147,7 +150,7 @@ public class StudentExamService {
             SubmissionVersionService submissionVersionService, SubmissionService submissionService, StudentParticipationRepository studentParticipationRepository,
             ExamQuizService examQuizService, ProgrammingExerciseRepository programmingExerciseRepository, ProgrammingTriggerService programmingTriggerService,
             ExamRepository examRepository, CacheManager cacheManager, WebsocketMessagingService websocketMessagingService, @Qualifier("taskScheduler") TaskScheduler scheduler,
-            ExamService examService) {
+            ExamService examService, StudentExamSubmitMapper studentExamSubmitMapper) {
         this.participationService = participationService;
         this.studentExamRepository = studentExamRepository;
         this.userRepository = userRepository;
@@ -168,6 +171,24 @@ public class StudentExamService {
         this.websocketMessagingService = websocketMessagingService;
         this.scheduler = scheduler;
         this.examService = examService;
+        this.studentExamSubmitMapper = studentExamSubmitMapper;
+    }
+
+    /**
+     * Reconstructs the transient submission graph from the slim client DTO onto the authoritative student exam and then
+     * submits it. This is the single service entry point for the hand-in endpoint, so the controller does not need to
+     * depend on the reconstruction mapper directly.
+     * <p>
+     * The per-exercise degrade semantics of the reconstruction are owned by {@link StudentExamSubmitMapper} and left
+     * unchanged: a broken exercise drops only its own last-second changes while the hand-in still succeeds.
+     *
+     * @param existingStudentExam  the student exam loaded from the database (with its exercises)
+     * @param submitStudentExamDTO the slim request body carrying the last-second submission changes
+     * @param currentUser          the current user
+     */
+    public void submitStudentExam(StudentExam existingStudentExam, SubmitStudentExamDTO submitStudentExamDTO, User currentUser) {
+        studentExamSubmitMapper.attachSubmissions(existingStudentExam, submitStudentExamDTO, currentUser);
+        submitStudentExam(existingStudentExam, currentUser);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamSubmitMapper.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamSubmitMapper.java
@@ -1,0 +1,161 @@
+package de.tum.cit.aet.artemis.exam.service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+import de.tum.cit.aet.artemis.account.domain.User;
+import de.tum.cit.aet.artemis.exam.config.ExamEnabled;
+import de.tum.cit.aet.artemis.exam.domain.StudentExam;
+import de.tum.cit.aet.artemis.exam.dto.submit.ModelingExamSubmissionDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.QuizExamSubmissionDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.SubmitExamExerciseDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.SubmitExamParticipationDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.SubmitExamSubmissionDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.SubmitStudentExamDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.TextExamSubmissionDTO;
+import de.tum.cit.aet.artemis.exercise.domain.Exercise;
+import de.tum.cit.aet.artemis.exercise.domain.Submission;
+import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.modeling.domain.ModelingSubmission;
+import de.tum.cit.aet.artemis.quiz.domain.QuizExercise;
+import de.tum.cit.aet.artemis.quiz.dto.submission.QuizSubmissionFromLiveClientDTO;
+import de.tum.cit.aet.artemis.quiz.repository.QuizExerciseRepository;
+import de.tum.cit.aet.artemis.quiz.service.QuizSubmissionService;
+import de.tum.cit.aet.artemis.text.domain.TextSubmission;
+
+/**
+ * Reconstructs the transient {@link StudentExam} object graph that {@link StudentExamService#submitStudentExam} needs,
+ * from the slim {@link SubmitStudentExamDTO} the client posts on hand-in.
+ * <p>
+ * The reconstruction intentionally keeps the exam-conduction save machinery
+ * ({@code StudentExamService.saveSubmissions}/{@code saveSubmission}) byte-for-byte unchanged: it only changes how the
+ * graph is built at the controller boundary. The DB-loaded exercise instances are reused (so the {@code instanceof}
+ * type switch keeps working), and onto each we hang transient participations (id + participant = current user, so
+ * {@code isOwnedBy(currentUser)} passes for both individual and team exercises) carrying transient submissions rebuilt
+ * per type with their client ids preserved (so the DB id-match in {@code saveSubmission} still resolves them).
+ */
+@Conditional(ExamEnabled.class)
+@Lazy
+@Component
+public class StudentExamSubmitMapper {
+
+    private static final Logger log = LoggerFactory.getLogger(StudentExamSubmitMapper.class);
+
+    private final QuizExerciseRepository quizExerciseRepository;
+
+    private final QuizSubmissionService quizSubmissionService;
+
+    public StudentExamSubmitMapper(QuizExerciseRepository quizExerciseRepository, QuizSubmissionService quizSubmissionService) {
+        this.quizExerciseRepository = quizExerciseRepository;
+        this.quizSubmissionService = quizSubmissionService;
+    }
+
+    /**
+     * Attaches the client-supplied last-second submission changes onto the DB-loaded exercises of the given student
+     * exam, producing the transient graph the submit machinery consumes.
+     * <p>
+     * Every exercise's {@code studentParticipations} collection is (re)initialized to a concrete set — this is
+     * required because the student exam was loaded without its participations, so leaving the lazy collection
+     * untouched would trigger a {@link org.hibernate.LazyInitializationException} when the (non-transactional) submit
+     * code reads {@code exercise.getStudentParticipations().size()}. Exercises with no matching entry in the DTO get an
+     * empty set and are skipped downstream.
+     *
+     * @param existingStudentExam  the student exam loaded from the database (with its exercises)
+     * @param submitStudentExamDTO the slim request body
+     * @param currentUser          the authenticated user, used as the participant of every reconstructed participation
+     */
+    public void attachSubmissions(StudentExam existingStudentExam, SubmitStudentExamDTO submitStudentExamDTO, User currentUser) {
+        Map<Long, SubmitExamExerciseDTO> exerciseDtosById = indexById(submitStudentExamDTO.exercises(), SubmitExamExerciseDTO::id);
+        for (Exercise exercise : existingStudentExam.getExercises()) {
+            SubmitExamExerciseDTO exerciseDTO = exerciseDtosById.get(exercise.getId());
+            exercise.setStudentParticipations(buildParticipations(exercise, exerciseDTO, currentUser));
+        }
+    }
+
+    private Set<StudentParticipation> buildParticipations(Exercise exercise, @Nullable SubmitExamExerciseDTO exerciseDTO, User currentUser) {
+        Set<StudentParticipation> participations = new HashSet<>();
+        if (exerciseDTO == null || exerciseDTO.studentParticipations() == null) {
+            return participations;
+        }
+        for (SubmitExamParticipationDTO participationDTO : exerciseDTO.studentParticipations()) {
+            StudentParticipation participation = new StudentParticipation();
+            participation.setId(participationDTO.id());
+            // the participant is re-derived from the authenticated user (the client no longer sends it); this passes
+            // isOwnedBy(currentUser) for individual exercises directly and for team exercises the DB participation
+            // still carries the real team, which is what the second (DB-side) ownership check validates.
+            participation.setParticipant(currentUser);
+            participation.setSubmissions(buildSubmissions(exercise, participationDTO));
+            participations.add(participation);
+        }
+        return participations;
+    }
+
+    private Set<Submission> buildSubmissions(Exercise exercise, SubmitExamParticipationDTO participationDTO) {
+        Set<Submission> submissions = new HashSet<>();
+        if (participationDTO.submissions() == null) {
+            return submissions;
+        }
+        for (SubmitExamSubmissionDTO submissionDTO : participationDTO.submissions()) {
+            Submission submission = buildSubmission(exercise, submissionDTO);
+            if (submission != null) {
+                submissions.add(submission);
+            }
+        }
+        return submissions;
+    }
+
+    @Nullable
+    private Submission buildSubmission(Exercise exercise, SubmitExamSubmissionDTO submissionDTO) {
+        return switch (submissionDTO) {
+            case TextExamSubmissionDTO textDTO -> {
+                TextSubmission textSubmission = new TextSubmission();
+                textSubmission.setId(textDTO.id());
+                textSubmission.setText(textDTO.text());
+                yield textSubmission;
+            }
+            case ModelingExamSubmissionDTO modelingDTO -> {
+                ModelingSubmission modelingSubmission = new ModelingSubmission();
+                modelingSubmission.setId(modelingDTO.id());
+                modelingSubmission.setModel(modelingDTO.model());
+                modelingSubmission.setExplanationText(modelingDTO.explanationText());
+                yield modelingSubmission;
+            }
+            case QuizExamSubmissionDTO quizDTO -> buildQuizSubmission(exercise, quizDTO);
+            // programming and file-upload submissions are never saved via the exam hand-in; accepted and ignored.
+            default -> null;
+        };
+    }
+
+    @Nullable
+    private Submission buildQuizSubmission(Exercise exercise, QuizExamSubmissionDTO quizDTO) {
+        if (!(exercise instanceof QuizExercise)) {
+            // defensive: a quiz submission for a non-quiz exercise would be dropped by the type switch anyway.
+            log.warn("Ignoring quiz submission {} for non-quiz exercise {}", quizDTO.id(), exercise.getId());
+            return null;
+        }
+        // The quiz exercise must be loaded WITH its questions (and their nested options/items/spots) so
+        // buildSubmissionFromLiveClientDTO can re-resolve the client-supplied answer ids; without it every answer is
+        // dropped. This mirrors the quiz live/exam auto-save path (#12832).
+        QuizExercise quizExerciseWithQuestions = quizExerciseRepository.findByIdWithQuestionsElseThrow(exercise.getId());
+        return quizSubmissionService.buildSubmissionFromLiveClientDTO(new QuizSubmissionFromLiveClientDTO(quizDTO.id(), quizDTO.submittedAnswers()), quizExerciseWithQuestions);
+    }
+
+    private static <T> Map<Long, T> indexById(@Nullable List<T> items, Function<T, Long> idExtractor) {
+        if (items == null) {
+            return Map.of();
+        }
+        // keep the last entry on the (client-invalid) case of duplicate ids rather than throwing.
+        return items.stream().filter(item -> idExtractor.apply(item) != null).collect(Collectors.toMap(idExtractor, Function.identity(), (first, second) -> second));
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamSubmitMapper.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamSubmitMapper.java
@@ -46,9 +46,17 @@ import de.tum.cit.aet.artemis.text.domain.TextSubmission;
  * The reconstruction intentionally keeps the exam-conduction save machinery
  * ({@code StudentExamService.saveSubmissions}/{@code saveSubmission}) byte-for-byte unchanged: it only changes how the
  * graph is built at the controller boundary. The DB-loaded exercise instances are reused (so the {@code instanceof}
- * type switch keeps working), and onto each we hang transient participations (id + participant = current user, so
- * {@code isOwnedBy(currentUser)} passes for both individual and team exercises) carrying transient submissions rebuilt
+ * type switch keeps working), and onto each we hang transient participations (id + participant = current user, so the
+ * swallowed {@code isOwnedBy(currentUser)} check in {@code saveSubmission} passes) carrying transient submissions rebuilt
  * per type with their client ids preserved (so the DB id-match in {@code saveSubmission} still resolves them).
+ * <p>
+ * <b>Exam team mode is unsupported downstream.</b> Re-deriving the participant from the authenticated user makes
+ * {@code isOwnedBy(currentUser)} pass regardless of exercise mode, but this is <i>not</i> a claim that team exams submit
+ * end-to-end: the exam submit/summary queries filter on {@code p.student.id} and {@code StudentParticipationRepository}
+ * documents that "in an exam there is only one submission for file upload, text, modeling and quiz and there is no team
+ * support" (see {@code findGradesByExamIdAndStudentId}). This mapper deliberately adds no team-rejection logic (that
+ * would be a behavior change); it merely reconstructs whatever the client posts, and exam team participations remain as
+ * unsupported here as they are everywhere else in the exam flow.
  * <p>
  * <b>Failure containment.</b> The reconstruction runs at the controller boundary <i>before</i>
  * {@code submitStudentExam} marks the exam submitted, so any exception it throws would abort the whole hand-in with a
@@ -135,9 +143,10 @@ public class StudentExamSubmitMapper {
         }
         StudentParticipation participation = new StudentParticipation();
         participation.setId(participationDTO.id());
-        // the participant is re-derived from the authenticated user (the client no longer sends it); this passes
-        // isOwnedBy(currentUser) for individual exercises directly and for team exercises the DB participation
-        // still carries the real team, which is what the second (DB-side) ownership check validates.
+        // the participant is re-derived from the authenticated user (the client no longer sends it); this passes the
+        // swallowed isOwnedBy(currentUser) check for individual exercises, and the second (DB-side) ownership check
+        // validates the persisted participation independently. Exam team mode is unsupported downstream regardless (see
+        // the class javadoc and StudentParticipationRepository); this mapper adds no team-specific handling either way.
         participation.setParticipant(currentUser);
         // Re-attach the exercise back-reference the legacy full-entity graph always carried. Without it the test-run /
         // test-exam quiz evaluation (ExamQuizService.evaluateQuizParticipationsForTestRunAndTestExam) filters this
@@ -181,6 +190,10 @@ public class StudentExamSubmitMapper {
                 TextSubmission textSubmission = new TextSubmission();
                 textSubmission.setId(textDTO.id());
                 textSubmission.setText(textDTO.text());
+                // Preserve the client-detected language: saveSubmissionTextExercise persists this submission via a JPA
+                // merge that overwrites every mapped column from the entity, so a dropped language would be written as
+                // null on every hand-in text edit (regression vs the legacy full-entity body). See TextExamSubmissionDTO.
+                textSubmission.setLanguage(textDTO.language());
                 yield textSubmission;
             }
             case ModelingExamSubmissionDTO modelingDTO -> {

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamSubmitMapper.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamSubmitMapper.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.artemis.exam.service;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -27,11 +28,14 @@ import de.tum.cit.aet.artemis.exam.dto.submit.TextExamSubmissionDTO;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingSubmission;
 import de.tum.cit.aet.artemis.quiz.domain.QuizExercise;
+import de.tum.cit.aet.artemis.quiz.domain.QuizSubmission;
 import de.tum.cit.aet.artemis.quiz.dto.submission.QuizSubmissionFromLiveClientDTO;
 import de.tum.cit.aet.artemis.quiz.repository.QuizExerciseRepository;
 import de.tum.cit.aet.artemis.quiz.service.QuizSubmissionService;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
 import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 
 /**
@@ -44,6 +48,22 @@ import de.tum.cit.aet.artemis.text.domain.TextSubmission;
  * type switch keeps working), and onto each we hang transient participations (id + participant = current user, so
  * {@code isOwnedBy(currentUser)} passes for both individual and team exercises) carrying transient submissions rebuilt
  * per type with their client ids preserved (so the DB id-match in {@code saveSubmission} still resolves them).
+ * <p>
+ * <b>Failure containment.</b> The reconstruction runs at the controller boundary <i>before</i>
+ * {@code submitStudentExam} marks the exam submitted, so any exception it throws would abort the whole hand-in with a
+ * 5xx and leave the exam un-submitted. To preserve the legacy semantics (the exam is ALWAYS marked submitted, and a
+ * broken exercise degrades to a logged drop of only that exercise's answers) the per-exercise reconstruction is wrapped
+ * in a try/catch that mirrors the legacy per-exercise swallow: on failure the exercise is given an empty participation
+ * set (its last-second changes are dropped) and the hand-in proceeds. One poisoned exercise can therefore never lose
+ * another exercise's answers, nor turn the hand-in into an error.
+ * <p>
+ * <b>Duplicate / ambiguity resolution (single documented rule).</b> The only client-invalid duplicate that is silently
+ * resolved is the exercise lookup map, which keeps the last entry on a duplicate exercise id (see {@link #indexById}).
+ * Any other ambiguity — an exercise carrying anything other than exactly one participation, or a participation carrying
+ * anything other than exactly one submission — is <i>not</i> resolved by collapsing into a {@code Set}; it attaches
+ * nothing for that exercise, reproducing the server's {@code size() != 1 -> skip} outcome on the wire {@code List}
+ * before it is ever folded into an entity {@code Set}. This is enforced here (rather than left to the downstream
+ * {@code Set}) because folding same-id duplicates into a {@code HashSet} would collapse them and defeat the skip.
  */
 @Conditional(ExamEnabled.class)
 @Lazy
@@ -68,8 +88,8 @@ public class StudentExamSubmitMapper {
      * Every exercise's {@code studentParticipations} collection is (re)initialized to a concrete set — this is
      * required because the student exam was loaded without its participations, so leaving the lazy collection
      * untouched would trigger a {@link org.hibernate.LazyInitializationException} when the (non-transactional) submit
-     * code reads {@code exercise.getStudentParticipations().size()}. Exercises with no matching entry in the DTO get an
-     * empty set and are skipped downstream.
+     * code reads {@code exercise.getStudentParticipations().size()}. Exercises with no matching entry in the DTO (or
+     * whose reconstruction fails) get an empty set and are skipped downstream.
      *
      * @param existingStudentExam  the student exam loaded from the database (with its exercises)
      * @param submitStudentExamDTO the slim request body
@@ -77,77 +97,117 @@ public class StudentExamSubmitMapper {
      */
     public void attachSubmissions(StudentExam existingStudentExam, SubmitStudentExamDTO submitStudentExamDTO, User currentUser) {
         Map<Long, SubmitExamExerciseDTO> exerciseDtosById = indexById(submitStudentExamDTO.exercises(), SubmitExamExerciseDTO::id);
+        // One question-loaded quiz exercise per distinct quiz id per request; the exact-one participation/submission
+        // rules already bound this to a single load per quiz, but memoizing keeps that guarantee explicit and cheap.
+        Map<Long, QuizExercise> quizExerciseCache = new HashMap<>();
         for (Exercise exercise : existingStudentExam.getExercises()) {
-            SubmitExamExerciseDTO exerciseDTO = exerciseDtosById.get(exercise.getId());
-            exercise.setStudentParticipations(buildParticipations(exercise, exerciseDTO, currentUser));
+            if (exercise == null) {
+                continue;
+            }
+            try {
+                SubmitExamExerciseDTO exerciseDTO = exerciseDtosById.get(exercise.getId());
+                exercise.setStudentParticipations(buildParticipations(exercise, exerciseDTO, currentUser, quizExerciseCache));
+            }
+            catch (Exception e) {
+                // Mirror the legacy per-exercise swallow: never let one broken exercise abort the hand-in or lose
+                // another exercise's answers. The exam is still marked submitted downstream; only this exercise's
+                // last-second changes are dropped.
+                log.error("Failed to reconstruct the submitted answers for exercise {}; dropping its last-second changes so the hand-in still succeeds", exercise.getId(), e);
+                exercise.setStudentParticipations(new HashSet<>());
+            }
         }
     }
 
-    private Set<StudentParticipation> buildParticipations(Exercise exercise, @Nullable SubmitExamExerciseDTO exerciseDTO, User currentUser) {
+    private Set<StudentParticipation> buildParticipations(Exercise exercise, @Nullable SubmitExamExerciseDTO exerciseDTO, User currentUser,
+            Map<Long, QuizExercise> quizExerciseCache) {
         Set<StudentParticipation> participations = new HashSet<>();
-        if (exerciseDTO == null || exerciseDTO.studentParticipations() == null) {
+        // Enforce the exact-one-participation semantics on the wire List (see class javadoc): anything other than a
+        // single participation attaches nothing, matching the server's studentParticipations.size() != 1 -> skip.
+        if (exerciseDTO == null || exerciseDTO.studentParticipations() == null || exerciseDTO.studentParticipations().size() != 1) {
             return participations;
         }
-        for (SubmitExamParticipationDTO participationDTO : exerciseDTO.studentParticipations()) {
-            StudentParticipation participation = new StudentParticipation();
-            participation.setId(participationDTO.id());
-            // the participant is re-derived from the authenticated user (the client no longer sends it); this passes
-            // isOwnedBy(currentUser) for individual exercises directly and for team exercises the DB participation
-            // still carries the real team, which is what the second (DB-side) ownership check validates.
-            participation.setParticipant(currentUser);
-            participation.setSubmissions(buildSubmissions(exercise, participationDTO));
-            participations.add(participation);
+        SubmitExamParticipationDTO participationDTO = exerciseDTO.studentParticipations().getFirst();
+        // Enforce the exact-one-submission semantics on the wire List, matching the server's submissions.size() != 1 -> skip.
+        if (participationDTO == null || participationDTO.submissions() == null || participationDTO.submissions().size() != 1) {
+            return participations;
         }
+        StudentParticipation participation = new StudentParticipation();
+        participation.setId(participationDTO.id());
+        // the participant is re-derived from the authenticated user (the client no longer sends it); this passes
+        // isOwnedBy(currentUser) for individual exercises directly and for team exercises the DB participation
+        // still carries the real team, which is what the second (DB-side) ownership check validates.
+        participation.setParticipant(currentUser);
+        participation.setSubmissions(buildSubmissions(exercise, participationDTO.submissions().getFirst(), quizExerciseCache));
+        participations.add(participation);
         return participations;
     }
 
-    private Set<Submission> buildSubmissions(Exercise exercise, SubmitExamParticipationDTO participationDTO) {
+    private Set<Submission> buildSubmissions(Exercise exercise, @Nullable SubmitExamSubmissionDTO submissionDTO, Map<Long, QuizExercise> quizExerciseCache) {
         Set<Submission> submissions = new HashSet<>();
-        if (participationDTO.submissions() == null) {
+        // null-tolerate an individual null element in the client array (skip it) rather than throwing.
+        if (submissionDTO == null) {
             return submissions;
         }
-        for (SubmitExamSubmissionDTO submissionDTO : participationDTO.submissions()) {
-            Submission submission = buildSubmission(exercise, submissionDTO);
-            if (submission != null) {
-                submissions.add(submission);
-            }
+        Submission submission = buildSubmission(exercise, submissionDTO, quizExerciseCache);
+        if (submission != null) {
+            submissions.add(submission);
         }
         return submissions;
     }
 
     @Nullable
-    private Submission buildSubmission(Exercise exercise, SubmitExamSubmissionDTO submissionDTO) {
+    private Submission buildSubmission(Exercise exercise, SubmitExamSubmissionDTO submissionDTO, Map<Long, QuizExercise> quizExerciseCache) {
         return switch (submissionDTO) {
             case TextExamSubmissionDTO textDTO -> {
+                if (!(exercise instanceof TextExercise)) {
+                    // matches the legacy ClassCastException-swallow: a text submission for a non-text exercise is dropped.
+                    log.warn("Ignoring text submission {} for non-text exercise {}", textDTO.id(), exercise.getId());
+                    yield null;
+                }
                 TextSubmission textSubmission = new TextSubmission();
                 textSubmission.setId(textDTO.id());
                 textSubmission.setText(textDTO.text());
                 yield textSubmission;
             }
             case ModelingExamSubmissionDTO modelingDTO -> {
+                if (!(exercise instanceof ModelingExercise)) {
+                    // matches the legacy ClassCastException-swallow: a modeling submission for a non-modeling exercise is dropped.
+                    log.warn("Ignoring modeling submission {} for non-modeling exercise {}", modelingDTO.id(), exercise.getId());
+                    yield null;
+                }
                 ModelingSubmission modelingSubmission = new ModelingSubmission();
                 modelingSubmission.setId(modelingDTO.id());
                 modelingSubmission.setModel(modelingDTO.model());
                 modelingSubmission.setExplanationText(modelingDTO.explanationText());
                 yield modelingSubmission;
             }
-            case QuizExamSubmissionDTO quizDTO -> buildQuizSubmission(exercise, quizDTO);
+            case QuizExamSubmissionDTO quizDTO -> buildQuizSubmission(exercise, quizDTO, quizExerciseCache);
             // programming and file-upload submissions are never saved via the exam hand-in; accepted and ignored.
             default -> null;
         };
     }
 
     @Nullable
-    private Submission buildQuizSubmission(Exercise exercise, QuizExamSubmissionDTO quizDTO) {
+    private Submission buildQuizSubmission(Exercise exercise, QuizExamSubmissionDTO quizDTO, Map<Long, QuizExercise> quizExerciseCache) {
         if (!(exercise instanceof QuizExercise)) {
-            // defensive: a quiz submission for a non-quiz exercise would be dropped by the type switch anyway.
+            // matches the legacy ClassCastException-swallow: a quiz submission for a non-quiz exercise is dropped.
             log.warn("Ignoring quiz submission {} for non-quiz exercise {}", quizDTO.id(), exercise.getId());
             return null;
         }
+        // Efficiency: when there are no submitted answers there is nothing to re-resolve, so we skip the (expensive)
+        // questions-with-nested-options load entirely and hand back an empty submission carrying just the id. This is
+        // byte-for-byte what buildSubmissionFromLiveClientDTO returns for null/empty answers (QuizSubmission already
+        // initializes submittedAnswers to an empty set, so the downstream save iterates over nothing).
+        if (quizDTO.submittedAnswers() == null || quizDTO.submittedAnswers().isEmpty()) {
+            QuizSubmission quizSubmission = new QuizSubmission();
+            quizSubmission.setId(quizDTO.id());
+            return quizSubmission;
+        }
         // The quiz exercise must be loaded WITH its questions (and their nested options/items/spots) so
         // buildSubmissionFromLiveClientDTO can re-resolve the client-supplied answer ids; without it every answer is
-        // dropped. This mirrors the quiz live/exam auto-save path (#12832).
-        QuizExercise quizExerciseWithQuestions = quizExerciseRepository.findByIdWithQuestionsElseThrow(exercise.getId());
+        // dropped. This mirrors the quiz live/exam auto-save path (#12832). Memoized so at most one load happens per
+        // distinct quiz exercise per request.
+        QuizExercise quizExerciseWithQuestions = quizExerciseCache.computeIfAbsent(exercise.getId(), quizExerciseRepository::findByIdWithQuestionsElseThrow);
         return quizSubmissionService.buildSubmissionFromLiveClientDTO(new QuizSubmissionFromLiveClientDTO(quizDTO.id(), quizDTO.submittedAnswers()), quizExerciseWithQuestions);
     }
 
@@ -155,7 +215,9 @@ public class StudentExamSubmitMapper {
         if (items == null) {
             return Map.of();
         }
-        // keep the last entry on the (client-invalid) case of duplicate ids rather than throwing.
-        return items.stream().filter(item -> idExtractor.apply(item) != null).collect(Collectors.toMap(idExtractor, Function.identity(), (first, second) -> second));
+        // The single documented duplicate-resolution rule (see class javadoc): on the client-invalid case of duplicate
+        // ids, keep the last entry rather than throwing. Null elements and null ids are skipped.
+        return items.stream().filter(item -> item != null && idExtractor.apply(item) != null)
+                .collect(Collectors.toMap(idExtractor, Function.identity(), (first, second) -> second));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamSubmitMapper.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamSubmitMapper.java
@@ -26,6 +26,7 @@ import de.tum.cit.aet.artemis.exam.dto.submit.SubmitExamSubmissionDTO;
 import de.tum.cit.aet.artemis.exam.dto.submit.SubmitStudentExamDTO;
 import de.tum.cit.aet.artemis.exam.dto.submit.TextExamSubmissionDTO;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
+import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
@@ -100,13 +101,14 @@ public class StudentExamSubmitMapper {
         // One question-loaded quiz exercise per distinct quiz id per request; the exact-one participation/submission
         // rules already bound this to a single load per quiz, but memoizing keeps that guarantee explicit and cheap.
         Map<Long, QuizExercise> quizExerciseCache = new HashMap<>();
+        boolean testRun = existingStudentExam.isTestRun();
         for (Exercise exercise : existingStudentExam.getExercises()) {
             if (exercise == null) {
                 continue;
             }
             try {
                 SubmitExamExerciseDTO exerciseDTO = exerciseDtosById.get(exercise.getId());
-                exercise.setStudentParticipations(buildParticipations(exercise, exerciseDTO, currentUser, quizExerciseCache));
+                exercise.setStudentParticipations(buildParticipations(exercise, exerciseDTO, currentUser, quizExerciseCache, testRun));
             }
             catch (Exception e) {
                 // Mirror the legacy per-exercise swallow: never let one broken exercise abort the hand-in or lose
@@ -119,7 +121,7 @@ public class StudentExamSubmitMapper {
     }
 
     private Set<StudentParticipation> buildParticipations(Exercise exercise, @Nullable SubmitExamExerciseDTO exerciseDTO, User currentUser,
-            Map<Long, QuizExercise> quizExerciseCache) {
+            Map<Long, QuizExercise> quizExerciseCache, boolean testRun) {
         Set<StudentParticipation> participations = new HashSet<>();
         // Enforce the exact-one-participation semantics on the wire List (see class javadoc): anything other than a
         // single participation attaches nothing, matching the server's studentParticipations.size() != 1 -> skip.
@@ -137,6 +139,18 @@ public class StudentExamSubmitMapper {
         // isOwnedBy(currentUser) for individual exercises directly and for team exercises the DB participation
         // still carries the real team, which is what the second (DB-side) ownership check validates.
         participation.setParticipant(currentUser);
+        // Re-attach the exercise back-reference the legacy full-entity graph always carried. Without it the test-run /
+        // test-exam quiz evaluation (ExamQuizService.evaluateQuizParticipationsForTestRunAndTestExam) filters this
+        // participation out via `participation.getExercise() instanceof QuizExercise` and never persists the quiz
+        // participation/result.
+        participation.setExercise(exercise);
+        // Preserve the two participation metadata fields the legacy conduction-loaded graph round-tripped and that the
+        // downstream save must not clobber: the test-run flag (ExamQuizService persists this reconstructed participation,
+        // and the summary's test-run query filters on `p.testRun = TRUE`, so a lost flag hides the quiz participation) and
+        // the initialization state (a null would break consumers that read getInitializationState() and the participation
+        // is INITIALIZED while it is being worked on).
+        participation.setTestRun(testRun);
+        participation.setInitializationState(InitializationState.INITIALIZED);
         participation.setSubmissions(buildSubmissions(exercise, participationDTO.submissions().getFirst(), quizExerciseCache));
         participations.add(participation);
         return participations;

--- a/src/main/java/de/tum/cit/aet/artemis/exam/web/StudentExamResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/web/StudentExamResource.java
@@ -62,6 +62,7 @@ import de.tum.cit.aet.artemis.exam.dto.StudentExamDTO;
 import de.tum.cit.aet.artemis.exam.dto.StudentExamWithGradeDTO;
 import de.tum.cit.aet.artemis.exam.dto.examevent.ExamAttendanceCheckEventDTO;
 import de.tum.cit.aet.artemis.exam.dto.examevent.ExamLiveEventBaseDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.SubmitStudentExamDTO;
 import de.tum.cit.aet.artemis.exam.repository.ExamLiveEventRepository;
 import de.tum.cit.aet.artemis.exam.repository.ExamRepository;
 import de.tum.cit.aet.artemis.exam.repository.StudentExamRepository;
@@ -73,6 +74,7 @@ import de.tum.cit.aet.artemis.exam.service.ExamSessionService;
 import de.tum.cit.aet.artemis.exam.service.StudentExamAccessService;
 import de.tum.cit.aet.artemis.exam.service.StudentExamLiveEventService;
 import de.tum.cit.aet.artemis.exam.service.StudentExamService;
+import de.tum.cit.aet.artemis.exam.service.StudentExamSubmitMapper;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
@@ -123,6 +125,8 @@ public class StudentExamResource {
 
     private final StudentExamLiveEventService studentExamLiveEventService;
 
+    private final StudentExamSubmitMapper studentExamSubmitMapper;
+
     @Value("${info.studentExamStoreSessionData:#{true}}")
     private boolean storeSessionDataInStudentExamSession;
 
@@ -136,7 +140,7 @@ public class StudentExamResource {
             StudentExamRepository studentExamRepository, ExamDateService examDateService, ExamSessionService examSessionService, ExamRepository examRepository,
             ExerciseRepository exerciseRepository, AuthorizationCheckService authorizationCheckService, ExamService examService,
             WebsocketMessagingService websocketMessagingService, SubmissionPolicyRepository submissionPolicyRepository, ExamLiveEventRepository examLiveEventRepository,
-            StudentExamLiveEventService studentExamLiveEventService) {
+            StudentExamLiveEventService studentExamLiveEventService, StudentExamSubmitMapper studentExamSubmitMapper) {
         this.examAccessService = examAccessService;
         this.examDeletionService = examDeletionService;
         this.studentExamService = studentExamService;
@@ -154,6 +158,7 @@ public class StudentExamResource {
         this.submissionPolicyRepository = submissionPolicyRepository;
         this.examLiveEventRepository = examLiveEventRepository;
         this.studentExamLiveEventService = studentExamLiveEventService;
+        this.studentExamSubmitMapper = studentExamSubmitMapper;
     }
 
     /**
@@ -237,35 +242,39 @@ public class StudentExamResource {
 
     /**
      * POST /courses/{courseId}/exams/{examId}/student-exams/submit : Submits the student exam
-     * Updates all submissions and marks student exam as submitted according to given student exam
-     * NOTE: the studentExam has to be sent with all exercises, participations and submissions
+     * Updates all submissions and marks student exam as submitted. Only the student exam id and the last-second
+     * submission changes are read from the body; ownership, exam/course validation and the test-run/test-exam gating
+     * are derived from the authoritative student exam loaded from the database.
      *
      * @param courseId              the course to which the student exams belong to
      * @param examId                the exam to which the student exams belong to
-     * @param studentExamFromClient the student exam with exercises, participations and submissions
+     * @param studentExamFromClient the student exam id with the exercises, participations and submissions carrying the last-second changes
      * @return empty response with status code:
      *         200 if successful
      *         400 if student exam was in an illegal state
      */
     @PostMapping("courses/{courseId}/exams/{examId}/student-exams/submit")
     @EnforceAtLeastStudent
-    public ResponseEntity<Void> submitStudentExam(@PathVariable Long courseId, @PathVariable Long examId, @RequestBody StudentExam studentExamFromClient) {
+    public ResponseEntity<Void> submitStudentExam(@PathVariable Long courseId, @PathVariable Long examId, @RequestBody SubmitStudentExamDTO studentExamFromClient) {
         long start = System.nanoTime();
-        log.debug("REST request to mark the studentExam as submitted : {}", studentExamFromClient.getId());
+        log.debug("REST request to mark the studentExam as submitted : {}", studentExamFromClient.id());
 
         // 1. DB Call: read
         User currentUser = userRepository.getUser();
-        // prevent manipulation of the user object that is attached to the student exam in the request body (which is saved later on into the database as part of this request)
-        if (!Objects.equals(studentExamFromClient.getUser().getId(), currentUser.getId())) {
+
+        // 2. DB Call: read the authoritative student exam; all downstream truth (ownership, exam/course, submitted
+        // flag, test-run/test-exam gating) comes from this DB entity, not from the client body.
+        StudentExam existingStudentExam = studentExamRepository.findByIdWithExercisesElseThrow(studentExamFromClient.id());
+        // Ownership is now checked against the persisted owner instead of a client-supplied user field. This is the
+        // behavior-equivalent replacement for the previous anti-manipulation gate and closes the latent hole where the
+        // client-claimed user was the only ownership check.
+        if (!Objects.equals(existingStudentExam.getUser().getId(), currentUser.getId())) {
             throw new AccessForbiddenException("Current user is not the user of the requested student exam");
         }
+        validateExamRequestParametersElseThrow(existingStudentExam, examId, courseId);
 
-        // 2. DB Call: read
-        StudentExam existingStudentExam = studentExamRepository.findByIdWithExercisesElseThrow(studentExamFromClient.getId());
-        validateExamRequestParametersElseThrow(studentExamFromClient, examId, courseId);
-
-        if (Boolean.TRUE.equals(studentExamFromClient.isSubmitted()) || Boolean.TRUE.equals(existingStudentExam.isSubmitted())) {
-            log.error("Student exam with id {} for user {} is already submitted.", studentExamFromClient.getId(), currentUser.getLogin());
+        if (Boolean.TRUE.equals(existingStudentExam.isSubmitted())) {
+            log.error("Student exam with id {} for user {} is already submitted.", studentExamFromClient.id(), currentUser.getLogin());
             // NOTE: we should not send an error message to the user here, due to overload it could happen that the call is sent multiple times
             return ResponseEntity.ok().build();
         }
@@ -278,7 +287,9 @@ public class StudentExamResource {
 
         log.debug("Completed input validation for submitStudentExam in {}", formatDurationFrom(start));
 
-        studentExamService.submitStudentExam(studentExamFromClient, currentUser);
+        // Reconstruct the transient graph the (unchanged) submit machinery consumes from the slim DTO.
+        studentExamSubmitMapper.attachSubmissions(existingStudentExam, studentExamFromClient, currentUser);
+        studentExamService.submitStudentExam(existingStudentExam, currentUser);
 
         websocketMessagingService.sendMessage("/topic/exam/" + examId + "/submitted", "");
 

--- a/src/main/java/de/tum/cit/aet/artemis/exam/web/StudentExamResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/web/StudentExamResource.java
@@ -255,6 +255,9 @@ public class StudentExamResource {
      */
     @PostMapping("courses/{courseId}/exams/{examId}/student-exams/submit")
     @EnforceAtLeastStudent
+    // NOTE: the body is intentionally NOT @Valid — the legacy full-entity endpoint activated no Bean Validation, and the
+    // DTO migration must not add validation the legacy endpoint lacked (a rejected body would break the hand-in instead
+    // of degrading gracefully). Malformed/ambiguous parts are tolerated and dropped during reconstruction.
     public ResponseEntity<Void> submitStudentExam(@PathVariable Long courseId, @PathVariable Long examId, @RequestBody SubmitStudentExamDTO studentExamFromClient) {
         long start = System.nanoTime();
         log.debug("REST request to mark the studentExam as submitted : {}", studentExamFromClient.id());

--- a/src/main/java/de/tum/cit/aet/artemis/exam/web/StudentExamResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/web/StudentExamResource.java
@@ -74,7 +74,6 @@ import de.tum.cit.aet.artemis.exam.service.ExamSessionService;
 import de.tum.cit.aet.artemis.exam.service.StudentExamAccessService;
 import de.tum.cit.aet.artemis.exam.service.StudentExamLiveEventService;
 import de.tum.cit.aet.artemis.exam.service.StudentExamService;
-import de.tum.cit.aet.artemis.exam.service.StudentExamSubmitMapper;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
@@ -125,8 +124,6 @@ public class StudentExamResource {
 
     private final StudentExamLiveEventService studentExamLiveEventService;
 
-    private final StudentExamSubmitMapper studentExamSubmitMapper;
-
     @Value("${info.studentExamStoreSessionData:#{true}}")
     private boolean storeSessionDataInStudentExamSession;
 
@@ -140,7 +137,7 @@ public class StudentExamResource {
             StudentExamRepository studentExamRepository, ExamDateService examDateService, ExamSessionService examSessionService, ExamRepository examRepository,
             ExerciseRepository exerciseRepository, AuthorizationCheckService authorizationCheckService, ExamService examService,
             WebsocketMessagingService websocketMessagingService, SubmissionPolicyRepository submissionPolicyRepository, ExamLiveEventRepository examLiveEventRepository,
-            StudentExamLiveEventService studentExamLiveEventService, StudentExamSubmitMapper studentExamSubmitMapper) {
+            StudentExamLiveEventService studentExamLiveEventService) {
         this.examAccessService = examAccessService;
         this.examDeletionService = examDeletionService;
         this.studentExamService = studentExamService;
@@ -158,7 +155,6 @@ public class StudentExamResource {
         this.submissionPolicyRepository = submissionPolicyRepository;
         this.examLiveEventRepository = examLiveEventRepository;
         this.studentExamLiveEventService = studentExamLiveEventService;
-        this.studentExamSubmitMapper = studentExamSubmitMapper;
     }
 
     /**
@@ -290,9 +286,8 @@ public class StudentExamResource {
 
         log.debug("Completed input validation for submitStudentExam in {}", formatDurationFrom(start));
 
-        // Reconstruct the transient graph the (unchanged) submit machinery consumes from the slim DTO.
-        studentExamSubmitMapper.attachSubmissions(existingStudentExam, studentExamFromClient, currentUser);
-        studentExamService.submitStudentExam(existingStudentExam, currentUser);
+        // The service reconstructs the transient graph from the slim DTO and then runs the (unchanged) submit machinery.
+        studentExamService.submitStudentExam(existingStudentExam, studentExamFromClient, currentUser);
 
         websocketMessagingService.sendMessage("/topic/exam/" + examId + "/submitted", "");
 

--- a/src/main/webapp/app/exam/overview/services/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/overview/services/exam-participation.service.ts
@@ -8,6 +8,7 @@ import { StudentParticipation } from 'app/exercise/shared/entities/participation
 import { QuizSubmission } from 'app/quiz/shared/entities/quiz-submission.model';
 import { StudentExam } from 'app/exam/shared/entities/student-exam.model';
 import { StudentExamDTO } from 'app/exam/shared/entities/student-exam-dto.model';
+import { toSubmitStudentExamDTO } from 'app/exam/overview/services/submit-student-exam-dto.mapper';
 import { Submission, getAllResultsOfAllSubmissions, getLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
 import { StudentExamWithGradeDTO } from 'app/exam/manage/exam-scores/exam-score-dtos.model';
 import { ExerciseService } from 'app/exercise/services/exercise.service';
@@ -193,10 +194,9 @@ export class ExamParticipationService {
      */
     public submitStudentExam(courseId: number, examId: number, studentExam: StudentExam): Observable<void> {
         const url = this.getResourceURL(courseId, examId) + '/student-exams/submit';
-        const studentExamCopy = cloneDeep(studentExam);
-        ExamParticipationService.breakCircularDependency(studentExamCopy);
+        const submitStudentExamDTO = toSubmitStudentExamDTO(studentExam);
 
-        return this.httpClient.post<void>(url, studentExamCopy).pipe(
+        return this.httpClient.post<void>(url, submitStudentExamDTO).pipe(
             catchError((error: HttpErrorResponse) => {
                 if (error.status === 403 && error.headers.get('x-null-error') === 'error.submissionNotInTime') {
                     return throwError(() => new Error('artemisApp.studentExam.submissionNotInTime'));

--- a/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.spec.ts
+++ b/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.spec.ts
@@ -10,6 +10,7 @@ import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
 import { ModelingSubmission } from 'app/modeling/shared/entities/modeling-submission.model';
 import { QuizSubmission } from 'app/quiz/shared/entities/quiz-submission.model';
 import { ProgrammingSubmission } from 'app/programming/shared/entities/programming-submission.model';
+import { FileUploadSubmission } from 'app/fileupload/shared/entities/file-upload-submission.model';
 import { MultipleChoiceSubmittedAnswer } from 'app/quiz/shared/entities/multiple-choice-submitted-answer.model';
 import { DragAndDropSubmittedAnswer } from 'app/quiz/shared/entities/drag-and-drop-submitted-answer.model';
 import { ShortAnswerSubmittedAnswer } from 'app/quiz/shared/entities/short-answer-submitted-answer.model';
@@ -53,6 +54,16 @@ describe('toSubmitStudentExamDTO', () => {
         expect(dto).not.toHaveProperty('user');
         expect(dto).not.toHaveProperty('exam');
         expect(dto).not.toHaveProperty('workingTime');
+    });
+
+    it('tolerates a student exam without an exercises array', () => {
+        const studentExam = new StudentExam();
+        studentExam.id = 9;
+        studentExam.exercises = undefined;
+
+        const dto = toSubmitStudentExamDTO(studentExam);
+
+        expect(dto).toEqual({ id: 9, exercises: [] });
     });
 
     it('maps a text submission to the slim text variant preserving the submission id', () => {
@@ -137,6 +148,109 @@ describe('toSubmitStudentExamDTO', () => {
         const dto = toSubmitStudentExamDTO(studentExam);
 
         expect(dto.exercises[0].studentParticipations[0].submissions[0]).toEqual({ submissionExerciseType: 'programming', id: 103 });
+    });
+
+    it('maps a file-upload submission to the inert id-only variant', () => {
+        const submission = withId(new FileUploadSubmission(), 105);
+
+        const studentExam = new StudentExam();
+        studentExam.exercises = [exerciseWith(14, 1004, [submission])];
+
+        const dto = toSubmitStudentExamDTO(studentExam);
+
+        expect(dto.exercises[0].studentParticipations[0].submissions[0]).toEqual({ submissionExerciseType: 'file-upload', id: 105 });
+    });
+
+    it('skips a submission with an unknown submissionExerciseType, keeping the valid ones', () => {
+        const malformed = withId(new TextSubmission(), 106);
+        // force the malformed state the narrow union cannot represent: an undefined discriminator
+        (malformed as any).submissionExerciseType = undefined;
+        const valid = withId(new TextSubmission(), 107);
+        valid.text = 'kept';
+
+        const studentExam = new StudentExam();
+        studentExam.exercises = [exerciseWith(15, 1005, [malformed, valid])];
+
+        const dto = toSubmitStudentExamDTO(studentExam);
+
+        // the malformed submission is dropped, the valid one survives
+        expect(dto.exercises[0].studentParticipations[0].submissions).toEqual([{ submissionExerciseType: 'text', id: 107, text: 'kept' }]);
+    });
+
+    it('maps a quiz submission without submitted answers to an empty answer array', () => {
+        const submission = withId(new QuizSubmission(), 108);
+        submission.submittedAnswers = undefined;
+
+        const studentExam = new StudentExam();
+        studentExam.exercises = [exerciseWith(16, 1006, [submission])];
+
+        const dto = toSubmitStudentExamDTO(studentExam);
+        const mappedSubmission = dto.exercises[0].studentParticipations[0].submissions[0];
+
+        expect(mappedSubmission.submissionExerciseType).toBe(SubmissionExerciseType.QUIZ);
+        if (mappedSubmission.submissionExerciseType !== SubmissionExerciseType.QUIZ) {
+            throw new Error('expected a quiz submission');
+        }
+        expect(mappedSubmission.submittedAnswers).toEqual([]);
+    });
+
+    it('skips a submitted answer with an unknown type and tolerates undefined nested collections', () => {
+        // an answer whose discriminator is undefined must be dropped
+        const malformedAnswer = new MultipleChoiceSubmittedAnswer();
+        (malformedAnswer as any).type = undefined;
+
+        // valid answers with undefined nested collections / question exercise the `?? []` and `?.id` fallbacks
+        const mcAnswer = new MultipleChoiceSubmittedAnswer();
+        mcAnswer.quizQuestion = undefined;
+        mcAnswer.selectedOptions = undefined;
+
+        const dndAnswer = new DragAndDropSubmittedAnswer();
+        dndAnswer.quizQuestion = withId(new DragAndDropQuestion(), 30);
+        dndAnswer.mappings = undefined;
+
+        const saAnswer = new ShortAnswerSubmittedAnswer();
+        saAnswer.quizQuestion = withId(new ShortAnswerQuestion(), 31);
+        saAnswer.submittedTexts = undefined;
+
+        const submission = withId(new QuizSubmission(), 109);
+        submission.submittedAnswers = [malformedAnswer, mcAnswer, dndAnswer, saAnswer];
+
+        const studentExam = new StudentExam();
+        studentExam.exercises = [exerciseWith(17, 1007, [submission])];
+
+        const dto = toSubmitStudentExamDTO(studentExam);
+        const mappedSubmission = dto.exercises[0].studentParticipations[0].submissions[0];
+
+        expect(mappedSubmission.submissionExerciseType).toBe(SubmissionExerciseType.QUIZ);
+        if (mappedSubmission.submissionExerciseType !== SubmissionExerciseType.QUIZ) {
+            throw new Error('expected a quiz submission');
+        }
+        // the malformed answer is dropped; the three valid ones keep their type with empty nested collections
+        expect(mappedSubmission.submittedAnswers).toEqual([
+            { type: 'multiple-choice', quizQuestion: { id: undefined }, selectedOptions: [] },
+            { type: 'drag-and-drop', quizQuestion: { id: 30 }, mappings: [] },
+            { type: 'short-answer', quizQuestion: { id: 31 }, submittedTexts: [] },
+        ]);
+    });
+
+    it('tolerates a participation with undefined submissions and an exercise with undefined participations', () => {
+        const exerciseWithoutParticipations = withId(new TextExercise(undefined, undefined), 18);
+        exerciseWithoutParticipations.studentParticipations = undefined;
+
+        const exerciseWithNullSubmissions = withId(new TextExercise(undefined, undefined), 19);
+        const participation = new StudentParticipation();
+        participation.id = 1008;
+        participation.submissions = undefined;
+        exerciseWithNullSubmissions.studentParticipations = [participation];
+
+        const studentExam = new StudentExam();
+        studentExam.id = 6;
+        studentExam.exercises = [exerciseWithoutParticipations, exerciseWithNullSubmissions];
+
+        const dto = toSubmitStudentExamDTO(studentExam);
+
+        expect(dto.exercises[0]).toEqual({ id: 18, studentParticipations: [] });
+        expect(dto.exercises[1]).toEqual({ id: 19, studentParticipations: [{ id: 1008, submissions: [] }] });
     });
 
     it('emits explicit empty arrays (never omitted) so the server does not read null', () => {

--- a/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.spec.ts
+++ b/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.spec.ts
@@ -23,6 +23,7 @@ import { DropLocation } from 'app/quiz/shared/entities/drop-location.model';
 import { DragAndDropMapping } from 'app/quiz/shared/entities/drag-and-drop-mapping.model';
 import { ShortAnswerSpot } from 'app/quiz/shared/entities/short-answer-spot.model';
 import { ShortAnswerSubmittedText } from 'app/quiz/shared/entities/short-answer-submitted-text.model';
+import { Language } from 'app/course/shared/entities/course.model';
 
 function withId<T extends { id?: number }>(entity: T, id: number): T {
     entity.id = id;
@@ -66,9 +67,12 @@ describe('toSubmitStudentExamDTO', () => {
         expect(dto).toEqual({ id: 9, exercises: [] });
     });
 
-    it('maps a text submission to the slim text variant preserving the submission id', () => {
+    it('maps a text submission to the slim text variant preserving the submission id and language', () => {
         const submission = withId(new TextSubmission(), 100);
         submission.text = 'my answer';
+        // the client-detected language must ride along: the server persists via a merge that overwrites the column, so a
+        // dropped language would be nulled out on every hand-in text edit. See the mapper's TextSubmissionDTO.
+        submission.language = Language.GERMAN;
 
         const studentExam = new StudentExam();
         studentExam.id = 1;
@@ -78,7 +82,7 @@ describe('toSubmitStudentExamDTO', () => {
 
         expect(dto.exercises[0]).toEqual({
             id: 10,
-            studentParticipations: [{ id: 1000, submissions: [{ submissionExerciseType: 'text', id: 100, text: 'my answer' }] }],
+            studentParticipations: [{ id: 1000, submissions: [{ submissionExerciseType: 'text', id: 100, text: 'my answer', language: Language.GERMAN }] }],
         });
     });
 

--- a/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.spec.ts
+++ b/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.spec.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { toSubmitStudentExamDTO } from 'app/exam/overview/services/submit-student-exam-dto.mapper';
+import { StudentExam } from 'app/exam/shared/entities/student-exam.model';
+import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
+import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
+import { TextExercise } from 'app/text/shared/entities/text-exercise.model';
+import { Submission } from 'app/exercise/shared/entities/submission/submission.model';
+import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
+import { ModelingSubmission } from 'app/modeling/shared/entities/modeling-submission.model';
+import { QuizSubmission } from 'app/quiz/shared/entities/quiz-submission.model';
+import { ProgrammingSubmission } from 'app/programming/shared/entities/programming-submission.model';
+import { MultipleChoiceSubmittedAnswer } from 'app/quiz/shared/entities/multiple-choice-submitted-answer.model';
+import { DragAndDropSubmittedAnswer } from 'app/quiz/shared/entities/drag-and-drop-submitted-answer.model';
+import { ShortAnswerSubmittedAnswer } from 'app/quiz/shared/entities/short-answer-submitted-answer.model';
+import { MultipleChoiceQuestion } from 'app/quiz/shared/entities/multiple-choice-question.model';
+import { DragAndDropQuestion } from 'app/quiz/shared/entities/drag-and-drop-question.model';
+import { ShortAnswerQuestion } from 'app/quiz/shared/entities/short-answer-question.model';
+import { AnswerOption } from 'app/quiz/shared/entities/answer-option.model';
+import { DragItem } from 'app/quiz/shared/entities/drag-item.model';
+import { DropLocation } from 'app/quiz/shared/entities/drop-location.model';
+import { DragAndDropMapping } from 'app/quiz/shared/entities/drag-and-drop-mapping.model';
+import { ShortAnswerSpot } from 'app/quiz/shared/entities/short-answer-spot.model';
+import { ShortAnswerSubmittedText } from 'app/quiz/shared/entities/short-answer-submitted-text.model';
+
+function withId<T extends { id?: number }>(entity: T, id: number): T {
+    entity.id = id;
+    return entity;
+}
+
+// The mapper only reads exercise.id and exercise.studentParticipations, not the exercise runtime type (the submission's
+// submissionExerciseType drives the per-type mapping), so a TextExercise is a fine generic carrier for every case.
+function exerciseWith(id: number, participationId: number, submissions: Submission[]): Exercise {
+    const exercise = withId(new TextExercise(undefined, undefined), id);
+    const participation = new StudentParticipation();
+    participation.id = participationId;
+    participation.submissions = submissions;
+    exercise.studentParticipations = [participation];
+    return exercise;
+}
+
+describe('toSubmitStudentExamDTO', () => {
+    it('maps only id and exercises, dropping user/exam/dates/sessions', () => {
+        const studentExam = new StudentExam();
+        studentExam.id = 42;
+        studentExam.user = { id: 7, login: 'student1' } as any;
+        studentExam.workingTime = 3600;
+        studentExam.exercises = [];
+
+        const dto = toSubmitStudentExamDTO(studentExam);
+
+        expect(dto).toEqual({ id: 42, exercises: [] });
+        expect(dto).not.toHaveProperty('user');
+        expect(dto).not.toHaveProperty('exam');
+        expect(dto).not.toHaveProperty('workingTime');
+    });
+
+    it('maps a text submission to the slim text variant preserving the submission id', () => {
+        const submission = withId(new TextSubmission(), 100);
+        submission.text = 'my answer';
+
+        const studentExam = new StudentExam();
+        studentExam.id = 1;
+        studentExam.exercises = [exerciseWith(10, 1000, [submission])];
+
+        const dto = toSubmitStudentExamDTO(studentExam);
+
+        expect(dto.exercises[0]).toEqual({
+            id: 10,
+            studentParticipations: [{ id: 1000, submissions: [{ submissionExerciseType: 'text', id: 100, text: 'my answer' }] }],
+        });
+    });
+
+    it('maps a modeling submission preserving model and explanation', () => {
+        const submission = withId(new ModelingSubmission(), 101);
+        submission.model = '{"elements":[]}';
+        submission.explanationText = 'because';
+
+        const studentExam = new StudentExam();
+        studentExam.exercises = [exerciseWith(11, 1001, [submission])];
+
+        const dto = toSubmitStudentExamDTO(studentExam);
+
+        expect(dto.exercises[0].studentParticipations[0].submissions[0]).toEqual({
+            submissionExerciseType: 'modeling',
+            id: 101,
+            model: '{"elements":[]}',
+            explanationText: 'because',
+        });
+    });
+
+    it('maps quiz submitted answers to the reused FromLiveClient id-ref shape for every answer type', () => {
+        const mcAnswer = new MultipleChoiceSubmittedAnswer();
+        mcAnswer.quizQuestion = withId(new MultipleChoiceQuestion(), 20);
+        mcAnswer.selectedOptions = [withId(new AnswerOption(), 201), withId(new AnswerOption(), 202)];
+
+        const dndAnswer = new DragAndDropSubmittedAnswer();
+        dndAnswer.quizQuestion = withId(new DragAndDropQuestion(), 21);
+        dndAnswer.mappings = [new DragAndDropMapping(withId(new DragItem(), 211), withId(new DropLocation(), 212))];
+
+        const saAnswer = new ShortAnswerSubmittedAnswer();
+        saAnswer.quizQuestion = withId(new ShortAnswerQuestion(), 22);
+        const submittedText = new ShortAnswerSubmittedText();
+        submittedText.text = 'answer';
+        submittedText.spot = withId(new ShortAnswerSpot(), 221);
+        saAnswer.submittedTexts = [submittedText];
+
+        const submission = withId(new QuizSubmission(), 102);
+        submission.submittedAnswers = [mcAnswer, dndAnswer, saAnswer];
+
+        const studentExam = new StudentExam();
+        studentExam.exercises = [exerciseWith(12, 1002, [submission])];
+
+        const dto = toSubmitStudentExamDTO(studentExam);
+        const quizDto = dto.exercises[0].studentParticipations[0].submissions[0];
+
+        expect(quizDto.submissionExerciseType).toBe('quiz');
+        expect(quizDto.id).toBe(102);
+        expect(quizDto.submittedAnswers).toEqual([
+            { type: 'multiple-choice', quizQuestion: { id: 20 }, selectedOptions: [{ id: 201 }, { id: 202 }] },
+            { type: 'drag-and-drop', quizQuestion: { id: 21 }, mappings: [{ dragItem: { id: 211 }, dropLocation: { id: 212 } }] },
+            { type: 'short-answer', quizQuestion: { id: 22 }, submittedTexts: [{ text: 'answer', spot: { id: 221 } }] },
+        ]);
+    });
+
+    it('maps a programming submission to the inert id-only variant', () => {
+        const submission = withId(new ProgrammingSubmission(), 103);
+
+        const studentExam = new StudentExam();
+        studentExam.exercises = [exerciseWith(13, 1003, [submission])];
+
+        const dto = toSubmitStudentExamDTO(studentExam);
+
+        expect(dto.exercises[0].studentParticipations[0].submissions[0]).toEqual({ submissionExerciseType: 'programming', id: 103 });
+    });
+
+    it('emits explicit empty arrays (never omitted) so the server does not read null', () => {
+        const studentExam = new StudentExam();
+        studentExam.id = 5;
+        studentExam.exercises = [exerciseWith(10, 1000, [])];
+
+        const dto = toSubmitStudentExamDTO(studentExam);
+
+        expect(dto.exercises[0].studentParticipations[0].submissions).toEqual([]);
+        // JSON round-trip proves the empty array survives on the wire (no @JsonInclude omission on the client side).
+        expect(JSON.parse(JSON.stringify(dto)).exercises[0].studentParticipations[0].submissions).toEqual([]);
+    });
+});

--- a/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.spec.ts
+++ b/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { toSubmitStudentExamDTO } from 'app/exam/overview/services/submit-student-exam-dto.mapper';
+import { QuizSubmissionDTO, toSubmitStudentExamDTO } from 'app/exam/overview/services/submit-student-exam-dto.mapper';
+import { SubmissionExerciseType } from 'app/exercise/shared/entities/submission/submission.model';
 import { StudentExam } from 'app/exam/shared/entities/student-exam.model';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
@@ -111,9 +112,14 @@ describe('toSubmitStudentExamDTO', () => {
         studentExam.exercises = [exerciseWith(12, 1002, [submission])];
 
         const dto = toSubmitStudentExamDTO(studentExam);
-        const quizDto = dto.exercises[0].studentParticipations[0].submissions[0];
+        const mappedSubmission = dto.exercises[0].studentParticipations[0].submissions[0];
 
-        expect(quizDto.submissionExerciseType).toBe('quiz');
+        // narrow the discriminated union to the quiz variant so submittedAnswers is statically visible
+        expect(mappedSubmission.submissionExerciseType).toBe(SubmissionExerciseType.QUIZ);
+        if (mappedSubmission.submissionExerciseType !== SubmissionExerciseType.QUIZ) {
+            throw new Error('expected a quiz submission');
+        }
+        const quizDto: QuizSubmissionDTO = mappedSubmission;
         expect(quizDto.id).toBe(102);
         expect(quizDto.submittedAnswers).toEqual([
             { type: 'multiple-choice', quizQuestion: { id: 20 }, selectedOptions: [{ id: 201 }, { id: 202 }] },

--- a/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.ts
+++ b/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.ts
@@ -37,28 +37,65 @@ interface EntityIdRef {
     id?: number;
 }
 
-export interface SubmitExamSubmissionDTO {
-    submissionExerciseType: SubmissionExerciseType;
+/**
+ * Discriminated union of the per-type submission variants, keyed by {@code submissionExerciseType} — the same
+ * discriminator the server DTO hierarchy binds on. Modelling each variant separately (instead of one flat interface
+ * with every optional field) makes the impossible states — e.g. a text submission carrying quiz answers —
+ * unrepresentable and lets the compiler narrow field access after a {@code submissionExerciseType} check.
+ */
+interface BaseSubmissionDTO {
     id?: number;
-    // text
+}
+
+export interface TextSubmissionDTO extends BaseSubmissionDTO {
+    submissionExerciseType: SubmissionExerciseType.TEXT;
     text?: string;
-    // modeling
+}
+
+export interface ModelingSubmissionDTO extends BaseSubmissionDTO {
+    submissionExerciseType: SubmissionExerciseType.MODELING;
     model?: string;
     explanationText?: string;
-    // quiz
+}
+
+export interface QuizSubmissionDTO extends BaseSubmissionDTO {
+    submissionExerciseType: SubmissionExerciseType.QUIZ;
     submittedAnswers?: SubmittedAnswerFromLiveClientDTO[];
 }
 
-export interface SubmittedAnswerFromLiveClientDTO {
-    type: QuizQuestionType;
+/**
+ * Programming and file-upload submissions are never persisted through the exam hand-in; they are modelled as an inert
+ * id-only variant so a legacy body still binds, but carry no content.
+ */
+export interface InertSubmissionDTO extends BaseSubmissionDTO {
+    submissionExerciseType: SubmissionExerciseType.PROGRAMMING | SubmissionExerciseType.FILE_UPLOAD;
+}
+
+export type SubmitExamSubmissionDTO = TextSubmissionDTO | ModelingSubmissionDTO | QuizSubmissionDTO | InertSubmissionDTO;
+
+/**
+ * Discriminated union of the quiz submitted-answer variants, keyed by {@code type} (matching the server's
+ * {@code QuizQuestionType} discriminator).
+ */
+export interface MultipleChoiceSubmittedAnswerDTO {
+    type: QuizQuestionType.MULTIPLE_CHOICE;
     quizQuestion?: EntityIdRef;
-    // multiple-choice
     selectedOptions?: EntityIdRef[];
-    // drag-and-drop
+}
+
+export interface DragAndDropSubmittedAnswerDTO {
+    type: QuizQuestionType.DRAG_AND_DROP;
+    quizQuestion?: EntityIdRef;
     mappings?: { dragItem?: EntityIdRef; dropLocation?: EntityIdRef }[];
-    // short-answer
+}
+
+export interface ShortAnswerSubmittedAnswerDTO {
+    type: QuizQuestionType.SHORT_ANSWER;
+    quizQuestion?: EntityIdRef;
     submittedTexts?: { text?: string; spot?: EntityIdRef }[];
 }
+
+export type SubmittedAnswerFromLiveClientDTO = MultipleChoiceSubmittedAnswerDTO | DragAndDropSubmittedAnswerDTO | ShortAnswerSubmittedAnswerDTO;
 
 /**
  * Builds the slim submit request body from the live in-memory {@link StudentExam}.
@@ -103,9 +140,15 @@ function toSubmissionDTO(submission: Submission): SubmitExamSubmissionDTO {
                 id: submission.id,
                 submittedAnswers: ((submission as QuizSubmission).submittedAnswers ?? []).map(toSubmittedAnswerDTO),
             };
-        default:
+        case SubmissionExerciseType.PROGRAMMING:
+        case SubmissionExerciseType.FILE_UPLOAD:
             // programming / file-upload: never saved via the hand-in, the server accepts and ignores them.
-            return { submissionExerciseType: submission.submissionExerciseType!, id: submission.id };
+            return { submissionExerciseType: submission.submissionExerciseType, id: submission.id };
+        default:
+            // Only reachable if submissionExerciseType is undefined (malformed submission). Preserve the legacy inert
+            // shape verbatim (no runtime change); the narrow union cannot type an undefined discriminator.
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            return { submissionExerciseType: submission.submissionExerciseType, id: submission.id } as InertSubmissionDTO;
     }
 }
 
@@ -136,6 +179,9 @@ function toSubmittedAnswerDTO(answer: SubmittedAnswer): SubmittedAnswerFromLiveC
                 })),
             };
         default:
-            return { type: answer.type!, quizQuestion: { id: answer.quizQuestion?.id } };
+            // Only reachable if type is undefined (all three real quiz question types are handled above). Preserve the
+            // legacy defensive id-only fallback verbatim (no runtime change); the narrow union cannot type undefined.
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            return { type: answer.type, quizQuestion: { id: answer.quizQuestion?.id } } as SubmittedAnswerFromLiveClientDTO;
     }
 }

--- a/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.ts
+++ b/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.ts
@@ -8,6 +8,7 @@ import { MultipleChoiceSubmittedAnswer } from 'app/quiz/shared/entities/multiple
 import { DragAndDropSubmittedAnswer } from 'app/quiz/shared/entities/drag-and-drop-submitted-answer.model';
 import { ShortAnswerSubmittedAnswer } from 'app/quiz/shared/entities/short-answer-submitted-answer.model';
 import { QuizQuestionType } from 'app/quiz/shared/entities/quiz-question.model';
+import { Language } from 'app/course/shared/entities/course.model';
 
 /**
  * Wire shape of the exam hand-in request body ({@code POST .../student-exams/submit}).
@@ -50,6 +51,10 @@ interface BaseSubmissionDTO {
 export interface TextSubmissionDTO extends BaseSubmissionDTO {
     submissionExerciseType: SubmissionExerciseType.TEXT;
     text?: string;
+    // The client-detected language must ride along: the server persists the reconstructed submission via a JPA merge that
+    // overwrites every column, so a dropped language would be nulled out on every hand-in text edit. Mirrors the server
+    // TextExamSubmissionDTO. The language is detected in text-exam-submission.component.ts.
+    language?: Language;
 }
 
 export interface ModelingSubmissionDTO extends BaseSubmissionDTO {
@@ -125,7 +130,12 @@ export function toSubmitStudentExamDTO(studentExam: StudentExam): SubmitStudentE
 function toSubmissionDTO(submission: Submission): SubmitExamSubmissionDTO | undefined {
     switch (submission.submissionExerciseType) {
         case SubmissionExerciseType.TEXT:
-            return { submissionExerciseType: SubmissionExerciseType.TEXT, id: submission.id, text: (submission as TextSubmission).text };
+            return {
+                submissionExerciseType: SubmissionExerciseType.TEXT,
+                id: submission.id,
+                text: (submission as TextSubmission).text,
+                language: (submission as TextSubmission).language,
+            };
         case SubmissionExerciseType.MODELING: {
             const modelingSubmission = submission as ModelingSubmission;
             return {

--- a/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.ts
+++ b/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.ts
@@ -115,13 +115,14 @@ export function toSubmitStudentExamDTO(studentExam: StudentExam): SubmitStudentE
             id: exercise.id,
             studentParticipations: (exercise.studentParticipations ?? []).map((participation) => ({
                 id: participation.id,
-                submissions: (participation.submissions ?? []).map(toSubmissionDTO),
+                // flatMap + `?? []` drops any submission the builder cannot type (undefined discriminator); see toSubmissionDTO.
+                submissions: (participation.submissions ?? []).flatMap((submission) => toSubmissionDTO(submission) ?? []),
             })),
         })),
     };
 }
 
-function toSubmissionDTO(submission: Submission): SubmitExamSubmissionDTO {
+function toSubmissionDTO(submission: Submission): SubmitExamSubmissionDTO | undefined {
     switch (submission.submissionExerciseType) {
         case SubmissionExerciseType.TEXT:
             return { submissionExerciseType: SubmissionExerciseType.TEXT, id: submission.id, text: (submission as TextSubmission).text };
@@ -138,22 +139,22 @@ function toSubmissionDTO(submission: Submission): SubmitExamSubmissionDTO {
             return {
                 submissionExerciseType: SubmissionExerciseType.QUIZ,
                 id: submission.id,
-                submittedAnswers: ((submission as QuizSubmission).submittedAnswers ?? []).map(toSubmittedAnswerDTO),
+                submittedAnswers: ((submission as QuizSubmission).submittedAnswers ?? []).flatMap((answer) => toSubmittedAnswerDTO(answer) ?? []),
             };
         case SubmissionExerciseType.PROGRAMMING:
         case SubmissionExerciseType.FILE_UPLOAD:
             // programming / file-upload: never saved via the hand-in, the server accepts and ignores them.
             return { submissionExerciseType: submission.submissionExerciseType, id: submission.id };
         default:
-            // Only reachable if submissionExerciseType is undefined (malformed submission). Preserve the legacy inert
-            // shape verbatim (no runtime change); the narrow union cannot type an undefined discriminator, so the
-            // object must pass through `unknown` (the AOT compiler rejects a direct assertion).
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            return { submissionExerciseType: submission.submissionExerciseType, id: submission.id } as unknown as InertSubmissionDTO;
+            // Only reachable if submissionExerciseType is undefined (malformed submission): the discriminator cannot be
+            // typed, so skip the entry (the caller filters out undefined). This is behavior-equivalent to the legacy
+            // full-entity hand-in, whose server-side reconstruction already drops submissions of unknown/mismatched
+            // type, so emitting nothing client-side is honest rather than shipping an untypeable inert shape.
+            return undefined;
     }
 }
 
-function toSubmittedAnswerDTO(answer: SubmittedAnswer): SubmittedAnswerFromLiveClientDTO {
+function toSubmittedAnswerDTO(answer: SubmittedAnswer): SubmittedAnswerFromLiveClientDTO | undefined {
     switch (answer.type) {
         case QuizQuestionType.MULTIPLE_CHOICE:
             return {
@@ -180,10 +181,9 @@ function toSubmittedAnswerDTO(answer: SubmittedAnswer): SubmittedAnswerFromLiveC
                 })),
             };
         default:
-            // Only reachable if type is undefined (all three real quiz question types are handled above). Preserve the
-            // legacy defensive id-only fallback verbatim (no runtime change); the narrow union cannot type undefined,
-            // so the object must pass through `unknown` (the AOT compiler rejects a direct assertion).
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            return { type: answer.type, quizQuestion: { id: answer.quizQuestion?.id } } as unknown as SubmittedAnswerFromLiveClientDTO;
+            // Only reachable if type is undefined (all three real quiz question types are handled above): the
+            // discriminator cannot be typed, so skip the entry (the caller filters out undefined). The server drops
+            // answers of unknown type during reconstruction, so emitting nothing is behavior-equivalent.
+            return undefined;
     }
 }

--- a/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.ts
+++ b/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.ts
@@ -146,9 +146,10 @@ function toSubmissionDTO(submission: Submission): SubmitExamSubmissionDTO {
             return { submissionExerciseType: submission.submissionExerciseType, id: submission.id };
         default:
             // Only reachable if submissionExerciseType is undefined (malformed submission). Preserve the legacy inert
-            // shape verbatim (no runtime change); the narrow union cannot type an undefined discriminator.
+            // shape verbatim (no runtime change); the narrow union cannot type an undefined discriminator, so the
+            // object must pass through `unknown` (the AOT compiler rejects a direct assertion).
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            return { submissionExerciseType: submission.submissionExerciseType, id: submission.id } as InertSubmissionDTO;
+            return { submissionExerciseType: submission.submissionExerciseType, id: submission.id } as unknown as InertSubmissionDTO;
     }
 }
 
@@ -180,8 +181,9 @@ function toSubmittedAnswerDTO(answer: SubmittedAnswer): SubmittedAnswerFromLiveC
             };
         default:
             // Only reachable if type is undefined (all three real quiz question types are handled above). Preserve the
-            // legacy defensive id-only fallback verbatim (no runtime change); the narrow union cannot type undefined.
+            // legacy defensive id-only fallback verbatim (no runtime change); the narrow union cannot type undefined,
+            // so the object must pass through `unknown` (the AOT compiler rejects a direct assertion).
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-            return { type: answer.type, quizQuestion: { id: answer.quizQuestion?.id } } as SubmittedAnswerFromLiveClientDTO;
+            return { type: answer.type, quizQuestion: { id: answer.quizQuestion?.id } } as unknown as SubmittedAnswerFromLiveClientDTO;
     }
 }

--- a/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.ts
+++ b/src/main/webapp/app/exam/overview/services/submit-student-exam-dto.mapper.ts
@@ -1,0 +1,141 @@
+import { StudentExam } from 'app/exam/shared/entities/student-exam.model';
+import { Submission, SubmissionExerciseType } from 'app/exercise/shared/entities/submission/submission.model';
+import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
+import { ModelingSubmission } from 'app/modeling/shared/entities/modeling-submission.model';
+import { QuizSubmission } from 'app/quiz/shared/entities/quiz-submission.model';
+import { SubmittedAnswer } from 'app/quiz/shared/entities/submitted-answer.model';
+import { MultipleChoiceSubmittedAnswer } from 'app/quiz/shared/entities/multiple-choice-submitted-answer.model';
+import { DragAndDropSubmittedAnswer } from 'app/quiz/shared/entities/drag-and-drop-submitted-answer.model';
+import { ShortAnswerSubmittedAnswer } from 'app/quiz/shared/entities/short-answer-submitted-answer.model';
+import { QuizQuestionType } from 'app/quiz/shared/entities/quiz-question.model';
+
+/**
+ * Wire shape of the exam hand-in request body ({@code POST .../student-exams/submit}).
+ *
+ * These interfaces mirror the server-side {@code SubmitStudentExamDTO} record hierarchy. They intentionally carry only
+ * the student exam id and the last-second submission changes; ownership, exam/course validation, the submitted flag and
+ * the test-run/test-exam gating are all re-derived server-side from the persisted student exam. The polymorphic
+ * discriminators ({@code submissionExerciseType}, and {@code type} for quiz answers) match the entity annotations so the
+ * body binds to the server DTO exactly as a full-entity body used to.
+ */
+export interface SubmitStudentExamDTO {
+    id?: number;
+    exercises: SubmitExamExerciseDTO[];
+}
+
+export interface SubmitExamExerciseDTO {
+    id?: number;
+    studentParticipations: SubmitExamParticipationDTO[];
+}
+
+export interface SubmitExamParticipationDTO {
+    id?: number;
+    submissions: SubmitExamSubmissionDTO[];
+}
+
+interface EntityIdRef {
+    id?: number;
+}
+
+export interface SubmitExamSubmissionDTO {
+    submissionExerciseType: SubmissionExerciseType;
+    id?: number;
+    // text
+    text?: string;
+    // modeling
+    model?: string;
+    explanationText?: string;
+    // quiz
+    submittedAnswers?: SubmittedAnswerFromLiveClientDTO[];
+}
+
+export interface SubmittedAnswerFromLiveClientDTO {
+    type: QuizQuestionType;
+    quizQuestion?: EntityIdRef;
+    // multiple-choice
+    selectedOptions?: EntityIdRef[];
+    // drag-and-drop
+    mappings?: { dragItem?: EntityIdRef; dropLocation?: EntityIdRef }[];
+    // short-answer
+    submittedTexts?: { text?: string; spot?: EntityIdRef }[];
+}
+
+/**
+ * Builds the slim submit request body from the live in-memory {@link StudentExam}.
+ *
+ * This is a pure mapper: it only copies scalars and ids into freshly-created objects, so — unlike the previous
+ * {@code cloneDeep + breakCircularDependency} approach — it never carries back-references and needs no circular-reference
+ * stripping. It is the single choke point for the submit body, so the normal hand-in and the localStorage recovery/resume
+ * flow (which re-enters through the same {@code submitStudentExam} call) build an identical body.
+ *
+ * @param studentExam the in-memory student exam to submit
+ * @returns the request body for the submit endpoint
+ */
+export function toSubmitStudentExamDTO(studentExam: StudentExam): SubmitStudentExamDTO {
+    return {
+        id: studentExam.id,
+        exercises: (studentExam.exercises ?? []).map((exercise) => ({
+            id: exercise.id,
+            studentParticipations: (exercise.studentParticipations ?? []).map((participation) => ({
+                id: participation.id,
+                submissions: (participation.submissions ?? []).map(toSubmissionDTO),
+            })),
+        })),
+    };
+}
+
+function toSubmissionDTO(submission: Submission): SubmitExamSubmissionDTO {
+    switch (submission.submissionExerciseType) {
+        case SubmissionExerciseType.TEXT:
+            return { submissionExerciseType: SubmissionExerciseType.TEXT, id: submission.id, text: (submission as TextSubmission).text };
+        case SubmissionExerciseType.MODELING: {
+            const modelingSubmission = submission as ModelingSubmission;
+            return {
+                submissionExerciseType: SubmissionExerciseType.MODELING,
+                id: submission.id,
+                model: modelingSubmission.model,
+                explanationText: modelingSubmission.explanationText,
+            };
+        }
+        case SubmissionExerciseType.QUIZ:
+            return {
+                submissionExerciseType: SubmissionExerciseType.QUIZ,
+                id: submission.id,
+                submittedAnswers: ((submission as QuizSubmission).submittedAnswers ?? []).map(toSubmittedAnswerDTO),
+            };
+        default:
+            // programming / file-upload: never saved via the hand-in, the server accepts and ignores them.
+            return { submissionExerciseType: submission.submissionExerciseType!, id: submission.id };
+    }
+}
+
+function toSubmittedAnswerDTO(answer: SubmittedAnswer): SubmittedAnswerFromLiveClientDTO {
+    switch (answer.type) {
+        case QuizQuestionType.MULTIPLE_CHOICE:
+            return {
+                type: QuizQuestionType.MULTIPLE_CHOICE,
+                quizQuestion: { id: answer.quizQuestion?.id },
+                selectedOptions: ((answer as MultipleChoiceSubmittedAnswer).selectedOptions ?? []).map((option) => ({ id: option.id })),
+            };
+        case QuizQuestionType.DRAG_AND_DROP:
+            return {
+                type: QuizQuestionType.DRAG_AND_DROP,
+                quizQuestion: { id: answer.quizQuestion?.id },
+                mappings: ((answer as DragAndDropSubmittedAnswer).mappings ?? []).map((mapping) => ({
+                    dragItem: { id: mapping.dragItem?.id },
+                    dropLocation: { id: mapping.dropLocation?.id },
+                })),
+            };
+        case QuizQuestionType.SHORT_ANSWER:
+            return {
+                type: QuizQuestionType.SHORT_ANSWER,
+                quizQuestion: { id: answer.quizQuestion?.id },
+                submittedTexts: ((answer as ShortAnswerSubmittedAnswer).submittedTexts ?? []).map((submittedText) => ({
+                    text: submittedText.text,
+                    spot: { id: submittedText.spot?.id },
+                })),
+            };
+        default:
+            return { type: answer.type!, quizQuestion: { id: answer.quizQuestion?.id } };
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
@@ -3021,11 +3021,14 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         // TODO: Hibernate 7 increased base query count from 5 to 6 — investigate remaining extra query in a follow-up
         private final int BASE_QUERY_COUNT = 6;
 
-        // The submit path now rebuilds the quiz submission from the slim SubmitStudentExamDTO via
+        // The submit path rebuilds the quiz submission from the slim SubmitStudentExamDTO via
         // QuizSubmissionService.buildSubmissionFromLiveClientDTO (reusing the #12832 quiz live-save mapper). That mapper
         // re-resolves the client-supplied answer ids against the quiz exercise, so the submit reconstruction loads the
-        // quiz exercise WITH its questions (and their eager nested options/items/spots) — a fixed cost incurred whenever
-        // the hand-in contains a quiz exercise, independent of whether the quiz answer actually changed.
+        // quiz exercise WITH its questions (and their eager nested options/items/spots). This cost is incurred ONLY when
+        // the quiz submission actually carries answers: an empty/absent answer set has nothing to re-resolve, so the
+        // reconstruction skips the load entirely and builds an empty submission from the id alone (see
+        // StudentExamSubmitMapper#buildQuizSubmission). Hence it appears in the changed-answers test but not the
+        // unchanged one, whose conduction quiz submission has no answers.
         private final int QUIZ_RECONSTRUCTION_QUERY_COUNT = 9;
 
         private TextExercise textExercise;
@@ -3099,10 +3102,11 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         @Test
         @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
         void testUnchangedSubmissionsDoNotChangeQueryCount() throws Exception {
-            // Even when nothing changed, the DTO reconstruction still loads the quiz exercise with questions to rebuild
-            // the (unchanged) quiz submission before the content-equality check decides not to persist it.
+            // The conduction quiz submission carries no answers, so the reconstruction skips the quiz question-tree load
+            // (FIX 5) and no content actually changes, so nothing is persisted: the hand-in stays at the bare skeleton
+            // cost. Tightened from BASE + QUIZ_RECONSTRUCTION to just BASE now that the empty-answer reload is elided.
             assertThatDb(() -> request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", studentExamForConduction,
-                    StudentExam.class, HttpStatus.OK)).hasBeenCalledAtMostTimes(BASE_QUERY_COUNT + QUIZ_RECONSTRUCTION_QUERY_COUNT);
+                    StudentExam.class, HttpStatus.OK)).hasBeenCalledAtMostTimes(BASE_QUERY_COUNT);
         }
 
         @Test
@@ -3170,6 +3174,35 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
             verifyDragAndDropSubmission(changedMapping, quizSubmissionAfterExamSubmission);
             verifyShortAnswerSubmission(changedText, quizSubmissionAfterExamSubmission);
             verifyMultipleChoiceSubmission(changedAnswerOptions, quizSubmissionAfterExamSubmission);
+        }
+
+        @Test
+        @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+        void testPoisonedExerciseIsDroppedWhileHandInSucceedsAndOtherExercisesSave() throws Exception {
+            // Governing principle: the exam is ALWAYS marked submitted, and a broken per-exercise submission degrades to
+            // a logged drop of only that exercise's answers — never a 5xx and never data loss for other exercises. Here
+            // the quiz submission references a non-existent submission id, so the per-exercise save rejects and swallows
+            // it, while the healthy text change is still persisted and the exam is submitted.
+            final String healthyAnswer = "This healthy text answer must survive a poisoned sibling exercise";
+            textSubmission.setText(healthyAnswer);
+            quizSubmission.setId(999_999_999L);
+
+            // must return 200 (not 5xx): the hand-in is never aborted by a broken exercise
+            request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", studentExamForConduction, StudentExam.class,
+                    HttpStatus.OK);
+
+            // the exam is marked submitted despite the poisoned quiz
+            StudentExam submitted = studentExamRepository.findById(studentExamForConduction.getId()).orElseThrow();
+            assertThat(submitted.isSubmitted()).isTrue();
+            assertThat(submitted.getSubmissionDate()).isNotNull();
+
+            // no data loss for the healthy sibling: the changed text answer is persisted
+            StudentExam summary = request.get(
+                    "/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/" + studentExamForConduction.getId() + "/summary", HttpStatus.OK,
+                    StudentExam.class);
+            TextExercise textExerciseAfter = ExerciseUtilService.getFirstExerciseWithType(summary, TextExercise.class);
+            TextSubmission textSubmissionAfter = (TextSubmission) textExerciseAfter.getStudentParticipations().iterator().next().findLatestSubmission().orElseThrow();
+            assertThat(textSubmissionAfter.getText()).isEqualTo(healthyAnswer);
         }
 
         @Test

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
@@ -55,6 +55,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
@@ -1004,24 +1006,20 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         submission.setText("Test2");
         submission.setSubmitted(false);
 
-        // if the submitted exam has the submitted flag set to true, the request should be ignored, but still return OK
+        // The client-supplied submitted flag is no longer read (it is dropped from the DTO): the submitted state is
+        // derived from the database. A client that claims submitted=true while its DB copy is not yet submitted therefore
+        // does NOT short-circuit — the exam is legitimately submitted and the change is saved.
         studentExam1.setSubmitted(true);
         request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", studentExam1, HttpStatus.OK, null);
-
-        // Check that submission change is not saved
-        assertStudentExam1HasSingleTextSubmissionWithTextAndIsSubmitted("Test1", null);
-
-        // if the submitted exam has the submitted flag set to false, and the studentExam is not yet submitted, the request should be accepted ...
-        studentExam1.setSubmitted(false);
-        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", studentExam1, HttpStatus.OK, null);
-        // ... and the exam actually be submitted and the change be saved
         assertStudentExam1HasSingleTextSubmissionWithTextAndIsSubmitted("Test2", true);
 
         // Change submission again
         submission.setText("Test3");
         submission.setSubmitted(false);
 
-        // Subsequent calls should still return OK, but not persist my new submission change
+        // Subsequent calls are ignored because the DATABASE now marks the exam as submitted (the idempotent double-submit
+        // guard), regardless of the client-supplied flag, and still return OK without persisting the new change.
+        studentExam1.setSubmitted(false);
         request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", studentExam1, HttpStatus.OK, null);
         assertStudentExam1HasSingleTextSubmissionWithTextAndIsSubmitted("Test2", true);
     }
@@ -1052,16 +1050,20 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testSubmitStudentExam_differentUser() throws Exception {
+    void testSubmitStudentExam_manipulatedUserInBodyIsIgnored() throws Exception {
         studentExam1.setSubmitted(false);
         studentExamRepository.save(studentExam1);
-        // Forbidden because user object is wrong
+        // The submit body no longer carries a user field: ownership is derived from the persisted student exam (owned by
+        // student1, the authenticated user), not from a client claim. A body that still claims a different user (a stale
+        // full-entity body from before the DTO rollout) is deserialized ignoring that field, so the request succeeds and
+        // the DB ownership stays student1. Cross-user submission is rejected by DB truth in testSubmitExamOtherUser_forbidden.
         User student2 = userUtilService.getUserByLogin(TEST_PREFIX + "student2");
         studentExam1.setUser(student2);
-        request.post("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", studentExam1, HttpStatus.FORBIDDEN);
+        request.postWithoutLocation("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", studentExam1, HttpStatus.OK, null);
 
         studentExam1 = studentExamRepository.findByIdElseThrow(studentExam1.getId());
         assertThat(studentExam1.getUser()).isEqualTo(student1);
+        assertThat(studentExam1.isSubmitted()).isTrue();
     }
 
     @Test
@@ -3019,6 +3021,13 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         // TODO: Hibernate 7 increased base query count from 5 to 6 — investigate remaining extra query in a follow-up
         private final int BASE_QUERY_COUNT = 6;
 
+        // The submit path now rebuilds the quiz submission from the slim SubmitStudentExamDTO via
+        // QuizSubmissionService.buildSubmissionFromLiveClientDTO (reusing the #12832 quiz live-save mapper). That mapper
+        // re-resolves the client-supplied answer ids against the quiz exercise, so the submit reconstruction loads the
+        // quiz exercise WITH its questions (and their eager nested options/items/spots) — a fixed cost incurred whenever
+        // the hand-in contains a quiz exercise, independent of whether the quiz answer actually changed.
+        private final int QUIZ_RECONSTRUCTION_QUERY_COUNT = 9;
+
         private TextExercise textExercise;
 
         private ModelingExercise modeExercise;
@@ -3090,8 +3099,10 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         @Test
         @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
         void testUnchangedSubmissionsDoNotChangeQueryCount() throws Exception {
+            // Even when nothing changed, the DTO reconstruction still loads the quiz exercise with questions to rebuild
+            // the (unchanged) quiz submission before the content-equality check decides not to persist it.
             assertThatDb(() -> request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", studentExamForConduction,
-                    StudentExam.class, HttpStatus.OK)).hasBeenCalledAtMostTimes(BASE_QUERY_COUNT);
+                    StudentExam.class, HttpStatus.OK)).hasBeenCalledAtMostTimes(BASE_QUERY_COUNT + QUIZ_RECONSTRUCTION_QUERY_COUNT);
         }
 
         @Test
@@ -3118,16 +3129,15 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
 
             request.put("/api/quiz/exercises/" + quizExercise.getId() + "/submissions/exam", quizSubmission, HttpStatus.OK);
 
-            // load Quiz Submissions Submitted Answers (for comparison)
-            // TODO: Hibernate 7 increased quiz query count from 3 to 8 due to EAGER @ManyToOne on SubmittedAnswer.quizQuestion — needs FetchType.LAZY
-            // The bidirectional @OrderColumn refactor (#12584 fix) added 2 more — Hibernate now issues per-child-collection
-            // SELECTs to refresh the order indices on the question's EAGER child Lists when the question is touched.
-            // Tracked in #12808 to evaluate switching those collections to FetchType.LAZY and reclaiming the +2.
-            final int quizQueryCount = 10;
+            // Additional cost of actually persisting the changed quiz submission (loadQuizSubmissionsSubmittedAnswers +
+            // save), on top of the DTO reconstruction load (QUIZ_RECONSTRUCTION_QUERY_COUNT). The reconstruction load
+            // warms the quiz questions into the session, so this incremental save cost is 8 (previously 10 when the
+            // client posted the fully-hydrated answers and no reconstruction load happened).
+            final int quizSaveQueryCount = 8;
 
             // When
             assertThatDb(() -> request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", studentExamForConduction,
-                    StudentExam.class, HttpStatus.OK)).hasBeenCalledAtMostTimes(BASE_QUERY_COUNT + quizQueryCount);
+                    StudentExam.class, HttpStatus.OK)).hasBeenCalledAtMostTimes(BASE_QUERY_COUNT + QUIZ_RECONSTRUCTION_QUERY_COUNT + quizSaveQueryCount);
             StudentExam submittedExam = request.get(
                     "/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/" + studentExamForConduction.getId() + "/summary", HttpStatus.OK,
                     StudentExam.class);
@@ -3356,6 +3366,185 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
                     .getSubmittedAnswerForQuestion(multipleChoiceQuestion);
 
             assertThat(answerAfterSubmission.toSelectedIds()).containsAll(changedAnswerOption.stream().map(AnswerOption::getId).collect(Collectors.toSet()));
+        }
+
+        private long participationId(Exercise exercise) {
+            return exercise.getStudentParticipations().iterator().next().getId();
+        }
+
+        private ObjectNode idRef(long id) {
+            return objectMapper.createObjectNode().put("id", id);
+        }
+
+        private ObjectNode participationNode(long participationId, ArrayNode submissions) {
+            ObjectNode participation = objectMapper.createObjectNode();
+            participation.put("id", participationId);
+            participation.set("submissions", submissions);
+            return participation;
+        }
+
+        private ObjectNode exerciseNode(long exerciseId, ArrayNode participations) {
+            ObjectNode exercise = objectMapper.createObjectNode();
+            exercise.put("id", exerciseId);
+            exercise.set("studentParticipations", participations);
+            return exercise;
+        }
+
+        private ArrayNode arrayOf(ObjectNode... nodes) {
+            ArrayNode array = objectMapper.createArrayNode();
+            for (ObjectNode node : nodes) {
+                array.add(node);
+            }
+            return array;
+        }
+
+        /**
+         * Trap #4 + slim-path proof: post the actual slim {@code SubmitStudentExamDTO} wire shape (NOT a full entity),
+         * then reload from fresh queries and assert every answer type persisted exactly. A silently-dropped field would
+         * leave the persisted content unchanged and this test would fail.
+         */
+        @Test
+        @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+        void testSubmitViaSlimDtoPersistsEveryAnswerTypeFromFreshQueries() throws Exception {
+            long selectedOptionId = multipleChoiceQuestion.getAnswerOptions().get(1).getId();
+            long dragItemId = dragAndDropQuestion.getDragItems().get(0).getId();
+            long dropLocationId = dragAndDropQuestion.getDropLocations().get(1).getId();
+            long spotId = shortAnswerQuestion.getSpots().get(0).getId();
+
+            ObjectNode mcAnswer = objectMapper.createObjectNode();
+            mcAnswer.put("type", "multiple-choice");
+            mcAnswer.set("quizQuestion", idRef(multipleChoiceQuestion.getId()));
+            mcAnswer.set("selectedOptions", arrayOf(idRef(selectedOptionId)));
+
+            ObjectNode dndMapping = objectMapper.createObjectNode();
+            dndMapping.set("dragItem", idRef(dragItemId));
+            dndMapping.set("dropLocation", idRef(dropLocationId));
+            ObjectNode dndAnswer = objectMapper.createObjectNode();
+            dndAnswer.put("type", "drag-and-drop");
+            dndAnswer.set("quizQuestion", idRef(dragAndDropQuestion.getId()));
+            dndAnswer.set("mappings", arrayOf(dndMapping));
+
+            ObjectNode saText = objectMapper.createObjectNode();
+            saText.put("text", "slim short answer");
+            saText.set("spot", idRef(spotId));
+            ObjectNode saAnswer = objectMapper.createObjectNode();
+            saAnswer.put("type", "short-answer");
+            saAnswer.set("quizQuestion", idRef(shortAnswerQuestion.getId()));
+            saAnswer.set("submittedTexts", arrayOf(saText));
+
+            ObjectNode textSubmissionNode = objectMapper.createObjectNode();
+            textSubmissionNode.put("submissionExerciseType", "text");
+            textSubmissionNode.put("id", textSubmission.getId());
+            textSubmissionNode.put("text", "slim text answer");
+
+            ObjectNode modelingSubmissionNode = objectMapper.createObjectNode();
+            modelingSubmissionNode.put("submissionExerciseType", "modeling");
+            modelingSubmissionNode.put("id", modeSubmission.getId());
+            modelingSubmissionNode.put("model", "slim model");
+            modelingSubmissionNode.put("explanationText", "slim explanation");
+
+            ObjectNode quizSubmissionNode = objectMapper.createObjectNode();
+            quizSubmissionNode.put("submissionExerciseType", "quiz");
+            quizSubmissionNode.put("id", quizSubmission.getId());
+            quizSubmissionNode.set("submittedAnswers", arrayOf(mcAnswer, dndAnswer, saAnswer));
+
+            ArrayNode exercises = arrayOf(exerciseNode(textExercise.getId(), arrayOf(participationNode(participationId(textExercise), arrayOf(textSubmissionNode)))),
+                    exerciseNode(modeExercise.getId(), arrayOf(participationNode(participationId(modeExercise), arrayOf(modelingSubmissionNode)))),
+                    exerciseNode(quizExercise.getId(), arrayOf(participationNode(participationId(quizExercise), arrayOf(quizSubmissionNode)))));
+            ObjectNode body = objectMapper.createObjectNode();
+            body.put("id", studentExamForConduction.getId());
+            body.set("exercises", exercises);
+
+            request.postWithoutResponseBody("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", body, HttpStatus.OK);
+
+            // reload text + modeling from fresh repository queries
+            TextSubmission reloadedText = (TextSubmission) submissionRepository.findById(textSubmission.getId()).orElseThrow();
+            assertThat(reloadedText.getText()).isEqualTo("slim text answer");
+            ModelingSubmission reloadedModeling = (ModelingSubmission) submissionRepository.findById(modeSubmission.getId()).orElseThrow();
+            assertThat(reloadedModeling.getModel()).isEqualTo("slim model");
+            assertThat(reloadedModeling.getExplanationText()).isEqualTo("slim explanation");
+
+            // reload quiz answers via a fresh summary request and assert each answer type persisted
+            StudentExam submittedExam = request.get(
+                    "/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/" + studentExamForConduction.getId() + "/summary", HttpStatus.OK,
+                    StudentExam.class);
+            QuizSubmission reloadedQuiz = (QuizSubmission) ExerciseUtilService.getFirstExerciseWithType(submittedExam, QuizExercise.class).getStudentParticipations().iterator()
+                    .next().findLatestSubmission().orElseThrow();
+            MultipleChoiceSubmittedAnswer mc = (MultipleChoiceSubmittedAnswer) reloadedQuiz.getSubmittedAnswerForQuestion(multipleChoiceQuestion);
+            assertThat(mc.toSelectedIds()).containsExactly(selectedOptionId);
+            DragAndDropSubmittedAnswer dnd = (DragAndDropSubmittedAnswer) reloadedQuiz.getSubmittedAnswerForQuestion(dragAndDropQuestion);
+            assertThat(dnd.getMappings()).hasSize(1);
+            assertThat(dnd.getMappings().iterator().next().getDragItem().getId()).isEqualTo(dragItemId);
+            assertThat(dnd.getMappings().iterator().next().getDropLocation().getId()).isEqualTo(dropLocationId);
+            ShortAnswerSubmittedAnswer sa = (ShortAnswerSubmittedAnswer) reloadedQuiz.getSubmittedAnswerForQuestion(shortAnswerQuestion);
+            assertThat(sa.getSubmittedTexts()).hasSize(1);
+            assertThat(sa.getSubmittedTexts().iterator().next().getText()).isEqualTo("slim short answer");
+            assertThat(sa.getSubmittedTexts().iterator().next().getSpot().getId()).isEqualTo(spotId);
+        }
+
+        /**
+         * Trap #3: a raw body with explicit empty arrays (the shape a real client emits, which a DTO-serialized test
+         * body would silently omit via {@code @JsonInclude(NON_EMPTY)}). The submit must return 200, mark the exam
+         * submitted, and persist nothing — matching the early-return / skip semantics.
+         */
+        @Test
+        @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+        void testSubmitViaSlimDtoWithExplicitEmptyExercisesArrayMarksSubmittedWithoutSaving() throws Exception {
+            String originalText = ((TextSubmission) submissionRepository.findById(textSubmission.getId()).orElseThrow()).getText();
+
+            ObjectNode body = objectMapper.createObjectNode();
+            body.put("id", studentExamForConduction.getId());
+            body.set("exercises", objectMapper.createArrayNode());
+
+            request.postWithoutResponseBody("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", body, HttpStatus.OK);
+
+            assertThat(studentExamRepository.findById(studentExamForConduction.getId()).orElseThrow().isSubmitted()).isTrue();
+            assertThat(((TextSubmission) submissionRepository.findById(textSubmission.getId()).orElseThrow()).getText()).isEqualTo(originalText);
+        }
+
+        /**
+         * Trap #3, nested variant: an exercise whose participation carries an explicit empty submissions array, and a
+         * quiz submission with an explicit empty submittedAnswers array. Both must be handled without error (skip / empty
+         * rebuild), the exam still marked submitted, and the untouched text submission preserved.
+         */
+        @Test
+        @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+        void testSubmitViaSlimDtoWithExplicitEmptyNestedArraysIsSafe() throws Exception {
+            String originalText = ((TextSubmission) submissionRepository.findById(textSubmission.getId()).orElseThrow()).getText();
+
+            // text exercise participation with an explicit empty submissions array -> size != 1 -> skipped
+            ObjectNode textParticipation = participationNode(participationId(textExercise), objectMapper.createArrayNode());
+            // quiz submission with an explicit empty submittedAnswers array -> rebuilt as an empty answer set
+            ObjectNode quizSubmissionNode = objectMapper.createObjectNode();
+            quizSubmissionNode.put("submissionExerciseType", "quiz");
+            quizSubmissionNode.put("id", quizSubmission.getId());
+            quizSubmissionNode.set("submittedAnswers", objectMapper.createArrayNode());
+
+            ArrayNode exercises = arrayOf(exerciseNode(textExercise.getId(), arrayOf(textParticipation)),
+                    exerciseNode(quizExercise.getId(), arrayOf(participationNode(participationId(quizExercise), arrayOf(quizSubmissionNode)))));
+            ObjectNode body = objectMapper.createObjectNode();
+            body.put("id", studentExamForConduction.getId());
+            body.set("exercises", exercises);
+
+            request.postWithoutResponseBody("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", body, HttpStatus.OK);
+
+            assertThat(studentExamRepository.findById(studentExamForConduction.getId()).orElseThrow().isSubmitted()).isTrue();
+            assertThat(((TextSubmission) submissionRepository.findById(textSubmission.getId()).orElseThrow()).getText()).isEqualTo(originalText);
+        }
+
+        /**
+         * Trap #2: a stale client tab opened before the DTO rollout still posts the full-entity {@code StudentExam}
+         * body. It must deserialize losslessly into the DTO (matching discriminators + ignore-unknown) and persist the
+         * changed answer exactly as the slim body would.
+         */
+        @Test
+        @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+        void testSubmitLegacyFullEntityBodyStillPersistsChangedText() throws Exception {
+            textSubmission.setText("legacy full entity text");
+
+            request.postWithoutResponseBody("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", studentExamForConduction, HttpStatus.OK);
+
+            assertThat(((TextSubmission) submissionRepository.findById(textSubmission.getId()).orElseThrow()).getText()).isEqualTo("legacy full entity text");
         }
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
@@ -3231,6 +3231,29 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
 
         @Test
         @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+        void testHandInPersistsTextSubmissionLanguageFromSlimDto() throws Exception {
+            // Wire-parity regression guard: the slim submit DTO must carry the client-detected language. The downstream
+            // save (saveSubmissionTextExercise) persists the reconstructed submission via a JPA merge that overwrites
+            // every mapped column, so a language dropped from the DTO would be nulled out on this hand-in. The conduction
+            // submission starts with a null language; here we set it the way the client does (predictLanguage) and change
+            // the text so the content-equality short-circuit does not skip the save, hand in, then re-read the row.
+            assertThat(textSubmission.getLanguage()).as("the conduction submission starts without a language").isNull();
+            final String changedAnswer = "Dies ist eine geänderte Antwort auf Deutsch";
+            textSubmission.setText(changedAnswer);
+            textSubmission.setLanguage(Language.GERMAN);
+
+            request.postWithResponseBody("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/submit", studentExamForConduction, StudentExam.class,
+                    HttpStatus.OK);
+
+            // fresh query straight from the repository (not the summary DTO): both the text AND the language must have
+            // been persisted, proving the language survived the slim-DTO round-trip and the overwriting merge.
+            TextSubmission persisted = (TextSubmission) submissionRepository.findById(textSubmission.getId()).orElseThrow();
+            assertThat(persisted.getText()).isEqualTo(changedAnswer);
+            assertThat(persisted.getLanguage()).isEqualTo(Language.GERMAN);
+        }
+
+        @Test
+        @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
         void testChangedAndNotSubmittedModelingSubmission() throws Exception {
             // Given
             final String changedModel = "This is a changed model";

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamSubmitMapperTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamSubmitMapperTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import de.tum.cit.aet.artemis.account.domain.User;
+import de.tum.cit.aet.artemis.core.domain.Language;
 import de.tum.cit.aet.artemis.exam.domain.StudentExam;
 import de.tum.cit.aet.artemis.exam.dto.submit.ModelingExamSubmissionDTO;
 import de.tum.cit.aet.artemis.exam.dto.submit.QuizExamSubmissionDTO;
@@ -44,9 +45,12 @@ import de.tum.cit.aet.artemis.text.domain.TextSubmission;
 
 /**
  * Unit tests for {@link StudentExamSubmitMapper}, the boundary that turns the slim submit DTO into the transient graph
- * the (unchanged) submit machinery consumes. These deterministically pin the two silent-answer-loss traps that live in
- * the reconstruction: the participant must be re-derived so the swallowed {@code isOwnedBy} check passes (for individual
- * AND team exercises), and every submission's client id must survive so the swallowed DB id-match resolves it.
+ * the (unchanged) submit machinery consumes. These deterministically pin the silent-answer-loss traps that live in the
+ * reconstruction: the participant must be re-derived so the swallowed {@code isOwnedBy} check passes, and every
+ * submission's client id must survive so the swallowed DB id-match resolves it. They do <i>not</i> assert that exam team
+ * mode works end-to-end — it is unsupported downstream (see the mapper's class javadoc and
+ * {@code StudentParticipationRepository}); they only assert that the reconstruction sets the participant such that
+ * {@code isOwnedBy} passes regardless of exercise mode.
  */
 @ExtendWith(MockitoExtension.class)
 class StudentExamSubmitMapperTest {
@@ -102,7 +106,7 @@ class StudentExamSubmitMapperTest {
         StudentExam studentExam = studentExamWith(exercise);
 
         var dto = new SubmitStudentExamDTO(1L,
-                List.of(new SubmitExamExerciseDTO(10L, List.of(new SubmitExamParticipationDTO(1000L, List.of(new TextExamSubmissionDTO(100L, "answer")))))));
+                List.of(new SubmitExamExerciseDTO(10L, List.of(new SubmitExamParticipationDTO(1000L, List.of(new TextExamSubmissionDTO(100L, "answer", Language.GERMAN)))))));
 
         mapper.attachSubmissions(studentExam, dto, currentUser());
 
@@ -122,6 +126,9 @@ class StudentExamSubmitMapperTest {
         // the client id must survive so existingParticipationInDatabase.getSubmissions().contains(...) id-matches
         assertThat(submission.getId()).isEqualTo(100L);
         assertThat(((TextSubmission) submission).getText()).isEqualTo("answer");
+        // the client-detected language must survive: the downstream merge overwrites the column, so a dropped language
+        // would be persisted as null (regression). See TextExamSubmissionDTO.
+        assertThat(((TextSubmission) submission).getLanguage()).isEqualTo(Language.GERMAN);
         assertThat(submission.getLatestResult()).as("no result injected -> passes the result-injection guard").isNull();
     }
 
@@ -135,7 +142,7 @@ class StudentExamSubmitMapperTest {
         StudentExam testRunStudentExam = testRunStudentExamWith(exercise);
 
         var dto = new SubmitStudentExamDTO(1L,
-                List.of(new SubmitExamExerciseDTO(12L, List.of(new SubmitExamParticipationDTO(1002L, List.of(new TextExamSubmissionDTO(102L, "answer")))))));
+                List.of(new SubmitExamExerciseDTO(12L, List.of(new SubmitExamParticipationDTO(1002L, List.of(new TextExamSubmissionDTO(102L, "answer", null)))))));
 
         mapper.attachSubmissions(testRunStudentExam, dto, currentUser());
 
@@ -145,16 +152,20 @@ class StudentExamSubmitMapperTest {
     }
 
     @Test
-    void shouldReconstructTeamExerciseParticipationOwnedByCurrentUser() {
-        // Team mode is the trap: the client participation carries no team, yet isOwnedBy(currentUser) must still pass.
-        // Setting the participant to the authenticated user makes getStudent().login match, independent of exercise mode.
+    void shouldSetParticipantSoIsOwnedByPassesRegardlessOfExerciseMode() {
+        // NOT a claim that team exams submit end-to-end (they are unsupported downstream — the exam submit/summary
+        // queries filter p.student.id and StudentParticipationRepository documents there is no exam team support). This
+        // only pins the reconstruction contract: re-deriving the participant from the authenticated user makes the
+        // swallowed isOwnedBy(currentUser) check in saveSubmission pass independent of exercise mode, so the answer is
+        // not silently dropped there. A TEAM-mode exercise is used purely to show the re-derivation does not depend on
+        // the mode.
         TextExercise exercise = new TextExercise();
         exercise.setId(11L);
         exercise.setMode(ExerciseMode.TEAM);
         StudentExam studentExam = studentExamWith(exercise);
 
         var dto = new SubmitStudentExamDTO(1L,
-                List.of(new SubmitExamExerciseDTO(11L, List.of(new SubmitExamParticipationDTO(1001L, List.of(new TextExamSubmissionDTO(101L, "team answer")))))));
+                List.of(new SubmitExamExerciseDTO(11L, List.of(new SubmitExamParticipationDTO(1001L, List.of(new TextExamSubmissionDTO(101L, "answer", null)))))));
 
         mapper.attachSubmissions(studentExam, dto, currentUser());
 
@@ -218,7 +229,7 @@ class StudentExamSubmitMapperTest {
         StudentExam studentExam = studentExamWith(submittedExercise, untouchedExercise);
 
         var dto = new SubmitStudentExamDTO(1L,
-                List.of(new SubmitExamExerciseDTO(10L, List.of(new SubmitExamParticipationDTO(1000L, List.of(new TextExamSubmissionDTO(100L, "answer")))))));
+                List.of(new SubmitExamExerciseDTO(10L, List.of(new SubmitExamParticipationDTO(1000L, List.of(new TextExamSubmissionDTO(100L, "answer", null)))))));
 
         mapper.attachSubmissions(studentExam, dto, currentUser());
 
@@ -237,7 +248,7 @@ class StudentExamSubmitMapperTest {
         StudentExam studentExam = studentExamWith(exercise);
 
         var dto = new SubmitStudentExamDTO(1L,
-                List.of(new SubmitExamExerciseDTO(30L, List.of(new SubmitExamParticipationDTO(3000L, List.of(new TextExamSubmissionDTO(300L, "mismatched")))))));
+                List.of(new SubmitExamExerciseDTO(30L, List.of(new SubmitExamParticipationDTO(3000L, List.of(new TextExamSubmissionDTO(300L, "mismatched", null)))))));
 
         mapper.attachSubmissions(studentExam, dto, currentUser());
 
@@ -270,8 +281,9 @@ class StudentExamSubmitMapperTest {
         exercise.setId(40L);
         StudentExam studentExam = studentExamWith(exercise);
 
-        var dto = new SubmitStudentExamDTO(1L, List.of(new SubmitExamExerciseDTO(40L, List.of(new SubmitExamParticipationDTO(4000L, List.of(new TextExamSubmissionDTO(400L, "a"))),
-                new SubmitExamParticipationDTO(4000L, List.of(new TextExamSubmissionDTO(401L, "b")))))));
+        var dto = new SubmitStudentExamDTO(1L,
+                List.of(new SubmitExamExerciseDTO(40L, List.of(new SubmitExamParticipationDTO(4000L, List.of(new TextExamSubmissionDTO(400L, "a", null))),
+                        new SubmitExamParticipationDTO(4000L, List.of(new TextExamSubmissionDTO(401L, "b", null)))))));
 
         mapper.attachSubmissions(studentExam, dto, currentUser());
 
@@ -286,7 +298,7 @@ class StudentExamSubmitMapperTest {
         StudentExam studentExam = studentExamWith(exercise);
 
         var dto = new SubmitStudentExamDTO(1L, List.of(new SubmitExamExerciseDTO(41L,
-                List.of(new SubmitExamParticipationDTO(4100L, List.of(new TextExamSubmissionDTO(410L, "a"), new TextExamSubmissionDTO(411L, "b")))))));
+                List.of(new SubmitExamParticipationDTO(4100L, List.of(new TextExamSubmissionDTO(410L, "a", null), new TextExamSubmissionDTO(411L, "b", null)))))));
 
         mapper.attachSubmissions(studentExam, dto, currentUser());
 
@@ -329,7 +341,7 @@ class StudentExamSubmitMapperTest {
         Set<SubmittedAnswerFromLiveClientDTO> answers = Set.of(new MultipleChoiceSubmittedAnswerFromLiveClientDTO(new EntityIdRefDTO(20L), Set.of(new EntityIdRefDTO(201L))));
         var dto = new SubmitStudentExamDTO(1L,
                 List.of(new SubmitExamExerciseDTO(50L, List.of(new SubmitExamParticipationDTO(5000L, List.of(new QuizExamSubmissionDTO(500L, answers))))),
-                        new SubmitExamExerciseDTO(51L, List.of(new SubmitExamParticipationDTO(5100L, List.of(new TextExamSubmissionDTO(510L, "healthy")))))));
+                        new SubmitExamExerciseDTO(51L, List.of(new SubmitExamParticipationDTO(5100L, List.of(new TextExamSubmissionDTO(510L, "healthy", null)))))));
 
         mapper.attachSubmissions(studentExam, dto, currentUser());
 

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamSubmitMapperTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamSubmitMapperTest.java
@@ -194,4 +194,117 @@ class StudentExamSubmitMapperTest {
         // no exercise here is a quiz, so the quiz collaborators must never be touched
         verifyNoInteractions(quizExerciseRepository, quizSubmissionService);
     }
+
+    @Test
+    void shouldDropTextSubmissionSentForANonTextExercise() {
+        // FIX 2: the text branch must validate the exercise type like the quiz branch, matching the legacy
+        // ClassCastException-swallow. A text submission bound to a quiz exercise is dropped, not cast-and-crashed.
+        QuizExercise exercise = new QuizExercise();
+        exercise.setId(30L);
+        StudentExam studentExam = studentExamWith(exercise);
+
+        var dto = new SubmitStudentExamDTO(1L,
+                List.of(new SubmitExamExerciseDTO(30L, List.of(new SubmitExamParticipationDTO(3000L, List.of(new TextExamSubmissionDTO(300L, "mismatched")))))));
+
+        mapper.attachSubmissions(studentExam, dto, currentUser());
+
+        // the participation is still initialized, but the type-mismatched submission is dropped
+        assertThat(onlyParticipation(exercise).getSubmissions()).isEmpty();
+        // a text submission never touches the quiz collaborators
+        verifyNoInteractions(quizExerciseRepository, quizSubmissionService);
+    }
+
+    @Test
+    void shouldDropModelingSubmissionSentForANonModelingExercise() {
+        // FIX 2: same for the modeling branch.
+        TextExercise exercise = new TextExercise();
+        exercise.setId(31L);
+        StudentExam studentExam = studentExamWith(exercise);
+
+        var dto = new SubmitStudentExamDTO(1L,
+                List.of(new SubmitExamExerciseDTO(31L, List.of(new SubmitExamParticipationDTO(3100L, List.of(new ModelingExamSubmissionDTO(310L, "{model}", "explanation")))))));
+
+        mapper.attachSubmissions(studentExam, dto, currentUser());
+
+        assertThat(onlyParticipation(exercise).getSubmissions()).isEmpty();
+    }
+
+    @Test
+    void shouldSkipExerciseWhenMoreThanOneParticipationIsPresent() {
+        // FIX 3: the ambiguity check must run on the wire List BEFORE folding into a Set. Two same-id participations
+        // would collapse to one in a HashSet and wrongly proceed; on the List they are size 2 -> attach nothing.
+        TextExercise exercise = new TextExercise();
+        exercise.setId(40L);
+        StudentExam studentExam = studentExamWith(exercise);
+
+        var dto = new SubmitStudentExamDTO(1L, List.of(new SubmitExamExerciseDTO(40L, List.of(new SubmitExamParticipationDTO(4000L, List.of(new TextExamSubmissionDTO(400L, "a"))),
+                new SubmitExamParticipationDTO(4000L, List.of(new TextExamSubmissionDTO(401L, "b")))))));
+
+        mapper.attachSubmissions(studentExam, dto, currentUser());
+
+        assertThat(exercise.getStudentParticipations()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void shouldSkipExerciseWhenTheParticipationCarriesMoreThanOneSubmission() {
+        // FIX 3: same ambiguity rule for submissions.
+        TextExercise exercise = new TextExercise();
+        exercise.setId(41L);
+        StudentExam studentExam = studentExamWith(exercise);
+
+        var dto = new SubmitStudentExamDTO(1L, List.of(new SubmitExamExerciseDTO(41L,
+                List.of(new SubmitExamParticipationDTO(4100L, List.of(new TextExamSubmissionDTO(410L, "a"), new TextExamSubmissionDTO(411L, "b")))))));
+
+        mapper.attachSubmissions(studentExam, dto, currentUser());
+
+        assertThat(exercise.getStudentParticipations()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void shouldBuildEmptyQuizSubmissionWithoutLoadingQuestionsWhenNoAnswers() {
+        // FIX 5: an empty answer set has nothing to re-resolve, so the expensive question-tree load is skipped and an
+        // empty submission carrying only the id is produced (matching buildSubmissionFromLiveClientDTO for empty input).
+        QuizExercise exercise = new QuizExercise();
+        exercise.setId(60L);
+        StudentExam studentExam = studentExamWith(exercise);
+
+        var dto = new SubmitStudentExamDTO(1L,
+                List.of(new SubmitExamExerciseDTO(60L, List.of(new SubmitExamParticipationDTO(6000L, List.of(new QuizExamSubmissionDTO(600L, Set.of())))))));
+
+        mapper.attachSubmissions(studentExam, dto, currentUser());
+
+        Submission submission = onlySubmission(onlyParticipation(exercise));
+        assertThat(submission).isInstanceOf(QuizSubmission.class);
+        assertThat(submission.getId()).isEqualTo(600L);
+        assertThat(((QuizSubmission) submission).getSubmittedAnswers()).isEmpty();
+        // neither the question-tree load nor the live-client rebuild run for an empty answer set
+        verifyNoInteractions(quizExerciseRepository, quizSubmissionService);
+    }
+
+    @Test
+    void shouldDropPoisonedExerciseButReconstructHealthyOnesInTheSameCall() {
+        // FIX 1: a per-exercise reconstruction failure (here: the quiz question-tree load throws) must never abort the
+        // hand-in nor lose a sibling exercise's answers. The poisoned quiz degrades to empty; the healthy text survives.
+        QuizExercise poisonedQuiz = new QuizExercise();
+        poisonedQuiz.setId(50L);
+        TextExercise healthyText = new TextExercise();
+        healthyText.setId(51L);
+        StudentExam studentExam = studentExamWith(poisonedQuiz, healthyText);
+
+        when(quizExerciseRepository.findByIdWithQuestionsElseThrow(50L)).thenThrow(new RuntimeException("boom"));
+
+        Set<SubmittedAnswerFromLiveClientDTO> answers = Set.of(new MultipleChoiceSubmittedAnswerFromLiveClientDTO(new EntityIdRefDTO(20L), Set.of(new EntityIdRefDTO(201L))));
+        var dto = new SubmitStudentExamDTO(1L,
+                List.of(new SubmitExamExerciseDTO(50L, List.of(new SubmitExamParticipationDTO(5000L, List.of(new QuizExamSubmissionDTO(500L, answers))))),
+                        new SubmitExamExerciseDTO(51L, List.of(new SubmitExamParticipationDTO(5100L, List.of(new TextExamSubmissionDTO(510L, "healthy")))))));
+
+        mapper.attachSubmissions(studentExam, dto, currentUser());
+
+        // poisoned quiz: reconstruction threw -> empty participations (its last-second changes dropped), no crash
+        assertThat(poisonedQuiz.getStudentParticipations()).isNotNull().isEmpty();
+        // healthy text: reconstructed despite the sibling failure
+        Submission submission = onlySubmission(onlyParticipation(healthyText));
+        assertThat(submission).isInstanceOf(TextSubmission.class);
+        assertThat(((TextSubmission) submission).getText()).isEqualTo("healthy");
+    }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamSubmitMapperTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamSubmitMapperTest.java
@@ -1,0 +1,197 @@
+package de.tum.cit.aet.artemis.exam;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.tum.cit.aet.artemis.account.domain.User;
+import de.tum.cit.aet.artemis.exam.domain.StudentExam;
+import de.tum.cit.aet.artemis.exam.dto.submit.ModelingExamSubmissionDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.QuizExamSubmissionDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.SubmitExamExerciseDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.SubmitExamParticipationDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.SubmitStudentExamDTO;
+import de.tum.cit.aet.artemis.exam.dto.submit.TextExamSubmissionDTO;
+import de.tum.cit.aet.artemis.exam.service.StudentExamSubmitMapper;
+import de.tum.cit.aet.artemis.exercise.domain.Exercise;
+import de.tum.cit.aet.artemis.exercise.domain.ExerciseMode;
+import de.tum.cit.aet.artemis.exercise.domain.Submission;
+import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
+import de.tum.cit.aet.artemis.modeling.domain.ModelingSubmission;
+import de.tum.cit.aet.artemis.quiz.domain.QuizExercise;
+import de.tum.cit.aet.artemis.quiz.domain.QuizSubmission;
+import de.tum.cit.aet.artemis.quiz.dto.submission.QuizSubmissionFromLiveClientDTO;
+import de.tum.cit.aet.artemis.quiz.dto.submittedanswer.EntityIdRefDTO;
+import de.tum.cit.aet.artemis.quiz.dto.submittedanswer.MultipleChoiceSubmittedAnswerFromLiveClientDTO;
+import de.tum.cit.aet.artemis.quiz.dto.submittedanswer.SubmittedAnswerFromLiveClientDTO;
+import de.tum.cit.aet.artemis.quiz.service.QuizSubmissionService;
+import de.tum.cit.aet.artemis.quiz.test_repository.QuizExerciseTestRepository;
+import de.tum.cit.aet.artemis.text.domain.TextExercise;
+import de.tum.cit.aet.artemis.text.domain.TextSubmission;
+
+/**
+ * Unit tests for {@link StudentExamSubmitMapper}, the boundary that turns the slim submit DTO into the transient graph
+ * the (unchanged) submit machinery consumes. These deterministically pin the two silent-answer-loss traps that live in
+ * the reconstruction: the participant must be re-derived so the swallowed {@code isOwnedBy} check passes (for individual
+ * AND team exercises), and every submission's client id must survive so the swallowed DB id-match resolves it.
+ */
+@ExtendWith(MockitoExtension.class)
+class StudentExamSubmitMapperTest {
+
+    @Mock
+    private QuizExerciseTestRepository quizExerciseRepository;
+
+    @Mock
+    private QuizSubmissionService quizSubmissionService;
+
+    @InjectMocks
+    private StudentExamSubmitMapper mapper;
+
+    private static final Long CURRENT_USER_ID = 7L;
+
+    private static final String CURRENT_USER_LOGIN = "student1";
+
+    private User currentUser() {
+        User user = new User();
+        user.setId(CURRENT_USER_ID);
+        user.setLogin(CURRENT_USER_LOGIN);
+        return user;
+    }
+
+    private StudentExam studentExamWith(Exercise... exercises) {
+        StudentExam studentExam = new StudentExam();
+        studentExam.setId(1L);
+        studentExam.setExercises(List.of(exercises));
+        return studentExam;
+    }
+
+    private static StudentParticipation onlyParticipation(Exercise exercise) {
+        assertThat(exercise.getStudentParticipations()).hasSize(1);
+        return exercise.getStudentParticipations().iterator().next();
+    }
+
+    private static Submission onlySubmission(StudentParticipation participation) {
+        assertThat(participation.getSubmissions()).hasSize(1);
+        return participation.getSubmissions().iterator().next();
+    }
+
+    @Test
+    void shouldReconstructIndividualTextSubmissionOwnedByCurrentUser() {
+        TextExercise exercise = new TextExercise();
+        exercise.setId(10L);
+        exercise.setMode(ExerciseMode.INDIVIDUAL);
+        StudentExam studentExam = studentExamWith(exercise);
+
+        var dto = new SubmitStudentExamDTO(1L,
+                List.of(new SubmitExamExerciseDTO(10L, List.of(new SubmitExamParticipationDTO(1000L, List.of(new TextExamSubmissionDTO(100L, "answer")))))));
+
+        mapper.attachSubmissions(studentExam, dto, currentUser());
+
+        StudentParticipation participation = onlyParticipation(exercise);
+        assertThat(participation.getId()).isEqualTo(1000L);
+        // the swallowed isOwnedBy(currentUser) in saveSubmission must pass, otherwise the answer is silently dropped
+        assertThat(participation.isOwnedBy(currentUser())).isTrue();
+        Submission submission = onlySubmission(participation);
+        assertThat(submission).isInstanceOf(TextSubmission.class);
+        // the client id must survive so existingParticipationInDatabase.getSubmissions().contains(...) id-matches
+        assertThat(submission.getId()).isEqualTo(100L);
+        assertThat(((TextSubmission) submission).getText()).isEqualTo("answer");
+        assertThat(submission.getLatestResult()).as("no result injected -> passes the result-injection guard").isNull();
+    }
+
+    @Test
+    void shouldReconstructTeamExerciseParticipationOwnedByCurrentUser() {
+        // Team mode is the trap: the client participation carries no team, yet isOwnedBy(currentUser) must still pass.
+        // Setting the participant to the authenticated user makes getStudent().login match, independent of exercise mode.
+        TextExercise exercise = new TextExercise();
+        exercise.setId(11L);
+        exercise.setMode(ExerciseMode.TEAM);
+        StudentExam studentExam = studentExamWith(exercise);
+
+        var dto = new SubmitStudentExamDTO(1L,
+                List.of(new SubmitExamExerciseDTO(11L, List.of(new SubmitExamParticipationDTO(1001L, List.of(new TextExamSubmissionDTO(101L, "team answer")))))));
+
+        mapper.attachSubmissions(studentExam, dto, currentUser());
+
+        StudentParticipation participation = onlyParticipation(exercise);
+        assertThat(participation.isOwnedBy(currentUser())).isTrue();
+        assertThat(onlySubmission(participation).getId()).isEqualTo(101L);
+    }
+
+    @Test
+    void shouldReconstructModelingSubmissionPreservingContent() {
+        ModelingExercise exercise = new ModelingExercise();
+        exercise.setId(12L);
+        StudentExam studentExam = studentExamWith(exercise);
+
+        var dto = new SubmitStudentExamDTO(1L,
+                List.of(new SubmitExamExerciseDTO(12L, List.of(new SubmitExamParticipationDTO(1002L, List.of(new ModelingExamSubmissionDTO(102L, "{model}", "explanation")))))));
+
+        mapper.attachSubmissions(studentExam, dto, currentUser());
+
+        Submission submission = onlySubmission(onlyParticipation(exercise));
+        assertThat(submission).isInstanceOf(ModelingSubmission.class);
+        assertThat(submission.getId()).isEqualTo(102L);
+        assertThat(((ModelingSubmission) submission).getModel()).isEqualTo("{model}");
+        assertThat(((ModelingSubmission) submission).getExplanationText()).isEqualTo("explanation");
+    }
+
+    @Test
+    void shouldDelegateQuizReconstructionToLiveClientMapperWithQuestionLoadedExercise() {
+        QuizExercise exercise = new QuizExercise();
+        exercise.setId(13L);
+        StudentExam studentExam = studentExamWith(exercise);
+
+        QuizExercise questionLoadedExercise = new QuizExercise();
+        questionLoadedExercise.setId(13L);
+        when(quizExerciseRepository.findByIdWithQuestionsElseThrow(13L)).thenReturn(questionLoadedExercise);
+        QuizSubmission rebuiltSubmission = new QuizSubmission();
+        rebuiltSubmission.setId(103L);
+        var answerCaptor = ArgumentCaptor.forClass(QuizSubmissionFromLiveClientDTO.class);
+        when(quizSubmissionService.buildSubmissionFromLiveClientDTO(answerCaptor.capture(), eq(questionLoadedExercise))).thenReturn(rebuiltSubmission);
+
+        Set<SubmittedAnswerFromLiveClientDTO> answers = Set.of(new MultipleChoiceSubmittedAnswerFromLiveClientDTO(new EntityIdRefDTO(20L), Set.of(new EntityIdRefDTO(201L))));
+        var dto = new SubmitStudentExamDTO(1L,
+                List.of(new SubmitExamExerciseDTO(13L, List.of(new SubmitExamParticipationDTO(1003L, List.of(new QuizExamSubmissionDTO(103L, answers)))))));
+
+        mapper.attachSubmissions(studentExam, dto, currentUser());
+
+        // the exercise must be loaded WITH questions and the id + answers forwarded verbatim to the reused #12832 mapper
+        assertThat(answerCaptor.getValue().id()).isEqualTo(103L);
+        assertThat(answerCaptor.getValue().submittedAnswers()).isEqualTo(answers);
+        assertThat(onlySubmission(onlyParticipation(exercise))).isSameAs(rebuiltSubmission);
+    }
+
+    @Test
+    void shouldInitializeParticipationsToEmptySetForExercisesAbsentFromTheDto() {
+        // The student exam is loaded without participations; every exercise must end up with a concrete (never lazy)
+        // collection, or the non-transactional submit code throws LazyInitializationException when it reads size().
+        TextExercise submittedExercise = new TextExercise();
+        submittedExercise.setId(10L);
+        TextExercise untouchedExercise = new TextExercise();
+        untouchedExercise.setId(99L);
+        StudentExam studentExam = studentExamWith(submittedExercise, untouchedExercise);
+
+        var dto = new SubmitStudentExamDTO(1L,
+                List.of(new SubmitExamExerciseDTO(10L, List.of(new SubmitExamParticipationDTO(1000L, List.of(new TextExamSubmissionDTO(100L, "answer")))))));
+
+        mapper.attachSubmissions(studentExam, dto, currentUser());
+
+        assertThat(submittedExercise.getStudentParticipations()).hasSize(1);
+        assertThat(untouchedExercise.getStudentParticipations()).isNotNull().isEmpty();
+        // no exercise here is a quiz, so the quiz collaborators must never be touched
+        verifyNoInteractions(quizExerciseRepository, quizSubmissionService);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamSubmitMapperTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamSubmitMapperTest.java
@@ -26,6 +26,7 @@ import de.tum.cit.aet.artemis.exam.dto.submit.TextExamSubmissionDTO;
 import de.tum.cit.aet.artemis.exam.service.StudentExamSubmitMapper;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.ExerciseMode;
+import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
@@ -77,6 +78,12 @@ class StudentExamSubmitMapperTest {
         return studentExam;
     }
 
+    private StudentExam testRunStudentExamWith(Exercise... exercises) {
+        StudentExam studentExam = studentExamWith(exercises);
+        studentExam.setTestRun(true);
+        return studentExam;
+    }
+
     private static StudentParticipation onlyParticipation(Exercise exercise) {
         assertThat(exercise.getStudentParticipations()).hasSize(1);
         return exercise.getStudentParticipations().iterator().next();
@@ -101,6 +108,13 @@ class StudentExamSubmitMapperTest {
 
         StudentParticipation participation = onlyParticipation(exercise);
         assertThat(participation.getId()).isEqualTo(1000L);
+        // the exercise back-reference must be re-attached: the test-run/test-exam quiz evaluation filters participations
+        // by `participation.getExercise() instanceof QuizExercise`, so a null exercise would silently drop the evaluation
+        assertThat(participation.getExercise()).isSameAs(exercise);
+        // the initialization state must be re-attached so the persisted participation is not clobbered to null
+        assertThat(participation.getInitializationState()).isEqualTo(InitializationState.INITIALIZED);
+        // a non-test-run student exam yields non-test-run participations
+        assertThat(participation.isTestRun()).isFalse();
         // the swallowed isOwnedBy(currentUser) in saveSubmission must pass, otherwise the answer is silently dropped
         assertThat(participation.isOwnedBy(currentUser())).isTrue();
         Submission submission = onlySubmission(participation);
@@ -109,6 +123,25 @@ class StudentExamSubmitMapperTest {
         assertThat(submission.getId()).isEqualTo(100L);
         assertThat(((TextSubmission) submission).getText()).isEqualTo("answer");
         assertThat(submission.getLatestResult()).as("no result injected -> passes the result-injection guard").isNull();
+    }
+
+    @Test
+    void shouldFlagReconstructedParticipationsOfATestRunAsTestRun() {
+        // Regression guard: a test-run participation must be reconstructed with testRun=true, otherwise the evaluate step
+        // persists it as a non-test-run participation and the summary's `WHERE p.testRun = TRUE` query hides the quiz.
+        TextExercise exercise = new TextExercise();
+        exercise.setId(12L);
+        exercise.setMode(ExerciseMode.INDIVIDUAL);
+        StudentExam testRunStudentExam = testRunStudentExamWith(exercise);
+
+        var dto = new SubmitStudentExamDTO(1L,
+                List.of(new SubmitExamExerciseDTO(12L, List.of(new SubmitExamParticipationDTO(1002L, List.of(new TextExamSubmissionDTO(102L, "answer")))))));
+
+        mapper.attachSubmissions(testRunStudentExam, dto, currentUser());
+
+        StudentParticipation participation = onlyParticipation(exercise);
+        assertThat(participation.isTestRun()).isTrue();
+        assertThat(participation.getInitializationState()).isEqualTo(InitializationState.INITIALIZED);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/exam/architecture/ExamEntityUsageArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/architecture/ExamEntityUsageArchitectureTest.java
@@ -24,7 +24,7 @@ class ExamEntityUsageArchitectureTest extends AbstractModuleEntityUsageArchitect
     // TODO: Reduce this to 0 by accepting DTOs instead of entities in @RequestBody/@RequestPart
     @Override
     protected int getExpectedEntityInputViolations() {
-        return 4;
+        return 3;
     }
 
     // TODO: Reduce this to 0 by removing entity references from DTOs.


### PR DESCRIPTION
**Stacked PR** — base branch is `chore/exam-mode/student-exam-dtos` (#13186). This PR targets and depends on #13186; it will be rebased onto `develop` once #13186 merges. Please review the diff against that base branch, not against `develop`.

### Summary
Migrates `POST .../student-exams/submit` — the exam-conduction hand-in write path — from `@RequestBody StudentExam` (the raw entity, with all its exercises/participations/submissions) to a narrow `SubmitStudentExamDTO`: ids plus per-type submission content only. The server re-derives every flag/date/ownership fact from the database and no longer trusts client-supplied results. Sealed polymorphic submission records reuse the exact wire discriminators the entity used, and every record ignores unknown fields, so a stale full-entity body from an exam tab that has been open since before this rollout still binds losslessly — proven directly by a dedicated legacy-body integration test (`testSubmitLegacyFullEntityBodyStillPersistsChangedText`). This makes the rollout itself zero-risk regardless of client cache/version skew.

### Motivation and Context
Continues the exam-mode entity-to-DTO migration (#13097, #13186). The submit endpoint is the highest-stakes remaining `StudentExam` entity input in exam conduction: it is the last thing a student's browser sends before their exam is sealed, so the DTO had to preserve every piece of legacy fault-tolerance (the exam is *always* marked submitted, a broken exercise degrades instead of failing the whole request) while also closing a manipulation gap the raw-entity body left open.

### Description

**Server**
- New `exam.dto.submit` package: `SubmitStudentExamDTO` (id + per-exercise submissions) and a sealed `SubmitExamSubmissionDTO` hierarchy (`TextExamSubmissionDTO`, `ModelingExamSubmissionDTO`, `FileUploadExamSubmissionDTO`, `ProgrammingExamSubmissionDTO`, `QuizExamSubmissionDTO`) with the same Jackson type discriminators as the entity classes, each `@JsonIgnoreProperties(ignoreUnknown = true)`.
- New `StudentExamSubmitMapper.attachSubmissions(...)`: reconstructs the transient object graph `StudentExamService.submitStudentExam` needs, hanging transient participations/submissions off the DB-loaded exercises so the existing (byte-for-byte unchanged) save machinery keeps working.
- `StudentExamResource#submitStudentExam` now loads the authoritative `StudentExam` from the DB and checks ownership and the already-submitted short-circuit against that DB copy — not against client-supplied `user`/`submitted` fields, which no longer exist on the wire type. This closes a latent hole where the ownership check trusted a client-claimed user id; cross-user submits are still rejected with 403, now via DB truth.
- Quiz answers are re-resolved through the existing #12832 live-client quiz mapper (`QuizSubmissionService.buildSubmissionFromLiveClientDTO`) rather than trusted as-is from the client. This is a deliberate, stricter behavior change: an answer that no longer resolves against the current quiz exercise (e.g. references a deleted/changed option) is dropped instead of persisted, consistent with how the live-sync save path already behaves.
- Robustness hardening (this branch's second commit): per-exercise reconstruction failures are caught and degrade to an empty participation set for that exercise only — the hand-in still succeeds and the exam is still marked submitted (legacy semantics). Type-mismatch guards were added on every submission-type branch. List-ambiguity (an exercise with anything other than exactly one participation, or a participation with anything other than exactly one submission) is now skipped *before* collapsing into an entity `Set`, reproducing the server's pre-existing `size() != 1 → skip` outcome instead of silently losing the ambiguity in a `HashSet` collapse. Covered by dedicated poisoned-exercise tests at both the mapper level and the integration-test level (`testPoisonedExerciseIsDroppedWhileHandInSucceedsAndOtherExercisesSave`).
- Efficiency: the quiz exercise (with its question tree) is only reloaded when the submitted quiz submission actually carries answers, and is memoized per request so a quiz with multiple participations only pays the load once. Query-count guard tests were re-tightened accordingly — the unchanged-submission path is back to the pre-existing baseline of 6 queries (previously allowed extra headroom for an unconditional quiz reload).
- `ExamEntityUsageArchitectureTest.getExpectedEntityInputViolations()` tightened from 4 to 3.

**Client**
- New pure `submit-student-exam-dto.mapper.ts` (`toSubmitStudentExamDTO`), building the discriminated-union submit body from the existing client-side exam state. `exam-participation.service.ts` now posts this DTO instead of the full entity.
- The localStorage recovery/resume hand-in path goes through the same submission code path, so it picks up the new DTO body automatically — no separate handling needed.
- No Playwright helper changes: all E2E hand-in flows are UI-driven (click submit / navigate), not direct HTTP calls, so they were unaffected by the wire-format change.

### Steps for Testing
All testing must be done on a **Helios test server** (deploy this branch's PR from the [CI/CD page](https://helios.aet.cit.tum.de/repo/69562331/ci-cd)) through the UI only — no localhost, curl, or direct API calls. Check toasts/confirmation dialogs at every hand-in step, and clean up any exams/courses you create afterward.

Prerequisites:
- 1 Instructor
- 2 Students
- 1 real Exam with a Text, a Modeling, and a Quiz exercise (mixed question types), visible to both students
- 1 Test Exam with at least one exercise

1. **Real exam, full hand-in with verification**: As student1, log in, start the exam, answer the text exercise, the modeling exercise, and the quiz (mix of correct/incorrect answers), then hand in normally before the end. Confirm the hand-in success toast/confirmation. As the instructor (or student, once results are released), open the exam summary/assessment view and verify the text, modeling diagram, and quiz answers all appear exactly as submitted.
2. **Early hand-in**: As student2, start the same exam, answer only some exercises, and use "Submit early" well before the exam end time. Confirm the exam is marked submitted and no further edits are possible.
3. **Test exam submit**: As a student, start the Test Exam, answer at least one exercise, submit, and confirm the test-exam-specific submit/result flow completes normally.
4. **Instructor test-run**: As the instructor, start a test run for the real exam, answer the exercises, and submit it. Confirm the test run completes and appears correctly in the instructor's test-run overview.
5. **Reload-mid-exam (recovery path)**: As a student in a fresh exam attempt, answer a couple of exercises, then hard-reload the browser tab mid-exam. Confirm the local recovery/resume flow restores the answers, then hand in. Verify in the summary/assessment view afterward that the recovered answers (not stale/empty ones) were the ones actually persisted.
6. Throughout all of the above, watch for any unexpected error toasts, and confirm the "already submitted" case is handled gracefully (e.g., double-clicking submit, or resubmitting after already-submitted) without an error toast.

#### Exam Mode Testing
Covered by Steps for Testing above — this PR *is* an exam-mode change (the exam hand-in endpoint itself), so ordinary and exam-mode testing are the same steps here.

### Testserver States
pending (draft — do not deploy/assign a state yet; will request a Helios test-server slot once out of draft)

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| exam-participation.service.ts | 72.85% | 283 | 24 | 8.5 |
| submit-student-exam-dto.mapper.ts | 100.00% | 136 | 21 | 15.4 |

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| FileUploadExamSubmissionDTO.java | 100.00% | 7 |
| ModelingExamSubmissionDTO.java | 100.00% | 7 |
| ProgrammingExamSubmissionDTO.java | 100.00% | 7 |
| QuizExamSubmissionDTO.java | 100.00% | 9 |
| SubmitExamExerciseDTO.java | 100.00% | 8 |
| SubmitExamParticipationDTO.java | 100.00% | 8 |
| SubmitExamSubmissionDTO.java | 100.00% | 18 |
| SubmitStudentExamDTO.java | 100.00% | 8 |
| TextExamSubmissionDTO.java | 100.00% | 8 |
| StudentExamService.java | 90.35% | 622 |
| StudentExamSubmitMapper.java | 94.67% | 148 |
| StudentExamResource.java | 90.04% | 499 |

_Last updated: 2026-07-11 20:33:42 UTC_


### Screenshots
<!-- To be added once UI hand-in flows are exercised on Helios. -->
