### PR TITLE
`Development`: Sanitize inside SafeHtmlPipe to harden against XSS

### DIFF
--- a/src/main/webapp/app/foundation/pipes/safe-html.pipe.spec.ts
+++ b/src/main/webapp/app/foundation/pipes/safe-html.pipe.spec.ts
@@ -15,9 +15,7 @@ describe('SafeHtmlPipe', () => {
 
     // The pipe returns a trusted SafeHtml wrapper; read the underlying string that DOMPurify produced.
     function unwrap(safeHtml: SafeHtml): string {
-        return (safeHtml && typeof safeHtml === 'object' && 'changingThisBreaksApplicationSecurity' in safeHtml
-            ? (safeHtml as { changingThisBreaksApplicationSecurity: string }).changingThisBreaksApplicationSecurity
-            : '') as string;
+        return (safeHtml as { changingThisBreaksApplicationSecurity?: string })?.changingThisBreaksApplicationSecurity ?? '';
     }
 
     it('strips script tags and event-handler attributes (XSS payload)', () => {

--- a/src/main/webapp/app/foundation/pipes/safe-html.pipe.spec.ts
+++ b/src/main/webapp/app/foundation/pipes/safe-html.pipe.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import { SafeHtml } from '@angular/platform-browser';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SafeHtmlPipe } from 'app/foundation/pipes/safe-html.pipe';
+
+describe('SafeHtmlPipe', () => {
+    let pipe: SafeHtmlPipe;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({});
+        pipe = TestBed.runInInjectionContext(() => new SafeHtmlPipe());
+    });
+
+    // The pipe returns a trusted SafeHtml wrapper; read the underlying string that DOMPurify produced.
+    function unwrap(safeHtml: SafeHtml): string {
+        return (safeHtml && typeof safeHtml === 'object' && 'changingThisBreaksApplicationSecurity' in safeHtml
+            ? (safeHtml as { changingThisBreaksApplicationSecurity: string }).changingThisBreaksApplicationSecurity
+            : '') as string;
+    }
+
+    it('strips script tags and event-handler attributes (XSS payload)', () => {
+        const result = unwrap(pipe.transform('<img src="x" onerror="alert(1)">before<script>alert(2)</script>after'));
+        expect(result).not.toContain('onerror');
+        expect(result).not.toContain('<script');
+        expect(result).not.toContain('alert(2)');
+        // benign surrounding text is preserved
+        expect(result).toContain('before');
+        expect(result).toContain('after');
+    });
+
+    it('strips javascript: URLs from links', () => {
+        const result = unwrap(pipe.transform('<a href="javascript:alert(1)">click</a>'));
+        expect(result).not.toContain('javascript:');
+        expect(result).toContain('click');
+    });
+
+    it('preserves benign inline markup and entities that callers rely on', () => {
+        const result = unwrap(pipe.transform('<strong>bold</strong> <sub>x</sub> [95 - &infin;)'));
+        expect(result).toContain('<strong>bold</strong>');
+        expect(result).toContain('<sub>x</sub>');
+        // the infinity entity survives (kept as entity or decoded to the glyph)
+        expect(result).toMatch(/&infin;|∞/);
+    });
+
+    it('returns an empty result for null/undefined input', () => {
+        expect(unwrap(pipe.transform(undefined))).toBe('');
+        expect(unwrap(pipe.transform(null))).toBe('');
+    });
+});

--- a/src/main/webapp/app/foundation/pipes/safe-html.pipe.spec.ts
+++ b/src/main/webapp/app/foundation/pipes/safe-html.pipe.spec.ts
@@ -1,13 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 import { SafeHtml } from '@angular/platform-browser';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { SafeHtmlPipe } from 'app/foundation/pipes/safe-html.pipe';
 
 describe('SafeHtmlPipe', () => {
+    setupTestBed({ zoneless: true });
+
     let pipe: SafeHtmlPipe;
 
     beforeEach(() => {
-        TestBed.configureTestingModule({});
         pipe = TestBed.runInInjectionContext(() => new SafeHtmlPipe());
     });
 

--- a/src/main/webapp/app/foundation/pipes/safe-html.pipe.ts
+++ b/src/main/webapp/app/foundation/pipes/safe-html.pipe.ts
@@ -13,7 +13,7 @@ export class SafeHtmlPipe implements PipeTransform {
      * markup and entities (e.g. <sub>, <sup>, <strong>, &infin;) that existing callers rely on.
      * @param value The HTML to sanitize and render.
      */
-    transform(value: string): SafeHtml {
+    transform(value: string | null | undefined): SafeHtml {
         return this.sanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(value ?? ''));
     }
 }

--- a/src/main/webapp/app/foundation/pipes/safe-html.pipe.ts
+++ b/src/main/webapp/app/foundation/pipes/safe-html.pipe.ts
@@ -1,15 +1,19 @@
 import { Pipe, PipeTransform, inject } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import DOMPurify from 'dompurify';
 
 @Pipe({ name: 'safeHtml' })
 export class SafeHtmlPipe implements PipeTransform {
     private sanitizer = inject(DomSanitizer);
 
     /**
-     * Bypasses the security checks for a specified HTML.
-     * @param value The HTML that is considered safe.
+     * Sanitizes the given HTML with DOMPurify and marks the result as trusted so Angular renders it via
+     * [innerHTML]. Sanitizing inside the pipe makes it safe regardless of the caller: a caller that passes
+     * user-controlled HTML can no longer introduce XSS through this pipe. DOMPurify keeps benign inline
+     * markup and entities (e.g. <sub>, <sup>, <strong>, &infin;) that existing callers rely on.
+     * @param value The HTML to sanitize and render.
      */
-    transform(value: string) {
-        return this.sanitizer.bypassSecurityTrustHtml(value);
+    transform(value: string): SafeHtml {
+        return this.sanitizer.bypassSecurityTrustHtml(DOMPurify.sanitize(value ?? ''));
     }
 }


### PR DESCRIPTION
### Summary
Makes `SafeHtmlPipe` sanitize its input with DOMPurify before marking it trusted, so the pipe is safe by construction regardless of caller. Single-file client change.

### Checklist
#### General
- [x] I chose a title conforming to the naming conventions for pull requests.
- [x] Small, self-contained change; behavior for existing callers is unchanged (DOMPurify preserves the benign markup they use).
#### Client
- [x] I **strictly** followed the client coding guidelines.
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
`SafeHtmlPipe.transform` previously called `bypassSecurityTrustHtml(value)` with **no** sanitization. It was safe only because every current caller pre-sanitizes (via `htmlForMarkdown`/DOMPurify, or by HTML-escaping). That is a latent footgun: a future caller could pipe user-controlled HTML through `| safeHtml` and silently reintroduce stored XSS, with no compile-time or review signal. This surfaced while triaging Codacy `angular-bypasssecuritytrust` findings.

### Description
`transform` now returns `bypassSecurityTrustHtml(DOMPurify.sanitize(value ?? ""))`. DOMPurify keeps the benign inline markup and entities existing callers rely on (`<sub>`, `<sup>`, `<strong>`, `&infin;`), so rendered output is unchanged; double-sanitizing an already-clean caller is harmless. The 12 current usages were audited and all feed either non-user data (numbers, app i18n strings) or already-sanitized HTML, so none change behavior.

### Steps for Testing
1. Open a grading/bonus page and a grading key table — grade-bound intervals (e.g. `[95 - ∞)`) still render correctly (the `∞` entity is preserved).
2. Open a programming exercise problem statement — task names still render.
3. Verify no visual regression in any `| safeHtml` usage.

### Testserver States
Not applicable — no server change.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| safe-html.pipe.ts | 100.00% | 10 | 12 | 120.0 |

_Last updated: 2026-07-12 19:44:59 UTC_


### Screenshots
Not applicable — no visual change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML rendering safety by sanitizing content before displaying it.
  * Reduced the risk of cross-site scripting (XSS) from rendered HTML.
  * Added safer handling for null or missing HTML values (now consistently returns safe output).
* **Tests**
  * Added coverage to verify sanitization and safe rendering behaviors (including script removal and unsafe attribute/URL stripping).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->