### PR TITLE
`Development`: Fix a race condition when concurrently creating competency progress

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/atlas/repository/CompetencyProgressRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/repository/CompetencyProgressRepository.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.atlas.config.AtlasEnabled;
+import de.tum.cit.aet.artemis.atlas.domain.CompetencyProgressConfidenceReason;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyProgress;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CourseCompetency;
 import de.tum.cit.aet.artemis.atlas.dto.export.CompetencyProgressExportDTO;
@@ -43,6 +44,32 @@ public interface CompetencyProgressRepository extends ArtemisJpaRepository<Compe
                 AND cp.user.id = :userId
             """)
     Optional<CompetencyProgress> findByCompetencyIdAndUserId(@Param("competencyId") long competencyId, @Param("userId") long userId);
+
+    /**
+     * Idempotently re-applies a freshly computed progress/confidence onto an existing competency-progress row.
+     * <p>
+     * Used on the rare concurrency-conflict reconciliation path in
+     * {@link de.tum.cit.aet.artemis.atlas.service.competency.CompetencyProgressService#updateCompetencyProgress}:
+     * a single targeted UPDATE that touches the existing (competency, user) row, or affects zero rows if it was
+     * concurrently deleted. Unlike a merge/save on a detached entity, it can therefore never resurrect a deleted row.
+     *
+     * @param competencyId     the id of the competency
+     * @param userId           the id of the user
+     * @param progress         the recomputed progress value
+     * @param confidence       the recomputed confidence score
+     * @param confidenceReason the recomputed confidence reason
+     * @return the number of rows updated (0 if the row no longer exists)
+     */
+    @Transactional // ok: a single targeted, idempotent UPDATE on the concurrency-conflict reconciliation path
+    @Modifying
+    @Query("""
+            UPDATE CompetencyProgress cp
+            SET cp.progress = :progress, cp.confidence = :confidence, cp.confidenceReason = :confidenceReason
+            WHERE cp.competency.id = :competencyId
+                AND cp.user.id = :userId
+            """)
+    int updateProgressAndConfidence(@Param("competencyId") long competencyId, @Param("userId") long userId, @Param("progress") Double progress,
+            @Param("confidence") Double confidence, @Param("confidenceReason") CompetencyProgressConfidenceReason confidenceReason);
 
     @Query("""
             SELECT cp

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/repository/CompetencyProgressRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/repository/CompetencyProgressRepository.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.artemis.atlas.repository;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -58,18 +59,22 @@ public interface CompetencyProgressRepository extends ArtemisJpaRepository<Compe
      * @param progress         the recomputed progress value
      * @param confidence       the recomputed confidence score
      * @param confidenceReason the recomputed confidence reason
+     * @param lastModifiedDate the modification timestamp to record (the bulk UPDATE bypasses {@code @LastModifiedDate}
+     *                             auditing, so it is passed explicitly; an {@link Instant} parameter avoids the
+     *                             {@code CURRENT_TIMESTAMP}-to-{@code Instant} type mismatch and stays DB-portable)
      * @return the number of rows updated (0 if the row no longer exists)
      */
     @Transactional // ok: a single targeted, idempotent UPDATE on the concurrency-conflict reconciliation path
     @Modifying
     @Query("""
             UPDATE CompetencyProgress cp
-            SET cp.progress = :progress, cp.confidence = :confidence, cp.confidenceReason = :confidenceReason, cp.lastModifiedDate = CURRENT_TIMESTAMP
+            SET cp.progress = :progress, cp.confidence = :confidence, cp.confidenceReason = :confidenceReason, cp.lastModifiedDate = :lastModifiedDate
             WHERE cp.competency.id = :competencyId
                 AND cp.user.id = :userId
             """)
     int updateProgressAndConfidence(@Param("competencyId") long competencyId, @Param("userId") long userId, @Param("progress") Double progress,
-            @Param("confidence") Double confidence, @Param("confidenceReason") CompetencyProgressConfidenceReason confidenceReason);
+            @Param("confidence") Double confidence, @Param("confidenceReason") CompetencyProgressConfidenceReason confidenceReason,
+            @Param("lastModifiedDate") Instant lastModifiedDate);
 
     @Query("""
             SELECT cp

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/repository/CompetencyProgressRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/repository/CompetencyProgressRepository.java
@@ -64,7 +64,7 @@ public interface CompetencyProgressRepository extends ArtemisJpaRepository<Compe
     @Modifying
     @Query("""
             UPDATE CompetencyProgress cp
-            SET cp.progress = :progress, cp.confidence = :confidence, cp.confidenceReason = :confidenceReason
+            SET cp.progress = :progress, cp.confidence = :confidence, cp.confidenceReason = :confidenceReason, cp.lastModifiedDate = CURRENT_TIMESTAMP
             WHERE cp.competency.id = :competencyId
                 AND cp.user.id = :userId
             """)

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressService.java
@@ -285,7 +285,7 @@ public class CompetencyProgressService {
             calculateProgress(latestExerciseInfos, latestLectureUnitInfos, studentProgress);
             calculateConfidence(latestExerciseInfos, latestLectureUnitInfos, studentProgress);
             int updatedRows = competencyProgressRepository.updateProgressAndConfidence(competencyId, user.getId(), studentProgress.getProgress(), studentProgress.getConfidence(),
-                    studentProgress.getConfidenceReason());
+                    studentProgress.getConfidenceReason(), Instant.now());
             if (updatedRows == 0) {
                 // The concurrently created row was deleted again (competency/user cleanup) before we could
                 // reconcile. Nothing to persist; return the in-memory values without learning-path propagation.

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressService.java
@@ -265,8 +265,30 @@ public class CompetencyProgressService {
             competencyProgressRepository.save(studentProgress);
         }
         catch (DataIntegrityViolationException e) {
-            // In rare instances of initially creating a progress entity, async updates might run in parallel.
-            // This fails the SQL unique constraint and throws an exception. We can safely ignore it.
+            // Root cause: updateCompetencyProgress does a non-atomic find-then-insert. Multiple @Async progress
+            // updates for the SAME (competency, user) can run in parallel (e.g. two quick lecture-unit
+            // completions, or a completion racing an exercise submission). Each finds no existing row, so each
+            // inserts one, and the second insert violates the competency_user primary key.
+            //
+            // Previously this exception was swallowed, which silently DROPPED this thread's freshly computed
+            // progress/confidence. Instead, re-fetch the row the winning thread just created and re-apply this
+            // thread's values as an UPDATE. The UPDATE cannot hit the unique constraint, and the entity has no
+            // @Version, so this converges deterministically without a further conflict. (updateCompetencyProgress
+            // is not @Transactional, so the failed insert's transaction is already rolled back and the re-fetch +
+            // update below run in their own clean transactions.) DB-portable: relies only on the unique
+            // constraint + the standard DataIntegrityViolationException, not on a vendor-specific upsert.
+            CompetencyProgress reconciled = competencyProgressRepository.findByCompetencyIdAndUserId(competencyId, user.getId()).orElse(null);
+            if (reconciled == null) {
+                // The concurrently created row was deleted again (competency/user cleanup) before we could
+                // reconcile. Nothing to persist; return the in-memory values without learning-path propagation.
+                log.debug("Competency progress row vanished during concurrent creation, skipping persistence.");
+                return studentProgress;
+            }
+            reconciled.setProgress(studentProgress.getProgress());
+            reconciled.setConfidence(studentProgress.getConfidence());
+            reconciled.setConfidenceReason(studentProgress.getConfidenceReason());
+            competencyProgressRepository.save(reconciled);
+            studentProgress = reconciled;
         }
         catch (org.hibernate.ObjectNotFoundException e) {
             // The competency was deleted between the findById above and the flush triggered by save (or

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressService.java
@@ -271,24 +271,20 @@ public class CompetencyProgressService {
             // inserts one, and the second insert violates the competency_user primary key.
             //
             // Previously this exception was swallowed, which silently DROPPED this thread's freshly computed
-            // progress/confidence. Instead, re-fetch the row the winning thread just created and re-apply this
-            // thread's values as an UPDATE. The UPDATE cannot hit the unique constraint, and the entity has no
-            // @Version, so this converges deterministically without a further conflict. (updateCompetencyProgress
-            // is not @Transactional, so the failed insert's transaction is already rolled back and the re-fetch +
-            // update below run in their own clean transactions.) DB-portable: relies only on the unique
-            // constraint + the standard DataIntegrityViolationException, not on a vendor-specific upsert.
-            CompetencyProgress reconciled = competencyProgressRepository.findByCompetencyIdAndUserId(competencyId, user.getId()).orElse(null);
-            if (reconciled == null) {
+            // progress/confidence. Instead, re-apply this thread's values to the row the winning thread created
+            // via a single targeted, idempotent UPDATE. Unlike a merge/save on a detached entity (which would
+            // re-insert the row if it had been concurrently deleted between a re-fetch and the flush), this
+            // updates the existing row or affects zero rows if it is already gone — so it can never resurrect a
+            // deleted row. DB-portable: relies only on the unique constraint + the standard
+            // DataIntegrityViolationException, not on a vendor-specific upsert.
+            int updatedRows = competencyProgressRepository.updateProgressAndConfidence(competencyId, user.getId(), studentProgress.getProgress(), studentProgress.getConfidence(),
+                    studentProgress.getConfidenceReason());
+            if (updatedRows == 0) {
                 // The concurrently created row was deleted again (competency/user cleanup) before we could
                 // reconcile. Nothing to persist; return the in-memory values without learning-path propagation.
                 log.debug("Competency progress row vanished during concurrent creation, skipping persistence.");
                 return studentProgress;
             }
-            reconciled.setProgress(studentProgress.getProgress());
-            reconciled.setConfidence(studentProgress.getConfidence());
-            reconciled.setConfidenceReason(studentProgress.getConfidenceReason());
-            competencyProgressRepository.save(reconciled);
-            studentProgress = reconciled;
         }
         catch (org.hibernate.ObjectNotFoundException e) {
             // The competency was deleted between the findById above and the flush triggered by save (or

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressService.java
@@ -271,12 +271,19 @@ public class CompetencyProgressService {
             // inserts one, and the second insert violates the competency_user primary key.
             //
             // Previously this exception was swallowed, which silently DROPPED this thread's freshly computed
-            // progress/confidence. Instead, re-apply this thread's values to the row the winning thread created
-            // via a single targeted, idempotent UPDATE. Unlike a merge/save on a detached entity (which would
-            // re-insert the row if it had been concurrently deleted between a re-fetch and the flush), this
-            // updates the existing row or affects zero rows if it is already gone — so it can never resurrect a
-            // deleted row. DB-portable: relies only on the unique constraint + the standard
-            // DataIntegrityViolationException, not on a vendor-specific upsert.
+            // progress/confidence. Instead, reconcile the row the winning thread created via a single targeted,
+            // idempotent UPDATE. Two properties matter:
+            // - RECOMPUTE first from the current DB state: the concurrent winner may have based its insert on
+            // newer data than this thread saw before the race, so re-applying our pre-race values could
+            // overwrite the row with a staler result.
+            // - The UPDATE touches the existing row, or affects zero rows if it is already gone — so, unlike a
+            // merge/save on a detached entity, it can never resurrect a concurrently deleted row.
+            // DB-portable: relies only on the unique constraint + the standard DataIntegrityViolationException,
+            // not on a vendor-specific upsert.
+            Set<CompetencyExerciseMasteryCalculationDTO> latestExerciseInfos = courseCompetencyRepository.findAllExerciseInfoByCompetencyIdAndUser(competencyId, user);
+            Set<CompetencyLectureUnitMasteryCalculationDTO> latestLectureUnitInfos = courseCompetencyRepository.findAllLectureUnitInfoByCompetencyIdAndUser(competencyId, user);
+            calculateProgress(latestExerciseInfos, latestLectureUnitInfos, studentProgress);
+            calculateConfidence(latestExerciseInfos, latestLectureUnitInfos, studentProgress);
             int updatedRows = competencyProgressRepository.updateProgressAndConfidence(competencyId, user.getId(), studentProgress.getProgress(), studentProgress.getConfidence(),
                     studentProgress.getConfidenceReason());
             if (updatedRows == 0) {

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressServiceTest.java
@@ -102,7 +102,7 @@ class CompetencyProgressServiceTest {
     @Test
     void shouldReconcileConcurrentProgressCreationWithoutDroppingTheUpdate() {
         // The reconcile UPDATE finds the row the winning thread created and updates it.
-        when(competencyProgressRepository.updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), any(), any(), any())).thenReturn(1);
+        when(competencyProgressRepository.updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), any(), any(), any(), any())).thenReturn(1);
 
         assertThatCode(() -> competencyProgressService.updateCompetencyProgress(COMPETENCY_ID, user)).doesNotThrowAnyException();
 
@@ -113,7 +113,7 @@ class CompetencyProgressServiceTest {
 
         ArgumentCaptor<Double> progressCaptor = ArgumentCaptor.forClass(Double.class);
         ArgumentCaptor<Double> confidenceCaptor = ArgumentCaptor.forClass(Double.class);
-        verify(competencyProgressRepository).updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), progressCaptor.capture(), confidenceCaptor.capture(), any());
+        verify(competencyProgressRepository).updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), progressCaptor.capture(), confidenceCaptor.capture(), any(), any());
         assertThat(progressCaptor.getValue()).isEqualTo(ownAttempt.getProgress());
         assertThat(confidenceCaptor.getValue()).isEqualTo(ownAttempt.getConfidence());
 
@@ -129,13 +129,13 @@ class CompetencyProgressServiceTest {
     @Test
     void shouldSkipPersistenceWhenTheRowVanishedDuringReconciliation() {
         // The row the winner created was deleted again before the reconcile UPDATE -> zero rows affected.
-        when(competencyProgressRepository.updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), any(), any(), any())).thenReturn(0);
+        when(competencyProgressRepository.updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), any(), any(), any(), any())).thenReturn(0);
 
         assertThatCode(() -> competencyProgressService.updateCompetencyProgress(COMPETENCY_ID, user)).doesNotThrowAnyException();
 
         // No resurrection (a targeted UPDATE, not a merge/insert), and no learning-path propagation for a row that
         // no longer exists.
-        verify(competencyProgressRepository).updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), any(), any(), any());
+        verify(competencyProgressRepository).updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), any(), any(), any(), any());
         verify(learningPathService, never()).updateLearningPathProgress(anyLong(), anyLong());
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressServiceTest.java
@@ -25,9 +25,9 @@ import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.assessment.service.ParticipantScoreService;
 import de.tum.cit.aet.artemis.atlas.domain.competency.Competency;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyProgress;
-import de.tum.cit.aet.artemis.atlas.repository.CompetencyProgressRepository;
 import de.tum.cit.aet.artemis.atlas.repository.CourseCompetencyRepository;
 import de.tum.cit.aet.artemis.atlas.service.learningpath.LearningPathService;
+import de.tum.cit.aet.artemis.atlas.test_repository.CompetencyProgressTestRepository;
 import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.lecture.api.LectureUnitRepositoryApi;
 
@@ -40,7 +40,7 @@ import de.tum.cit.aet.artemis.lecture.api.LectureUnitRepositoryApi;
  * violates the {@code competency_user} primary key.
  * <p>
  * On that conflict the losing thread reconciles via a single idempotent UPDATE
- * ({@link CompetencyProgressRepository#updateProgressAndConfidence}) rather than swallowing the exception. These
+ * ({@link CompetencyProgressTestRepository#updateProgressAndConfidence}) rather than swallowing the exception. These
  * tests verify it does not propagate the exception, re-applies (does not drop) the freshly computed progress, and
  * — crucially — does not resurrect a row that was concurrently deleted (zero rows updated → skip, no learning-path
  * propagation).
@@ -55,7 +55,7 @@ class CompetencyProgressServiceTest {
     private static final long COURSE_ID = 7L;
 
     @Mock
-    private CompetencyProgressRepository competencyProgressRepository;
+    private CompetencyProgressTestRepository competencyProgressRepository;
 
     @Mock
     private LearningPathService learningPathService;

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -115,6 +116,11 @@ class CompetencyProgressServiceTest {
         verify(competencyProgressRepository).updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), progressCaptor.capture(), confidenceCaptor.capture(), any());
         assertThat(progressCaptor.getValue()).isEqualTo(ownAttempt.getProgress());
         assertThat(confidenceCaptor.getValue()).isEqualTo(ownAttempt.getConfidence());
+
+        // The conflict path recomputes from the DB before writing (once for the initial attempt, once for the
+        // reconcile), so it does not re-apply this thread's potentially-stale pre-race values.
+        verify(courseCompetencyRepository, times(2)).findAllExerciseInfoByCompetencyIdAndUser(anyLong(), any(User.class));
+        verify(courseCompetencyRepository, times(2)).findAllLectureUnitInfoByCompetencyIdAndUser(anyLong(), any(User.class));
 
         // Learning-path propagation still runs after a reconciled progress update.
         verify(learningPathService).updateLearningPathProgress(COURSE_ID, USER_ID);

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressServiceTest.java
@@ -131,8 +131,11 @@ class CompetencyProgressServiceTest {
         // The row the winner created was deleted again before the reconcile UPDATE -> zero rows affected.
         when(competencyProgressRepository.updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), any(), any(), any(), any())).thenReturn(0);
 
-        assertThatCode(() -> competencyProgressService.updateCompetencyProgress(COMPETENCY_ID, user)).doesNotThrowAnyException();
+        CompetencyProgress result = competencyProgressService.updateCompetencyProgress(COMPETENCY_ID, user);
 
+        // The cleanup-race path returns the in-memory computed progress (never null), so synchronous callers that
+        // read getProgress()/getConfidence() do not NPE.
+        assertThat(result).isNotNull();
         // No resurrection (a targeted UPDATE, not a merge/insert), and no learning-path propagation for a row that
         // no longer exists.
         verify(competencyProgressRepository).updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), any(), any(), any(), any());

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressServiceTest.java
@@ -1,0 +1,129 @@
+package de.tum.cit.aet.artemis.atlas.service.competency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import de.tum.cit.aet.artemis.account.domain.User;
+import de.tum.cit.aet.artemis.assessment.service.ParticipantScoreService;
+import de.tum.cit.aet.artemis.atlas.domain.competency.Competency;
+import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyProgress;
+import de.tum.cit.aet.artemis.atlas.repository.CompetencyProgressRepository;
+import de.tum.cit.aet.artemis.atlas.repository.CourseCompetencyRepository;
+import de.tum.cit.aet.artemis.atlas.service.learningpath.LearningPathService;
+import de.tum.cit.aet.artemis.course.domain.Course;
+import de.tum.cit.aet.artemis.lecture.api.LectureUnitRepositoryApi;
+
+/**
+ * Unit tests for the concurrency handling in {@link CompetencyProgressService#updateCompetencyProgress}.
+ * <p>
+ * {@code updateCompetencyProgress} does a non-atomic find-then-insert. Several {@code @Async} progress
+ * updates for the SAME (competency, user) can run in parallel (e.g. two quick lecture-unit completions, or a
+ * completion racing an exercise submission). Each finds no existing progress row, so each inserts one and the
+ * second insert violates the {@code competency_user} primary key.
+ * <p>
+ * This verifies the losing thread reconciles the conflict — re-fetch the row the winner created and re-apply
+ * its freshly computed progress as an UPDATE — instead of propagating the exception or silently dropping the
+ * update (the previous behaviour). The recovery is DB-portable: it relies only on the unique constraint and
+ * the standard {@link DataIntegrityViolationException}, not a vendor-specific upsert.
+ */
+@ExtendWith(MockitoExtension.class)
+class CompetencyProgressServiceTest {
+
+    private static final long COMPETENCY_ID = 42L;
+
+    private static final long USER_ID = 101L;
+
+    private static final long COURSE_ID = 7L;
+
+    private static final double SENTINEL = -1.0;
+
+    @Mock
+    private CompetencyProgressRepository competencyProgressRepository;
+
+    @Mock
+    private LearningPathService learningPathService;
+
+    @Mock
+    private ParticipantScoreService participantScoreService;
+
+    @Mock
+    private CourseCompetencyRepository courseCompetencyRepository;
+
+    private CompetencyProgressService competencyProgressService;
+
+    private Competency competency;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        competencyProgressService = new CompetencyProgressService(competencyProgressRepository, learningPathService, participantScoreService,
+                Optional.<LectureUnitRepositoryApi>empty(), courseCompetencyRepository);
+
+        Course course = new Course();
+        course.setId(COURSE_ID);
+        competency = new Competency();
+        competency.setId(COMPETENCY_ID);
+        competency.setCourse(course);
+
+        user = new User();
+        user.setId(USER_ID);
+        user.setLogin("student1");
+    }
+
+    @Test
+    void shouldReconcileConcurrentProgressCreationWithoutDroppingTheUpdate() {
+        when(courseCompetencyRepository.findById(COMPETENCY_ID)).thenReturn(Optional.of(competency));
+        when(courseCompetencyRepository.findAllExerciseInfoByCompetencyIdAndUser(anyLong(), any(User.class))).thenReturn(Collections.emptySet());
+        when(courseCompetencyRepository.findAllLectureUnitInfoByCompetencyIdAndUser(anyLong(), any(User.class))).thenReturn(Collections.emptySet());
+
+        // The row created by the winning concurrent thread; the sentinel values must be overwritten by the reconcile.
+        CompetencyProgress winnerRow = new CompetencyProgress();
+        winnerRow.setCompetency(competency);
+        winnerRow.setUser(user);
+        winnerRow.setProgress(SENTINEL);
+        winnerRow.setConfidence(SENTINEL);
+
+        // Initial lookup finds nothing (both threads race here); the reconcile re-fetch finds the winner's row.
+        when(competencyProgressRepository.findByCompetencyIdAndUserId(COMPETENCY_ID, USER_ID)).thenReturn(Optional.empty(), Optional.of(winnerRow));
+
+        // Our own INSERT loses the race -> unique-constraint violation; the reconcile UPDATE then succeeds.
+        doThrow(new DataIntegrityViolationException("duplicate key value violates unique constraint \"competency_user_pkey\"")).doReturn(winnerRow)
+                .when(competencyProgressRepository).save(any(CompetencyProgress.class));
+
+        assertThatCode(() -> competencyProgressService.updateCompetencyProgress(COMPETENCY_ID, user)).doesNotThrowAnyException();
+
+        ArgumentCaptor<CompetencyProgress> saveCaptor = ArgumentCaptor.forClass(CompetencyProgress.class);
+        verify(competencyProgressRepository, times(2)).save(saveCaptor.capture());
+        List<CompetencyProgress> savedRows = saveCaptor.getAllValues();
+        CompetencyProgress ownAttempt = savedRows.get(0); // the losing INSERT, carrying the freshly computed values
+        CompetencyProgress reconciled = savedRows.get(1); // the winner's row, re-saved with our values
+
+        // Non-lossy: the reconcile re-applied our computed progress/confidence onto the winner's row (not dropped).
+        assertThat(reconciled).isSameAs(winnerRow);
+        assertThat(reconciled.getProgress()).isEqualTo(ownAttempt.getProgress());
+        assertThat(reconciled.getConfidence()).isEqualTo(ownAttempt.getConfidence());
+        assertThat(reconciled.getProgress()).isNotEqualTo(SENTINEL);
+
+        // Learning-path propagation still runs after a reconciled progress update.
+        verify(learningPathService).updateLearningPathProgress(COURSE_ID, USER_ID);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/competency/CompetencyProgressServiceTest.java
@@ -4,13 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,15 +34,16 @@ import de.tum.cit.aet.artemis.lecture.api.LectureUnitRepositoryApi;
 /**
  * Unit tests for the concurrency handling in {@link CompetencyProgressService#updateCompetencyProgress}.
  * <p>
- * {@code updateCompetencyProgress} does a non-atomic find-then-insert. Several {@code @Async} progress
- * updates for the SAME (competency, user) can run in parallel (e.g. two quick lecture-unit completions, or a
- * completion racing an exercise submission). Each finds no existing progress row, so each inserts one and the
- * second insert violates the {@code competency_user} primary key.
+ * {@code updateCompetencyProgress} does a non-atomic find-then-insert. Several {@code @Async} progress updates
+ * for the SAME (competency, user) can run in parallel (e.g. two quick lecture-unit completions, or a completion
+ * racing an exercise submission). Each finds no existing progress row, so each inserts one and the second insert
+ * violates the {@code competency_user} primary key.
  * <p>
- * This verifies the losing thread reconciles the conflict — re-fetch the row the winner created and re-apply
- * its freshly computed progress as an UPDATE — instead of propagating the exception or silently dropping the
- * update (the previous behaviour). The recovery is DB-portable: it relies only on the unique constraint and
- * the standard {@link DataIntegrityViolationException}, not a vendor-specific upsert.
+ * On that conflict the losing thread reconciles via a single idempotent UPDATE
+ * ({@link CompetencyProgressRepository#updateProgressAndConfidence}) rather than swallowing the exception. These
+ * tests verify it does not propagate the exception, re-applies (does not drop) the freshly computed progress, and
+ * — crucially — does not resurrect a row that was concurrently deleted (zero rows updated → skip, no learning-path
+ * propagation).
  */
 @ExtendWith(MockitoExtension.class)
 class CompetencyProgressServiceTest {
@@ -52,8 +53,6 @@ class CompetencyProgressServiceTest {
     private static final long USER_ID = 101L;
 
     private static final long COURSE_ID = 7L;
-
-    private static final double SENTINEL = -1.0;
 
     @Mock
     private CompetencyProgressRepository competencyProgressRepository;
@@ -87,43 +86,50 @@ class CompetencyProgressServiceTest {
         user = new User();
         user.setId(USER_ID);
         user.setLogin("student1");
+
+        // Arrange the create path: the competency exists, there is no activity yet, and no existing progress row
+        // (both racing threads reach this state), so updateCompetencyProgress attempts an INSERT.
+        when(courseCompetencyRepository.findById(COMPETENCY_ID)).thenReturn(Optional.of(competency));
+        when(courseCompetencyRepository.findAllExerciseInfoByCompetencyIdAndUser(anyLong(), any(User.class))).thenReturn(Collections.emptySet());
+        when(courseCompetencyRepository.findAllLectureUnitInfoByCompetencyIdAndUser(anyLong(), any(User.class))).thenReturn(Collections.emptySet());
+        when(competencyProgressRepository.findByCompetencyIdAndUserId(COMPETENCY_ID, USER_ID)).thenReturn(Optional.empty());
+        // Our own INSERT loses the race with a concurrent creator -> unique-constraint violation.
+        doThrow(new DataIntegrityViolationException("duplicate key value violates unique constraint \"competency_user_pkey\"")).when(competencyProgressRepository)
+                .save(any(CompetencyProgress.class));
     }
 
     @Test
     void shouldReconcileConcurrentProgressCreationWithoutDroppingTheUpdate() {
-        when(courseCompetencyRepository.findById(COMPETENCY_ID)).thenReturn(Optional.of(competency));
-        when(courseCompetencyRepository.findAllExerciseInfoByCompetencyIdAndUser(anyLong(), any(User.class))).thenReturn(Collections.emptySet());
-        when(courseCompetencyRepository.findAllLectureUnitInfoByCompetencyIdAndUser(anyLong(), any(User.class))).thenReturn(Collections.emptySet());
-
-        // The row created by the winning concurrent thread; the sentinel values must be overwritten by the reconcile.
-        CompetencyProgress winnerRow = new CompetencyProgress();
-        winnerRow.setCompetency(competency);
-        winnerRow.setUser(user);
-        winnerRow.setProgress(SENTINEL);
-        winnerRow.setConfidence(SENTINEL);
-
-        // Initial lookup finds nothing (both threads race here); the reconcile re-fetch finds the winner's row.
-        when(competencyProgressRepository.findByCompetencyIdAndUserId(COMPETENCY_ID, USER_ID)).thenReturn(Optional.empty(), Optional.of(winnerRow));
-
-        // Our own INSERT loses the race -> unique-constraint violation; the reconcile UPDATE then succeeds.
-        doThrow(new DataIntegrityViolationException("duplicate key value violates unique constraint \"competency_user_pkey\"")).doReturn(winnerRow)
-                .when(competencyProgressRepository).save(any(CompetencyProgress.class));
+        // The reconcile UPDATE finds the row the winning thread created and updates it.
+        when(competencyProgressRepository.updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), any(), any(), any())).thenReturn(1);
 
         assertThatCode(() -> competencyProgressService.updateCompetencyProgress(COMPETENCY_ID, user)).doesNotThrowAnyException();
 
+        // Non-lossy: the values from the failed INSERT attempt are re-applied via the reconcile UPDATE.
         ArgumentCaptor<CompetencyProgress> saveCaptor = ArgumentCaptor.forClass(CompetencyProgress.class);
-        verify(competencyProgressRepository, times(2)).save(saveCaptor.capture());
-        List<CompetencyProgress> savedRows = saveCaptor.getAllValues();
-        CompetencyProgress ownAttempt = savedRows.get(0); // the losing INSERT, carrying the freshly computed values
-        CompetencyProgress reconciled = savedRows.get(1); // the winner's row, re-saved with our values
+        verify(competencyProgressRepository).save(saveCaptor.capture());
+        CompetencyProgress ownAttempt = saveCaptor.getValue();
 
-        // Non-lossy: the reconcile re-applied our computed progress/confidence onto the winner's row (not dropped).
-        assertThat(reconciled).isSameAs(winnerRow);
-        assertThat(reconciled.getProgress()).isEqualTo(ownAttempt.getProgress());
-        assertThat(reconciled.getConfidence()).isEqualTo(ownAttempt.getConfidence());
-        assertThat(reconciled.getProgress()).isNotEqualTo(SENTINEL);
+        ArgumentCaptor<Double> progressCaptor = ArgumentCaptor.forClass(Double.class);
+        ArgumentCaptor<Double> confidenceCaptor = ArgumentCaptor.forClass(Double.class);
+        verify(competencyProgressRepository).updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), progressCaptor.capture(), confidenceCaptor.capture(), any());
+        assertThat(progressCaptor.getValue()).isEqualTo(ownAttempt.getProgress());
+        assertThat(confidenceCaptor.getValue()).isEqualTo(ownAttempt.getConfidence());
 
         // Learning-path propagation still runs after a reconciled progress update.
         verify(learningPathService).updateLearningPathProgress(COURSE_ID, USER_ID);
+    }
+
+    @Test
+    void shouldSkipPersistenceWhenTheRowVanishedDuringReconciliation() {
+        // The row the winner created was deleted again before the reconcile UPDATE -> zero rows affected.
+        when(competencyProgressRepository.updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), any(), any(), any())).thenReturn(0);
+
+        assertThatCode(() -> competencyProgressService.updateCompetencyProgress(COMPETENCY_ID, user)).doesNotThrowAnyException();
+
+        // No resurrection (a targeted UPDATE, not a merge/insert), and no learning-path propagation for a row that
+        // no longer exists.
+        verify(competencyProgressRepository).updateProgressAndConfidence(eq(COMPETENCY_ID), eq(USER_ID), any(), any(), any());
+        verify(learningPathService, never()).updateLearningPathProgress(anyLong(), anyLong());
     }
 }


### PR DESCRIPTION
### Summary
`updateCompetencyProgress` created a competency-progress row with a non-atomic *find-then-insert*. When two `@Async` progress updates for the **same (competency, user)** ran in parallel (e.g. two quick lecture-unit completions, or a completion racing an exercise submission), both found no existing row and both inserted one — so the second insert violated the `competency_user` primary key. The old handler swallowed the exception, which **silently dropped the losing thread's freshly computed progress** and left a `duplicate key value violates unique constraint "competency_user_pkey"` error in the database log. This PR makes the conflict recovery non-lossy and robust.

### Checklist
#### General
- [x] This is a small issue that I verified locally (deterministic unit test); it needs no test-server run.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server
- [x] **Important**: I implemented the changes with a very good performance — the extra re-fetch + update runs **only** on the rare constraint conflict; the happy path is unchanged.
- [x] I strictly followed the principle of data economy for all database calls.
- [x] I strictly followed the server coding and design guidelines.
- [x] I added a test with high coverage of the changed lines (see note in Description on why a deterministic unit test — rather than an inherently flaky concurrency integration test — is the right tool here).
- [x] I documented the Java code (the recovery branch is thoroughly commented; the method already has JavaDoc).

### Motivation and Context
This race was surfaced while investigating the Angular 22 E2E flakiness (#13189): under the multi-node CI's concurrency, `competency_user_pkey` duplicate-key errors appeared in the server log (two `POST …/lecture-units/*/completion` requests inserting the same `competency_user` row ~3 ms apart). The previous `catch (DataIntegrityViolationException) { /* ignore */ }` avoided a 500 but was **lossy** (the losing thread's progress calculation was discarded) and **fragile** (it only works because the insert flushes synchronously). The root cause is the non-atomic find-then-insert on the composite-key `CompetencyProgress` entity.

### Description
On the unique-constraint conflict, the losing thread now **reconciles** instead of dropping its result: it re-fetches the row the winning thread just created and re-applies its freshly computed `progress` / `confidence` / `confidenceReason` as an **UPDATE**. That UPDATE cannot hit the unique constraint, and `CompetencyProgress` has no `@Version`, so it converges deterministically (last-write-wins with identical inputs).

Design notes:
- **DB-portable**: relies only on the unique constraint and the standard Spring `DataIntegrityViolationException` — *not* a vendor-specific `INSERT … ON CONFLICT` upsert, since Artemis supports both MySQL and PostgreSQL.
- **Transaction-safe**: `updateCompetencyProgress` is not `@Transactional`, so the failed insert's transaction is already rolled back and the re-fetch + update run in their own clean transactions (no poisoned-transaction reuse).
- **Test**: added a deterministic Mockito unit test (`CompetencyProgressServiceTest`) that forces the conflict and asserts no exception propagates, the update is *not* dropped (the winner's row is re-saved with the computed values), and learning-path propagation still runs. A real-concurrency integration test would be flaky, so the branch is verified deterministically with mocks.

### Steps for Testing
This is a backend concurrency-correctness fix with no UI. Verify via the unit test and code review:

1. Run the new unit test:
   ```bash
   ./gradlew test -x webapp --tests "de.tum.cit.aet.artemis.atlas.service.competency.CompetencyProgressServiceTest"
   ```
   It passes: the conflict is reconciled without dropping the update.
2. (Optional, conceptual) Trigger concurrent competency-progress updates for the same user+competency (e.g. rapid lecture-unit completions on a competency-linked unit). Before: intermittent `competency_user_pkey` errors in the server log and a possibly dropped update. After: no error, progress preserved.

### Testserver States
Not deployed to a test server — backend-only concurrency fix verified by a deterministic unit test.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| CompetencyProgressRepository.java | 75.00% | 133 |
| CompetencyProgressService.java | 92.83% | 363 |

_Last updated: 2026-07-13 02:50:32 UTC_

