### PR TITLE
`Development`: Sanitize jhiTranslate output to prevent XSS via translateValues

### DIFF
--- a/src/main/webapp/app/foundation/language/translate.directive.spec.ts
+++ b/src/main/webapp/app/foundation/language/translate.directive.spec.ts
@@ -3,6 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { of } from 'rxjs';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 
@@ -66,5 +67,32 @@ describe('TranslateDirective', () => {
         dynamicFixture.componentInstance.key.set('test');
         dynamicFixture.detectChanges();
         expect(spy).toHaveBeenCalledWith('test', undefined);
+    });
+
+    it('sanitizes the translated value before assigning to innerHTML (XSS via translateValues)', () => {
+        // Simulate a translation whose interpolated translateValues carry user-controlled markup (e.g. a course
+        // title). ngx-translate does not HTML-escape interpolation params, so the directive must sanitize.
+        spy.mockReturnValue(of('Course <img src="x" onerror="alert(1)"><script>alert(2)</script> title') as ReturnType<typeof translateService.get>);
+
+        const fixture = TestBed.createComponent(TestTranslateDirectiveComponent);
+        fixture.detectChanges();
+        const element: HTMLElement = fixture.nativeElement.querySelector('div');
+
+        expect(element.innerHTML).not.toContain('onerror');
+        expect(element.innerHTML).not.toContain('<script');
+        expect(element.innerHTML).not.toContain('alert(2)');
+        // benign text around the stripped payload is preserved
+        expect(element.textContent).toContain('Course');
+    });
+
+    it('preserves benign inline markup in the translated value', () => {
+        spy.mockReturnValue(of('Click <a href="/x"><strong>here</strong></a>') as ReturnType<typeof translateService.get>);
+
+        const fixture = TestBed.createComponent(TestTranslateDirectiveComponent);
+        fixture.detectChanges();
+        const element: HTMLElement = fixture.nativeElement.querySelector('div');
+
+        expect(element.innerHTML).toContain('<strong>here</strong>');
+        expect(element.innerHTML).toContain('href="/x"');
     });
 });

--- a/src/main/webapp/app/foundation/language/translate.directive.ts
+++ b/src/main/webapp/app/foundation/language/translate.directive.ts
@@ -2,6 +2,7 @@ import { DestroyRef, Directive, ElementRef, OnInit, effect, inject, input } from
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslateService } from '@ngx-translate/core';
 import { translationNotFoundMessage } from 'app/core/config/translation.config';
+import DOMPurify from 'dompurify';
 
 /**
  * A wrapper directive on top of the translate pipe as the inbuilt translate directive from ngx-translate is too verbose and buggy
@@ -47,7 +48,11 @@ export class TranslateDirective implements OnInit {
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe({
                 next: (value) => {
-                    this.el.nativeElement.innerHTML = value;
+                    // Sanitize before assigning to innerHTML. Translations may legitimately contain benign markup
+                    // (e.g. <a>, <strong>), but ngx-translate does NOT HTML-escape interpolated `translateValues`,
+                    // so a user-controlled value (course/exercise/exam title, user name, ...) could otherwise inject
+                    // markup here. DOMPurify keeps the benign translation markup while stripping scripts/handlers.
+                    this.el.nativeElement.innerHTML = DOMPurify.sanitize(value);
                 },
                 // Render the not-found fallback on a genuine stream error (the common missing-key case already
                 // flows through `next` via ngx-translate's MissingTranslationHandler). textContent avoids markup injection.


### PR DESCRIPTION
### Summary
Makes the `[jhiTranslate]` directive sanitize its rendered value with DOMPurify before assigning to `innerHTML`, closing a stored-XSS surface where user-controlled `translateValues` (titles, names) could inject markup. Single-file client change.

### Checklist
#### General
- [x] I chose a title conforming to the naming conventions for pull requests.
- [x] Small, self-contained change; behavior for existing usages is unchanged (DOMPurify preserves benign translation markup).
#### Client
- [x] I **strictly** followed the client coding guidelines.
- [x] I documented the TypeScript code using JSDoc/inline comments.

### Motivation and Context
The `jhiTranslate` directive renders translations via `innerHTML` to allow benign markup in translation strings (`<a>`, `<strong>`, ...). But ngx-translate does **not** HTML-escape interpolated `[translateValues]`. Many usages pass user-controlled strings — e.g. course/exercise/exam/channel titles and user names — which are free-text (no HTML restriction). A content author (instructor/TA) could set a title like `<img src=x onerror=…>` and have it execute in the browser of anyone viewing it through such a usage (students on the dashboard, assessors), i.e. stored XSS across role/tenant boundaries. Found while triaging Codacy `insecure-innerhtml` / `insecure-document-method` findings on `translate.directive.ts`.

### Description
`getTranslation` now assigns `DOMPurify.sanitize(value)` instead of the raw `value`. DOMPurify keeps the benign inline markup translations rely on while stripping scripts, event handlers, and `javascript:` URIs, so rendered output is unchanged for legitimate translations. This protects **all** `jhiTranslate` usages at once, independent of per-field input validation.

Scope note: the student-uploaded filename path (`submittedFileName`) is already safe — the server sanitizes uploaded filenames to `[a-zA-Z0-9.-]`. This PR addresses the remaining author-controlled title/name vectors. Complements the SafeHtmlPipe hardening (#13204).

### Steps for Testing
1. As an instructor, set a course/exercise title to `<img src=x onerror=alert(1)>`; as a student, open the dashboard/exam views that show it — verify no alert fires and the title renders as inert text.
2. Verify translations that legitimately contain markup (links, bold) still render correctly (e.g. any `jhiTranslate` with `<a>`/`<strong>` in its string).
3. General smoke test of translated headings/labels across a few pages.

### Testserver States
Not applicable — no server change.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/29203741886) did not pass (`failure`). Coverage below may be partial.

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| translate.directive.ts | 93.75% | 40 | 12 | 30.0 |

_Last updated: 2026-07-12 19:07:12 UTC_


### Screenshots
Not applicable — no intended visual change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety of translated content rendered as HTML by sanitizing the output before display.
  * Missing translations and stream errors continue to render as plain text (not HTML).
* **Tests**
  * Added coverage to verify dangerous markup is blocked while safe inline HTML is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->