### PR TITLE
`Development`: Exclude exercise templates from codacy security scanners

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,14 +1,20 @@
 ---
 # Codacy configuration — read by Codacy Cloud from the default branch (develop).
-# Scopes security scanners to production code: hardcoded test credentials, non-literal
-# fs/regexp in test helpers, and similar security findings in test code are intentional
-# fixtures, not vulnerabilities. Other tools (ESLint, Stylelint, PMD) still analyze tests.
+# Scopes security scanners to production code. Excluded from the SAST/security scanners:
+#   - test code (src/test/**, *.spec.ts): hardcoded test credentials, non-literal fs/regexp in
+#     test helpers, etc. are intentional fixtures, not vulnerabilities;
+#   - programming-exercise templates (src/main/resources/templates/**) and test resources
+#     (src/test/resources/**): sample/starter code shipped for exercises, not application code
+#     Artemis maintains for quality (e.g. npm-dependency checks on template package.json files).
+# Other tools (ESLint, Stylelint, PMD) still analyze the code they apply to.
 engines:
   opengrep: # Semgrep — SAST security scanning
     exclude_paths:
       - "src/test/**"
       - "src/test/**/*"
       - "**/*.spec.ts"
+      - "src/main/resources/templates/**"
+      - "src/main/resources/templates/**/*"
   bandit: # Python security scanning
     exclude_paths:
       - "src/test/**"
@@ -16,3 +22,5 @@ engines:
       - "**/test_*.py"
       - "**/*_test.py"
       - "**/tests/**"
+      - "src/main/resources/templates/**"
+      - "src/main/resources/templates/**/*"


### PR DESCRIPTION
### Summary
Extends `.codacy.yaml` to exclude programming-exercise templates (`src/main/resources/templates/**`) from the Semgrep (opengrep) and Bandit security scanners. Config-only change.

### Checklist
#### General
- [x] I chose a title conforming to the naming conventions for pull requests.
- [x] Config-only change (`.codacy.yaml`), verified as valid YAML.

### Motivation and Context
After enabling Semgrep on Codacy, ~23 of the security findings on `develop` are in exercise-template code under `src/main/resources/templates/**` — mostly `json.npm...package-dependencies-check` on template `package.json` files, plus assorted template Python. These templates are sample/starter code shipped for exercises, not application code Artemis maintains for quality, so the findings are noise (and recur as templates change). This mirrors the existing test-code exclusion already in `.codacy.yaml`.

### Description
Add `src/main/resources/templates/**` (and the `/**/*` variant) to the `opengrep` and `bandit` `exclude_paths` in `.codacy.yaml`. Codacy Cloud reads `.codacy.yaml` from the default branch, so this takes effect on `develop` once merged. Other tools (ESLint, Stylelint, PMD) are unaffected.

### Steps for Testing
1. After merge, confirm on Codacy that Semgrep/Bandit findings under `src/main/resources/templates/**` (e.g. the `package-dependencies-check` hits on template `package.json`) no longer appear.
2. Confirm production security findings (under `src/main`, excluding templates) are unaffected.

### Testserver States
Not applicable — Codacy configuration change, no deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-12 20:01:28 UTC_


### Screenshots
Not applicable — no UI changes.