### PR TITLE
`Development`: Improve github action deploy workflows

### DIFF
--- a/.github/workflows/prod-like-deployment.yml
+++ b/.github/workflows/prod-like-deployment.yml
@@ -59,17 +59,19 @@ jobs:
         id: set_build_workflow_id
         env:
           WORKFLOW_DATA: ${{ steps.get_workflow_run.outputs.data }}
+          COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name }}
         run: |
           WORKFLOW_ID=$(echo "$WORKFLOW_DATA" | jq -r '
             .workflow_runs[0].id // empty
           ')
 
           if [ -z "$WORKFLOW_ID" ]; then
-            echo "::error::No build found for commit ${{ github.event.inputs.commit_sha }} on branch ${{ github.event.inputs.branch_name }}"
+            echo "::error::No build found for commit $COMMIT_SHA on branch $BRANCH_NAME"
             exit 1
           fi
 
-          echo "Found build workflow ID: $WORKFLOW_ID for commit ${{ github.event.inputs.commit_sha }} on branch ${{ github.event.inputs.branch_name }}"
+          echo "Found build workflow ID: $WORKFLOW_ID for commit $COMMIT_SHA on branch $BRANCH_NAME"
           echo "workflow_id=$WORKFLOW_ID" >> $GITHUB_OUTPUT
 
       - name: Check for war artifact
@@ -84,13 +86,14 @@ jobs:
         id: check_result
         env:
           ARTIFACT_DATA: ${{ steps.verify_artifact.outputs.data }}
+          COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
         run: |
           TOTAL_COUNT=$(echo "$ARTIFACT_DATA" | jq -r '.total_count')
 
           if [ "$TOTAL_COUNT" -gt 0 ]; then
-            echo "Found Artemis.war artifact in build for commit ${{ github.event.inputs.commit_sha }}"
+            echo "Found Artemis.war artifact in build for commit $COMMIT_SHA"
           else
-            echo "::error::No Artemis.war artifact found in build for commit ${{ github.event.inputs.commit_sha }}!"
+            echo "::error::No Artemis.war artifact found in build for commit $COMMIT_SHA!"
             exit 1
           fi
 

--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -59,7 +59,7 @@ jobs:
           echo "Branch: $BRANCH_NAME"
           echo "Environment: $ENVIRONMENT_NAME"
           echo "Triggered by: $TRIGGERED_BY"
-          echo "RAW_URL: ${{ env.RAW_URL }}"
+          echo "RAW_URL: $RAW_URL"
 
   determine-build-context:
     name: Determine Build Context
@@ -237,7 +237,7 @@ jobs:
       # Download artemis-server-cli from GH without cloning the Repo
       - name: Fetch Artemis CLI
         run: |
-          wget ${{ env.RAW_URL }}/artemis-server-cli
+          wget "$RAW_URL/artemis-server-cli"
           chmod +x artemis-server-cli
 
       # Configure SSH Key

--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -75,14 +75,14 @@ jobs:
         id: get_pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ github.event.inputs.branch_name }}
+          REPO_NAME: ${{ github.repository }}
         run: |
-          BRANCH_NAME=${{ github.event.inputs.branch_name }}
           IS_MAIN_OR_DEVELOP=false
 
-          REPO_NAME=${{ github.repository }}
           echo "Checking if PR exists for branch: $BRANCH_NAME targeting 'develop' in $REPO_NAME (excluding forks)."
 
-          PR_DETAILS=$(gh api repos/${{ github.repository }}/pulls \
+          PR_DETAILS=$(gh api "repos/$REPO_NAME/pulls" \
             --paginate \
             --jq ".[] | select(.head.repo.full_name == \"$REPO_NAME\" and .head.ref == \"$BRANCH_NAME\" and .base.ref == \"develop\") | {number: .number, sha: .head.sha}")
 
@@ -99,7 +99,7 @@ jobs:
             echo "pr_number=" >> $GITHUB_OUTPUT
 
             # Fetch the latest commit SHA of the branch
-            LATEST_SHA=$(gh api repos/${{ github.repository }}/git/refs/heads/$BRANCH_NAME --jq '.object.sha')
+            LATEST_SHA=$(gh api "repos/$REPO_NAME/git/refs/heads/$BRANCH_NAME" --jq '.object.sha')
 
             if [ -z "$LATEST_SHA" ]; then
               echo "::error::Could not find the latest commit SHA for branch $BRANCH_NAME."


### PR DESCRIPTION
### Summary
Follow-up to #13203. Moves the remaining `workflow_dispatch` inputs out of `run:` shell interpolation in the test-server and prod-like deployment workflows, closing the two `run-shell-injection` findings Codacy still reports. CI/config-only change.

### Checklist
#### General
- [x] I chose a title conforming to the naming conventions for pull requests.
- [x] Self-contained workflow change; validated that both edited workflows parse as YAML and that no `github.event.inputs.*` remains in any `run:` block.

### Motivation and Context
#13203 fixed the "Print inputs" debug steps, but Codacy (Semgrep `run-shell-injection`) still flags two further `run:` steps that interpolate `${{ github.event.inputs.* }}` directly into shell — a code-injection vector on the (self-hosted) deployment runners:
- `testserver-deployment.yml` → "Check if a PR exists" (`BRANCH_NAME=${{ github.event.inputs.branch_name }}`, `REPO_NAME`)
- `prod-like-deployment.yml` → "Extract workflow ID" (`${{ github.event.inputs.commit_sha }}` / `branch_name` in `echo`/`::error`), plus the sibling "Verify artifact exists" step with the same pattern.

### Description
Move each `github.event.inputs.*` (and the `github.repository` used alongside it in `testserver`) into the steps `env:` block and reference them as quoted shell variables (`"$BRANCH_NAME"`, `"$COMMIT_SHA"`, `"$REPO_NAME"`). A python scan confirms **no `github.event.inputs.*` interpolation remains in any `run:` block** in either file. `github.repository` elsewhere is the fixed repo slug (not user-controllable) and is left as-is.

### Steps for Testing
1. (These are `workflow_dispatch`-only deployment workflows.) Review that the affected steps still produce the same PR-lookup / workflow-id-extraction / artifact-verification behaviour via the new env vars.
2. Confirm Codacy no longer reports `run-shell-injection` for these two workflows after merge.

### Testserver States
Not applicable — CI/workflow configuration change, no deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-13 10:18:31 UTC_


### Screenshots
Not applicable — no UI changes.