### PR TITLE
`Lectures`: Use SHA 256 for attachment versioning

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/lecture/domain/Attachment.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/domain/Attachment.java
@@ -39,6 +39,9 @@ public class Attachment extends DomainObject implements Serializable {
     @Column(name = "version")
     private Integer version;
 
+    @Column(name = "sha256_hash")
+    private String sha256Hash;
+
     @Column(name = "upload_date")
     private ZonedDateTime uploadDate;
 
@@ -91,6 +94,14 @@ public class Attachment extends DomainObject implements Serializable {
 
     public void setVersion(Integer version) {
         this.version = version;
+    }
+
+    public String getSha256Hash() {
+        return sha256Hash;
+    }
+
+    public void setSha256Hash(String sha256Hash) {
+        this.sha256Hash = sha256Hash;
     }
 
     public ZonedDateTime getUploadDate() {

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/domain/AttachmentUpdateIntent.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/domain/AttachmentUpdateIntent.java
@@ -1,0 +1,5 @@
+package de.tum.cit.aet.artemis.lecture.domain;
+
+public enum AttachmentUpdateIntent {
+    NO_FILE_CHANGE, FILE_UPLOAD, EDITOR_PDF_CONTENT_CHANGED
+}

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/dto/AttachmentVideoUnitDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/dto/AttachmentVideoUnitDTO.java
@@ -18,7 +18,7 @@ import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
  * DTO for the {@link AttachmentVideoUnit} REST boundary.
  * <p>
  * It is used both as the request part on create/update (the client only populates {@code name}, {@code releaseDate},
- * {@code description}, {@code videoSource} and {@code competencyLinks}) and as the response body (additionally carrying
+ * {@code description}, {@code videoSource}, {@code competencyLinks}, and {@code attachmentUpdateIntent}) and as the response body (additionally carrying
  * the mapped {@link AttachmentDTO} and {@link SlideDTO}s). Lazy associations are mapped defensively so the DTO can also
  * be created right after persisting, before all associations are initialized.
  */

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/dto/AttachmentVideoUnitDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/dto/AttachmentVideoUnitDTO.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import de.tum.cit.aet.artemis.lecture.domain.AttachmentUpdateIntent;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 
 /**
@@ -24,8 +25,8 @@ import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record AttachmentVideoUnitDTO(Long id, String name, ZonedDateTime releaseDate, String description, String videoSource, Set<CompetencyLinkDTO> competencyLinks,
-        AttachmentDTO attachment, List<SlideDTO> slides, boolean completed, boolean visibleToStudents, AttachmentDTO.LectureReferenceDTO lecture, @JsonProperty("type") String type)
-        implements LectureUnitDTO {
+        AttachmentDTO attachment, List<SlideDTO> slides, boolean completed, boolean visibleToStudents, AttachmentDTO.LectureReferenceDTO lecture,
+        AttachmentUpdateIntent attachmentUpdateIntent, @JsonProperty("type") String type) implements LectureUnitDTO {
 
     public AttachmentVideoUnitDTO {
         type = "attachment";
@@ -38,6 +39,17 @@ public record AttachmentVideoUnitDTO(Long id, String name, ZonedDateTime release
      * @return the populated DTO including the mapped attachment and (initialized) slides
      */
     public static AttachmentVideoUnitDTO of(AttachmentVideoUnit unit) {
+        return from(unit, null);
+    }
+
+    /**
+     * Maps an {@link AttachmentVideoUnit} entity and the explicit attachment update intent to its DTO.
+     *
+     * @param unit   the attachment video unit to map
+     * @param intent the requested attachment update operation
+     * @return the populated DTO
+     */
+    public static AttachmentVideoUnitDTO from(AttachmentVideoUnit unit, AttachmentUpdateIntent intent) {
         Set<CompetencyLinkDTO> competencyLinks = unit.getCompetencyLinks() != null && Hibernate.isInitialized(unit.getCompetencyLinks())
                 ? unit.getCompetencyLinks().stream().map(CompetencyLinkDTO::of).collect(Collectors.toSet())
                 : Set.of();
@@ -46,6 +58,6 @@ public record AttachmentVideoUnitDTO(Long id, String name, ZonedDateTime release
         // The PDF preview reads attachmentVideoUnit.lecture.id when saving/updating, so keep the lightweight lecture reference.
         AttachmentDTO.LectureReferenceDTO lecture = AttachmentDTO.LectureReferenceDTO.of(unit.getLecture());
         return new AttachmentVideoUnitDTO(unit.getId(), unit.getName(), unit.getReleaseDate(), unit.getDescription(), unit.getVideoSource(), competencyLinks, attachment, slides,
-                unit.isCompleted(), unit.isVisibleToStudents(), lecture, unit.getType());
+                unit.isCompleted(), unit.isVisibleToStudents(), lecture, intent, unit.getType());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentFileHashException.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentFileHashException.java
@@ -1,0 +1,8 @@
+package de.tum.cit.aet.artemis.lecture.service;
+
+public class AttachmentFileHashException extends RuntimeException {
+
+    public AttachmentFileHashException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentFileHashService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentFileHashService.java
@@ -1,0 +1,85 @@
+package de.tum.cit.aet.artemis.lecture.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import de.tum.cit.aet.artemis.lecture.config.LectureEnabled;
+
+@Conditional(LectureEnabled.class)
+@Lazy
+@Service
+public class AttachmentFileHashService {
+
+    private static final String SHA_256 = "SHA-256";
+
+    private static final int BUFFER_SIZE = 8192;
+
+    /**
+     * Calculates the SHA-256 hash of an uploaded attachment file.
+     *
+     * @param file the uploaded file to hash
+     * @return the calculated SHA-256 hash
+     */
+    public FileHash sha256(MultipartFile file) {
+        try (InputStream inputStream = file.getInputStream()) {
+            return sha256(inputStream);
+        }
+        catch (IOException e) {
+            throw new AttachmentFileHashException("Could not hash uploaded attachment file", e);
+        }
+    }
+
+    /**
+     * Calculates the SHA-256 hash of a stored attachment file.
+     *
+     * @param path the path of the stored file to hash
+     * @return the calculated SHA-256 hash
+     */
+    public FileHash sha256(Path path) {
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            return sha256(inputStream);
+        }
+        catch (IOException e) {
+            throw new AttachmentFileHashException("Could not hash stored attachment file", e);
+        }
+    }
+
+    private FileHash sha256(InputStream inputStream) {
+        MessageDigest messageDigest = createMessageDigest();
+        byte[] buffer = new byte[BUFFER_SIZE];
+
+        try (DigestInputStream digestInputStream = new DigestInputStream(inputStream, messageDigest)) {
+            while (digestInputStream.read(buffer) != -1) {
+                // Read the stream fully so DigestInputStream can update the digest incrementally.
+            }
+        }
+        catch (IOException e) {
+            throw new AttachmentFileHashException("Could not hash attachment file stream", e);
+        }
+
+        return new FileHash(SHA_256, HexFormat.of().formatHex(messageDigest.digest()));
+    }
+
+    private static MessageDigest createMessageDigest() {
+        try {
+            return MessageDigest.getInstance(SHA_256);
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new AttachmentFileHashException("Could not initialize SHA-256 digest", e);
+        }
+    }
+
+    public record FileHash(String algorithm, String value) {
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentFileUpdateResult.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentFileUpdateResult.java
@@ -1,0 +1,12 @@
+package de.tum.cit.aet.artemis.lecture.service;
+
+public record AttachmentFileUpdateResult(boolean fileBytesChanged, boolean attachmentAdded, boolean attachmentRemoved, Integer oldVersion, Integer newVersion) {
+
+    public static AttachmentFileUpdateResult unchanged(Integer version) {
+        return new AttachmentFileUpdateResult(false, false, false, version, version);
+    }
+
+    public static AttachmentFileUpdateResult changed(Integer oldVersion, Integer newVersion) {
+        return new AttachmentFileUpdateResult(true, false, false, oldVersion, newVersion);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentVideoUnitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentVideoUnitService.java
@@ -1,16 +1,9 @@
 package de.tum.cit.aet.artemis.lecture.service;
 
-import java.awt.image.BufferedImage;
-import java.awt.image.DataBufferByte;
-import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.ZonedDateTime;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -18,10 +11,6 @@ import java.util.Set;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.pdfbox.Loader;
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.rendering.ImageType;
-import org.apache.pdfbox.rendering.PDFRenderer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Conditional;
@@ -50,16 +39,13 @@ public class AttachmentVideoUnitService {
 
     private static final Logger log = LoggerFactory.getLogger(AttachmentVideoUnitService.class);
 
-    /**
-     * DPI used to render PDF pages for the content fingerprint. Low enough to keep rendering cheap, high enough to detect visual changes (replaced diagrams, vector graphics, ...).
-     */
-    private static final int FINGERPRINT_RENDER_DPI = 50;
-
     private final AttachmentVideoUnitRepository attachmentVideoUnitRepository;
 
     private final AttachmentRepository attachmentRepository;
 
     private final FileService fileService;
+
+    private final AttachmentFileHashService attachmentFileHashService;
 
     private final SlideSplitterService slideSplitterService;
 
@@ -71,10 +57,11 @@ public class AttachmentVideoUnitService {
 
     public AttachmentVideoUnitService(SlideSplitterService slideSplitterService, AttachmentVideoUnitRepository attachmentVideoUnitRepository,
             AttachmentRepository attachmentRepository, FileService fileService, Optional<CompetencyProgressApi> competencyProgressApi, LectureUnitService lectureUnitService,
-            Optional<LectureContentProcessingService> contentProcessingService) {
+            Optional<LectureContentProcessingService> contentProcessingService, AttachmentFileHashService attachmentFileHashService) {
         this.attachmentVideoUnitRepository = attachmentVideoUnitRepository;
         this.attachmentRepository = attachmentRepository;
         this.fileService = fileService;
+        this.attachmentFileHashService = attachmentFileHashService;
         this.slideSplitterService = slideSplitterService;
         this.competencyProgressApi = competencyProgressApi;
         this.lectureUnitService = lectureUnitService;
@@ -151,24 +138,20 @@ public class AttachmentVideoUnitService {
             else if (existingAttachment != null) {
                 updateAttachment(existingAttachment, updateAttachment, savedAttachmentVideoUnit, hiddenPages);
 
-                // Re-uploading a file whose content is unchanged must not bump the version or trigger a re-ingest. The pdf-preview client re-serializes the PDF on every save
-                // (e.g. when only hidden-slide dates change), so the raw bytes always differ; we therefore compare the PDF content (extracted text + page count), which is stable
-                // across re-serialization. Only a genuine content change bumps the version.
-                boolean fileContentChanged = hasUploadedFile && !isUploadedFileContentIdenticalToStored(updateFile, existingAttachment);
-
-                // Update file and increment version number only when the uploaded content actually changed
-                if (fileContentChanged) {
-                    handleFile(updateFile, existingAttachment, keepFilename, savedAttachmentVideoUnit.getId());
-                    final int revision = existingAttachment.getVersion() == null ? 1 : existingAttachment.getVersion() + 1;
-                    existingAttachment.setVersion(revision);
+                if (hasUploadedFile) {
+                    AttachmentFileUpdateResult fileUpdateResult = updateAttachmentFileIfChanged(updateFile, existingAttachment, keepFilename, savedAttachmentVideoUnit.getId());
+                    if (fileUpdateResult.fileBytesChanged()) {
+                        log.debug("Updated attachment {} file bytes from version {} to {}", existingAttachment.getId(), fileUpdateResult.oldVersion(),
+                                fileUpdateResult.newVersion());
+                    }
                 }
 
                 Attachment savedAttachment = attachmentRepository.saveAndFlush(existingAttachment);
                 savedAttachmentVideoUnit.setAttachment(savedAttachment);
                 evictCache(updateFile, savedAttachmentVideoUnit);
 
-                // Slide splitting is intentionally identical to develop: it runs on every uploaded file, independent of the content fingerprint. The fingerprint only gates the
-                // version bump (and therefore the Pyris re-ingestion) above; it deliberately does not change the existing slide-splitting behavior.
+                // Slide splitting is intentionally identical to develop: it runs on every uploaded file. The SHA-256 comparison only gates the version bump (and therefore the
+                // Pyris re-ingestion) above; it deliberately does not change the existing slide-splitting behavior.
                 if (updateFile != null) {
                     // Split PDF into slides, respecting custom page order if provided
                     if ("pdf".equalsIgnoreCase(FilenameUtils.getExtension(updateFile.getOriginalFilename()))) {
@@ -214,81 +197,54 @@ public class AttachmentVideoUnitService {
                 unit.getVideoSource() != null && !unit.getVideoSource().isBlank() ? unit.getVideoSource() : null);
     }
 
-    /**
-     * Checks whether the uploaded file has the same content as the file currently stored for the attachment. This is used to avoid bumping the attachment version (and triggering
-     * a costly re-ingest) when a file with unchanged content is re-uploaded. For PDFs the comparison is based on a content fingerprint (extracted text + page count) rather than
-     * the raw bytes, because the pdf-preview client re-serializes the PDF on every save (e.g. when only hidden-slide dates change), which changes the bytes but not the content.
-     *
-     * @param uploadedFile       the newly uploaded file
-     * @param existingAttachment the attachment whose currently stored file the upload is compared against
-     * @return {@code true} if a stored file exists and its content fingerprint matches the uploaded file's fingerprint, {@code false} otherwise
-     */
-    private boolean isUploadedFileContentIdenticalToStored(MultipartFile uploadedFile, Attachment existingAttachment) {
-        if (existingAttachment == null || existingAttachment.getLink() == null) {
-            return false;
+    private AttachmentFileUpdateResult updateAttachmentFileIfChanged(MultipartFile uploadedFile, Attachment existingAttachment, boolean keepFilename, Long attachmentVideoUnitId) {
+        Integer oldVersion = existingAttachment.getVersion();
+        String uploadedHash = attachmentFileHashService.sha256(uploadedFile).value();
+        Optional<String> storedHash = getOrBackfillStoredFileSha256Hash(existingAttachment);
+
+        if (storedHash.isPresent() && storedHash.get().equals(uploadedHash)) {
+            existingAttachment.setSha256Hash(uploadedHash);
+            return AttachmentFileUpdateResult.unchanged(oldVersion);
         }
-        Path existingFilePath = FilePathConverter.fileSystemPathForExternalUri(URI.create(existingAttachment.getLink()), FilePathType.ATTACHMENT_UNIT);
-        if (!Files.exists(existingFilePath)) {
-            return false;
+
+        handleFile(uploadedFile, existingAttachment, keepFilename, attachmentVideoUnitId);
+        int newVersion = oldVersion == null ? 1 : oldVersion + 1;
+        existingAttachment.setVersion(newVersion);
+        existingAttachment.setSha256Hash(uploadedHash);
+        return AttachmentFileUpdateResult.changed(oldVersion, newVersion);
+    }
+
+    private Optional<String> getOrBackfillStoredFileSha256Hash(Attachment existingAttachment) {
+        String existingHash = existingAttachment.getSha256Hash();
+        if (existingHash != null) {
+            return Optional.of(existingHash);
         }
+        if (existingAttachment.getLink() == null) {
+            return Optional.empty();
+        }
+
         try {
-            String uploadedFingerprint = computeContentFingerprint(uploadedFile.getBytes(), uploadedFile.getOriginalFilename());
-            String existingFingerprint = computeContentFingerprint(Files.readAllBytes(existingFilePath), existingFilePath.getFileName().toString());
-            return uploadedFingerprint.equals(existingFingerprint);
+            Path existingFilePath = FilePathConverter.fileSystemPathForExternalUri(URI.create(existingAttachment.getLink()), FilePathType.ATTACHMENT_UNIT);
+            if (!Files.exists(existingFilePath)) {
+                log.warn("Stored attachment file {} does not exist. Treating uploaded file as changed content.", existingAttachment.getLink());
+                return Optional.empty();
+            }
+
+            String storedHash = attachmentFileHashService.sha256(existingFilePath).value();
+            existingAttachment.setSha256Hash(storedHash);
+            return Optional.of(storedHash);
         }
-        catch (IOException e) {
-            // If the comparison fails for any reason, fall back to treating the upload as changed content so that processing still happens.
-            log.warn("Could not compare uploaded file with the stored attachment file (attachment {}). Treating the upload as changed content: {}", existingAttachment.getId(),
+        catch (AttachmentFileHashException | IllegalArgumentException | SecurityException e) {
+            log.warn("Could not compute stored attachment SHA-256 hash for attachment {}. Treating uploaded file as changed content: {}", existingAttachment.getId(),
                     e.getMessage());
-            return false;
-        }
-    }
-
-    /**
-     * Computes a content fingerprint for the given file. For PDFs this is a SHA-256 hash over the page count and the rendered pixels of every page, so that re-serializing the same
-     * PDF (which changes the raw bytes but not the visual appearance) yields the same fingerprint, while any visual change - text, vector graphics, diagrams, images or annotations
-     * -
-     * is detected because it changes the rendered pixels. For non-PDF files (or PDFs that cannot be rendered) it falls back to a hash of the raw bytes.
-     *
-     * @param fileBytes the file content
-     * @param filename  the original filename, used to detect PDFs
-     * @return a hex-encoded SHA-256 fingerprint of the file content
-     */
-    private String computeContentFingerprint(byte[] fileBytes, String filename) {
-        if (filename != null && "pdf".equalsIgnoreCase(FilenameUtils.getExtension(filename))) {
-            try (PDDocument document = Loader.loadPDF(fileBytes)) {
-                StringBuilder fingerprintInput = new StringBuilder();
-                fingerprintInput.append(document.getNumberOfPages()).append('\n');
-                PDFRenderer renderer = new PDFRenderer(document);
-                for (int pageIndex = 0; pageIndex < document.getNumberOfPages(); pageIndex++) {
-                    // Render at a low DPI in grayscale: enough to detect visual changes while keeping the rendering cheap. The page order is part of the fingerprint, so reordering
-                    // pages is detected as well.
-                    BufferedImage renderedPage = renderer.renderImageWithDPI(pageIndex, FINGERPRINT_RENDER_DPI, ImageType.GRAY);
-                    fingerprintInput.append(sha256Hex(((DataBufferByte) renderedPage.getRaster().getDataBuffer()).getData())).append('\n');
-                }
-                return sha256Hex(fingerprintInput.toString());
-            }
-            catch (IOException e) {
-                log.warn("Could not render uploaded PDF for content fingerprinting, falling back to raw bytes: {}", e.getMessage());
-            }
-        }
-        return sha256Hex(fileBytes);
-    }
-
-    private static String sha256Hex(String value) {
-        return sha256Hex(value.getBytes(StandardCharsets.UTF_8));
-    }
-
-    private static String sha256Hex(byte[] value) {
-        try {
-            return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(value));
-        }
-        catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 algorithm not available", e);
+            return Optional.empty();
         }
     }
 
     private void createAttachment(Attachment attachment, AttachmentVideoUnit attachmentVideoUnit, MultipartFile file, boolean keepFilename) {
+        if (file != null && !file.isEmpty()) {
+            attachment.setSha256Hash(attachmentFileHashService.sha256(file).value());
+        }
         handleFile(file, attachment, keepFilename, attachmentVideoUnit.getId());
         // Default attachment
         attachment.setVersion(1);

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentVideoUnitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentVideoUnitService.java
@@ -81,7 +81,7 @@ public class AttachmentVideoUnitService {
         // TODO: switch to the new mechanism of lectureUnitService.updateCompetencyLinks
         AttachmentVideoUnit savedAttachmentVideoUnit = attachmentVideoUnitRepository.save(attachmentVideoUnit);
 
-        if (attachment != null && file != null) {
+        if (attachment != null) {
             createAttachment(attachment, savedAttachmentVideoUnit, file, keepFilename);
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/AttachmentVideoUnitResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/AttachmentVideoUnitResource.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -166,7 +167,7 @@ public class AttachmentVideoUnitResource {
 
         validateYouTubeVideoSource(attachmentVideoUnitDTO.videoSource());
         AttachmentUpdateIntent updateIntent = attachmentVideoUnitDTO.attachmentUpdateIntent();
-        validateAttachmentUpdateIntent(updateIntent, file);
+        validateAttachmentUpdateIntent(updateIntent, attachment, file);
 
         // Capture original competency IDs BEFORE updating links (for progress tracking)
         Set<Long> originalCompetencyIds = existingAttachmentVideoUnit.getCompetencyLinks().stream().map(CompetencyLearningObjectLink::getCompetency).map(c -> c.getId())
@@ -200,15 +201,15 @@ public class AttachmentVideoUnitResource {
         return ResponseEntity.ok(AttachmentVideoUnitDTO.of(savedAttachmentVideoUnit));
     }
 
-    private void validateAttachmentUpdateIntent(AttachmentUpdateIntent updateIntent, MultipartFile file) {
+    private void validateAttachmentUpdateIntent(AttachmentUpdateIntent updateIntent, AttachmentDTO attachment, MultipartFile file) {
         boolean hasFile = file != null && !file.isEmpty();
         if (updateIntent == null) {
             throw new BadRequestAlertException("Attachment update intent is required", ENTITY_NAME, "attachmentUpdateIntentRequired");
         }
-        if (updateIntent == AttachmentUpdateIntent.NO_FILE_CHANGE && hasFile) {
+        if (updateIntent == AttachmentUpdateIntent.NO_FILE_CHANGE && file != null) {
             throw new BadRequestAlertException("NO_FILE_CHANGE requests must not include a file", ENTITY_NAME, "fileNotAllowedForNoFileChange");
         }
-        if ((updateIntent == AttachmentUpdateIntent.FILE_UPLOAD || updateIntent == AttachmentUpdateIntent.EDITOR_PDF_CONTENT_CHANGED) && !hasFile) {
+        if ((updateIntent == AttachmentUpdateIntent.FILE_UPLOAD || updateIntent == AttachmentUpdateIntent.EDITOR_PDF_CONTENT_CHANGED) && (!hasFile || attachment == null)) {
             throw new BadRequestAlertException("File update requests must include a file", ENTITY_NAME, "fileRequiredForFileChange");
         }
     }
@@ -240,6 +241,9 @@ public class AttachmentVideoUnitResource {
 
         if (attachment == null && attachmentVideoUnitDTO.videoSource() == null) {
             throw new BadRequestAlertException("A attachment must have a an attachment or a video source", ENTITY_NAME, "videosourceAndAttachment");
+        }
+        if (attachment != null && (file == null || file.isEmpty()) && !StringUtils.hasText(attachment.link())) {
+            throw new BadRequestAlertException("A fileless attachment must include a link", ENTITY_NAME, "attachmentLinkRequired");
         }
 
         validateYouTubeVideoSource(attachmentVideoUnitDTO.videoSource());

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/AttachmentVideoUnitResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/AttachmentVideoUnitResource.java
@@ -48,6 +48,7 @@ import de.tum.cit.aet.artemis.globalsearch.dto.searchableentity.LectureUnitSearc
 import de.tum.cit.aet.artemis.globalsearch.service.SearchableEntityWeaviateService;
 import de.tum.cit.aet.artemis.lecture.config.LectureEnabled;
 import de.tum.cit.aet.artemis.lecture.domain.Attachment;
+import de.tum.cit.aet.artemis.lecture.domain.AttachmentUpdateIntent;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.dto.AttachmentDTO;
@@ -164,6 +165,8 @@ public class AttachmentVideoUnitResource {
         }
 
         validateYouTubeVideoSource(attachmentVideoUnitDTO.videoSource());
+        AttachmentUpdateIntent updateIntent = attachmentVideoUnitDTO.attachmentUpdateIntent();
+        validateAttachmentUpdateIntent(updateIntent, file);
 
         // Capture original competency IDs BEFORE updating links (for progress tracking)
         Set<Long> originalCompetencyIds = existingAttachmentVideoUnit.getCompetencyLinks().stream().map(CompetencyLearningObjectLink::getCompetency).map(c -> c.getId())
@@ -195,6 +198,19 @@ public class AttachmentVideoUnitResource {
         });
 
         return ResponseEntity.ok(AttachmentVideoUnitDTO.of(savedAttachmentVideoUnit));
+    }
+
+    private void validateAttachmentUpdateIntent(AttachmentUpdateIntent updateIntent, MultipartFile file) {
+        boolean hasFile = file != null && !file.isEmpty();
+        if (updateIntent == null) {
+            throw new BadRequestAlertException("Attachment update intent is required", ENTITY_NAME, "attachmentUpdateIntentRequired");
+        }
+        if (updateIntent == AttachmentUpdateIntent.NO_FILE_CHANGE && hasFile) {
+            throw new BadRequestAlertException("NO_FILE_CHANGE requests must not include a file", ENTITY_NAME, "fileNotAllowedForNoFileChange");
+        }
+        if ((updateIntent == AttachmentUpdateIntent.FILE_UPLOAD || updateIntent == AttachmentUpdateIntent.EDITOR_PDF_CONTENT_CHANGED) && !hasFile) {
+            throw new BadRequestAlertException("File update requests must include a file", ENTITY_NAME, "fileRequiredForFileChange");
+        }
     }
 
     /**

--- a/src/main/resources/config/liquibase/changelog/20260702120000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260702120000_changelog.xml
@@ -5,35 +5,5 @@
         <addColumn tableName="attachment">
             <column name="sha256_hash" type="varchar(64)"/>
         </addColumn>
-
-        <createTable tableName="iris_lecture_unit_sync_state">
-            <column name="id" type="bigint" autoIncrement="true">
-                <constraints primaryKey="true" primaryKeyName="pk_iris_lecture_unit_sync_state" nullable="false"/>
-            </column>
-            <column name="lecture_unit_id" type="bigint">
-                <constraints nullable="false" unique="true" uniqueConstraintName="uk_iris_lecture_unit_sync_state_lecture_unit_id"/>
-            </column>
-            <column name="metadata_hash" type="varchar(64)"/>
-            <column name="last_synced_metadata_hash" type="varchar(64)"/>
-            <column name="visibility_hash" type="varchar(64)"/>
-            <column name="last_synced_visibility_hash" type="varchar(64)"/>
-            <column name="status" type="varchar(30)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="retry_count" type="integer" defaultValueNumeric="0">
-                <constraints nullable="false"/>
-            </column>
-            <column name="next_retry_at" type="timestamp"/>
-            <column name="last_error_key" type="varchar(255)"/>
-        </createTable>
-
-        <addForeignKeyConstraint baseColumnNames="lecture_unit_id" baseTableName="iris_lecture_unit_sync_state"
-                                 constraintName="fk_iris_lecture_unit_sync_state_lecture_unit_id" referencedColumnNames="id" referencedTableName="lecture_unit"
-                                 onDelete="CASCADE" onUpdate="RESTRICT"/>
-
-        <createIndex indexName="idx_iris_lecture_unit_sync_state_status_retry" tableName="iris_lecture_unit_sync_state">
-            <column name="status"/>
-            <column name="next_retry_at"/>
-        </createIndex>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20260702120000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260702120000_changelog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
-    <changeSet id="20260702120000-1" author="artemis">
+    <changeSet id="20260702120000-1" author="bassner">
         <addColumn tableName="attachment">
             <column name="sha256_hash" type="varchar(64)"/>
         </addColumn>

--- a/src/main/resources/config/liquibase/changelog/20260702120000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260702120000_changelog.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="20260702120000-1" author="artemis">
+        <addColumn tableName="attachment">
+            <column name="sha256_hash" type="varchar(64)"/>
+        </addColumn>
+
+        <createTable tableName="iris_lecture_unit_sync_state">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" primaryKeyName="pk_iris_lecture_unit_sync_state" nullable="false"/>
+            </column>
+            <column name="lecture_unit_id" type="bigint">
+                <constraints nullable="false" unique="true" uniqueConstraintName="uk_iris_lecture_unit_sync_state_lecture_unit_id"/>
+            </column>
+            <column name="metadata_hash" type="varchar(64)"/>
+            <column name="last_synced_metadata_hash" type="varchar(64)"/>
+            <column name="visibility_hash" type="varchar(64)"/>
+            <column name="last_synced_visibility_hash" type="varchar(64)"/>
+            <column name="status" type="varchar(30)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retry_count" type="integer" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="next_retry_at" type="timestamp"/>
+            <column name="last_error_key" type="varchar(255)"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseColumnNames="lecture_unit_id" baseTableName="iris_lecture_unit_sync_state"
+                                 constraintName="fk_iris_lecture_unit_sync_state_lecture_unit_id" referencedColumnNames="id" referencedTableName="lecture_unit"
+                                 onDelete="CASCADE" onUpdate="RESTRICT"/>
+
+        <createIndex indexName="idx_iris_lecture_unit_sync_state_status_retry" tableName="iris_lecture_unit_sync_state">
+            <column name="status"/>
+            <column name="next_retry_at"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -27,7 +27,6 @@
     <include file="classpath:config/liquibase/changelog/20260715120000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260718160235_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260720120000_changelog.xml" relativeToChangelogFile="false"/>
-    <include file="classpath:config/liquibase/changelog/20260702120000_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command "date '+%Y%m%d%H%M%S'" to get the current date and time in the correct format -->

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -18,6 +18,7 @@
     <include file="classpath:config/liquibase/changelog/20260611220000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260619084135_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260620120000_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20260702120000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260702150000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260705120000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260705130000_changelog.xml" relativeToChangelogFile="false"/>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -26,6 +26,7 @@
     <include file="classpath:config/liquibase/changelog/20260715120000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260718160235_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260720120000_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20260702120000_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command "date '+%Y%m%d%H%M%S'" to get the current date and time in the correct format -->

--- a/src/main/webapp/app/lecture/manage/lecture-units/edit-attachment-video-unit/edit-attachment-video-unit.component.spec.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/edit-attachment-video-unit/edit-attachment-video-unit.component.spec.ts
@@ -102,7 +102,7 @@ describe('EditAttachmentVideoUnitComponent', () => {
         attachmentVideoUnit.releaseDate = dayjs().year(2010).month(3).date(5);
         attachmentVideoUnit.videoSource = 'https://live.rbg.tum.de';
 
-        fakeFile = new File([''], 'Test-File.pdf', { type: 'application/pdf' });
+        fakeFile = new File(['content'], 'Test-File.pdf', { type: 'application/pdf' });
 
         baseFormData = new FormData();
         baseFormData.append('file', fakeFile, 'updated file');
@@ -234,5 +234,30 @@ describe('EditAttachmentVideoUnitComponent', () => {
         const updateFormData = updateAttachmentVideoUnitSpy.mock.calls[0][2] as FormData;
         await expect(getAttachmentVideoUnitPayload(updateFormData)).resolves.toMatchObject({ attachmentUpdateIntent: AttachmentUpdateIntent.NO_FILE_CHANGE });
         expect(navigateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should treat a zero-byte file as no file change', async () => {
+        fixture.detectChanges();
+        const attachmentVideoUnitFormComponent: AttachmentVideoUnitFormComponent = fixture.debugElement.query(By.directive(AttachmentVideoUnitFormComponent)).componentInstance;
+        const attachmentVideoUnitFormData: AttachmentVideoUnitFormData = {
+            formProperties: {
+                name: attachmentVideoUnit.name,
+                description: attachmentVideoUnit.description,
+                releaseDate: attachmentVideoUnit.releaseDate,
+                version: 1,
+            },
+            fileProperties: {
+                file: new File([], 'empty.pdf', { type: 'application/pdf' }),
+                fileName: 'empty.pdf',
+            },
+        };
+        updateAttachmentVideoUnitSpy.mockReturnValue(of(new HttpResponse({ body: attachmentVideoUnit, status: 200 })));
+
+        attachmentVideoUnitFormComponent.formSubmitted.emit(attachmentVideoUnitFormData);
+        fixture.detectChanges();
+
+        const updateFormData = updateAttachmentVideoUnitSpy.mock.calls[0][2] as FormData;
+        await expect(getAttachmentVideoUnitPayload(updateFormData)).resolves.toMatchObject({ attachmentUpdateIntent: AttachmentUpdateIntent.NO_FILE_CHANGE });
+        expect(updateFormData.has('file')).toBe(false);
     });
 });

--- a/src/main/webapp/app/lecture/manage/lecture-units/edit-attachment-video-unit/edit-attachment-video-unit.component.spec.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/edit-attachment-video-unit/edit-attachment-video-unit.component.spec.ts
@@ -8,7 +8,7 @@ import { of } from 'rxjs';
 import { AttachmentVideoUnitFormComponent, AttachmentVideoUnitFormData } from '../attachment-video-unit-form/attachment-video-unit-form.component';
 import { AttachmentVideoUnitService } from '../services/attachment-video-unit.service';
 import { EditAttachmentVideoUnitComponent } from './edit-attachment-video-unit.component';
-import { AttachmentVideoUnit } from '../../../shared/entities/lecture-unit/attachmentVideoUnit.model';
+import { AttachmentUpdateIntent, AttachmentVideoUnit } from '../../../shared/entities/lecture-unit/attachmentVideoUnit.model';
 import { Attachment, AttachmentType } from '../../../shared/entities/attachment.model';
 import { HttpResponse, provideHttpClient } from '@angular/common/http';
 import { By } from '@angular/platform-browser';
@@ -32,6 +32,11 @@ describe('EditAttachmentVideoUnitComponent', () => {
     let attachmentVideoUnit: AttachmentVideoUnit;
     let baseFormData: FormData;
     let fakeFile: File;
+
+    const getAttachmentVideoUnitPayload = async (formData: FormData) => {
+        const attachmentVideoUnitPart = formData.get('attachmentVideoUnit') as Blob;
+        return JSON.parse(await attachmentVideoUnitPart.text());
+    };
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
@@ -165,6 +170,8 @@ describe('EditAttachmentVideoUnitComponent', () => {
         fixture.detectChanges();
 
         expect(updateAttachmentVideoUnitSpy).toHaveBeenCalledWith(1, 1, expect.any(FormData), undefined);
+        const updateFormData = updateAttachmentVideoUnitSpy.mock.calls[0][2] as FormData;
+        await expect(getAttachmentVideoUnitPayload(updateFormData)).resolves.toMatchObject({ attachmentUpdateIntent: AttachmentUpdateIntent.FILE_UPLOAD });
         expect(navigateSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -224,6 +231,8 @@ describe('EditAttachmentVideoUnitComponent', () => {
         fixture.detectChanges();
 
         expect(updateAttachmentVideoUnitSpy).toHaveBeenCalledWith(1, 1, expect.any(FormData), undefined);
+        const updateFormData = updateAttachmentVideoUnitSpy.mock.calls[0][2] as FormData;
+        await expect(getAttachmentVideoUnitPayload(updateFormData)).resolves.toMatchObject({ attachmentUpdateIntent: AttachmentUpdateIntent.NO_FILE_CHANGE });
         expect(navigateSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/main/webapp/app/lecture/manage/lecture-units/edit-attachment-video-unit/edit-attachment-video-unit.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/edit-attachment-video-unit/edit-attachment-video-unit.component.ts
@@ -113,19 +113,20 @@ export class EditAttachmentVideoUnitComponent implements OnInit {
             attachmentType: AttachmentType.FILE,
         });
 
+        const hasUpload = !!file && file.size > 0;
         const updatedUnit = Object.assign(new AttachmentVideoUnit(), currentUnit, {
             name,
             description,
             releaseDate,
             competencyLinks,
             videoSource,
-            attachmentUpdateIntent: file ? AttachmentUpdateIntent.FILE_UPLOAD : AttachmentUpdateIntent.NO_FILE_CHANGE,
+            attachmentUpdateIntent: hasUpload ? AttachmentUpdateIntent.FILE_UPLOAD : AttachmentUpdateIntent.NO_FILE_CHANGE,
         });
 
         this.isLoading.set(true);
 
         const formData = new FormData();
-        if (file) {
+        if (hasUpload) {
             formData.append('file', file, fileName);
         }
         formData.append('attachment', objectToJsonBlob(updatedAttachment));

--- a/src/main/webapp/app/lecture/manage/lecture-units/edit-attachment-video-unit/edit-attachment-video-unit.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/edit-attachment-video-unit/edit-attachment-video-unit.component.ts
@@ -4,7 +4,7 @@ import { onError } from 'app/foundation/util/global.utils';
 import { ActivatedRoute, Router } from '@angular/router';
 import { filter, finalize, switchMap, take } from 'rxjs/operators';
 import { AttachmentVideoUnitService } from 'app/lecture/manage/lecture-units/services/attachment-video-unit.service';
-import { AttachmentVideoUnit } from 'app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model';
+import { AttachmentUpdateIntent, AttachmentVideoUnit } from 'app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { AlertService } from 'app/foundation/service/alert.service';
 import { AttachmentVideoUnitFormComponent, AttachmentVideoUnitFormData } from 'app/lecture/manage/lecture-units/attachment-video-unit-form/attachment-video-unit-form.component';
@@ -119,6 +119,7 @@ export class EditAttachmentVideoUnitComponent implements OnInit {
             releaseDate,
             competencyLinks,
             videoSource,
+            attachmentUpdateIntent: file ? AttachmentUpdateIntent.FILE_UPLOAD : AttachmentUpdateIntent.NO_FILE_CHANGE,
         });
 
         this.isLoading.set(true);

--- a/src/main/webapp/app/lecture/manage/lecture-units/lecture-units.component.spec.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/lecture-units.component.spec.ts
@@ -390,7 +390,7 @@ describe('LectureUpdateUnitsComponent', () => {
     it('should send POST request upon attachment form submission and update units', async () => {
         const attachmentVideoUnitService = TestBed.inject(AttachmentVideoUnitService);
 
-        const fakeFile = new File([''], 'Test-File.pdf', { type: 'application/pdf' });
+        const fakeFile = new File(['content'], 'Test-File.pdf', { type: 'application/pdf' });
 
         const attachmentVideoUnitFormData: AttachmentVideoUnitFormData = {
             formProperties: {
@@ -449,7 +449,7 @@ describe('LectureUpdateUnitsComponent', () => {
     it('should send POST request upon attachment form submission and update units when editing lecture', async () => {
         const attachmentVideoUnitService = TestBed.inject(AttachmentVideoUnitService);
 
-        const fakeFile = new File([''], 'Test-File.pdf', { type: 'application/pdf' });
+        const fakeFile = new File(['content'], 'Test-File.pdf', { type: 'application/pdf' });
 
         const attachmentVideoUnitFormData: AttachmentVideoUnitFormData = {
             formProperties: {
@@ -505,6 +505,20 @@ describe('LectureUpdateUnitsComponent', () => {
         await expect(getAttachmentVideoUnitPayload(updateFormData)).resolves.toMatchObject({ attachmentUpdateIntent: AttachmentUpdateIntent.FILE_UPLOAD });
         expect(updateSpy).toHaveBeenCalledTimes(1);
 
+        createAttachmentVideoUnitStub.mockClear();
+        wizardUnitComponent.isEditingLectureUnit.set(true);
+        wizardUnitComponent.currentlyProcessedAttachmentVideoUnit.set(editingAttachmentVideoUnit);
+        wizardUnitComponent.createEditAttachmentVideoUnit({
+            ...attachmentVideoUnitFormData,
+            formProperties: { ...attachmentVideoUnitFormData.formProperties, videoSource: 'https://video.example/source' },
+            fileProperties: { file: new File([], 'empty.pdf', { type: 'application/pdf' }), fileName: '' },
+        });
+        await wizardUnitComponentFixture.whenStable();
+
+        const zeroByteUpdateFormData = createAttachmentVideoUnitStub.mock.calls[0][2] as FormData;
+        await expect(getAttachmentVideoUnitPayload(zeroByteUpdateFormData)).resolves.toMatchObject({ attachmentUpdateIntent: AttachmentUpdateIntent.NO_FILE_CHANGE });
+        expect(zeroByteUpdateFormData.has('file')).toBe(false);
+
         updateSpy.mockRestore();
     });
 
@@ -512,7 +526,7 @@ describe('LectureUpdateUnitsComponent', () => {
         const attachmentVideoUnitService = TestBed.inject(AttachmentVideoUnitService);
         const alertService = TestBed.inject(AlertService);
 
-        const fakeFile = new File([''], 'Test-File.pdf', { type: 'application/pdf' });
+        const fakeFile = new File(['content'], 'Test-File.pdf', { type: 'application/pdf' });
 
         const attachmentVideoUnitFormData: AttachmentVideoUnitFormData = {
             formProperties: {
@@ -564,7 +578,7 @@ describe('LectureUpdateUnitsComponent', () => {
         const attachmentVideoUnitService = TestBed.inject(AttachmentVideoUnitService);
         const alertService = TestBed.inject(AlertService);
 
-        const fakeFile = new File([''], 'Test-File.pdf', { type: 'application/pdf' });
+        const fakeFile = new File(['content'], 'Test-File.pdf', { type: 'application/pdf' });
 
         const attachmentVideoUnitFormData: AttachmentVideoUnitFormData = {
             formProperties: {

--- a/src/main/webapp/app/lecture/manage/lecture-units/lecture-units.component.spec.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/lecture-units.component.spec.ts
@@ -20,7 +20,7 @@ import { OnlineUnitFormComponent, OnlineUnitFormData } from 'app/lecture/manage/
 import { AttachmentVideoUnitFormComponent, AttachmentVideoUnitFormData } from 'app/lecture/manage/lecture-units/attachment-video-unit-form/attachment-video-unit-form.component';
 import { OnlineUnit } from 'app/lecture/shared/entities/lecture-unit/onlineUnit.model';
 import { Attachment, AttachmentType } from 'app/lecture/shared/entities/attachment.model';
-import { AttachmentVideoUnit } from 'app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model';
+import { AttachmentUpdateIntent, AttachmentVideoUnit } from 'app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model';
 import { objectToJsonBlob } from 'app/foundation/util/blob-util';
 import { CreateExerciseUnitComponent } from 'app/lecture/manage/lecture-units/create-exercise-unit/create-exercise-unit.component';
 import { LectureUpdateUnitsComponent } from 'app/lecture/manage/lecture-units/lecture-units.component';
@@ -73,6 +73,11 @@ describe('LectureUpdateUnitsComponent', () => {
     let wizardUnitComponent: LectureUpdateUnitsComponent;
     let attachmentVideoUnitService: AttachmentVideoUnitService;
     let unitManagementComponentMock: Pick<LectureUnitManagementComponent, 'loadData'>;
+
+    const getAttachmentVideoUnitPayload = async (formData: FormData) => {
+        const attachmentVideoUnitPart = formData.get('attachmentVideoUnit') as Blob;
+        return JSON.parse(await attachmentVideoUnitPart.text());
+    };
 
     const mockUnitManagementComponent = () => {
         unitManagementComponentMock = {
@@ -496,6 +501,8 @@ describe('LectureUpdateUnitsComponent', () => {
         await wizardUnitComponentFixture.whenStable();
 
         expect(createAttachmentVideoUnitStub).toHaveBeenCalledTimes(1);
+        const updateFormData = createAttachmentVideoUnitStub.mock.calls[0][2] as FormData;
+        await expect(getAttachmentVideoUnitPayload(updateFormData)).resolves.toMatchObject({ attachmentUpdateIntent: AttachmentUpdateIntent.FILE_UPLOAD });
         expect(updateSpy).toHaveBeenCalledTimes(1);
 
         updateSpy.mockRestore();

--- a/src/main/webapp/app/lecture/manage/lecture-units/lecture-units.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/lecture-units.component.ts
@@ -208,13 +208,14 @@ export class LectureUpdateUnitsComponent implements OnInit {
             attachmentVideoUnit.description = description;
         }
         attachmentVideoUnit.competencyLinks = competencyLinks;
+        const hasUpload = !!file && !!fileName && file.size > 0;
         if (this.isEditingLectureUnit()) {
-            attachmentVideoUnit.attachmentUpdateIntent = file ? AttachmentUpdateIntent.FILE_UPLOAD : AttachmentUpdateIntent.NO_FILE_CHANGE;
+            attachmentVideoUnit.attachmentUpdateIntent = hasUpload ? AttachmentUpdateIntent.FILE_UPLOAD : AttachmentUpdateIntent.NO_FILE_CHANGE;
         }
         this.currentlyProcessedAttachmentVideoUnit.set(attachmentVideoUnit);
 
         const formData = new FormData();
-        if (!!file && !!fileName) {
+        if (hasUpload) {
             formData.append('file', file, fileName);
             formData.append('attachment', objectToJsonBlob(attachmentToCreateOrEdit));
         }

--- a/src/main/webapp/app/lecture/manage/lecture-units/lecture-units.component.ts
+++ b/src/main/webapp/app/lecture/manage/lecture-units/lecture-units.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, OnInit, computed, inject, input, signal, viewChi
 import { Lecture } from 'app/lecture/shared/entities/lecture.model';
 import { TextUnit } from 'app/lecture/shared/entities/lecture-unit/textUnit.model';
 import { OnlineUnit } from 'app/lecture/shared/entities/lecture-unit/onlineUnit.model';
-import { AttachmentVideoUnit } from 'app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model';
+import { AttachmentUpdateIntent, AttachmentVideoUnit } from 'app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model';
 import { TextUnitFormComponent, TextUnitFormData } from 'app/lecture/manage/lecture-units/text-unit-form/text-unit-form.component';
 import { OnlineUnitFormComponent, OnlineUnitFormData } from 'app/lecture/manage/lecture-units/online-unit-form/online-unit-form.component';
 import { AttachmentVideoUnitFormComponent, AttachmentVideoUnitFormData } from 'app/lecture/manage/lecture-units/attachment-video-unit-form/attachment-video-unit-form.component';
@@ -208,6 +208,9 @@ export class LectureUpdateUnitsComponent implements OnInit {
             attachmentVideoUnit.description = description;
         }
         attachmentVideoUnit.competencyLinks = competencyLinks;
+        if (this.isEditingLectureUnit()) {
+            attachmentVideoUnit.attachmentUpdateIntent = file ? AttachmentUpdateIntent.FILE_UPLOAD : AttachmentUpdateIntent.NO_FILE_CHANGE;
+        }
         this.currentlyProcessedAttachmentVideoUnit.set(attachmentVideoUnit);
 
         const formData = new FormData();

--- a/src/main/webapp/app/lecture/manage/pdf-preview/pdf-preview.component.spec.ts
+++ b/src/main/webapp/app/lecture/manage/pdf-preview/pdf-preview.component.spec.ts
@@ -14,6 +14,7 @@ import { LectureUnitService } from 'app/lecture/manage/lecture-units/services/le
 import { PdfEngineService } from 'app/core/pdf/pdf-engine.service';
 import { MockPdfEngineService } from 'test/helpers/mocks/service/mock-pdf-engine.service';
 import { OrderedPage, PdfPreviewComponent } from 'app/lecture/manage/pdf-preview/pdf-preview.component';
+import { AttachmentUpdateIntent } from 'app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model';
 
 describe('PdfPreviewComponent', () => {
     let component: PdfPreviewComponent;
@@ -26,6 +27,11 @@ describe('PdfPreviewComponent', () => {
     let router: { navigate: ReturnType<typeof vi.fn> };
     // Mutable route data so ngOnInit-driven tests can inject an attachment / attachmentVideoUnit resolver payload.
     let routeData: any;
+
+    const getAttachmentVideoUnitPayload = async (formData: FormData) => {
+        const attachmentVideoUnitPart = formData.get('attachmentVideoUnit') as Blob;
+        return JSON.parse(await attachmentVideoUnitPart.text());
+    };
 
     beforeEach(async () => {
         engineService = new MockPdfEngineService();
@@ -215,6 +221,11 @@ describe('PdfPreviewComponent', () => {
         await component.updateAttachmentWithFile();
 
         expect(attachmentVideoUnitService.update).toHaveBeenCalledOnce();
+        const updateFormData = attachmentVideoUnitService.update.mock.calls[0][2] as FormData;
+        await expect(getAttachmentVideoUnitPayload(updateFormData)).resolves.toMatchObject({
+            attachmentUpdateIntent: AttachmentUpdateIntent.EDITOR_PDF_CONTENT_CHANGED,
+        });
+        expect(component.attachmentVideoUnit()!.attachmentUpdateIntent).toBeUndefined();
         expect(attachmentVideoUnitService.updateStudentVersion).toHaveBeenCalledOnce();
         expect(alertService.success).toHaveBeenCalled();
     });

--- a/src/main/webapp/app/lecture/manage/pdf-preview/pdf-preview.component.ts
+++ b/src/main/webapp/app/lecture/manage/pdf-preview/pdf-preview.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, OnDestroy, OnInit, computed, effect, inject, sig
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { AttachmentService } from 'app/lecture/manage/services/attachment.service';
 import { Attachment } from 'app/lecture/shared/entities/attachment.model';
-import { AttachmentVideoUnit } from 'app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model';
+import { AttachmentUpdateIntent, AttachmentVideoUnit } from 'app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model';
 import { AttachmentVideoUnitService } from 'app/lecture/manage/lecture-units/services/attachment-video-unit.service';
 import { getErrorMessage, onError } from 'app/foundation/util/global.utils';
 import { AlertService } from 'app/foundation/service/alert.service';
@@ -552,7 +552,10 @@ export class PdfPreviewComponent implements OnInit, OnDestroy {
             const formData = new FormData();
             formData.append('file', instructorPdfFile);
             formData.append('attachment', objectToJsonBlob(this.attachmentToBeEdited()!));
-            formData.append('attachmentVideoUnit', objectToJsonBlob(this.attachmentVideoUnit()!));
+            const attachmentVideoUnit = Object.assign(new AttachmentVideoUnit(), this.attachmentVideoUnit()!, {
+                attachmentUpdateIntent: AttachmentUpdateIntent.EDITOR_PDF_CONTENT_CHANGED,
+            });
+            formData.append('attachmentVideoUnit', objectToJsonBlob(attachmentVideoUnit));
 
             void this.getFinalPageOrder().then((finalPageOrder) => {
                 formData.append(

--- a/src/main/webapp/app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model.ts
+++ b/src/main/webapp/app/lecture/shared/entities/lecture-unit/attachmentVideoUnit.model.ts
@@ -2,6 +2,12 @@ import { LectureUnit, LectureUnitType } from 'app/lecture/shared/entities/lectur
 import { Attachment } from 'app/lecture/shared/entities/attachment.model';
 import { Slide } from 'app/lecture/shared/entities/lecture-unit/slide.model';
 
+export enum AttachmentUpdateIntent {
+    NO_FILE_CHANGE = 'NO_FILE_CHANGE',
+    FILE_UPLOAD = 'FILE_UPLOAD',
+    EDITOR_PDF_CONTENT_CHANGED = 'EDITOR_PDF_CONTENT_CHANGED',
+}
+
 export class AttachmentVideoUnit extends LectureUnit {
     public description?: string;
     public attachment?: Attachment;
@@ -10,6 +16,7 @@ export class AttachmentVideoUnit extends LectureUnit {
     public videoSourceType?: 'TUM_LIVE' | 'YOUTUBE' | null;
     public youtubeVideoId?: string | null;
     public transcriptionProperties?: LectureTranscriptionDTO;
+    public attachmentUpdateIntent?: AttachmentUpdateIntent;
 
     constructor() {
         super(LectureUnitType.ATTACHMENT_VIDEO);

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/AttachmentVideoUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/AttachmentVideoUnitIntegrationTest.java
@@ -63,6 +63,7 @@ import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Slide;
+import de.tum.cit.aet.artemis.lecture.dto.AttachmentDTO;
 import de.tum.cit.aet.artemis.lecture.dto.AttachmentVideoUnitDTO;
 import de.tum.cit.aet.artemis.lecture.repository.AttachmentRepository;
 import de.tum.cit.aet.artemis.lecture.test_repository.AttachmentVideoUnitTestRepository;
@@ -200,6 +201,12 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         return new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(attachmentVideoUnitDTO).getBytes());
     }
 
+    private MockMultipartFile createAttachmentVideoUnitPart(AttachmentVideoUnitDTO attachmentVideoUnitDTO, AttachmentUpdateIntent intent) throws IOException {
+        ObjectNode attachmentVideoUnitJson = mapper.valueToTree(attachmentVideoUnitDTO);
+        attachmentVideoUnitJson.put("attachmentUpdateIntent", intent.name());
+        return new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsBytes(attachmentVideoUnitJson));
+    }
+
     private MockMultipartHttpServletRequestBuilder buildCreateAttachmentVideoUnit(@NonNull AttachmentVideoUnit attachmentVideoUnit, @NonNull Attachment attachment)
             throws Exception {
         var attachmentVideoUnitPart = new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(attachmentVideoUnit).getBytes());
@@ -316,7 +323,7 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         // Wait for async operation to complete (after attachment video unit is saved, the file gets split into slides)
         await().untilAsserted(() -> assertThat(slideRepository.findAllByAttachmentVideoUnitId(persistedAttachmentVideoUnit.id())).hasSize(SLIDE_COUNT));
         assertThat(updatedAttachmentVideoUnit.getAttachment().getId()).isEqualTo(persistedAttachment.id());
-        assertThat(updatedAttachmentVideoUnit.getAttachment().getSha256Hash()).hasSize(64);
+        assertThat(attachmentRepository.findById(persistedAttachment.id()).orElseThrow().getSha256Hash()).hasSize(64);
         assertThat(updatedAttachmentVideoUnit.getAttachment().getName()).isEqualTo("LoremIpsum");
         assertThat(updatedAttachmentVideoUnit.getCompetencyLinks()).anyMatch(link -> link.getCompetency().getId().equals(competency.getId()));
         verify(competencyProgressApi).updateProgressByLearningObjectAsync(eq(updatedAttachmentVideoUnit));
@@ -455,6 +462,23 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         request.performMvcRequest(builder).andExpect(status().isBadRequest()).andExpect(jsonPath("$.errorKey").value("fileNotAllowedForNoFileChange"));
     }
 
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateAttachmentVideoUnitNoFileChangeWithEmptyFileReturnsBadRequest() throws Exception {
+        var createResult = request.performMvcRequest(buildCreateAttachmentVideoUnit(attachmentVideoUnit, attachment)).andExpect(status().isCreated()).andReturn();
+        var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
+        var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
+
+        var attachmentVideoUnitPart = createAttachmentVideoUnitPart(persistedAttachmentVideoUnit, AttachmentUpdateIntent.NO_FILE_CHANGE);
+        var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsBytes(persistedAttachment));
+        var emptyFilePart = new MockMultipartFile("file", "empty.pdf", MediaType.APPLICATION_PDF_VALUE, new byte[0]);
+        var builder = MockMvcRequestBuilders
+                .multipart(HttpMethod.PUT, "/api/lecture/lectures/" + lecture1.getId() + "/attachment-video-units/" + persistedAttachmentVideoUnit.getId())
+                .file(attachmentVideoUnitPart).file(attachmentPart).file(emptyFilePart).contentType(MediaType.MULTIPART_FORM_DATA_VALUE);
+
+        request.performMvcRequest(builder).andExpect(status().isBadRequest()).andExpect(jsonPath("$.errorKey").value("fileNotAllowedForNoFileChange"));
+    }
+
     @ParameterizedTest
     @EnumSource(value = AttachmentUpdateIntent.class, names = { "FILE_UPLOAD", "EDITOR_PDF_CONTENT_CHANGED" })
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
@@ -464,6 +488,21 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
 
         var builder = buildUpdateAttachmentVideoUnit(persistedAttachmentVideoUnit, persistedAttachment, null, true, intent);
+
+        request.performMvcRequest(builder).andExpect(status().isBadRequest()).andExpect(jsonPath("$.errorKey").value("fileRequiredForFileChange"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AttachmentUpdateIntent.class, names = { "FILE_UPLOAD", "EDITOR_PDF_CONTENT_CHANGED" })
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateAttachmentVideoUnitFileChangeWithoutAttachmentMetadataReturnsBadRequest(AttachmentUpdateIntent intent) throws Exception {
+        var createResult = request.performMvcRequest(buildCreateAttachmentVideoUnit(attachmentVideoUnit, attachment)).andExpect(status().isCreated()).andReturn();
+        var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
+
+        var attachmentVideoUnitPart = createAttachmentVideoUnitPart(persistedAttachmentVideoUnit, intent);
+        var builder = MockMvcRequestBuilders
+                .multipart(HttpMethod.PUT, "/api/lecture/lectures/" + lecture1.getId() + "/attachment-video-units/" + persistedAttachmentVideoUnit.getId())
+                .file(attachmentVideoUnitPart).file(createAttachmentVideoUnitPdf()).contentType(MediaType.MULTIPART_FORM_DATA_VALUE);
 
         request.performMvcRequest(builder).andExpect(status().isBadRequest()).andExpect(jsonPath("$.errorKey").value("fileRequiredForFileChange"));
     }
@@ -485,7 +524,37 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
 
         assertThat(updatedAttachmentVideoUnit.getAttachment().getVersion()).isEqualTo(originalVersion);
         assertThat(updatedAttachmentVideoUnit.getAttachment().getLink()).isEqualTo(originalLink);
-        assertThat(updatedAttachmentVideoUnit.getAttachment().getSha256Hash()).hasSize(64);
+        assertThat(attachmentRepository.findById(persistedAttachment.getId()).orElseThrow().getSha256Hash()).hasSize(64);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void createAttachmentVideoUnitWithExternalAttachmentLinkPersistsAttachment() throws Exception {
+        attachment.setLink("https://example.org/lecture-notes.pdf");
+        var attachmentVideoUnitPart = new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE,
+                mapper.writeValueAsBytes(AttachmentVideoUnitDTO.of(attachmentVideoUnit)));
+        var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsBytes(AttachmentDTO.of(attachment)));
+        var builder = MockMvcRequestBuilders.multipart(HttpMethod.POST, "/api/lecture/lectures/" + lecture1.getId() + "/attachment-video-units").file(attachmentVideoUnitPart)
+                .file(attachmentPart).contentType(MediaType.MULTIPART_FORM_DATA_VALUE);
+
+        var result = request.performMvcRequest(builder).andExpect(status().isCreated()).andReturn();
+        var persistedUnit = mapper.readValue(result.getResponse().getContentAsString(), AttachmentVideoUnitDTO.class);
+
+        assertThat(persistedUnit.attachment()).isNotNull();
+        assertThat(persistedUnit.attachment().link()).isEqualTo("https://example.org/lecture-notes.pdf");
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void createAttachmentVideoUnitWithFilelessEmptyAttachmentReturnsBadRequest() throws Exception {
+        attachment.setLink(" ");
+        var attachmentVideoUnitPart = new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE,
+                mapper.writeValueAsBytes(AttachmentVideoUnitDTO.of(attachmentVideoUnit)));
+        var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsBytes(AttachmentDTO.of(attachment)));
+        var builder = MockMvcRequestBuilders.multipart(HttpMethod.POST, "/api/lecture/lectures/" + lecture1.getId() + "/attachment-video-units").file(attachmentVideoUnitPart)
+                .file(attachmentPart).contentType(MediaType.MULTIPART_FORM_DATA_VALUE);
+
+        request.performMvcRequest(builder).andExpect(status().isBadRequest()).andExpect(jsonPath("$.errorKey").value("attachmentLinkRequired"));
     }
 
     @Test
@@ -507,7 +576,7 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
 
         assertThat(updatedAttachmentVideoUnit.getAttachment().getVersion()).isEqualTo(originalVersion);
         assertThat(updatedAttachmentVideoUnit.getAttachment().getLink()).isEqualTo(originalLink);
-        assertThat(updatedAttachmentVideoUnit.getAttachment().getSha256Hash()).hasSize(64);
+        assertThat(attachmentRepository.findById(persistedAttachment.getId()).orElseThrow().getSha256Hash()).hasSize(64);
     }
 
     @Test
@@ -517,7 +586,7 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
         var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
         int originalVersion = persistedAttachment.getVersion();
-        String originalHash = persistedAttachment.getSha256Hash();
+        String originalHash = attachmentRepository.findById(persistedAttachment.getId()).orElseThrow().getSha256Hash();
 
         await().untilAsserted(() -> assertThat(slideRepository.findAllByAttachmentVideoUnitId(persistedAttachmentVideoUnit.getId())).hasSize(SLIDE_COUNT));
 
@@ -525,8 +594,9 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         var updatedAttachmentVideoUnit = updateAttachmentVideoUnitWithFile(persistedAttachmentVideoUnit, persistedAttachment, changedFile);
 
         assertThat(updatedAttachmentVideoUnit.getAttachment().getVersion()).isEqualTo(originalVersion + 1);
-        assertThat(updatedAttachmentVideoUnit.getAttachment().getSha256Hash()).hasSize(64);
-        assertThat(updatedAttachmentVideoUnit.getAttachment().getSha256Hash()).isNotEqualTo(originalHash);
+        String updatedHash = attachmentRepository.findById(persistedAttachment.getId()).orElseThrow().getSha256Hash();
+        assertThat(updatedHash).hasSize(64);
+        assertThat(updatedHash).isNotEqualTo(originalHash);
     }
 
     @Test
@@ -543,7 +613,7 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         var updatedAttachmentVideoUnit = updateAttachmentVideoUnitWithFile(persistedAttachmentVideoUnit, persistedAttachment, byteDifferentFileWithSameVisualContent);
 
         assertThat(updatedAttachmentVideoUnit.getAttachment().getVersion()).isEqualTo(originalVersion + 1);
-        assertThat(updatedAttachmentVideoUnit.getAttachment().getSha256Hash()).hasSize(64);
+        assertThat(attachmentRepository.findById(persistedAttachment.getId()).orElseThrow().getSha256Hash()).hasSize(64);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/AttachmentVideoUnitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/AttachmentVideoUnitIntegrationTest.java
@@ -10,11 +10,10 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -31,16 +30,17 @@ import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
-import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
-import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.client.ExpectedCount;
@@ -48,13 +48,17 @@ import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequ
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import de.tum.cit.aet.artemis.atlas.competency.util.CompetencyUtilService;
 import de.tum.cit.aet.artemis.atlas.domain.competency.Competency;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyLectureUnitLink;
+import de.tum.cit.aet.artemis.core.FilePathType;
 import de.tum.cit.aet.artemis.core.connector.IrisRequestMockProvider;
 import de.tum.cit.aet.artemis.core.security.SecurityUtils;
+import de.tum.cit.aet.artemis.core.util.FilePathConverter;
 import de.tum.cit.aet.artemis.lecture.domain.Attachment;
+import de.tum.cit.aet.artemis.lecture.domain.AttachmentUpdateIntent;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
@@ -76,6 +80,9 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
 
     @Autowired
     private AttachmentRepository attachmentRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @Autowired
     private AttachmentVideoUnitTestRepository attachmentVideoUnitRepository;
@@ -144,12 +151,22 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
 
     private MockMultipartHttpServletRequestBuilder buildUpdateAttachmentVideoUnit(@NonNull AttachmentVideoUnit attachmentVideoUnit, @NonNull Attachment attachment)
             throws Exception {
-        return buildUpdateAttachmentVideoUnit(attachmentVideoUnit, attachment, null, true);
+        return buildUpdateAttachmentVideoUnit(attachmentVideoUnit, attachment, null, true, AttachmentUpdateIntent.NO_FILE_CHANGE);
     }
 
     private MockMultipartHttpServletRequestBuilder buildUpdateAttachmentVideoUnit(@NonNull AttachmentVideoUnit attachmentVideoUnit, @NonNull Attachment attachment,
             String fileContent, boolean contentType) throws Exception {
-        MockMultipartHttpServletRequestBuilder builder = buildUpdateAttachmentVideoUnit(attachmentVideoUnit, attachment, fileContent);
+        AttachmentUpdateIntent intent = fileContent == null ? AttachmentUpdateIntent.NO_FILE_CHANGE : AttachmentUpdateIntent.FILE_UPLOAD;
+        MockMultipartHttpServletRequestBuilder builder = buildUpdateAttachmentVideoUnit(attachmentVideoUnit, attachment, fileContent, intent);
+        if (contentType) {
+            builder.contentType(MediaType.MULTIPART_FORM_DATA_VALUE);
+        }
+        return builder;
+    }
+
+    private MockMultipartHttpServletRequestBuilder buildUpdateAttachmentVideoUnit(@NonNull AttachmentVideoUnit attachmentVideoUnit, @NonNull Attachment attachment,
+            String fileContent, boolean contentType, AttachmentUpdateIntent intent) throws Exception {
+        MockMultipartHttpServletRequestBuilder builder = buildUpdateAttachmentVideoUnit(attachmentVideoUnit, attachment, fileContent, intent);
         if (contentType) {
             builder.contentType(MediaType.MULTIPART_FORM_DATA_VALUE);
         }
@@ -158,7 +175,13 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
 
     private MockMultipartHttpServletRequestBuilder buildUpdateAttachmentVideoUnit(@NonNull AttachmentVideoUnit attachmentVideoUnit, @NonNull Attachment attachment,
             String fileContent) throws Exception {
-        var attachmentVideoUnitPart = new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(attachmentVideoUnit).getBytes());
+        AttachmentUpdateIntent intent = fileContent == null ? AttachmentUpdateIntent.NO_FILE_CHANGE : AttachmentUpdateIntent.FILE_UPLOAD;
+        return buildUpdateAttachmentVideoUnit(attachmentVideoUnit, attachment, fileContent, intent);
+    }
+
+    private MockMultipartHttpServletRequestBuilder buildUpdateAttachmentVideoUnit(@NonNull AttachmentVideoUnit attachmentVideoUnit, @NonNull Attachment attachment,
+            String fileContent, AttachmentUpdateIntent intent) throws Exception {
+        var attachmentVideoUnitPart = createAttachmentVideoUnitPart(attachmentVideoUnit, intent);
         var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(attachment).getBytes());
 
         var builder = MockMvcRequestBuilders.multipart(HttpMethod.PUT, "/api/lecture/lectures/" + lecture1.getId() + "/attachment-video-units/" + attachmentVideoUnit.getId());
@@ -170,6 +193,11 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         }
 
         return builder.file(attachmentVideoUnitPart).file(attachmentPart);
+    }
+
+    private MockMultipartFile createAttachmentVideoUnitPart(AttachmentVideoUnit attachmentVideoUnit, AttachmentUpdateIntent intent) throws IOException {
+        AttachmentVideoUnitDTO attachmentVideoUnitDTO = AttachmentVideoUnitDTO.from(attachmentVideoUnit, intent);
+        return new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(attachmentVideoUnitDTO).getBytes());
     }
 
     private MockMultipartHttpServletRequestBuilder buildCreateAttachmentVideoUnit(@NonNull AttachmentVideoUnit attachmentVideoUnit, @NonNull Attachment attachment)
@@ -192,8 +220,7 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
     }
 
     /**
-     * Generates an attachment video unit pdf file using the given body text on its content pages. Two PDFs generated with the same body text have identical extractable text
-     * (even though their raw bytes differ), which is what the content-fingerprint comparison relies on.
+     * Generates an attachment video unit pdf file using the given body text on its content pages.
      *
      * @param bodyText the text rendered on the content pages
      * @return MockMultipartFile attachment video unit pdf file
@@ -233,77 +260,16 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         }
     }
 
-    /**
-     * Generates a PDF with the default text on every page and a solid-color image of the given color embedded on the first page. The text and page count are independent of the
-     * color, so two PDFs that differ only in {@code imageColor} have the same extracted text and page count but different embedded images.
-     *
-     * @param imageColor the color of the embedded image
-     * @return MockMultipartFile attachment video unit pdf file containing an embedded image
-     */
-    private MockMultipartFile createAttachmentVideoUnitPdfWithImage(Color imageColor) throws IOException {
-        var font = new PDType1Font(Standard14Fonts.FontName.TIMES_ROMAN);
-
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(); PDDocument document = new PDDocument()) {
-            BufferedImage bufferedImage = new BufferedImage(50, 50, BufferedImage.TYPE_INT_RGB);
-            Graphics2D graphics = bufferedImage.createGraphics();
-            graphics.setColor(imageColor);
-            graphics.fillRect(0, 0, 50, 50);
-            graphics.dispose();
-            PDImageXObject image = LosslessFactory.createFromImage(document, bufferedImage);
-
-            for (int i = 1; i <= SLIDE_COUNT; i++) {
-                document.addPage(new PDPage());
-                try (PDPageContentStream contentStream = new PDPageContentStream(document, document.getPage(i - 1))) {
-                    contentStream.beginText();
-                    contentStream.setFont(font, 12);
-                    contentStream.newLineAtOffset(25, 500);
-                    contentStream.showText("This is the sample document");
-                    contentStream.endText();
-                    if (i == 1) {
-                        contentStream.drawImage(image, 25, 25, 50, 50);
-                    }
-                }
-            }
-            document.save(outputStream);
-            return new MockMultipartFile("file", "lectureFile.pdf", "application/pdf", outputStream.toByteArray());
-        }
-    }
-
-    /**
-     * Generates a PDF with the default text on every page and a filled vector rectangle (not an embedded image) of the given width on the first page. Two PDFs that differ only in
-     * {@code rectangleWidth} have the same text, page count and no embedded images, but differ visually only in their vector graphics.
-     *
-     * @param rectangleWidth the width of the vector rectangle
-     * @return MockMultipartFile attachment video unit pdf file containing a vector graphic
-     */
-    private MockMultipartFile createAttachmentVideoUnitPdfWithVectorGraphic(float rectangleWidth) throws IOException {
-        var font = new PDType1Font(Standard14Fonts.FontName.TIMES_ROMAN);
-
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(); PDDocument document = new PDDocument()) {
-            for (int i = 1; i <= SLIDE_COUNT; i++) {
-                document.addPage(new PDPage());
-                try (PDPageContentStream contentStream = new PDPageContentStream(document, document.getPage(i - 1))) {
-                    contentStream.beginText();
-                    contentStream.setFont(font, 12);
-                    contentStream.newLineAtOffset(25, 500);
-                    contentStream.showText("This is the sample document");
-                    contentStream.endText();
-                    if (i == 1) {
-                        contentStream.addRect(100, 100, rectangleWidth, 100);
-                        contentStream.fill();
-                    }
-                }
-            }
-            document.save(outputStream);
-            return new MockMultipartFile("file", "lectureFile.pdf", "application/pdf", outputStream.toByteArray());
-        }
-    }
-
     private AttachmentVideoUnit updateAttachmentVideoUnitWithFile(AttachmentVideoUnit attachmentVideoUnit, Attachment attachment, MockMultipartFile file) throws Exception {
-        var builder = buildUpdateAttachmentVideoUnit(attachmentVideoUnit, attachment, null);
+        var builder = buildUpdateAttachmentVideoUnit(attachmentVideoUnit, attachment, null, AttachmentUpdateIntent.FILE_UPLOAD);
         builder.file(file).contentType(MediaType.MULTIPART_FORM_DATA_VALUE).param("keepFilename", "true");
         var result = request.performMvcRequest(builder).andExpect(status().isOk()).andReturn();
         return mapper.readValue(result.getResponse().getContentAsString(), AttachmentVideoUnit.class);
+    }
+
+    private MockMultipartFile createAttachmentVideoUnitPdfFromStoredAttachment(Attachment attachment) throws IOException {
+        Path storedFilePath = FilePathConverter.fileSystemPathForExternalUri(URI.create(attachment.getLink()), FilePathType.ATTACHMENT_UNIT);
+        return new MockMultipartFile("file", storedFilePath.getFileName().toString(), "application/pdf", Files.readAllBytes(storedFilePath));
     }
 
     @Test
@@ -327,7 +293,8 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         lectureUtilService.addLectureUnitsToLecture(lecture1, List.of(attachmentVideoUnit));
 
         String fileName = Path.of(attachmentVideoUnit.getAttachment().getLink()).getFileName().toString();
-        MockMultipartHttpServletRequestBuilder attachmentVideoUnitBuilder = buildUpdateAttachmentVideoUnit(attachmentVideoUnit, attachmentVideoUnit.getAttachment(), null);
+        MockMultipartHttpServletRequestBuilder attachmentVideoUnitBuilder = buildUpdateAttachmentVideoUnit(attachmentVideoUnit, attachmentVideoUnit.getAttachment(), null,
+                AttachmentUpdateIntent.FILE_UPLOAD);
         MockMultipartFile file = new MockMultipartFile("file", fileName, "application/json", "test".getBytes());
         attachmentVideoUnitBuilder.file(file).contentType(MediaType.MULTIPART_FORM_DATA_VALUE).param("keepFilename", "true");
         AttachmentVideoUnitDTO updatedAttachmentVideoUnit = request.getObjectMapper().readValue(
@@ -349,6 +316,7 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         // Wait for async operation to complete (after attachment video unit is saved, the file gets split into slides)
         await().untilAsserted(() -> assertThat(slideRepository.findAllByAttachmentVideoUnitId(persistedAttachmentVideoUnit.id())).hasSize(SLIDE_COUNT));
         assertThat(updatedAttachmentVideoUnit.getAttachment().getId()).isEqualTo(persistedAttachment.id());
+        assertThat(updatedAttachmentVideoUnit.getAttachment().getSha256Hash()).hasSize(64);
         assertThat(updatedAttachmentVideoUnit.getAttachment().getName()).isEqualTo("LoremIpsum");
         assertThat(updatedAttachmentVideoUnit.getCompetencyLinks()).anyMatch(link -> link.getCompetency().getId().equals(competency.getId()));
         verify(competencyProgressApi).updateProgressByLearningObjectAsync(eq(updatedAttachmentVideoUnit));
@@ -451,7 +419,58 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void updateAttachmentVideoUnit_reUploadingSameContent_shouldNotBumpVersion() throws Exception {
+    void updateAttachmentVideoUnitWithoutIntentReturnsBadRequest() throws Exception {
+        var createResult = request.performMvcRequest(buildCreateAttachmentVideoUnit(attachmentVideoUnit, attachment)).andExpect(status().isCreated()).andReturn();
+        var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
+        var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
+
+        var attachmentVideoUnitPart = new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE,
+                mapper.writeValueAsString(persistedAttachmentVideoUnit).getBytes());
+        var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(persistedAttachment).getBytes());
+
+        var builder = MockMvcRequestBuilders
+                .multipart(HttpMethod.PUT, "/api/lecture/lectures/" + lecture1.getId() + "/attachment-video-units/" + persistedAttachmentVideoUnit.getId())
+                .file(attachmentVideoUnitPart).file(attachmentPart).contentType(MediaType.MULTIPART_FORM_DATA_VALUE);
+
+        request.performMvcRequest(builder).andExpect(status().isBadRequest()).andExpect(jsonPath("$.errorKey").value("attachmentUpdateIntentRequired"));
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateAttachmentVideoUnitNoFileChangeWithFileReturnsBadRequest() throws Exception {
+        var createResult = request.performMvcRequest(buildCreateAttachmentVideoUnit(attachmentVideoUnit, attachment)).andExpect(status().isCreated()).andReturn();
+        var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
+        var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
+
+        ObjectNode attachmentVideoUnitJson = mapper.valueToTree(persistedAttachmentVideoUnit);
+        attachmentVideoUnitJson.put("attachmentUpdateIntent", "NO_FILE_CHANGE");
+        var attachmentVideoUnitPart = new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE,
+                mapper.writeValueAsString(attachmentVideoUnitJson).getBytes());
+        var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(persistedAttachment).getBytes());
+
+        var builder = MockMvcRequestBuilders
+                .multipart(HttpMethod.PUT, "/api/lecture/lectures/" + lecture1.getId() + "/attachment-video-units/" + persistedAttachmentVideoUnit.getId())
+                .file(attachmentVideoUnitPart).file(attachmentPart).file(createAttachmentVideoUnitPdf()).contentType(MediaType.MULTIPART_FORM_DATA_VALUE);
+
+        request.performMvcRequest(builder).andExpect(status().isBadRequest()).andExpect(jsonPath("$.errorKey").value("fileNotAllowedForNoFileChange"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = AttachmentUpdateIntent.class, names = { "FILE_UPLOAD", "EDITOR_PDF_CONTENT_CHANGED" })
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateAttachmentVideoUnitFileChangeWithoutFileReturnsBadRequest(AttachmentUpdateIntent intent) throws Exception {
+        var createResult = request.performMvcRequest(buildCreateAttachmentVideoUnit(attachmentVideoUnit, attachment)).andExpect(status().isCreated()).andReturn();
+        var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
+        var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
+
+        var builder = buildUpdateAttachmentVideoUnit(persistedAttachmentVideoUnit, persistedAttachment, null, true, intent);
+
+        request.performMvcRequest(builder).andExpect(status().isBadRequest()).andExpect(jsonPath("$.errorKey").value("fileRequiredForFileChange"));
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateAttachmentVideoUnitWithIdenticalUploadDoesNotBumpVersion() throws Exception {
         var createResult = request.performMvcRequest(buildCreateAttachmentVideoUnit(attachmentVideoUnit, attachment)).andExpect(status().isCreated()).andReturn();
         var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
         var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
@@ -461,81 +480,79 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         // Wait for the initial slide splitting to finish before re-uploading
         await().untilAsserted(() -> assertThat(slideRepository.findAllByAttachmentVideoUnitId(persistedAttachmentVideoUnit.getId())).hasSize(SLIDE_COUNT));
 
-        // Re-upload a freshly generated PDF with identical content. Its raw bytes differ (like the pdf-preview client re-serializing the PDF), but its extracted text is the same,
-        // so the version and stored file must stay unchanged.
-        var sameContentFile = createAttachmentVideoUnitPdf();
-        var sameBuilder = buildUpdateAttachmentVideoUnit(persistedAttachmentVideoUnit, persistedAttachment, null);
-        sameBuilder.file(sameContentFile).contentType(MediaType.MULTIPART_FORM_DATA_VALUE).param("keepFilename", "true");
-        var sameResult = request.performMvcRequest(sameBuilder).andExpect(status().isOk()).andReturn();
-        var afterSameUpload = mapper.readValue(sameResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
-        assertThat(afterSameUpload.getAttachment().getVersion()).isEqualTo(originalVersion);
-        assertThat(afterSameUpload.getAttachment().getLink()).isEqualTo(originalLink);
+        var identicalStoredFile = createAttachmentVideoUnitPdfFromStoredAttachment(persistedAttachment);
+        var updatedAttachmentVideoUnit = updateAttachmentVideoUnitWithFile(persistedAttachmentVideoUnit, persistedAttachment, identicalStoredFile);
 
-        // Uploading a PDF with genuinely different content must bump the version
-        var changedFile = createAttachmentVideoUnitPdf("a completely different lecture body");
-        var changedBuilder = buildUpdateAttachmentVideoUnit(persistedAttachmentVideoUnit, afterSameUpload.getAttachment(), null);
-        changedBuilder.file(changedFile).contentType(MediaType.MULTIPART_FORM_DATA_VALUE).param("keepFilename", "true");
-        var changedResult = request.performMvcRequest(changedBuilder).andExpect(status().isOk()).andReturn();
-        var afterChangedUpload = mapper.readValue(changedResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
-        assertThat(afterChangedUpload.getAttachment().getVersion()).isEqualTo(originalVersion + 1);
+        assertThat(updatedAttachmentVideoUnit.getAttachment().getVersion()).isEqualTo(originalVersion);
+        assertThat(updatedAttachmentVideoUnit.getAttachment().getLink()).isEqualTo(originalLink);
+        assertThat(updatedAttachmentVideoUnit.getAttachment().getSha256Hash()).hasSize(64);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void updateAttachmentVideoUnit_withSameTextButChangedImage_shouldBumpVersion() throws Exception {
-        var createResult = request.performMvcRequest(buildCreateAttachmentVideoUnit(attachmentVideoUnit, attachment)).andExpect(status().isCreated()).andReturn();
-        var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
-        var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
-        int originalVersion = persistedAttachment.getVersion();
-
-        await().untilAsserted(() -> assertThat(slideRepository.findAllByAttachmentVideoUnitId(persistedAttachmentVideoUnit.getId())).hasSize(SLIDE_COUNT));
-
-        // Upload a PDF with the same text and page count but an embedded image -> visual content changed -> version bumps
-        var afterImageA = updateAttachmentVideoUnitWithFile(persistedAttachmentVideoUnit, persistedAttachment, createAttachmentVideoUnitPdfWithImage(Color.RED));
-        int versionAfterImageA = afterImageA.getAttachment().getVersion();
-        assertThat(versionAfterImageA).isEqualTo(originalVersion + 1);
-
-        // Re-upload the same text and the same image (freshly generated, different raw bytes) -> content unchanged -> no bump
-        var afterImageAagain = updateAttachmentVideoUnitWithFile(persistedAttachmentVideoUnit, afterImageA.getAttachment(), createAttachmentVideoUnitPdfWithImage(Color.RED));
-        assertThat(afterImageAagain.getAttachment().getVersion()).isEqualTo(versionAfterImageA);
-
-        // Upload a PDF with the same text and page count but a different image -> visual content changed -> version bumps again
-        var afterImageB = updateAttachmentVideoUnitWithFile(persistedAttachmentVideoUnit, afterImageAagain.getAttachment(), createAttachmentVideoUnitPdfWithImage(Color.BLUE));
-        assertThat(afterImageB.getAttachment().getVersion()).isEqualTo(versionAfterImageA + 1);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void updateAttachmentVideoUnit_withSameTextButChangedVectorGraphic_shouldBumpVersion() throws Exception {
-        var createResult = request.performMvcRequest(buildCreateAttachmentVideoUnit(attachmentVideoUnit, attachment)).andExpect(status().isCreated()).andReturn();
-        var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
-        var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
-        int originalVersion = persistedAttachment.getVersion();
-
-        await().untilAsserted(() -> assertThat(slideRepository.findAllByAttachmentVideoUnitId(persistedAttachmentVideoUnit.getId())).hasSize(SLIDE_COUNT));
-
-        // Upload a PDF with the same text and page count but a vector graphic (no embedded image) -> visual content changed -> version bumps
-        var afterShapeA = updateAttachmentVideoUnitWithFile(persistedAttachmentVideoUnit, persistedAttachment, createAttachmentVideoUnitPdfWithVectorGraphic(200));
-        int versionAfterShapeA = afterShapeA.getAttachment().getVersion();
-        assertThat(versionAfterShapeA).isEqualTo(originalVersion + 1);
-
-        // Re-upload the same vector graphic (freshly generated, different raw bytes) -> content unchanged -> no bump
-        var afterShapeAagain = updateAttachmentVideoUnitWithFile(persistedAttachmentVideoUnit, afterShapeA.getAttachment(), createAttachmentVideoUnitPdfWithVectorGraphic(200));
-        assertThat(afterShapeAagain.getAttachment().getVersion()).isEqualTo(versionAfterShapeA);
-
-        // Upload a PDF whose only difference is the vector graphic (different rectangle size, same text/page count) -> version bumps again
-        var afterShapeB = updateAttachmentVideoUnitWithFile(persistedAttachmentVideoUnit, afterShapeAagain.getAttachment(), createAttachmentVideoUnitPdfWithVectorGraphic(100));
-        assertThat(afterShapeB.getAttachment().getVersion()).isEqualTo(versionAfterShapeA + 1);
-    }
-
-    @Test
-    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void updateAttachmentVideoUnit_withSameContentButChangedHiddenPages_shouldApplyHiddenWithoutBumpingVersion() throws Exception {
+    void updateAttachmentVideoUnitWithIdenticalUploadBackfillsMissingHashWithoutBumpingVersion() throws Exception {
         var createResult = request.performMvcRequest(buildCreateAttachmentVideoUnit(attachmentVideoUnit, attachment)).andExpect(status().isCreated()).andReturn();
         var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
         var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
         int originalVersion = persistedAttachment.getVersion();
         String originalLink = persistedAttachment.getLink();
+
+        await().untilAsserted(() -> assertThat(slideRepository.findAllByAttachmentVideoUnitId(persistedAttachmentVideoUnit.getId())).hasSize(SLIDE_COUNT));
+
+        jdbcTemplate.update("UPDATE attachment SET sha256_hash = NULL WHERE id = ?", persistedAttachment.getId());
+        persistedAttachment.setSha256Hash(null);
+
+        var identicalStoredFile = createAttachmentVideoUnitPdfFromStoredAttachment(persistedAttachment);
+        var updatedAttachmentVideoUnit = updateAttachmentVideoUnitWithFile(persistedAttachmentVideoUnit, persistedAttachment, identicalStoredFile);
+
+        assertThat(updatedAttachmentVideoUnit.getAttachment().getVersion()).isEqualTo(originalVersion);
+        assertThat(updatedAttachmentVideoUnit.getAttachment().getLink()).isEqualTo(originalLink);
+        assertThat(updatedAttachmentVideoUnit.getAttachment().getSha256Hash()).hasSize(64);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateAttachmentVideoUnitWithDifferentUploadBumpsVersionAndStoresHash() throws Exception {
+        var createResult = request.performMvcRequest(buildCreateAttachmentVideoUnit(attachmentVideoUnit, attachment)).andExpect(status().isCreated()).andReturn();
+        var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
+        var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
+        int originalVersion = persistedAttachment.getVersion();
+        String originalHash = persistedAttachment.getSha256Hash();
+
+        await().untilAsserted(() -> assertThat(slideRepository.findAllByAttachmentVideoUnitId(persistedAttachmentVideoUnit.getId())).hasSize(SLIDE_COUNT));
+
+        var changedFile = createAttachmentVideoUnitPdf("a completely different lecture body");
+        var updatedAttachmentVideoUnit = updateAttachmentVideoUnitWithFile(persistedAttachmentVideoUnit, persistedAttachment, changedFile);
+
+        assertThat(updatedAttachmentVideoUnit.getAttachment().getVersion()).isEqualTo(originalVersion + 1);
+        assertThat(updatedAttachmentVideoUnit.getAttachment().getSha256Hash()).hasSize(64);
+        assertThat(updatedAttachmentVideoUnit.getAttachment().getSha256Hash()).isNotEqualTo(originalHash);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateAttachmentVideoUnitWithVisuallyIdenticalButByteDifferentUploadBumpsVersion() throws Exception {
+        var createResult = request.performMvcRequest(buildCreateAttachmentVideoUnit(attachmentVideoUnit, attachment)).andExpect(status().isCreated()).andReturn();
+        var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
+        var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
+        int originalVersion = persistedAttachment.getVersion();
+
+        await().untilAsserted(() -> assertThat(slideRepository.findAllByAttachmentVideoUnitId(persistedAttachmentVideoUnit.getId())).hasSize(SLIDE_COUNT));
+
+        var byteDifferentFileWithSameVisualContent = createAttachmentVideoUnitPdf();
+        var updatedAttachmentVideoUnit = updateAttachmentVideoUnitWithFile(persistedAttachmentVideoUnit, persistedAttachment, byteDifferentFileWithSameVisualContent);
+
+        assertThat(updatedAttachmentVideoUnit.getAttachment().getVersion()).isEqualTo(originalVersion + 1);
+        assertThat(updatedAttachmentVideoUnit.getAttachment().getSha256Hash()).hasSize(64);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void updateAttachmentVideoUnit_withByteDifferentFileAndChangedHiddenPages_shouldApplyHiddenAndBumpVersion() throws Exception {
+        var createResult = request.performMvcRequest(buildCreateAttachmentVideoUnit(attachmentVideoUnit, attachment)).andExpect(status().isCreated()).andReturn();
+        var persistedAttachmentVideoUnit = mapper.readValue(createResult.getResponse().getContentAsString(), AttachmentVideoUnit.class);
+        var persistedAttachment = persistedAttachmentVideoUnit.getAttachment();
+        int originalVersion = persistedAttachment.getVersion();
 
         await().untilAsserted(() -> assertThat(slideRepository.findAllByAttachmentVideoUnitId(persistedAttachmentVideoUnit.getId())).hasSize(SLIDE_COUNT));
 
@@ -545,15 +562,14 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         assertThat(slides).allMatch(slide -> slide.getHidden() == null);
         Long hiddenSlideId = slides.getFirst().getId();
 
-        // Simulate the real hidden-slide edit: the client re-serializes the PDF (different bytes, same content) and changes only the hidden-slide metadata
+        // SHA-256 file identity treats a re-serialized PDF with different bytes as a content change. Task 4 will add a metadata-only path; Task 3 still bumps the version.
         var reSerializedFile = createAttachmentVideoUnitPdf();
         String futureDate = ZonedDateTime.now().plusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
         String hiddenPagesJson = "[{\"slideId\": \"" + hiddenSlideId + "\", \"date\": \"" + futureDate + "\"}]";
         String pageOrderJson = slides.stream().map(slide -> "{\"slideId\": \"" + slide.getId() + "\", \"order\": " + slide.getSlideNumber() + "}")
                 .collect(Collectors.joining(",", "[", "]"));
 
-        var attachmentUnitPart = new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE,
-                mapper.writeValueAsString(persistedAttachmentVideoUnit).getBytes());
+        var attachmentUnitPart = createAttachmentVideoUnitPart(persistedAttachmentVideoUnit, AttachmentUpdateIntent.FILE_UPLOAD);
         var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(persistedAttachment).getBytes());
         var hiddenPagesPart = new MockMultipartFile("hiddenPages", "", MediaType.APPLICATION_JSON_VALUE, hiddenPagesJson.getBytes());
         var pageOrderPart = new MockMultipartFile("pageOrder", "", MediaType.APPLICATION_JSON_VALUE, pageOrderJson.getBytes());
@@ -564,13 +580,13 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
                 .param("keepFilename", "true");
         request.performMvcRequest(builder).andExpect(status().isOk());
 
-        // The hidden-slide metadata must be applied even though the PDF content (and therefore the version) did not change
+        // The hidden-slide metadata must still be applied while the byte-different upload bumps the attachment version.
         await().untilAsserted(() -> assertThat(slideRepository.findById(hiddenSlideId).orElseThrow().getHidden()).isNotNull());
 
-        // The version and stored file must stay unchanged because the PDF content did not change
+        // The version changes because Task 3 compares file bytes, not rendered PDF content.
         Attachment reloadedAttachment = attachmentRepository.findById(persistedAttachment.getId()).orElseThrow();
-        assertThat(reloadedAttachment.getVersion()).isEqualTo(originalVersion);
-        assertThat(reloadedAttachment.getLink()).isEqualTo(originalLink);
+        assertThat(reloadedAttachment.getVersion()).isEqualTo(originalVersion + 1);
+        assertThat(reloadedAttachment.getSha256Hash()).hasSize(64);
     }
 
     @Test
@@ -736,7 +752,7 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         String hiddenPagesJson = "[{\"slideId\": \"1\", \"date\": \"" + pastDate + "\"}]";
 
         // Create multipart request parts
-        var attachmentUnitPart = new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(persistedAttachmentUnit).getBytes());
+        var attachmentUnitPart = createAttachmentVideoUnitPart(persistedAttachmentUnit, AttachmentUpdateIntent.NO_FILE_CHANGE);
         var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(persistedAttachment).getBytes());
         var hiddenPagesPart = new MockMultipartFile("hiddenPages", "", MediaType.APPLICATION_JSON_VALUE, hiddenPagesJson.getBytes());
 
@@ -782,7 +798,7 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         String hiddenPagesJson = "[{\"slideId\": \"1\", \"date\": \"" + foreverDate + "\"}]";
 
         // Create multipart request parts
-        var attachmentUnitPart = new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(persistedAttachmentUnit).getBytes());
+        var attachmentUnitPart = createAttachmentVideoUnitPart(persistedAttachmentUnit, AttachmentUpdateIntent.NO_FILE_CHANGE);
         var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(persistedAttachment).getBytes());
         var hiddenPagesPart = new MockMultipartFile("hiddenPages", "", MediaType.APPLICATION_JSON_VALUE, hiddenPagesJson.getBytes());
 
@@ -816,8 +832,7 @@ class AttachmentVideoUnitIntegrationTest extends AbstractSpringIntegrationIndepe
         String hiddenPagesJson = "[{\"slideId\": \"1\", \"date\": \"" + pastDate + "\"}]";
 
         // Create multipart request parts
-        var attachmentUnitPart = new MockMultipartFile("attachmentVideoUnit", "", MediaType.APPLICATION_JSON_VALUE,
-                mapper.writeValueAsString(persistedAttachmentVideoUnit).getBytes());
+        var attachmentUnitPart = createAttachmentVideoUnitPart(persistedAttachmentVideoUnit, AttachmentUpdateIntent.NO_FILE_CHANGE);
         var attachmentPart = new MockMultipartFile("attachment", "", MediaType.APPLICATION_JSON_VALUE, mapper.writeValueAsString(persistedAttachment).getBytes());
         var hiddenPagesPart = new MockMultipartFile("hiddenPages", "", MediaType.APPLICATION_JSON_VALUE, hiddenPagesJson.getBytes());
 

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/service/AttachmentFileHashServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/service/AttachmentFileHashServiceTest.java
@@ -1,0 +1,101 @@
+package de.tum.cit.aet.artemis.lecture.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+class AttachmentFileHashServiceTest {
+
+    private static final String SHA_256_ABC = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    private final AttachmentFileHashService service = new AttachmentFileHashService();
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void hashesMultipartFileWithSha256() {
+        MultipartFile file = new MockMultipartFile("file", "abc.txt", "text/plain", "abc".getBytes(StandardCharsets.UTF_8));
+
+        AttachmentFileHashService.FileHash fileHash = service.sha256(file);
+
+        assertThat(fileHash.algorithm()).isEqualTo("SHA-256");
+        assertThat(fileHash.value()).isEqualTo(SHA_256_ABC);
+    }
+
+    @Test
+    void hashesPathWithSha256() throws IOException {
+        Path file = tempDir.resolve("abc.txt");
+        FileUtils.writeStringToFile(file.toFile(), "abc", StandardCharsets.UTF_8);
+
+        AttachmentFileHashService.FileHash fileHash = service.sha256(file);
+
+        assertThat(fileHash.algorithm()).isEqualTo("SHA-256");
+        assertThat(fileHash.value()).isEqualTo(SHA_256_ABC);
+    }
+
+    @Test
+    void wrapsMultipartFileInputStreamOpenIOException() throws IOException {
+        MultipartFile file = new OpeningFailingMultipartFile();
+
+        assertThatThrownBy(() -> service.sha256(file)).isInstanceOf(AttachmentFileHashException.class).hasMessageContaining("Could not hash uploaded attachment file")
+                .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    void wrapsMultipartFileInputStreamReadIOException() throws IOException {
+        IOException readException = new IOException("Cannot read stream");
+        MultipartFile file = new ReadFailingMultipartFile(readException);
+
+        assertThatThrownBy(() -> service.sha256(file)).isInstanceOf(AttachmentFileHashException.class).hasMessageContaining("Could not hash attachment file stream")
+                .hasCause(readException);
+    }
+
+    private static final class OpeningFailingMultipartFile extends MockMultipartFile {
+
+        private OpeningFailingMultipartFile() {
+            super("file", new byte[0]);
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            throw new IOException("Cannot read file");
+        }
+    }
+
+    private static final class ReadFailingMultipartFile extends MockMultipartFile {
+
+        private final IOException readException;
+
+        private ReadFailingMultipartFile(IOException readException) {
+            super("file", new byte[0]);
+            this.readException = readException;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new InputStream() {
+
+                @Override
+                public int read() throws IOException {
+                    throw readException;
+                }
+
+                @Override
+                public int read(byte[] bytes, int offset, int length) throws IOException {
+                    throw readException;
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Versions lecture attachments by their SHA-256 content hash and makes the client's file-update intent explicit. This is the first focused replacement for #13098.

### Checklist

#### General

- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server

- [x] I implemented the changes with a very good performance and prevented unnecessary or overly complex database calls.
- [x] I strictly followed the principle of data economy for all database calls.
- [x] I strictly followed the server coding and design guidelines and the REST API guidelines.
- [x] I added integration and unit tests related to the feature.
- [x] I documented the Java code using JavaDoc style.

#### Client

- [x] I implemented the changes without additional REST calls.
- [x] I strictly followed the client coding guidelines.
- [x] I added Vitest coverage for the update-intent behavior.

### Motivation and Context

Attachment versions previously changed based on upload activity rather than actual file bytes. This caused unnecessary downstream ingestion when an editor re-serialized an unchanged PDF. The multipart update API also could not distinguish a deliberate no-file update from a missing required file.

### Description

- Persist a SHA-256 hash for attachment files and backfill it lazily for existing attachments.
- Increment the attachment version only when uploaded bytes differ.
- Require an explicit `NO_FILE_CHANGE`, `FILE_UPLOAD`, or `EDITOR_PDF_CONTENT_CHANGED` intent.
- Send the matching intent from lecture unit editing and PDF preview flows.

Follow-up stack:

1. This PR
2. Retryable Iris/Pyris synchronization (base: this branch)
3. PDF slide metadata and visibility updates (base: synchronization branch)

### Steps for Testing

1. Create an attachment video unit with a PDF.
2. Upload the same bytes again and verify the attachment version does not change.
3. Upload changed bytes and verify the version increments once.
4. Edit lecture metadata without a file and verify the request uses `NO_FILE_CHANGE`.

### Local Verification

- `./gradlew spotlessCheck checkstyleMain -x webapp`
- `AttachmentFileHashServiceTest`: 4 tests passed.
- Targeted lecture client specs: 81 tests passed.
- `AttachmentVideoUnitIntegrationTest` compiles; local execution requires Docker, which was unavailable, so CI must execute the integration suite.

### Review Progress

#### Code Review

- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests

- [ ] Test 1
- [ ] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persisted SHA-256 tracking for lecture attachment files to more reliably detect content changes.
  * Added attachment update intents for attachment-video editing (no change, file upload, editor PDF content change).
  * Improved attachment update handling and versioning based on SHA-256 comparisons, including stricter request validation tied to the selected intent.
* **Tests**
  * Expanded integration and component coverage to verify update-intent payloads, SHA-256 hashing and error handling, validation rules, and correct version bump behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->