### PR TITLE
`Programming exercises`: Fix an intermittent edge case error when deleting an exercise while a result arrives

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Feedback.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Feedback.java
@@ -76,6 +76,14 @@ public class Feedback extends DomainObject {
     /**
      * Reference to the test case which created this feedback.
      * null if the feedback was not created by an automatic test case.
+     * <p>
+     * The {@code feedback.test_case_id} foreign key is defined with {@code ON DELETE CASCADE} at the database
+     * level (Liquibase changelog {@code 20260713120000}): when a {@link ProgrammingExerciseTestCase} is deleted,
+     * the database removes the feedback referencing it. This closes a deletion race in which the async
+     * build-result processing could persist feedback for a test case that the concurrent programming-exercise
+     * deletion cascade is removing. There is intentionally no JPA cascade here — the normal deletion path removes
+     * feedback via the participation → result → feedback cascade; the database cascade is the safety net for that
+     * concurrent re-creation.
      */
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnoreProperties({ "tasks", "exercise" })

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/LongFeedbackText.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/LongFeedbackText.java
@@ -18,6 +18,17 @@ public class LongFeedbackText extends DomainObject {
     @Column(name = "feedback_text", nullable = false)
     private String text;
 
+    /**
+     * The feedback this long text belongs to. A long feedback text is overflow storage for a single
+     * {@link Feedback} (1:1 via the unique index on {@code feedback_id}) and is never meaningful on its own.
+     * <p>
+     * On the database side {@code fk_long_feedback_to_feedback} is {@code ON DELETE CASCADE}: deleting a feedback
+     * row removes its long feedback text as well. This matters for the database-level cascade that deletes
+     * feedback together with a {@code programming_exercise_test_case} (see {@link Feedback#testCase}); that path
+     * bypasses JPA, so without the database cascade a long feedback text would block the feedback delete. In the
+     * normal, JPA-driven path the child is already removed via {@code cascade = ALL, orphanRemoval = true} on
+     * {@link Feedback#getLongFeedbackText()}.
+     */
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "feedback_id", nullable = false)
     @JsonIgnore

--- a/src/main/resources/config/liquibase/changelog/20260713120000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260713120000_changelog.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        Change the feedback -> programming_exercise_test_case foreign key (feedback.test_case_id) from
+        ON DELETE RESTRICT to ON DELETE CASCADE.
+
+        A test-case feedback is produced by, and only meaningful together with, the programming_exercise_test_case
+        it references. Test cases are never deleted on their own (they are deactivated, not removed); they are
+        removed only when their programming exercise is deleted, via the cascade/orphan-removal on
+        ProgrammingExercise.testCases. In that flow the referencing feedback is being deleted anyway (through the
+        participation -> result -> feedback cascade), so nothing legitimately keeps a feedback pointing at a
+        deleted test case.
+
+        RESTRICT was therefore both unnecessary and harmful: during exercise deletion the async build-result
+        processing (ProgrammingExerciseGradingService.processNewProgrammingExerciseResult) can save a result with
+        feedback referencing a test case in the window while the exercise's deleteById cascade removes those test
+        cases, and the test-case delete then violated FK_feedback_test_case_id (intermittent HTTP 500,
+        SQLState 23503). ON DELETE CASCADE makes the database delete any such dependent feedback together with the
+        test case, closing the race cluster-wide (it is enforced by the database, independent of which node
+        processes the build result or runs the deletion) without any application-level transaction or cross-node
+        coordination. This mirrors the participant_score -> result SET NULL fix (changelog 20260708093000).
+    -->
+    <!--
+        The constraint is re-added with validate="true" (the default), i.e. a normal validated foreign key on both
+        PostgreSQL and MySQL. Only the ON DELETE action changes (RESTRICT -> CASCADE); the referential integrity is
+        identical, so the pre-existing rows already satisfy it. We deliberately do NOT use validate="false"
+        (PostgreSQL NOT VALID): it is a Postgres-only lock optimization that MySQL (a supported production database)
+        ignores, so keeping the default guarantees identical, well-understood behavior on both engines.
+    -->
+    <changeSet id="20260713120000-1-feedback-test-case-fk-cascade" author="artemis">
+        <dropForeignKeyConstraint baseTableName="feedback" constraintName="FK_feedback_test_case_id"/>
+        <addForeignKeyConstraint baseColumnNames="test_case_id" baseTableName="feedback" constraintName="FK_feedback_test_case_id" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="RESTRICT" referencedColumnNames="id" referencedTableName="programming_exercise_test_case" validate="true"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20260713120000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260713120000_changelog.xml
@@ -4,9 +4,15 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <!--
-        Change the feedback -> programming_exercise_test_case foreign key (feedback.test_case_id) from
-        ON DELETE RESTRICT to ON DELETE CASCADE.
+        Make the feedback -> programming_exercise_test_case delete chain cascade at the database level.
 
+        Two foreign keys are switched from ON DELETE RESTRICT to ON DELETE CASCADE in one migration because
+        they form a single parent -> child -> grandchild chain that must be deletable atomically by the database:
+
+            programming_exercise_test_case  -(feedback.test_case_id)->          feedback
+            feedback                        -(long_feedback_text.feedback_id)-> long_feedback_text
+
+        (1) feedback.test_case_id (FK_feedback_test_case_id):
         A test-case feedback is produced by, and only meaningful together with, the programming_exercise_test_case
         it references. Test cases are never deleted on their own (they are deactivated, not removed); they are
         removed only when their programming exercise is deleted, via the cascade/orphan-removal on
@@ -22,16 +28,33 @@
         test case, closing the race cluster-wide (it is enforced by the database, independent of which node
         processes the build result or runs the deletion) without any application-level transaction or cross-node
         coordination. This mirrors the participant_score -> result SET NULL fix (changelog 20260708093000).
+
+        (2) long_feedback_text.feedback_id (fk_long_feedback_to_feedback):
+        A failed-test feedback whose detail text exceeds Constants.FEEDBACK_DETAIL_TEXT_SOFT_MAX_LENGTH (1000 chars)
+        spawns a long_feedback_text child row (Feedback.setDetailText). In the normal deletion path this child is
+        removed by JPA (Feedback.longFeedbackText is cascade=ALL, orphanRemoval=true), so the RESTRICT never bit.
+        But the database-level cascade added in (1) bypasses JPA entirely: when the database deletes a feedback row
+        as the child of a test-case delete, the still-RESTRICT long_feedback_text child would block that delete and
+        the original exercise deletion would still 500. Switching this FK to ON DELETE CASCADE as well lets the
+        database remove the long_feedback_text grandchild together with its feedback, so the whole chain deletes
+        atomically. This only aligns the database with the ownership JPA already declares (orphanRemoval=true);
+        a long_feedback_text is overflow storage that is never meaningful without its feedback (1:1 via the unique
+        index on feedback_id).
     -->
     <!--
-        The constraint is re-added with validate="true" (the default), i.e. a normal validated foreign key on both
-        PostgreSQL and MySQL. Only the ON DELETE action changes (RESTRICT -> CASCADE); the referential integrity is
-        identical, so the pre-existing rows already satisfy it. We deliberately do NOT use validate="false"
-        (PostgreSQL NOT VALID): it is a Postgres-only lock optimization that MySQL (a supported production database)
-        ignores, so keeping the default guarantees identical, well-understood behavior on both engines.
+        Both constraints are re-added with validate="true" (the default), i.e. normal validated foreign keys on
+        both PostgreSQL and MySQL. Only the ON DELETE action changes (RESTRICT -> CASCADE); the referential
+        integrity is identical, so the pre-existing rows already satisfy it. We deliberately do NOT use
+        validate="false" (PostgreSQL NOT VALID): it is a Postgres-only lock optimization that MySQL (a supported
+        production database) ignores, so keeping the default guarantees identical, well-understood behavior on both
+        engines.
     -->
     <changeSet id="20260713120000-1-feedback-test-case-fk-cascade" author="artemis">
         <dropForeignKeyConstraint baseTableName="feedback" constraintName="FK_feedback_test_case_id"/>
         <addForeignKeyConstraint baseColumnNames="test_case_id" baseTableName="feedback" constraintName="FK_feedback_test_case_id" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="RESTRICT" referencedColumnNames="id" referencedTableName="programming_exercise_test_case" validate="true"/>
+    </changeSet>
+    <changeSet id="20260713120000-2-long-feedback-text-fk-cascade" author="artemis">
+        <dropForeignKeyConstraint baseTableName="long_feedback_text" constraintName="fk_long_feedback_to_feedback"/>
+        <addForeignKeyConstraint baseColumnNames="feedback_id" baseTableName="long_feedback_text" constraintName="fk_long_feedback_to_feedback" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="RESTRICT" referencedColumnNames="id" referencedTableName="feedback" validate="true"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -22,6 +22,7 @@
     <include file="classpath:config/liquibase/changelog/20260705120000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260705130000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260708093000_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20260713120000_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command "date '+%Y%m%d%H%M%S'" to get the current date and time in the correct format -->

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseTestCaseServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseTestCaseServiceTest.java
@@ -20,6 +20,7 @@ import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.assessment.domain.Feedback;
 import de.tum.cit.aet.artemis.assessment.domain.Visibility;
 import de.tum.cit.aet.artemis.assessment.repository.FeedbackRepository;
+import de.tum.cit.aet.artemis.assessment.repository.LongFeedbackTextRepository;
 import de.tum.cit.aet.artemis.core.security.SecurityUtils;
 import de.tum.cit.aet.artemis.exam.domain.ExerciseGroup;
 import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
@@ -35,6 +36,9 @@ class ProgrammingExerciseTestCaseServiceTest extends AbstractProgrammingIntegrat
 
     @Autowired
     private FeedbackRepository feedbackRepository;
+
+    @Autowired
+    private LongFeedbackTextRepository longFeedbackTextRepository;
 
     private ProgrammingExercise programmingExercise;
 
@@ -71,16 +75,22 @@ class ProgrammingExerciseTestCaseServiceTest extends AbstractProgrammingIntegrat
         // task/coverage RESTRICT constraints that a seeded, task-linked test case would also hit.
         ProgrammingExerciseTestCase testCase = testCaseRepository.save(new ProgrammingExerciseTestCase().exercise(programmingExercise).testName("cascadeTest").active(true)
                 .weight(1.).bonusMultiplier(1.).bonusPoints(0.).visibility(Visibility.ALWAYS));
-        Feedback feedback = feedbackRepository.save(new Feedback().detailText("references the test case").testCase(testCase));
+        // A detail text over FEEDBACK_DETAIL_TEXT_SOFT_MAX_LENGTH (1000) forces a long_feedback_text child row, so
+        // this also covers the feedback -> long_feedback_text link in the same delete chain (a failed-test feedback
+        // with a long detail text is exactly the case a build result can produce during the deletion race).
+        Feedback feedback = feedbackRepository.save(new Feedback().detailText("x".repeat(1500)).testCase(testCase));
         long feedbackId = feedback.getId();
         assertThat(feedbackRepository.findById(feedbackId)).isPresent();
+        assertThat(longFeedbackTextRepository.findByFeedbackId(feedbackId)).isPresent();
 
-        // feedback.test_case_id is now ON DELETE CASCADE: deleting the test case must remove the referencing
-        // feedback rather than fail on the previous RESTRICT constraint.
+        // feedback.test_case_id and long_feedback_text.feedback_id are now ON DELETE CASCADE: deleting the test
+        // case must remove the referencing feedback AND its long feedback text rather than fail on the previous
+        // RESTRICT constraints. The database performs the whole chain; JPA is not involved.
         testCaseRepository.deleteById(testCase.getId());
 
         assertThat(testCaseRepository.findById(testCase.getId())).isEmpty();
         assertThat(feedbackRepository.findById(feedbackId)).isEmpty();
+        assertThat(longFeedbackTextRepository.findByFeedbackId(feedbackId)).isEmpty();
     }
 
     private void testResetTestCases(ProgrammingExercise programmingExercise, Visibility expectedVisibility) {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseTestCaseServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseTestCaseServiceTest.java
@@ -13,10 +13,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
+import de.tum.cit.aet.artemis.assessment.domain.Feedback;
 import de.tum.cit.aet.artemis.assessment.domain.Visibility;
+import de.tum.cit.aet.artemis.assessment.repository.FeedbackRepository;
 import de.tum.cit.aet.artemis.core.security.SecurityUtils;
 import de.tum.cit.aet.artemis.exam.domain.ExerciseGroup;
 import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
@@ -29,6 +32,9 @@ import de.tum.cit.aet.artemis.programming.util.RepositoryExportTestUtil;
 class ProgrammingExerciseTestCaseServiceTest extends AbstractProgrammingIntegrationLocalCILocalVCTest {
 
     private static final String TEST_PREFIX = "progextestcase";
+
+    @Autowired
+    private FeedbackRepository feedbackRepository;
 
     private ProgrammingExercise programmingExercise;
 
@@ -56,6 +62,25 @@ class ProgrammingExerciseTestCaseServiceTest extends AbstractProgrammingIntegrat
     void shouldResetExamExerciseTestCases() {
         programmingExercise.setExerciseGroup(new ExerciseGroup());
         testResetTestCases(programmingExercise, Visibility.AFTER_DUE_DATE);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void shouldCascadeDeleteFeedbackWhenTestCaseIsDeleted() {
+        // A fresh, unlinked test case so deleting it exercises only the feedback -> test_case foreign key, not the
+        // task/coverage RESTRICT constraints that a seeded, task-linked test case would also hit.
+        ProgrammingExerciseTestCase testCase = testCaseRepository.save(new ProgrammingExerciseTestCase().exercise(programmingExercise).testName("cascadeTest").active(true)
+                .weight(1.).bonusMultiplier(1.).bonusPoints(0.).visibility(Visibility.ALWAYS));
+        Feedback feedback = feedbackRepository.save(new Feedback().detailText("references the test case").testCase(testCase));
+        long feedbackId = feedback.getId();
+        assertThat(feedbackRepository.findById(feedbackId)).isPresent();
+
+        // feedback.test_case_id is now ON DELETE CASCADE: deleting the test case must remove the referencing
+        // feedback rather than fail on the previous RESTRICT constraint.
+        testCaseRepository.deleteById(testCase.getId());
+
+        assertThat(testCaseRepository.findById(testCase.getId())).isEmpty();
+        assertThat(feedbackRepository.findById(feedbackId)).isEmpty();
     }
 
     private void testResetTestCases(ProgrammingExercise programmingExercise, Visibility expectedVisibility) {


### PR DESCRIPTION
### Summary
Deleting a programming exercise could intermittently fail with HTTP 500 (`SQLState 23503`) on the `feedback → programming_exercise_test_case` foreign key. When an exercise is deleted, its `deleteById` cascade removes the test cases (`@OneToMany(cascade=REMOVE, orphanRemoval=true)`), but the **async** build-result processing (`ProgrammingExerciseGradingService.processNewProgrammingExerciseResult`) can persist a result whose feedback references those test cases in the same window — the test-case delete then violated `FK_feedback_test_case_id` (`ON DELETE RESTRICT`). This migration switches that foreign key to **`ON DELETE CASCADE`** so the database removes dependent feedback together with the test case, closing the race.

Because a failed-test feedback with a long detail text (> 1000 chars) also owns a `long_feedback_text` child whose foreign key was `ON DELETE RESTRICT`, the same migration additionally flips `fk_long_feedback_to_feedback` to **`ON DELETE CASCADE`**, so the whole `programming_exercise_test_case → feedback → long_feedback_text` chain deletes atomically at the database level.

### Checklist
#### General
- [x] This is a small, targeted schema change that I validated via CI (migration applies on both MySQL and PostgreSQL) and an integration test covering the full cascade chain.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server
- [x] **Important**: performance is unaffected — two `ON DELETE` action changes on existing foreign keys; no new queries.
- [x] I followed the [database guidelines](https://docs.artemis.tum.de/developer/guidelines/database): both constraints are re-added with `validate="true"` for identical, well-understood behavior on **both** MySQL and PostgreSQL (no Postgres-only `NOT VALID`).
- [x] I documented the change (extensive rationale in the changelog comment and on the `LongFeedbackText.feedback` relationship).
- [x] I added an integration test (`shouldCascadeDeleteFeedbackWhenTestCaseIsDeleted`) verifying the cascade removes both the feedback and its long feedback text.

### Motivation and Context
Surfaced repeatedly as intermittent `RESTRICT`-violation failures on `programming_exercise_test_case` during CI. It is the **sibling** of the `participant_score → result` race fixed in #13168 (changelog `20260708093000`, `RESTRICT → SET NULL`): an async writer re-creates a referencing row during exercise deletion and the cascade delete then hits a `RESTRICT` foreign key. `CASCADE` is semantically correct here — a test-case feedback (and its long feedback text) is only meaningful together with its test case; test cases are **deactivated, never deleted standalone** (they are removed only when the exercise is deleted, where the feedback is being deleted anyway), so nothing legitimately keeps feedback pointing at a deleted test case.

### Description
Liquibase changelog `20260713120000_changelog.xml` (registered in `master.xml`) with two changeSets:
1. `20260713120000-1-feedback-test-case-fk-cascade`: drop `FK_feedback_test_case_id`, re-add with `onDelete="CASCADE"`.
2. `20260713120000-2-long-feedback-text-fk-cascade`: drop `fk_long_feedback_to_feedback`, re-add with `onDelete="CASCADE"`.

Both keep `onUpdate="RESTRICT"` and `validate="true"`. The race is now closed **by the database**, enforced cluster-wide regardless of which node processes the build result or runs the deletion — no application-level transaction or cross-node coordination. No Java production-logic changes: the normal deletion path already removes feedback (and its long feedback text, via `Feedback.longFeedbackText` `cascade=ALL, orphanRemoval=true`) through the participation → result → feedback cascade; the DB `CASCADE` is the safety net for the concurrent re-creation, which bypasses JPA. A Javadoc comment on `LongFeedbackText.feedback` documents the DB-level cascade.

### Steps for Testing
Schema change validated by CI + an integration test:
1. CI runs the Liquibase migration against **both** MySQL and PostgreSQL — confirm both are green.
2. `ProgrammingExerciseTestCaseServiceTest.shouldCascadeDeleteFeedbackWhenTestCaseIsDeleted` creates a test case and a feedback with a long detail text (forcing a `long_feedback_text` row), deletes the test case, and asserts both the feedback and the long feedback text are cascade-deleted.
3. Existing programming-exercise deletion integration tests exercise the normal delete path and must stay green.

### Testserver States
Not deployed to a test server — DB-migration-only change validated by CI (both databases) and integration tests.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| Feedback.java | 98.25% | 295 |
| LongFeedbackText.java | 100.00% | 35 |

_Last updated: 2026-07-13 12:44:43 UTC_

