### PR TITLE
`Development`: Exclude supporting scripts from codacy security scanners

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -5,7 +5,10 @@
 #     test helpers, etc. are intentional fixtures, not vulnerabilities;
 #   - programming-exercise templates (src/main/resources/templates/**) and test resources
 #     (src/test/resources/**): sample/starter code shipped for exercises, not application code
-#     Artemis maintains for quality (e.g. npm-dependency checks on template package.json files).
+#     Artemis maintains for quality (e.g. npm-dependency checks on template package.json files);
+#   - supporting_scripts/** : internal developer/CI tooling (coverage reporting, course setup,
+#     transcription, benchmarks). Not part of the deployed application and not exposed to
+#     untrusted end-user input, so its subprocess/XML/tmp findings are advisory noise.
 # Other tools (ESLint, Stylelint, PMD) still analyze the code they apply to.
 engines:
   opengrep: # Semgrep — SAST security scanning
@@ -15,6 +18,8 @@ engines:
       - "**/*.spec.ts"
       - "src/main/resources/templates/**"
       - "src/main/resources/templates/**/*"
+      - "supporting_scripts/**"
+      - "supporting_scripts/**/*"
   bandit: # Python security scanning
     exclude_paths:
       - "src/test/**"
@@ -24,3 +29,5 @@ engines:
       - "**/tests/**"
       - "src/main/resources/templates/**"
       - "src/main/resources/templates/**/*"
+      - "supporting_scripts/**"
+      - "supporting_scripts/**/*"


### PR DESCRIPTION
### Summary
Extends `.codacy.yaml` to exclude `supporting_scripts/**` from the Semgrep (opengrep) and Bandit security scanners. Config-only change.

### Checklist
#### General
- [x] I chose a title conforming to the naming conventions for pull requests.
- [x] Config-only change (`.codacy.yaml`), verified as valid YAML.

### Motivation and Context
`supporting_scripts/**` is internal developer/CI tooling — coverage reporting, course setup, lecture transcription, Hyperion benchmarks. It is not part of the deployed Artemis application and is not exposed to untrusted end-user input. After enabling Semgrep/Bandit, ~31 of the remaining `develop` security findings live there and are advisory noise: subprocess use with trusted commands, `xml.etree` parsing of Artemis own CI JaCoCo reports (flagged as "use defusedxml"), `xml` imports, and tmp handling. Each was reviewed and none represents a real vulnerability. This mirrors the existing test-code and exercise-template exclusions, scoping SAST to the deployed application.

Trade-off (for reviewer): this stops SAST from scanning the tooling scripts. Given they are dev/CI-only and process trusted input, that is an accepted trade — consistent with standard practice of focusing SAST on the deployed app. If preferred, individual findings could instead be ignored on Codacy with a reason; excluding the directory is more maintainable as the scripts evolve.

### Description
Add `supporting_scripts/**` (and the `/**/*` variant) to the `opengrep` and `bandit` `exclude_paths` in `.codacy.yaml`. Codacy Cloud reads `.codacy.yaml` from the default branch, so this takes effect on `develop` once merged. Other tools (ESLint, Stylelint, PMD, and Java/TS SAST on `src/main`) are unaffected.

### Steps for Testing
1. After merge, confirm on Codacy that Semgrep/Bandit findings under `supporting_scripts/**` (defused-xml, dangerous-subprocess, Bandit B4xx) no longer appear.
2. Confirm production security findings under `src/main` are unaffected.

### Testserver States
Not applicable — Codacy configuration change, no deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-13 09:57:22 UTC_


### Screenshots
Not applicable — no UI changes.