### PR TITLE
`Development`: Scope checkov and trivy appropriately in codacy

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -31,3 +31,19 @@ engines:
       - "src/main/resources/templates/**/*"
       - "supporting_scripts/**"
       - "supporting_scripts/**/*"
+  checkov: # IaC / secrets scanning
+    exclude_paths:
+      - "src/test/**"
+      - "src/test/**/*"
+      - "src/main/resources/templates/**"
+      - "src/main/resources/templates/**/*"
+      - "supporting_scripts/**"
+      - "supporting_scripts/**/*"
+  trivy: # dependency-vulnerability / secret scanning
+    exclude_paths:
+      - "src/test/**"
+      - "src/test/**/*"
+      - "src/main/resources/templates/**"
+      - "src/main/resources/templates/**/*"
+      - "supporting_scripts/**"
+      - "supporting_scripts/**/*"


### PR DESCRIPTION
### Summary
Adds the existing test / exercise-template / `supporting_scripts` path exclusions to the `checkov` and `trivy` engines in `.codacy.yaml`, so all four Codacy security scanners are consistently scoped to the deployed application. Config-only change.

### Checklist
#### General
- [x] I chose a title conforming to the naming conventions for pull requests.
- [x] Config-only change (`.codacy.yaml`), verified as valid YAML.

### Motivation and Context
`opengrep` and `bandit` already exclude test code, exercise templates and `supporting_scripts` (#13208, #13217), but `checkov` and `trivy` still scan those paths and produce noise (9 findings on `develop`):
- **Checkov** flags fake test credentials in `src/test/resources/config/*.yml` — `password: fake-password`, `admin:admin@localhost:8761`, and a `base64-secret` explicitly labelled "should-be-changed". These are test fixtures, not real secrets.
- **Trivy** flags dependency CVEs in Ruby **exercise-template** `Gemfile.lock` files (not Artemis dependencies — exercise starter code) and in `supporting_scripts` tooling requirements (`torch` — *no fix available*; `filelock` — dev-only tooling).

### Description
Add `src/test/**`, `src/main/resources/templates/**` and `supporting_scripts/**` to the `checkov` and `trivy` `exclude_paths`, mirroring the existing `opengrep`/`bandit` configuration. Trade-off (for reviewer): Trivy no longer scans exercise-template / tooling dependency manifests. Those are not the deployed applications dependencies; production dependency scanning (`build.gradle`, root `package.json`) is unaffected. If desired, the one fixable tooling CVE (`filelock` in `supporting_scripts/lecture-transcription/requirements.txt`, → 3.20.3) can be bumped separately.

### Steps for Testing
1. After merge, confirm on Codacy that Checkov `CKV_SECRET_*` findings under `src/test/resources` and Trivy dependency findings under `src/main/resources/templates` / `supporting_scripts` no longer appear.
2. Confirm dependency findings for the deployed app (`build.gradle`, root `package.json`) are unaffected.

### Testserver States
Not applicable — Codacy configuration change, no deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-13 09:53:51 UTC_


### Screenshots
Not applicable — no UI changes.