### PR TITLE
`Development`: Add least privilege permissions to github actions workflows

### DIFF
--- a/.github/workflows/append_feature_proposal.yml
+++ b/.github/workflows/append_feature_proposal.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [assigned, unassigned, labeled]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/prod-like-deployment.yml
+++ b/.github/workflows/prod-like-deployment.yml
@@ -29,6 +29,10 @@ env:
   # The single CI entry point that publishes the Artemis.war artifact (via ci-build.yml).
   build_workflow_name: ci.yml
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   check-build-status:
     runs-on: [self-hosted, artemis-prod-deployment]

--- a/.github/workflows/pullrequest-closed.yml
+++ b/.github/workflows/pullrequest-closed.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   # If a PR is closed the docker image should be deleted to save space
   purge-image:

--- a/.github/workflows/pullrequest-coverage-reporter.yml
+++ b/.github/workflows/pullrequest-coverage-reporter.yml
@@ -34,6 +34,9 @@ env:
   CI: true
   node: 24
 
+permissions:
+  contents: read
+
 jobs:
   report-coverage:
     name: Report PR Coverage

--- a/.github/workflows/pullrequest-labeler.yml
+++ b/.github/workflows/pullrequest-labeler.yml
@@ -1,6 +1,10 @@
 name: Pull Request Labeler
 on: [pull_request_target]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/pullrequest-opened.yml
+++ b/.github/workflows/pullrequest-opened.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   assign:
     runs-on: ubuntu-latest

--- a/.github/workflows/pullrequest-ready-to-merge-validator.yml
+++ b/.github/workflows/pullrequest-ready-to-merge-validator.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   validate-ready-to-merge:
     if: github.event.label.name == 'ready to merge'

--- a/.github/workflows/pullrequest-readyforreview.yml
+++ b/.github/workflows/pullrequest-readyforreview.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types: [ready_for_review]
 
+permissions:
+  pull-requests: write
+
 jobs:
   pullequestReadyForReview:
     runs-on: ubuntu-latest

--- a/.github/workflows/pullrequest-stale.yml
+++ b/.github/workflows/pullrequest-stale.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: "0 12 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     if: github.repository_owner == 'ls1intum'

--- a/.github/workflows/test-mysql.yml
+++ b/.github/workflows/test-mysql.yml
@@ -18,6 +18,11 @@ env:
   java: 25
   RUN_ALL_TESTS: ${{ (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event.repository.default_branch == github.ref_name }}
 
+permissions:
+  contents: read
+  checks: write
+  actions: read
+
 jobs:
 
   server-tests-mysql:

--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -44,6 +44,11 @@ env:
 #     • anything else → build the branch on-the-fly
 #  3. Deploy the resolved Docker image to the requested environment
 # ------------------------------------------------------------------------------
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
 jobs:
   # Log the inputs for debugging
   log-inputs:

--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -129,6 +129,11 @@ jobs:
   conditional-build:
     if: ${{ needs.determine-build-context.outputs.pr_number == '' && needs.determine-build-context.outputs.is_main_or_develop == 'false' }}
     needs: determine-build-context
+    # The reusable workflow checks out and pushes the image to GHCR via GITHUB_TOKEN; a called
+    # workflow cannot elevate beyond its caller, so grant packages: write here (matches ci-build.yml).
+    permissions:
+      contents: read
+      packages: write
     uses: ls1intum/.github/.github/workflows/build-and-push-docker-image.yml@v1.2.0
     with:
       ref: ${{ github.event.inputs.branch_name }}

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -4,6 +4,9 @@ on:
     pull_request_target:
         types: [opened, edited, ready_for_review, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
     validate-pr-description:
         # Only run on non-draft PRs targeting develop from non-forked repos


### PR DESCRIPTION
### Summary
Adds a top-level least-privilege `permissions:` block to 12 GitHub Actions workflows that previously had none (so their `GITHUB_TOKEN` inherited the repository default). Config-only change to `.github/workflows/**`.

### Checklist
#### General
- [x] I chose a title conforming to the naming conventions for pull requests.
- [x] Self-contained CI change; each workflow validated as YAML and scoped to the permissions its steps actually use.

### Motivation and Context
Codacy (Checkov `CKV2_GHA_1`) flags these 12 workflows for not declaring `permissions:`, meaning `GITHUB_TOKEN` runs with the repositorys broad default scope. Setting least-privilege permissions reduces the blast radius if a workflow (or a third-party action it uses) is compromised — standard supply-chain hardening, complementing the run-injection fixes in #13203/#13209.

### Description
Each workflow gets exactly the scopes its steps use (see the commit body for the per-workflow rationale). Highlights:
- **Write only where needed:** `issues:write` (feature-proposal, stale), `pull-requests:write` (labeler, opened, readyforreview, stale), `checks:write` (test-mysql test-reporter).
- **Read-only** for the deploy workflows (`testserver-deployment`, `prod-like-deployment`) — their `GITHUB_TOKEN` use is PR/artifact lookups via `gh api` GET; deployment itself uses SSH, not the token.
- Workflows that already declare **per-job** permissions (`coverage-reporter`, `ready-to-merge-validator`, `validate-pr-description`) get a restrictive top-level default (`contents: read`); the per-job blocks still override where writes are required.

Reviewers who own these workflows should sanity-check the scopes — a too-tight grant would surface as a 403 in the affected workflow, and can be widened per-workflow.

### Steps for Testing
1. On this PR, confirm the CI workflows that run on `pull_request` (e.g. `test-mysql`, validators, coverage reporter) still succeed.
2. Post-merge, confirm the PR-automation workflows (labeler, assign-author, ready-for-review label, stale) still perform their actions.

### Testserver States
Not applicable — CI/workflow configuration change, no deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-13 16:40:23 UTC_


### Screenshots
Not applicable — no UI changes.