### PR TITLE
`Development`: Harden shell scripts and docker files

### DIFF
--- a/.ci/E2E-tests/execute-locally.sh
+++ b/.ci/E2E-tests/execute-locally.sh
@@ -105,9 +105,9 @@ services:
             PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-reports/results.xml pnpm exec playwright test e2e --grep "${TEST_FILTER}" --reporter=list,junit,monocart-reporter
             '
 EOF
-    OVERRIDE_ARGS="-f playwright-local-override.yml"
+    OVERRIDE_ARGS=(-f playwright-local-override.yml)
 else
-    OVERRIDE_ARGS=""
+    OVERRIDE_ARGS=()
 fi
 
 # Cleanup function
@@ -120,12 +120,12 @@ trap cleanup EXIT
 # Pull required images (except artemis-app which we build)
 echo ""
 echo "Pulling Docker images..."
-docker compose --env-file ../.env -f $COMPOSE_FILE pull $DB nginx 2>/dev/null || true
+docker compose --env-file ../.env -f "$COMPOSE_FILE" pull "$DB" nginx 2>/dev/null || true
 
 # Build Artemis image from external WAR file
 echo ""
 echo "Building Artemis Docker image from WAR file..."
-docker compose --env-file ../.env -f $COMPOSE_FILE build \
+docker compose --env-file ../.env -f "$COMPOSE_FILE" build \
     --build-arg WAR_FILE_STAGE=external_builder \
     --no-cache \
     --pull \
@@ -143,10 +143,10 @@ echo ""
 # Disable exit on error to capture exit code
 set +e
 if [ "$DEBUG" = true ]; then
-    docker compose --env-file ../.env -f $COMPOSE_FILE $OVERRIDE_ARGS up --exit-code-from artemis-playwright
+    docker compose --env-file ../.env -f "$COMPOSE_FILE" "${OVERRIDE_ARGS[@]}" up --exit-code-from artemis-playwright
 else
     # Only show Playwright output; other service logs are saved to the log directory
-    docker compose --env-file ../.env -f $COMPOSE_FILE $OVERRIDE_ARGS up --attach artemis-playwright --exit-code-from artemis-playwright
+    docker compose --env-file ../.env -f "$COMPOSE_FILE" "${OVERRIDE_ARGS[@]}" up --attach artemis-playwright --exit-code-from artemis-playwright
 fi
 EXIT_CODE=$?
 set -e

--- a/.ci/migration-check/execute.sh
+++ b/.ci/migration-check/execute.sh
@@ -20,6 +20,6 @@ export HOST_HOSTNAME=$(hostname)
 
 cd docker
 #just pull everything else than artemis-app as we build it later either way
-docker compose -f $COMPOSE_FILE pull artemis-app $DB
-docker compose -f $COMPOSE_FILE build --build-arg WAR_FILE_STAGE=external_builder --no-cache --pull artemis-app
-docker compose -f $COMPOSE_FILE up --exit-code-from migration-check
+docker compose -f "$COMPOSE_FILE" pull artemis-app "$DB"
+docker compose -f "$COMPOSE_FILE" build --build-arg WAR_FILE_STAGE=external_builder --no-cache --pull artemis-app
+docker compose -f "$COMPOSE_FILE" up --exit-code-from migration-check

--- a/docker/artemis/Dockerfile
+++ b/docker/artemis/Dockerfile
@@ -100,6 +100,9 @@ ARG GID=1337
 
 # Docker Compose: wget (healthcheck docker compose)
 # Artemis: graphviz, locales
+# Not pinning apt versions (DL3008): these are base-image system packages whose pinned versions age
+# out of the Debian repos and would break the image build over time.
+# hadolint ignore=DL3008
 RUN echo "Installing needed dependencies" \
   && apt-get update && apt-get install -y --no-install-recommends locales graphviz wget \
   && apt-get clean \

--- a/docker/jenkins/Dockerfile
+++ b/docker/jenkins/Dockerfile
@@ -13,15 +13,20 @@ RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.yml
 # ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
 
 # setup docker
+# Not pinning apt versions (DL3008): these are base-image system packages whose pinned versions age
+# out of the Debian repos and would break the image build over time.
+# hadolint ignore=DL3008
 RUN apt-get update -y \
-    && apt-get install -qqy apt-transport-https ca-certificates curl gnupg2 software-properties-common
+    && apt-get install -qqy --no-install-recommends apt-transport-https ca-certificates curl gnupg2 software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN add-apt-repository \
    "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/debian \
    $(lsb_release -cs) \
    stable"
+# hadolint ignore=DL3008
 RUN apt-get update -y \
-    && apt-get -y install docker-ce && rm -rf /var/apt/cache/*
+    && apt-get -y install --no-install-recommends docker-ce && rm -rf /var/apt/cache/*
 RUN usermod -aG docker jenkins
 
 USER jenkins

--- a/docker/jenkins/Dockerfile
+++ b/docker/jenkins/Dockerfile
@@ -26,7 +26,7 @@ RUN add-apt-repository \
    stable"
 # hadolint ignore=DL3008
 RUN apt-get update -y \
-    && apt-get -y install --no-install-recommends docker-ce && rm -rf /var/apt/cache/*
+    && apt-get -y install --no-install-recommends docker-ce && rm -rf /var/lib/apt/lists/*
 RUN usermod -aG docker jenkins
 
 USER jenkins

--- a/docker/nginx/70-artemis-setup.sh
+++ b/docker/nginx/70-artemis-setup.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 # disable default.conf
 mv  /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf.disabled || true

--- a/run-e2e-tests-local-fast.sh
+++ b/run-e2e-tests-local-fast.sh
@@ -690,6 +690,10 @@ if [ $TOTAL_TESTS -gt 0 ]; then
             # Build a grep pattern from failed test names (escape regex special chars)
             RERUN_PATTERN=""
             for name in "${FAIL_NAMES[@]}"; do
+                # The $ and () inside the single-quoted sed script are regex metacharacters, not shell
+                # expansions, so they are intentionally literal (SC2016); sed is clearer here than a
+                # bash parameter expansion (SC2001).
+                # shellcheck disable=SC2001,SC2016
                 escaped=$(echo "$name" | sed 's/[.[\*^$()+?{|]/\\&/g')
                 if [ -z "$RERUN_PATTERN" ]; then
                     RERUN_PATTERN="$escaped"

--- a/run-e2e-tests-local-multinode-fast.sh
+++ b/run-e2e-tests-local-multinode-fast.sh
@@ -77,7 +77,10 @@ COMPOSE_FILE="docker/playwright-E2E-tests-multi-node-fast.yml"
 
 # Per-node port allocation. Indexes match node1/node2/node3 below.
 HTTP_PORTS=(8080 8081 8082)
+# HZ_PORTS/SSH_PORTS document the per-node port scheme for reference; not referenced directly (SC2034).
+# shellcheck disable=SC2034
 HZ_PORTS=(5701 5702)            # node-3 has no Hazelcast bind port (client)
+# shellcheck disable=SC2034
 SSH_PORTS=(7921 7922)            # node-3 has no Git SSH
 
 # All host ports the script claims; freed during preflight + --stop.

--- a/run-e2e-tests-local-multinode.sh
+++ b/run-e2e-tests-local-multinode.sh
@@ -287,7 +287,7 @@ rm -rf "$REPORT_DIR"/monocart-report*/
 # With a --filter argument we need to override the default playwright command the
 # artemis-playwright container would run. Mirror the pattern used by
 # .ci/E2E-tests/execute-locally.sh.
-OVERRIDE_ARGS=""
+OVERRIDE_ARGS=()
 if [ -n "$TEST_FILTER" ]; then
     cat > docker/playwright-local-override.yml << EOF
 # AUTO-GENERATED — DO NOT COMMIT
@@ -304,7 +304,7 @@ services:
             PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-reports/results.xml pnpm exec playwright test e2e --grep "${TEST_FILTER}" --reporter=list,junit,monocart-reporter
             '
 EOF
-    OVERRIDE_ARGS="-f docker/playwright-local-override.yml"
+    OVERRIDE_ARGS=(-f docker/playwright-local-override.yml)
 fi
 
 cleanup() {
@@ -315,9 +315,9 @@ trap cleanup EXIT
 TEST_START=$(date +%s)
 set +e
 if [ "$DEBUG" = true ]; then
-    docker compose "${COMPOSE_ARGS[@]}" $OVERRIDE_ARGS up --exit-code-from artemis-playwright artemis-playwright
+    docker compose "${COMPOSE_ARGS[@]}" "${OVERRIDE_ARGS[@]}" up --exit-code-from artemis-playwright artemis-playwright
 else
-    docker compose "${COMPOSE_ARGS[@]}" $OVERRIDE_ARGS up --attach artemis-playwright --exit-code-from artemis-playwright artemis-playwright
+    docker compose "${COMPOSE_ARGS[@]}" "${OVERRIDE_ARGS[@]}" up --attach artemis-playwright --exit-code-from artemis-playwright artemis-playwright
 fi
 TEST_EXIT=$?
 set -e

--- a/src/main/resources/config/liquibase/consolidate-changelogs.sh
+++ b/src/main/resources/config/liquibase/consolidate-changelogs.sh
@@ -135,16 +135,17 @@ apply_lb "$PROJECT_DIR"  "jdbc:postgresql://localhost:$PG_NEW_PORT/Artemis" arte
 # --- Step 5: Dump schemas ---
 echo "=== Step 4: Dumping schemas ==="
 
-MYSQL_EXCLUDE="--ignore-table=artemis.DATABASECHANGELOG --ignore-table=artemis.DATABASECHANGELOGLOCK --ignore-table=artemis.migration_changelog --ignore-table=artemis.artemis_version"
-PG_EXCLUDE="-T databasechangelog -T databasechangeloglock -T migration_changelog -T artemis_version"
+# Arrays so each flag stays a separate argument (see SC2086 — these must not be a single word-split string).
+MYSQL_EXCLUDE=(--ignore-table=artemis.DATABASECHANGELOG --ignore-table=artemis.DATABASECHANGELOGLOCK --ignore-table=artemis.migration_changelog --ignore-table=artemis.artemis_version)
+PG_EXCLUDE=(-T databasechangelog -T databasechangeloglock -T migration_changelog -T artemis_version)
 
-docker exec av-mysql-dev mysqldump -u root --no-data --skip-comments --skip-add-drop-table --skip-add-locks --skip-disable-keys $MYSQL_EXCLUDE artemis 2>/dev/null | \
+docker exec av-mysql-dev mysqldump -u root --no-data --skip-comments --skip-add-drop-table --skip-add-locks --skip-disable-keys "${MYSQL_EXCLUDE[@]}" artemis 2>/dev/null | \
     sed 's/ AUTO_INCREMENT=[0-9]*//' > "$DUMP_DIR/mysql-develop-schema.sql"
-docker exec av-mysql-new mysqldump -u root --no-data --skip-comments --skip-add-drop-table --skip-add-locks --skip-disable-keys $MYSQL_EXCLUDE artemis 2>/dev/null | \
+docker exec av-mysql-new mysqldump -u root --no-data --skip-comments --skip-add-drop-table --skip-add-locks --skip-disable-keys "${MYSQL_EXCLUDE[@]}" artemis 2>/dev/null | \
     sed 's/ AUTO_INCREMENT=[0-9]*//' > "$DUMP_DIR/mysql-new-schema.sql"
 
-docker exec av-pg-dev pg_dump -U artemis -d Artemis --schema-only --no-owner --no-privileges --no-comments $PG_EXCLUDE 2>/dev/null > "$DUMP_DIR/pg-develop-schema.sql"
-docker exec av-pg-new pg_dump -U artemis -d Artemis --schema-only --no-owner --no-privileges --no-comments $PG_EXCLUDE 2>/dev/null > "$DUMP_DIR/pg-new-schema.sql"
+docker exec av-pg-dev pg_dump -U artemis -d Artemis --schema-only --no-owner --no-privileges --no-comments "${PG_EXCLUDE[@]}" 2>/dev/null > "$DUMP_DIR/pg-develop-schema.sql"
+docker exec av-pg-new pg_dump -U artemis -d Artemis --schema-only --no-owner --no-privileges --no-comments "${PG_EXCLUDE[@]}" 2>/dev/null > "$DUMP_DIR/pg-new-schema.sql"
 
 # --- Step 6: Compare ---
 echo ""

--- a/src/test/playwright/run-tests.sh
+++ b/src/test/playwright/run-tests.sh
@@ -56,7 +56,7 @@ run_playwright() {
     NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=8192" PLAYWRIGHT_TEST_TYPE="$test_type" pnpm exec playwright test "$@" 2>&1 | tee "./test-reports/pw-output-${test_type}.log"
     local exit_code=${PIPESTATUS[0]}
 
-    if [ $exit_code -ne 0 ]; then
+    if [ "$exit_code" -ne 0 ]; then
         local junit_file="./test-reports/results-${test_type}.xml"
         check_test_results "$junit_file"
         local check_result=$?

--- a/supporting_scripts/check_modules.sh
+++ b/supporting_scripts/check_modules.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -o pipefail
 
 chmod +x ./changed-modules.sh

--- a/supporting_scripts/per-module-coverage-recorder.sh
+++ b/supporting_scripts/per-module-coverage-recorder.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 MODULES=("assessment" "athena" "atlas" "buildagent" "communication" "core" "exam" "exercise" "fileupload" "hyperion" "iris"
     "lecture" "lti" "modeling" "plagiarism" "programming" "quiz" "text" "tutorialgroup")
 


### PR DESCRIPTION
### Summary
Fixes the genuinely-local `shellcheck` and `hadolint` findings from Codacy across shell scripts and Dockerfiles. Each was reviewed in context rather than blanket-applied.

### Checklist
#### General
- [x] I chose a title conforming to the naming conventions for pull requests.
- [x] Verified locally: `shellcheck` reports none of the targeted codes; array-converted scripts pass `bash -n`; `hadolint` reports none of the targeted codes on the edited Dockerfiles.

### Motivation and Context
`shellcheck` and `hadolint` are Codacy-unique tools (not run in the projects own CI) and — unlike the ESLint type-aware rules — have no bundled-vs-pinned toolchain divergence, so their findings are locally accurate. These are the real, non-false-positive quality/robustness findings that remained after the security triage.

### Description
**Shell scripts (shellcheck):**
- **SC2148** — add a shebang to `per-module-coverage-recorder.sh`, `check_modules.sh` (`#!/usr/bin/env bash`) and `docker/nginx/70-artemis-setup.sh` (`#!/bin/sh`).
- **SC2086** — quote scalar expansions (`$COMPOSE_FILE`, `$DB`, `$exit_code`); convert the **intentional** multi-flag word-splits to arrays so the deliberate splitting is preserved safely: `MYSQL_EXCLUDE`/`PG_EXCLUDE` (`consolidate-changelogs.sh`) and `OVERRIDE_ARGS` (`run-e2e-tests-local-multinode.sh`, `.ci/E2E-tests/execute-locally.sh`). Naively quoting those would have broken them — hence arrays.
- **SC2034 / SC2001 / SC2016** — annotate the intentional/false-positive cases with a justified `# shellcheck disable` (documented per-node port arrays; a `sed` regex whose `$`/`()` are metacharacters, not shell expansions).

**Dockerfiles (hadolint):**
- **DL3015** — add `--no-install-recommends` to the Jenkins-image `apt-get install`s.
- **DL3009** — delete `/var/lib/apt/lists` after the Jenkins setup install.
- **DL3008** — `hadolint ignore` with a rationale: pinning base-image apt package versions is brittle (pins age out of the Debian repos and break the image build). Left deliberately unpinned rather than introduce build fragility.

### Steps for Testing
1. `shellcheck` the changed scripts — no SC2086/SC2148/SC2034/SC2001/SC2016.
2. `hadolint docker/jenkins/Dockerfile docker/artemis/Dockerfile` — no DL3008/DL3009/DL3015.
3. Smoke-run an affected script (e.g. `./run-e2e-tests-local-multinode.sh --help` / a filtered run) to confirm the array conversions behave identically.

### Testserver States
Not applicable — build/CI scripts and Dockerfiles only, no deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-13 16:44:52 UTC_


### Screenshots
Not applicable — no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of local end-to-end, migration-check, and Playwright test runners when paths/options include spaces or special characters.
  * Fixed Docker Compose override argument handling for local multinode test runs.
  * Improved schema dump exclusion handling for more reliable mysqldump/pg_dump arguments.

* **Chores**
  * Updated Docker images with clearer apt install steps, cleanup, and lint guidance (including version pinning commentary).
  * Added explicit shell interpreters to supporting scripts and strengthened shell quoting/lint-suppression comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->