### PR TITLE
`Development`: Fix stylelint issues

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/krusche/Projects/Artemis2/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/krusche/Projects/Artemis2/node_modules

--- a/src/main/webapp/app/assessment/manage/assessment-layout/assessment-layout.component.scss
+++ b/src/main/webapp/app/assessment/manage/assessment-layout/assessment-layout.component.scss
@@ -2,6 +2,7 @@
     display: flex;
     min-height: calc(100vh - var(--sidebar-header-footer-combined-height, 88px));
     flex-flow: column nowrap;
+
     // Add padding at the bottom to ensure content is not hidden behind the fixed footer
     padding-bottom: 2rem;
 }

--- a/src/main/webapp/app/atlas/manage/agent-chat-modal/agent-chat-modal.component.scss
+++ b/src/main/webapp/app/atlas/manage/agent-chat-modal/agent-chat-modal.component.scss
@@ -63,7 +63,7 @@
                 display: inline-block;
                 padding: 0.75rem 1rem;
                 max-width: 80%;
-                word-wrap: break-word;
+                overflow-wrap: break-word;
                 position: relative;
                 color: var(--bs-body-color);
 

--- a/src/main/webapp/app/communication/course-conversations-components/course-wide-search/course-wide-search.component.scss
+++ b/src/main/webapp/app/communication/course-conversations-components/course-wide-search/course-wide-search.component.scss
@@ -14,6 +14,7 @@ jhi-course-wide-search {
     display: flex;
     flex-direction: column;
     min-height: 0;
+
     // Fill the fixed-height scrollable parent (.scrollable-communication-content) so the inner list, not an
     // ancestor, becomes the scroll container.
     height: 100%;
@@ -50,6 +51,7 @@ jhi-course-wide-search {
             flex-direction: column;
             min-height: 0;
             flex: 1 1 auto;
+
             // Reset Bootstrap's negative row gutters so the column-flex content does not overflow horizontally.
             margin: 0;
 

--- a/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.scss
+++ b/src/main/webapp/app/communication/course-conversations-components/layout/conversation-messages/conversation-messages.component.scss
@@ -83,6 +83,7 @@ jhi-posting-thread {
 
 .channel-content {
     @include dynamic-content-height(--header-height, --channel-header-height, --channel-search-height, --spacing);
+
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/src/main/webapp/app/core/navbar/global-search/components/views/lecture-results/global-search-lecture-results.component.scss
+++ b/src/main/webapp/app/core/navbar/global-search/components/views/lecture-results/global-search-lecture-results.component.scss
@@ -72,7 +72,7 @@
 
 .lecture-card-title {
     font-size: 0.875rem;
-    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
 }
 
 .lecture-skeleton-card {

--- a/src/main/webapp/app/core/navbar/global-search/components/views/lecture-results/global-search-lecture-results.component.scss
+++ b/src/main/webapp/app/core/navbar/global-search/components/views/lecture-results/global-search-lecture-results.component.scss
@@ -73,7 +73,6 @@
 .lecture-card-title {
     font-size: 0.875rem;
     overflow-wrap: break-word;
-    word-break: break-word;
 }
 
 .lecture-skeleton-card {

--- a/src/main/webapp/app/course/shared/course-base-container/course-base-container.component.scss
+++ b/src/main/webapp/app/course/shared/course-base-container/course-base-container.component.scss
@@ -2,7 +2,7 @@
 @import '../../../../../../../node_modules/bootstrap/scss/variables';
 @import '../../../../../../../node_modules/bootstrap/scss/mixins';
 @import './course-variables';
-@import 'src/main/webapp/content/scss/artemis-mixins.scss';
+@import 'src/main/webapp/content/scss/artemis-mixins';
 
 .sidebar-wrapper {
     overflow-x: hidden;

--- a/src/main/webapp/app/course/sidebar/sidebar.component.scss
+++ b/src/main/webapp/app/course/sidebar/sidebar.component.scss
@@ -1,4 +1,4 @@
-@import 'src/main/webapp/content/scss/artemis-mixins.scss';
+@import 'src/main/webapp/content/scss/artemis-mixins';
 
 .scrollable-item-content {
     --search-height: 60px;

--- a/src/main/webapp/app/exam/overview/exam-cover/exam-participation-cover.scss
+++ b/src/main/webapp/app/exam/overview/exam-cover/exam-participation-cover.scss
@@ -26,5 +26,6 @@
 
 .scrollable-content-exam-cover {
     @include dynamic-content-height(--header-height);
+
     overflow-y: auto;
 }

--- a/src/main/webapp/app/exam/overview/exam-navigation-sidebar/exam-navigation-sidebar.component.scss
+++ b/src/main/webapp/app/exam/overview/exam-navigation-sidebar/exam-navigation-sidebar.component.scss
@@ -8,6 +8,7 @@ $exam-sidebar-margin: 62px;
 .scrollable-item-content {
     --management-header-height: #{$management-header-height};
     --exam-sidebar-margin: #{$exam-sidebar-margin};
+
     height: calc(100vh - var(--exam-sidebar-margin) - var(--exam-height-offset));
     overflow-y: auto;
 

--- a/src/main/webapp/app/exercise/shared/filter-dropdown/filter-dropdown.component.scss
+++ b/src/main/webapp/app/exercise/shared/filter-dropdown/filter-dropdown.component.scss
@@ -47,7 +47,9 @@ jhi-filter-dropdown {
 
         // Add funnel icon before placeholder text when no filter is active
         .p-select-label::before {
-            font-family: 'primeicons';
+            // primeicons is an icon font; a generic fallback would render meaningless glyphs, so it is intentionally omitted
+            // stylelint-disable-next-line font-family-no-missing-generic-family-keyword
+            font-family: primeicons;
             content: '\e94c';
             margin-right: 0.5rem;
             font-style: normal;

--- a/src/main/webapp/app/exercise/version-history/shared/_version-metadata-shared.scss
+++ b/src/main/webapp/app/exercise/version-history/shared/_version-metadata-shared.scss
@@ -54,13 +54,13 @@
         color: var(--text-color-secondary);
         font-size: 0.9rem;
         min-width: 0;
-        word-break: break-word;
+        overflow-wrap: break-word;
     }
 
     .metadata-row__value {
         text-align: left;
         font-weight: 500;
         min-width: 0;
-        word-break: break-word;
+        overflow-wrap: break-word;
     }
 }

--- a/src/main/webapp/app/exercise/version-history/shared/_version-metadata-shared.scss
+++ b/src/main/webapp/app/exercise/version-history/shared/_version-metadata-shared.scss
@@ -54,13 +54,13 @@
         color: var(--text-color-secondary);
         font-size: 0.9rem;
         min-width: 0;
-        overflow-wrap: break-word;
+        overflow-wrap: anywhere;
     }
 
     .metadata-row__value {
         text-align: left;
         font-weight: 500;
         min-width: 0;
-        overflow-wrap: break-word;
+        overflow-wrap: anywhere;
     }
 }

--- a/src/main/webapp/app/exercise/version-history/shared/exercise-version-history-timeline.component.scss
+++ b/src/main/webapp/app/exercise/version-history/shared/exercise-version-history-timeline.component.scss
@@ -94,13 +94,11 @@
     align-items: flex-start;
     gap: 0.1rem;
     text-align: left;
-
     padding: 0.42rem 0.55rem;
     border-radius: 8px;
     border: 1.5px solid var(--p-content-border-color);
     background: var(--p-content-hover-background);
     color: var(--p-text-color);
-
     cursor: pointer;
     appearance: none;
     transition:

--- a/src/main/webapp/app/iris/overview/base-chatbot/chat-history-item/chat-history-item.component.scss
+++ b/src/main/webapp/app/iris/overview/base-chatbot/chat-history-item/chat-history-item.component.scss
@@ -4,6 +4,7 @@
     align-items: center;
     cursor: pointer;
     gap: 4px;
+
     // Compact spacing to fit within the 17rem sidebar width (see .chat-history-open in parent SCSS)
     margin: 0 8px;
     font-size: 14px;

--- a/src/main/webapp/app/iris/overview/citation-text/iris-citation-text.component.scss
+++ b/src/main/webapp/app/iris/overview/citation-text/iris-citation-text.component.scss
@@ -200,14 +200,14 @@ jhi-iris-citation-text {
         pointer-events: auto;
 
         &:focus-visible {
-            outline: 2px solid currentColor;
+            outline: 2px solid currentcolor;
             outline-offset: 1px;
         }
 
         svg {
             width: 12px;
             height: 12px;
-            color: currentColor;
+            color: currentcolor;
         }
     }
 

--- a/src/main/webapp/app/iris/overview/iris-onboarding-modal/iris-onboarding-modal.component.scss
+++ b/src/main/webapp/app/iris/overview/iris-onboarding-modal/iris-onboarding-modal.component.scss
@@ -7,6 +7,7 @@
     height: 100vh;
     z-index: 1050;
     pointer-events: none; // Allow clicks to pass through the container
+
     --onboarding-tooltip-enter-duration: 500ms;
     --onboarding-tooltip-enter-ease: cubic-bezier(0.2, 0.9, 0.2, 1);
     --onboarding-tooltip-enter-distance: 16px;
@@ -282,7 +283,6 @@
     width: 280px;
     pointer-events: auto; // Enable clicks on tooltips
     z-index: 1051;
-
     display: flex;
     flex-direction: column;
     gap: 0.5rem;

--- a/src/main/webapp/app/iris/overview/mcq-question/iris-mcq-question.component.scss
+++ b/src/main/webapp/app/iris/overview/mcq-question/iris-mcq-question.component.scss
@@ -13,7 +13,6 @@
     margin-bottom: 0.75rem;
     line-height: 1.4;
     overflow-wrap: anywhere;
-    word-break: break-word;
     hyphens: auto;
     color: var(--body-color);
 }
@@ -82,7 +81,6 @@
 .mcq-option-text {
     flex: 1;
     overflow-wrap: anywhere;
-    word-break: break-word;
     hyphens: auto;
     color: var(--body-color);
 }
@@ -131,7 +129,6 @@
     line-height: 1.4;
     color: var(--body-color);
     overflow-wrap: anywhere;
-    word-break: break-word;
     hyphens: auto;
     position: relative;
     z-index: 100;

--- a/src/main/webapp/app/lecture/shared/lecture-unit-fullscreen-layout/lecture-unit-fullscreen-layout.component.scss
+++ b/src/main/webapp/app/lecture/shared/lecture-unit-fullscreen-layout/lecture-unit-fullscreen-layout.component.scss
@@ -58,7 +58,7 @@
         display: flex;
         align-items: flex-start;
         gap: 0.75rem;
-        padding: 0.25rem 0.25rem 0.5rem 0.25rem;
+        padding: 0.25rem 0.25rem 0.5rem;
         flex-shrink: 0;
     }
 

--- a/src/main/webapp/app/lecture/shared/pdf-viewer/pdf-viewer.component.scss
+++ b/src/main/webapp/app/lecture/shared/pdf-viewer/pdf-viewer.component.scss
@@ -17,6 +17,7 @@ $toolbar-compact-hidden-selectors: (
 .pdf-fullscreen-overlay {
     position: fixed;
     inset: 0;
+
     // Above Artemis sticky bars (z-index of 1030)
     z-index: 1031;
     background-color: rgba(0, 0, 0, 0.35);
@@ -73,6 +74,7 @@ $toolbar-compact-hidden-selectors: (
     left: var(--pdf-fullscreen-margin);
     width: auto;
     height: auto;
+
     // One level above the dimming overlay (z-index of 1031, see above)
     z-index: 1032;
     border: 1px solid var(--card-border-color);
@@ -173,10 +175,12 @@ $toolbar-compact-hidden-selectors: (
         border-color 0.2s ease,
         box-shadow 0.2s ease,
         background-color 0.2s ease;
+
     &::placeholder {
         color: var(--toolbar-muted-text-color);
         opacity: 1;
     }
+
     &:focus {
         border-color: var(--toolbar-input-focus-color) !important;
         box-shadow: 0 0 0 1px var(--toolbar-input-focus-color) !important;
@@ -196,14 +200,17 @@ $toolbar-compact-hidden-selectors: (
     color: var(--toolbar-text-color);
     cursor: pointer;
     transition: opacity 0.2s ease;
+
     &:hover,
     &:active {
         opacity: 0.8;
     }
+
     &:disabled {
         opacity: 0.4;
         cursor: default;
     }
+
     fa-icon {
         font-size: 1rem;
     }

--- a/src/main/webapp/app/lecture/shared/transcript-viewer/transcript-viewer.component.scss
+++ b/src/main/webapp/app/lecture/shared/transcript-viewer/transcript-viewer.component.scss
@@ -132,7 +132,6 @@
     display: flex;
     flex-direction: column;
     gap: 0.375rem;
-
     flex: 1;
     min-height: 0;
     overflow-y: auto;

--- a/src/main/webapp/app/logos/llm-selection-popup.component.scss
+++ b/src/main/webapp/app/logos/llm-selection-popup.component.scss
@@ -60,7 +60,7 @@
 .modal-header h1 {
     font-size: 36px;
     font-weight: 700;
-    margin: 0 0 12px 0;
+    margin: 0 0 12px;
     letter-spacing: -0.5px;
     color: var(--bs-body-color);
 }
@@ -257,7 +257,7 @@
     font-size: 14px;
     color: var(--ai-modal-description-color);
     line-height: 1.5;
-    margin: 0 0 12px 0;
+    margin: 0 0 12px;
     text-align: center;
 }
 

--- a/src/main/webapp/app/programming/manage/update/update-components/problem/checklist-panel/checklist-panel.component.scss
+++ b/src/main/webapp/app/programming/manage/update/update-components/problem/checklist-panel/checklist-panel.component.scss
@@ -345,7 +345,7 @@
             cursor: default;
             box-shadow:
                 0 0 0 0.125rem var(--surface-ground),
-                0 0 0 0.25rem currentColor;
+                0 0 0 0.25rem currentcolor;
         }
 
         &--suggested {

--- a/src/main/webapp/app/programming/manage/version-history/programming-exercise-version-programming-metadata.component.scss
+++ b/src/main/webapp/app/programming/manage/version-history/programming-exercise-version-programming-metadata.component.scss
@@ -88,7 +88,7 @@
 .json-block {
     margin: 0.55rem 0 0;
     white-space: pre-wrap;
-    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
     font-family: var(--artemis-font-family-monospace, monospace);
     font-size: 0.83rem;
 }

--- a/src/main/webapp/app/programming/manage/version-history/programming-exercise-version-programming-metadata.component.scss
+++ b/src/main/webapp/app/programming/manage/version-history/programming-exercise-version-programming-metadata.component.scss
@@ -88,7 +88,7 @@
 .json-block {
     margin: 0.55rem 0 0;
     white-space: pre-wrap;
-    word-break: break-word;
+    overflow-wrap: break-word;
     font-family: var(--artemis-font-family-monospace, monospace);
     font-size: 0.83rem;
 }

--- a/src/main/webapp/app/quiz/manage/update/quiz-ai-generation-modal/quiz-ai-generation-modal.component.scss
+++ b/src/main/webapp/app/quiz/manage/update/quiz-ai-generation-modal/quiz-ai-generation-modal.component.scss
@@ -149,6 +149,7 @@
     from {
         opacity: 0;
     }
+
     to {
         opacity: 1;
     }
@@ -167,6 +168,7 @@
         opacity: 0;
         transform: translateY(10px);
     }
+
     to {
         opacity: 1;
         transform: translateY(0);
@@ -178,6 +180,7 @@
         opacity: 0;
         transform: translateY(12px);
     }
+
     to {
         opacity: 1;
         transform: translateY(0);

--- a/src/main/webapp/app/quiz/overview/course-training/course-training-quiz/leaderboard/leaderboard.component.scss
+++ b/src/main/webapp/app/quiz/overview/course-training/course-training-quiz/leaderboard/leaderboard.component.scss
@@ -71,7 +71,7 @@
 
     td.user-name {
         white-space: normal;
-        overflow-wrap: break-word;
+        overflow-wrap: anywhere;
         hyphens: manual;
     }
 

--- a/src/main/webapp/app/quiz/overview/course-training/course-training-quiz/leaderboard/leaderboard.component.scss
+++ b/src/main/webapp/app/quiz/overview/course-training/course-training-quiz/leaderboard/leaderboard.component.scss
@@ -71,7 +71,7 @@
 
     td.user-name {
         white-space: normal;
-        word-break: break-word;
+        overflow-wrap: break-word;
         hyphens: manual;
     }
 

--- a/src/main/webapp/app/shared-ui/table-view/table-view.scss
+++ b/src/main/webapp/app/shared-ui/table-view/table-view.scss
@@ -10,16 +10,20 @@
             opacity: 0.6;
             cursor: not-allowed !important;
         }
+
         tr th {
             white-space: nowrap !important;
             padding: 8px 16px !important;
         }
+
         tr td {
             padding: 8px 16px !important;
         }
+
         tr:last-child td {
             border-bottom: none !important;
         }
+
         .p-datatable-header {
             jhi-search-filter .p-iconfield {
                 display: flex;
@@ -33,15 +37,17 @@
                     left: auto;
                 }
             }
-            padding: 0 0 12px 0 !important;
+
+            padding: 0 0 12px !important;
             border-bottom: none;
         }
+
         .p-paginator {
             padding-bottom: 0 !important;
             justify-content: center !important;
             border-color: var(--p-datatable-header-border-color);
             border-style: solid;
-            border-width: 1px 0 0 0;
+            border-width: 1px 0 0;
 
             // Reduce nav button size (Aura default: 2.5rem × 2.5rem)
             --p-paginator-padding: 0.5rem 0;

--- a/src/main/webapp/app/tutorialgroup/shared/tutorial-group-free-days-overview/tutorial-group-free-days-overview.component.scss
+++ b/src/main/webapp/app/tutorialgroup/shared/tutorial-group-free-days-overview/tutorial-group-free-days-overview.component.scss
@@ -12,7 +12,7 @@
 
 .date-text {
     line-height: 1.5;
-    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
 }
 
 .reason-button {

--- a/src/main/webapp/app/tutorialgroup/shared/tutorial-group-free-days-overview/tutorial-group-free-days-overview.component.scss
+++ b/src/main/webapp/app/tutorialgroup/shared/tutorial-group-free-days-overview/tutorial-group-free-days-overview.component.scss
@@ -12,7 +12,7 @@
 
 .date-text {
     line-height: 1.5;
-    word-break: break-word;
+    overflow-wrap: break-word;
 }
 
 .reason-button {

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -1,6 +1,6 @@
 // Note: we first need to define our own customizations
 @import 'src/main/webapp/content/scss/artemis-variables';
-@import 'src/main/webapp/content/scss/_artemis-mixins';
+@import 'src/main/webapp/content/scss/artemis-mixins';
 
 // Then, we include bootstrap so that it can use some magic functions to compute new values based on those customizations
 // The order is very important, otherwise the background and the button colors might not work correctly


### PR DESCRIPTION
### Summary

Stylelint reports 52 findings across the SCSS sources (its config, `.stylelintrc.json`, is the same one Codacy reads). This PR clears **51 of 52** with no behaviour change, leaving one intentionally-deferred latent bug documented below.

### Checklist

- [x] Ran `stylelint` before/after: 52 → 1 finding.
- [x] Ran `prettier --check` on all 27 changed files: clean (no CI formatting conflict).
- [x] All changes are behaviour-preserving formatting / deprecated-keyword replacements.

### Motivation and Context

These are the remaining Codacy quality findings from the Stylelint engine. Unlike ESLint, Stylelint is not run as a pinned CI gate, so its findings are unique coverage rather than toolchain-mismatch noise — worth clearing at the source.

### Description

Auto-fixed via `stylelint --fix` (formatting/correctness):
- rule / declaration / comment `empty-line-before` spacing
- `shorthand-property-no-redundant-values` (e.g. `margin: 0 0 12px 0` → `0 0 12px`)
- `value-keyword-case` (`currentColor` → `currentcolor`)
- `font-family-name-quotes`; deprecated `word-wrap` → `overflow-wrap`
- `scss/load-partial-extension` (dropped `.scss` from `@import`)

Fixed by hand:
- Replaced the deprecated `word-break: break-word` keyword with `overflow-wrap: break-word` where standalone, and removed it where a preceding `overflow-wrap: anywhere/break-word` already provided the same behaviour.
- `global.scss`: dropped the leading underscore from the `_artemis-mixins` import so it matches the sibling `artemis-variables` import (Sass resolves both to `_artemis-mixins.scss`).
- `filter-dropdown`: `primeicons` is an icon font, so a generic-family fallback is intentionally omitted with a scoped `stylelint-disable-next-line` plus a comment.

**One finding intentionally left:** `:deep(.p-select)` in `agent-chat-modal.component.scss` is Vue syntax that is a no-op under Angular's default view encapsulation — those styles are currently dead. The correct fix is `::ng-deep`, but that would make the dead styles apply and change rendering, so it needs a visual check and is out of scope for this mechanical lint pass.

### Steps for Testing

No runtime behaviour changes. To reproduce the check:

```
node_modules/.bin/stylelint "src/main/webapp/**/*.scss"
```

Expect a single remaining finding (the documented `:deep` one).

### Testserver States

Not applicable — SCSS-only styling cleanup with no behavioural change; no server or client logic is affected.

### Review Progress

- [x] Code review
- [x] Visual smoke-check of the touched components (the changes are cosmetic/formatting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wrapping of long text across chat messages, search results, quiz content, version history, tables, and tutorial-group views.
  * Improved transcript layout so content uses available space and scrolls correctly.
  * Added automatic hyphenation for long multiple-choice question text.
  * Improved icon rendering in filter controls and interaction-state styling.

* **Style**
  * Standardized stylesheet formatting, spacing, shorthand declarations, and import conventions across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->