### PR TITLE
`Exam mode`: Fix flash to white theme when printing exam summary in dark theme

### DIFF
--- a/src/main/webapp/app/core/theme/shared/theme.service.spec.ts
+++ b/src/main/webapp/app/core/theme/shared/theme.service.spec.ts
@@ -191,4 +191,23 @@ describe('ThemeService', () => {
         expect(winSpy).toHaveBeenCalledOnce();
         expect(returnedElement.style.display).toBe(initialDisplayClass);
     });
+
+    it('should keep dark theme visible on screen while printing', async () => {
+        const winSpy = vi.spyOn(window, 'print').mockImplementation(() => {});
+        const overrideElement = { rel: 'stylesheet', media: '', style: { display: '' }, remove: vi.fn() };
+        vi.spyOn(document, 'getElementById').mockReturnValue(overrideElement as unknown as HTMLElement);
+
+        // Capture the rel attribute during window.print() to verify the stylesheet stays active on screen
+        let relDuringPrint: string | undefined;
+        winSpy.mockImplementation(() => {
+            relDuringPrint = overrideElement.rel;
+        });
+
+        await service.print();
+
+        // The stylesheet must remain rel="stylesheet" at all times
+        expect(relDuringPrint).toBe('stylesheet');
+        // After printing, rel must still be intact
+        expect(overrideElement.rel).toBe('stylesheet');
+    });
 });

--- a/src/main/webapp/app/core/theme/shared/theme.service.spec.ts
+++ b/src/main/webapp/app/core/theme/shared/theme.service.spec.ts
@@ -169,26 +169,26 @@ describe('ThemeService', () => {
     });
 
     it('does print correctly', async () => {
-        vi.useFakeTimers();
         const initialDisplayClass = 'someDisplayClass';
 
         const winSpy = vi.spyOn(window, 'print').mockImplementation(() => {});
-        const returnedElement = { rel: 'stylesheet', style: { display: initialDisplayClass }, remove: vi.fn() };
+        const returnedElement = { media: '', style: { display: initialDisplayClass }, remove: vi.fn() };
         const docSpy = vi.spyOn(document, 'getElementById').mockReturnValue(returnedElement as unknown as HTMLElement);
 
-        service.print();
-        TestBed.tick();
+        // Track media attribute changes during print
+        let mediaAtPrintTime: string | undefined;
+        winSpy.mockImplementation(() => {
+            mediaAtPrintTime = returnedElement.media;
+        });
 
-        expect(docSpy).toHaveBeenCalledTimes(2);
+        await service.print();
+
         expect(docSpy).toHaveBeenCalledWith(THEME_OVERRIDE_ID);
-        expect(returnedElement.rel).toBe('none-tmp');
-        await vi.advanceTimersByTimeAsync(250);
-        expect(docSpy).toHaveBeenCalledWith('notification-sidebar');
-        expect(docSpy).toHaveBeenCalledTimes(4); // 1x for theme override, 2x for notification sidebar (changing style to display: none and back to initial value)
+        // During printing, the dark theme should be excluded from print output
+        expect(mediaAtPrintTime).toBe('not print');
+        // After printing, the media attribute should be restored
+        expect(returnedElement.media).toBe('');
         expect(winSpy).toHaveBeenCalledOnce();
-        await vi.advanceTimersByTimeAsync(250);
-        expect(returnedElement.rel).toBe('stylesheet');
         expect(returnedElement.style.display).toBe(initialDisplayClass);
-        vi.useRealTimers();
     });
 });

--- a/src/main/webapp/app/core/theme/shared/theme.service.ts
+++ b/src/main/webapp/app/core/theme/shared/theme.service.ts
@@ -131,29 +131,28 @@ export class ThemeService {
 
     /**
      * Prints the current page.
-     * Disables any theme override before doing that to ensure that we print in default theme.
-     * Resets the theme afterward if needed
+     * Excludes any theme override from print output to ensure that we print in the default (light) theme,
+     * without visually changing the on-screen theme.
      */
     public async print(): Promise<void> {
-        return new Promise<void>((resolve) => {
-            const overrideTag = document.getElementById(THEME_OVERRIDE_ID) as HTMLLinkElement | null;
-            if (overrideTag) {
-                overrideTag.rel = 'none-tmp';
-            }
-            setTimeout(() => {
-                const notificationSidebarDisplayAttribute = this.hideNotificationSidebar();
+        const overrideTag = document.getElementById(THEME_OVERRIDE_ID) as HTMLLinkElement | null;
+        const previousMedia = overrideTag?.media;
+        if (overrideTag) {
+            // Exclude the dark theme from print output only; the screen still shows dark mode.
+            overrideTag.media = 'not print';
+        }
 
-                window.print();
+        const notificationSidebarDisplayAttribute = this.hideNotificationSidebar();
 
-                this.showNotificationSidebar(notificationSidebarDisplayAttribute);
-            }, 250);
-            setTimeout(() => {
-                if (overrideTag) {
-                    overrideTag.rel = 'stylesheet';
-                }
-                resolve();
-            }, 500);
-        });
+        // window.print() blocks the main thread until the dialog is closed,
+        // so all cleanup below runs immediately after the user dismisses it.
+        window.print();
+
+        this.showNotificationSidebar(notificationSidebarDisplayAttribute);
+
+        if (overrideTag) {
+            overrideTag.media = previousMedia ?? '';
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
Fixes #8905

The issue is that when a student prints their exam the background (Artemis UI) flashes white.
This behavior is fixed.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix a small bug.

### Description
<!-- Describe your changes in detail -->
Now to the theme override `link` element `not print` is set for the media. (like `@media not print` but directly on the `link` element)
The UI is left as is and the page still prints as white.

### Steps for Testing

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor
- 1 Students (Test User 1)
- 1 Exam with a student participation

1. Go to ... as Test User 1 or find any other exam that you have participated in on a test server as a student.
2. Switch theme to dark.
3. Press Export PDF.
4. Check that the background stays in dark theme.
5. Cancel
6. Switch to light theme
7. Check that the background stays in light theme

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Exam Mode Test
- [ ] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/29278509047) did not pass (`failure`). Coverage below may be partial.

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| theme.service.ts | 90.90% | 131 | 45 | 34.4 |

_Last updated: 2026-07-13 19:54:30 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved printing behavior by reliably excluding theme overrides from printed output.
  * Preserved the theme override’s original settings after printing.
  * Ensured the notification sidebar is hidden during printing and restored afterward.
  * Kept the dark theme override correctly applied on screen while printing.
* **Tests**
  * Updated and added coverage to verify print-time behavior without relying on timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Before:

https://github.com/user-attachments/assets/233ec9a0-f830-48e5-bafb-51e7141aefc1

After:

https://github.com/user-attachments/assets/59bb9d99-e64d-44ae-aed1-3273d9446fe1

