### PR TITLE
`Development`: Remove unused loop variable in analyze_module_complexity

### DIFF
--- a/supporting_scripts/analyze_module_complexity.py
+++ b/supporting_scripts/analyze_module_complexity.py
@@ -121,7 +121,7 @@ def analyze_module(module_path):
         '@EntityGraph': 0
     }
 
-    for root, dirs, files in os.walk(module_path):
+    for root, _, files in os.walk(module_path):
         java_files = [f for f in files if f.endswith('.java')]
         total_files += len(java_files)
 
@@ -203,7 +203,7 @@ def analyze_services_entities(module_path):
     service_complexities = []
     entity_complexities = []
 
-    for root, dirs, files in os.walk(module_path):
+    for root, _, files in os.walk(module_path):
         java_files = [f for f in files if f.endswith('.java')]
 
         for file in java_files:


### PR DESCRIPTION
### Summary

Clears the two remaining Pylint `unused-variable` (W0612) findings in `analyze_module_complexity.py` — the follow-up to the unused-import cleanup in #13227.

### Checklist

- [x] Verified `dirs` is referenced only on the two `for` lines (unused in both loop bodies).
- [x] Syntax-checked with `ast.parse` (no bytecode generated/committed).
- [x] Change is limited to a single helper script.

### Motivation and Context

Both `os.walk` loops unpack a `dirs` binding that is never used. Pylint flags this as `W0612`; replacing it with `_` documents the intent and drops the findings.

### Description

`for root, dirs, files in os.walk(...)` → `for root, _, files in os.walk(...)` in both loops (lines 124 and 206).

### Steps for Testing

No behaviour change. To reproduce the check:

```
pip install pylint
pylint --disable=all --enable=W0612 supporting_scripts/analyze_module_complexity.py
```

Expect zero findings.

### Testserver States

Not applicable — offline helper script only; no server or client artifact is affected.

### Review Progress

- [x] Code review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal directory traversal logic without changing functionality or user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->