### PR TITLE
`Development`: Exclude exercise templates and jenkins scripts from codacy quality linters

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -9,7 +9,11 @@
 #   - supporting_scripts/** : internal developer/CI tooling (coverage reporting, course setup,
 #     transcription, benchmarks). Not part of the deployed application and not exposed to
 #     untrusted end-user input, so its subprocess/XML/tmp findings are advisory noise.
-# Other tools (ESLint, Stylelint, PMD) still analyze the code they apply to.
+# The quality linters below (CodeNarc, ShellCheck, PyLint) also exclude the programming-exercise
+# templates for the same reason: the Jenkins pipeline / build-script / helper scaffolding shipped
+# for exercises is starter code, not application code Artemis maintains for quality. They still
+# analyze the rest of the repository (e.g. supporting_scripts for PyLint). ESLint, Stylelint, and
+# PMD still analyze the code they apply to.
 engines:
   opengrep: # Semgrep — SAST security scanning
     exclude_paths:
@@ -47,3 +51,15 @@ engines:
       - "src/main/resources/templates/**/*"
       - "supporting_scripts/**"
       - "supporting_scripts/**/*"
+  codenarc: # Groovy linting — exercise-template Jenkins pipelines are scaffolding, not app code
+    exclude_paths:
+      - "src/main/resources/templates/**"
+      - "src/main/resources/templates/**/*"
+  shellcheck: # shell linting — exercise-template build scripts are scaffolding, not app code
+    exclude_paths:
+      - "src/main/resources/templates/**"
+      - "src/main/resources/templates/**/*"
+  pylintpython3: # Python linting — exercise-template scripts are scaffolding, not app code
+    exclude_paths:
+      - "src/main/resources/templates/**"
+      - "src/main/resources/templates/**/*"

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -51,10 +51,14 @@ engines:
       - "src/main/resources/templates/**/*"
       - "supporting_scripts/**"
       - "supporting_scripts/**/*"
-  codenarc: # Groovy linting — exercise-template Jenkins pipelines are scaffolding, not app code
+  codenarc: # Groovy linting — exercise-template Jenkins pipelines + docker Jenkins init scripts are scaffolding/infra, not app code
     exclude_paths:
       - "src/main/resources/templates/**"
       - "src/main/resources/templates/**/*"
+      # Jenkins init.groovy.d scripts (e.g. disabling the CSRF crumb issuer) are dynamic-Groovy by
+      # design; @CompileStatic / explicit-type rules are inappropriate for them.
+      - "docker/jenkins/**"
+      - "docker/jenkins/**/*"
   shellcheck: # shell linting — exercise-template build scripts are scaffolding, not app code
     exclude_paths:
       - "src/main/resources/templates/**"


### PR DESCRIPTION
### Summary

**79 of Codacy's 89 remaining quality findings (89%) are in `src/main/resources/templates/**`** — programming-exercise scaffolding (Jenkins pipeline `.groovy`, bash build scripts, Python helpers), not application code. This scopes the quality linters (CodeNarc, ShellCheck, PyLint) away from that scaffolding, exactly as the security scanners already are. It additionally excludes the `docker/jenkins` init scripts from CodeNarc (see below).

### Checklist

- [x] `.codacy.yaml` parses as valid YAML; engine keys verified (`codenarc`, `shellcheck`, `pylintpython3` — the canonical Codacy engine names).
- [x] Enumerated the findings from Codacy to confirm the split: 79 in templates, ~10 in real code.
- [x] Only exercise-template / Jenkins-init paths are excluded; the tools still analyze the rest of the repo.

### Motivation and Context

Template code under `src/main/resources/templates/` is starter/sample code shipped for exercises — Artemis does not maintain it for code quality. The security scanners (Semgrep/Bandit/Checkov/Trivy) already exclude it for this reason. CodeNarc/ShellCheck/PyLint were still flagging it, and many of those findings are intrinsic to the template substitution syntax (e.g. `#dockerImage` placeholders → GString warnings) or inappropriate for the file type (e.g. `@CompileStatic` on Jenkins pipeline scaffolding). Fixing scaffolding to satisfy a linter would be wrong; excluding it is the consistent, correct action.

The same reasoning covers `docker/jenkins/jenkins-disable-csrf.groovy`, a Jenkins `init.groovy.d` script that is dynamic-Groovy by design — CodeNarc's `@CompileStatic` / explicit-type / no-`def` findings do not apply to it — so `docker/jenkins/**` is excluded from CodeNarc too.

### Description

Added per-engine `exclude_paths` mirroring the existing security-scanner blocks:
- `codenarc` → `src/main/resources/templates/**` (clears ~53 Groovy findings) + `docker/jenkins/**` (clears the 5 Jenkins-init findings)
- `shellcheck` → `src/main/resources/templates/**` (clears ~15 shell findings)
- `pylintpython3` → `src/main/resources/templates/**` (clears ~11 Python findings)

PyLint continues to analyze `supporting_scripts/` (where the recently-fixed import/variable cleanups live); only the exercise templates are excluded there.

### Steps for Testing

`.codacy.yaml` is read by Codacy Cloud from the default branch, so the effect is visible after merge on the next develop analysis: the template-sourced CodeNarc/ShellCheck/PyLint findings and the Jenkins-init CodeNarc findings drop out, taking the repository from ~89 to ~5 quality findings. No code behaviour changes.

### Testserver States

Not applicable — this only changes Codacy analysis configuration; no server or client artifact is affected.

### Review Progress

- [x] Code review
