### PR TITLE
`Development`: Silence false positive hadolint warning on the war file stage

### DIFF
--- a/docker/artemis/Dockerfile
+++ b/docker/artemis/Dockerfile
@@ -85,6 +85,9 @@ COPY ./build/libs/*.war Artemis.war
 #-----------------------------------------------------------------------------------------------------------------------
 # war file stage (decides whether an external .war file will be used or the Docker built .war file)
 #-----------------------------------------------------------------------------------------------------------------------
+# WAR_FILE_STAGE resolves to a build stage defined above (builder / external_builder), not an
+# external image, so there is no version tag to pin (DL3006 is a false positive here).
+# hadolint ignore=DL3006
 FROM ${WAR_FILE_STAGE} AS war_file
 
 #-----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Clears the one real-code Hadolint finding Codacy reports (`DL3006` at `docker/artemis/Dockerfile:88`), which is a false positive.

### Checklist

- [x] Verified with local hadolint: `DL3006` no longer reported after the change.
- [x] Change is a single scoped `ignore` directive with an explanatory comment — no build behaviour change.

### Motivation and Context

`FROM ${WAR_FILE_STAGE} AS war_file` references a **build stage** defined earlier in this multi-stage build (`WAR_FILE_STAGE` is an `ARG` defaulting to `builder`, or `external_builder`), not an external image. DL3006 ("always tag the version of an image explicitly") does not apply — a stage reference has no image tag to pin. This is the last genuine-code finding after the exercise-template/Jenkins-init exclusions in the companion `.codacy.yaml` PR.

### Description

Added a scoped `# hadolint ignore=DL3006` on the `FROM ${WAR_FILE_STAGE}` line with a comment explaining that it resolves to a build stage, not a taggable image.

### Steps for Testing

```
hadolint docker/artemis/Dockerfile
```

Expect no `DL3006` in the output.

### Testserver States

Not applicable — a Hadolint suppression comment only; the resulting image and build are unchanged.

### Review Progress

- [x] Code review