### PR TITLE
`Exam mode`: Fix student import styling

### DIFF
--- a/src/main/webapp/app/exam/manage/students/upload-images/students-upload-images-dialog.component.html
+++ b/src/main/webapp/app/exam/manage/students/upload-images/students-upload-images-dialog.component.html
@@ -28,10 +28,10 @@
                 @if (hasParsed()) {
                     <div>
                         <div class="ms-2">
-                            <strong jhiTranslate="artemisApp.importUsers.numberOfUsersNotImported"></strong>
-                            <span
-                                ><b style="color: red">{{ usersNotFound }}</b></span
-                            >
+                            <strong jhiTranslate="artemisApp.importUsers.numberOfUsersNotFound"></strong>
+                            <span>
+                                <b class="text-state-danger">{{ usersNotFound }}</b>
+                            </span>
                         </div>
                         <div class="ms-2">
                             <strong>{{ 'artemisApp.exam.examUsers.numberOfImagesSaved' | artemisTranslate }}:</strong>

--- a/src/main/webapp/app/shared-ui/user-import/dialog/user-import-dialog.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/user-import/dialog/user-import-dialog.component.spec.ts
@@ -313,7 +313,7 @@ describe('UsersImportDialogComponent', () => {
         importedStudents.forEach((student) => expect(component.wasImported(student)).toBe(true));
         notImportedStudents.forEach((student) => expect(component.wasImported(student)).toBe(false));
         expect(component.numberOfUsersImported).toBe(importedStudents.length);
-        expect(component.numberOfUsersNotImported).toBe(notImportedStudents.length);
+        expect(component.numberOfUsersNotFound).toBe(notImportedStudents.length);
     });
 
     it('should invoke REST call on "Import" but not on "Finish"', () => {
@@ -509,9 +509,11 @@ describe('UsersImportDialogComponent', () => {
 
         expect(component.notFoundUsers).toHaveLength(0);
         expect(component.rejectedStaffUsers).toHaveLength(2);
-        rejectedStaff.forEach((student) => expect(component.wasNotImported(student)).toBe(true));
+        rejectedStaff.forEach((student) => expect(component.wasNotFound(student)).toBe(false));
+        rejectedStaff.forEach((student) => expect(component.wasRejectedStaff(student)).toBe(true));
         rejectedStaff.forEach((student) => expect(component.wasImported(student)).toBe(false));
-        expect(component.numberOfUsersNotImported).toBe(2);
+        expect(component.numberOfUsersNotFound).toBe(0);
+        expect(component.numberOfStaffRejected).toBe(2);
         expect(component.numberOfUsersImported).toBe(1);
     });
 
@@ -549,12 +551,20 @@ describe('UsersImportDialogComponent', () => {
         component.importUsers();
 
         expect(component.numberOfUsersImported).toBe(1);
-        expect(component.numberOfUsersNotImported).toBe(2);
+        expect(component.numberOfUsersNotFound).toBe(1);
+        expect(component.numberOfStaffRejected).toBe(1);
         expect(component.wasImported(studentsToImport[0])).toBe(true);
-        expect(component.wasNotImported(studentsToImport[0])).toBe(false);
-        expect(component.wasNotImported(studentsToImport[1])).toBe(true);
+        expect(component.wasNotFound(studentsToImport[0])).toBe(false);
+        expect(component.wasRejectedStaff(studentsToImport[0])).toBe(false);
+
+        // This one was rejected staff
+        expect(component.wasNotFound(studentsToImport[1])).toBe(false);
+        expect(component.wasRejectedStaff(studentsToImport[1])).toBe(true);
         expect(component.wasImported(studentsToImport[1])).toBe(false);
-        expect(component.wasNotImported(studentsToImport[2])).toBe(true);
+
+        // This one was not found
+        expect(component.wasNotFound(studentsToImport[2])).toBe(true);
+        expect(component.wasRejectedStaff(studentsToImport[2])).toBe(false);
         expect(component.wasImported(studentsToImport[2])).toBe(false);
     });
 });

--- a/src/main/webapp/app/shared-ui/user-import/dialog/users-import-dialog.component.html
+++ b/src/main/webapp/app/shared-ui/user-import/dialog/users-import-dialog.component.html
@@ -123,8 +123,8 @@
                         </tr>
                     </ng-template>
                     <ng-template #body let-user let-i="rowIndex">
-                        <tr [class.import-success]="wasImported(user)" [class.import-fail]="wasNotImported(user)">
-                            <th scope="row">{{ i + 1 }}</th>
+                        <tr [class.import-success]="wasImported(user)" [class.import-not-found]="wasNotFound(user)" [class.import-warning]="wasRejectedStaff(user)">
+                            <td>{{ i + 1 }}</td>
                             <td style="width: 300px">{{ user.registrationNumber }}</td>
                             <td>{{ user.login }}</td>
                             <td>{{ user.email }}</td>
@@ -155,8 +155,8 @@
                         </tr>
                     </ng-template>
                     <ng-template #body let-user let-i="rowIndex">
-                        <tr [class.import-success]="wasImported(user)" [class.import-fail]="wasNotImported(user)">
-                            <th scope="row">{{ i + 1 }}</th>
+                        <tr [class.import-success]="wasImported(user)" [class.import-not-found]="wasNotFound(user)" [class.import-warning]="wasRejectedStaff(user)">
+                            <td>{{ i + 1 }}</td>
                             <td style="width: 350px">{{ user.registrationNumber }}</td>
                             <td>{{ user.login }}</td>
                             <td>{{ user.email }}</td>
@@ -185,9 +185,9 @@
                             <span>{{ numberOfUsersImported }}</span>
                         </div>
                         <div class="ms-2">
-                            <strong jhiTranslate="artemisApp.importUsers.numberOfUsersNotImported"></strong>
+                            <strong jhiTranslate="artemisApp.importUsers.numberOfUsersNotFound"></strong>
                             <span
-                                ><b class="text-state-danger">{{ numberOfUsersNotImported }}</b></span
+                                ><b class="text-state-danger">{{ numberOfUsersNotFound }}</b></span
                             >
                         </div>
                     }
@@ -203,14 +203,24 @@
                     } @else {
                         <div>
                             <strong jhiTranslate="artemisApp.importUsers.numberOfUsersImported"></strong>
-                            <span>{{ numberOfUsersImported }}</span>
+                            <span>
+                                <b class="text-state-success">{{ numberOfUsersImported }}</b>
+                            </span>
                         </div>
                         <div class="ms-2">
-                            <strong jhiTranslate="artemisApp.importUsers.numberOfUsersNotImported"></strong>
-                            <span
-                                ><b class="text-state-danger">{{ numberOfUsersNotImported }}</b></span
-                            >
+                            <strong jhiTranslate="artemisApp.importUsers.numberOfUsersNotFound"></strong>
+                            <span>
+                                <b class="text-state-danger">{{ numberOfUsersNotFound }}</b>
+                            </span>
                         </div>
+                        @if (numberOfStaffRejected > 0) {
+                            <div class="ms-2">
+                                <strong jhiTranslate="artemisApp.importUsers.numberOfStaffRejected"></strong>
+                                <span>
+                                    <b class="text-state-warning">{{ numberOfStaffRejected }}</b>
+                                </span>
+                            </div>
+                        }
                     }
                 </div>
             }

--- a/src/main/webapp/app/shared-ui/user-import/dialog/users-import-dialog.component.scss
+++ b/src/main/webapp/app/shared-ui/user-import/dialog/users-import-dialog.component.scss
@@ -12,36 +12,19 @@
     margin-bottom: 0.1rem;
 }
 
-.import-success,
-.import-fail {
-    position: relative;
-
-    &:nth-child(odd)::before {
-        content: '';
-        pointer-events: none;
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: rgba(0, 0, 0, 0.03);
-    }
+tr.import-success {
+    background-color: color-mix(in srgb, var(--success) 12%, transparent) !important;
+    color: var(--success) !important;
 }
 
-.import-success {
-    td,
-    th {
-        color: var(--color-state-success);
-        background-color: color-mix(in srgb, var(--color-state-success) 12%, transparent);
-    }
+tr.import-not-found {
+    background-color: color-mix(in srgb, var(--danger) 12%, transparent) !important;
+    color: var(--danger) !important;
 }
 
-.import-fail {
-    td,
-    th {
-        color: var(--color-state-danger);
-        background-color: color-mix(in srgb, var(--color-state-danger) 12%, transparent);
-    }
+tr.import-warning {
+    background-color: color-mix(in srgb, var(--warning) 12%, transparent) !important;
+    color: var(--warning) !important;
 }
 
 .header-fixed {

--- a/src/main/webapp/app/shared-ui/user-import/dialog/users-import-dialog.component.ts
+++ b/src/main/webapp/app/shared-ui/user-import/dialog/users-import-dialog.component.ts
@@ -210,15 +210,15 @@ export class UsersImportDialogComponent implements OnDestroy {
      * @param user The user to be checked
      */
     wasImported(user: StudentDTO): boolean {
-        return this.hasImported() && !this.wasNotImported(user);
+        return this.hasImported() && !this.wasNotFound(user) && !this.wasRejectedStaff(user);
     }
 
     /**
-     * True if this user could not be imported, false otherwise
+     * True if this user could not be imported because it was not found
      * @param user The user to be checked
      */
-    wasNotImported(user: StudentDTO): boolean {
-        if (this.hasImported() && this.notFoundUsers?.length === 0 && this.rejectedStaffUsers?.length === 0) {
+    wasNotFound(user: StudentDTO): boolean {
+        if (!this.hasImported() && this.notFoundUsers?.length === 0) {
             return false;
         }
 
@@ -230,6 +230,18 @@ export class UsersImportDialogComponent implements OnDestroy {
             ) {
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    /**
+     * True if this user could not be imported because it is staff
+     * @param user The user to be checked
+     */
+    wasRejectedStaff(user: StudentDTO): boolean {
+        if (this.hasImported() && this.rejectedStaffUsers?.length === 0) {
+            return false;
         }
 
         for (const rejected of this.rejectedStaffUsers) {
@@ -252,15 +264,22 @@ export class UsersImportDialogComponent implements OnDestroy {
         return !this.hasImported()
             ? 0
             : this.examUserMode()
-              ? this.examUsersToImport().length - this.numberOfUsersNotImported
-              : this.usersToImport().length - this.numberOfUsersNotImported;
+              ? this.examUsersToImport().length - this.numberOfUsersNotFound - this.numberOfStaffRejected
+              : this.usersToImport().length - this.numberOfUsersNotFound - this.numberOfStaffRejected;
     }
 
     /**
      * Number of users which could not be imported
      */
-    get numberOfUsersNotImported(): number {
-        return !this.hasImported() ? 0 : this.notFoundUsers.length + this.rejectedStaffUsers.length;
+    get numberOfUsersNotFound(): number {
+        return !this.hasImported() ? 0 : this.notFoundUsers.length;
+    }
+
+    /**
+     * Number of staff users which could not be imported
+     */
+    get numberOfStaffRejected(): number {
+        return !this.hasImported() ? 0 : this.rejectedStaffUsers.length;
     }
 
     get isSubmitDisabled(): boolean {

--- a/src/main/webapp/app/shared-ui/user-import/dialog/users-import-dialog.component.ts
+++ b/src/main/webapp/app/shared-ui/user-import/dialog/users-import-dialog.component.ts
@@ -218,7 +218,7 @@ export class UsersImportDialogComponent implements OnDestroy {
      * @param user The user to be checked
      */
     wasNotFound(user: StudentDTO): boolean {
-        if (!this.hasImported() && this.notFoundUsers?.length === 0) {
+        if (!this.hasImported() || this.notFoundUsers?.length === 0) {
             return false;
         }
 
@@ -240,7 +240,7 @@ export class UsersImportDialogComponent implements OnDestroy {
      * @param user The user to be checked
      */
     wasRejectedStaff(user: StudentDTO): boolean {
-        if (this.hasImported() && this.rejectedStaffUsers?.length === 0) {
+        if (this.hasImported() || this.rejectedStaffUsers?.length === 0) {
             return false;
         }
 

--- a/src/main/webapp/app/shared-ui/user-import/dialog/users-import-dialog.component.ts
+++ b/src/main/webapp/app/shared-ui/user-import/dialog/users-import-dialog.component.ts
@@ -240,7 +240,7 @@ export class UsersImportDialogComponent implements OnDestroy {
      * @param user The user to be checked
      */
     wasRejectedStaff(user: StudentDTO): boolean {
-        if (this.hasImported() || this.rejectedStaffUsers?.length === 0) {
+        if (!this.hasImported() || this.rejectedStaffUsers?.length === 0) {
             return false;
         }
 

--- a/src/main/webapp/i18n/de/importUsers.json
+++ b/src/main/webapp/i18n/de/importUsers.json
@@ -18,8 +18,9 @@
                 "noUsersFound": "Es wurden keine Benutzer zum Importieren gefunden"
             },
             "numberOfUsers": "Anzahl an Nutzern:",
-            "numberOfUsersImported": "Importierte Studierende:",
-            "numberOfUsersNotImported": "Nicht gefundene Studierende:",
+            "numberOfUsersImported": "Importiert:",
+            "numberOfUsersNotFound": "Nicht gefunden:",
+            "numberOfStaffRejected": "Abgelehnte Mitarbeiter:",
             "genericErrorMessage": "Der Import von Nutzern in den Kurs oder die Klausur ist fehlgeschlagen!",
             "firstName": "Vorname",
             "lastName": "Nachname",

--- a/src/main/webapp/i18n/en/importUsers.json
+++ b/src/main/webapp/i18n/en/importUsers.json
@@ -18,8 +18,9 @@
                 "noUsersFound": "No users to import have been found"
             },
             "numberOfUsers": "Number of users:",
-            "numberOfUsersImported": "Imported students:",
-            "numberOfUsersNotImported": "Not found students:",
+            "numberOfUsersImported": "Imported:",
+            "numberOfUsersNotFound": "Not found:",
+            "numberOfStaffRejected": "Rejected staff:",
             "genericErrorMessage": "Import of users failed!",
             "firstName": "First name",
             "lastName": "Last name",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
Fixed issues with styling when importing students to exams, see screenshots.
#8879 can be closed after merge.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix issues with styling

### Description
I think because of the recent tailwind migration the styling was broken in this import UI.


### Steps for Testing

#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- 1 Instructor

1. Download this [CSV]([exam-137-students.csv](https://github.com/user-attachments/files/30006742/exam-137-students.csv))
2. Create a new course set to run in the future and go to its students page
3. Import the students and see everything is highlighted correctly

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Exam Mode Test
- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| users-import-dialog.component.ts | 94.73% | 254 | ? | ? |

_Last updated: 2026-07-14 13:59:27 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
<img width="1145" height="714" alt="Screenshot 2026-07-14 at 13 52 36" src="https://github.com/user-attachments/assets/f4f1b983-fad0-4fd4-a31f-f83fa5096a13" />

After:
<img width="1147" height="698" alt="Screenshot 2026-07-14 at 13 49 35" src="https://github.com/user-attachments/assets/e86224ec-e2f4-46da-b9c5-0c3add783644" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User imports now distinguish between users who were not found and staff members rejected during import.
  - Import results display separate counts and status indicators for imported users, missing users, and rejected staff.
  - Updated styling makes import outcomes easier to identify at a glance.

- **Bug Fixes**
  - Corrected user import and image upload summaries to show accurate “not found” counts.

- **Documentation**
  - Updated English and German labels for import results, including rejected staff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->