### PR TITLE
`Exam mode`: Fix duplicate participations in test runs

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exam/web/StudentExamResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/web/StudentExamResource.java
@@ -709,7 +709,8 @@ public class StudentExamResource {
     private void prepareStudentExamForConduction(HttpServletRequest request, User currentUser, StudentExam studentExam) {
 
         // In case the studentExam is not yet started, a new participation with a specific initialization date should be created - isStarted uses Boolean
-        if (studentExam.isTestExam()) {
+        // Test runs are already prepared when they are created.
+        if (studentExam.isTestExam() && !studentExam.isTestRun()) {
             boolean setupTestExamNeeded = studentExam.isStarted() == null || !studentExam.isStarted();
             if (setupTestExamNeeded) {
 

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
@@ -2488,6 +2488,28 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testTestExamTestRunConductionDoesNotCreateAdditionalParticipations() throws Exception {
+        Exam testExam = examUtilService.addTestExam(course1);
+        testExam = examUtilService.addTextModelingProgrammingExercisesToExam(testExam, false, true);
+        StudentExam testRun = createTestRun(testExam);
+        User instructor = userUtilService.getUserByLogin(TEST_PREFIX + "instructor1");
+
+        Set<Long> participationIdsBeforeConduction = testRun.getExercises().stream()
+                .flatMap(exercise -> studentParticipationRepository.findByExerciseIdAndStudentId(exercise.getId(), instructor.getId()).stream()).map(StudentParticipation::getId)
+                .collect(Collectors.toSet());
+        assertThat(participationIdsBeforeConduction).hasSize(testRun.getExercises().size());
+
+        userUtilService.changeUser(TEST_PREFIX + "instructor1");
+        request.get("/api/exam/courses/" + course1.getId() + "/exams/" + testExam.getId() + "/test-runs/" + testRun.getId() + "/conduction", HttpStatus.OK, StudentExam.class);
+
+        Set<Long> participationIdsAfterConduction = testRun.getExercises().stream()
+                .flatMap(exercise -> studentParticipationRepository.findByExerciseIdAndStudentId(exercise.getId(), instructor.getId()).stream()).map(StudentParticipation::getId)
+                .collect(Collectors.toSet());
+        assertThat(participationIdsAfterConduction).isEqualTo(participationIdsBeforeConduction);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testSubmitTestRun() throws Exception {
         var testRun = createTestRun();
         userUtilService.changeUser(TEST_PREFIX + "instructor1");

--- a/src/test/java/de/tum/cit/aet/artemis/localvc/service/LocalVCFetchAndPushIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localvc/service/LocalVCFetchAndPushIntegrationTest.java
@@ -1395,15 +1395,16 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             exam.setTestExam(true);
             examRepository.save(exam);
 
-            // Create an instructor exam test run (not a student exam)
-            StudentExam instructorTestRunExam = examUtilService.addStudentExam(exam);
-            instructorTestRunExam.setUser(instructor1);
-            instructorTestRunExam.setExercises(List.of(examProgrammingExercise));
-            instructorTestRunExam.setTestRun(true);
-            // Don't set startedAndStartDate - let the conduction endpoint handle it
-            studentExamRepository.save(instructorTestRunExam);
+            // Create an instructor exam test run, including its participation and repository.
+            StudentExam testRunConfiguration = new StudentExam();
+            testRunConfiguration.setExam(exam);
+            testRunConfiguration.setExercises(List.of(examProgrammingExercise));
+            testRunConfiguration.setWorkingTime(3600);
+            StudentExam instructorTestRunExam = request.postWithResponseBody("/api/exam/courses/" + course.getId() + "/exams/" + exam.getId() + "/test-runs", testRunConfiguration,
+                    StudentExam.class, HttpStatus.OK);
 
-            // Start the test run via conduction endpoint - this creates the participation and repository
+            // Start the test run via conduction endpoint.
+            userUtilService.changeUser(instructor1.getLogin());
             request.get("/api/exam/courses/" + course.getId() + "/exams/" + exam.getId() + "/test-runs/" + instructorTestRunExam.getId() + "/conduction", HttpStatus.OK,
                     StudentExam.class);
 


### PR DESCRIPTION
### Summary

Prevents test-exam test runs from creating a second set of exercise participations when an instructor starts the run.

### Checklist

#### General

- [x] This is a small server-side issue that I tested locally with focused integration tests.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server

- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many unnecessary or complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added a focused Spring integration test with extensive assertions for the regression.

### Motivation and Context

Test runs are fully prepared when they are created. Starting a test run for an exam marked as a test exam prepared it a second time, creating duplicate participations for every exercise. These duplicates caused downstream submission failures, including misleading assignment-repository errors for exam exercises.

### Description

- Skip test-exam preparation during conduction when the student exam is a test run.
- Preserve the existing preparation behavior for regular test-exam attempts.
- Assert that starting a test run does not change its exercise participation IDs.
- Exercise programming-repository access through the supported test-run creation endpoint.

### Steps for Testing

Prerequisites:

- 1 instructor
- 1 test exam with text, modeling, or quiz exercises

1. Create a test run for the test exam.
2. Start the test run.
3. Open each exercise and save a submission.
4. Confirm that no internal-server or assignment-repository error appears.

#### Exam Mode Testing

The focused server integration suite covers creation, conduction, and submission in test runs as well as regular test-exam conduction.

### Testserver States

No test-server deployment was performed.

### Review Progress

#### Performance Review

- [ ] I (as a reviewer) confirm that the server changes are implemented with very good performance even for very large courses.

#### Code Review

- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests

- [ ] Test-run creation and conduction

#### Exam Mode Test

- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| StudentExamResource.java | 89.76% | 485 |

_Last updated: 2026-07-15 00:14:37 UTC_

