### PR TITLE
`General`: Restore black admin sidebar entries and unify title bar heights

### DIFF
--- a/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.html
+++ b/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.html
@@ -30,7 +30,7 @@
                     @for (item of group.items; track item.routerLink) {
                         <li>
                             <a
-                                class="nav-link-sidebar flex items-center px-3 py-2 whitespace-nowrap text-color no-underline"
+                                class="nav-link-sidebar flex items-center px-3 py-2 whitespace-nowrap no-underline"
                                 [attr.id]="item.testId"
                                 [class.collapsed]="isNavbarCollapsed()"
                                 [routerLink]="item.routerLink"

--- a/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.scss
+++ b/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.scss
@@ -28,6 +28,14 @@ $menu-width-open: 220px;
 }
 
 /*
+ * Base text color for nav links. A layered `text-color` template utility would lose to the unlayered global
+ * `a { color: $link-color }` rule in global.scss (unlayered beats layered), so the color must be set here.
+ */
+.nav-link-sidebar {
+    color: var(--p-text-color);
+}
+
+/*
  * Hover / router-active state for nav links. Stateful selectors plus an `!important` override of the global
  * anchor hover style, so they cannot be plain template utilities.
  */

--- a/src/main/webapp/app/admin/shared/admin-title-bar/admin-title-bar.component.scss
+++ b/src/main/webapp/app/admin/shared/admin-title-bar/admin-title-bar.component.scss
@@ -1,10 +1,5 @@
 @import 'src/main/webapp/content/scss/artemis-mixins';
 
-// Must match or exceed the quiz participation bar's z-index (1030)
-#course-title-bar {
-    z-index: 1030;
-}
-
 /* The action controls are projected from page templates, so their styling requires piercing encapsulation. */
 :host ::ng-deep {
     @include title-bar-compact-controls;

--- a/src/main/webapp/app/admin/shared/admin-title-bar/admin-title-bar.component.ts
+++ b/src/main/webapp/app/admin/shared/admin-title-bar/admin-title-bar.component.ts
@@ -6,6 +6,7 @@ import { TranslateDirective } from 'app/foundation/language/translate.directive'
 @Component({
     selector: 'jhi-admin-title-bar',
     templateUrl: './admin-title-bar.component.html',
+    styleUrl: './admin-title-bar.component.scss',
     imports: [NgTemplateOutlet, TranslateDirective],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/main/webapp/content/scss/_artemis-mixins.scss
+++ b/src/main/webapp/content/scss/_artemis-mixins.scss
@@ -47,6 +47,33 @@
     opacity: 1;
 }
 
+/*
+ * Compact PrimeNG controls inside the title bars rendered below the breadcrumbs. Caps them at 28px so that
+ * together with the bars' py-2 (16px) every bar renders at the 44px floor (`min-h-11`) of the admin title bar,
+ * whether or not it contains action controls. Vertical centering of the control content is handled by the
+ * components' own flex layout.
+ */
+@mixin title-bar-compact-controls {
+    .p-button,
+    .p-togglebutton,
+    .p-select {
+        height: 1.75rem;
+        padding-block: 0;
+    }
+
+    .p-togglebutton-content {
+        padding-block: 0;
+    }
+
+    .p-select {
+        align-items: center;
+
+        .p-select-label {
+            padding-block: 0;
+        }
+    }
+}
+
 @mixin dynamic-content-height($extra-height-to-subtract...) {
     $base: calc(100vh - var(--sidebar-header-footer-combined-height));
     $base-dvh: calc(100dvh - var(--sidebar-header-footer-combined-height));


### PR DESCRIPTION
### Summary
Two small consistency fixes for the admin UI: sidebar entries are black again (instead of link blue), and the horizontal title bar below the breadcrumbs now has the same height on every page, whether or not it contains action controls.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.

### Motivation and Context
1. Since the Tailwind migration of the admin module (#12963), all admin sidebar entries render in link blue instead of the body text color. The migration replaced the anchors' unlayered Bootstrap `nav-link` class (which carried `color: var(--bs-body-color)`) with the `text-color` Tailwind utility. That utility lives in the `utilities` CSS layer, and unlayered rules beat layered rules regardless of specificity, so the unlayered global `a { color: $link-color }` rule from `global.scss` wins and paints every entry blue.
2. The title bar below the breadcrumbs had inconsistent heights across pages: 44px when it contains only the title (the bar's `min-h-11` floor), ~52px when it contains PrimeNG `size="small"` controls (~35px tall: 14px font x 1.5 inherited Bootstrap line-height + 2x6px padding + 2x1px border).

### Description
- `admin-sidebar.component.scss`: set the base color of `.nav-link-sidebar` to `var(--p-text-color)` in the (unlayered) component stylesheet, mirroring how the course sidebar keeps its entries black. The ineffective `text-color` utility is removed from the template. Hover/active styling is unchanged. The token is theme-aware, so light and dark mode both stay correct.
- New `title-bar-compact-controls` mixin in `_artemis-mixins.scss`: caps `p-button`, `p-togglebutton`, and `p-select` inside the title bars at 28px height, so together with the bars' `py-2` (16px) every bar renders at the 44px `min-h-11` floor, with and without action controls. Applied via `:host ::ng-deep` in both `admin-title-bar` (new stylesheet) and `course-title-bar`, since the action controls are projected from page templates.

Measured after the change (local dev server, 1720px viewport):

| Page | Content | Bar height |
|---|---|---|
| /admin/audits | title only | 44px |
| /admin/user-management | title + 2 buttons | 44px (was ~52px) |
| /admin/user-statistics | title + selectbutton | 44px (was ~52px) |
| /admin/metrics | title + 7 buttons + select | 44px (was ~52px) |

Sidebar anchors computed color is now `#334155` (`--p-text-color`) instead of `#3e8acc` (`$link-color`).

### Steps for Testing
Prerequisites:
- 1 Admin

1. Log in to Artemis as admin
2. Open Server Administration and check that all sidebar entries are black (body text color), and only hover/active states are highlighted
3. Navigate between pages with toolbar buttons (User Management, Metrics, Statistics, Health) and without (Audits, Configuration, Logs): the title bar below the breadcrumbs keeps the same height everywhere
4. Check both the light and the dark theme

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved sidebar navigation link alignment and text color.
  * Added consistent compact styling for action controls in admin and course title bars.
  * Standardized button, toggle, and select control sizing for a cleaner title-bar layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Screenshots

Light theme — sidebar body-text color and 44px title bar with select-button controls:

![Admin statistics in light theme](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/fb31e2b2-5835-4ee1-95a7-501778ea1d30.png)

Dark theme — sidebar body-text color and 44px title bar with buttons and select controls:

![Admin metrics in dark theme](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/89ed9421-d233-499a-9b6f-09312a10b886.png)