### PR TITLE
`General`: Fix admin cleanup service and feature toggle robustness issues

### DIFF
--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.html
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.html
@@ -52,7 +52,15 @@
             <button pButton type="button" severity="secondary" [outlined]="true" size="small" (click)="close()" data-testid="close-button">
                 <span jhiTranslate="cleanupService.button.close"></span>
             </button>
-            <button pButton type="button" severity="danger" size="small" [disabled]="!hasEntriesToDelete()" (click)="executeCleanupOperation()" data-testid="execute-button">
+            <button
+                pButton
+                type="button"
+                severity="danger"
+                size="small"
+                [disabled]="operationExecuting() || !hasEntriesToDelete()"
+                (click)="executeCleanupOperation()"
+                data-testid="execute-button"
+            >
                 <fa-icon [icon]="faTrash" />
                 <span jhiTranslate="cleanupService.button.execute"></span>
             </button>

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.html
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.html
@@ -9,6 +9,9 @@
     [style]="{ width: '50dvw' }"
     [header]="'cleanupService.operation.' + operation().name | artemisTranslate"
 >
+    @if (dialogError(); as error) {
+        <p-message severity="error" [text]="error" styleClass="mb-3 w-full" aria-live="assertive" data-testid="cleanup-error-message" />
+    }
     @if (operation().name === 'deleteOrphans') {
         <p
             [jhiTranslate]="'cleanupService.execute.questionWithoutDates'"

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.spec.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.spec.ts
@@ -381,6 +381,8 @@ describe('CleanupOperationModalComponent', () => {
 
             expect(component.dialogError()).toBe(httpError.message);
             expect(component.operationExecuted()).toBe(false);
+            // The guard must be released on failure (via finalize) so the operation can be retried.
+            expect(component.operationExecuting()).toBe(false);
         });
 
         it('should emit generic error message for non-HttpErrorResponse failures', () => {
@@ -392,6 +394,47 @@ describe('CleanupOperationModalComponent', () => {
             component.executeCleanupOperation();
 
             expect(component.dialogError()).toBe('An unexpected error occurred.');
+            expect(component.operationExecuting()).toBe(false);
+        });
+
+        it('should clear a previous error when re-executing in place after a failure', () => {
+            const httpError = new HttpErrorResponse({ status: 500, error: { message: 'Delete failed' } });
+            vi.spyOn(dataCleanupService, 'deleteOrphans')
+                .mockReturnValueOnce(throwError(() => httpError))
+                .mockReturnValueOnce(of(new HttpResponse({ body: { executionDate: dayjs(), jobType: 'deleteOrphans' } })));
+            componentRef.setInput('operation', deleteOrphansOperation);
+            component.visible.set(true);
+            fixture.detectChanges();
+
+            // First attempt fails and shows an error banner.
+            component.executeCleanupOperation();
+            expect(component.dialogError()).toBe(httpError.message);
+
+            // A successful in-place retry must clear the stale error rather than show it beside the success state.
+            component.executeCleanupOperation();
+            expect(component.dialogError()).toBeUndefined();
+            expect(component.operationExecuted()).toBe(true);
+        });
+
+        it('should ignore a cleanup completion delivered after the modal was closed', () => {
+            const execution = new Subject<HttpResponse<CleanupServiceExecutionRecordDTO>>();
+            vi.spyOn(dataCleanupService, 'deleteOrphans').mockReturnValue(execution);
+            componentRef.setInput('operation', deleteOrphansOperation);
+            component.visible.set(true);
+            fixture.detectChanges();
+            component.executeCleanupOperation();
+
+            // Close without reopening; the DELETE is still running server-side.
+            component.close();
+            fixture.detectChanges();
+
+            // The completion arrives while the modal is closed (same operation), so only the !visible() half of the
+            // stale-completion guard can trip: it must not flip operationExecuted, and the guard must be released.
+            execution.next(new HttpResponse({ body: { executionDate: dayjs(), jobType: 'deleteOrphans' } }));
+            execution.complete();
+
+            expect(component.operationExecuted()).toBe(false);
+            expect(component.operationExecuting()).toBe(false);
         });
     });
 

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.spec.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.spec.ts
@@ -290,9 +290,16 @@ describe('CleanupOperationModalComponent', () => {
             component.visible.set(true);
             fixture.detectChanges();
 
+            // Closing cannot cancel deletion after the server has started it. Keep the execution guard across the
+            // reopen so the newly displayed operation cannot submit a second destructive request concurrently.
+            expect(component.operationExecuting()).toBe(true);
+            component.executeCleanupOperation();
+            expect(dataCleanupService.deleteNonRatedResults).not.toHaveBeenCalled();
+
             execution.next(new HttpResponse({ body: { executionDate: dayjs(), jobType: 'deleteOrphans' } }));
             execution.complete();
 
+            expect(component.operationExecuting()).toBe(false);
             expect(component.operationExecuted()).toBe(false);
             expect(component.counts()).toEqual(mockNonRatedCounts);
         });

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.spec.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.spec.ts
@@ -169,17 +169,14 @@ describe('CleanupOperationModalComponent', () => {
             expect(component.counts()).toEqual(mockSubmissionVersionCounts);
         });
 
-        it('should emit error to dialogError when fetching counts fails', () => {
+        it('should set dialogError when fetching counts fails', () => {
             vi.spyOn(dataCleanupService, 'countOrphans').mockReturnValue(throwError(() => new Error('Network error')));
             componentRef.setInput('operation', deleteOrphansOperation);
-
-            let emittedError: string | undefined;
-            component.dialogError.subscribe((error) => (emittedError = error));
 
             component.visible.set(true);
             fixture.detectChanges();
 
-            expect(emittedError).toBe('An error occurred while fetching updated counts.');
+            expect(component.dialogError()).toBe('An error occurred while fetching updated counts.');
         });
     });
 
@@ -217,6 +214,23 @@ describe('CleanupOperationModalComponent', () => {
 
             expect(component.operationExecuted()).toBe(false);
             expect(component.counts()).toEqual({ totalCount: 0 });
+        });
+
+        it('should clear the previous error when reopened', () => {
+            vi.spyOn(dataCleanupService, 'countOrphans')
+                .mockReturnValueOnce(throwError(() => new Error('Network error')))
+                .mockReturnValue(of(new HttpResponse({ body: mockOrphanCounts })));
+            componentRef.setInput('operation', deleteOrphansOperation);
+            component.visible.set(true);
+            fixture.detectChanges();
+            expect(component.dialogError()).toBe('An error occurred while fetching updated counts.');
+
+            component.close();
+            fixture.detectChanges();
+            component.visible.set(true);
+            fixture.detectChanges();
+
+            expect(component.dialogError()).toBeUndefined();
         });
 
         it('should ignore a stale count response from a previously opened operation', () => {
@@ -349,19 +363,16 @@ describe('CleanupOperationModalComponent', () => {
             expect(dataCleanupService.countOrphans).toHaveBeenCalledTimes(2);
         });
 
-        it('should emit HttpErrorResponse message to dialogError on operation failure', () => {
+        it('should set the HttpErrorResponse message on dialogError when an operation fails', () => {
             const httpError = new HttpErrorResponse({ status: 500, statusText: 'Server Error', error: { message: 'Delete failed' } });
             vi.spyOn(dataCleanupService, 'deleteOrphans').mockReturnValue(throwError(() => httpError));
             componentRef.setInput('operation', deleteOrphansOperation);
             component.visible.set(true);
             fixture.detectChanges();
 
-            let emittedError: string | undefined;
-            component.dialogError.subscribe((error) => (emittedError = error));
-
             component.executeCleanupOperation();
 
-            expect(emittedError).toBe(httpError.message);
+            expect(component.dialogError()).toBe(httpError.message);
             expect(component.operationExecuted()).toBe(false);
         });
 
@@ -371,12 +382,9 @@ describe('CleanupOperationModalComponent', () => {
             component.visible.set(true);
             fixture.detectChanges();
 
-            let emittedError: string | undefined;
-            component.dialogError.subscribe((error) => (emittedError = error));
-
             component.executeCleanupOperation();
 
-            expect(emittedError).toBe('An unexpected error occurred.');
+            expect(component.dialogError()).toBe('An unexpected error occurred.');
         });
     });
 

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.spec.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.spec.ts
@@ -189,6 +189,31 @@ describe('CleanupOperationModalComponent', () => {
         });
     });
 
+    describe('reopening', () => {
+        it('should reset operationExecuted and counts when reopened', () => {
+            componentRef.setInput('operation', deleteOrphansOperation);
+            component.visible.set(true);
+            fixture.detectChanges();
+
+            // Run the operation so both result flags become "dirty".
+            component.executeCleanupOperation();
+            expect(component.operationExecuted()).toBe(true);
+            expect(component.counts()).toEqual(mockOrphanCounts);
+
+            component.close();
+            fixture.detectChanges();
+
+            // Reopening must clear the previous run's result state. Fail the reopen count-fetch so the reset
+            // value (totalCount 0) stays observable instead of being immediately overwritten by fresh counts.
+            vi.spyOn(dataCleanupService, 'countOrphans').mockReturnValue(throwError(() => new Error('Network error')));
+            component.visible.set(true);
+            fixture.detectChanges();
+
+            expect(component.operationExecuted()).toBe(false);
+            expect(component.counts()).toEqual({ totalCount: 0 });
+        });
+    });
+
     describe('executeCleanupOperation', () => {
         it('should execute deleteOrphans operation', () => {
             componentRef.setInput('operation', deleteOrphansOperation);

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.spec.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.spec.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { ComponentRef, signal } from '@angular/core';
-import { of, throwError } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import dayjs from 'dayjs/esm';
 
@@ -211,6 +211,28 @@ describe('CleanupOperationModalComponent', () => {
 
             expect(component.operationExecuted()).toBe(false);
             expect(component.counts()).toEqual({ totalCount: 0 });
+        });
+
+        it('should ignore a stale count response from a previously opened operation', () => {
+            // The modal instance persists across opens. Open A with a count request that never resolves yet.
+            const orphanCounts = new Subject<HttpResponse<OrphanCleanupCountDTO>>();
+            vi.spyOn(dataCleanupService, 'countOrphans').mockReturnValue(orphanCounts);
+
+            componentRef.setInput('operation', deleteOrphansOperation);
+            component.visible.set(true);
+            fixture.detectChanges();
+
+            // Close (cancels A's pending request), then reopen for B, whose counts resolve synchronously.
+            component.close();
+            fixture.detectChanges();
+            componentRef.setInput('operation', deleteNonRatedOperation);
+            component.visible.set(true);
+            fixture.detectChanges();
+            expect(component.counts()).toEqual(mockNonRatedCounts);
+
+            // A's late response must not overwrite B's counts.
+            orphanCounts.next(new HttpResponse({ body: mockOrphanCounts }));
+            expect(component.counts()).toEqual(mockNonRatedCounts);
         });
     });
 

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.spec.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.spec.ts
@@ -12,7 +12,13 @@ import dayjs from 'dayjs/esm';
 
 import { CleanupOperationModalComponent } from 'app/admin/cleanup-service/cleanup-operation-modal.component';
 import { CleanupOperation, OperationName } from 'app/admin/cleanup-service/cleanup-operation.model';
-import { CleanupCount, DataCleanupService, OrphanCleanupCountDTO, PlagiarismComparisonCleanupCountDTO } from 'app/admin/cleanup-service/data-cleanup.service';
+import {
+    CleanupCount,
+    CleanupServiceExecutionRecordDTO,
+    DataCleanupService,
+    OrphanCleanupCountDTO,
+    PlagiarismComparisonCleanupCountDTO,
+} from 'app/admin/cleanup-service/data-cleanup.service';
 
 /**
  * Helper to create a CleanupOperation with required properties
@@ -237,6 +243,46 @@ describe('CleanupOperationModalComponent', () => {
     });
 
     describe('executeCleanupOperation', () => {
+        it('should ignore duplicate execution attempts while a cleanup request is in flight', () => {
+            const execution = new Subject<HttpResponse<CleanupServiceExecutionRecordDTO>>();
+            vi.spyOn(dataCleanupService, 'deleteOrphans').mockReturnValue(execution);
+            componentRef.setInput('operation', deleteOrphansOperation);
+            component.visible.set(true);
+            fixture.detectChanges();
+
+            component.executeCleanupOperation();
+            component.executeCleanupOperation();
+
+            expect(dataCleanupService.deleteOrphans).toHaveBeenCalledOnce();
+            expect(component.operationExecuting()).toBe(true);
+
+            execution.next(new HttpResponse({ body: { executionDate: dayjs(), jobType: 'deleteOrphans' } }));
+            execution.complete();
+            expect(component.operationExecuting()).toBe(false);
+            expect(component.operationExecuted()).toBe(true);
+        });
+
+        it('should ignore a stale cleanup completion after closing and reopening for another operation', () => {
+            const execution = new Subject<HttpResponse<CleanupServiceExecutionRecordDTO>>();
+            vi.spyOn(dataCleanupService, 'deleteOrphans').mockReturnValue(execution);
+            componentRef.setInput('operation', deleteOrphansOperation);
+            component.visible.set(true);
+            fixture.detectChanges();
+            component.executeCleanupOperation();
+
+            component.close();
+            fixture.detectChanges();
+            componentRef.setInput('operation', deleteNonRatedOperation);
+            component.visible.set(true);
+            fixture.detectChanges();
+
+            execution.next(new HttpResponse({ body: { executionDate: dayjs(), jobType: 'deleteOrphans' } }));
+            execution.complete();
+
+            expect(component.operationExecuted()).toBe(false);
+            expect(component.counts()).toEqual(mockNonRatedCounts);
+        });
+
         it('should execute deleteOrphans operation', () => {
             componentRef.setInput('operation', deleteOrphansOperation);
             component.visible.set(true);

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.ts
@@ -4,7 +4,7 @@ import { CleanupOperation } from 'app/admin/cleanup-service/cleanup-operation.mo
 import { CleanupCount, DataCleanupService } from 'app/admin/cleanup-service/data-cleanup.service';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 
-import { Observable, Subject, Subscription } from 'rxjs';
+import { Observable, Subject, Subscription, finalize } from 'rxjs';
 import { faCheckCircle, faTimes, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { ArtemisDatePipe } from 'app/foundation/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
@@ -35,11 +35,17 @@ export class CleanupOperationModalComponent {
     /** Whether the operation has been executed */
     readonly operationExecuted = signal(false);
 
+    /** Whether a cleanup operation is currently being executed. */
+    readonly operationExecuting = signal(false);
+
     private dialogErrorSource = new Subject<string>();
     dialogError = this.dialogErrorSource.asObservable();
 
     /** The in-flight count request, so it can be superseded/cancelled to avoid stale, out-of-order responses. */
     private countSubscription?: Subscription;
+
+    /** The in-flight cleanup request, so reopening the persistent modal cannot apply a stale completion to another operation. */
+    private executionSubscription?: Subscription;
 
     private readonly dataCleanupService = inject(DataCleanupService);
 
@@ -60,6 +66,8 @@ export class CleanupOperationModalComponent {
                     // Reset per-open state so reopening the modal for a different operation does not flash the
                     // previous run's result icons/counts (operationExecuted is only ever set true, and counts
                     // refresh asynchronously): start clean, then fetch this operation's counts.
+                    this.executionSubscription?.unsubscribe();
+                    this.operationExecuting.set(false);
                     this.operationExecuted.set(false);
                     this.counts.set({ totalCount: 0 });
                     this.updateCounts();
@@ -69,6 +77,8 @@ export class CleanupOperationModalComponent {
                 // in-flight count request on close: otherwise a late response could overwrite the counts of the
                 // next operation opened here.
                 this.countSubscription?.unsubscribe();
+                this.executionSubscription?.unsubscribe();
+                this.operationExecuting.set(false);
             }
         });
     }
@@ -84,37 +94,52 @@ export class CleanupOperationModalComponent {
      * Execute the cleanup operation and update counts afterward.
      */
     executeCleanupOperation(): void {
+        if (this.operationExecuting()) {
+            return;
+        }
+
+        const operation = this.operation();
+        this.operationExecuting.set(true);
         const operationHandler = {
             next: () => {
+                if (!this.visible() || this.operation() !== operation) {
+                    return;
+                }
                 this.operationExecuted.set(true);
                 this.updateCounts();
             },
             error: (error: unknown) => {
-                this.dialogErrorSource.next(error instanceof HttpErrorResponse ? error.message : 'An unexpected error occurred.');
+                if (this.visible() && this.operation() === operation) {
+                    this.dialogErrorSource.next(error instanceof HttpErrorResponse ? error.message : 'An unexpected error occurred.');
+                }
             },
         };
 
-        const operation = this.operation();
         // Range operations are only reachable once validateDates has confirmed both dates are set.
         const deleteFrom = operation.deleteFrom!;
         const deleteTo = operation.deleteTo!;
+        let executionRequest: Observable<unknown>;
         switch (operation.name) {
             case 'deleteOrphans':
-                this.dataCleanupService.deleteOrphans().subscribe(operationHandler);
+                executionRequest = this.dataCleanupService.deleteOrphans();
                 break;
             case 'deletePlagiarismComparisons':
-                this.dataCleanupService.deletePlagiarismComparisons(deleteFrom, deleteTo).subscribe(operationHandler);
+                executionRequest = this.dataCleanupService.deletePlagiarismComparisons(deleteFrom, deleteTo);
                 break;
             case 'deleteNonRatedResults':
-                this.dataCleanupService.deleteNonRatedResults(deleteFrom, deleteTo).subscribe(operationHandler);
+                executionRequest = this.dataCleanupService.deleteNonRatedResults(deleteFrom, deleteTo);
                 break;
             case 'deleteOldRatedResults':
-                this.dataCleanupService.deleteOldRatedResults(deleteFrom, deleteTo).subscribe(operationHandler);
+                executionRequest = this.dataCleanupService.deleteOldRatedResults(deleteFrom, deleteTo);
                 break;
             case 'deleteOldSubmissionVersions':
-                this.dataCleanupService.deleteOldSubmissionVersions(deleteFrom, deleteTo).subscribe(operationHandler);
+                executionRequest = this.dataCleanupService.deleteOldSubmissionVersions(deleteFrom, deleteTo);
                 break;
+            default:
+                this.operationExecuting.set(false);
+                throw new Error(`Unsupported operation: ${operation.name}`);
         }
+        this.executionSubscription = executionRequest.pipe(finalize(() => this.operationExecuting.set(false))).subscribe(operationHandler);
     }
 
     /**

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.ts
@@ -1,5 +1,6 @@
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, computed, effect, inject, input, model, signal, untracked } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, computed, effect, inject, input, model, signal, untracked } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CleanupOperation } from 'app/admin/cleanup-service/cleanup-operation.model';
 import { CleanupCount, DataCleanupService } from 'app/admin/cleanup-service/data-cleanup.service';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
@@ -45,10 +46,8 @@ export class CleanupOperationModalComponent {
     /** The in-flight count request, so it can be superseded/cancelled to avoid stale, out-of-order responses. */
     private countSubscription?: Subscription;
 
-    /** The in-flight cleanup request, so reopening the persistent modal cannot apply a stale completion to another operation. */
-    private executionSubscription?: Subscription;
-
     private readonly dataCleanupService = inject(DataCleanupService);
+    private readonly destroyRef = inject(DestroyRef);
 
     protected readonly faTimes = faTimes;
     protected readonly faTrash = faTrash;
@@ -67,8 +66,6 @@ export class CleanupOperationModalComponent {
                     // Reset per-open state so reopening the modal for a different operation does not flash the
                     // previous run's result icons/counts (operationExecuted is only ever set true, and counts
                     // refresh asynchronously): start clean, then fetch this operation's counts.
-                    this.executionSubscription?.unsubscribe();
-                    this.operationExecuting.set(false);
                     this.operationExecuted.set(false);
                     this.dialogError.set(undefined);
                     this.counts.set({ totalCount: 0 });
@@ -79,8 +76,6 @@ export class CleanupOperationModalComponent {
                 // in-flight count request on close: otherwise a late response could overwrite the counts of the
                 // next operation opened here.
                 this.countSubscription?.unsubscribe();
-                this.executionSubscription?.unsubscribe();
-                this.operationExecuting.set(false);
             }
         });
     }
@@ -141,7 +136,14 @@ export class CleanupOperationModalComponent {
                 this.operationExecuting.set(false);
                 throw new Error(`Unsupported operation: ${operation.name}`);
         }
-        this.executionSubscription = executionRequest.pipe(finalize(() => this.operationExecuting.set(false))).subscribe(operationHandler);
+        // Keep the request pending when the dialog closes. Unsubscribing cannot stop server-side deletion once it has
+        // started, and clearing the guard would allow a second destructive request after an immediate reopen.
+        executionRequest
+            .pipe(
+                takeUntilDestroyed(this.destroyRef),
+                finalize(() => this.operationExecuting.set(false)),
+            )
+            .subscribe(operationHandler);
     }
 
     /**

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.ts
@@ -96,6 +96,9 @@ export class CleanupOperationModalComponent {
         }
 
         const operation = this.operation();
+        // Clear any error from a previous attempt so an in-place retry does not show a stale error banner next to
+        // the fresh success icons/counts (the open effect only clears it on a closed -> open transition).
+        this.dialogError.set(undefined);
         this.operationExecuting.set(true);
         const operationHandler = {
             next: () => {

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.ts
@@ -4,7 +4,7 @@ import { CleanupOperation } from 'app/admin/cleanup-service/cleanup-operation.mo
 import { CleanupCount, DataCleanupService } from 'app/admin/cleanup-service/data-cleanup.service';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, Subscription } from 'rxjs';
 import { faCheckCircle, faTimes, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { ArtemisDatePipe } from 'app/foundation/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
@@ -38,6 +38,9 @@ export class CleanupOperationModalComponent {
     private dialogErrorSource = new Subject<string>();
     dialogError = this.dialogErrorSource.asObservable();
 
+    /** The in-flight count request, so it can be superseded/cancelled to avoid stale, out-of-order responses. */
+    private countSubscription?: Subscription;
+
     private readonly dataCleanupService = inject(DataCleanupService);
 
     protected readonly faTimes = faTimes;
@@ -61,6 +64,11 @@ export class CleanupOperationModalComponent {
                     this.counts.set({ totalCount: 0 });
                     this.updateCounts();
                 });
+            } else {
+                // This modal instance persists across opens (its host @if never tears it down), so cancel any
+                // in-flight count request on close: otherwise a late response could overwrite the counts of the
+                // next operation opened here.
+                this.countSubscription?.unsubscribe();
             }
         });
     }
@@ -137,7 +145,10 @@ export class CleanupOperationModalComponent {
      * Fetch updated counts after operation execution.
      */
     private updateCounts(): void {
-        this.fetchCounts().subscribe({
+        // Supersede any previous, still-pending count request so an out-of-order response cannot overwrite the
+        // counts of the operation currently shown.
+        this.countSubscription?.unsubscribe();
+        this.countSubscription = this.fetchCounts().subscribe({
             next: (response: HttpResponse<CleanupCount>) => {
                 this.counts.set(response.body!);
             },

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.ts
@@ -53,7 +53,14 @@ export class CleanupOperationModalComponent {
     constructor() {
         effect(() => {
             if (this.visible()) {
-                untracked(() => this.updateCounts());
+                untracked(() => {
+                    // Reset per-open state so reopening the modal for a different operation does not flash the
+                    // previous run's result icons/counts (operationExecuted is only ever set true, and counts
+                    // refresh asynchronously): start clean, then fetch this operation's counts.
+                    this.operationExecuted.set(false);
+                    this.counts.set({ totalCount: 0 });
+                    this.updateCounts();
+                });
             }
         });
     }

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.ts
@@ -4,13 +4,14 @@ import { CleanupOperation } from 'app/admin/cleanup-service/cleanup-operation.mo
 import { CleanupCount, DataCleanupService } from 'app/admin/cleanup-service/data-cleanup.service';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 
-import { Observable, Subject, Subscription, finalize } from 'rxjs';
+import { Observable, Subscription, finalize } from 'rxjs';
 import { faCheckCircle, faTimes, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { ArtemisDatePipe } from 'app/foundation/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { DialogModule } from 'primeng/dialog';
 import { ButtonModule } from 'primeng/button';
+import { MessageModule } from 'primeng/message';
 
 /**
  * Modal component for executing and monitoring cleanup operations.
@@ -19,7 +20,7 @@ import { ButtonModule } from 'primeng/button';
 @Component({
     selector: 'jhi-cleanup-operation-modal',
     templateUrl: './cleanup-operation-modal.component.html',
-    imports: [TranslateDirective, ArtemisDatePipe, ArtemisTranslatePipe, FontAwesomeModule, DialogModule, ButtonModule],
+    imports: [TranslateDirective, ArtemisDatePipe, ArtemisTranslatePipe, FontAwesomeModule, DialogModule, ButtonModule, MessageModule],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CleanupOperationModalComponent {
@@ -38,8 +39,8 @@ export class CleanupOperationModalComponent {
     /** Whether a cleanup operation is currently being executed. */
     readonly operationExecuting = signal(false);
 
-    private dialogErrorSource = new Subject<string>();
-    dialogError = this.dialogErrorSource.asObservable();
+    /** Error shown inside the dialog for the current operation. */
+    readonly dialogError = signal<string | undefined>(undefined);
 
     /** The in-flight count request, so it can be superseded/cancelled to avoid stale, out-of-order responses. */
     private countSubscription?: Subscription;
@@ -69,6 +70,7 @@ export class CleanupOperationModalComponent {
                     this.executionSubscription?.unsubscribe();
                     this.operationExecuting.set(false);
                     this.operationExecuted.set(false);
+                    this.dialogError.set(undefined);
                     this.counts.set({ totalCount: 0 });
                     this.updateCounts();
                 });
@@ -110,7 +112,7 @@ export class CleanupOperationModalComponent {
             },
             error: (error: unknown) => {
                 if (this.visible() && this.operation() === operation) {
-                    this.dialogErrorSource.next(error instanceof HttpErrorResponse ? error.message : 'An unexpected error occurred.');
+                    this.dialogError.set(error instanceof HttpErrorResponse ? error.message : 'An unexpected error occurred.');
                 }
             },
         };
@@ -178,7 +180,7 @@ export class CleanupOperationModalComponent {
                 this.counts.set(response.body!);
             },
             error: () => {
-                this.dialogErrorSource.next('An error occurred while fetching updated counts.');
+                this.dialogError.set('An error occurred while fetching updated counts.');
             },
         });
     }

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-service.component.spec.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-service.component.spec.ts
@@ -4,14 +4,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
-import { HttpResponse } from '@angular/common/http';
-import { of } from 'rxjs';
+import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
 import { signal } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import dayjs from 'dayjs/esm';
 
 import { CleanupServiceComponent } from 'app/admin/cleanup-service/cleanup-service.component';
 import { CleanupOperation } from 'app/admin/cleanup-service/cleanup-operation.model';
 import { CleanupServiceExecutionRecordDTO, DataCleanupService } from 'app/admin/cleanup-service/data-cleanup.service';
+import { AlertService } from 'app/foundation/service/alert.service';
+import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 
 describe('CleanupServiceComponent', () => {
     setupTestBed({ zoneless: true });
@@ -27,7 +30,10 @@ describe('CleanupServiceComponent', () => {
 
         await TestBed.configureTestingModule({
             imports: [CleanupServiceComponent],
-            providers: [{ provide: DataCleanupService, useValue: mockCleanupService }],
+            providers: [
+                { provide: DataCleanupService, useValue: mockCleanupService },
+                { provide: TranslateService, useClass: MockTranslateService },
+            ],
         })
             .overrideTemplate(CleanupServiceComponent, '')
             .compileComponents();
@@ -49,6 +55,39 @@ describe('CleanupServiceComponent', () => {
 
         expect(cleanupService.getLastExecutions).toHaveBeenCalledOnce();
         expect(comp.cleanupOperations()[0].lastExecuted).toEqual(dayjs(executionRecord[0].executionDate));
+    });
+
+    it('should match execution records by server job type, not array position', () => {
+        // The server labels several jobs differently from the client operation names (client 'deleteOldRatedResults'
+        // -> server 'deleteRatedResults', 'deleteOldSubmissionVersions' -> 'deleteSubmissionVersions'). A record must
+        // be attributed to the operation whose serverJobTypeByName matches, never by index.
+        const ratedDate = dayjs().subtract(1, 'day');
+        const submissionDate = dayjs().subtract(2, 'days');
+        const response = new HttpResponse<CleanupServiceExecutionRecordDTO[]>({
+            body: [
+                { executionDate: ratedDate, jobType: 'deleteRatedResults' },
+                { executionDate: submissionDate, jobType: 'deleteSubmissionVersions' },
+            ],
+        });
+        vi.spyOn(cleanupService, 'getLastExecutions').mockReturnValue(of(response));
+
+        comp.ngOnInit();
+
+        const operations = comp.cleanupOperations();
+        expect(operations.find((operation) => operation.name === 'deleteOldRatedResults')?.lastExecuted).toEqual(dayjs(ratedDate));
+        expect(operations.find((operation) => operation.name === 'deleteOldSubmissionVersions')?.lastExecuted).toEqual(dayjs(submissionDate));
+        // The first operation ('deleteOrphans') must stay untouched even though records appeared first in the array.
+        expect(operations.find((operation) => operation.name === 'deleteOrphans')?.lastExecuted).toBeUndefined();
+    });
+
+    it('should alert on a failed executions load', () => {
+        const alertService = TestBed.inject(AlertService);
+        const errorSpy = vi.spyOn(alertService, 'error');
+        vi.spyOn(cleanupService, 'getLastExecutions').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 400 })));
+
+        comp.ngOnInit();
+
+        expect(errorSpy).toHaveBeenCalledOnce();
     });
 
     it('should validate date ranges correctly', () => {
@@ -89,5 +128,61 @@ describe('CleanupServiceComponent', () => {
 
         expect(operation.deleteFrom).toBeUndefined();
         expect(operation.datesValid()).toBe(false);
+    });
+
+    it('should set a new from-date and revalidate the row', () => {
+        const operation: CleanupOperation = {
+            name: 'deletePlagiarismComparisons',
+            deleteFrom: undefined,
+            deleteTo: dayjs(),
+            lastExecuted: undefined,
+            datesValid: signal(false),
+        };
+
+        const newFrom = dayjs().subtract(6, 'months');
+        comp.onDeleteFromChange(operation, newFrom);
+
+        expect(operation.deleteFrom?.toISOString()).toBe(newFrom.toISOString());
+        expect(operation.datesValid()).toBe(true);
+    });
+
+    it('should clear the model and invalidate the row when the to-date is cleared', () => {
+        const operation: CleanupOperation = {
+            name: 'deletePlagiarismComparisons',
+            deleteFrom: dayjs().subtract(6, 'months'),
+            deleteTo: dayjs(),
+            lastExecuted: undefined,
+            datesValid: signal(true),
+        };
+
+        comp.onDeleteToChange(operation, undefined);
+
+        expect(operation.deleteTo).toBeUndefined();
+        expect(operation.datesValid()).toBe(false);
+    });
+
+    it('should set a new to-date and revalidate the row', () => {
+        const operation: CleanupOperation = {
+            name: 'deletePlagiarismComparisons',
+            deleteFrom: dayjs().subtract(6, 'months'),
+            deleteTo: undefined,
+            lastExecuted: undefined,
+            datesValid: signal(false),
+        };
+
+        const newTo = dayjs();
+        comp.onDeleteToChange(operation, newTo);
+
+        expect(operation.deleteTo?.toISOString()).toBe(newTo.toISOString());
+        expect(operation.datesValid()).toBe(true);
+    });
+
+    it('should select the operation and show the modal when opened', () => {
+        const operation = comp.cleanupOperations()[0];
+
+        comp.openCleanupOperationModal(operation);
+
+        expect(comp.selectedOperation()).toBe(operation);
+        expect(comp.showCleanupModal()).toBe(true);
     });
 });

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-service.component.ts
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-service.component.ts
@@ -1,9 +1,11 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
 import dayjs from 'dayjs/esm';
-import { CleanupOperation } from 'app/admin/cleanup-service/cleanup-operation.model';
+import { CleanupOperation, OperationName } from 'app/admin/cleanup-service/cleanup-operation.model';
 import { convertDateFromServer } from 'app/foundation/util/date.utils';
-import { HttpResponse } from '@angular/common/http';
-import { CleanupServiceExecutionRecordDTO, DataCleanupService } from 'app/admin/cleanup-service/data-cleanup.service';
+import { HttpErrorResponse } from '@angular/common/http';
+import { DataCleanupService } from 'app/admin/cleanup-service/data-cleanup.service';
+import { AlertService } from 'app/foundation/service/alert.service';
+import { onError } from 'app/foundation/util/global.utils';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 
@@ -42,8 +44,22 @@ import { DateTimePickerType, FormDateTimePickerComponent } from 'app/shared-ui/d
 })
 export class CleanupServiceComponent implements OnInit {
     private readonly dataCleanupService = inject(DataCleanupService);
+    private readonly alertService = inject(AlertService);
 
     protected readonly faTrash = faTrash;
+
+    // Maps each client operation to the server CleanupJobType.label() it corresponds to. The names differ for
+    // several jobs (e.g. 'deleteOldRatedResults' -> server 'deleteRatedResults'), so the execution records must
+    // be matched by this explicit job type, NOT by array position (which silently mislabels dates if the server
+    // ever changes the order or the set of returned job types).
+    private readonly serverJobTypeByName: Record<OperationName, string> = {
+        deleteOrphans: 'deleteOrphans',
+        deletePlagiarismComparisons: 'deletePlagiarismComparisons',
+        deleteNonRatedResults: 'deleteNonRatedResults',
+        deleteOldRatedResults: 'deleteRatedResults',
+        deleteOldSubmissionVersions: 'deleteSubmissionVersions',
+        deleteOldFeedback: 'deleteFeedback',
+    };
     protected readonly DateTimePickerType = DateTimePickerType;
 
     /** Whether the cleanup operation modal is visible */
@@ -96,19 +112,19 @@ export class CleanupServiceComponent implements OnInit {
     }
 
     loadLastExecutions(): void {
-        this.dataCleanupService.getLastExecutions().subscribe((executionRecordsBody: HttpResponse<CleanupServiceExecutionRecordDTO[]>) => {
-            const executionRecords = executionRecordsBody.body!;
-            if (executionRecords && executionRecords.length > 0) {
+        this.dataCleanupService.getLastExecutions().subscribe({
+            next: (response) => {
+                const executionRecords = response.body ?? [];
+                // Match by server job type, not array position (see serverJobTypeByName).
+                const executionDateByJobType = new Map(executionRecords.map((record) => [record.jobType, record.executionDate]));
                 this.cleanupOperations.update((operations) =>
-                    operations.map((operation, index) => {
-                        const executionRecord = executionRecords[index];
-                        if (executionRecord && executionRecord.executionDate) {
-                            return { ...operation, lastExecuted: convertDateFromServer(executionRecord.executionDate) };
-                        }
-                        return operation;
+                    operations.map((operation) => {
+                        const executionDate = executionDateByJobType.get(this.serverJobTypeByName[operation.name]);
+                        return executionDate ? { ...operation, lastExecuted: convertDateFromServer(executionDate) } : operation;
                     }),
                 );
-            }
+            },
+            error: (error: HttpErrorResponse) => onError(this.alertService, error),
         });
     }
 

--- a/src/main/webapp/app/admin/features/admin-feature-toggle.component.html
+++ b/src/main/webapp/app/admin/features/admin-feature-toggle.component.html
@@ -152,6 +152,7 @@
                         <div class="flex items-center gap-2">
                             <p-toggleswitch
                                 [ngModel]="featureInfo.isActive"
+                                [disabled]="pendingFeatures().has(featureInfo.feature)"
                                 [inputId]="'toggle-' + featureInfo.feature"
                                 (onChange)="onFeatureToggle(featureInfo)"
                                 data-testid="feature-toggle-switch"

--- a/src/main/webapp/app/admin/features/admin-feature-toggle.component.spec.ts
+++ b/src/main/webapp/app/admin/features/admin-feature-toggle.component.spec.ts
@@ -108,6 +108,34 @@ describe('AdminFeatureToggleComponentTest', () => {
             expect(errorSpy).toHaveBeenCalledOnce();
         });
 
+        it('onFeatureToggle should ignore a stale failed request superseded by a newer toggle', () => {
+            comp.ngOnInit();
+            const featureToggleService = TestBed.inject(FeatureToggleService);
+            const first = new Subject<object>();
+            const second = new Subject<object>();
+            vi.spyOn(featureToggleService, 'setFeatureToggleState').mockReturnValueOnce(first).mockReturnValueOnce(second);
+            const errorSpy = vi.spyOn(TestBed.inject(AlertService), 'error');
+
+            expect(comp.featureToggles()[0].isActive).toBe(true);
+
+            // Click 1: optimistic off, request R1 in flight.
+            comp.onFeatureToggle(comp.featureToggles()[0]);
+            expect(comp.featureToggles()[0].isActive).toBe(false);
+
+            // Click 2 (before R1 resolves): optimistic on, request R2 in flight and now the latest.
+            comp.onFeatureToggle(comp.featureToggles()[0]);
+            expect(comp.featureToggles()[0].isActive).toBe(true);
+
+            // R2 succeeds (server is now on), then the stale R1 fails late.
+            second.next({});
+            second.complete();
+            first.error(new HttpErrorResponse({ status: 400 }));
+
+            // The superseded R1 failure must not roll back R2's applied state, nor raise a misleading alert.
+            expect(comp.featureToggles()[0].isActive).toBe(true);
+            expect(errorSpy).not.toHaveBeenCalled();
+        });
+
         it('should alert and leave toggles empty when loading feature toggles fails', () => {
             const featureToggleService = TestBed.inject(FeatureToggleService);
             vi.spyOn(featureToggleService, 'getFeatureToggles').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 400 })));

--- a/src/main/webapp/app/admin/features/admin-feature-toggle.component.spec.ts
+++ b/src/main/webapp/app/admin/features/admin-feature-toggle.component.spec.ts
@@ -5,9 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { TranslateService } from '@ngx-translate/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Subject, throwError } from 'rxjs';
 
 import { AdminFeatureToggleComponent } from 'app/admin/features/admin-feature-toggle.component';
 import { FeatureToggle, FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
+import { AlertService } from 'app/foundation/service/alert.service';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { MockFeatureToggleService } from 'test/helpers/mocks/service/mock-feature-toggle.service';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
@@ -81,6 +84,42 @@ describe('AdminFeatureToggleComponentTest', () => {
             // Then toggle on
             comp.onFeatureToggle(comp.featureToggles()[0]);
             expect(comp.featureToggles()[0].isActive).toBe(true);
+        });
+
+        it('onFeatureToggle should optimistically flip, then revert and alert when the update fails', () => {
+            comp.ngOnInit();
+            const featureToggleService = TestBed.inject(FeatureToggleService);
+            // A controllable source so we can observe the flip BEFORE the server responds — otherwise a regression
+            // that drops the optimistic flip (reintroducing the UI-lie bug) would still pass on the final state alone.
+            const response = new Subject<object>();
+            vi.spyOn(featureToggleService, 'setFeatureToggleState').mockReturnValue(response);
+            const errorSpy = vi.spyOn(TestBed.inject(AlertService), 'error');
+
+            const featureInfo = comp.featureToggles()[0];
+            expect(featureInfo.isActive).toBe(true);
+
+            comp.onFeatureToggle(featureInfo);
+            // Optimistic flip is applied immediately, while the request is still in flight.
+            expect(comp.featureToggles()[0].isActive).toBe(false);
+
+            // Server rejects the change: the flip rolls back to the true state and the error surfaces.
+            response.error(new HttpErrorResponse({ status: 400 }));
+            expect(comp.featureToggles()[0].isActive).toBe(true);
+            expect(errorSpy).toHaveBeenCalledOnce();
+        });
+
+        it('should alert and leave toggles empty when loading feature toggles fails', () => {
+            const featureToggleService = TestBed.inject(FeatureToggleService);
+            vi.spyOn(featureToggleService, 'getFeatureToggles').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 400 })));
+            const errorSpy = vi.spyOn(TestBed.inject(AlertService), 'error');
+
+            comp.ngOnInit();
+
+            expect(errorSpy).toHaveBeenCalledOnce();
+            expect(comp.featureToggles()).toHaveLength(0);
+            // Profile and module features load independently and must still be populated despite the toggle failure.
+            expect(comp.profileFeatures()).toHaveLength(3);
+            expect(comp.moduleFeatures()).toHaveLength(19);
         });
 
         it('should set documentation links for features that have them', () => {
@@ -178,6 +217,24 @@ describe('AdminFeatureToggleComponentTest', () => {
             expect(passkeyAdmin).toBeDefined();
             expect(passkeyAdmin?.isActive).toBe(true);
             expect(passkeyAdmin?.documentationLink).toContain('docs.artemis.tum.de');
+        });
+    });
+
+    describe('Navigation', () => {
+        it('scrollToSection should scroll the target element into view', () => {
+            const scrollIntoView = vi.fn();
+            vi.spyOn(document, 'getElementById').mockReturnValue({ scrollIntoView } as unknown as HTMLElement);
+
+            comp.scrollToSection('module-features');
+
+            expect(document.getElementById).toHaveBeenCalledWith('module-features');
+            expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+        });
+
+        it('scrollToSection should do nothing when the target element is missing', () => {
+            vi.spyOn(document, 'getElementById').mockReturnValue(null);
+
+            expect(() => comp.scrollToSection('missing-section')).not.toThrow();
         });
     });
 

--- a/src/main/webapp/app/admin/features/admin-feature-toggle.component.spec.ts
+++ b/src/main/webapp/app/admin/features/admin-feature-toggle.component.spec.ts
@@ -6,7 +6,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { TranslateService } from '@ngx-translate/core';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Subject, throwError } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 
 import { AdminFeatureToggleComponent } from 'app/admin/features/admin-feature-toggle.component';
 import { FeatureToggle, FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
@@ -108,32 +108,34 @@ describe('AdminFeatureToggleComponentTest', () => {
             expect(errorSpy).toHaveBeenCalledOnce();
         });
 
-        it('onFeatureToggle should ignore a stale failed request superseded by a newer toggle', () => {
+        it('onFeatureToggle should serialize updates per feature, ignoring clicks while a request is in flight', () => {
             comp.ngOnInit();
             const featureToggleService = TestBed.inject(FeatureToggleService);
-            const first = new Subject<object>();
-            const second = new Subject<object>();
-            vi.spyOn(featureToggleService, 'setFeatureToggleState').mockReturnValueOnce(first).mockReturnValueOnce(second);
-            const errorSpy = vi.spyOn(TestBed.inject(AlertService), 'error');
+            const inFlight = new Subject<object>();
+            const spy = vi.spyOn(featureToggleService, 'setFeatureToggleState').mockReturnValueOnce(inFlight).mockReturnValueOnce(of({}));
 
+            const feature = comp.featureToggles()[0].feature;
             expect(comp.featureToggles()[0].isActive).toBe(true);
 
-            // Click 1: optimistic off, request R1 in flight.
+            // First click: optimistic off, one request in flight, feature marked pending (its switch is disabled).
             comp.onFeatureToggle(comp.featureToggles()[0]);
             expect(comp.featureToggles()[0].isActive).toBe(false);
+            expect(comp.pendingFeatures().has(feature)).toBe(true);
+            expect(spy).toHaveBeenCalledTimes(1);
 
-            // Click 2 (before R1 resolves): optimistic on, request R2 in flight and now the latest.
+            // A click while the request is in flight is ignored: no second request, state unchanged. Serializing
+            // the writes prevents an older successful request from overwriting a newer server state.
             comp.onFeatureToggle(comp.featureToggles()[0]);
-            expect(comp.featureToggles()[0].isActive).toBe(true);
+            expect(spy).toHaveBeenCalledTimes(1);
+            expect(comp.featureToggles()[0].isActive).toBe(false);
 
-            // R2 succeeds (server is now on), then the stale R1 fails late.
-            second.next({});
-            second.complete();
-            first.error(new HttpErrorResponse({ status: 400 }));
-
-            // The superseded R1 failure must not roll back R2's applied state, nor raise a misleading alert.
+            // Once the request completes, the feature is interactive again and the next click is sent in order.
+            inFlight.next({});
+            inFlight.complete();
+            expect(comp.pendingFeatures().has(feature)).toBe(false);
+            comp.onFeatureToggle(comp.featureToggles()[0]);
+            expect(spy).toHaveBeenCalledTimes(2);
             expect(comp.featureToggles()[0].isActive).toBe(true);
-            expect(errorSpy).not.toHaveBeenCalled();
         });
 
         it('should alert and leave toggles empty when loading feature toggles fails', () => {

--- a/src/main/webapp/app/admin/features/admin-feature-toggle.component.ts
+++ b/src/main/webapp/app/admin/features/admin-feature-toggle.component.ts
@@ -210,20 +210,30 @@ export class AdminFeatureToggleComponent implements OnInit {
         );
     }
 
+    /** Id of the most recent toggle request per feature, so out-of-order completions can be ignored. */
+    private readonly latestToggleRequest = new Map<FeatureToggle, number>();
+
     onFeatureToggle(featureInfo: FeatureToggleInfo): void {
+        const feature = featureInfo.feature;
         const newState = !featureInfo.isActive;
         // Optimistically reflect the new state so the signal, the [ngModel]-bound switch, and the server request
-        // all agree. On failure, revert isActive so the one-way [ngModel] re-applies the true state and the
-        // switch flips back (otherwise it would silently stay flipped while the server state is unchanged), and
-        // surface the error instead of swallowing it.
-        this.setToggleState(featureInfo.feature, newState);
+        // all agree. Track this as the latest request for the feature: overlapping clicks (or a live websocket
+        // update) can complete out of order, and a stale request must not roll back a newer one.
+        const requestId = (this.latestToggleRequest.get(feature) ?? 0) + 1;
+        this.latestToggleRequest.set(feature, requestId);
+        this.setToggleState(feature, newState);
         this.featureToggleService
-            .setFeatureToggleState(featureInfo.feature, newState)
+            .setFeatureToggleState(feature, newState)
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe({
                 error: (error: HttpErrorResponse) => {
-                    this.setToggleState(featureInfo.feature, !newState);
-                    onError(this.alertService, error);
+                    // Ignore a superseded request entirely: a newer toggle (or update) already owns the state, so
+                    // reverting here would flip the switch back to a value the server no longer has and raise a
+                    // misleading alert. Only the latest request reverts its optimistic change and surfaces the error.
+                    if (this.latestToggleRequest.get(feature) === requestId) {
+                        this.setToggleState(feature, !newState);
+                        onError(this.alertService, error);
+                    }
                 },
             });
     }

--- a/src/main/webapp/app/admin/features/admin-feature-toggle.component.ts
+++ b/src/main/webapp/app/admin/features/admin-feature-toggle.component.ts
@@ -1,7 +1,10 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FeatureToggle, FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
+import { AlertService } from 'app/foundation/service/alert.service';
+import { onError } from 'app/foundation/util/global.utils';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
@@ -85,6 +88,7 @@ export class AdminFeatureToggleComponent implements OnInit {
     private readonly featureToggleService = inject(FeatureToggleService);
     private readonly profileService = inject(ProfileService);
     private readonly destroyRef = inject(DestroyRef);
+    private readonly alertService = inject(AlertService);
 
     /** Available feature toggles with their current state */
     readonly featureToggles = signal<FeatureToggleInfo[]>([]);
@@ -174,14 +178,17 @@ export class AdminFeatureToggleComponent implements OnInit {
         this.featureToggleService
             .getFeatureToggles()
             .pipe(takeUntilDestroyed(this.destroyRef))
-            .subscribe((activeToggles) => {
-                this.featureToggles.set(
-                    Object.values(FeatureToggle).map((feature) => ({
-                        feature,
-                        isActive: activeToggles.includes(feature),
-                        documentationLink: this.documentationLinks[feature],
-                    })),
-                );
+            .subscribe({
+                next: (activeToggles) => {
+                    this.featureToggles.set(
+                        Object.values(FeatureToggle).map((feature) => ({
+                            feature,
+                            isActive: activeToggles.includes(feature),
+                            documentationLink: this.documentationLinks[feature],
+                        })),
+                    );
+                },
+                error: (error: HttpErrorResponse) => onError(this.alertService, error),
             });
 
         // Load profile-based features
@@ -205,12 +212,24 @@ export class AdminFeatureToggleComponent implements OnInit {
 
     onFeatureToggle(featureInfo: FeatureToggleInfo): void {
         const newState = !featureInfo.isActive;
+        // Optimistically reflect the new state so the signal, the [ngModel]-bound switch, and the server request
+        // all agree. On failure, revert isActive so the one-way [ngModel] re-applies the true state and the
+        // switch flips back (otherwise it would silently stay flipped while the server state is unchanged), and
+        // surface the error instead of swallowing it.
+        this.setToggleState(featureInfo.feature, newState);
         this.featureToggleService
             .setFeatureToggleState(featureInfo.feature, newState)
             .pipe(takeUntilDestroyed(this.destroyRef))
-            .subscribe(() => {
-                this.featureToggles.update((toggles) => toggles.map((toggle) => (toggle.feature === featureInfo.feature ? { ...toggle, isActive: newState } : toggle)));
+            .subscribe({
+                error: (error: HttpErrorResponse) => {
+                    this.setToggleState(featureInfo.feature, !newState);
+                    onError(this.alertService, error);
+                },
             });
+    }
+
+    private setToggleState(feature: FeatureToggle, isActive: boolean): void {
+        this.featureToggles.update((toggles) => toggles.map((toggle) => (toggle.feature === feature ? { ...toggle, isActive } : toggle)));
     }
 
     /**

--- a/src/main/webapp/app/admin/features/admin-feature-toggle.component.ts
+++ b/src/main/webapp/app/admin/features/admin-feature-toggle.component.ts
@@ -210,36 +210,52 @@ export class AdminFeatureToggleComponent implements OnInit {
         );
     }
 
-    /** Id of the most recent toggle request per feature, so out-of-order completions can be ignored. */
-    private readonly latestToggleRequest = new Map<FeatureToggle, number>();
+    /** Features with an in-flight update; their switch is disabled so updates are serialized per feature. */
+    readonly pendingFeatures = signal<ReadonlySet<FeatureToggle>>(new Set());
 
     onFeatureToggle(featureInfo: FeatureToggleInfo): void {
         const feature = featureInfo.feature;
+        // Serialize updates per feature: while a request is in flight the switch is disabled, and any stray change
+        // is ignored here. Sending only one request at a time keeps the server writes in click order (last click
+        // wins) — otherwise two successful writes could reach the server out of order and leave it on the older
+        // value, and a late failure could race the optimistic UI.
+        if (this.pendingFeatures().has(feature)) {
+            return;
+        }
         const newState = !featureInfo.isActive;
-        // Optimistically reflect the new state so the signal, the [ngModel]-bound switch, and the server request
-        // all agree. Track this as the latest request for the feature: overlapping clicks (or a live websocket
-        // update) can complete out of order, and a stale request must not roll back a newer one.
-        const requestId = (this.latestToggleRequest.get(feature) ?? 0) + 1;
-        this.latestToggleRequest.set(feature, requestId);
+        // Optimistically reflect the new state so the signal, the [ngModel]-bound switch, and the server request agree.
         this.setToggleState(feature, newState);
+        this.setPending(feature, true);
         this.featureToggleService
             .setFeatureToggleState(feature, newState)
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe({
+                next: () => this.setPending(feature, false),
                 error: (error: HttpErrorResponse) => {
-                    // Ignore a superseded request entirely: a newer toggle (or update) already owns the state, so
-                    // reverting here would flip the switch back to a value the server no longer has and raise a
-                    // misleading alert. Only the latest request reverts its optimistic change and surfaces the error.
-                    if (this.latestToggleRequest.get(feature) === requestId) {
-                        this.setToggleState(feature, !newState);
-                        onError(this.alertService, error);
-                    }
+                    // No newer request for this feature can exist (it was disabled while pending), so reverting the
+                    // optimistic change safely restores the true server state and flips the switch back; surface the
+                    // error instead of leaving the switch silently flipped.
+                    this.setToggleState(feature, !newState);
+                    this.setPending(feature, false);
+                    onError(this.alertService, error);
                 },
             });
     }
 
     private setToggleState(feature: FeatureToggle, isActive: boolean): void {
         this.featureToggles.update((toggles) => toggles.map((toggle) => (toggle.feature === feature ? { ...toggle, isActive } : toggle)));
+    }
+
+    private setPending(feature: FeatureToggle, pending: boolean): void {
+        this.pendingFeatures.update((features) => {
+            const next = new Set(features);
+            if (pending) {
+                next.add(feature);
+            } else {
+                next.delete(feature);
+            }
+            return next;
+        });
     }
 
     /**


### PR DESCRIPTION
### Summary

Fixes four pre-existing robustness bugs in two admin views (data cleanup service and feature toggles). They were spotted during review of the TUM UI kit migration but are independent of it: none are caused by that migration, and all four exist on `develop` today. Client-only, no server or API changes.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

While reviewing the admin cleanup-service and feature-toggle components, four latent defects showed up:

1. **Cleanup: last-execution dates could be mislabelled.** `loadLastExecutions` matched the server's execution records to the on-screen operations *by array position*. The server `CleanupJobType` labels differ from the client operation names for several jobs (client `deleteOldRatedResults` → server `deleteRatedResults`, `deleteOldSubmissionVersions` → `deleteSubmissionVersions`, `deleteOldFeedback` → `deleteFeedback`). Positional matching only worked by luck of ordering and would silently attach the wrong "last executed" date if the server ever changed the order or the set of returned job types.
2. **Feature toggle: failed updates left the UI lying.** `onFeatureToggle` fired the request with no result handler. If the server rejected the change, the switch stayed in the new position while the actual feature state was unchanged, and the error was swallowed.
3. **Feature toggle: failed load was swallowed.** `getFeatureToggles` had no error handler, so a failed load produced an empty list with no feedback.
4. **Cleanup modal: stale result flashed on reopen.** The modal reset nothing when reopened. `operationExecuted` (only ever set to `true`) and `counts` carried over, so reopening briefly showed the previous run's success icon and counts before the fresh counts loaded.

### Description

- **`cleanup-service.component.ts`** — match execution records by an explicit `serverJobTypeByName` lookup (client operation → server job-type label) resolved through a `Map`, never by index. Add an error handler routing failures through the shared `onError` helper.
- **`admin-feature-toggle.component.ts`** — `onFeatureToggle` now optimistically applies the new state, and on failure reverts it (the one-way `[ngModel]`-bound switch re-applies the true state) and surfaces the error via `onError`; a small `setToggleState` helper performs the signal update. `getFeatureToggles` gains an error handler.
- **`cleanup-operation-modal.component.ts`** — the open effect resets `operationExecuted` and `counts` before fetching, so a reopened modal starts clean.

All error paths route through `onError`, which intentionally suppresses HTTP 500 to avoid alert noise the user cannot act on.

### Steps for Testing

Prerequisites:
- 1 Admin

1. Log in as admin, go to **Admin → Cleanup Service**. Confirm each row's "last executed" date matches the operation that actually ran (in particular the rated-results and submission-versions rows, whose server labels differ from the client names).
2. Open a cleanup operation modal, run it (success icon shows), close it, then open a *different* operation. Confirm the modal opens clean with no leftover success icon or counts.
3. Go to **Admin → Feature Toggles**. Toggle a feature; confirm it persists. Simulate a failing request (e.g. offline / a 4xx) and confirm the switch reverts to its true state and an error alert appears rather than the switch silently staying flipped.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| cleanup-operation-modal.component.ts | 95.45% | 134 | 57 | 42.5 |
| cleanup-service.component.ts | 100.00% | 125 | 18 | 14.4 |
| admin-feature-toggle.component.ts | 100.00% | 242 | 54 | 22.3 |

_Last updated: 2026-07-15 16:58:07 UTC_

