### PR TITLE
`Development`: Isolate test server workflow checkouts

### DIFF
--- a/.github/workflows/testserver-deployment.yml
+++ b/.github/workflows/testserver-deployment.yml
@@ -32,6 +32,7 @@ permissions: {}
 
 env:
   IMAGE_NAME: ghcr.io/ls1intum/artemis
+  WORKFLOW_CHECKOUT_ROOT: .workflow-checkouts/${{ github.run_id }}-${{ github.run_attempt }}
 
 # The registry is the source of truth: resolve the commit to deploy, verify its immutable
 # `sha-<commit>` image exists in GHCR (or build it on the fly for a branch with no PR), then
@@ -151,18 +152,28 @@ jobs:
       packages: read
     steps:
       # Check out only the verify action, from the workflow's own ref (Helios dispatches this workflow
-      # from the branch being deployed). It is a build-correctness gate, not a trust boundary against
-      # the deployer, so it needs no pinned ref — and a pin to the default branch would break any
-      # branch that adds or edits the action.
-      - uses: actions/checkout@v6
+      # from the branch being deployed). Keep it out of the root workspace: this job can run in
+      # parallel with the database approval check, and sparse checkouts mutate the worktree.
+      - name: Check out verify action
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github/actions/verify-image-build
           sparse-checkout-cone-mode: false
-      - uses: ./.github/actions/verify-image-build
-        with:
-          image: ${{ env.IMAGE_NAME }}
-          sha: ${{ needs.determine-build-context.outputs.head_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ env.WORKFLOW_CHECKOUT_ROOT }}/verify-image-build
+
+      - name: Verify deployable image exists
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}
+          SHA: ${{ needs.determine-build-context.outputs.head_sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY_USER: ${{ github.actor }}
+        run: |
+          set -Eeuo pipefail
+          bash "${WORKFLOW_CHECKOUT_ROOT}/verify-image-build/.github/actions/verify-image-build/verify-image-build.sh"
+
+      - name: Cleanup verify checkout
+        if: always()
+        run: rm -rf -- "${WORKFLOW_CHECKOUT_ROOT}/verify-image-build"
 
   check-database-migration-approval:
     name: Check Database Migration Approval
@@ -173,29 +184,35 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout Repository
+      - name: Check out database approval check
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: supporting_scripts/database_approval_check
+          path: ${{ env.WORKFLOW_CHECKOUT_ROOT }}/database-approval-check
       - name: Install Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
       - name: Install Dependencies
+        working-directory: ${{ env.WORKFLOW_CHECKOUT_ROOT }}/database-approval-check/supporting_scripts/database_approval_check
         run: |
           set -Eeuo pipefail
           python -m pip install --upgrade pip
-          cd supporting_scripts/database_approval_check
-          pip install -r requirements.txt
+          python -m pip install -r requirements.txt
       - name: Check Migration Approval
+        working-directory: ${{ env.WORKFLOW_CHECKOUT_ROOT }}/database-approval-check/supporting_scripts/database_approval_check
         env:
           GITHUB_TOKEN: ${{ secrets.DB_MIGRATON_APPROVAL_GITHUB_TOKEN }}
           GITHUB_PR: ${{ needs.determine-build-context.outputs.pr_number }}
         run: |
           set -Eeuo pipefail
-          cd supporting_scripts/database_approval_check
           python main.py || {
             echo "::error::Database migration approval check failed. Ensure the latest database migration changes have been approved by a database maintainer."
             exit 1
           }
+      - name: Cleanup database approval checkout
+        if: always()
+        run: rm -rf -- "${WORKFLOW_CHECKOUT_ROOT}/database-approval-check"
 
   deploy:
     name: Deploy to Test-Server
@@ -234,6 +251,7 @@ jobs:
         with:
           sparse-checkout: artemis-server-cli
           sparse-checkout-cone-mode: false
+          path: ${{ env.WORKFLOW_CHECKOUT_ROOT }}/deploy-cli
 
       - name: Setup SSH Keys and known_hosts
         env:
@@ -259,11 +277,13 @@ jobs:
           DEPLOYMENT_FOLDER: ${{ vars.DEPLOYMENT_FOLDER }}
         run: |
           set -Eeuo pipefail
-          chmod +x artemis-server-cli
-          ./artemis-server-cli docker-deploy "$DEPLOYMENT_USER@$DEPLOYMENT_HOSTS" \
+          chmod +x "${WORKFLOW_CHECKOUT_ROOT}/deploy-cli/artemis-server-cli"
+          "${WORKFLOW_CHECKOUT_ROOT}/deploy-cli/artemis-server-cli" docker-deploy "$DEPLOYMENT_USER@$DEPLOYMENT_HOSTS" \
             -g "$GATEWAY_USER@$GATEWAY_HOST" \
             -t "$TAG" -b "$BRANCH_NAME" -d "$DEPLOYMENT_FOLDER" -y
 
       - name: Cleanup
         if: always()
-        run: rm -f /tmp/ssh_agent.sock
+        run: |
+          rm -f /tmp/ssh_agent.sock
+          rm -rf -- "${WORKFLOW_CHECKOUT_ROOT}/deploy-cli"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary
Fixes failing test-server deployments where the DB approval check cannot find `supporting_scripts/database_approval_check`.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

  Since PR #13224, the workflow uses sparse checkouts for helper files. On self-hosted runners, parallel sparse checkouts can mutate the root workspace, so the DB approval job may no longer see its script
  directory.

### Description

This PR isolates workflow checkouts into per-run subdirectories:
- `verify-image-build`
- `supporting_scripts/database_approval_check`
- `artemis-server-cli`

This prevents sparse checkouts from truncating the root workspace used by other jobs.

### Steps for Testing

  1. Trigger `Deploy to a test-server` for a PR branch.
  2. Verify that `Check Database Migration Approval` no longer fails with `No such file or directory`.
  3. Verify that the deployment still reaches the deploy step.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-15 19:53:48 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
