### PR TITLE
`Lectures`: Fix merging PDFs with malformed tags

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/util/FileUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/FileUtil.java
@@ -3,7 +3,6 @@ package de.tum.cit.aet.artemis.core.util;
 import static de.tum.cit.aet.artemis.core.config.BinaryFileExtensionConfiguration.isBinaryFile;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -19,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,16 +33,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
-import org.apache.pdfbox.Loader;
-import org.apache.pdfbox.cos.COSName;
-import org.apache.pdfbox.cos.COSStream;
-import org.apache.pdfbox.multipdf.PDFMergerUtility;
-import org.apache.pdfbox.multipdf.PDFMergerUtility.DocumentMergeMode;
-import org.apache.pdfbox.pdmodel.PDDocument;
-import org.apache.pdfbox.pdmodel.PDDocumentInformation;
-import org.apache.pdfbox.pdmodel.PDResources;
-import org.apache.pdfbox.pdmodel.graphics.PDXObject;
-import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -833,115 +821,7 @@ public class FileUtil {
      * @return byte array of the merged file
      */
     public static Optional<byte[]> mergePdfFiles(List<Path> paths, String mergedPdfFilename) {
-        if (paths == null || paths.isEmpty()) {
-            return Optional.empty();
-        }
-
-        List<Path> existingPaths = paths.stream().filter(Files::exists).toList();
-        if (existingPaths.isEmpty()) {
-            return Optional.of(new byte[0]);
-        }
-
-        try {
-            return Optional.of(mergePdfFiles(existingPaths, mergedPdfFilename, DocumentMergeMode.PDFBOX_LEGACY_MODE));
-        }
-        catch (IOException legacyMergeException) {
-            log.warn(
-                    "Could not fully merge PDF files {}. Retrying with a page-only merge that omits PDF tags, bookmarks, and internal destinations. Re-export or repair the source PDFs to preserve these elements.",
-                    existingPaths, legacyMergeException);
-            return mergePdfFilesPageOnly(existingPaths, mergedPdfFilename);
-        }
-    }
-
-    private static byte[] mergePdfFiles(List<Path> paths, String mergedPdfFilename, DocumentMergeMode mergeMode) throws IOException {
-        PDFMergerUtility pdfMerger = new PDFMergerUtility();
-        pdfMerger.setDocumentMergeMode(mergeMode);
-        for (Path path : paths) {
-            pdfMerger.addSource(path.toFile());
-        }
-
-        PDDocumentInformation documentInformation = new PDDocumentInformation();
-        documentInformation.setTitle(mergedPdfFilename);
-        pdfMerger.setDestinationDocumentInformation(documentInformation);
-
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-            pdfMerger.setDestinationStream(outputStream);
-            pdfMerger.mergeDocuments(null);
-            return outputStream.toByteArray();
-        }
-    }
-
-    private static Optional<byte[]> mergePdfFilesPageOnly(List<Path> paths, String mergedPdfFilename) {
-        try {
-            int expectedPageCount = getPdfPageCount(paths);
-            byte[] mergedPdf = mergePdfFiles(paths, mergedPdfFilename, DocumentMergeMode.OPTIMIZE_RESOURCES_MODE);
-            if (!hasExpectedPageCount(mergedPdf, expectedPageCount)) {
-                log.error("Page-only merge of PDF files {} did not produce the expected {} pages", paths, expectedPageCount);
-                return Optional.empty();
-            }
-
-            byte[] mergedPdfWithTitle = setPdfTitleAndRemoveStructureParentReferences(mergedPdf, mergedPdfFilename);
-            if (!hasExpectedPageCount(mergedPdfWithTitle, expectedPageCount)) {
-                log.error("Adding the title to the page-only merge of PDF files {} changed the expected {} pages", paths, expectedPageCount);
-                return Optional.empty();
-            }
-            return Optional.of(mergedPdfWithTitle);
-        }
-        catch (IOException fallbackMergeException) {
-            log.error("Could not merge PDF files {} with the page-only fallback", paths, fallbackMergeException);
-            return Optional.empty();
-        }
-    }
-
-    private static int getPdfPageCount(List<Path> paths) throws IOException {
-        int pageCount = 0;
-        for (Path path : paths) {
-            try (PDDocument document = Loader.loadPDF(path.toFile())) {
-                pageCount += document.getNumberOfPages();
-            }
-        }
-        return pageCount;
-    }
-
-    private static boolean hasExpectedPageCount(byte[] pdf, int expectedPageCount) throws IOException {
-        try (PDDocument document = Loader.loadPDF(pdf)) {
-            return document.getNumberOfPages() == expectedPageCount;
-        }
-    }
-
-    private static byte[] setPdfTitleAndRemoveStructureParentReferences(byte[] pdf, String title) throws IOException {
-        try (PDDocument document = Loader.loadPDF(pdf); ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-            document.getDocumentInformation().setTitle(title);
-            Set<COSStream> visitedXObjectStreams = Collections.newSetFromMap(new IdentityHashMap<>());
-            for (var page : document.getPages()) {
-                page.getCOSObject().removeItem(COSName.STRUCT_PARENTS);
-                for (var annotation : page.getAnnotations()) {
-                    annotation.getCOSObject().removeItem(COSName.STRUCT_PARENT);
-                }
-                removeStructureParentReferences(page.getResources(), visitedXObjectStreams);
-            }
-            document.save(outputStream);
-            return outputStream.toByteArray();
-        }
-    }
-
-    private static void removeStructureParentReferences(PDResources resources, Set<COSStream> visitedXObjectStreams) throws IOException {
-        if (resources == null) {
-            return;
-        }
-
-        for (COSName xObjectName : resources.getXObjectNames()) {
-            PDXObject xObject = resources.getXObject(xObjectName);
-            if (!visitedXObjectStreams.add(xObject.getCOSObject())) {
-                continue;
-            }
-
-            xObject.getCOSObject().removeItem(COSName.STRUCT_PARENT);
-            if (xObject instanceof PDFormXObject form) {
-                form.getCOSObject().removeItem(COSName.STRUCT_PARENTS);
-                removeStructureParentReferences(form.getResources(), visitedXObjectStreams);
-            }
-        }
+        return PdfMergeUtil.mergePdfFiles(paths, mergedPdfFilename);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/FileUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/FileUtil.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -34,8 +35,16 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSStream;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
+import org.apache.pdfbox.multipdf.PDFMergerUtility.DocumentMergeMode;
+import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentInformation;
+import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.graphics.PDXObject;
+import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -827,30 +836,112 @@ public class FileUtil {
         if (paths == null || paths.isEmpty()) {
             return Optional.empty();
         }
-        PDFMergerUtility pdfMerger = new PDFMergerUtility();
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        List<Path> existingPaths = paths.stream().filter(Files::exists).toList();
+        if (existingPaths.isEmpty()) {
+            return Optional.of(new byte[0]);
+        }
 
         try {
-            for (Path path : paths) {
-                if (Files.exists(path)) {
-                    pdfMerger.addSource(path.toFile());
-                }
-            }
+            return Optional.of(mergePdfFiles(existingPaths, mergedPdfFilename, DocumentMergeMode.PDFBOX_LEGACY_MODE));
+        }
+        catch (IOException legacyMergeException) {
+            log.warn(
+                    "Could not fully merge PDF files {}. Retrying with a page-only merge that omits PDF tags, bookmarks, and internal destinations. Re-export or repair the source PDFs to preserve these elements.",
+                    existingPaths, legacyMergeException);
+            return mergePdfFilesPageOnly(existingPaths, mergedPdfFilename);
+        }
+    }
 
-            PDDocumentInformation pdDocumentInformation = new PDDocumentInformation();
-            pdDocumentInformation.setTitle(mergedPdfFilename);
-            pdfMerger.setDestinationDocumentInformation(pdDocumentInformation);
+    private static byte[] mergePdfFiles(List<Path> paths, String mergedPdfFilename, DocumentMergeMode mergeMode) throws IOException {
+        PDFMergerUtility pdfMerger = new PDFMergerUtility();
+        pdfMerger.setDocumentMergeMode(mergeMode);
+        for (Path path : paths) {
+            pdfMerger.addSource(path.toFile());
+        }
 
+        PDDocumentInformation documentInformation = new PDDocumentInformation();
+        documentInformation.setTitle(mergedPdfFilename);
+        pdfMerger.setDestinationDocumentInformation(documentInformation);
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             pdfMerger.setDestinationStream(outputStream);
             pdfMerger.mergeDocuments(null);
-
+            return outputStream.toByteArray();
         }
-        catch (IOException e) {
-            log.warn("Could not merge files");
+    }
+
+    private static Optional<byte[]> mergePdfFilesPageOnly(List<Path> paths, String mergedPdfFilename) {
+        try {
+            int expectedPageCount = getPdfPageCount(paths);
+            byte[] mergedPdf = mergePdfFiles(paths, mergedPdfFilename, DocumentMergeMode.OPTIMIZE_RESOURCES_MODE);
+            if (!hasExpectedPageCount(mergedPdf, expectedPageCount)) {
+                log.error("Page-only merge of PDF files {} did not produce the expected {} pages", paths, expectedPageCount);
+                return Optional.empty();
+            }
+
+            byte[] mergedPdfWithTitle = setPdfTitleAndRemoveStructureParentReferences(mergedPdf, mergedPdfFilename);
+            if (!hasExpectedPageCount(mergedPdfWithTitle, expectedPageCount)) {
+                log.error("Adding the title to the page-only merge of PDF files {} changed the expected {} pages", paths, expectedPageCount);
+                return Optional.empty();
+            }
+            return Optional.of(mergedPdfWithTitle);
+        }
+        catch (IOException fallbackMergeException) {
+            log.error("Could not merge PDF files {} with the page-only fallback", paths, fallbackMergeException);
             return Optional.empty();
         }
+    }
 
-        return Optional.of(outputStream.toByteArray());
+    private static int getPdfPageCount(List<Path> paths) throws IOException {
+        int pageCount = 0;
+        for (Path path : paths) {
+            try (PDDocument document = Loader.loadPDF(path.toFile())) {
+                pageCount += document.getNumberOfPages();
+            }
+        }
+        return pageCount;
+    }
+
+    private static boolean hasExpectedPageCount(byte[] pdf, int expectedPageCount) throws IOException {
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            return document.getNumberOfPages() == expectedPageCount;
+        }
+    }
+
+    private static byte[] setPdfTitleAndRemoveStructureParentReferences(byte[] pdf, String title) throws IOException {
+        try (PDDocument document = Loader.loadPDF(pdf); ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            document.getDocumentInformation().setTitle(title);
+            Set<COSStream> visitedXObjectStreams = Collections.newSetFromMap(new IdentityHashMap<>());
+            for (var page : document.getPages()) {
+                page.getCOSObject().removeItem(COSName.STRUCT_PARENTS);
+                for (var annotation : page.getAnnotations()) {
+                    annotation.getCOSObject().removeItem(COSName.STRUCT_PARENT);
+                }
+                removeStructureParentReferences(page.getResources(), visitedXObjectStreams);
+            }
+            document.save(outputStream);
+            return outputStream.toByteArray();
+        }
+    }
+
+    private static void removeStructureParentReferences(PDResources resources, Set<COSStream> visitedXObjectStreams) throws IOException {
+        if (resources == null) {
+            return;
+        }
+
+        for (COSName xObjectName : resources.getXObjectNames()) {
+            PDXObject xObject = resources.getXObject(xObjectName);
+            if (!visitedXObjectStreams.add(xObject.getCOSObject())) {
+                continue;
+            }
+
+            xObject.getCOSObject().removeItem(COSName.STRUCT_PARENT);
+            if (xObject instanceof PDFormXObject form) {
+                form.getCOSObject().removeItem(COSName.STRUCT_PARENTS);
+                removeStructureParentReferences(form.getResources(), visitedXObjectStreams);
+            }
+        }
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/PdfMergeUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/PdfMergeUtil.java
@@ -1,0 +1,144 @@
+package de.tum.cit.aet.artemis.core.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSStream;
+import org.apache.pdfbox.multipdf.PDFMergerUtility;
+import org.apache.pdfbox.multipdf.PDFMergerUtility.DocumentMergeMode;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDDocumentInformation;
+import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.graphics.PDXObject;
+import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class PdfMergeUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(PdfMergeUtil.class);
+
+    private PdfMergeUtil() {
+    }
+
+    static Optional<byte[]> mergePdfFiles(List<Path> paths, String mergedPdfFilename) {
+        if (paths == null || paths.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<Path> existingPaths = paths.stream().filter(Files::exists).toList();
+        if (existingPaths.isEmpty()) {
+            return Optional.of(new byte[0]);
+        }
+
+        try {
+            return Optional.of(mergePdfFiles(existingPaths, mergedPdfFilename, DocumentMergeMode.PDFBOX_LEGACY_MODE));
+        }
+        catch (IOException legacyMergeException) {
+            log.warn(
+                    "Could not fully merge PDF files {}. Retrying with a page-only merge that omits PDF tags, bookmarks, and internal destinations. Re-export or repair the source PDFs to preserve these elements.",
+                    existingPaths, legacyMergeException);
+            return mergePdfFilesPageOnly(existingPaths, mergedPdfFilename);
+        }
+    }
+
+    private static byte[] mergePdfFiles(List<Path> paths, String mergedPdfFilename, DocumentMergeMode mergeMode) throws IOException {
+        PDFMergerUtility pdfMerger = new PDFMergerUtility();
+        pdfMerger.setDocumentMergeMode(mergeMode);
+        for (Path path : paths) {
+            pdfMerger.addSource(path.toFile());
+        }
+
+        PDDocumentInformation documentInformation = new PDDocumentInformation();
+        documentInformation.setTitle(mergedPdfFilename);
+        pdfMerger.setDestinationDocumentInformation(documentInformation);
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            pdfMerger.setDestinationStream(outputStream);
+            pdfMerger.mergeDocuments(null);
+            return outputStream.toByteArray();
+        }
+    }
+
+    private static Optional<byte[]> mergePdfFilesPageOnly(List<Path> paths, String mergedPdfFilename) {
+        try {
+            int expectedPageCount = getPdfPageCount(paths);
+            byte[] mergedPdf = mergePdfFiles(paths, mergedPdfFilename, DocumentMergeMode.OPTIMIZE_RESOURCES_MODE);
+            if (!hasExpectedPageCount(mergedPdf, expectedPageCount)) {
+                log.error("Page-only merge of PDF files {} did not produce the expected {} pages", paths, expectedPageCount);
+                return Optional.empty();
+            }
+
+            byte[] mergedPdfWithTitle = setPdfTitleAndRemoveStructureParentReferences(mergedPdf, mergedPdfFilename);
+            if (!hasExpectedPageCount(mergedPdfWithTitle, expectedPageCount)) {
+                log.error("Adding the title to the page-only merge of PDF files {} changed the expected {} pages", paths, expectedPageCount);
+                return Optional.empty();
+            }
+            return Optional.of(mergedPdfWithTitle);
+        }
+        catch (IOException fallbackMergeException) {
+            log.error("Could not merge PDF files {} with the page-only fallback", paths, fallbackMergeException);
+            return Optional.empty();
+        }
+    }
+
+    private static int getPdfPageCount(List<Path> paths) throws IOException {
+        int pageCount = 0;
+        for (Path path : paths) {
+            try (PDDocument document = Loader.loadPDF(path.toFile())) {
+                pageCount += document.getNumberOfPages();
+            }
+        }
+        return pageCount;
+    }
+
+    private static boolean hasExpectedPageCount(byte[] pdf, int expectedPageCount) throws IOException {
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            return document.getNumberOfPages() == expectedPageCount;
+        }
+    }
+
+    private static byte[] setPdfTitleAndRemoveStructureParentReferences(byte[] pdf, String title) throws IOException {
+        try (PDDocument document = Loader.loadPDF(pdf); ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            document.getDocumentInformation().setTitle(title);
+            Set<COSStream> visitedXObjectStreams = Collections.newSetFromMap(new IdentityHashMap<>());
+            for (var page : document.getPages()) {
+                page.getCOSObject().removeItem(COSName.STRUCT_PARENTS);
+                for (var annotation : page.getAnnotations()) {
+                    annotation.getCOSObject().removeItem(COSName.STRUCT_PARENT);
+                }
+                removeStructureParentReferences(page.getResources(), visitedXObjectStreams);
+            }
+            document.save(outputStream);
+            return outputStream.toByteArray();
+        }
+    }
+
+    private static void removeStructureParentReferences(PDResources resources, Set<COSStream> visitedXObjectStreams) throws IOException {
+        if (resources == null) {
+            return;
+        }
+
+        for (COSName xObjectName : resources.getXObjectNames()) {
+            PDXObject xObject = resources.getXObject(xObjectName);
+            if (!visitedXObjectStreams.add(xObject.getCOSObject())) {
+                continue;
+            }
+
+            xObject.getCOSObject().removeItem(COSName.STRUCT_PARENT);
+            if (xObject instanceof PDFormXObject form) {
+                form.getCOSObject().removeItem(COSName.STRUCT_PARENTS);
+                removeStructureParentReferences(form.getResources(), visitedXObjectStreams);
+            }
+        }
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/PdfMergeUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/PdfMergeUtil.java
@@ -20,6 +20,8 @@ import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.apache.pdfbox.pdmodel.PDResources;
 import org.apache.pdfbox.pdmodel.graphics.PDXObject;
 import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceDictionary;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,11 +117,37 @@ final class PdfMergeUtil {
                 page.getCOSObject().removeItem(COSName.STRUCT_PARENTS);
                 for (var annotation : page.getAnnotations()) {
                     annotation.getCOSObject().removeItem(COSName.STRUCT_PARENT);
+                    removeStructureParentReferences(annotation.getAppearance(), visitedXObjectStreams);
                 }
                 removeStructureParentReferences(page.getResources(), visitedXObjectStreams);
             }
             document.save(outputStream);
             return outputStream.toByteArray();
+        }
+    }
+
+    private static void removeStructureParentReferences(PDAppearanceDictionary appearance, Set<COSStream> visitedXObjectStreams) throws IOException {
+        if (appearance == null) {
+            return;
+        }
+
+        removeStructureParentReferences(appearance.getNormalAppearance(), visitedXObjectStreams);
+        removeStructureParentReferences(appearance.getRolloverAppearance(), visitedXObjectStreams);
+        removeStructureParentReferences(appearance.getDownAppearance(), visitedXObjectStreams);
+    }
+
+    private static void removeStructureParentReferences(PDAppearanceEntry appearanceEntry, Set<COSStream> visitedXObjectStreams) throws IOException {
+        if (appearanceEntry == null) {
+            return;
+        }
+
+        if (appearanceEntry.isStream()) {
+            removeStructureParentReferences(appearanceEntry.getAppearanceStream(), visitedXObjectStreams);
+        }
+        else if (appearanceEntry.isSubDictionary()) {
+            for (var appearanceStream : appearanceEntry.getSubDictionary().values()) {
+                removeStructureParentReferences(appearanceStream, visitedXObjectStreams);
+            }
         }
     }
 
@@ -129,16 +157,24 @@ final class PdfMergeUtil {
         }
 
         for (COSName xObjectName : resources.getXObjectNames()) {
-            PDXObject xObject = resources.getXObject(xObjectName);
-            if (!visitedXObjectStreams.add(xObject.getCOSObject())) {
-                continue;
+            try {
+                removeStructureParentReferences(resources.getXObject(xObjectName), visitedXObjectStreams);
             }
+            catch (IOException unreadableXObjectException) {
+                log.debug("Skipping unreadable XObject {} while removing structure parent references", xObjectName, unreadableXObjectException);
+            }
+        }
+    }
 
-            xObject.getCOSObject().removeItem(COSName.STRUCT_PARENT);
-            if (xObject instanceof PDFormXObject form) {
-                form.getCOSObject().removeItem(COSName.STRUCT_PARENTS);
-                removeStructureParentReferences(form.getResources(), visitedXObjectStreams);
-            }
+    private static void removeStructureParentReferences(PDXObject xObject, Set<COSStream> visitedXObjectStreams) throws IOException {
+        if (xObject == null || !visitedXObjectStreams.add(xObject.getCOSObject())) {
+            return;
+        }
+
+        xObject.getCOSObject().removeItem(COSName.STRUCT_PARENT);
+        if (xObject instanceof PDFormXObject form) {
+            form.getCOSObject().removeItem(COSName.STRUCT_PARENTS);
+            removeStructureParentReferences(form.getResources(), visitedXObjectStreams);
         }
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/FileUtilUnitTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/FileUtilUnitTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -26,8 +27,30 @@ import java.util.Optional;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.contentstream.operator.Operator;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSInteger;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.multipdf.PDFMergerUtility;
+import org.apache.pdfbox.pdfparser.PDFStreamParser;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDFormContentStream;
 import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.common.PDNumberTreeNode;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDMarkInfo;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDMarkedContentReference;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDParentTreeValue;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureElement;
+import org.apache.pdfbox.pdmodel.documentinterchange.logicalstructure.PDStructureTreeRoot;
+import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject;
+import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.pdmodel.interactive.action.PDActionURI;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -288,35 +311,212 @@ class FileUtilUnitTest {
     }
 
     @Test
+    void testMergePdf_nonexistentFiles_shouldReturnPresentEmptyFile() {
+        Optional<byte[]> result = FileUtil.mergePdfFiles(List.of(exportTestRootPath.resolve("missing.pdf")), "missing");
+        assertThat(result).contains(new byte[0]);
+    }
+
+    @Test
     void testMergePdf() throws IOException {
-        List<Path> paths = new ArrayList<>();
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        PDDocument doc1 = new PDDocument();
-        doc1.addPage(new PDPage());
-        doc1.addPage(new PDPage());
-        doc1.addPage(new PDPage());
-        doc1.save(outputStream);
-        doc1.close();
+        Path firstPdf = createPdf("testfile1.pdf", List.of(new PDRectangle(100, 100), new PDRectangle(110, 110), new PDRectangle(120, 120)));
+        Path secondPdf = createPdf("testfile2.pdf", List.of(new PDRectangle(200, 200), new PDRectangle(210, 210)));
 
-        writeFile("testfile1.pdf", outputStream.toByteArray());
+        Optional<byte[]> mergedFile = FileUtil.mergePdfFiles(List.of(firstPdf, secondPdf), "list_of_pdfs");
 
-        outputStream.reset();
-        PDDocument doc2 = new PDDocument();
-        doc2.addPage(new PDPage());
-        doc2.addPage(new PDPage());
-        doc2.save(outputStream);
-        doc2.close();
-
-        writeFile("testfile2.pdf", outputStream.toByteArray());
-
-        paths.add(exportTestRootPath.resolve("testfile1.pdf"));
-        paths.add(exportTestRootPath.resolve("testfile2.pdf"));
-
-        Optional<byte[]> mergedFile = FileUtil.mergePdfFiles(paths, "list_of_pdfs");
         assertThat(mergedFile).isPresent();
-        assertThat(mergedFile.get()).isNotEmpty();
-        PDDocument mergedDoc = Loader.loadPDF(mergedFile.get());
-        assertThat(mergedDoc.getNumberOfPages()).isEqualTo(5);
+        try (PDDocument mergedDocument = Loader.loadPDF(mergedFile.orElseThrow())) {
+            assertThat(mergedDocument.getNumberOfPages()).isEqualTo(5);
+            assertThat(mergedDocument.getDocumentInformation().getTitle()).isEqualTo("list_of_pdfs");
+            assertThat(mergedDocument.getPages()).extracting(page -> page.getMediaBox().getWidth()).containsExactly(100F, 110F, 120F, 200F, 210F);
+        }
+    }
+
+    @Test
+    void testMergePdfMalformedStructureTreeUsesPageOnlyFallback() throws IOException {
+        Path malformedPdf = createPdf("malformed.pdf", List.of(new PDRectangle(100, 100)));
+        addMalformedStructureTreeAndUriLink(malformedPdf);
+        Path secondPdf = createPdf("second.pdf", List.of(new PDRectangle(200, 200)));
+
+        assertThatThrownBy(() -> mergeWithLegacyMode(List.of(malformedPdf, secondPdf))).isInstanceOf(IOException.class).hasMessageContaining("number tree");
+
+        Optional<byte[]> mergedFile = FileUtil.mergePdfFiles(List.of(malformedPdf, secondPdf), "fallback_title");
+
+        assertThat(mergedFile).isPresent();
+        try (PDDocument mergedDocument = Loader.loadPDF(mergedFile.orElseThrow())) {
+            assertThat(mergedDocument.getNumberOfPages()).isEqualTo(2);
+            assertThat(mergedDocument.getDocumentInformation().getTitle()).isEqualTo("fallback_title");
+            assertThat(mergedDocument.getPages()).extracting(page -> page.getMediaBox().getWidth()).containsExactly(100F, 200F);
+            assertThat(mergedDocument.getDocumentCatalog().getStructureTreeRoot()).isNull();
+            assertThat(mergedDocument.getPage(0).getCOSObject().containsKey(COSName.STRUCT_PARENTS)).isFalse();
+
+            PDAnnotationLink link = (PDAnnotationLink) mergedDocument.getPage(0).getAnnotations().getFirst();
+            assertThat(link.getCOSObject().containsKey(COSName.STRUCT_PARENT)).isFalse();
+            assertThat(link.getAction()).isInstanceOf(PDActionURI.class);
+            assertThat(((PDActionURI) link.getAction()).getURI()).isEqualTo("https://example.com/lecture-slide");
+
+            PDFormXObject outerForm = (PDFormXObject) mergedDocument.getPage(0).getResources().getXObject(COSName.getPDFName("OuterForm"));
+            PDFormXObject innerForm = (PDFormXObject) outerForm.getResources().getXObject(COSName.getPDFName("InnerForm"));
+            PDImageXObject taggedImage = (PDImageXObject) innerForm.getResources().getXObject(COSName.getPDFName("TaggedImage"));
+            assertThat(outerForm.getCOSObject().containsKey(COSName.STRUCT_PARENTS)).isFalse();
+            assertThat(innerForm.getCOSObject().containsKey(COSName.STRUCT_PARENTS)).isFalse();
+            assertThat(taggedImage.getCOSObject().containsKey(COSName.STRUCT_PARENT)).isFalse();
+            assertThat(taggedImage.getWidth()).isEqualTo(2);
+            assertThat(taggedImage.getHeight()).isEqualTo(2);
+            assertThat(new PDFStreamParser(innerForm).parse()).filteredOn(Operator.class::isInstance).extracting(token -> ((Operator) token).getName()).containsSubsequence("Do",
+                    "re", "S");
+        }
+    }
+
+    @Test
+    void testMergePdfWellFormedStructureTreeUsesLegacyMerge() throws IOException {
+        Path taggedPdf = createPdf("tagged.pdf", List.of(new PDRectangle(100, 100)));
+        addWellFormedStructureTree(taggedPdf);
+
+        Optional<byte[]> mergedFile = FileUtil.mergePdfFiles(List.of(taggedPdf), "legacy_title");
+
+        assertThat(mergedFile).isPresent();
+        try (PDDocument mergedDocument = Loader.loadPDF(mergedFile.orElseThrow())) {
+            assertThat(mergedDocument.getDocumentInformation().getTitle()).isEqualTo("legacy_title");
+            PDStructureTreeRoot mergedStructureTree = mergedDocument.getDocumentCatalog().getStructureTreeRoot();
+            assertThat(mergedStructureTree).isNotNull();
+            assertThat(mergedStructureTree.getParentTree().getNumbers()).containsKey(0);
+            assertThat(mergedDocument.getDocumentCatalog().getMarkInfo().isMarked()).isTrue();
+            assertThat(mergedDocument.getPage(0).getCOSObject().getInt(COSName.STRUCT_PARENTS)).isZero();
+            PDStructureElement mergedStructureElement = (PDStructureElement) mergedStructureTree.getKids().getFirst();
+            assertThat(mergedStructureElement.getPage()).isEqualTo(mergedDocument.getPage(0));
+            PDMarkedContentReference markedContentReference = (PDMarkedContentReference) mergedStructureElement.getKids().getFirst();
+            assertThat(markedContentReference.getMCID()).isZero();
+            assertThat(markedContentReference.getPage()).isEqualTo(mergedDocument.getPage(0));
+            assertThat(new PDFStreamParser(mergedDocument.getPage(0)).parse()).filteredOn(Operator.class::isInstance).extracting(token -> ((Operator) token).getName())
+                    .containsSubsequence("BDC", "re", "f", "EMC");
+        }
+    }
+
+    @Test
+    void testMergePdfCorruptSourceReturnsEmptyOptional() throws IOException {
+        Path corruptPdf = exportTestRootPath.resolve("corrupt.pdf");
+        writeFile("corrupt.pdf", "%PDF-1.7\n1 0 obj\n<< /Type /Catalog".getBytes(StandardCharsets.US_ASCII));
+
+        assertThatThrownBy(() -> mergePdf(corruptPdf, PDFMergerUtility.DocumentMergeMode.PDFBOX_LEGACY_MODE)).isInstanceOf(IOException.class);
+        assertThatThrownBy(() -> mergePdf(corruptPdf, PDFMergerUtility.DocumentMergeMode.OPTIMIZE_RESOURCES_MODE)).isInstanceOf(IOException.class);
+        assertThat(FileUtil.mergePdfFiles(List.of(corruptPdf), "corrupt")).isEmpty();
+    }
+
+    private static Path createPdf(String filename, List<PDRectangle> pageSizes) throws IOException {
+        Path path = exportTestRootPath.resolve(filename);
+        Files.createDirectories(path.getParent());
+        try (PDDocument document = new PDDocument()) {
+            pageSizes.stream().map(PDPage::new).forEach(document::addPage);
+            document.save(path.toFile());
+        }
+        return path;
+    }
+
+    private static void addMalformedStructureTreeAndUriLink(Path path) throws IOException {
+        try (PDDocument document = Loader.loadPDF(path.toFile())) {
+            PDStructureTreeRoot structureTreeRoot = new PDStructureTreeRoot();
+            COSDictionary parentTree = new COSDictionary();
+            COSArray numbers = new COSArray();
+            numbers.add(COSInteger.ZERO);
+            numbers.add(COSInteger.ONE);
+            parentTree.setItem(COSName.NUMS, numbers);
+            structureTreeRoot.getCOSObject().setItem(COSName.PARENT_TREE, parentTree);
+            document.getDocumentCatalog().setStructureTreeRoot(structureTreeRoot);
+
+            document.getPage(0).getCOSObject().setInt(COSName.STRUCT_PARENTS, 0);
+            PDAnnotationLink link = new PDAnnotationLink();
+            link.getCOSObject().setInt(COSName.STRUCT_PARENT, 1);
+            link.setRectangle(new PDRectangle(10, 10, 20, 20));
+            PDActionURI action = new PDActionURI();
+            action.setURI("https://example.com/lecture-slide");
+            link.setAction(action);
+            document.getPage(0).getAnnotations().add(link);
+
+            PDFormXObject innerForm = new PDFormXObject(document);
+            innerForm.setBBox(new PDRectangle(20, 20));
+            PDResources innerFormResources = new PDResources();
+            PDImageXObject taggedImage = LosslessFactory.createFromImage(document, new BufferedImage(2, 2, BufferedImage.TYPE_INT_RGB));
+            taggedImage.setStructParent(4);
+            innerFormResources.put(COSName.getPDFName("TaggedImage"), taggedImage);
+            innerForm.setResources(innerFormResources);
+            innerForm.setStructParents(2);
+            try (PDFormContentStream contentStream = new PDFormContentStream(innerForm)) {
+                contentStream.drawImage(taggedImage, 1, 1, 2, 2);
+                contentStream.addRect(1, 1, 10, 10);
+                contentStream.stroke();
+            }
+
+            PDFormXObject outerForm = new PDFormXObject(document);
+            outerForm.setBBox(new PDRectangle(20, 20));
+            PDResources outerFormResources = new PDResources();
+            outerFormResources.put(COSName.getPDFName("InnerForm"), innerForm);
+            outerForm.setResources(outerFormResources);
+            outerForm.setStructParents(3);
+            try (PDFormContentStream contentStream = new PDFormContentStream(outerForm)) {
+                contentStream.drawForm(innerForm);
+            }
+
+            PDResources pageResources = new PDResources();
+            pageResources.put(COSName.getPDFName("OuterForm"), outerForm);
+            document.getPage(0).setResources(pageResources);
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, document.getPage(0))) {
+                contentStream.drawForm(outerForm);
+            }
+            document.save(path.toFile());
+        }
+    }
+
+    private static void addWellFormedStructureTree(Path path) throws IOException {
+        try (PDDocument document = Loader.loadPDF(path.toFile())) {
+            PDStructureTreeRoot structureTreeRoot = new PDStructureTreeRoot();
+            PDStructureElement structureElement = new PDStructureElement("Document", structureTreeRoot);
+            structureElement.setPage(document.getPage(0));
+            PDMarkedContentReference markedContentReference = new PDMarkedContentReference();
+            markedContentReference.setPage(document.getPage(0));
+            markedContentReference.setMCID(0);
+            structureElement.appendKid(markedContentReference);
+            structureTreeRoot.appendKid(structureElement);
+
+            COSArray parentTreeEntry = new COSArray();
+            parentTreeEntry.add(structureElement);
+            PDNumberTreeNode parentTree = new PDNumberTreeNode(PDParentTreeValue.class);
+            parentTree.setNumbers(Map.of(0, new PDParentTreeValue(parentTreeEntry)));
+            structureTreeRoot.setParentTree(parentTree);
+            structureTreeRoot.setParentTreeNextKey(1);
+            document.getPage(0).getCOSObject().setInt(COSName.STRUCT_PARENTS, 0);
+            document.getDocumentCatalog().setStructureTreeRoot(structureTreeRoot);
+            PDMarkInfo markInfo = new PDMarkInfo();
+            markInfo.setMarked(true);
+            document.getDocumentCatalog().setMarkInfo(markInfo);
+            try (PDPageContentStream contentStream = new PDPageContentStream(document, document.getPage(0))) {
+                contentStream.beginMarkedContent(COSName.P, 0);
+                contentStream.addRect(10, 10, 20, 20);
+                contentStream.fill();
+                contentStream.endMarkedContent();
+            }
+            document.save(path.toFile());
+        }
+    }
+
+    private static void mergeWithLegacyMode(List<Path> paths) throws IOException {
+        PDFMergerUtility merger = new PDFMergerUtility();
+        for (Path path : paths) {
+            merger.addSource(path.toFile());
+        }
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            merger.setDestinationStream(outputStream);
+            merger.mergeDocuments(null);
+        }
+    }
+
+    private static void mergePdf(Path path, PDFMergerUtility.DocumentMergeMode mergeMode) throws IOException {
+        PDFMergerUtility merger = new PDFMergerUtility();
+        merger.setDocumentMergeMode(mergeMode);
+        merger.addSource(path.toFile());
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            merger.setDestinationStream(outputStream);
+            merger.mergeDocuments(null);
+        }
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/FileUtilUnitTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/FileUtilUnitTest.java
@@ -32,6 +32,7 @@ import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSInteger;
 import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSNull;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
 import org.apache.pdfbox.pdfparser.PDFStreamParser;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -51,6 +52,9 @@ import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 import org.apache.pdfbox.pdmodel.interactive.action.PDActionURI;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotationLink;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceDictionary;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceEntry;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAppearanceStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -353,6 +357,10 @@ class FileUtilUnitTest {
             assertThat(link.getCOSObject().containsKey(COSName.STRUCT_PARENT)).isFalse();
             assertThat(link.getAction()).isInstanceOf(PDActionURI.class);
             assertThat(((PDActionURI) link.getAction()).getURI()).isEqualTo("https://example.com/lecture-slide");
+            PDAppearanceDictionary appearance = link.getAppearance();
+            assertAppearanceHasNoStructureParentReferences(appearance.getNormalAppearance());
+            assertAppearanceHasNoStructureParentReferences(appearance.getRolloverAppearance());
+            assertAppearanceHasNoStructureParentReferences(appearance.getDownAppearance());
 
             PDFormXObject outerForm = (PDFormXObject) mergedDocument.getPage(0).getResources().getXObject(COSName.getPDFName("OuterForm"));
             PDFormXObject innerForm = (PDFormXObject) outerForm.getResources().getXObject(COSName.getPDFName("InnerForm"));
@@ -430,6 +438,13 @@ class FileUtilUnitTest {
             PDActionURI action = new PDActionURI();
             action.setURI("https://example.com/lecture-slide");
             link.setAction(action);
+            PDAppearanceDictionary appearance = new PDAppearanceDictionary();
+            appearance.setNormalAppearance(createAppearanceStream(document, 5));
+            COSDictionary rolloverAppearances = new COSDictionary();
+            rolloverAppearances.setItem(COSName.getPDFName("Default"), createAppearanceStream(document, 6));
+            appearance.setRolloverAppearance(new PDAppearanceEntry(rolloverAppearances));
+            appearance.setDownAppearance(createAppearanceStream(document, 7));
+            link.setAppearance(appearance);
             document.getPage(0).getAnnotations().add(link);
 
             PDFormXObject innerForm = new PDFormXObject(document);
@@ -458,11 +473,39 @@ class FileUtilUnitTest {
 
             PDResources pageResources = new PDResources();
             pageResources.put(COSName.getPDFName("OuterForm"), outerForm);
+            COSDictionary xObjects = pageResources.getCOSObject().getCOSDictionary(COSName.XOBJECT);
+            xObjects.setItem(COSName.getPDFName("NullXObject"), COSNull.NULL);
+            COSDictionary unreadableXObject = new COSDictionary();
+            unreadableXObject.setItem(COSName.TYPE, COSName.XOBJECT);
+            xObjects.setItem(COSName.getPDFName("UnreadableXObject"), unreadableXObject);
             document.getPage(0).setResources(pageResources);
             try (PDPageContentStream contentStream = new PDPageContentStream(document, document.getPage(0))) {
                 contentStream.drawForm(outerForm);
             }
             document.save(path.toFile());
+        }
+    }
+
+    private static PDAppearanceStream createAppearanceStream(PDDocument document, int structureParent) throws IOException {
+        PDAppearanceStream appearanceStream = new PDAppearanceStream(document);
+        appearanceStream.setBBox(new PDRectangle(20, 20));
+        appearanceStream.setResources(new PDResources());
+        appearanceStream.setStructParents(structureParent);
+        try (PDPageContentStream contentStream = new PDPageContentStream(document, appearanceStream)) {
+            contentStream.addRect(2, 2, 5, 5);
+            contentStream.stroke();
+        }
+        return appearanceStream;
+    }
+
+    private static void assertAppearanceHasNoStructureParentReferences(PDAppearanceEntry appearanceEntry) throws IOException {
+        List<PDAppearanceStream> appearanceStreams = appearanceEntry.isStream() ? List.of(appearanceEntry.getAppearanceStream())
+                : List.copyOf(appearanceEntry.getSubDictionary().values());
+        assertThat(appearanceStreams).isNotEmpty();
+        for (PDAppearanceStream appearanceStream : appearanceStreams) {
+            assertThat(appearanceStream.getCOSObject().containsKey(COSName.STRUCT_PARENTS)).isFalse();
+            assertThat(new PDFStreamParser(appearanceStream).parse()).filteredOn(Operator.class::isInstance).extracting(token -> ((Operator) token).getName())
+                    .containsSubsequence("re", "S");
         }
     }
 


### PR DESCRIPTION
### Summary

Fixes lecture attachment PDF downloads when one source PDF contains malformed tagged-PDF structure metadata. Artemis now keeps the high-fidelity PDFBox merge as the primary path and retries with a validated page-only merge if that merge fails with an I/O error.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by an independent code review.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added focused unit coverage and verified the existing file endpoint integration tests.

### Motivation and Context

Downloading all PDF attachments for a lecture can fail with HTTP 500 when PDFBox encounters malformed logical-structure metadata in one otherwise readable source PDF. The affected pages can still be decoded and merged, but the existing implementation aborted the entire download after the document-level merge failed.

### Description

- Keep PDFBox legacy mode as the first merge attempt so valid PDFs retain tags, bookmarks, destinations, and other document-level structures.
- Retry once with PDFBox's page-only optimized mode after an `IOException`.
- Freeze the ordered list of existing source paths before either attempt so both attempts process the same inputs.
- Validate the exact output page count before and after restoring the merged document title.
- Remove dangling structure-parent references from pages, annotations, image XObjects, and recursively nested Form XObjects because page-only mode omits the document-level structure tree.
- Log the affected source paths and explain that repairing or re-exporting source PDFs is required to preserve omitted structural elements.
- Preserve existing behavior for null, empty, and missing source lists.
- Keep the PDFBox-specific implementation in a focused package-private utility while preserving `FileUtil.mergePdfFiles(...)` as the public entry point.

### Steps for Testing

1. Run `JAVA_HOME="/Users/pat/.sdkman/candidates/java/25-tem" ./gradlew test --tests FileUtilUnitTest -x webapp`.
2. Verify all 37 unit tests pass, including:
   - normal high-fidelity merge with page order and title preservation;
   - a materially tagged PDF retaining its MCID-based structure through legacy mode;
   - malformed ParentTree metadata triggering page-only fallback;
   - URI links and nested Form/image content remaining intact;
   - dangling structure-parent references being removed;
   - corrupt input failing cleanly.
3. Run `JAVA_HOME="/Users/pat/.sdkman/candidates/java/25-tem" ./gradlew test --tests FileIntegrationTest -x webapp` and verify all 31 endpoint integration tests pass.
4. Run `JAVA_HOME="/Users/pat/.sdkman/candidates/java/25-tem" ./gradlew spotlessCheck -x webapp`.
5. Run `JAVA_HOME="/Users/pat/.sdkman/candidates/java/25-tem" ./gradlew checkstyleMain -x webapp`.

### Testserver States

Not deployed; this server-side utility fix is covered by focused local regression and endpoint integration tests.

### Review Progress

#### Performance Review
- [ ] I (as a reviewer) confirm that the server changes are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| FileUtil.java | 83.93% | 494 |
| PdfMergeUtil.java | 91.95% | 156 |

_Last updated: 2026-07-16 17:35:51 UTC_

