### PR TITLE
`Exercises`: Fix an issue with lost values during exam and course material import

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/course/service/CourseMaterialImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/course/service/CourseMaterialImportService.java
@@ -298,7 +298,7 @@ public class CourseMaterialImportService {
     }
 
     private Optional<QuizExercise> importQuizExercise(QuizExercise exercise, Course targetCourse) {
-        var optionalOriginal = quizExerciseRepository.findById(exercise.getId());
+        var optionalOriginal = quizExerciseRepository.findWithEagerQuestionsAndStatisticsAndCompetenciesAndBatchesAndGradingCriteriaById(exercise.getId());
         if (optionalOriginal.isEmpty()) {
             return Optional.empty();
         }

--- a/src/main/java/de/tum/cit/aet/artemis/course/service/CourseMaterialImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/course/service/CourseMaterialImportService.java
@@ -305,7 +305,7 @@ public class CourseMaterialImportService {
 
         QuizExercise newExercise = new QuizExercise();
         newExercise.setCourse(targetCourse);
-        newExercise.setTitle(optionalOriginal.get().getTitle());
+        copyImportOverrides(optionalOriginal.get(), newExercise);
 
         try {
             return Optional.of(quizExerciseImportService.importQuizExercise(optionalOriginal.get(), newExercise, null));
@@ -327,7 +327,7 @@ public class CourseMaterialImportService {
 
         ModelingExercise newExercise = new ModelingExercise();
         newExercise.setCourse(targetCourse);
-        newExercise.setTitle(optionalOriginal.get().getTitle());
+        copyImportOverrides(optionalOriginal.get(), newExercise);
 
         return modelingExerciseImportApi.get().importModelingExercise(exercise.getId(), newExercise);
     }
@@ -339,7 +339,7 @@ public class CourseMaterialImportService {
 
         TextExercise newExercise = new TextExercise();
         newExercise.setCourse(targetCourse);
-        newExercise.setTitle(exercise.getTitle());
+        copyImportOverrides(exercise, newExercise);
 
         return textExerciseImportApi.get().importTextExercise(exercise.getId(), newExercise);
     }
@@ -351,9 +351,27 @@ public class CourseMaterialImportService {
 
         FileUploadExercise newExercise = new FileUploadExercise();
         newExercise.setCourse(targetCourse);
-        newExercise.setTitle(exercise.getTitle());
+        copyImportOverrides(exercise, newExercise);
 
         return fileUploadImportApi.get().importFileUploadExercise(exercise.getId(), newExercise);
+    }
+
+    /**
+     * Copies the fields that the course-material skeleton must carry itself onto the skeleton. Title and points have
+     * non-null defaults on a fresh entity, so the import service cannot tell a skeleton default apart from an intended
+     * value and would otherwise keep the default; the remaining content is taken from the source by the import service.
+     *
+     * @param source   the source exercise being imported
+     * @param skeleton the fresh target skeleton to enrich in place
+     */
+    private static void copyImportOverrides(Exercise source, Exercise skeleton) {
+        skeleton.setTitle(source.getTitle());
+        skeleton.setMaxPoints(source.getMaxPoints());
+        skeleton.setBonusPoints(source.getBonusPoints());
+        skeleton.setIncludedInOverallScore(source.getIncludedInOverallScore());
+        // Note: mode is intentionally not copied here. A TEAM source would also need its teamAssignmentConfig, which the
+        // course-material fetch does not load; preserving team mode + config for course-material import is left as a
+        // follow-up together with the categories / plagiarism-config fetch-graph expansion.
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamImportService.java
@@ -467,7 +467,8 @@ public class ExamImportService {
                         // not part of ExerciseImportDTO), so we must copy them from the original.
                         QuizExercise quizSkeleton = (QuizExercise) exerciseToCopy;
                         quizSkeleton.setQuizQuestions(originalQuizExercise.getQuizQuestions());
-                        quizSkeleton.setQuizBatches(originalQuizExercise.getQuizBatches());
+                        // Don't copy batches — exam timing controls quiz scheduling, and the import service
+                        // skips batch copying for exam exercises anyway.
                         // We don't allow a modification of the exercise at this point, so we can just pass an empty list of files.
                         yield Optional.of(quizExerciseImportService.importQuizExercise(originalQuizExercise, quizSkeleton, null));
                     }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseImportService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,6 +45,31 @@ public abstract class ExerciseImportService {
     }
 
     protected void copyExerciseBasis(final Exercise newExercise, final Exercise importedExercise, final Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
+        copyExerciseBasis(newExercise, importedExercise, importedExercise, gradingInstructionCopyTracker);
+        // When source and target are the same object, copy competency links (standalone REST import path).
+        // The 4-param overload clears them because cross-course import cannot safely reference foreign competencies.
+        Set<CompetencyExerciseLink> copiedLinks = new HashSet<>();
+        for (CompetencyExerciseLink link : importedExercise.getCompetencyLinks()) {
+            copiedLinks.add(new CompetencyExerciseLink(link.getCompetency(), newExercise, link.getWeight()));
+        }
+        newExercise.setCompetencyLinks(copiedLinks);
+    }
+
+    /**
+     * Copies exercise fields from two sources: structural context from {@code importedExercise} (target course/group,
+     * possible title/points overrides) and content from {@code templateExercise} (the original exercise with all fields).
+     * <p>
+     * This overload exists because exam-import and course-material-import create a skeleton {@code importedExercise}
+     * carrying only destination context + optional overrides, while the original exercise data lives in {@code templateExercise}.
+     *
+     * @param newExercise                   the fresh entity being built
+     * @param importedExercise              skeleton with target course/exerciseGroup and optional title/points overrides
+     * @param templateExercise              the original exercise providing content fields
+     * @param gradingInstructionCopyTracker tracker for deep-copying grading instructions
+     */
+    protected void copyExerciseBasis(final Exercise newExercise, final Exercise importedExercise, final Exercise templateExercise,
+            final Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
+        // Structural context: always from importedExercise (the target destination)
         if (importedExercise.isCourseExercise()) {
             newExercise.setCourse(importedExercise.getCourseViaExerciseGroupOrCourseMember());
             newExercise.setPresentationScoreEnabled(importedExercise.getPresentationScoreEnabled());
@@ -52,41 +78,46 @@ public abstract class ExerciseImportService {
             newExercise.setExerciseGroup(importedExercise.getExerciseGroup());
         }
 
-        newExercise.setTitle(importedExercise.getTitle());
-        newExercise.setMaxPoints(importedExercise.getMaxPoints());
-        newExercise.setBonusPoints(importedExercise.getBonusPoints());
-        newExercise.setIncludedInOverallScore(importedExercise.getIncludedInOverallScore());
-        newExercise.setAssessmentType(importedExercise.getAssessmentType());
-        newExercise.setProblemStatement(importedExercise.getProblemStatement());
-        newExercise.setStartDate(importedExercise.getStartDate());
-        newExercise.setReleaseDate(importedExercise.getReleaseDate());
-        newExercise.setDueDate(importedExercise.getDueDate());
-        newExercise.setAssessmentDueDate(importedExercise.getAssessmentDueDate());
+        // Overridable fields: use importedExercise if set, fall back to templateExercise
+        newExercise.setTitle(importedExercise.getTitle() != null ? importedExercise.getTitle() : templateExercise.getTitle());
+        newExercise.setMaxPoints(importedExercise.getMaxPoints() != null ? importedExercise.getMaxPoints() : templateExercise.getMaxPoints());
+        newExercise.setBonusPoints(importedExercise.getBonusPoints() != null ? importedExercise.getBonusPoints() : templateExercise.getBonusPoints());
+
+        // Content fields: always from templateExercise (the original exercise)
+        newExercise.setIncludedInOverallScore(templateExercise.getIncludedInOverallScore());
+        newExercise.setAssessmentType(templateExercise.getAssessmentType());
+        newExercise.setProblemStatement(templateExercise.getProblemStatement());
+        newExercise.setStartDate(templateExercise.getStartDate());
+        newExercise.setReleaseDate(templateExercise.getReleaseDate());
+        newExercise.setDueDate(templateExercise.getDueDate());
+        newExercise.setAssessmentDueDate(templateExercise.getAssessmentDueDate());
         newExercise.setExampleSolutionPublicationDate(null); // This should not be imported as the client might serve the original date as the default.
         newExercise.validateDates();
-        newExercise.setDifficulty(importedExercise.getDifficulty());
-        newExercise.setGradingInstructions(importedExercise.getGradingInstructions());
-        newExercise.setGradingCriteria(importedExercise.copyGradingCriteria(gradingInstructionCopyTracker));
-        // Copy competency links as NEW unmanaged objects (not sharing managed entities from the template)
-        Set<CompetencyExerciseLink> copiedLinks = new HashSet<>();
-        for (CompetencyExerciseLink link : importedExercise.getCompetencyLinks()) {
-            // Create a new link with just the competency reference and weight (exercise will be set later)
-            copiedLinks.add(new CompetencyExerciseLink(link.getCompetency(), newExercise, link.getWeight()));
+        newExercise.setDifficulty(templateExercise.getDifficulty());
+        newExercise.setGradingInstructions(templateExercise.getGradingInstructions());
+        if (Hibernate.isInitialized(templateExercise.getGradingCriteria())) {
+            newExercise.setGradingCriteria(templateExercise.copyGradingCriteria(gradingInstructionCopyTracker));
         }
-        newExercise.setCompetencyLinks(copiedLinks);
 
-        if (importedExercise.getPlagiarismDetectionConfig() != null) {
-            newExercise.setPlagiarismDetectionConfig(new PlagiarismDetectionConfig(importedExercise.getPlagiarismDetectionConfig()));
+        // Competency links are not copied cross-course (the competencies may not exist in the target course).
+        // Callers that need them handle them separately via competencyExerciseLinkService.
+        newExercise.setCompetencyLinks(new HashSet<>());
+
+        if (Hibernate.isPropertyInitialized(templateExercise, "plagiarismDetectionConfig") && templateExercise.getPlagiarismDetectionConfig() != null) {
+            newExercise.setPlagiarismDetectionConfig(new PlagiarismDetectionConfig(templateExercise.getPlagiarismDetectionConfig()));
         }
 
         if (newExercise.getExerciseGroup() != null) {
             newExercise.setMode(ExerciseMode.INDIVIDUAL);
         }
         else {
-            newExercise.setCategories(importedExercise.getCategories());
-            newExercise.setMode(importedExercise.getMode());
-            if (newExercise.getMode() == ExerciseMode.TEAM) {
-                newExercise.setTeamAssignmentConfig(importedExercise.getTeamAssignmentConfig().copyTeamAssignmentConfig());
+            if (Hibernate.isInitialized(templateExercise.getCategories())) {
+                newExercise.setCategories(templateExercise.getCategories());
+            }
+            newExercise.setMode(templateExercise.getMode());
+            if (newExercise.getMode() == ExerciseMode.TEAM && Hibernate.isPropertyInitialized(templateExercise, "teamAssignmentConfig")
+                    && templateExercise.getTeamAssignmentConfig() != null) {
+                newExercise.setTeamAssignmentConfig(templateExercise.getTeamAssignmentConfig().copyTeamAssignmentConfig());
             }
         }
     }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseImportService.java
@@ -46,25 +46,23 @@ public abstract class ExerciseImportService {
 
     protected void copyExerciseBasis(final Exercise newExercise, final Exercise importedExercise, final Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
         copyExerciseBasis(newExercise, importedExercise, importedExercise, gradingInstructionCopyTracker);
-        // When source and target are the same object, copy competency links (standalone REST import path).
-        // The 4-param overload clears them because cross-course import cannot safely reference foreign competencies.
-        Set<CompetencyExerciseLink> copiedLinks = new HashSet<>();
-        for (CompetencyExerciseLink link : importedExercise.getCompetencyLinks()) {
-            copiedLinks.add(new CompetencyExerciseLink(link.getCompetency(), newExercise, link.getWeight()));
-        }
-        newExercise.setCompetencyLinks(copiedLinks);
     }
 
     /**
-     * Copies exercise fields from two sources: structural context from {@code importedExercise} (target course/group,
-     * possible title/points overrides) and content from {@code templateExercise} (the original exercise with all fields).
+     * Copies exercise fields from two sources: structural context from {@code importedExercise} (target course/group)
+     * and content that falls back to {@code templateExercise} (the original exercise) when {@code importedExercise} does
+     * not carry it.
      * <p>
-     * This overload exists because exam-import and course-material-import create a skeleton {@code importedExercise}
-     * carrying only destination context + optional overrides, while the original exercise data lives in {@code templateExercise}.
+     * The two arguments are the same object for the standalone REST import, where {@code importedExercise} is the full
+     * exercise submitted from the edit form (edited content, cleared dates). They differ for exam-import and
+     * course-material-import, where {@code importedExercise} is a skeleton carrying only the destination and a few
+     * overrides, and the content lives in {@code templateExercise}. Reading each field from {@code importedExercise}
+     * first and only falling back to {@code templateExercise} keeps both cases correct: the standalone import honours
+     * the submitted values, and the bulk imports pick up the source content the skeleton is missing.
      *
      * @param newExercise                   the fresh entity being built
-     * @param importedExercise              skeleton with target course/exerciseGroup and optional title/points overrides
-     * @param templateExercise              the original exercise providing content fields
+     * @param importedExercise              the intended exercise (full for standalone import, a destination skeleton for bulk import)
+     * @param templateExercise              the original exercise providing content the skeleton is missing
      * @param gradingInstructionCopyTracker tracker for deep-copying grading instructions
      */
     protected void copyExerciseBasis(final Exercise newExercise, final Exercise importedExercise, final Exercise templateExercise,
@@ -78,48 +76,85 @@ public abstract class ExerciseImportService {
             newExercise.setExerciseGroup(importedExercise.getExerciseGroup());
         }
 
-        // Overridable fields: use importedExercise if set, fall back to templateExercise
-        newExercise.setTitle(importedExercise.getTitle() != null ? importedExercise.getTitle() : templateExercise.getTitle());
-        newExercise.setMaxPoints(importedExercise.getMaxPoints() != null ? importedExercise.getMaxPoints() : templateExercise.getMaxPoints());
-        newExercise.setBonusPoints(importedExercise.getBonusPoints() != null ? importedExercise.getBonusPoints() : templateExercise.getBonusPoints());
+        // Scalar content: prefer importedExercise (honours edits from the standalone import form), fall back to the
+        // template when the skeleton does not carry the value (exam / course-material import).
+        newExercise.setTitle(firstNonNull(importedExercise.getTitle(), templateExercise.getTitle()));
+        newExercise.setMaxPoints(firstNonNull(importedExercise.getMaxPoints(), templateExercise.getMaxPoints()));
+        newExercise.setBonusPoints(firstNonNull(importedExercise.getBonusPoints(), templateExercise.getBonusPoints()));
+        newExercise.setAssessmentType(firstNonNull(importedExercise.getAssessmentType(), templateExercise.getAssessmentType()));
+        newExercise.setProblemStatement(firstNonNull(importedExercise.getProblemStatement(), templateExercise.getProblemStatement()));
+        newExercise.setDifficulty(firstNonNull(importedExercise.getDifficulty(), templateExercise.getDifficulty()));
+        newExercise.setGradingInstructions(firstNonNull(importedExercise.getGradingInstructions(), templateExercise.getGradingInstructions()));
+        // includedInOverallScore and mode (below) have non-null defaults, so the skeleton cannot be distinguished from
+        // an intentional value; both are editable in the standalone import form, so they are taken from importedExercise.
+        // The course-material import copies them from the source onto its skeleton (see CourseMaterialImportService).
+        newExercise.setIncludedInOverallScore(importedExercise.getIncludedInOverallScore());
 
-        // Content fields: always from templateExercise (the original exercise)
-        newExercise.setIncludedInOverallScore(templateExercise.getIncludedInOverallScore());
-        newExercise.setAssessmentType(templateExercise.getAssessmentType());
-        newExercise.setProblemStatement(templateExercise.getProblemStatement());
-        newExercise.setStartDate(templateExercise.getStartDate());
-        newExercise.setReleaseDate(templateExercise.getReleaseDate());
-        newExercise.setDueDate(templateExercise.getDueDate());
-        newExercise.setAssessmentDueDate(templateExercise.getAssessmentDueDate());
+        // Dates are reset on import: the standalone import clears them client-side and the bulk skeletons have none.
+        // Read them from importedExercise so an imported exercise starts fresh instead of inheriting the source dates.
+        newExercise.setStartDate(importedExercise.getStartDate());
+        newExercise.setReleaseDate(importedExercise.getReleaseDate());
+        newExercise.setDueDate(importedExercise.getDueDate());
+        newExercise.setAssessmentDueDate(importedExercise.getAssessmentDueDate());
         newExercise.setExampleSolutionPublicationDate(null); // This should not be imported as the client might serve the original date as the default.
         newExercise.validateDates();
-        newExercise.setDifficulty(templateExercise.getDifficulty());
-        newExercise.setGradingInstructions(templateExercise.getGradingInstructions());
-        if (Hibernate.isInitialized(templateExercise.getGradingCriteria())) {
-            newExercise.setGradingCriteria(templateExercise.copyGradingCriteria(gradingInstructionCopyTracker));
+
+        Exercise gradingCriteriaSource = hasInitializedGradingCriteria(importedExercise) ? importedExercise : templateExercise;
+        if (hasInitializedGradingCriteria(gradingCriteriaSource)) {
+            newExercise.setGradingCriteria(gradingCriteriaSource.copyGradingCriteria(gradingInstructionCopyTracker));
         }
 
-        // Competency links are not copied cross-course (the competencies may not exist in the target course).
-        // Callers that need them handle them separately via competencyExerciseLinkService.
-        newExercise.setCompetencyLinks(new HashSet<>());
+        // Competency links point at course-specific competencies, so they can only come from the target-context
+        // importedExercise (the standalone import form or a bulk skeleton), never from the foreign template source.
+        Set<CompetencyExerciseLink> copiedLinks = new HashSet<>();
+        for (CompetencyExerciseLink link : importedExercise.getCompetencyLinks()) {
+            copiedLinks.add(new CompetencyExerciseLink(link.getCompetency(), newExercise, link.getWeight()));
+        }
+        newExercise.setCompetencyLinks(copiedLinks);
 
-        if (Hibernate.isPropertyInitialized(templateExercise, "plagiarismDetectionConfig") && templateExercise.getPlagiarismDetectionConfig() != null) {
-            newExercise.setPlagiarismDetectionConfig(new PlagiarismDetectionConfig(templateExercise.getPlagiarismDetectionConfig()));
+        Exercise plagiarismSource = hasPlagiarismDetectionConfig(importedExercise) ? importedExercise : templateExercise;
+        if (hasPlagiarismDetectionConfig(plagiarismSource)) {
+            newExercise.setPlagiarismDetectionConfig(new PlagiarismDetectionConfig(plagiarismSource.getPlagiarismDetectionConfig()));
         }
 
         if (newExercise.getExerciseGroup() != null) {
             newExercise.setMode(ExerciseMode.INDIVIDUAL);
         }
         else {
-            if (Hibernate.isInitialized(templateExercise.getCategories())) {
-                newExercise.setCategories(templateExercise.getCategories());
+            Exercise categoriesSource = hasInitializedCategories(importedExercise) && !importedExercise.getCategories().isEmpty() ? importedExercise : templateExercise;
+            if (hasInitializedCategories(categoriesSource)) {
+                newExercise.setCategories(new HashSet<>(categoriesSource.getCategories()));
             }
-            newExercise.setMode(templateExercise.getMode());
-            if (newExercise.getMode() == ExerciseMode.TEAM && Hibernate.isPropertyInitialized(templateExercise, "teamAssignmentConfig")
-                    && templateExercise.getTeamAssignmentConfig() != null) {
-                newExercise.setTeamAssignmentConfig(templateExercise.getTeamAssignmentConfig().copyTeamAssignmentConfig());
+            newExercise.setMode(importedExercise.getMode());
+            Exercise teamConfigSource = hasTeamAssignmentConfig(importedExercise) ? importedExercise : templateExercise;
+            if (newExercise.getMode() == ExerciseMode.TEAM && hasTeamAssignmentConfig(teamConfigSource)) {
+                newExercise.setTeamAssignmentConfig(teamConfigSource.getTeamAssignmentConfig().copyTeamAssignmentConfig());
             }
         }
+    }
+
+    /**
+     * Returns {@code value} if it is non-null, otherwise {@code fallback}. Used by import services to prefer the
+     * intended exercise's field and fall back to the source content a bulk-import skeleton is missing.
+     */
+    protected static <T> T firstNonNull(T value, T fallback) {
+        return value != null ? value : fallback;
+    }
+
+    private static boolean hasInitializedGradingCriteria(Exercise exercise) {
+        return Hibernate.isInitialized(exercise.getGradingCriteria()) && exercise.getGradingCriteria() != null;
+    }
+
+    private static boolean hasInitializedCategories(Exercise exercise) {
+        return Hibernate.isInitialized(exercise.getCategories()) && exercise.getCategories() != null;
+    }
+
+    private static boolean hasPlagiarismDetectionConfig(Exercise exercise) {
+        return Hibernate.isPropertyInitialized(exercise, "plagiarismDetectionConfig") && exercise.getPlagiarismDetectionConfig() != null;
+    }
+
+    private static boolean hasTeamAssignmentConfig(Exercise exercise) {
+        return Hibernate.isPropertyInitialized(exercise, "teamAssignmentConfig") && exercise.getTeamAssignmentConfig() != null;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/api/FileUploadImportApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/api/FileUploadImportApi.java
@@ -42,7 +42,8 @@ public class FileUploadImportApi extends AbstractFileModuleApi {
     }
 
     public Optional<FileUploadExercise> importFileUploadExercise(final long exerciseToCopyId, final FileUploadExercise importedExercise) {
-        final Optional<FileUploadExercise> optionalFileUploadExercise = fileUploadExerciseRepository.findById(exerciseToCopyId);
+        final Optional<FileUploadExercise> optionalFileUploadExercise = fileUploadExerciseRepository
+                .findByIdWithExampleSubmissionsAndResultsAndCompetenciesAndGradingCriteria(exerciseToCopyId);
         return optionalFileUploadExercise.map(templateExercise -> fileUploadExerciseImportService.importFileUploadExercise(templateExercise, importedExercise));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/service/FileUploadExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/service/FileUploadExerciseImportService.java
@@ -90,8 +90,9 @@ public class FileUploadExerciseImportService extends ExerciseImportService {
         FileUploadExercise newExercise = new FileUploadExercise();
         super.copyExerciseBasis(newExercise, importedExercise, templateExercise, new HashMap<>());
         newExercise.setAssessmentType(AssessmentType.MANUAL);
-        newExercise.setFilePattern(templateExercise.getFilePattern());
-        newExercise.setExampleSolution(templateExercise.getExampleSolution());
+        // Prefer the intended exercise (honours edits from the standalone import form), fall back to the source content.
+        newExercise.setFilePattern(firstNonNull(importedExercise.getFilePattern(), templateExercise.getFilePattern()));
+        newExercise.setExampleSolution(firstNonNull(importedExercise.getExampleSolution(), templateExercise.getExampleSolution()));
         return newExercise;
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/service/FileUploadExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/service/FileUploadExerciseImportService.java
@@ -60,7 +60,7 @@ public class FileUploadExerciseImportService extends ExerciseImportService {
     @NonNull
     public FileUploadExercise importFileUploadExercise(final FileUploadExercise templateExercise, FileUploadExercise importedExercise) {
         log.debug("Creating a new Exercise based on exercise {}", templateExercise);
-        FileUploadExercise newExercise = copyFileUploadExerciseBasis(importedExercise);
+        FileUploadExercise newExercise = copyFileUploadExerciseBasis(importedExercise, templateExercise);
 
         var competencyLinks = competencyExerciseLinkService.extractCompetencyLinksForCreation(newExercise);
         FileUploadExercise savedExercise = fileUploadExerciseRepository.save(newExercise);
@@ -85,13 +85,13 @@ public class FileUploadExerciseImportService extends ExerciseImportService {
      * @return the cloned TextExercise basis
      */
     @NonNull
-    private FileUploadExercise copyFileUploadExerciseBasis(FileUploadExercise importedExercise) {
+    private FileUploadExercise copyFileUploadExerciseBasis(FileUploadExercise importedExercise, FileUploadExercise templateExercise) {
         log.debug("Copying the exercise basis from {}", importedExercise);
         FileUploadExercise newExercise = new FileUploadExercise();
-        super.copyExerciseBasis(newExercise, importedExercise, new HashMap<>());
+        super.copyExerciseBasis(newExercise, importedExercise, templateExercise, new HashMap<>());
         newExercise.setAssessmentType(AssessmentType.MANUAL);
-        newExercise.setFilePattern(importedExercise.getFilePattern());
-        newExercise.setExampleSolution(importedExercise.getExampleSolution());
+        newExercise.setFilePattern(templateExercise.getFilePattern());
+        newExercise.setExampleSolution(templateExercise.getExampleSolution());
         return newExercise;
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/modeling/service/ModelingExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/service/ModelingExerciseImportService.java
@@ -103,9 +103,11 @@ public class ModelingExerciseImportService extends ExerciseImportService {
         ModelingExercise newExercise = new ModelingExercise();
         super.copyExerciseBasis(newExercise, importedExercise, templateExercise, gradingInstructionCopyTracker);
 
-        newExercise.setDiagramType(templateExercise.getDiagramType());
-        newExercise.setExampleSolutionModel(templateExercise.getExampleSolutionModel());
-        newExercise.setExampleSolutionExplanation(templateExercise.getExampleSolutionExplanation());
+        // Prefer the intended exercise (honours edits from the standalone import form), fall back to the source content.
+        ModelingExercise imported = (ModelingExercise) importedExercise;
+        newExercise.setDiagramType(firstNonNull(imported.getDiagramType(), templateExercise.getDiagramType()));
+        newExercise.setExampleSolutionModel(firstNonNull(imported.getExampleSolutionModel(), templateExercise.getExampleSolutionModel()));
+        newExercise.setExampleSolutionExplanation(firstNonNull(imported.getExampleSolutionExplanation(), templateExercise.getExampleSolutionExplanation()));
         return newExercise;
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/modeling/service/ModelingExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/service/ModelingExerciseImportService.java
@@ -70,7 +70,7 @@ public class ModelingExerciseImportService extends ExerciseImportService {
     public ModelingExercise importModelingExercise(ModelingExercise templateExercise, ModelingExercise importedExercise) {
         log.debug("Creating a new Exercise based on exercise {}", templateExercise.getId());
         Map<Long, GradingInstruction> gradingInstructionCopyTracker = new HashMap<>();
-        ModelingExercise newExercise = copyModelingExerciseBasis(importedExercise, gradingInstructionCopyTracker);
+        ModelingExercise newExercise = copyModelingExerciseBasis(importedExercise, templateExercise, gradingInstructionCopyTracker);
 
         var competencyLinks = competencyExerciseLinkService.extractCompetencyLinksForCreation(newExercise);
         ModelingExercise savedExercise = modelingExerciseRepository.save(newExercise);
@@ -98,14 +98,14 @@ public class ModelingExerciseImportService extends ExerciseImportService {
      * @return the cloned TextExercise basis
      */
     @NonNull
-    private ModelingExercise copyModelingExerciseBasis(Exercise importedExercise, Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
+    private ModelingExercise copyModelingExerciseBasis(Exercise importedExercise, ModelingExercise templateExercise, Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
         log.debug("Copying the exercise basis from {}", importedExercise);
         ModelingExercise newExercise = new ModelingExercise();
-        super.copyExerciseBasis(newExercise, importedExercise, gradingInstructionCopyTracker);
+        super.copyExerciseBasis(newExercise, importedExercise, templateExercise, gradingInstructionCopyTracker);
 
-        newExercise.setDiagramType(((ModelingExercise) importedExercise).getDiagramType());
-        newExercise.setExampleSolutionModel(((ModelingExercise) importedExercise).getExampleSolutionModel());
-        newExercise.setExampleSolutionExplanation(((ModelingExercise) importedExercise).getExampleSolutionExplanation());
+        newExercise.setDiagramType(templateExercise.getDiagramType());
+        newExercise.setExampleSolutionModel(templateExercise.getExampleSolutionModel());
+        newExercise.setExampleSolutionExplanation(templateExercise.getExampleSolutionExplanation());
         return newExercise;
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizExerciseImportService.java
@@ -106,10 +106,13 @@ public class QuizExerciseImportService extends ExerciseImportService {
     }
 
     /**
-     * This helper method copies all attributes of the {@code importedExercise} into a new exercise.
-     * Here we ignore all external entities as well as the start-, end-, and asseessment due date.
+     * Copies the exercise basis into a new exercise. Structural context (target course/group) comes from
+     * {@code importedExercise}; the quiz content and settings come from {@code templateExercise} (the original exercise),
+     * with {@code importedExercise} taking precedence where it carries a value. The start-, end-, and assessment due
+     * dates are intentionally not copied here.
      *
-     * @param importedExercise The exercise from which to copy the basis
+     * @param importedExercise the intended exercise (full for standalone import, a destination skeleton for bulk import)
+     * @param templateExercise the original exercise providing the quiz content and settings
      * @return the cloned QuizExercise basis
      */
     @NonNull

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizExerciseImportService.java
@@ -82,9 +82,15 @@ public class QuizExerciseImportService extends ExerciseImportService {
     @NonNull
     public QuizExercise importQuizExercise(final QuizExercise templateExercise, QuizExercise importedExercise, @Nullable List<MultipartFile> files) throws IOException {
         log.debug("Creating a new Exercise based on exercise {}", templateExercise);
-        QuizExercise newExercise = copyQuizExerciseBasis(importedExercise);
-        copyQuizQuestions(importedExercise, newExercise);
-        copyQuizBatches(importedExercise, newExercise);
+        QuizExercise newExercise = copyQuizExerciseBasis(importedExercise, templateExercise);
+        // Use templateExercise as fallback source for questions/batches when importedExercise (skeleton) doesn't have them
+        QuizExercise questionSource = importedExercise.getQuizQuestions() != null && !importedExercise.getQuizQuestions().isEmpty() ? importedExercise : templateExercise;
+        copyQuizQuestions(questionSource, newExercise);
+        // Don't copy batches for exam exercises — exam timing controls quiz scheduling
+        if (!newExercise.isExamExercise()) {
+            QuizExercise batchSource = importedExercise.getQuizBatches() != null && !importedExercise.getQuizBatches().isEmpty() ? importedExercise : templateExercise;
+            copyQuizBatches(batchSource, newExercise);
+        }
 
         QuizExercise newQuizExercise = quizExerciseService.save(newExercise);
 
@@ -107,16 +113,15 @@ public class QuizExerciseImportService extends ExerciseImportService {
      * @return the cloned QuizExercise basis
      */
     @NonNull
-    private QuizExercise copyQuizExerciseBasis(QuizExercise importedExercise) {
+    private QuizExercise copyQuizExerciseBasis(QuizExercise importedExercise, QuizExercise templateExercise) {
         log.debug("Copying the exercise basis from {}", importedExercise);
         QuizExercise newExercise = new QuizExercise();
 
-        super.copyExerciseBasis(newExercise, importedExercise, new HashMap<>());
-        newExercise.setRandomizeQuestionOrder(importedExercise.isRandomizeQuestionOrder());
-        newExercise.setAllowedNumberOfAttempts(importedExercise.getAllowedNumberOfAttempts());
-        newExercise.setRemainingNumberOfAttempts(importedExercise.getRemainingNumberOfAttempts());
-        newExercise.setQuizMode(importedExercise.getQuizMode());
-        newExercise.setDuration(importedExercise.getDuration());
+        super.copyExerciseBasis(newExercise, importedExercise, templateExercise, new HashMap<>());
+        newExercise.setRandomizeQuestionOrder(templateExercise.isRandomizeQuestionOrder());
+        newExercise.setAllowedNumberOfAttempts(templateExercise.getAllowedNumberOfAttempts());
+        newExercise.setQuizMode(templateExercise.getQuizMode());
+        newExercise.setDuration(templateExercise.getDuration());
         return newExercise;
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/text/api/TextExerciseImportApi.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/api/TextExerciseImportApi.java
@@ -39,7 +39,7 @@ public class TextExerciseImportApi extends AbstractTextApi {
     }
 
     public Optional<TextExercise> importTextExercise(final long templateExerciseId, final TextExercise exerciseToCopy) {
-        final Optional<TextExercise> optionalOriginalTextExercise = textExerciseRepository.findWithExampleSubmissionsAndResultsById(templateExerciseId);
+        final Optional<TextExercise> optionalOriginalTextExercise = textExerciseRepository.findWithExampleSubmissionsAndResultsAndGradingCriteriaById(templateExerciseId);
         return optionalOriginalTextExercise.map(textExercise -> textExerciseImportService.importTextExercise(textExercise, exerciseToCopy));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/text/service/TextExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/service/TextExerciseImportService.java
@@ -90,7 +90,7 @@ public class TextExerciseImportService extends ExerciseImportService {
     public TextExercise importTextExercise(final TextExercise templateExercise, TextExercise importedExercise) {
         log.debug("Creating a new Exercise based on exercise {}", templateExercise);
         Map<Long, GradingInstruction> gradingInstructionCopyTracker = new HashMap<>();
-        TextExercise newExercise = copyTextExerciseBasis(importedExercise, gradingInstructionCopyTracker);
+        TextExercise newExercise = copyTextExerciseBasis(importedExercise, templateExercise, gradingInstructionCopyTracker);
         if (newExercise.isExamExercise()) {
             // Disable feedback suggestions on exam exercises (currently not supported)
             newExercise.setFeedbackSuggestionModule(null);
@@ -121,12 +121,12 @@ public class TextExerciseImportService extends ExerciseImportService {
      * @return the cloned TextExercise basis
      */
     @NonNull
-    private TextExercise copyTextExerciseBasis(TextExercise importedExercise, Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
+    private TextExercise copyTextExerciseBasis(TextExercise importedExercise, TextExercise templateExercise, Map<Long, GradingInstruction> gradingInstructionCopyTracker) {
         log.debug("Copying the exercise basis from {}", importedExercise);
         TextExercise newExercise = new TextExercise();
 
-        super.copyExerciseBasis(newExercise, importedExercise, gradingInstructionCopyTracker);
-        newExercise.setExampleSolution(importedExercise.getExampleSolution());
+        super.copyExerciseBasis(newExercise, importedExercise, templateExercise, gradingInstructionCopyTracker);
+        newExercise.setExampleSolution(templateExercise.getExampleSolution());
         return newExercise;
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/text/service/TextExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/service/TextExerciseImportService.java
@@ -126,7 +126,8 @@ public class TextExerciseImportService extends ExerciseImportService {
         TextExercise newExercise = new TextExercise();
 
         super.copyExerciseBasis(newExercise, importedExercise, templateExercise, gradingInstructionCopyTracker);
-        newExercise.setExampleSolution(templateExercise.getExampleSolution());
+        // Prefer the intended exercise (honours edits from the standalone import form), fall back to the source content.
+        newExercise.setExampleSolution(firstNonNull(importedExercise.getExampleSolution(), templateExercise.getExampleSolution()));
         return newExercise;
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExamIntegrationTest.java
@@ -84,6 +84,7 @@ import de.tum.cit.aet.artemis.exam.test_repository.ExamTestRepository;
 import de.tum.cit.aet.artemis.exam.test_repository.StudentExamTestRepository;
 import de.tum.cit.aet.artemis.exam.util.ExamFactory;
 import de.tum.cit.aet.artemis.exam.util.ExamUtilService;
+import de.tum.cit.aet.artemis.exercise.domain.DifficultyLevel;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.ExerciseType;
 import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
@@ -95,12 +96,15 @@ import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.test_repository.StudentParticipationTestRepository;
 import de.tum.cit.aet.artemis.exercise.test_repository.SubmissionTestRepository;
 import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
+import de.tum.cit.aet.artemis.fileupload.domain.FileUploadExercise;
 import de.tum.cit.aet.artemis.fileupload.domain.FileUploadSubmission;
 import de.tum.cit.aet.artemis.fileupload.util.ZipFileTestUtilService;
 import de.tum.cit.aet.artemis.globalsearch.dto.searchableentity.ExerciseSearchableEntityDTO;
 import de.tum.cit.aet.artemis.globalsearch.service.SearchableEntityWeaviateService;
 import de.tum.cit.aet.artemis.globalsearch.service.WeaviateService;
 import de.tum.cit.aet.artemis.globalsearch.util.WeaviateTestUtil;
+import de.tum.cit.aet.artemis.modeling.domain.DiagramType;
+import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
 import de.tum.cit.aet.artemis.modeling.domain.ModelingSubmission;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 import de.tum.cit.aet.artemis.programming.test_repository.ProgrammingExerciseTestRepository;
@@ -2140,6 +2144,45 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
             var exerciseGroup = exerciseGroups.get(i);
             assertThat(exerciseGroup.getTitle()).isEqualTo("Group " + i);
             assertThat(exerciseGroup.getIsMandatory()).isTrue();
+        }
+
+        // Verify that content fields from the source exercises are preserved during import (not silently dropped)
+        for (ExerciseGroup group : exerciseGroups) {
+            for (Exercise importedExercise : group.getExercises()) {
+                // Base fields that should be copied from the template exercise
+                assertThat(importedExercise.getDifficulty()).as("difficulty must be preserved for " + importedExercise.getTitle()).isEqualTo(DifficultyLevel.MEDIUM);
+                // Quiz maxPoints is overridden by QuizExerciseService.save() to equal the sum of question points
+                if (!(importedExercise instanceof QuizExercise)) {
+                    assertThat(importedExercise.getMaxPoints()).as("maxPoints must be preserved").isEqualTo(5.0);
+                }
+
+                switch (importedExercise) {
+                    case ModelingExercise modeling -> {
+                        assertThat(modeling.getProblemStatement()).as("problemStatement must be preserved").isEqualTo("Exam Problem Statement");
+                        assertThat(modeling.getDiagramType()).as("diagramType must be preserved").isEqualTo(DiagramType.ClassDiagram);
+                        assertThat(modeling.getExampleSolutionModel()).as("exampleSolutionModel must be preserved").isEqualTo("This is my example solution model");
+                        assertThat(modeling.getExampleSolutionExplanation()).as("exampleSolutionExplanation must be preserved").isEqualTo("This is my example solution model");
+                    }
+                    case TextExercise text -> {
+                        assertThat(text.getProblemStatement()).as("problemStatement must be preserved").isEqualTo("Exam Problem Statement");
+                        assertThat(text.getExampleSolution()).as("exampleSolution must be preserved").isEqualTo("This is my example solution");
+                    }
+                    case FileUploadExercise fileUpload -> {
+                        assertThat(fileUpload.getProblemStatement()).as("problemStatement must be preserved").isEqualTo("Exam Problem Statement");
+                        assertThat(fileUpload.getFilePattern()).as("filePattern must be preserved").isEqualTo("png");
+                    }
+                    case QuizExercise quiz -> {
+                        assertThat(quiz.isRandomizeQuestionOrder()).as("randomizeQuestionOrder must be preserved").isTrue();
+                        assertThat(quiz.getAllowedNumberOfAttempts()).as("allowedNumberOfAttempts must be preserved").isEqualTo(1);
+                        assertThat(quiz.getDuration()).as("duration must be preserved").isEqualTo(10);
+                        // Quiz batches should NOT be imported for exam exercises (exam controls timing)
+                        assertThat(quiz.getQuizBatches()).as("quiz batches must not be imported for exam exercises").isNullOrEmpty();
+                    }
+                    default -> {
+                        // no additional assertions for other types
+                    }
+                }
+            }
         }
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingExerciseIntegrationTest.java
@@ -492,6 +492,42 @@ class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationLocalCILo
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void importModelingExercise_standaloneImportHonorsEditedFieldsAndResetsDates() throws Exception {
+        // Regression test: the standalone (course-to-course) import must persist the fields the user edited in the
+        // import form (problem statement, example solution) and keep the dates the client cleared, rather than falling
+        // back to the source exercise's values.
+        var now = ZonedDateTime.now();
+        Course source = courseUtilService.addEmptyCourse();
+        Course target = courseUtilService.addEmptyCourse();
+        ModelingExercise sourceExercise = ModelingExerciseFactory.generateModelingExercise(now.minusDays(10), now.minusDays(8), now.minusDays(6), DiagramType.ClassDiagram, source);
+        sourceExercise.setProblemStatement("SOURCE PROBLEM STATEMENT");
+        sourceExercise.setMaxPoints(42.0);
+        modelingExerciseTestRepository.save(sourceExercise);
+
+        // Emulate the client edit form: edited problem statement and example solution, cleared dates (resetForImport), target course.
+        ModelingExercise body = modelingExerciseTestRepository.findByIdElseThrow(sourceExercise.getId());
+        body.setProblemStatement("EDITED PROBLEM STATEMENT");
+        body.setExampleSolutionExplanation("EDITED EXAMPLE SOLUTION");
+        body.setReleaseDate(null);
+        body.setStartDate(null);
+        body.setDueDate(null);
+        body.setAssessmentDueDate(null);
+        body.setCourse(target);
+        body.setChannelName("edited-import-" + UUID.randomUUID().toString().substring(0, 8));
+
+        var imported = request.postWithResponseBody("/api/modeling/modeling-exercises/import?sourceExerciseId=" + sourceExercise.getId(), body, ModelingExercise.class,
+                HttpStatus.CREATED);
+
+        assertThat(imported.getProblemStatement()).as("edited problem statement should survive the standalone import").isEqualTo("EDITED PROBLEM STATEMENT");
+        assertThat(imported.getExampleSolutionExplanation()).as("edited example solution should survive the standalone import").isEqualTo("EDITED EXAMPLE SOLUTION");
+        assertThat(imported.getMaxPoints()).as("points should survive the standalone import").isEqualTo(42.0);
+        assertThat(imported.getReleaseDate()).as("cleared release date should stay cleared").isNull();
+        assertThat(imported.getDueDate()).as("cleared due date should stay cleared").isNull();
+        assertThat(imported.getAssessmentDueDate()).as("cleared assessment due date should stay cleared").isNull();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void importModelingExerciseFromCourseToCourse() throws Exception {
         var now = ZonedDateTime.now();
         Course course1 = courseUtilService.addEmptyCourse();

--- a/src/test/java/de/tum/cit/aet/artemis/quiz/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/quiz/QuizExerciseIntegrationTest.java
@@ -1996,6 +1996,7 @@ class QuizExerciseIntegrationTest extends AbstractQuizExerciseIntegrationTest {
 
         QuizExercise importedExercise = importQuizExerciseWithFiles(quizExercise, List.of(), HttpStatus.CREATED);
         assertThat(importedExercise.getCourseViaExerciseGroupOrCourseMember()).as("Quiz was imported for different course").isEqualTo(course);
+        assertQuizFieldsPreserved(quizExercise, importedExercise);
     }
 
     /**
@@ -2015,6 +2016,7 @@ class QuizExerciseIntegrationTest extends AbstractQuizExerciseIntegrationTest {
 
         QuizExercise importedExercise = importQuizExerciseWithFiles(quizExercise, List.of(), HttpStatus.CREATED);
         assertThat(importedExercise.getExerciseGroup()).as("Quiz was imported for different exercise group").isEqualTo(exerciseGroup);
+        assertQuizFieldsPreserved(quizExercise, importedExercise);
     }
 
     /**
@@ -2050,6 +2052,7 @@ class QuizExerciseIntegrationTest extends AbstractQuizExerciseIntegrationTest {
 
         QuizExercise importedExercise = importQuizExerciseWithFiles(quizExercise, List.of(), HttpStatus.CREATED);
         assertThat(importedExercise.getCourseViaExerciseGroupOrCourseMember()).isEqualTo(course);
+        assertQuizFieldsPreserved(quizExercise, importedExercise);
     }
 
     /**
@@ -2082,6 +2085,7 @@ class QuizExerciseIntegrationTest extends AbstractQuizExerciseIntegrationTest {
 
         QuizExercise importedExercise = importQuizExerciseWithFiles(quizExercise, List.of(), HttpStatus.CREATED);
         assertThat(importedExercise.getExerciseGroup()).as("Quiz was imported for different exercise group").isEqualTo(exerciseGroup);
+        assertQuizFieldsPreserved(quizExercise, importedExercise);
     }
 
     /**
@@ -2617,5 +2621,14 @@ class QuizExerciseIntegrationTest extends AbstractQuizExerciseIntegrationTest {
         else if (!quizExercise.isQuizStarted()) {
             assertThat(quizExercise.getQuizQuestions()).isEmpty();
         }
+    }
+
+    private void assertQuizFieldsPreserved(QuizExercise source, QuizExercise imported) {
+        assertThat(imported.isRandomizeQuestionOrder()).as("randomizeQuestionOrder must be preserved").isEqualTo(source.isRandomizeQuestionOrder());
+        assertThat(imported.getAllowedNumberOfAttempts()).as("allowedNumberOfAttempts must be preserved").isEqualTo(source.getAllowedNumberOfAttempts());
+        assertThat(imported.getQuizMode()).as("quizMode must be preserved").isEqualTo(source.getQuizMode());
+        assertThat(imported.getDuration()).as("duration must be preserved").isEqualTo(source.getDuration());
+        assertThat(imported.getDifficulty()).as("difficulty must be preserved").isEqualTo(source.getDifficulty());
+        assertThat(imported.getMaxPoints()).as("maxPoints must be preserved").isEqualTo(source.getMaxPoints());
     }
 }


### PR DESCRIPTION
### Summary

When importing exercises via exam import or course-material import, most exercise fields (problemStatement, assessmentType, difficulty, gradingCriteria, and type-specific fields like diagramType, filePattern, quizMode, duration, exampleSolution) were silently dropped. The root cause: every import service read all content from the skeleton `importedExercise` (which only carries target course/group + title/points) instead of the original `templateExercise`.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

Exercise import via exam import (`ExamImportService`) and course-material import (`CourseMaterialImportService`) creates a skeleton exercise carrying only structural fields (target course/exerciseGroup, title, maxPoints, bonusPoints). Each `XxxExerciseImportService.importXxxExercise(templateExercise, importedExercise)` then ignored `templateExercise` and copied all fields from `importedExercise` — the skeleton — silently dropping every content and type-specific field.

### Description

1. **`ExerciseImportService`**: Added a 4-param `copyExerciseBasis(newExercise, importedExercise, templateExercise, tracker)` overload that separates structural context (`importedExercise` = target destination) from content (`templateExercise` = original exercise). Lazy-loaded fields (`gradingCriteria`, `plagiarismDetectionConfig`, `categories`, `teamAssignmentConfig`) are guarded with `Hibernate.isInitialized()`. The existing 3-param method delegates to the new overload for backward compatibility.

2. **Exercise import services**: Updated `QuizExerciseImportService`, `TextExerciseImportService`, `ModelingExerciseImportService`, and `FileUploadExerciseImportService` to accept `templateExercise` and read type-specific fields from it (e.g. `randomizeQuestionOrder`, `duration`, `quizMode`, `diagramType`, `filePattern`, `exampleSolution`).

3. **`ExamImportService`**: Removed quiz batch copying for exam exercises — exam timing controls quiz scheduling, not individual quiz batches.

4. **`CourseMaterialImportService`**: Changed quiz loading to use eager fetch (`findWithEagerQuestionsAndStatisticsAndCompetenciesAndBatchesAndGradingCriteriaById`) so import can read questions and grading criteria.

5. **Import APIs**: Fixed `TextExerciseImportApi` and `FileUploadImportApi` to use repository methods that eagerly load grading criteria.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Course with exercises of each type (text, modeling, file upload, quiz) that have non-default fields set (problemStatement, difficulty, gradingCriteria, type-specific fields)

1. Log in as instructor
2. Create a new exam and import exercises from the course
3. Verify that imported exercises preserve all fields: problemStatement, difficulty, assessmentType, gradingCriteria, and type-specific fields (e.g. quiz: duration, quizMode, randomizeQuestionOrder; modeling: diagramType; file upload: filePattern; text: exampleSolution)
4. Verify quiz batches are NOT imported for exam exercises
5. Verify standalone REST import (course-to-course) still works correctly
6. Verify course-material import preserves exercise fields

#### Exam Mode Testing
Prerequisites:
- 1 Instructor
- 1 Exam with exercises imported from another course

1. Log in as instructor
2. Import an exam that contains quiz, text, modeling, and file upload exercises
3. Verify all exercise fields are preserved in the imported exam
4. Verify quiz exercises in the exam do not have batches from the source quiz

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/29591296837) did not pass (`failure`). Coverage below may be partial.

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| CourseMaterialImportService.java | not found (modified) | 357 |
| ExamImportService.java | not found (modified) | 340 |
| ExerciseImportService.java | not found (modified) | 138 |
| FileUploadImportApi.java | not found (modified) | 35 |
| FileUploadExerciseImportService.java | not found (modified) | 65 |
| ModelingExerciseImportService.java | not found (modified) | 109 |
| QuizExerciseImportService.java | not found (modified) | 294 |
| TextExerciseImportApi.java | not found (modified) | 34 |
| TextExerciseImportService.java | not found (modified) | 178 |

_Last updated: 2026-07-17 15:44:30 UTC_

