### PR TITLE
`Development`: Flag persistently broken E2E tests instead of exonerating them as flaky

### DIFF
--- a/.github/scripts/classify-failures.js
+++ b/.github/scripts/classify-failures.js
@@ -1,26 +1,13 @@
 const { parseFailedTests, fetchFlakinessScores, classifyFailures } = require('./fetch-flakiness.js');
 
-// Helios' own thresholds (TestCaseStatisticsService), reused so exoneration matches the org's single
-// flaky-test authority rather than numbers invented for CI:
-//   LOW_FLAKINESS_THRESHOLD (30) - flakinessScore above which a test is flaky
-//   MIN_FLAKY_RATE (0.01 = 1%)    - default-branch failure rate above which a failure is base-branch
-//                                   noise, not a regression introduced by this change
-const KNOWN_FLAKY_THRESHOLD = 30;
-const MIN_BASE_FAILURE_RATE = 0.01;
-
 /**
- * Classify an E2E phase's failures so the advisory gate can decide its verdict accurately.
+ * Classify an E2E phase's failures into a single `phase_result` string the advisory gate reads:
+ * `real` | `broken` | `flaky` (see classifyFailures) or `clean` (no failures in results.xml).
  *
  * Playwright's JUnit reporter omits retries, so every failure in results.xml already survived all
- * retries — a genuine hard failure. The only open question per failure is "known-flaky or real",
- * which Helios' history answers.
- *
- * Sets `phase_result` to a POSITIVE classification, never a "couldn't find a real failure" guess:
- *   real  - at least one non-flaky test failed (a real regression)
- *   flaky - failures, and every one is known-flaky (safe to exonerate)
- *   clean - no failure elements in results.xml
- * The caller must treat a phase whose test step failed but that reports `clean` (e.g. a global-setup
- * crash that emits no per-test failure) as unexplained, not exonerated. Also sets real_count/flaky_count.
+ * retries — a genuine hard failure, no need to re-check. A phase whose test step failed but reports
+ * `clean` (e.g. a global-setup crash with no per-test failure) must be treated by the caller as
+ * unexplained, not exonerated.
  */
 module.exports = async (core) => {
     const resultsFile = process.env.INPUT_RESULTS_FILE;
@@ -29,16 +16,18 @@ module.exports = async (core) => {
     const failedTests = parseFailedTests(resultsFile);
     if (failedTests.length === 0) {
         core.setOutput('phase_result', 'clean');
-        core.setOutput('real_count', '0');
-        core.setOutput('flaky_count', '0');
         return;
     }
 
     const flakinessResults = await fetchFlakinessScores(failedTests, heliosSecret);
-    const { real, flaky } = classifyFailures(failedTests, flakinessResults, KNOWN_FLAKY_THRESHOLD, MIN_BASE_FAILURE_RATE);
+    const { real, flaky, broken } = classifyFailures(failedTests, flakinessResults);
 
-    core.setOutput('phase_result', real.length > 0 ? 'real' : 'flaky');
-    core.setOutput('real_count', String(real.length));
-    core.setOutput('flaky_count', String(flaky.length));
-    core.info(`E2E failures: ${real.length} real, ${flaky.length} known-flaky (exonerated)`);
+    let phaseResult = 'flaky';
+    if (real.length > 0) {
+        phaseResult = 'real';
+    } else if (broken.length > 0) {
+        phaseResult = 'broken';
+    }
+    core.setOutput('phase_result', phaseResult);
+    core.info(`E2E failures: ${real.length} real, ${broken.length} broken on default branch, ${flaky.length} known-flaky (exonerated)`);
 };

--- a/.github/scripts/fetch-flakiness.js
+++ b/.github/scripts/fetch-flakiness.js
@@ -1,6 +1,16 @@
 const fs = require('fs');
 const https = require('https');
 
+// Thresholds mirror Helios' TestCaseStatisticsService (github.com/ls1intum/Helios) so CI and the
+// flaky-test dashboard classify identically — keep them in sync with that source. Upstream names:
+// 30 = LOW_FLAKINESS_THRESHOLD, 0.01 = MIN_FLAKY_RATE, 0.5 = MAX_FLAKY_RATE. At dfr >= 0.5 Helios'
+// score is <= 29.4 (< 30), so flakinessScore alone can never exonerate a test that broken — the
+// failure rate must. defaultBranchFailureRate is a lifetime cumulative rate (no window, no run count
+// in the API), so `broken` cannot be sample-size-gated and persists until Helios' history dilutes.
+const KNOWN_FLAKY_THRESHOLD = 30;
+const MIN_BASE_FAILURE_RATE = 0.01;
+const BROKEN_FAILURE_RATE = 0.5;
+
 /**
  * Parse JUnit XML to extract unique failed test cases.
  * @param {string} resultsFile - Path to the JUnit XML results file
@@ -47,7 +57,8 @@ function parseFailedTests(resultsFile) {
 }
 
 /**
- * Fetch flakiness scores from the Helios API.
+ * Fetch flakiness scores from the Helios API. Always resolves an array, so callers never see a
+ * non-array body (a 200 returning {} or null) and every error path degrades to [] (=> all real).
  * @param {Array<{testName: string, className: string, testSuiteName: string}>} failedTests
  * @param {string} heliosSecret - The Helios repo secret
  * @returns {Promise<Array>}
@@ -57,6 +68,7 @@ async function fetchFlakinessScores(failedTests, heliosSecret) {
     try {
         const payload = JSON.stringify({ testCases: failedTests });
         return await new Promise((resolve) => {
+            const done = (data) => resolve(Array.isArray(data) ? data : []);
             const req = https.request('https://helios.aet.cit.tum.de/api/tests/flakiness-scores', {
                 method: 'POST',
                 headers: {
@@ -71,22 +83,22 @@ async function fetchFlakinessScores(failedTests, heliosSecret) {
                 res.on('end', () => {
                     if (res.statusCode !== 200) {
                         console.log(`Helios API returned status ${res.statusCode}: ${data}`);
-                        return resolve([]);
+                        return done([]);
                     }
                     try {
-                        resolve(JSON.parse(data));
+                        done(JSON.parse(data));
                     } catch {
-                        resolve([]);
+                        done([]);
                     }
                 });
             });
             req.on('error', (e) => {
                 console.log('Helios API error:', e.message);
-                resolve([]);
+                done([]);
             });
             req.on('timeout', () => {
                 req.destroy();
-                resolve([]);
+                done([]);
             });
             req.write(payload);
             req.end();
@@ -98,7 +110,7 @@ async function fetchFlakinessScores(failedTests, heliosSecret) {
 }
 
 /**
- * Build a markdown flakiness table from Helios API results.
+ * Build a markdown flakiness table (score + failure rates) for the failed tests Helios recognises.
  * @param {Array} flakinessResults
  * @returns {string} Markdown table or empty string
  */
@@ -118,37 +130,34 @@ function buildFlakinessTable(flakinessResults) {
 }
 
 /**
- * Split failed tests into real regressions vs known-flaky, using Helios history.
- *
- * A failure is exonerated (treated as known-flaky, not a regression introduced by this change) when
- * EITHER signal from Helios says the test is unreliable independent of the change:
- *   - flakinessScore > scoreThreshold (Helios' own LOW_FLAKINESS_THRESHOLD, 30): it flakes; or
- *   - defaultBranchFailureRate >= baseFailureRate (Helios' own MIN_FLAKY_RATE, 0.01 = 1%): it also
- *     fails on the base branch, so the failure is not attributable to this change — the base-branch
- *     signal Datadog and Chromium's commit-queue use to distinguish a real regression from noise.
- * Everything else — tests Helios does not know, and tests reliable on the default branch — is a real
- * regression. Fail-safe: if Helios returns no data (e.g. unreachable), every failure is real, so the
- * run is never silently exonerated.
- *
+ * Split failed tests into { real, flaky, broken } using Helios history. `broken` (fails on the default
+ * branch too often to be a flake) is tested before `flaky` so such a test is never exonerated as flaky.
+ * Fail-safe: a test Helios has no data for is `real`, so a Helios outage never exonerates a failure.
  * @param {Array<{testName: string, className: string}>} failedTests
  * @param {Array} flakinessResults - Helios response (empty if unavailable)
- * @param {number} scoreThreshold - flakinessScore above which a test counts as known-flaky
- * @param {number} baseFailureRate - default-branch failure rate at/above which a failure is not a regression
- * @returns {{real: Array, flaky: Array}}
+ * @returns {{real: Array, flaky: Array, broken: Array}}
  */
-function classifyFailures(failedTests, flakinessResults, scoreThreshold, baseFailureRate) {
+function classifyFailures(failedTests, flakinessResults) {
     const byKey = new Map();
     for (const r of flakinessResults) {
         byKey.set(`${r.className}#${r.testName}`, r);
     }
     const real = [];
     const flaky = [];
+    const broken = [];
     for (const test of failedTests) {
         const stats = byKey.get(`${test.className}#${test.testName}`);
-        const knownFlaky = stats !== undefined && (stats.flakinessScore > scoreThreshold || stats.defaultBranchFailureRate >= baseFailureRate);
-        (knownFlaky ? flaky : real).push(test);
+        if (stats === undefined) {
+            real.push(test);
+        } else if (stats.defaultBranchFailureRate >= BROKEN_FAILURE_RATE) {
+            broken.push(test);
+        } else if (stats.flakinessScore > KNOWN_FLAKY_THRESHOLD || stats.defaultBranchFailureRate >= MIN_BASE_FAILURE_RATE) {
+            flaky.push(test);
+        } else {
+            real.push(test);
+        }
     }
-    return { real, flaky };
+    return { real, flaky, broken };
 }
 
 module.exports = { parseFailedTests, fetchFlakinessScores, buildFlakinessTable, classifyFailures };

--- a/.github/scripts/fetch-flakiness.spec.mjs
+++ b/.github/scripts/fetch-flakiness.spec.mjs
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+import { EventEmitter } from 'node:events';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import https from 'node:https';
+
+// fetch-flakiness.js is CommonJS (loaded by actions/github-script); createRequire imports it cleanly.
+const require = createRequire(import.meta.url);
+const { parseFailedTests, fetchFlakinessScores, buildFlakinessTable, classifyFailures } = require('./fetch-flakiness.js');
+
+const test = (name) => ({ testName: name, className: 'spec.ts' });
+const helios = (name, flakinessScore, defaultBranchFailureRate, combinedFailureRate = 0) => ({
+    testName: name,
+    className: 'spec.ts',
+    flakinessScore,
+    defaultBranchFailureRate,
+    combinedFailureRate,
+});
+
+// Realistic Playwright JUnit output: <testsuite name> and <testcase classname> are both the spec path;
+// only failed/errored cases carry a <failure>/<error> child.
+const junit = (cases, suite = 'e2e/Exam.spec.ts') =>
+    `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites tests="${cases.length}">\n<testsuite name="${suite}" tests="${cases.length}">\n` +
+    cases
+        .map((c) => {
+            const child = c.fail ? `<failure message="expect(received)" type="FAILURE">stack</failure>` : c.err ? `<error message="crash"/>` : '';
+            return `<testcase name="${c.name}" classname="${suite}" time="1.0">${child}</testcase>`;
+        })
+        .join('\n') +
+    `\n</testsuite>\n</testsuites>\n`;
+
+const writeXml = (xml) => {
+    const dir = mkdtempSync(join(tmpdir(), 'flaky-'));
+    const path = join(dir, 'results.xml');
+    writeFileSync(path, xml);
+    return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+};
+
+// Simulate https.request(url, options, cb): drive the response/error/timeout paths the code handles.
+const stubHttps = ({ statusCode = 200, body = '', event } = {}) =>
+    vi.spyOn(https, 'request').mockImplementation((url, options, cb) => {
+        const req = new EventEmitter();
+        req.write = () => {};
+        req.destroy = () => {};
+        req.end = () => {
+            if (event === 'error') return void req.emit('error', new Error('ECONNRESET'));
+            if (event === 'timeout') return void req.emit('timeout');
+            const res = new EventEmitter();
+            res.statusCode = statusCode;
+            cb(res);
+            if (body) res.emit('data', body);
+            res.emit('end');
+        };
+        return req;
+    });
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('parseFailedTests', () => {
+    it('extracts only failed and errored cases, never the passing ones', () => {
+        const { path, cleanup } = writeXml(junit([{ name: 'passes' }, { name: 'fails', fail: true }, { name: 'crashes', err: true }]));
+        try {
+            const failed = parseFailedTests(path);
+            expect(failed.map((f) => f.testName).sort()).toEqual(['crashes', 'fails']);
+        } finally {
+            cleanup();
+        }
+    });
+
+    it('carries the suite path into testSuiteName and className (Helios needs both)', () => {
+        const { path, cleanup } = writeXml(junit([{ name: 'fails', fail: true }], 'e2e/Course.spec.ts'));
+        try {
+            expect(parseFailedTests(path)[0]).toEqual({ testName: 'fails', className: 'e2e/Course.spec.ts', testSuiteName: 'e2e/Course.spec.ts' });
+        } finally {
+            cleanup();
+        }
+    });
+
+    it('deduplicates a test that failed on multiple retries into one entry', () => {
+        // Playwright emits a testcase per retry; the same class#name must collapse to one.
+        const xml = junit([{ name: 'flaky', fail: true }]).replace(
+            '</testsuite>',
+            `<testcase name="flaky" classname="e2e/Exam.spec.ts" time="1.0"><failure message="again"/></testcase>\n</testsuite>`,
+        );
+        const { path, cleanup } = writeXml(xml);
+        try {
+            expect(parseFailedTests(path)).toHaveLength(1);
+        } finally {
+            cleanup();
+        }
+    });
+
+    it('returns [] for a passing suite, a missing file, and unreadable input (never throws)', () => {
+        const pass = writeXml(junit([{ name: 'a' }, { name: 'b' }]));
+        try {
+            expect(parseFailedTests(pass.path)).toEqual([]);
+        } finally {
+            pass.cleanup();
+        }
+        expect(parseFailedTests('/no/such/results.xml')).toEqual([]);
+    });
+});
+
+describe('fetchFlakinessScores', () => {
+    it('returns [] without touching the network when there are no failures or no secret', async () => {
+        const spy = stubHttps({ body: '[]' });
+        expect(await fetchFlakinessScores([], 'secret')).toEqual([]);
+        expect(await fetchFlakinessScores([test('t')], '')).toEqual([]);
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('returns the parsed array on a 200 with a JSON array body', async () => {
+        stubHttps({ statusCode: 200, body: JSON.stringify([helios('t', 40, 0.3)]) });
+        const res = await fetchFlakinessScores([test('t')], 'secret');
+        expect(res).toHaveLength(1);
+        expect(res[0].flakinessScore).toBe(40);
+    });
+
+    it('degrades a 200 with a non-array body ({} or null) to [] (the array guard)', async () => {
+        stubHttps({ statusCode: 200, body: '{}' });
+        expect(await fetchFlakinessScores([test('t')], 'secret')).toEqual([]);
+        stubHttps({ statusCode: 200, body: 'null' });
+        expect(await fetchFlakinessScores([test('t')], 'secret')).toEqual([]);
+    });
+
+    it('degrades malformed JSON, a non-200, a socket error, and a timeout all to []', async () => {
+        stubHttps({ statusCode: 200, body: '{not json' });
+        expect(await fetchFlakinessScores([test('t')], 'secret')).toEqual([]);
+        stubHttps({ statusCode: 503, body: 'upstream down' });
+        expect(await fetchFlakinessScores([test('t')], 'secret')).toEqual([]);
+        stubHttps({ event: 'error' });
+        expect(await fetchFlakinessScores([test('t')], 'secret')).toEqual([]);
+        stubHttps({ event: 'timeout' });
+        expect(await fetchFlakinessScores([test('t')], 'secret')).toEqual([]);
+    });
+});
+
+describe('buildFlakinessTable', () => {
+    it('returns an empty string for empty or non-array input', () => {
+        expect(buildFlakinessTable([])).toBe('');
+        expect(buildFlakinessTable(undefined)).toBe('');
+        expect(buildFlakinessTable({})).toBe('');
+    });
+
+    it('renders one row per result with rates as percentages', () => {
+        const table = buildFlakinessTable([helios('t', 42, 0.1, 0.2)]);
+        expect(table).toContain('`spec.ts#t`');
+        expect(table).toContain('**42%**');
+        expect(table).toContain('10.0%');
+        expect(table).toContain('20.0%');
+    });
+
+    it('escapes markdown-significant characters in test identifiers', () => {
+        const table = buildFlakinessTable([{ className: 'a|b', testName: 'c`d', flakinessScore: 1, defaultBranchFailureRate: 0, combinedFailureRate: 0 }]);
+        expect(table).toContain('a\\|b');
+        expect(table).toContain('c\\`d');
+    });
+});
+
+// classifyFailures reads Helios' thresholds from module scope: broken at dfr >= 0.5, flaky at
+// score > 30 or dfr >= 0.01, real otherwise. Pins the boundaries the required E2E merge gate depends on.
+describe('classifyFailures', () => {
+    it('marks a failure Helios has never seen as real (fail-safe against missing history)', () => {
+        expect(classifyFailures([test('t')], [])).toEqual({ real: [test('t')], flaky: [], broken: [] });
+    });
+
+    it('exonerates nothing when the Helios response is empty (outage => every failure is real)', () => {
+        const failed = [test('a'), test('b')];
+        expect(classifyFailures(failed, []).real).toHaveLength(2);
+    });
+
+    it('classifies a test broken at exactly the 50% ceiling as broken, not flaky (>= boundary)', () => {
+        const { broken, flaky } = classifyFailures([test('t')], [helios('t', 0, 0.5)]);
+        expect(broken).toHaveLength(1);
+        expect(flaky).toHaveLength(0);
+    });
+
+    it('classifies a test just under the ceiling (49.9%) as flaky, not broken', () => {
+        const { broken, flaky } = classifyFailures([test('t')], [helios('t', 2, 0.499)]);
+        expect(flaky).toHaveLength(1);
+        expect(broken).toHaveLength(0);
+    });
+
+    it('prefers broken over flaky when a test is both broken and highly flaky-scored', () => {
+        const { broken, flaky } = classifyFailures([test('t')], [helios('t', 90, 0.6)]);
+        expect(broken).toHaveLength(1);
+        expect(flaky).toHaveLength(0);
+    });
+
+    it('exonerates a classic flake (high score, low failure rate) as flaky', () => {
+        expect(classifyFailures([test('t')], [helios('t', 90, 0.05)]).flaky).toHaveLength(1);
+    });
+
+    it('exonerates a test that also fails on the default branch above the noise floor as flaky', () => {
+        expect(classifyFailures([test('t')], [helios('t', 0, 0.02)]).flaky).toHaveLength(1);
+    });
+
+    it('treats a test exactly at the 1% noise floor as flaky (>= boundary), below it as real', () => {
+        expect(classifyFailures([test('t')], [helios('t', 0, 0.01)]).flaky).toHaveLength(1);
+        expect(classifyFailures([test('t')], [helios('t', 0, 0.009)]).real).toHaveLength(1);
+    });
+
+    it('marks a test reliable on the default branch and not flaky-scored as a real regression', () => {
+        expect(classifyFailures([test('t')], [helios('t', 4, 0)]).real).toHaveLength(1);
+    });
+
+    it('routes a mixed batch into all three buckets at once', () => {
+        const failed = [test('regression'), test('flake'), test('broken'), test('unknown')];
+        const results = [helios('regression', 5, 0), helios('flake', 80, 0.03), helios('broken', 0, 0.9)];
+        const { real, flaky, broken } = classifyFailures(failed, results);
+        expect(real.map((t) => t.testName).sort()).toEqual(['regression', 'unknown']);
+        expect(flaky.map((t) => t.testName)).toEqual(['flake']);
+        expect(broken.map((t) => t.testName)).toEqual(['broken']);
+    });
+});
+
+// classify-failures.js is the actions/github-script entry point: it reads results.xml, asks Helios,
+// and reduces the three buckets to the single `phase_result` string the gate branches on. Stub only
+// the Helios network call (direct cache assignment, so afterEach's mock-restore leaves it intact);
+// parseFailedTests runs for real against a temp results.xml.
+const fetchCachePath = require.resolve('./fetch-flakiness.js');
+require('./fetch-flakiness.js');
+let heliosStub = [];
+require.cache[fetchCachePath].exports.fetchFlakinessScores = async () => heliosStub;
+const classifyPhase = require('./classify-failures.js');
+
+const runPhase = async (xml, stub) => {
+    heliosStub = stub;
+    const { path, cleanup } = writeXml(xml);
+    const outputs = {};
+    const core = { setOutput: (k, v) => (outputs[k] = v), info: () => {} };
+    process.env.INPUT_RESULTS_FILE = path;
+    try {
+        await classifyPhase(core);
+    } finally {
+        cleanup();
+        delete process.env.INPUT_RESULTS_FILE;
+    }
+    return outputs.phase_result;
+};
+
+describe('classify-failures (phase_result selection)', () => {
+    it('reports `clean` when the phase has no failures', async () => {
+        expect(await runPhase(junit([{ name: 'a' }, { name: 'b' }]), [])).toBe('clean');
+    });
+
+    it('reports `real` when any failure is a genuine regression, outranking broken and flaky', async () => {
+        const xml = junit([{ name: 'reg', fail: true }, { name: 'brk', fail: true }], 'e2e/Exam.spec.ts');
+        const stub = [helios('reg', 0, 0), helios('brk', 0, 0.9)].map((h) => ({ ...h, className: 'e2e/Exam.spec.ts' }));
+        expect(await runPhase(xml, stub)).toBe('real');
+    });
+
+    it('reports `broken` when there is no regression but a broken test failed', async () => {
+        const xml = junit([{ name: 'brk', fail: true }], 'e2e/Exam.spec.ts');
+        expect(await runPhase(xml, [{ ...helios('brk', 0, 0.9), className: 'e2e/Exam.spec.ts' }])).toBe('broken');
+    });
+
+    it('reports `flaky` when every failure is known-flaky', async () => {
+        const xml = junit([{ name: 'flk', fail: true }], 'e2e/Exam.spec.ts');
+        expect(await runPhase(xml, [{ ...helios('flk', 80, 0.03), className: 'e2e/Exam.spec.ts' }])).toBe('flaky');
+    });
+
+    it('reports `real` on a failure Helios does not recognise (fail-safe)', async () => {
+        expect(await runPhase(junit([{ name: 'unknown', fail: true }]), [])).toBe('real');
+    });
+});

--- a/.github/scripts/vitest.config.mjs
+++ b/.github/scripts/vitest.config.mjs
@@ -1,0 +1,17 @@
+/**
+ * Vitest config for the CI helper scripts in this directory (.github/scripts/*.spec.mjs).
+ *
+ * These are plain-Node CommonJS scripts run by actions/github-script, not client code — the repo's
+ * top-level vitest.config.ts globs only `src/main/webapp/app` under the Angular Vite/jsdom environment,
+ * which does not apply here. Mirrors rules/vitest.config.mjs. Run with:
+ *
+ *   pnpm exec vitest run --config .github/scripts/vitest.config.mjs
+ */
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['.github/scripts/**/*.spec.mjs'],
+        environment: 'node',
+    },
+});

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -68,11 +68,15 @@ so it blocks only on genuine regressions rather than on noise:
 
 - **`e2e`.** E2E takes up to ~2 hours and is flaky enough that a naive required gate would block
   good PRs on noise. Instead, `report-results` classifies each surviving failure against Helios
-  history (`classify-failures.js`): a real (non-flaky) regression fails the job and **blocks
-  merge**, while a run whose only failures are known-flaky is **exonerated and passes green**. The
-  per-test detail (✅/⚪/❌ per phase, plus Helios flakiness scores) lives in the E2E PR comment. The
-  test steps are `continue-on-error`, so the honest verdict is decided once in `report-results`, not
-  by any single phase job.
+  history (`classify-failures.js`) into three buckets: **real** (a genuine regression) **blocks
+  merge**; **flaky** (known-flaky) is **exonerated and passes green**; **broken** (already failing
+  ≥ 50% of the time on develop) passes green on PRs, the merge queue, and release branches — none of
+  which caused the breakage — but reds **develop's own push**, which owns it. Keeping broken out of
+  the flaky bucket is the point: a test that always fails carries no signal, so exonerating it as
+  "flaky" would hide it forever. Bucket definitions and their limitations live in
+  `.github/scripts/fetch-flakiness.js` and `documentation/.../e2e-testing-playwright.mdx`. The test
+  steps are `continue-on-error`, so the honest verdict is decided once in `report-results`, not by
+  any single phase job.
 
 `codeql` is deliberately **advisory** (not in the gate's `needs:`): it runs for signal and reds the
 run on a genuine failure, but never blocks merge.

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -754,8 +754,8 @@ jobs:
           REMAINING_RESULT: ${{ needs.run-e2e-remaining.outputs.tests }}
           ALL_PR_RESULT: ${{ needs.run-e2e-all-pr.outputs.tests }}
           ALL_NON_PR_RESULT: ${{ needs.run-e2e-all-non-pr.outputs.tests }}
-          # Per-phase failure classification from classify-failures.js: real | flaky | clean (empty
-          # when skipped). `real` = a non-flaky test failed; `flaky` = failures, all known-flaky.
+          # Per-phase classification from classify-failures.js: real | broken | flaky | clean (empty
+          # when skipped). The shell below branches on these exact strings.
           RELEVANT_CLASS: ${{ needs.run-e2e-relevant.outputs.phase_result }}
           REMAINING_CLASS: ${{ needs.run-e2e-remaining.outputs.phase_result }}
           ALL_PR_CLASS: ${{ needs.run-e2e-all-pr.outputs.phase_result }}
@@ -767,6 +767,10 @@ jobs:
           REMAINING_JOB: ${{ needs.run-e2e-remaining.result }}
           ALL_PR_JOB: ${{ needs.run-e2e-all-pr.result }}
           ALL_NON_PR_JOB: ${{ needs.run-e2e-all-non-pr.result }}
+          # develop's own push owns develop's breakage; no other trigger (PR, merge queue, release/*,
+          # dispatch) does, so a broken-only run reds only here. Not `is_pr`: that is also false for
+          # merge_group, which would red-eject a broken PR the moment it enters the merge queue.
+          IS_DEFAULT_BRANCH_PUSH: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
         run: |
           set -Eeuo pipefail
           # `status` is the raw honest outcome (any `failure` wins; else the first `success`; else
@@ -782,10 +786,11 @@ jobs:
           done
           echo "status=$status" >> "$GITHUB_OUTPUT"
 
-          any_real=false; any_flaky=false
+          any_real=false; any_flaky=false; any_broken=false
           for c in "$RELEVANT_CLASS" "$REMAINING_CLASS" "$ALL_PR_CLASS" "$ALL_NON_PR_CLASS"; do
             [ "$c" = real ] && any_real=true
             [ "$c" = flaky ] && any_flaky=true
+            [ "$c" = broken ] && any_broken=true
           done
           # Treat ANY needed-job result other than `success` or `skipped` as a blocking infra verdict —
           # not just `failure`. A `cancelled` phase (e.g. Phase 2 timing out with no outputs) would
@@ -801,19 +806,26 @@ jobs:
             esac
           done
 
-          # The E2E verdict. `neutral` (exonerate) ONLY on positive proof of flakiness (a phase
-          # classified `flaky`, none `real`, and no job broke) — it maps to a passing (green) run.
-          # A real regression, an infra job failure, or a failure we could not classify (test step
-          # failed but produced no failure element — e.g. a global-setup crash) all become `failure`
-          # (red): the run must never go green on a failure it cannot explain. The gate step below
-          # turns `failure` into a non-zero exit; `success`/`neutral` pass. The comment renders all
-          # three states (✅ / ⚪ exonerated / ❌) so the flaky-vs-real nuance is never lost.
+          # Verdict, fail-closed: a real regression, an infra failure, or an unclassifiable failure (a
+          # test step failed but emitted no failure element, e.g. a global-setup crash) all go `failure`
+          # (red) — never green on a failure we cannot explain. `neutral` (green) needs positive proof:
+          # only-flaky, or only-broken off develop. `broken` reds solely on develop's own push, which
+          # owns the breakage; on any other trigger it stays neutral so a pre-existing develop breakage
+          # does not block the wrong author.
           if [ "$any_real" = true ]; then
             conclusion=failure
             description="E2E: real (non-flaky) test failure"
           elif [ "$status" = success ] && [ "$any_job_failed" = false ]; then
             conclusion=success
             description="E2E tests passed"
+          elif [ "$any_broken" = true ] && [ "$any_job_failed" = false ] && [ "$status" != error ]; then
+            if [ "$IS_DEFAULT_BRANCH_PUSH" = true ]; then
+              conclusion=failure
+              description="E2E: test(s) broken on develop"
+            else
+              conclusion=neutral
+              description="E2E: pre-existing develop breakage failed (not caused by this run)"
+            fi
           elif [ "$any_flaky" = true ] && [ "$any_job_failed" = false ] && [ "$status" != error ]; then
             conclusion=neutral
             description="E2E: only known-flaky tests failed (exonerated)"
@@ -916,8 +928,9 @@ jobs:
             }
 
       # Fail the job (reds the run) on a real/infra/unclassified verdict; pass on success or an
-      # exonerated flaky-only run. Runs last, after the PR comment finalises, and always. Fail-safe:
-      # any verdict other than success/neutral — including an empty one — reds the run.
+      # exonerated neutral run (known-flaky, or a pre-existing develop breakage off develop). Runs last,
+      # after the PR comment finalises, and always. Fail-safe: any verdict other than success/neutral —
+      # including an empty one — reds the run.
       - name: Gate the run (and the required merge check) on the E2E verdict
         if: always()
         env:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -233,6 +233,10 @@ jobs:
         # separate Vitest config (rules/vitest.config.mjs, plain-Node env) so these .spec.mjs do
         # not run under the Angular jsdom/Vite environment of the client suite above.
         run: pnpm run test:rules
+      - name: CI Helper Script Tests
+        # Runs the plain-Node specs for .github/scripts (E2E flaky/broken classification), which
+        # decides the required E2E merge gate. Same isolated Vitest config rationale as the rules step.
+        run: pnpm run test:scripts
       - name: Per-Module Coverage Gate
         # Enforces the per-module client coverage thresholds (admin, etc.) defined in
         # supporting_scripts/code-coverage/module-coverage-client/check-client-module-coverage.mjs.

--- a/documentation/docs/developer/e2e-testing-playwright.mdx
+++ b/documentation/docs/developer/e2e-testing-playwright.mdx
@@ -571,8 +571,31 @@ Three outcomes are possible:
 
 After each phase, the pipeline queries the Helios API to retrieve flakiness scores for any failed tests.
 A **flakiness score** reflects how often a test has non-deterministically produced different results over recent CI runs.
-A high score suggests the failure may be a flake; a low score suggests a genuine regression. Scores appear in the
-PR comment alongside failed test names.
+Scores appear in the PR comment alongside failed test names.
+
+The score is **not** a simple "how often does this fail" measure — it peaks for tests that fail *occasionally* and
+decays back to 0 for tests that fail *most of the time*, because a test that almost always fails is not flaky, it is
+broken. Helios computes it from the default-branch failure rate, scoring 0 below `MIN_FLAKY_RATE` (1%), rising to its
+maximum just above it, and decaying to 0 again at `MAX_FLAKY_RATE` (50%).
+
+Each failed test therefore lands in one of three buckets (see `.github/scripts/fetch-flakiness.js`):
+
+| Bucket | Condition | Effect on the PR |
+|---|---|---|
+| **real** | Helios has no history for it, or it is reliable on the default branch | ❌ Blocks merge — a genuine regression |
+| **broken** | Fails ≥ 50% of the time on the default branch (`MAX_FLAKY_RATE`) | ⚪ Does not block — already failing on develop, not introduced here. Still reported, never counted as flaky |
+| **flaky** | Flakiness score > 30 (`LOW_FLAKINESS_THRESHOLD`), or fails ≥ 1% of the time on the default branch | ⚪ Exonerated, passes green |
+
+A **broken** test blocks nothing on a PR, the merge queue, or a release branch — none of those runs caused the
+breakage, so failing them would only block the wrong author. It turns the run red on **develop's own push**, which
+owns the failing statistic. The thresholds are Helios' own constants (`TestCaseStatisticsService`), reused so that CI
+and the flaky-test dashboard never disagree about what "flaky" means.
+
+**Limitations of the broken bucket.** Helios' failure rate is a lifetime cumulative rate with no time window, and the
+API exposes no run count, so the gate cannot require a minimum sample size: a test that failed its only two develop
+runs reads as 50% broken, and a test fixed today keeps a high rate until its history dilutes. The blast radius is
+small — off develop, `broken` and `flaky` are both neutral, so a misclassification only mislabels the report; it is
+load-bearing only on develop's own red run. A windowed or run-count-aware rate would need a change to the Helios API.
 
 ### Reports Dashboard
 

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
         "test": "pnpm run prebuild && pnpm exec vitest run",
         "test:one": "pnpm run prebuild && pnpm exec vitest run",
         "test:rules": "vitest run --config rules/vitest.config.mjs",
+        "test:scripts": "vitest run --config .github/scripts/vitest.config.mjs",
         "setupCourse": "node supporting_scripts/course-scripts/setup-course/setup-course.mjs",
         "vitest": "vitest",
         "vitest:run": "vitest run",


### PR DESCRIPTION
### Summary

The E2E merge gate asks [Helios](https://helios.aet.cit.tum.de/) how flaky each failing Playwright test has been, and exonerates "known-flaky" failures so they don't block good PRs. A test was treated as flaky whenever its default-branch failure rate was **at least 1%, with no upper limit** — so a test that fails **100% of the time on `develop`** also cleared that bar and was silently forgiven on every PR, indefinitely. A permanently broken test is not flaky, and quietly exonerating it means nobody is ever told to fix it.

This PR adds an upper threshold. Failures now fall into three buckets: **real** (a genuine regression, blocks merge), **flaky** (known-flaky, exonerated), and a new **broken** bucket for tests failing ≥ 50% of the time on `develop`. A broken test is surfaced under its own verdict instead of being laundered into "flaky", and it turns `develop`'s own build red so it gets fixed — without blaming PR authors for a breakage they didn't cause.

> [!NOTE]
> This is a **CI-only** change (GitHub Actions workflow + its helper scripts). It touches no server, client, database, or user-facing code, so the usual test-server / UI / performance checklist sections do not apply and have been removed. It cannot be exercised on a deployed test server the way a feature can; see **Steps for Testing** for how it was validated instead.

### Checklist

#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).
- [x] I added unit tests for the changed classification scripts (26 tests, run in CI via `pnpm run test:scripts`) and documented the code with JSDoc.

### Motivation and Context

`classifyFailures` in `.github/scripts/fetch-flakiness.js` exonerated a failure when **either** Helios signal indicated unreliability:

```js
flakinessScore > 30  ||  defaultBranchFailureRate >= 0.01
```

The second clause has no upper bound. Helios' own flakiness score is deliberately shaped like a hump — it peaks for tests that fail *occasionally* and decays back to **0** for tests that fail *most* of the time (its comment: *"more broken than flaky"*). So the tests Helios scores lowest — the genuinely broken ones — fell through the score clause into the unbounded failure-rate clause and were classified "flaky". The result: a test failing every single time on `develop` was exonerated on every PR, forever, and no signal was ever raised to fix it.

No linked issue — this was found while reviewing the flaky-test gate.

### Description

A third bucket, **broken**, is added for `defaultBranchFailureRate >= 0.5`. The number is not invented for CI: `0.5` is Helios' own `MAX_FLAKY_RATE`, the exact point where its flakiness score decays to 0. Reusing Helios' constants keeps CI and the flaky-test dashboard in agreement about what "flaky" means.

**Classification** (`.github/scripts/fetch-flakiness.js`, `classify-failures.js`)

| Bucket | Condition | Verdict |
|---|---|---|
| **real** | Unknown to Helios, or reliable on `develop` | ❌ Blocks merge — a genuine regression |
| **broken** | Fails ≥ 50% of the time on `develop` | ⚪ Neutral on PRs / merge queue / release; ❌ red on `develop`'s own build |
| **flaky** | Flakiness score > 30, or fails ≥ 1% of the time on `develop` | ⚪ Exonerated, passes green |

**Verdict wiring** (`.github/workflows/ci-e2e.yml`)

A broken-only run is **neutral** everywhere except `develop`'s own push, where it is red. This is keyed on `github.event_name == 'push' && github.ref == 'refs/heads/develop'` — deliberately **not** on `is_pr`, because `is_pr` is also false for `merge_group`: keying on it would let a broken test **red-eject a PR from the merge queue** right after the same test was exonerated on the PR run. Fail-safe behaviour is unchanged: if Helios is unreachable, every failure is treated as real, so an outage never greens a run.

**Cleanup along the way**
- Collapsed `classifyFailures` from 5 parameters to 2 (three were always the module's own constants, passed in a round-trip through the sibling module) and trimmed comments to load-bearing constraints only.
- Removed the `real_count` / `flaky_count` step outputs, which were set but never consumed by any workflow.

**Docs**: `documentation/docs/developer/e2e-testing-playwright.mdx` and `.github/workflows/README.md` updated, including an honest note on the broken bucket's limitations (Helios exposes no sample-size or time window, so the rate is cumulative — a caveat that needs a Helios-side change to resolve).

### Steps for Testing

This is CI logic, so it is validated by automated tests and by reading the workflow, not on a test server.

1. **Run the new unit suite** (added by this PR; also runs in CI):
   ```bash
   pnpm install --frozen-lockfile
   pnpm run test:scripts
   ```
   26 tests should pass. They cover JUnit parsing, the Helios API call (every error path plus the non-array-body guard), the markdown table, and the full classification — including the boundaries (`0.5` → broken, `0.499` → flaky) and precedence (broken beats flaky, real beats both).

2. **Review the verdict logic** in `.github/workflows/ci-e2e.yml` (the `Determine overall status` step). The intended behaviour, which I verified by driving the extracted shell through 17 scenarios:

   | Situation | Verdict |
   |---|---|
   | Broken test only, on a PR or in the merge queue | ⚪ neutral (does not block, not ejected) |
   | Broken test only, on `develop`'s own push | ❌ red |
   | Broken + flaky together | broken wins (neutral off `develop`, red on it) |
   | Real regression present | ❌ red (outranks broken and flaky) |
   | Infra/job failure or cancelled phase | ❌ red, regardless of classification |

3. **Confirm no behavioural change for the common cases**: a clean run stays green, a real regression still blocks, and a known-flaky-only run is still exonerated. The only new behaviour is the broken bucket.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
