### PR TITLE
`Quiz exercises`: Fix statistics charts that did not load and rendered incorrectly

### DIFF
--- a/src/main/webapp/app/quiz/manage/statistics/drag-and-drop-question-statistic/drag-and-drop-question-statistic.component.html
+++ b/src/main/webapp/app/quiz/manage/statistics/drag-and-drop-question-statistic/drag-and-drop-question-statistic.component.html
@@ -1,8 +1,8 @@
-@if (quizExercise) {
+@if (quizExercise()) {
     <div class="row">
         <div class="col-md-8 offset-md-2 text-center">
-            @if (quizExercise.title !== question.title) {
-                <h3>{{ quizExercise.title }}</h3>
+            @if (quizExercise().title !== question.title) {
+                <h3>{{ quizExercise().title }}</h3>
             }
             <div class="row">
                 @if (question) {

--- a/src/main/webapp/app/quiz/manage/statistics/multiple-choice-question-statistic/multiple-choice-question-statistic.component.html
+++ b/src/main/webapp/app/quiz/manage/statistics/multiple-choice-question-statistic/multiple-choice-question-statistic.component.html
@@ -1,8 +1,8 @@
-@if (quizExercise) {
+@if (quizExercise()) {
     <div>
         <div class="row">
             <div class="col-md-8 offset-md-2 text-center">
-                <h3>{{ quizExercise.title }}</h3>
+                <h3>{{ quizExercise().title }}</h3>
                 <div class="row">
                     @if (question) {
                         <div class="col-md-4 text-start">

--- a/src/main/webapp/app/quiz/manage/statistics/multiple-choice-question-statistic/multiple-choice-question-statistic.component.spec.ts
+++ b/src/main/webapp/app/quiz/manage/statistics/multiple-choice-question-statistic/multiple-choice-question-statistic.component.spec.ts
@@ -201,4 +201,29 @@ describe('QuizExercise Multiple Choice Question Statistic Component', () => {
             ]);
         });
     });
+
+    describe('tooltip labels', () => {
+        function labelFor(item: { dataIndex: number; parsed: { y: number } }): string {
+            return (comp.chartOptions().plugins as any).tooltip.callbacks.label(item);
+        }
+
+        it('uses the participant-share tooltip for answer-option bars, including the last one while the solution is hidden', () => {
+            comp.showSolution = false;
+            // four answer-option counters, no appended correct-solutions bar in the default view
+            comp.data = [2, 1, 1, 1];
+
+            expect(labelFor({ dataIndex: 0, parsed: { y: 2 } })).toContain('tooltip.participantShare');
+            expect(labelFor({ dataIndex: 3, parsed: { y: 1 } })).toContain('tooltip.participantShare');
+            expect(labelFor({ dataIndex: 3, parsed: { y: 1 } })).not.toContain('tooltip.correctOverall');
+        });
+
+        it('uses the correct-overall tooltip only for the appended summary bar in the solution view', () => {
+            comp.showSolution = true;
+            // four answer options + the appended "correct solutions" summary bar
+            comp.data = [2, 1, 1, 1, 3];
+
+            expect(labelFor({ dataIndex: 4, parsed: { y: 3 } })).toContain('tooltip.correctOverall');
+            expect(labelFor({ dataIndex: 0, parsed: { y: 2 } })).toContain('tooltip.participantShare');
+        });
+    });
 });

--- a/src/main/webapp/app/quiz/manage/statistics/question-statistic.component.ts
+++ b/src/main/webapp/app/quiz/manage/statistics/question-statistic.component.ts
@@ -7,7 +7,8 @@ import { WebsocketService } from 'app/foundation/service/websocket.service';
 import { Subscription } from 'rxjs';
 import { SafeHtml } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { TooltipItem } from 'chart.js';
 import { CanBecomeInvalid } from 'app/quiz/shared/entities/drop-location.model';
 import { AbstractQuizStatisticComponent } from 'app/quiz/manage/statistics/quiz-statistics';
 
@@ -30,7 +31,10 @@ export abstract class QuestionStatisticComponent extends AbstractQuizStatisticCo
     question!: QuizQuestion; // set in loadQuizCommon() before the chart is rendered
     questionStatistic!: QuizQuestionStatistic; // set in loadQuizCommon() before the chart is rendered
 
-    quizExercise!: QuizExercise; // set in loadQuizCommon() before it is read
+    // A signal so that setting it after the (async) quiz load schedules zoneless change detection.
+    // As a plain field the initial load would not render until an unrelated event (e.g. a click),
+    // because the `@if (quizExercise())` guard keeps the chart (the only other signal consumer) out of the DOM.
+    readonly quizExercise = signal<QuizExercise>(undefined!); // set in loadQuizCommon() before it is read
     questionIdParam!: number; // set in ngOnInit() from the route params
     sub?: Subscription;
 
@@ -140,8 +144,8 @@ export abstract class QuestionStatisticComponent extends AbstractQuizStatisticCo
             void this.router.navigateByUrl('courses');
         }
         // search selected question in quizExercise based on questionId
-        this.quizExercise = quiz;
-        const updatedQuestion = this.quizExercise.quizQuestions?.filter((question) => this.questionIdParam === question.id)[0];
+        this.quizExercise.set(quiz);
+        const updatedQuestion = this.quizExercise().quizQuestions?.filter((question) => this.questionIdParam === question.id)[0];
         // if anyone finds a way to the Website, with a wrong combination of QuizId and QuestionId, go back to Courses
         if (!updatedQuestion) {
             void this.router.navigateByUrl('courses');
@@ -208,5 +212,14 @@ export abstract class QuestionStatisticComponent extends AbstractQuizStatisticCo
 
         this.updateChartData();
         this.setAxisLabels('artemisApp.showStatistic.questionStatistic.xAxes', 'artemisApp.showStatistic.questionStatistic.yAxes');
+    }
+
+    protected override formatTooltipLabel(item: TooltipItem<'bar'>): string {
+        // The extra "correct solutions" bar (participants who answered the whole question correctly) is only
+        // appended to the data in the show-solution view (see loadDataInDiagram). In the default view the last
+        // bar is just the last answer option/element, so only treat it as the summary bar while the solution is shown.
+        const isCorrectSolutionBar = this.showSolution && item.dataIndex === this.data.length - 1;
+        const key = isCorrectSolutionBar ? 'artemisApp.showStatistic.tooltip.correctOverall' : 'artemisApp.showStatistic.tooltip.participantShare';
+        return this.tooltipLine(key, item.parsed.y ?? 0);
     }
 }

--- a/src/main/webapp/app/quiz/manage/statistics/quiz-point-statistic/quiz-point-statistic.component.scss
+++ b/src/main/webapp/app/quiz/manage/statistics/quiz-point-statistic/quiz-point-statistic.component.scss
@@ -2,6 +2,17 @@
     font-size: large;
 }
 
+.quiz-statistic-chart {
+    // PrimeNG's <p-chart> host element has no intrinsic height, so with maintainAspectRatio: false the
+    // canvas collapses to chart.js' 150px default instead of filling the wrapper's fixed height. That
+    // both shrinks the chart and leaves a large empty area below it. Forcing the host to fill the
+    // wrapper makes the chart use the intended height.
+    p-chart {
+        display: block;
+        height: 100%;
+    }
+}
+
 .question-title {
     font-size: medium;
 }

--- a/src/main/webapp/app/quiz/manage/statistics/quiz-point-statistic/quiz-point-statistic.component.spec.ts
+++ b/src/main/webapp/app/quiz/manage/statistics/quiz-point-statistic/quiz-point-statistic.component.spec.ts
@@ -265,4 +265,14 @@ describe('QuizExercise Point Statistic Component', () => {
             expect(loadQuizSucessMock).toHaveBeenCalledWith(quizExercise);
         });
     });
+
+    describe('tooltip labels', () => {
+        it('uses the point-range tooltip for every bar', () => {
+            comp.data = [3, 0, 2];
+            const label = (comp.chartOptions().plugins as any).tooltip.callbacks.label;
+
+            expect(label({ dataIndex: 0, parsed: { y: 3 } })).toContain('tooltip.pointRange');
+            expect(label({ dataIndex: 2, parsed: { y: 2 } })).toContain('tooltip.pointRange');
+        });
+    });
 });

--- a/src/main/webapp/app/quiz/manage/statistics/quiz-point-statistic/quiz-point-statistic.component.ts
+++ b/src/main/webapp/app/quiz/manage/statistics/quiz-point-statistic/quiz-point-statistic.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { TooltipItem } from 'chart.js';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AbstractQuizStatisticComponent } from 'app/quiz/manage/statistics/quiz-statistics';
 import { AccountService } from 'app/core/auth/account.service';
@@ -219,6 +220,10 @@ export class QuizPointStatisticComponent extends AbstractQuizStatisticComponent 
 
         // add Axes-labels based on selected language
         this.setAxisLabels('artemisApp.showStatistic.quizPointStatistic.xAxes', 'artemisApp.showStatistic.quizPointStatistic.yAxes');
+    }
+
+    protected override formatTooltipLabel(item: TooltipItem<'bar'>): string {
+        return this.tooltipLine('artemisApp.showStatistic.tooltip.pointRange', item.parsed.y ?? 0);
     }
 
     /**

--- a/src/main/webapp/app/quiz/manage/statistics/quiz-statistic/quiz-statistic.component.spec.ts
+++ b/src/main/webapp/app/quiz/manage/statistics/quiz-statistic/quiz-statistic.component.spec.ts
@@ -286,7 +286,6 @@ describe('QuizStatisticComponent', () => {
     it('should format correctly', () => {
         fixture = TestBed.createComponent(QuizStatisticComponent);
         comp = fixture.componentInstance;
-        comp.totalParticipants = 100;
         comp.participants = 100;
 
         // the data label formatter is wired into the chart options
@@ -294,8 +293,20 @@ describe('QuizStatisticComponent', () => {
 
         expect(formatter(30)).toBe('30 (30%)');
 
-        comp.totalParticipants = 0;
+        // without participants the percentage cannot be computed and falls back to 0%
+        comp.participants = 0;
 
-        expect(formatter(0)).toBe('0 (0%)');
+        expect(formatter(30)).toBe('30 (0%)');
+    });
+
+    it('uses the correct-solutions tooltip for question bars and the average tooltip for the last bar', () => {
+        fixture = TestBed.createComponent(QuizStatisticComponent);
+        comp = fixture.componentInstance;
+        // two question bars plus the trailing average bar
+        comp.data = [10, 20, 15];
+        const label = (comp.chartOptions().plugins as any).tooltip.callbacks.label;
+
+        expect(label({ dataIndex: 0, parsed: { y: 10 } })).toContain('tooltip.correctSolutions');
+        expect(label({ dataIndex: 2, parsed: { y: 15 } })).toContain('tooltip.average');
     });
 });

--- a/src/main/webapp/app/quiz/manage/statistics/quiz-statistic/quiz-statistic.component.ts
+++ b/src/main/webapp/app/quiz/manage/statistics/quiz-statistic/quiz-statistic.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { TooltipItem } from 'chart.js';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpResponse } from '@angular/common/http';
 import { AccountService } from 'app/core/auth/account.service';
@@ -156,5 +157,12 @@ export class QuizStatisticComponent extends AbstractQuizStatisticComponent imple
         this.setData(this.quizExercise().quizPointStatistic!);
         this.updateChartData();
         this.setAxisLabels('artemisApp.showStatistic.quizStatistic.xAxes', 'artemisApp.showStatistic.quizStatistic.yAxes');
+    }
+
+    protected override formatTooltipLabel(item: TooltipItem<'bar'>): string {
+        // the last bar aggregates the average across all questions rather than a single question
+        const isAverageBar = item.dataIndex === this.data.length - 1;
+        const key = isAverageBar ? 'artemisApp.showStatistic.tooltip.average' : 'artemisApp.showStatistic.tooltip.correctSolutions';
+        return this.tooltipLine(key, item.parsed.y ?? 0);
     }
 }

--- a/src/main/webapp/app/quiz/manage/statistics/quiz-statistics.ts
+++ b/src/main/webapp/app/quiz/manage/statistics/quiz-statistics.ts
@@ -1,4 +1,5 @@
 import { Component, computed, inject, signal } from '@angular/core';
+import { TooltipItem } from 'chart.js';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
 import { round } from 'app/foundation/util/utils';
 import { QuizStatistic } from 'app/quiz/shared/entities/quiz-statistic.model';
@@ -22,7 +23,6 @@ export abstract class AbstractQuizStatisticComponent {
     participants = 0;
 
     chartLabels: string[] = [];
-    totalParticipants = 0;
 
     /** The current bar entries; updated via {@link updateChartData}. */
     protected chartEntries = signal<ChartSeriesEntry[]>([]);
@@ -39,7 +39,7 @@ export abstract class AbstractQuizStatisticComponent {
         barChartOptions({
             xAxis: { label: this.xAxisLabel() },
             yAxis: { label: this.yAxisLabel(), max: this.maxScale() },
-            tooltip: false,
+            tooltip: { label: (item) => this.formatTooltipLabel(item) },
             dataLabels: { formatter: (value) => this.formatDataLabel(value) },
         }),
     );
@@ -91,10 +91,36 @@ export abstract class AbstractQuizStatisticComponent {
      * @returns string of the following pattern: absolute value (relative value)
      */
     protected formatDataLabel(absoluteValue: number): string {
-        if (!this.totalParticipants || !this.participants) {
-            return absoluteValue + ' (0%)';
-        }
-        return absoluteValue + ' (' + round((absoluteValue / this.participants) * 100, 1) + '%)';
+        return absoluteValue + ' (' + this.percentageOfParticipants(absoluteValue) + '%)';
+    }
+
+    /**
+     * Returns the given value as a percentage of the current participants, rounded to one decimal.
+     * Falls back to 0 when there are no participants (avoids division by zero).
+     * @param value the absolute value represented by a bar
+     */
+    private percentageOfParticipants(value: number): number {
+        return this.participants ? round((value / this.participants) * 100, 1) : 0;
+    }
+
+    /**
+     * Builds the explanatory tooltip line for a hovered bar. The default states how many of the
+     * participants a bar represents; subclasses override it to describe their specific metric
+     * (e.g. correct answers, point ranges).
+     * @param item the hovered bar, as provided by chart.js
+     */
+    protected formatTooltipLabel(item: TooltipItem<'bar'>): string {
+        return this.tooltipLine('artemisApp.showStatistic.tooltip.participantShare', item.parsed.y ?? 0);
+    }
+
+    /**
+     * Resolves a tooltip translation key, filling in the bar's absolute value, the participant count,
+     * and the value's percentage of the participants.
+     * @param key the translation key of the tooltip line
+     * @param value the absolute value represented by the bar
+     */
+    protected tooltipLine(key: string, value: number): string {
+        return this.translateService.instant(key, { count: value, participants: this.participants, percent: this.percentageOfParticipants(value) });
     }
 
     /**

--- a/src/main/webapp/app/quiz/manage/statistics/short-answer-question-statistic/short-answer-question-statistic.component.html
+++ b/src/main/webapp/app/quiz/manage/statistics/short-answer-question-statistic/short-answer-question-statistic.component.html
@@ -1,7 +1,7 @@
-@if (quizExercise) {
+@if (quizExercise()) {
     <div class="row">
         <div class="col-md-8 offset-md-2 text-center">
-            <h3>{{ quizExercise.title }}</h3>
+            <h3>{{ quizExercise().title }}</h3>
             <div class="row">
                 @if (question) {
                     <div class="col">

--- a/src/main/webapp/app/shared-ui/chart/chart-options.ts
+++ b/src/main/webapp/app/shared-ui/chart/chart-options.ts
@@ -112,18 +112,36 @@ function tickCallback(formatter: (value: number | string) => string, isCategoryA
     };
 }
 
-function buildScale(axis: ChartAxisConfig | undefined, options: { stacked?: boolean; isCategoryAxis: boolean; percent?: boolean }) {
+/** The subset of chart.js scale options that {@link buildScale} sets; `ticks` is optional on purpose (see below). */
+interface BuiltScaleOptions {
+    display: boolean;
+    stacked: boolean;
+    min?: number;
+    max?: number;
+    title?: { display: boolean; text: string };
+    grid?: { display: boolean };
+    ticks?: { callback: (this: Scale, value: number | string) => string };
+}
+
+function buildScale(axis: ChartAxisConfig | undefined, options: { stacked?: boolean; isCategoryAxis: boolean; percent?: boolean }): BuiltScaleOptions {
     const percentFormatter = (value: number | string) => `${value}%`;
     const formatter = axis?.tickFormatter ?? (options.percent ? percentFormatter : undefined);
-    return {
+    const scale: BuiltScaleOptions = {
         display: axis?.display ?? true,
         stacked: options.stacked ?? false,
         min: axis?.min,
         max: axis?.max ?? (options.percent ? 100 : undefined),
         title: axis?.label ? { display: true, text: axis.label } : undefined,
-        ticks: formatter ? { callback: tickCallback(formatter, options.isCategoryAxis) } : undefined,
         grid: options.isCategoryAxis ? { display: false } : undefined,
     };
+    // Only set `ticks` when a custom formatter is required. Passing `ticks: undefined` explicitly
+    // overrides chart.js' default category tick callback, which makes a category axis fall back to
+    // rendering the numeric data index instead of the label from `data.labels` (e.g. 0, 1, 2 instead
+    // of the quiz question numbers). Omitting the key keeps the built-in label rendering intact.
+    if (formatter) {
+        scale.ticks = { callback: tickCallback(formatter, options.isCategoryAxis) };
+    }
+    return scale;
 }
 
 function buildLegend(legend: BaseChartConfig['legend']) {

--- a/src/main/webapp/i18n/de/showStatistic.json
+++ b/src/main/webapp/i18n/de/showStatistic.json
@@ -43,6 +43,13 @@
                 "showSampleSolution": "Zeige Beispiellösung",
                 "hideSampleSolution": "Verberge Beispiellösung"
             },
+            "tooltip": {
+                "participantShare": "{{ count }} von {{ participants }} Teilnehmenden ({{ percent }} %)",
+                "correctSolutions": "{{ count }} von {{ participants }} Teilnehmenden haben diese Frage richtig beantwortet ({{ percent }} %)",
+                "average": "Durchschnitt: {{ count }} richtige Lösungen ({{ percent }} % der Teilnehmenden)",
+                "pointRange": "{{ count }} von {{ participants }} Teilnehmenden liegen in diesem Bereich ({{ percent }} %)",
+                "correctOverall": "{{ count }} von {{ participants }} Teilnehmenden haben die gesamte Frage richtig beantwortet ({{ percent }} %)"
+            },
             "invalid": "(ungültig)",
             "quizHasEnded": "Quiz ist zu Ende!",
             "now": "Läuft"

--- a/src/main/webapp/i18n/en/showStatistic.json
+++ b/src/main/webapp/i18n/en/showStatistic.json
@@ -43,6 +43,13 @@
                 "showSampleSolution": "Show Sample Solution",
                 "hideSampleSolution": "Hide Sample Solution"
             },
+            "tooltip": {
+                "participantShare": "{{ count }} of {{ participants }} participants ({{ percent }}%)",
+                "correctSolutions": "{{ count }} of {{ participants }} participants answered this question correctly ({{ percent }}%)",
+                "average": "Average: {{ count }} correct solutions ({{ percent }}% of participants)",
+                "pointRange": "{{ count }} of {{ participants }} participants scored in this range ({{ percent }}%)",
+                "correctOverall": "{{ count }} of {{ participants }} participants answered the whole question correctly ({{ percent }}%)"
+            },
             "invalid": "(invalid)",
             "quizHasEnded": "Quiz has ended!",
             "now": "Now"


### PR DESCRIPTION
### Summary

The quiz statistics views (quiz statistic, point distribution, and the per question statistics for multiple choice, drag and drop, and short answer) had several rendering regressions after the zoneless change detection and ngx-charts to PrimeNG/chart.js migrations. Charts showed numeric axis indices instead of the question numbers and answer letters, the per question statistics did not render until the page received an unrelated click, the charts collapsed to a small fixed height with a large empty area below them, and every data label showed `(0%)`. This PR fixes all of these at their root and adds explanatory hover tooltips.

### Checklist

#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context

Instructors reported that the quiz statistics were "beyond broken". Concretely:

1. The per question statistics did not load automatically. The page stayed blank until you clicked somewhere.
2. The bar charts labeled their bars with `0, 1, 2, ...` instead of the question numbers (`1.`, `2.`, `Average`) and the answer letters (`A.`, `B.`, `C.`), so the chart no longer mapped to the shown question or solution.
3. All charts were too small and left a large amount of empty whitespace below them.
4. The percentage in every bar label was always `(0%)`.

These were regressions from the migration to zoneless change detection (#12872) and from ngx-charts to PrimeNG/chart.js (#12900).

### Description

Four root causes, two of which were shared bugs affecting more than one chart:

- **Axis labels showed numeric indices (`chart-options.ts`).** `buildScale` emitted `ticks: undefined`. Explicitly setting `ticks` to `undefined` overrides chart.js' default category tick callback, so a category axis falls back to the numeric data index instead of `data.labels`. The fix omits the `ticks` key entirely when no custom formatter is required. This also transparently repairs any other category axis built through the same helper (for example line charts).
- **Charts collapsed to 150px (`quiz-point-statistic.component.scss`).** PrimeNG's `<p-chart>` host element has no intrinsic height, so with `maintainAspectRatio: false` the canvas fell back to chart.js' 150px default inside the taller wrapper, both shrinking the chart and leaving the empty area below it. Added `.quiz-statistic-chart p-chart { display: block; height: 100% }`, which applies to all five statistics components through the shared stylesheet.
- **Question statistics did not render until a click (`question-statistic.component.ts`).** `quizExercise` was a plain field, so writing it inside the asynchronous load did not schedule zoneless change detection, and the `@if (quizExercise)` guard kept the only signal bound element (the chart) out of the DOM. Converting `quizExercise` to a `signal()` (mirroring the sibling components that already auto load) makes the guard a live consumer so the load renders immediately.
- **Percentages always showed `(0%)` (`quiz-statistics.ts`).** `formatDataLabel` guarded on `totalParticipants`, a field that production code never assigned, so the guard always short circuited. The guard now uses `participants` (the actual denominator), and the dead field was removed.

In addition, following reviewer feedback, hover tooltips were added to every quiz chart with English and German translations, explaining what each bar represents (for example "2 of 3 participants answered this question correctly (66.7%)").

### Steps for Testing

Prerequisites:
- 1 Instructor
- 2 to 3 Students
- 1 Quiz exercise with at least one multiple choice question

1. Log in as instructor, create and start a quiz.
2. Have the students participate and submit different answers.
3. End the quiz and let it be evaluated.
4. As instructor, open the quiz and navigate to the statistics (Point Distribution, Quiz Statistic, and the per question statistics).
5. Verify for each page:
   - The page and its chart render immediately without needing a click.
   - The x-axis shows meaningful labels (`1.`, `Average` for the overview, `A.`, `B.`, ... for the multiple choice question, point ranges like `[0 - 0.5)` for the point distribution), matching the listed questions/answers.
   - The chart fills its area and there is no large empty space below it.
   - The data labels show real percentages (for example `2 (66.7%)`), not `(0%)`.
   - Hovering a bar shows an explanatory tooltip.
6. Switch the language to German and confirm the tooltips are translated.

#### Exam Mode Testing

The same statistics components are also reachable for quizzes used inside exams (see `QuizStatisticUtil.getBaseUrlForQuizExercise`). The changes are generic chart rendering fixes and apply identically there. Verify that the statistics of an exam quiz render with correct labels, height, and percentages.

### Screenshots

Verified locally against a seeded quiz with 3 participants (single node dev stack via `run-e2e-tests-local-fast.sh`):

- Quiz Statistic (overview): x-axis reads `1.` and `Average`, bars show `1 (33.3%)`, chart fills its height.
- Answer Distribution (multiple choice): x-axis reads `A. B. C. D.` matching the answer options, bars show `2 (66.7%)` / `1 (33.3%)`, rendered without any click, and hovering bar A shows the tooltip "A. -> 2 of 3 participants (66.7%)".
- Point Distribution: buckets `[0 - 0.5) ... [9.5 - 10]`, real percentages, chart fills its height.

(Before this PR the same views showed `0, 1, 2, ...` axis labels, `(0%)` on every bar, a ~150px chart with a large empty area, and the question statistics did not appear until a click.)

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| question-statistic.component.ts | 96.29% | 144 | ? | ? |
| quiz-point-statistic.component.ts | 89.28% | 164 | 33 | 20.1 |
| quiz-statistic.component.ts | 82.60% | 122 | 29 | 23.8 |
| quiz-statistics.ts | 95.45% | 86 | ? | ? |
| chart-options.ts | 100.00% | 194 | 34 | 17.5 |

_Last updated: 2026-07-17 18:17:24 UTC_

