### PR TITLE
`Exam mode`: Fix missing git clone access token in exam test runs

### DIFF
--- a/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.html
+++ b/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.html
@@ -22,16 +22,10 @@
         @if (selectedAuthenticationMechanism() === RepositoryAuthenticationMethod.SSH && areAnySshKeysExpired()) {
             <div class="alert alert-warning" [innerHTML]="sshKeysExpiredTip()"></div>
         }
-        @if (selectedAuthenticationMechanism() === RepositoryAuthenticationMethod.Token && isInCourseManagement() && !isBaseRepository() && !userTokenPresent()) {
+        @if (selectedAuthenticationMechanism() === RepositoryAuthenticationMethod.Token && usesStaffUserToken() && !userTokenPresent()) {
             <div class="alert alert-warning" [innerHTML]="tokenMissingTip()"></div>
         }
-        @if (
-            selectedAuthenticationMechanism() === RepositoryAuthenticationMethod.Token &&
-            isInCourseManagement() &&
-            !isBaseRepository() &&
-            userTokenPresent() &&
-            !userTokenStillValid()
-        ) {
+        @if (selectedAuthenticationMechanism() === RepositoryAuthenticationMethod.Token && usesStaffUserToken() && userTokenPresent() && !userTokenStillValid()) {
             <div class="alert alert-warning" [innerHTML]="tokenExpiredTip()"></div>
         }
         <h5 [jhiTranslate]="clonedHeadline()"></h5>

--- a/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.spec.ts
@@ -1,4 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+vi.mock('@sentry/angular', async (importOriginal) => {
+    const originalModule = await importOriginal<typeof import('@sentry/angular')>();
+    return {
+        ...originalModule,
+        captureException: vi.fn(),
+    };
+});
+
+import * as Sentry from '@sentry/angular';
 import { By } from '@angular/platform-browser';
 import { AccountService } from 'app/core/auth/account.service';
 import { AlertService } from 'app/foundation/service/alert.service';
@@ -500,6 +510,116 @@ describe('CodeButtonComponent', () => {
 
         url = component.getHttpOrSshRepositoryUri(false);
         expect(url).toBe(`https://${component.user.login}:${vcsToken}@artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise-team1.git`);
+    });
+
+    it('should use the participation token for the users own test run participation in course management', async () => {
+        // Exam test runs are served under a course-management URL, but the participation belongs to the current user,
+        // so its own participation token (not the personal staff token) must be used and loaded.
+        const participationToken = 'vcpat-own-test-run-participation-token';
+        getVcsAccessTokenSpy.mockReturnValue(of(new HttpResponse({ body: participationToken })));
+        localStorageState = RepositoryAuthenticationMethod.Token;
+
+        const ownTestRunParticipation = {
+            id: 42,
+            testRun: true,
+            student: { login: 'edx_userLogin' },
+            repositoryUri: 'https://artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.git',
+        } as ProgrammingExerciseStudentParticipation;
+
+        await component.ngOnInit();
+        component.isInCourseManagement.set(true);
+        fixture.componentRef.setInput('participations', [ownTestRunParticipation]);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        component.onClick();
+        fixture.detectChanges();
+
+        expect(component.isInCourseManagement()).toBe(true);
+        expect(getVcsAccessTokenSpy).toHaveBeenCalledWith(42);
+        expect(ownTestRunParticipation.vcsAccessToken).toEqual(participationToken);
+        const url = component.getHttpOrSshRepositoryUri(false);
+        expect(url).toBe(`https://edx_userLogin:${participationToken}@artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.git`);
+        expect(url).not.toContain('undefined');
+    });
+
+    it('should keep using the personal staff token for another users test run participation in course management', async () => {
+        // When course staff open another instructor's test run summary, the participation is not owned by them, so the
+        // personal staff token must still be used (fetching the participation token would be forbidden server-side).
+        localStorageState = RepositoryAuthenticationMethod.Token;
+
+        const othersTestRunParticipation = {
+            id: 43,
+            testRun: true,
+            student: { login: 'other_instructor' },
+            repositoryUri: 'https://artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.git',
+        } as ProgrammingExerciseStudentParticipation;
+
+        await component.ngOnInit();
+        component.isInCourseManagement.set(true);
+        fixture.componentRef.setInput('participations', [othersTestRunParticipation]);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        component.onClick();
+        fixture.detectChanges();
+
+        expect(getVcsAccessTokenSpy).not.toHaveBeenCalled();
+        const url = component.getHttpOrSshRepositoryUri(false);
+        expect(url).toBe(`https://edx_userLogin:${vcsToken}@artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.git`);
+    });
+
+    it('should omit the token and report to Sentry when a participation token is unexpectedly missing', async () => {
+        const captureSpy = vi.spyOn(Sentry, 'captureException').mockImplementation(() => '');
+        captureSpy.mockClear();
+        // Simulate a participation whose token can neither be fetched nor created (should never happen in practice).
+        getVcsAccessTokenSpy.mockReturnValue(of(new HttpResponse<string>({ body: undefined })));
+        createVcsAccessTokenSpy.mockReturnValue(of(new HttpResponse<string>({ body: undefined })));
+        localStorageState = RepositoryAuthenticationMethod.Token;
+
+        const participation = {
+            id: 7,
+            testRun: false,
+            repositoryUri: 'https://artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.git',
+        } as ProgrammingExerciseStudentParticipation;
+
+        await component.ngOnInit();
+        fixture.componentRef.setInput('participations', [participation]);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        component.onClick();
+        fixture.detectChanges();
+
+        const url = component.getHttpOrSshRepositoryUri(false);
+        expect(url).toBe('https://edx_userLogin@artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.git');
+        expect(url).not.toContain('undefined');
+        expect(captureSpy).toHaveBeenCalled();
+    });
+
+    it('should not report to Sentry when only the personal staff token is missing (known, UI-handled case)', async () => {
+        const captureSpy = vi.spyOn(Sentry, 'captureException').mockImplementation(() => '');
+        captureSpy.mockClear();
+        // Course staff browsing another participant's repository without having created a personal VCS token: the URL
+        // must still not contain "undefined", but this is an expected, already UI-surfaced state and must not be reported.
+        vi.spyOn(accountService, 'identity').mockReturnValue(Promise.resolve({ login: 'edx_userLogin', internal: true, vcsAccessToken: undefined }));
+        localStorageState = RepositoryAuthenticationMethod.Token;
+
+        const othersParticipation = {
+            id: 44,
+            student: { login: 'some_student' },
+            repositoryUri: 'https://artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.git',
+        } as ProgrammingExerciseStudentParticipation;
+
+        await component.ngOnInit();
+        component.isInCourseManagement.set(true);
+        fixture.componentRef.setInput('participations', [othersParticipation]);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        component.onClick();
+        fixture.detectChanges();
+
+        const url = component.getHttpOrSshRepositoryUri(false);
+        expect(url).toBe('https://edx_userLogin@artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.git');
+        expect(url).not.toContain('undefined');
+        expect(captureSpy).not.toHaveBeenCalled();
     });
 
     it('should add the user login and token to the URL', async () => {

--- a/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.spec.ts
@@ -15,6 +15,7 @@ import { AlertService } from 'app/foundation/service/alert.service';
 import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { ProgrammingExerciseStudentParticipation } from 'app/exercise/shared/entities/participation/programming-exercise-student-participation.model';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
+import { User } from 'app/account/user/user.model';
 import { CodeButtonComponent, RepositoryAuthenticationMethod } from 'app/shared-ui/components/buttons/code-button/code-button.component';
 import { LocalStorageService } from 'app/foundation/service/local-storage.service';
 import dayjs from 'dayjs/esm';
@@ -570,8 +571,9 @@ describe('CodeButtonComponent', () => {
     it('should omit the token and report to Sentry when a participation token is unexpectedly missing', async () => {
         const captureSpy = vi.spyOn(Sentry, 'captureException').mockImplementation(() => '');
         captureSpy.mockClear();
-        // Simulate a participation whose token can neither be fetched nor created (should never happen in practice).
-        getVcsAccessTokenSpy.mockReturnValue(of(new HttpResponse<string>({ body: undefined })));
+        // Simulate a participation whose token can neither be fetched (404) nor created (created but empty body); this is
+        // the terminal failure state that should be reported (should never happen in practice).
+        getVcsAccessTokenSpy.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' })));
         createVcsAccessTokenSpy.mockReturnValue(of(new HttpResponse<string>({ body: undefined })));
         localStorageState = RepositoryAuthenticationMethod.Token;
 
@@ -589,9 +591,74 @@ describe('CodeButtonComponent', () => {
         fixture.detectChanges();
 
         const url = component.getHttpOrSshRepositoryUri(false);
+        // Building the URL again must not report a second time (per-instance guard).
+        component.getHttpOrSshRepositoryUri(false);
+        expect(createVcsAccessTokenSpy).toHaveBeenCalledWith(7);
         expect(url).toBe('https://edx_userLogin@artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.git');
         expect(url).not.toContain('undefined');
-        expect(captureSpy).toHaveBeenCalled();
+        expect(captureSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not report to Sentry while a participation token is still loading (no terminal failure yet)', async () => {
+        const captureSpy = vi.spyOn(Sentry, 'captureException').mockImplementation(() => '');
+        captureSpy.mockClear();
+        // The token request never resolves during this test, so the token is merely in flight, not terminally missing.
+        getVcsAccessTokenSpy.mockReturnValue(new Subject<HttpResponse<string>>().asObservable());
+        localStorageState = RepositoryAuthenticationMethod.Token;
+
+        const participation = {
+            id: 8,
+            testRun: false,
+            repositoryUri: 'https://artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.git',
+        } as ProgrammingExerciseStudentParticipation;
+
+        await component.ngOnInit();
+        fixture.componentRef.setInput('participations', [participation]);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        component.onClick();
+        fixture.detectChanges();
+
+        const url = component.getHttpOrSshRepositoryUri(false);
+        // The URL omits the (not-yet-available) token, but no anomaly is reported while it is still loading.
+        expect(url).toBe('https://edx_userLogin@artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.git');
+        expect(url).not.toContain('undefined');
+        expect(captureSpy).not.toHaveBeenCalled();
+    });
+
+    it('should load the own participation token only after the current user resolves (async ordering)', async () => {
+        // Reproduces the real ordering: participations and the course-management context are known before the async
+        // identity resolves. The token-loading effect must re-run once the user becomes known.
+        let resolveIdentity!: (user: User) => void;
+        const identitySpy = vi.spyOn(accountService, 'identity').mockReturnValue(new Promise<User>((resolve) => (resolveIdentity = resolve)));
+        localStorageState = RepositoryAuthenticationMethod.Token;
+
+        const freshFixture = TestBed.createComponent(CodeButtonComponent);
+        freshFixture.componentRef.setInput('smallButtons', true);
+        freshFixture.componentRef.setInput('repositoryUri', '');
+        freshFixture.componentRef.setInput('routerLinkForRepositoryView', []);
+        freshFixture.componentInstance.isInCourseManagement.set(true);
+        freshFixture.componentRef.setInput('participations', [
+            {
+                id: 42,
+                testRun: true,
+                student: { login: 'edx_userLogin' },
+                repositoryUri: 'https://artemis.tum.de/git/ITCPLEASE1/itcplease1-exercise.git',
+            } as ProgrammingExerciseStudentParticipation,
+        ]);
+        freshFixture.detectChanges();
+
+        // Identity still pending → the owner is unknown → the participation token must not be requested yet.
+        expect(identitySpy).toHaveBeenCalled();
+        expect(getVcsAccessTokenSpy).not.toHaveBeenCalled();
+
+        resolveIdentity({ login: 'edx_userLogin', internal: true, vcsAccessToken: vcsToken } as User);
+        await freshFixture.whenStable();
+        freshFixture.detectChanges();
+
+        // Now that the user is known, the effect re-runs and loads the own participation token.
+        expect(getVcsAccessTokenSpy).toHaveBeenCalledWith(42);
+        freshFixture.destroy();
     });
 
     it('should not report to Sentry when only the personal staff token is missing (known, UI-handled case)', async () => {

--- a/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.ts
+++ b/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.ts
@@ -33,6 +33,7 @@ import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service
 import { IdeSettingsService } from 'app/account/user/settings/ide-preferences/ide-settings.service';
 import { Ide } from 'app/account/user/settings/ide-preferences/ide.model';
 import { ProfileInfo } from 'app/core/layouts/profiles/profile-info.model';
+import { captureException } from '@sentry/angular';
 
 export enum RepositoryAuthenticationMethod {
     Password = 'password',
@@ -103,6 +104,11 @@ export class CodeButtonComponent implements OnInit {
     sshSettingsUrl!: string; // set in configureTooltips() from ngOnInit()
     vcsTokenSettingsUrl!: string; // set in configureTooltips() from ngOnInit()
     user!: User; // set in ngOnInit() from accountService.identity()
+    // The current user's login as a signal (set in ngOnInit alongside `user`) so the token-loading effect and the
+    // usesStaffUserToken computed react once the user becomes known and can detect whether a participation is the user's own.
+    private readonly userLogin = signal<string | undefined>(undefined);
+    // Guards against reporting the same missing-token anomaly repeatedly (getHttpOrSshRepositoryUri runs on every change detection).
+    private vcsAccessTokenReportedMissing = false;
     sshKeys?: UserSshPublicKey[];
 
     // Signals (we ideally declare everything related to change detection/UI to signals and leave component fields
@@ -164,6 +170,11 @@ export class CodeButtonComponent implements OnInit {
         const type = this.repositoryType();
         return type === RepositoryType.TEMPLATE || type === RepositoryType.SOLUTION || type === RepositoryType.TESTS || type === RepositoryType.AUXILIARY;
     });
+    // True when the clone URL must authenticate with the user's personal (staff) VCS access token instead of a
+    // participation token: course staff browsing another participant's repository in course management. The user's OWN
+    // participation (including an exam test run they conduct, which is served under a course-management URL) is excluded,
+    // because its participation-scoped token is available to (and owned by) the user and must be used instead.
+    usesStaffUserToken = computed(() => this.isInCourseManagement() && !this.isBaseRepository() && !this.isOwnParticipation(this.activeParticipation()));
 
     vscodeFallback: Ide = { name: 'VS Code', deepLink: 'vscode://vscode.git/clone?url={cloneUrl}' };
     programmingLanguageToIde: Map<ProgrammingLanguage, Ide> = new Map([[ProgrammingLanguage.EMPTY, this.vscodeFallback]]);
@@ -180,7 +191,7 @@ export class CodeButtonComponent implements OnInit {
 
         // we only loadVcsAccessToken if participations exist => reduces potentially repeated HTTP calls
         effect(() => {
-            if (this.isInCourseManagement() || this.isBaseRepository()) {
+            if (this.isBaseRepository()) {
                 return;
             }
             const participations = this.participations();
@@ -204,6 +215,7 @@ export class CodeButtonComponent implements OnInit {
             return;
         }
         this.user = user;
+        this.userLogin.set(user.login);
 
         await this.checkForSshKeys();
 
@@ -243,7 +255,7 @@ export class CodeButtonComponent implements OnInit {
         this.selectedAuthenticationMechanism.set(RepositoryAuthenticationMethod.Token);
         if (this.isBaseRepository()) {
             this.copyEnabled.set(this.hasValidRepositoryAccessToken());
-        } else if (this.isInCourseManagement()) {
+        } else if (this.usesStaffUserToken()) {
             const stillValid = dayjs().isBefore(dayjs(this.user.vcsAccessTokenExpiryDate));
             const present = !!this.user.vcsAccessToken?.startsWith('vcpat');
             this.userTokenStillValid.set(stillValid);
@@ -311,9 +323,15 @@ export class CodeButtonComponent implements OnInit {
             return this.getSshCloneUrl(this.getRepositoryUri());
         }
         const url = this.getRepositoryUri();
+        const useToken = this.useToken() || alwaysUsetoken;
         const token = insertPlaceholder ? '**********' : this.getUsedToken(alwaysUsetoken);
 
-        const credentials = `://${this.user.login}${this.useToken() || alwaysUsetoken ? `:${token}` : ''}@`;
+        // Never interpolate a missing token into the clone URL: an undefined/empty token would produce a broken
+        // "://<login>:undefined@..." URL. If a token was expected but is unavailable, omit it entirely and report it.
+        if (useToken && !token) {
+            this.reportMissingVcsAccessToken();
+        }
+        const credentials = `://${this.user.login}${useToken && token ? `:${token}` : ''}@`;
 
         if (!url.includes('@')) {
             // the url has the format https://vcs-server.com
@@ -324,12 +342,47 @@ export class CodeButtonComponent implements OnInit {
         }
     }
 
+    /**
+     * Reports (once per component instance) that a clone URL had to be built without a VCS access token although one was
+     * expected, so the anomaly stays observable while the URL itself never leaks a literal "undefined". The known,
+     * already UI-surfaced cases are intentionally excluded: the personal staff token being absent (usesStaffUserToken)
+     * and base-repository tokens, which have their own dedicated error handling.
+     */
+    private reportMissingVcsAccessToken(): void {
+        if (this.vcsAccessTokenReportedMissing || this.isBaseRepository() || this.usesStaffUserToken()) {
+            return;
+        }
+        this.vcsAccessTokenReportedMissing = true;
+        const participation = this.activeParticipation();
+        captureException(
+            new Error(
+                `A VCS access token was expected but missing while building the clone URL (participationId=${participation?.id}, isInCourseManagement=${this.isInCourseManagement()}); the token was omitted from the URL.`,
+            ),
+        );
+    }
+
     loadVcsAccessTokensForAllParticipations() {
         this.participations().forEach((participation) => {
-            if (participation.id && !participation.vcsAccessToken) {
+            // Load the participation-scoped token only when the clone URL will actually use it: outside course management,
+            // or for the user's own participation inside course management (e.g. an exam test run the instructor conducts).
+            // For other participants' repositories in course management the personal staff token is used, and requesting
+            // their participation token would be forbidden server-side.
+            if ((!this.isInCourseManagement() || this.isOwnParticipation(participation)) && participation.id && !participation.vcsAccessToken) {
                 this.loadParticipationVcsAccessToken(participation);
             }
         });
+    }
+
+    /**
+     * Whether the given participation belongs to the currently logged-in user. Used to decide whether the participation's
+     * own VCS access token may be used (and loaded) even inside course management — e.g. an exam test run the instructor
+     * conducts for themselves. For participations of other users (a student's, another instructor's test run) this is false,
+     * so the personal staff token is used instead. Relies on the participation's `student` being populated, which is the
+     * case for the exam test run summary/conduction flows where this distinction matters.
+     */
+    private isOwnParticipation(participation: ProgrammingExerciseStudentParticipation | undefined): boolean {
+        const userLogin = this.userLogin();
+        return !!userLogin && participation?.student?.login === userLogin;
     }
 
     /**
@@ -483,7 +536,7 @@ export class CodeButtonComponent implements OnInit {
                 // Never embed a token cached for a different repository (exact-URI scoped); only the token for the current repository is valid.
                 return this.hasValidRepositoryAccessToken() ? this.repositoryAccessToken() : undefined;
             }
-            if (this.isInCourseManagement()) {
+            if (this.usesStaffUserToken()) {
                 return this.user.vcsAccessToken;
             } else {
                 return this.activeParticipation()?.vcsAccessToken;

--- a/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.ts
+++ b/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.ts
@@ -109,6 +109,10 @@ export class CodeButtonComponent implements OnInit {
     private readonly userLogin = signal<string | undefined>(undefined);
     // Guards against reporting the same missing-token anomaly repeatedly (getHttpOrSshRepositoryUri runs on every change detection).
     private vcsAccessTokenReportedMissing = false;
+    // Set once a participation VCS token request has terminally failed to yield a token (empty response or an error that
+    // is not the 404 → create fallback). Gates the missing-token Sentry report so it never fires while a token is still
+    // in flight (an expected transient state during which the clone URL simply omits the token).
+    private readonly participationTokenLoadFailed = signal(false);
     sshKeys?: UserSshPublicKey[];
 
     // Signals (we ideally declare everything related to change detection/UI to signals and leave component fields
@@ -349,7 +353,9 @@ export class CodeButtonComponent implements OnInit {
      * and base-repository tokens, which have their own dedicated error handling.
      */
     private reportMissingVcsAccessToken(): void {
-        if (this.vcsAccessTokenReportedMissing || this.isBaseRepository() || this.usesStaffUserToken()) {
+        // Only report once a participation token request has terminally failed; never while the token is still loading
+        // (the URL correctly omits the token during that transient window, so passive render must not raise an alarm).
+        if (this.vcsAccessTokenReportedMissing || this.isBaseRepository() || this.usesStaffUserToken() || !this.participationTokenLoadFailed()) {
             return;
         }
         this.vcsAccessTokenReportedMissing = true;
@@ -399,14 +405,19 @@ export class CodeButtonComponent implements OnInit {
                     if (this.useToken()) {
                         this.copyEnabled.set(true);
                     }
+                } else {
+                    // The server answered without a token: terminal failure, no create fallback follows.
+                    this.participationTokenLoadFailed.set(true);
                 }
             },
             error: (error: HttpErrorResponse) => {
                 if (error.status == 404) {
                     this.createNewParticipationVcsAccessToken(participation);
-                }
-                if (error.status == 403) {
-                    this.alertService.warning('403 Forbidden');
+                } else {
+                    if (error.status == 403) {
+                        this.alertService.warning('403 Forbidden');
+                    }
+                    this.participationTokenLoadFailed.set(true);
                 }
             },
         });
@@ -425,12 +436,16 @@ export class CodeButtonComponent implements OnInit {
                     if (this.useToken()) {
                         this.copyEnabled.set(true);
                     }
+                } else {
+                    // Creating the token succeeded but returned no token: terminal failure.
+                    this.participationTokenLoadFailed.set(true);
                 }
             },
             error: (error: HttpErrorResponse) => {
                 if (error.status == 403) {
                     this.alertService.warning('403 Forbidden');
                 }
+                this.participationTokenLoadFailed.set(true);
             },
         });
     }


### PR DESCRIPTION
### Summary

When an instructor conducts an **exam test run** and opens the code/clone button for a programming exercise, the generated git clone URL contained the literal string `undefined` instead of a VCS access token — even though it is the instructor's *own* test run participation. This PR makes the code button use the participation's own token in that case, and adds a defensive safety net so a missing token can never leak `undefined` into a clone URL again.

### Checklist

#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **LocalVC** and **Jenkins**.

### Motivation and Context

The `CodeButtonComponent` decides which token to embed in a repository clone URL based solely on whether the current URL contains `course-management`:

- if it does, it uses the logged-in user's **personal (staff) VCS access token** (`user.vcsAccessToken`) and skips loading the participation token;
- otherwise it uses the **participation-scoped token**.

Exam test runs (conduction and summary) are served under `.../course-management/.../exams/.../test-runs/...`. So for an instructor's own test run the button used the personal staff token — which is `undefined` when the instructor never created a personal token — and never loaded the participation token that actually exists. The template literal then stringified `undefined` into the URL: `https://<login>:undefined@...`.

The server side was already correct: the participation VCS access token is created for the test run participation and `isOwnedBy(instructor)` returns `true`, so it would be served. No server change is needed.

### Description

**1. Use the correct token for the user's own participation (root-cause fix).**
Instead of relying only on the URL, the button now detects whether the active participation belongs to the current user via `participation.student.login === currentUser.login` (`isOwnParticipation`). A new `usesStaffUserToken` computed means *"in course management and not my own participation"*. For the user's own participation — including exam test runs served under a course-management URL — the participation-scoped token is now loaded and embedded. For **another** user's participation (e.g. another instructor's test run summary, which staff can open) the personal staff token is still used, because fetching someone else's participation token is forbidden server-side.

**2. Never leak `undefined` into a clone URL (defensive safety net).**
`getHttpOrSshRepositoryUri` now omits the token entirely when it is missing (`://<login>@...` instead of `://<login>:undefined@...`), and `reportMissingVcsAccessToken` captures a Sentry exception (once per component instance) for the genuinely unexpected case. The known, already UI-surfaced cases (staff without a personal token; base-repository tokens with their own error handling) are intentionally excluded so this never becomes noise.

### Steps for Testing

Prerequisites:
- 1 Instructor **without** a personal VCS access token configured (User settings → VCS access tokens)
- 1 Exam with a Programming Exercise

1. Log in as the instructor.
2. Create a test run for the exam and conduct it for the programming exercise.
3. Finish/submit the test run and open its summary.
4. On the programming exercise, open the **Code** button and select the **Token** method.
5. Verify the clone URL contains a real token (`https://<login>:vcpat-…@…`) and **not** `:undefined@`, and that the "Copy" button is enabled and copies a working URL.
6. Optional regression check: as a second instructor, open the *other* instructor's submitted test run summary and confirm the clone still uses your personal staff token (create one first if needed) and shows the "create a token" hint when you have none — never `:undefined@`.

#### Exam Mode Testing

This change only affects the code/clone button rendered in the exam (test run) programming exercise summary; the exam conduction UI is unchanged.

Prerequisites:
- 1 Instructor
- 1 Exam with a Programming Exercise

1. Log in as the instructor and conduct a test run of the programming exercise.
2. Confirm the exam conduction UI of the programming exercise is unchanged.
3. Open the test run summary and confirm the Code button behaves as described above.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| code-button.component.ts | 93.84% | 476 | 131 | 27.5 |

_Last updated: 2026-07-18 10:54:05 UTC_

