### PR TITLE
`Development`: Fix admin sidebar visibility and page margins

### DIFF
--- a/src/main/webapp/app/app.routes.spec.ts
+++ b/src/main/webapp/app/app.routes.spec.ts
@@ -1,0 +1,20 @@
+import { Route } from '@angular/router';
+import routes from 'app/app.routes';
+
+describe('app.routes', () => {
+    function findRoute(path: string): Route | undefined {
+        return routes.find((route) => route.path === path);
+    }
+
+    describe('admin route layout', () => {
+        it('must NOT use the global module-background wrapper', () => {
+            // Regression guard (#admin sidebar/layout): the AdminContainerComponent is a self-contained layout that
+            // renders its own module-bg sidebar and content cards on the plain page background (like the course
+            // layouts). Wrapping it in the global `module-bg m-3 p-3` card again makes the sidebar blend into the
+            // wrapper (invisible) and adds excessive left/right margin. It must stay disabled for the admin section.
+            const adminRoute = findRoute('admin');
+            expect(adminRoute).toBeDefined();
+            expect(adminRoute?.data?.['usesModuleBackground']).toBe(false);
+        });
+    });
+});

--- a/src/main/webapp/app/app.routes.ts
+++ b/src/main/webapp/app/app.routes.ts
@@ -60,7 +60,11 @@ const routes: Routes = [
         path: 'admin',
         data: {
             authorities: IS_AT_LEAST_ADMIN,
-            usesModuleBackground: true,
+            // The AdminContainerComponent is a self-contained layout: it renders its own module-bg sidebar and
+            // module-bg content cards on the plain page background, exactly like the course layouts. It must NOT be
+            // wrapped in the global `module-bg m-3 p-3` card (usesModuleBackground) — that double background makes
+            // the sidebar (same module-bg) blend into the wrapper (invisible) and adds excessive left/right margin.
+            usesModuleBackground: false,
         },
         canActivate: [UserRouteAccessService, PasskeyAuthenticationGuard],
         loadChildren: () => import('app/admin/admin.routes'),


### PR DESCRIPTION
### Summary
Fixes a layout regression on **all admin pages**: the sidebar was not visible as a distinct panel and the content had excessive left/right margin (reported after #13229 was deployed to the test server).

### Root cause
The admin section renders a **self-contained** layout (`AdminContainerComponent`): it draws its *own* `module-bg` sidebar card and `module-bg` content card directly on the page background — exactly like the student/management course layouts (`course-base-container`).

The `admin` route also set `usesModuleBackground: true`, so the global app wrapper (`app.component.html`) added a **second** `module-bg m-3 p-3 rounded` card around the whole admin layout. That double background:
- made the sidebar (same `module-bg`) blend into the wrapper card → it looked invisible, and
- added the wrapper's margin + padding → excessive left/right margin.

Before the admin module's Bootstrap→Tailwind migration (#12963), `AdminContainerComponent` escaped this wrapper via `vw-100`; the migration dropped the escape, so the layout became trapped inside the wrapper.

### Solution
Set `usesModuleBackground: false` on the `admin` route so the self-contained admin layout sits directly on the page background — no double card. This matches the course layouts (both keep their own `module-bg` sidebar/content cards on the page background).

### How it now compares to the course layouts (measured at 1512px width)
| | Sidebar | Content body |
|---|---|---|
| **course-management** (reference) | left 0, width 220 | 228 → 1504 |
| **admin (after fix)** | left 0, width 220 | 228 → 1504 |

Identical geometry: sidebar flush-left at 220px, content filling the rest with the same small gaps.

### Steps for Testing
1. Log in as an admin.
2. Open any **Administration** page (e.g. Cleanup, Users, Health).
3. Confirm the sidebar is a distinct panel flush to the left (220px), the content fills the rest, and the left/right margins match a course page (**Course Management → any course**) and the student **course overview**.
4. Check both light and dark theme.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Client
- [x] I followed the client coding guidelines.
- [x] I verified the change visually in light and dark themes (sidebar flush-left, margins matching the course layouts).
- [x] Added a route-config regression guard (`app.routes.spec.ts`) so the admin section can't silently regress to the double-wrapper.

### Motivation and Context
The admin pages should look consistent with the student course sidebar and management course sidebar in margin, width, and appearance. This restores that consistency after the wrapper regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the admin area’s background layout to prevent duplicated or unwanted background styling.
  * Added a regression check to ensure the admin route does not use the global background wrapper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->