### PR TITLE
`General`: Refresh the profile picture after upload, edit, and delete

### DIFF
--- a/src/main/webapp/app/core/auth/account.service.spec.ts
+++ b/src/main/webapp/app/core/auth/account.service.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { SessionStorageService } from 'app/foundation/service/session-storage.service';
@@ -516,6 +517,50 @@ describe('AccountService', () => {
             url = accountService.getImageUrl();
 
             expect(url).toBe(`api/core/files/${expectedUrl}`);
+        });
+    });
+
+    describe('test setImageUrl', () => {
+        it('should emit a NEW identity reference so the signal notifies (upload / edit)', () => {
+            accountService.userIdentity.set({ login: 'user', imageUrl: 'old.png' } as User);
+            const before = accountService.userIdentity();
+
+            accountService.setImageUrl('new.png');
+
+            const after = accountService.userIdentity();
+            // A new reference is what makes the signal notify (Object.is); mutating in place would not refresh the UI.
+            expect(after).not.toBe(before);
+            expect(after?.imageUrl).toBe('new.png');
+            expect(after?.login).toBe('user');
+        });
+
+        it('should emit a NEW identity reference when clearing the image (delete)', () => {
+            accountService.userIdentity.set({ login: 'user', imageUrl: 'old.png' } as User);
+            const before = accountService.userIdentity();
+
+            accountService.setImageUrl(undefined);
+
+            const after = accountService.userIdentity();
+            expect(after).not.toBe(before);
+            expect(after?.imageUrl).toBeUndefined();
+        });
+
+        it('should trigger a dependent computed to recompute', () => {
+            accountService.userIdentity.set({ imageUrl: 'old.png' } as User);
+            const derived = computed(() => accountService.userIdentity()?.imageUrl);
+            expect(derived()).toBe('old.png');
+
+            accountService.setImageUrl('new.png');
+            expect(derived()).toBe('new.png');
+
+            accountService.setImageUrl(undefined);
+            expect(derived()).toBeUndefined();
+        });
+
+        it('should be a no-op when there is no user identity', () => {
+            accountService.userIdentity.set(undefined);
+            expect(() => accountService.setImageUrl('x.png')).not.toThrow();
+            expect(accountService.userIdentity()).toBeUndefined();
         });
     });
 

--- a/src/main/webapp/app/core/auth/account.service.spec.ts
+++ b/src/main/webapp/app/core/auth/account.service.spec.ts
@@ -998,6 +998,21 @@ describe('AccountService', () => {
             expect(accountService.userIdentity()?.memirisEnabled).toBe(true);
         });
 
+        it('should emit a NEW identity reference so the signal notifies', () => {
+            accountService.userIdentity.set({ id: 1, groups: ['USER'], memirisEnabled: false } as User);
+            const before = accountService.userIdentity();
+
+            accountService.setUserEnabledMemiris(true);
+            const req = httpMock.expectOne({ method: 'PUT', url: 'api/account/enable-memiris' });
+            req.flush({});
+
+            const after = accountService.userIdentity();
+            // A new reference is what makes the signal notify (Object.is); mutating in place would not refresh the UI.
+            expect(after).not.toBe(before);
+            expect(after?.memirisEnabled).toBe(true);
+            expect(after?.id).toBe(1);
+        });
+
         it('should not update user when user identity is undefined', () => {
             accountService.userIdentity.set(undefined);
 

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -318,8 +318,10 @@ export class AccountService implements IAccountService {
                 return currentUserIdentity;
             }
 
-            currentUserIdentity.imageUrl = url;
-            return currentUserIdentity;
+            // Return a NEW object rather than mutating in place: a signal compares with Object.is, so returning the
+            // same reference emits no notification and (under zoneless change detection) nothing re-renders — the
+            // account picture would not refresh after upload / edit / delete. Mirrors setUserLLMSelectionDecision.
+            return Object.assign({}, currentUserIdentity, { imageUrl: url });
         });
     }
 

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -423,8 +423,10 @@ export class AccountService implements IAccountService {
                         return currentUserIdentity;
                     }
 
-                    currentUserIdentity.memirisEnabled = memirisEnabled;
-                    return currentUserIdentity;
+                    // Return a NEW object rather than mutating in place: a signal compares with Object.is, so
+                    // returning the same reference emits no notification and (under zoneless change detection) any
+                    // dependent view would not react to the toggled setting. Mirrors setImageUrl / setUserLLMSelectionDecision.
+                    return Object.assign({}, currentUserIdentity, { memirisEnabled });
                 });
             },
             error: (_) => {},

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -13,6 +13,7 @@ import { Exercise, getCourseFromExercise } from 'app/exercise/shared/entities/ex
 import { Authority, IS_AT_LEAST_ADMIN, IS_AT_LEAST_SUPER_ADMIN, IS_AT_LEAST_TUTOR } from 'app/foundation/constants/authority.constants';
 import { TranslateService } from '@ngx-translate/core';
 import { EntityResponseType } from 'app/assessment/shared/services/complaint.service';
+import { deepClone } from 'app/foundation/util/deep-clone.util';
 import dayjs from 'dayjs/esm';
 import { addPublicFilePrefix } from 'app/app.constants';
 import { LLMSelectionDecision } from 'app/account/user/shared/dto/updateLLMSelectionDecision.dto';
@@ -320,8 +321,10 @@ export class AccountService implements IAccountService {
 
             // Return a NEW object rather than mutating in place: a signal compares with Object.is, so returning the
             // same reference emits no notification and (under zoneless change detection) nothing re-renders — the
-            // account picture would not refresh after upload / edit / delete. Mirrors setUserLLMSelectionDecision.
-            return Object.assign({}, currentUserIdentity, { imageUrl: url });
+            // account picture would not refresh after upload / edit / delete.
+            const updatedUserIdentity = deepClone(currentUserIdentity);
+            updatedUserIdentity.imageUrl = url;
+            return updatedUserIdentity;
         });
     }
 
@@ -425,8 +428,10 @@ export class AccountService implements IAccountService {
 
                     // Return a NEW object rather than mutating in place: a signal compares with Object.is, so
                     // returning the same reference emits no notification and (under zoneless change detection) any
-                    // dependent view would not react to the toggled setting. Mirrors setImageUrl / setUserLLMSelectionDecision.
-                    return Object.assign({}, currentUserIdentity, { memirisEnabled });
+                    // dependent view would not react to the toggled setting. Mirrors setImageUrl.
+                    const updatedUserIdentity = deepClone(currentUserIdentity);
+                    updatedUserIdentity.memirisEnabled = memirisEnabled;
+                    return updatedUserIdentity;
                 });
             },
             error: (_) => {},


### PR DESCRIPTION
### Summary
Fixes the account profile picture not updating automatically after uploading a new picture, replacing it, or deleting it (the page only refreshed after a manual reload), and fixes the identical latent bug in `setUserEnabledMemiris`.

### Root cause
Signal updaters in `AccountService` mutated the existing user object in place and returned the **same reference**:

```ts
this.userIdentity.update((currentUserIdentity) => {
    currentUserIdentity.imageUrl = url; // mutates in place
    return currentUserIdentity;         // same reference
});
```

A signal compares values with `Object.is`, so returning the same reference emits **no notification**. Under zoneless change detection nothing re-renders, so:
- the `account-information` template (`@if (currentUser(); as user)` → `<jhi-image [src]="…user.imageUrl…">`) never re-evaluated, and
- the `httpResource`-backed image component never refetched.

Upload/edit (`updateProfilePicture`) and delete (`deleteUserImage`) both call `setImageUrl`, so all three actions were affected. `setUserEnabledMemiris` had the same in-place-mutation pattern (same latent reactivity bug).

### Solution
Return a **new** object so the signal notifies its dependents, using `deepClone` (`app/foundation/util/deep-clone.util`) per the client guidelines (preferred over the spread operator / `Object.assign`; it also preserves the Day.js field on `User`):

```ts
const updatedUserIdentity = deepClone(currentUserIdentity);
updatedUserIdentity.imageUrl = url;
return updatedUserIdentity;
```

Applied to both `setImageUrl` and `setUserEnabledMemiris`.

### Testing
- Added reactivity regression tests to `account.service.spec.ts` for both methods: setting/clearing emits a **new identity reference**, and a dependent `computed` recomputes. These **fail** against the old in-place mutation and pass with the fix. (The pre-existing tests only asserted the resulting value, which mutation also satisfies — which is why the reactivity bug slipped through.)
- **Verified live in the running app** (logged in as admin, `/user-settings/account`): calling `setImageUrl(url)` reactively re-renders the picture branch (the image component fetches the new URL and its load result flows back through `onImageLoadingStatus`), and `setImageUrl(undefined)` clears it — all without a page reload. None of that chain fires with the old code.
- All 140 `account.service` tests pass; ESLint / Prettier clean; `tsc` (app + spec, strict) 0 errors.

### Steps for Testing
1. Log in, open **Account → Account information**.
2. Upload a new profile picture (crop + confirm) → the picture updates immediately, no reload.
3. Replace it with a different picture → updates immediately.
4. Delete the picture → it disappears immediately.
5. Check light and dark theme.

### Client
- [x] I followed the client coding guidelines (signal-safe update via `deepClone`, no spread operator / `Object.assign`).
- [x] Added regression tests that fail without the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile image updates so the UI refreshes immediately when the image URL is set or cleared.
  * Fixed memiris enable/disable updates to reliably propagate to dependent reactive UI.
  * Ensures updates safely no-op when no signed-in identity is available.
* **Tests**
  * Added assertions verifying reactive recomputation and new identity references for `setImageUrl(...)` and `setUserEnabledMemiris(...)`, including the no-identity case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->