### PR TITLE
`Development`: Remove the transactional scope from programming exercise import

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
@@ -59,23 +59,6 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
             "submissionPolicy", "buildConfig" })
     Optional<ProgrammingExercise> findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesAndBuildConfigById(long exerciseId);
 
-    @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation", "teamAssignmentConfig", "categories", "auxiliaryRepositories",
-            "submissionPolicy", "buildConfig", "gradingCriteria", "gradingCriteria.structuredGradingInstructions" })
-    Optional<ProgrammingExercise> findWithImportRelevantReferencesById(long exerciseId);
-
-    /**
-     * Fetches a programming exercise with the associations that the import result carries: template and solution
-     * participation, team assignment config, categories, auxiliary repositories, submission policy, build config and
-     * grading criteria (with their structured instructions). Used to return a fully initialized exercise from the import,
-     * which runs without an open session. Throws if the exercise does not exist.
-     *
-     * @param exerciseId the id of the imported programming exercise
-     * @return the programming exercise with the import-relevant associations initialized
-     */
-    default ProgrammingExercise findWithImportRelevantReferencesByIdElseThrow(long exerciseId) {
-        return getValueElseThrow(findWithImportRelevantReferencesById(exerciseId), exerciseId);
-    }
-
     @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation", "teamAssignmentConfig", "categories", "competencyLinks.competency",
             "auxiliaryRepositories", "submissionPolicy" })
     Optional<ProgrammingExercise> findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesAndCompetenciesById(long exerciseId);
@@ -105,7 +88,8 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
     Optional<Integer> findBuildTimeoutSecondsByExerciseId(@Param("exerciseId") long exerciseId);
 
     @EntityGraph(type = LOAD, attributePaths = { "categories", "teamAssignmentConfig", "templateParticipation.submissions.results", "solutionParticipation.submissions.results",
-            "auxiliaryRepositories", "plagiarismDetectionConfig", "templateParticipation", "solutionParticipation", "buildConfig" })
+            "auxiliaryRepositories", "plagiarismDetectionConfig", "templateParticipation", "solutionParticipation", "buildConfig", "submissionPolicy", "gradingCriteria",
+            "gradingCriteria.structuredGradingInstructions" })
     Optional<ProgrammingExercise> findForCreationById(long exerciseId);
 
     @EntityGraph(type = LOAD, attributePaths = "testCases")
@@ -933,7 +917,11 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
     }
 
     /**
-     * Find a programming exercise by its id, with eagerly loaded objects required for the creation of a programming exercise.
+     * Finds a programming exercise by its id, eagerly loading the associations that make up a freshly created (or
+     * imported) exercise: template and solution participation, team assignment config, categories, auxiliary
+     * repositories, plagiarism detection config, build config, submission policy and grading criteria (with their
+     * structured instructions). This is used to return a fully initialized exercise after creation or import, both of
+     * which run without an open session and would otherwise expose uninitialized proxies.
      *
      * @param programmingExerciseId of the programming exercise.
      * @return The programming exercise related to the given id

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
@@ -59,6 +59,23 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
             "submissionPolicy", "buildConfig" })
     Optional<ProgrammingExercise> findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesAndBuildConfigById(long exerciseId);
 
+    @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation", "teamAssignmentConfig", "categories", "auxiliaryRepositories",
+            "submissionPolicy", "buildConfig", "gradingCriteria", "gradingCriteria.structuredGradingInstructions" })
+    Optional<ProgrammingExercise> findWithImportRelevantReferencesById(long exerciseId);
+
+    /**
+     * Fetches a programming exercise with the associations that the import result carries: template and solution
+     * participation, team assignment config, categories, auxiliary repositories, submission policy, build config and
+     * grading criteria (with their structured instructions). Used to return a fully initialized exercise from the import,
+     * which runs without an open session. Throws if the exercise does not exist.
+     *
+     * @param exerciseId the id of the imported programming exercise
+     * @return the programming exercise with the import-relevant associations initialized
+     */
+    default ProgrammingExercise findWithImportRelevantReferencesByIdElseThrow(long exerciseId) {
+        return getValueElseThrow(findWithImportRelevantReferencesById(exerciseId), exerciseId);
+    }
+
     @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation", "teamAssignmentConfig", "categories", "competencyLinks.competency",
             "auxiliaryRepositories", "submissionPolicy" })
     Optional<ProgrammingExercise> findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesAndCompetenciesById(long exerciseId);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportBasicService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportBasicService.java
@@ -20,7 +20,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
 import de.tum.cit.aet.artemis.assessment.domain.GradingInstruction;
@@ -67,8 +66,6 @@ public class ProgrammingExerciseImportBasicService {
 
     private final ProgrammingExerciseBuildConfigRepository programmingExerciseBuildConfigRepository;
 
-    private final ProgrammingExerciseCreationUpdateService programmingExerciseCreationUpdateService;
-
     private final StaticCodeAnalysisService staticCodeAnalysisService;
 
     private final AuxiliaryRepositoryRepository auxiliaryRepositoryRepository;
@@ -90,8 +87,7 @@ public class ProgrammingExerciseImportBasicService {
     public ProgrammingExerciseImportBasicService(Optional<VersionControlService> versionControlService,
             ProgrammingExerciseParticipationService programmingExerciseParticipationService, ProgrammingExerciseTestCaseRepository programmingExerciseTestCaseRepository,
             StaticCodeAnalysisCategoryRepository staticCodeAnalysisCategoryRepository, ProgrammingExerciseRepository programmingExerciseRepository,
-            ProgrammingExerciseCreationUpdateService programmingExerciseCreationUpdateService, StaticCodeAnalysisService staticCodeAnalysisService,
-            AuxiliaryRepositoryRepository auxiliaryRepositoryRepository, SubmissionPolicyRepository submissionPolicyRepository,
+            StaticCodeAnalysisService staticCodeAnalysisService, AuxiliaryRepositoryRepository auxiliaryRepositoryRepository, SubmissionPolicyRepository submissionPolicyRepository,
             ProgrammingExerciseRepositoryService programmingExerciseRepositoryService, ProgrammingExerciseTaskRepository programmingExerciseTaskRepository,
             ProgrammingExerciseTaskService programmingExerciseTaskService, UriService uriService, ChannelService channelService,
             ProgrammingExerciseBuildConfigRepository programmingExerciseBuildConfigRepository, CompetencyExerciseLinkService competencyExerciseLinkService) {
@@ -100,7 +96,6 @@ public class ProgrammingExerciseImportBasicService {
         this.programmingExerciseTestCaseRepository = programmingExerciseTestCaseRepository;
         this.staticCodeAnalysisCategoryRepository = staticCodeAnalysisCategoryRepository;
         this.programmingExerciseRepository = programmingExerciseRepository;
-        this.programmingExerciseCreationUpdateService = programmingExerciseCreationUpdateService;
         this.staticCodeAnalysisService = staticCodeAnalysisService;
         this.auxiliaryRepositoryRepository = auxiliaryRepositoryRepository;
         this.submissionPolicyRepository = submissionPolicyRepository;
@@ -114,139 +109,147 @@ public class ProgrammingExerciseImportBasicService {
     }
 
     /**
-     * Imports a programming exercise creating a new entity, copying all basic
-     * values and saving it in the database.
-     * All basic include everything except for repositories, or build plans on a
-     * remote version control server, or
-     * continuous integration server. <br>
-     * There are however, a couple of things that will never get copied:
+     * Imports a programming exercise by creating a new entity, copying all basic values from the source exercise and
+     * saving it in the database. "Basic" covers everything except the actual repositories and build plans on the version
+     * control and continuous integration servers, which are created by the calling import service afterwards.
+     * <p>
+     * The following are deliberately never copied from the source:
      * <ul>
-     * <li>The ID</li>
-     * <li>The template and solution participation</li>
+     * <li>The id</li>
+     * <li>The template and solution participation (fresh ones are created)</li>
      * <li>The number of complaints, assessments and more feedback requests</li>
-     * <li>The tutor/student participations</li>
+     * <li>The tutor and student participations</li>
      * <li>The questions asked by students</li>
      * <li>The example submissions</li>
      * </ul>
+     * The method runs without an enclosing transaction: every entity it references is fetched and persisted explicitly,
+     * in an order that respects the foreign keys the exercise owns (build config and submission policy first, then the
+     * exercise, then its participations, test cases and tasks).
      *
-     * @param sourceExercise The template exercise which should get
-     *                           imported
-     * @param newExercise    The new exercise already containing values
-     *                           which should not get copied, i.e.
-     *                           overwritten
-     * @return The newly created exercise
+     * @param sourceExercise the source exercise providing the data to copy into the new exercise
+     * @param newExercise    the new exercise (potentially already carrying caller-provided overrides) to be persisted
+     * @return the newly created exercise, re-fetched with its import-relevant associations initialized
      */
-    @Transactional // TODO: NOT OK --> apply the transaction on a smaller scope
-    // IMPORTANT: the transactional context only works if you invoke this method
-    // from another class
-    public ProgrammingExercise importProgrammingExerciseBasis(final ProgrammingExercise sourceExercise, final ProgrammingExercise newExercise) {
+    public ProgrammingExercise importProgrammingExerciseBasis(final ProgrammingExercise sourceExercise, ProgrammingExercise newExercise) {
+
         prepareBasicExerciseInformation(sourceExercise, newExercise);
 
-        // Note: same order as when creating an exercise
+        // The exercise owns the foreign keys to its build config and submission policy, so both must be persisted before
+        // the exercise is first saved (otherwise the flush references transient entities). Set the branch and reuse the
+        // source build plan configuration if the caller did not provide one, then persist the build config.
+        newExercise.getBuildConfig().setBranch(defaultBranch);
+        if (newExercise.getBuildConfig().getBuildPlanConfiguration() == null) {
+            newExercise.getBuildConfig().setBuildPlanConfiguration(sourceExercise.getBuildConfig().getBuildPlanConfiguration());
+        }
+        newExercise.setBuildConfig(programmingExerciseBuildConfigRepository.save(newExercise.getBuildConfig()));
+
+        // Persist the submission policy (as a fresh entity) up front for the same reason.
+        importSubmissionPolicy(newExercise);
+
+        // Deep-copy the grading criteria from the source. They are cascaded (CascadeType.ALL) when the exercise is saved
+        // below, so no separate save is needed.
+        copyGradingCriteria(sourceExercise, newExercise);
+
+        // Persist the exercise once (cascading the grading criteria) so that the template and solution participations,
+        // the test cases and the tasks created below can reference it. Competency links are added afterwards because they
+        // must point at the persisted exercise.
+        var competencyLinks = competencyExerciseLinkService.extractCompetencyLinksForCreation(newExercise);
+        newExercise = programmingExerciseRepository.save(newExercise);
+        if (!competencyLinks.isEmpty()) {
+            competencyExerciseLinkService.addCompetencyLinksForCreation(newExercise, competencyLinks);
+            newExercise = programmingExerciseRepository.save(newExercise);
+        }
+
+        // Set up the template and solution participations (they reference the now-persisted exercise). Same order as when
+        // creating an exercise.
         programmingExerciseParticipationService.setupInitialTemplateParticipation(newExercise);
         programmingExerciseParticipationService.setupInitialSolutionParticipation(newExercise);
         setupTestRepository(newExercise);
-        programmingExerciseCreationUpdateService.initParticipations(newExercise);
 
-        newExercise.getBuildConfig().setBranch(defaultBranch);
-        if (newExercise.getBuildConfig().getBuildPlanConfiguration() == null) {
-            // this means the user did not override the build plan config when importing the
-            // exercise and want to reuse it from the existing exercise
-            newExercise.getBuildConfig().setBuildPlanConfiguration(sourceExercise.getBuildConfig().getBuildPlanConfiguration());
+        // Copy the test cases, then the tasks. Tasks reference the newly created test cases via the returned id mapping.
+        final Map<Long, Long> newTestCaseIdByOldId = importTestCases(sourceExercise, newExercise);
+        importTasks(sourceExercise, newExercise, newTestCaseIdByOldId);
+
+        // The problem statement cannot be edited during import, so copy it from the source and remap the test ids it
+        // embeds to the newly created ones.
+        newExercise.setProblemStatement(sourceExercise.getProblemStatement());
+        programmingExerciseTaskService.updateTestIds(newExercise, newTestCaseIdByOldId);
+
+        // Static code analysis categories: copy them from the source when both exercises use SCA, otherwise create the
+        // default categories for the new exercise.
+        if (Boolean.TRUE.equals(newExercise.isStaticCodeAnalysisEnabled()) && Boolean.TRUE.equals(sourceExercise.isStaticCodeAnalysisEnabled())) {
+            importStaticCodeAnalysisCategories(sourceExercise, newExercise);
+        }
+        else if (Boolean.TRUE.equals(newExercise.isStaticCodeAnalysisEnabled())) {
+            staticCodeAnalysisService.createDefaultCategories(newExercise);
         }
 
-        // Hints, tasks, test cases and static code analysis categories
-        newExercise.setBuildConfig(programmingExerciseBuildConfigRepository.save(newExercise.getBuildConfig()));
-
-        Set<GradingCriterion> oldCriteria = sourceExercise.getGradingCriteria();
-        if (oldCriteria != null) {
-            for (GradingCriterion oldCriterion : oldCriteria) {
-                // 1) Create and copy a new GradingCriterion
-                GradingCriterion copyCriterion = new GradingCriterion();
-                copyCriterion.setId(null); // ensure Hibernate treats it as new
-                copyCriterion.setTitle(oldCriterion.getTitle());
-                copyCriterion.setExercise(newExercise);
-
-                // 2) Copy each GradingInstruction (but skip feedbacks)
-                for (GradingInstruction oldInstr : oldCriterion.getStructuredGradingInstructions()) {
-                    GradingInstruction copyInstr = new GradingInstruction();
-                    copyInstr.setId(null);
-                    copyInstr.setCredits(oldInstr.getCredits());
-                    copyInstr.setGradingScale(oldInstr.getGradingScale());
-                    copyInstr.setInstructionDescription(oldInstr.getInstructionDescription());
-                    copyInstr.setFeedback(oldInstr.getFeedback());
-                    copyInstr.setUsageCount(oldInstr.getUsageCount());
-                    // do NOT copy oldInstr.getFeedbacks()
-
-                    // Link the new instruction to its parent:
-                    copyCriterion.addStructuredGradingInstruction(copyInstr);
-                }
-
-                // 3) Add the newly built criterion into the new exercise
-                newExercise.getGradingCriteria().add(copyCriterion);
-            }
+        // Exam exercises are always individual and must not carry a team assignment configuration.
+        if (newExercise.isExamExercise()) {
+            newExercise.setMode(ExerciseMode.INDIVIDUAL);
+            newExercise.setTeamAssignmentConfig(null);
         }
 
-        var competencyLinks = competencyExerciseLinkService.extractCompetencyLinksForCreation(newExercise);
-        ProgrammingExercise savedExercise = programmingExerciseRepository.save(newExercise);
-        if (!competencyLinks.isEmpty()) {
-            competencyExerciseLinkService.addCompetencyLinksForCreation(savedExercise, competencyLinks);
-            savedExercise = programmingExerciseRepository.save(savedExercise);
-        }
-
-        final Map<Long, Long> newTestCaseIdByOldId = importTestCases(sourceExercise, savedExercise);
-        importTasks(sourceExercise, savedExercise, newTestCaseIdByOldId);
-
-        // Set up new exercise submission policy before the solution entries are
-        // imported
-        importSubmissionPolicy(savedExercise);
-        // Having the submission policy in place prevents errors
-
-        // Use the template problem statement (with ids) as a new basis (You cannot edit
-        // the problem statement while importing)
-        // Then replace the old test ids by the newly created ones.
-        savedExercise.setProblemStatement(sourceExercise.getProblemStatement());
-        programmingExerciseTaskService.updateTestIds(savedExercise, newTestCaseIdByOldId);
-
-        // Copy or create SCA categories
-        if (Boolean.TRUE.equals(savedExercise.isStaticCodeAnalysisEnabled()) && Boolean.TRUE.equals(sourceExercise.isStaticCodeAnalysisEnabled())) {
-            importStaticCodeAnalysisCategories(sourceExercise, savedExercise);
-        }
-        else if (Boolean.TRUE.equals(savedExercise.isStaticCodeAnalysisEnabled()) && !Boolean.TRUE.equals(sourceExercise.isStaticCodeAnalysisEnabled())) {
-            staticCodeAnalysisService.createDefaultCategories(savedExercise);
-        }
-
-        // An exam exercise can only be in individual mode
-        if (savedExercise.isExamExercise()) {
-            savedExercise.setMode(ExerciseMode.INDIVIDUAL);
-            savedExercise.setTeamAssignmentConfig(null);
-        }
-
-        // Re-adding auxiliary repositories
-        final List<AuxiliaryRepository> auxiliaryRepositoriesToBeImported = sourceExercise.getAuxiliaryRepositories();
-
-        for (AuxiliaryRepository auxiliaryRepository : auxiliaryRepositoriesToBeImported) {
+        // Copy the auxiliary repositories.
+        for (AuxiliaryRepository auxiliaryRepository : sourceExercise.getAuxiliaryRepositories()) {
             AuxiliaryRepository newAuxiliaryRepository = auxiliaryRepository.cloneObjectForNewExercise();
             newAuxiliaryRepository = auxiliaryRepositoryRepository.save(newAuxiliaryRepository);
-            savedExercise.addAuxiliaryRepository(newAuxiliaryRepository);
+            newExercise.addAuxiliaryRepository(newAuxiliaryRepository);
         }
 
-        ProgrammingExercise persistedExercise = programmingExerciseRepository.save(savedExercise);
+        // Final save: persists the participation references, the remapped problem statement, the test repository uri and
+        // the auxiliary repositories set above.
+        newExercise = programmingExerciseRepository.save(newExercise);
 
-        channelService.createExerciseChannel(persistedExercise, Optional.ofNullable(newExercise.getChannelName()));
+        channelService.createExerciseChannel(newExercise, Optional.ofNullable(newExercise.getChannelName()));
 
-        return persistedExercise;
+        // This method runs without an open session, so the returned exercise must carry the associations its consumers
+        // (the surrounding import flow, the API callers and the serialized response) read, rather than relying on lazy
+        // proxies. Re-fetch it with the participations, build config, submission policy, grading criteria and auxiliary
+        // repositories explicitly initialized.
+        return programmingExerciseRepository.findWithImportRelevantReferencesByIdElseThrow(newExercise.getId());
     }
 
     /**
-     * Prepares information directly stored in the exercise for the copy process.
-     * <p>
-     * Replaces attributes in the new exercise that should not be copied from the
-     * previous one.
+     * Deep-copies the grading criteria (with their structured grading instructions) from the source exercise onto the new
+     * exercise. Each copy is a fresh entity (id cleared) linked to {@code newExercise}, so the copies are persisted via
+     * cascade when the exercise is saved. Feedback attached to the source instructions is intentionally not copied, since
+     * the imported exercise starts without assessments.
      *
-     * @param sourceExercise Some exercise the information is copied
-     *                           from.
-     * @param newExercise    The exercise that is prepared.
+     * @param sourceExercise the exercise whose grading criteria are copied
+     * @param newExercise    the exercise the copied grading criteria are attached to
+     */
+    private void copyGradingCriteria(final ProgrammingExercise sourceExercise, final ProgrammingExercise newExercise) {
+        Set<GradingCriterion> sourceCriteria = sourceExercise.getGradingCriteria();
+        if (sourceCriteria == null) {
+            return;
+        }
+        for (GradingCriterion sourceCriterion : sourceCriteria) {
+            GradingCriterion criterionCopy = new GradingCriterion();
+            criterionCopy.setId(null);
+            criterionCopy.setTitle(sourceCriterion.getTitle());
+            criterionCopy.setExercise(newExercise);
+            for (GradingInstruction sourceInstruction : sourceCriterion.getStructuredGradingInstructions()) {
+                GradingInstruction instructionCopy = new GradingInstruction();
+                instructionCopy.setId(null);
+                instructionCopy.setCredits(sourceInstruction.getCredits());
+                instructionCopy.setGradingScale(sourceInstruction.getGradingScale());
+                instructionCopy.setInstructionDescription(sourceInstruction.getInstructionDescription());
+                instructionCopy.setFeedback(sourceInstruction.getFeedback());
+                instructionCopy.setUsageCount(sourceInstruction.getUsageCount());
+                criterionCopy.addStructuredGradingInstruction(instructionCopy);
+            }
+            newExercise.getGradingCriteria().add(criterionCopy);
+        }
+    }
+
+    /**
+     * Resets the attributes on {@code newExercise} that must not be carried over from the source exercise (id, build
+     * config identity, participations, etc.) so it can be persisted as a brand-new exercise, and copies the build plan
+     * access secret setting from the source.
+     *
+     * @param sourceExercise the exercise being imported from
+     * @param newExercise    the exercise being prepared for persistence
      */
     private void prepareBasicExerciseInformation(final ProgrammingExercise sourceExercise, final ProgrammingExercise newExercise) {
         // Set values we don't want to copy to null
@@ -259,17 +262,24 @@ public class ProgrammingExerciseImportBasicService {
     }
 
     /**
-     * Sets up the test repository for a new exercise by setting the repository URI.
-     * This does not create the actual
-     * repository on the version control server!
+     * Sets the test repository URI on the new exercise. This only computes and stores the URI; it does not create the
+     * actual repository on the version control server.
      *
-     * @param newExercise the new exercises that should be created during import
+     * @param newExercise the exercise being imported
      */
     private void setupTestRepository(ProgrammingExercise newExercise) {
         final var testRepoName = newExercise.generateRepositoryName(RepositoryType.TESTS);
         newExercise.setTestRepositoryUri(versionControlService.orElseThrow().getCloneRepositoryUri(newExercise.getProjectKey(), testRepoName).toString());
     }
 
+    /**
+     * Prepares the build config of the new exercise so that it can be persisted as a fresh entity. When the caller
+     * already supplied a build config (e.g. the user overrode it during import) its id and back-reference are cleared;
+     * otherwise the config is copied from the source exercise, or a default config is created if the source has none.
+     *
+     * @param newExercise      the exercise being imported
+     * @param originalExercise the source exercise providing the fallback build config
+     */
     private void setupBuildConfig(ProgrammingExercise newExercise, ProgrammingExercise originalExercise) {
         if (newExercise.getBuildConfig() != null) {
             var buildConfig = newExercise.getBuildConfig();
@@ -287,11 +297,10 @@ public class ProgrammingExerciseImportBasicService {
     }
 
     /**
-     * Persists the submission policy of the new exercise. We ensure that the
-     * submission policy does not
-     * have any id or programming exercise set.
+     * Persists the submission policy of the new exercise as a fresh entity. Its id and back-reference to the programming
+     * exercise are cleared first so that it is inserted rather than updating the source exercise's policy.
      *
-     * @param newExercise containing the submission policy to persist
+     * @param newExercise the exercise whose submission policy is persisted (no-op if it has none)
      */
     private void importSubmissionPolicy(ProgrammingExercise newExercise) {
         if (newExercise.getSubmissionPolicy() != null) {
@@ -303,16 +312,12 @@ public class ProgrammingExerciseImportBasicService {
     }
 
     /**
-     * Copied test cases from one exercise to another. The test cases will get new
-     * IDs, thus being saved as a new entity.
-     * The remaining contents stay the same, especially the weights.
+     * Copies the test cases from the source exercise to the target exercise. Each copy is persisted as a new entity (new
+     * id); all other values, in particular the weights, are preserved.
      *
-     * @param templateExercise The template exercise which test cases should get
-     *                             copied
-     * @param targetExercise   The new exercise to which all test cases should get
-     *                             copied to
-     * @return A map with the old test case id as a key and the new test case id as
-     *         value
+     * @param templateExercise the source exercise whose test cases are copied
+     * @param targetExercise   the exercise the copied test cases are attached to
+     * @return a map from each source test case id to the id of its newly created copy
      */
     private Map<Long, Long> importTestCases(final ProgrammingExercise templateExercise, final ProgrammingExercise targetExercise) {
         Map<Long, Long> newIdByOldId = new HashMap<>();
@@ -337,34 +342,26 @@ public class ProgrammingExerciseImportBasicService {
     }
 
     /**
-     * Imports tasks from a template exercise to a new exercise. The tasks will get
-     * new IDs, thus being saved as a new entity.
-     * The remaining contents stay the same, especially the test cases.
+     * Copies the tasks from the source exercise to the target exercise. Each copy is persisted as a new entity (new id)
+     * and is linked to the test cases that were already copied to the target exercise.
      *
-     * @param sourceExercise    The template exercise which tasks should get copied
-     * @param targetExercise    The new exercise to which all tasks should get
-     *                              copied to
-     * @param testCaseIdMapping A map with the old test case id as a key and the new
-     *                              test case id as a value
+     * @param sourceExercise    the source exercise whose tasks are copied
+     * @param targetExercise    the exercise the copied tasks are attached to
+     * @param testCaseIdMapping a map from each source test case id to the id of its copy (see {@link #importTestCases})
      */
     private void importTasks(final ProgrammingExercise sourceExercise, final ProgrammingExercise targetExercise, Map<Long, Long> testCaseIdMapping) {
-        // Map the tasks from the template exercise to new tasks in the target exercise
-        List<ProgrammingExerciseTask> newTasks = sourceExercise.getTasks().stream().map(templateTask -> createTaskCopy(templateTask, targetExercise, testCaseIdMapping)).toList();
-
-        // Set the new tasks to the target exercise
+        List<ProgrammingExerciseTask> newTasks = sourceExercise.getTasks().stream().map(sourceTask -> createTaskCopy(sourceTask, targetExercise, testCaseIdMapping)).toList();
         targetExercise.setTasks(new ArrayList<>(newTasks));
     }
 
     /**
-     * Creates a copy of a task from a template exercise and links it to the target
-     * exercise. The test cases of the task
-     * are also copied and linked to the new task.
+     * Creates a copy of a single task, links it to the target exercise, and attaches the target exercise's copies of the
+     * task's test cases.
      *
-     * @param sourceTask        The template task which should be copied
-     * @param targetExercise    The new exercise to which the task should be linked
-     * @param testCaseIdMapping A map with the old test case id as a key and the new
-     *                              test case id as a value
-     * @return The new task
+     * @param sourceTask        the task to copy
+     * @param targetExercise    the exercise the copied task is linked to
+     * @param testCaseIdMapping a map from each source test case id to the id of its copy (see {@link #importTestCases})
+     * @return the newly created task
      */
     private ProgrammingExerciseTask createTaskCopy(ProgrammingExerciseTask sourceTask, ProgrammingExercise targetExercise, Map<Long, Long> testCaseIdMapping) {
         ProgrammingExerciseTask copiedTask = new ProgrammingExerciseTask();
@@ -386,15 +383,12 @@ public class ProgrammingExerciseImportBasicService {
     }
 
     /**
-     * Finds a test case in the target exercise that corresponds to a test case in
-     * the template exercise.
+     * Resolves the target exercise's copy of a source test case via the id mapping.
      *
-     * @param existingTestCase  The test case from the template exercise
-     * @param targetExercise    The new exercise to which the test case should be
-     *                              linked
-     * @param testCaseIdMapping A map with the old test case id as a key and the new
-     *                              test case id as a value
-     * @return The test case in the target exercise
+     * @param existingTestCase  the test case from the source exercise
+     * @param targetExercise    the exercise holding the copied test cases
+     * @param testCaseIdMapping a map from each source test case id to the id of its copy (see {@link #importTestCases})
+     * @return the corresponding test case in the target exercise
      */
     private ProgrammingExerciseTestCase findMappedTestCase(ProgrammingExerciseTestCase existingTestCase, ProgrammingExercise targetExercise, Map<Long, Long> testCaseIdMapping) {
         Long newTestCaseId = testCaseIdMapping.get(existingTestCase.getId());
@@ -404,14 +398,11 @@ public class ProgrammingExerciseImportBasicService {
     }
 
     /**
-     * Copies static code analysis categories from one exercise to another by
-     * creating new entities and copying the
-     * appropriate fields.
+     * Copies the static code analysis categories from the source exercise to the target exercise. Each category is
+     * persisted as a new entity linked to the target exercise.
      *
-     * @param templateExercise with static code analysis categories which should get
-     *                             copied
-     * @param targetExercise   for which static code analysis categories will be
-     *                             copied
+     * @param templateExercise the source exercise whose static code analysis categories are copied
+     * @param targetExercise   the exercise the copied categories are attached to
      */
     private void importStaticCodeAnalysisCategories(final ProgrammingExercise templateExercise, final ProgrammingExercise targetExercise) {
         if (targetExercise.getStaticCodeAnalysisCategories() == null) {
@@ -432,13 +423,12 @@ public class ProgrammingExerciseImportBasicService {
     }
 
     /**
-     * Sets up a new exercise for importing it by setting all values, that should
-     * either never get imported, or
-     * for which we should create new entities (e.g. test cases) to null. This
-     * ensures that we do not copy
-     * anything by accident.
+     * Clears the values that must not be carried over when the new exercise is persisted: identifiers, participations,
+     * statistics counters, and the collections for which fresh entities are created later (e.g. test cases). This
+     * ensures nothing from the source is copied by accident. Team assignment and plagiarism configs are reset or
+     * defaulted depending on whether the exercise belongs to a course or an exam.
      *
-     * @param newExercise the new exercises that should be created during import
+     * @param newExercise the exercise being prepared for persistence
      */
     private void setupExerciseForImport(ProgrammingExercise newExercise) {
         newExercise.setId(null);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportBasicService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportBasicService.java
@@ -197,17 +197,16 @@ public class ProgrammingExerciseImportBasicService {
             newExercise.addAuxiliaryRepository(newAuxiliaryRepository);
         }
 
-        // Final save: persists the participation references, the remapped problem statement, the test repository uri and
-        // the auxiliary repositories set above.
-        newExercise = programmingExerciseRepository.save(newExercise);
+        // Final save persisting the participation references, the remapped problem statement, the test repository uri
+        // and the auxiliary repositories set above. This runs without an open session, so the returned exercise must
+        // carry the associations its consumers (the surrounding import flow and the serialized response) read rather
+        // than relying on lazy proxies. saveForCreation re-fetches the complete new-exercise graph for exactly this
+        // reason, so we reuse it here (the import produces a new exercise just like a regular creation).
+        newExercise = programmingExerciseRepository.saveForCreation(newExercise);
 
         channelService.createExerciseChannel(newExercise, Optional.ofNullable(newExercise.getChannelName()));
 
-        // This method runs without an open session, so the returned exercise must carry the associations its consumers
-        // (the surrounding import flow, the API callers and the serialized response) read, rather than relying on lazy
-        // proxies. Re-fetch it with the participations, build config, submission policy, grading criteria and auxiliary
-        // repositories explicitly initialized.
-        return programmingExerciseRepository.findWithImportRelevantReferencesByIdElseThrow(newExercise.getId());
+        return newExercise;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseParticipationService.java
@@ -28,6 +28,7 @@ import de.tum.cit.aet.artemis.assessment.repository.ResultRepository;
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
 import de.tum.cit.aet.artemis.core.security.SecurityUtils;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
+import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
 import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
@@ -205,6 +206,8 @@ public class ProgrammingExerciseParticipationService {
         solutionParticipation.setBuildPlanId(newExercise.generateBuildPlanId(BuildPlanType.SOLUTION));
         solutionParticipation.setRepositoryUri(versionControlService.orElseThrow().getCloneRepositoryUri(newExercise.getProjectKey(), solutionRepoName).toString());
         solutionParticipation.setProgrammingExercise(newExercise);
+        solutionParticipation.setInitializationState(InitializationState.INITIALIZED);
+        solutionParticipation.setInitializationDate(ZonedDateTime.now());
         solutionParticipationRepository.save(solutionParticipation);
     }
 
@@ -219,6 +222,8 @@ public class ProgrammingExerciseParticipationService {
         TemplateProgrammingExerciseParticipation templateParticipation = new TemplateProgrammingExerciseParticipation();
         templateParticipation.setBuildPlanId(newExercise.generateBuildPlanId(BuildPlanType.TEMPLATE));
         templateParticipation.setRepositoryUri(versionControlService.orElseThrow().getCloneRepositoryUri(newExercise.getProjectKey(), exerciseRepoName).toString());
+        templateParticipation.setInitializationState(InitializationState.INITIALIZED);
+        templateParticipation.setInitializationDate(ZonedDateTime.now());
         templateParticipation.setProgrammingExercise(newExercise);
         newExercise.setTemplateParticipation(templateParticipation);
         templateParticipationRepository.save(templateParticipation);

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
@@ -50,6 +50,7 @@ import de.tum.cit.aet.artemis.core.util.CourseUtilService;
 import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.exam.util.InvalidExamExerciseDatesArgumentProvider;
 import de.tum.cit.aet.artemis.exam.util.InvalidExamExerciseDatesArgumentProvider.InvalidExamExerciseDateConfiguration;
+import de.tum.cit.aet.artemis.exercise.domain.InitializationState;
 import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
 import de.tum.cit.aet.artemis.globalsearch.config.schema.entityschemas.SearchableEntitySchema;
 import de.tum.cit.aet.artemis.globalsearch.dto.searchableentity.ExerciseSearchableEntityDTO;
@@ -482,6 +483,55 @@ class ProgrammingExerciseLocalVCLocalCIIntegrationTest extends AbstractProgrammi
         verify(competencyProgressApi).updateProgressByLearningObjectAsync(eq(importedExercise));
 
         assertProgrammingExerciseExistsInWeaviate(weaviateService, importedExercise);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testImportProgrammingExercise_initializesParticipationsAndClonesReferences() throws Exception {
+        // Stub the LocalCI build container reads. The git repositories themselves are real (LocalVC) and are not mocked.
+        dockerClientTestService.mockInputStreamReturnedFromContainer(dockerClient, LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + "/testing-dir/assignment/.git/refs/heads/[^/]+",
+                Map.of("assignmentComitHash", DUMMY_COMMIT_HASH), Map.of("assignmentComitHash", DUMMY_COMMIT_HASH));
+        dockerClientTestService.mockInputStreamReturnedFromContainer(dockerClient, LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + "/testing-dir/.git/refs/heads/[^/]+",
+                Map.of("testsCommitHash", DUMMY_COMMIT_HASH), Map.of("testsCommitHash", DUMMY_COMMIT_HASH));
+        dockerClientTestService.mockInspectImage(dockerClient);
+        Map<String, String> templateBuildTestResults = dockerClientTestService.createMapFromTestResultsFolder(ALL_FAIL_TEST_RESULTS_PATH);
+        Map<String, String> solutionBuildTestResults = dockerClientTestService.createMapFromTestResultsFolder(ALL_SUCCEED_TEST_RESULTS_PATH);
+        dockerClientTestService.mockInputStreamReturnedFromContainer(dockerClient, LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY + LOCAL_CI_RESULTS_DIRECTORY,
+                templateBuildTestResults, solutionBuildTestResults);
+
+        final long sourceBuildConfigId = programmingExercise.getBuildConfig().getId();
+        programmingExercise.setGradingCriteria(ProgrammingExerciseFactory.generateGradingCriteria(programmingExercise));
+        programmingExercise = programmingExerciseRepository.save(programmingExercise);
+        programmingExercise = programmingExerciseRepository.findWithPlagiarismDetectionConfigTeamConfigBuildConfigAndGradingCriteriaById(programmingExercise.getId()).orElseThrow();
+
+        ProgrammingExercise exerciseToBeImported = ProgrammingExerciseFactory.generateToBeImportedProgrammingExercise("InitTitle", "initimp", programmingExercise,
+                courseUtilService.addEmptyCourse());
+        exerciseToBeImported.setChannelName("testchannel-pe-init");
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("recreateBuildPlans", "true");
+
+        var importedExercise = request.postWithResponseBody("/api/programming/programming-exercises/import?sourceExerciseId=" + programmingExercise.getId(), exerciseToBeImported,
+                ProgrammingExercise.class, params, HttpStatus.OK);
+
+        // The template and solution participations are persisted and INITIALIZED even though the import no longer runs in
+        // a surrounding transaction (they are set up and saved explicitly). This is the core guarantee of the refactor.
+        TemplateProgrammingExerciseParticipation templateParticipation = templateProgrammingExerciseParticipationRepository.findByProgrammingExerciseId(importedExercise.getId())
+                .orElseThrow();
+        SolutionProgrammingExerciseParticipation solutionParticipation = solutionProgrammingExerciseParticipationRepository.findByProgrammingExerciseId(importedExercise.getId())
+                .orElseThrow();
+        assertThat(templateParticipation.getInitializationState()).isEqualTo(InitializationState.INITIALIZED);
+        assertThat(solutionParticipation.getInitializationState()).isEqualTo(InitializationState.INITIALIZED);
+
+        // The grading criteria and build config are deep-copied from the source: the grading criteria are preserved and
+        // the build config is a fresh entity (different id).
+        ProgrammingExercise importedWithReferences = programmingExerciseRepository
+                .findWithPlagiarismDetectionConfigTeamConfigBuildConfigAndGradingCriteriaById(importedExercise.getId()).orElseThrow();
+        assertThat(importedWithReferences.getGradingCriteria()).hasSize(1);
+        assertThat(importedWithReferences.getBuildConfig().getId()).isNotEqualTo(sourceBuildConfigId);
+
+        // The repositories were really created on the local VCS (not mocked).
+        localVCLocalCITestService.verifyRepositoryFoldersExist(programmingExerciseRepository.findWithAllParticipationsAndBuildConfigById(importedExercise.getId()).orElseThrow(),
+                localVCBasePath);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseServiceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseServiceIntegrationTest.java
@@ -54,7 +54,9 @@ class ProgrammingExerciseServiceIntegrationTest extends AbstractProgrammingInteg
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void importProgrammingExerciseBasis_baseReferencesGotCloned() {
-        final var newlyImported = importExerciseBase();
+        // Re-fetch the imported exercise with all references eagerly initialized instead of relying on lazy proxies:
+        // the import runs without an open session, so a returned lazy collection could not be read here.
+        final var newlyImported = programmingExerciseUtilService.loadProgrammingExerciseWithEagerReferences(importExerciseBase());
 
         assertThat(newlyImported.getId()).isNotEqualTo(programmingExercise.getId());
         assertThat(newlyImported).isNotSameAs(programmingExercise);
@@ -70,10 +72,11 @@ class ProgrammingExerciseServiceIntegrationTest extends AbstractProgrammingInteg
         assertThat(newlyImported.getNumberOfComplaints()).isNull();
         assertThat(newlyImported.getNumberOfMoreFeedbackRequests()).isNull();
         assertThat(newlyImported.getNumberOfSubmissions()).isNull();
-        assertThat(newlyImported.getAttachments()).isNull();
-        assertThat(newlyImported.getTutorParticipations()).isNull();
-        assertThat(newlyImported.getExampleSubmissions()).isNull();
-        assertThat(newlyImported.getStudentParticipations()).isNull();
+        // Student-facing data is not copied, so these collections are empty on the imported exercise.
+        assertThat(newlyImported.getAttachments()).isEmpty();
+        assertThat(newlyImported.getTutorParticipations()).isEmpty();
+        assertThat(newlyImported.getExampleSubmissions()).isEmpty();
+        assertThat(newlyImported.getStudentParticipations()).isEmpty();
         final var newTestCaseIDs = newlyImported.getTestCases().stream().map(ProgrammingExerciseTestCase::getId).collect(Collectors.toSet());
         assertThat(newlyImported.getTestCases()).hasSameSizeAs(programmingExercise.getTestCases());
         assertThat(programmingExercise.getTestCases()).noneMatch(testCase -> newTestCaseIDs.contains(testCase.getId()));


### PR DESCRIPTION
> **Stacked on #13272** (`chore/exercise-import-two-variables`). Please review/merge that PR first; this PR targets its branch and its diff will shrink to only the programming-import changes once the base is merged.

### Summary

Programming exercise import (`importProgrammingExerciseBasis`) was wrapped in a method-level `@Transactional` with a long-standing `// TODO: NOT OK` comment. This PR removes the transaction entirely and replaces the implicit Hibernate session behavior with an explicit fetch-and-persist flow, in line with the project policy of keeping transactions at the repository level only and fetching data explicitly. Behavior is unchanged; the change is covered by new full LocalVC/LocalCI integration tests.

### Motivation and Context

`@Transactional` on a service method that spans repository writes, version-control calls and cascade saves has real downsides: it holds a database connection and session open for the whole (slow) import, and it hides which data is actually loaded behind lazy proxies. The existing `// TODO: NOT OK --> apply the transaction on a smaller scope` acknowledged this. Rather than shrinking the transaction, we remove it and make every load and save explicit, so the persistence order and the data the method depends on are visible in the code.

### Description

- **Remove `@Transactional`** from `importProgrammingExerciseBasis` and the now-unused `ProgrammingExerciseCreationUpdateService` dependency.
- **Reorder persistence to respect ownership of foreign keys** (no open session to paper over transient references):
  - Persist the build config and submission policy first (the exercise owns their FKs).
  - Save the exercise once, cascading the copied grading criteria, so the template/solution participations, test cases and tasks can reference the persisted exercise.
  - Add competency links only after the exercise is persisted.
- **Return a fully initialized entity via an explicit query**: new `findWithImportRelevantReferencesById` entity graph (participations, team assignment config, categories, auxiliary repositories, submission policy, build config, grading criteria + structured instructions). Because the method runs without an open session, the result no longer relies on lazy proxies.
- **Persist participations as `INITIALIZED`** directly in the single save (in `ProgrammingExerciseParticipationService.setupInitial*Participation`), instead of a later transactional re-initialization.
- **Reduce the number of exercise saves** and extract the grading-criteria deep-copy into a documented `copyGradingCriteria` helper.
- **Rewrite the misleading and terse JavaDoc/inline documentation** throughout the service.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Programming Exercise (with grading criteria, tasks, test cases; optionally SCA and auxiliary repositories) in a course

1. Log in to Artemis as the instructor.
2. Import the programming exercise into another course.
3. Confirm the imported exercise has: the problem statement, grading criteria, tasks and test cases, build config, template/solution repositories, and auxiliary repositories cloned; and that the template/solution participations are initialized.
4. Repeat importing into an exam (exercise group) and confirm the exercise is individual mode and imports correctly.

#### Exam Mode Testing

Prerequisites:
- 1 Instructor
- 1 Exam with an exercise group

1. Log in as the instructor.
2. Import a programming exercise into the exam's exercise group.
3. Confirm it imports with all references and is set to individual mode.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the server coding and design guidelines and the REST API guidelines.
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

#### Changes affecting Programming Exercises
- [x] I tested the changes with the integrated lifecycle setup (LocalVC and LocalCI) via full server integration tests (no git repositories mocked).
