### PR TITLE
`Development`: Fix contrast issue in user management in dark mode

### DIFF
--- a/src/main/webapp/app/course/manage/user-management-dropdown/user-management-dropdown.component.ts
+++ b/src/main/webapp/app/course/manage/user-management-dropdown/user-management-dropdown.component.ts
@@ -37,6 +37,7 @@ export interface UserAddAction {
 
                 &:hover {
                     background: var(--overview-card-hover-bg, var(--bs-tertiary-bg));
+                    color: var(--overview-card-hover-color, var(--bs-body-color));
                     border-color: var(--bs-secondary-border-subtle);
                     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
                 }

--- a/src/main/webapp/content/scss/themes/theme-dark.scss
+++ b/src/main/webapp/content/scss/themes/theme-dark.scss
@@ -198,4 +198,5 @@ input:-webkit-autofill:active {
     --overview-card-bg: #16191d;
     --overview-card-nested-bg: #343a42;
     --overview-card-hover-bg: #434c56;
+    --overview-card-hover-color: #f8f9fa;
 }

--- a/src/main/webapp/content/scss/themes/theme-dark.scss
+++ b/src/main/webapp/content/scss/themes/theme-dark.scss
@@ -198,5 +198,5 @@ input:-webkit-autofill:active {
     --overview-card-bg: #16191d;
     --overview-card-nested-bg: #343a42;
     --overview-card-hover-bg: #434c56;
-    --overview-card-hover-color: #f8f9fa;
+    --overview-card-hover-color: #{$body-color};
 }

--- a/src/main/webapp/content/scss/themes/theme-default.scss
+++ b/src/main/webapp/content/scss/themes/theme-default.scss
@@ -58,5 +58,5 @@ html {
     --overview-card-bg: #ffffff;
     --overview-card-nested-bg: #f1f5f9;
     --overview-card-hover-bg: #e2e8f0;
-    --overview-card-hover-color: #212529;
+    --overview-card-hover-color: #{$body-color};
 }

--- a/src/main/webapp/content/scss/themes/theme-default.scss
+++ b/src/main/webapp/content/scss/themes/theme-default.scss
@@ -58,4 +58,5 @@ html {
     --overview-card-bg: #ffffff;
     --overview-card-nested-bg: #f1f5f9;
     --overview-card-hover-bg: #e2e8f0;
+    --overview-card-hover-color: #212529;
 }


### PR DESCRIPTION
### Summary
Fixes #12403. In dark mode, hovering the "User management" button on the course management Overview page made the label text unreadable (near-zero contrast).

### Motivation and Context
The `.user-mgmt-btn:hover` rule only overrode `background`/`border-color`, never `color`. Text color kept inheriting the base `--bs-body-color`. Because `--bs-body-color` and `--overview-card-hover-bg` are declared in two independently-loaded stylesheets (`theme-default.scss` compiled into the main bundle vs. `theme-dark.css` injected at runtime by `theme.service.ts` only when dark mode is active), the hover background and text color are not guaranteed to come from the same theme at the same time, which could produce a low/zero-contrast pairing.

### Description
- Added a theme-scoped `--overview-card-hover-color` custom property next to the existing `--overview-card-hover-bg` in both `theme-default.scss` and `theme-dark.scss`, so the hover background and hover text color are always sourced from the same theme file.
- Referenced `--overview-card-hover-color` explicitly in `.user-mgmt-btn:hover` in `user-management-dropdown.component.ts`, with a fallback to `--bs-body-color` for safety.

This keeps the same visual result in light mode (unchanged) while making the dark-mode hover state reliably readable, and removes the underlying fragility (a hover state relying on an un-declared, cross-stylesheet color) rather than only patching the specific value.

### Steps for Testing
- [x] I tested this small issue locally.

1. Log in to Artemis as an instructor.
2. Switch to dark mode.
3. Navigate to Course Management → a course → Overview.
4. Hover over the "User management" button.
5. Confirm the "User management" label text remains clearly readable on hover.
6. Repeat in light mode to confirm no visual regression.

Also verified:
- `pnpm exec eslint` on the changed TS file — clean.
- `npx stylelint` on the changed SCSS files — clean.
- `pnpm exec vitest run user-management-dropdown.component.spec.ts` — 3/3 passing.
- `pnpm run prettier:check` on changed files — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hover-state text visibility for user management dropdown buttons.
  * Updated the default and dark themes with matching course overview card hover text colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->