### PR TITLE
`Development`: Note plugins block bypasses Reposilite mirror in documentation

### DIFF
--- a/documentation/docs/instructor/exercises/programming-exercise.mdx
+++ b/documentation/docs/instructor/exercises/programming-exercise.mdx
@@ -864,6 +864,28 @@ repositories {
 }
 ```
 
+<Callout variant={CalloutVariant.warning}>
+
+  <strong>The <code>repositories</code> block does not cover Gradle plugins.</strong> The <code>plugins {"{ id '...' }"}</code> block in <code>build.gradle</code> (e.g. <code>id 'org.springframework.boot'</code>) is <strong>not</strong> resolved through <code>repositories {"{ ... }"}</code>. Gradle resolves plugins via the Gradle Plugin Portal, which falls back to Maven Central — bypassing the mirror entirely and still hitting HTTP 429 rate limits.
+
+  To route plugin resolution through the mirror as well, add a <code>pluginManagement</code> block at the <strong>top</strong> of <code>settings.gradle</code> (create the file if it does not exist yet):
+
+  ```groovy
+  pluginManagement {
+      repositories {
+          maven {
+              name "reposiliteRepositoryReleases"
+              url "https://reposilite.aet.cit.tum.de/releases"
+          }
+          gradlePluginPortal()
+      }
+  }
+  ```
+
+  As with dependencies, the mirror must be listed <strong>before</strong> <code>gradlePluginPortal()</code> so that plugins are resolved from the mirror first.
+
+</Callout>
+
 **Maven exercises:** In the `pom.xml` file of the test repository, add the mirror as the **first** entry in the `<repositories>` section (create the section if it does not exist yet):
 
 ```xml


### PR DESCRIPTION
### Summary
Update the Maven Central rate-limit documentation to explain that Gradle's `plugins { id '...' }` block does not go through `repositories {}` and therefore bypasses the Reposilite mirror, still hitting HTTP 429. Add a `pluginManagement` snippet for `settings.gradle` that routes plugin resolution through the mirror.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
While investigating recurring HTTP 429 build failures for Java/Kotlin exercises, we discovered that even test repositories that already declared the Reposilite mirror as the first entry in `repositories {}` were still hitting Maven Central. Root cause: Gradle resolves the `plugins { id 'org.springframework.boot' ... }` block through the Gradle Plugin Portal (which falls back to Maven Central), not through `repositories {}`. Without a `pluginManagement` block, the mirror is bypassed for plugin artifacts. The existing docs did not mention this, so instructors kept re-hitting the rate limit after configuring the mirror.

### Description
- Added a warning callout to the Gradle section of *Prevent Maven Central Rate Limits* explaining the `plugins {}` / `repositories {}` split.
- Documented a `pluginManagement` block for `settings.gradle` that lists the Reposilite mirror before `gradlePluginPortal()`.

Only `documentation/docs/instructor/exercises/programming-exercise.mdx` is changed.

### Steps for Testing
Prerequisites:
- Local checkout of this branch

1. Build the documentation site (or view the MDX file on GitHub).
2. Navigate to *Instructor > Exercises > Programming Exercise > Prevent Maven Central Rate Limits (Java and Kotlin) > Recommended: Add the Mirror to the Test Repository*.
3. Verify the new warning callout appears directly after the Gradle `build.gradle` snippet and renders the `pluginManagement` code block correctly.
4. Verify the existing "repository order matters" callout still appears after the Maven `pom.xml` snippet.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring Gradle plugin resolution through a repository mirror.
  * Clarified that the standard Gradle repositories block does not control plugin downloads.
  * Included instructions to place the plugin management configuration at the top of `settings.gradle` to help prevent rate-limit errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->