### PR TITLE
Programming exercises: Align Java Gradle template versions with the build agent image

### DIFF
--- a/src/main/resources/templates/java/test/gradle/projectTemplate/build.gradle
+++ b/src/main/resources/templates/java/test/gradle/projectTemplate/build.gradle
@@ -2,9 +2,9 @@ plugins {
     // %static-code-analysis-start%
     id 'checkstyle'
     id 'pmd'
-    id 'com.github.spotbugs' version '6.1.0'
+    id 'com.github.spotbugs' version '6.3.0'
     // %static-code-analysis-stop%
-    id 'com.teamscale' version '34.2.1'
+    id 'com.teamscale' version '35.2.1'
     id 'java'
 }
 
@@ -24,6 +24,10 @@ repositories {
 
 dependencies {
     testImplementation 'de.tum.in.ase:artemis-java-test-sandbox:1.15.0'
+    // Pinned to the version pre-installed in the build agent image (ls1tum/artemis-maven-template).
+    // Without this, assertj-core resolves byte-buddy transitively to a version that is not part of
+    // the image's offline cache and cannot be downloaded inside the build container.
+    testImplementation 'net.bytebuddy:byte-buddy:1.17.6'
     implementation 'org.apache.commons:commons-lang3:3.18.0'
 
     // testImplementation(':${exerciseNamePomXml}')


### PR DESCRIPTION
### Summary

Newly generated Java Gradle programming exercises currently fail their very first build on an integrated lifecycle (LocalVC/LocalCI) setup, before any student code is involved. The generated test project declares plugin and dependency versions that are **not present in the build agent image's offline cache**, and the build container has no outbound network, so they can never be resolved. This PR aligns the three drifted coordinates with the image.

Fixes #13306

### Motivation and Context

The build agent image `ls1tum/artemis-maven-template` bakes its dependency cache at image build time by running a bundled sample project, and then deletes it ([`artemis-maven-docker/Dockerfile`](https://github.com/ls1intum/artemis-maven-docker/blob/main/Dockerfile)):

```dockerfile
ADD artemis-java-template /opt/artemis-java-template
RUN cd /opt/artemis-java-template && mvn clean install test && ...
RUN cd /opt/artemis-java-template && ./gradlew clean test check -x test publishToMavenLocal ...
RUN rm -rf /opt/artemis-java-template
```

Consequently **only the exact coordinates declared by that bundled template end up cached**, and anything else is unresolvable inside the build container regardless of what `repositories { }` says — the container has no outbound network at test time (a build of mine failed with `reposilite.aet.cit.tum.de: Temporary failure in name resolution`, i.e. even the TUM mirror is unreachable from inside).

The generated test project had drifted from [`artemis-java-template/build.gradle`](https://github.com/ls1intum/artemis-maven-docker/blob/main/artemis-java-template/build.gradle):

| Coordinate | Generated exercise | Build agent image | |
|---|---|---|---|
| `com.teamscale` | `34.2.1` | `35.2.1` | ❌ |
| `com.github.spotbugs` | `6.1.0` | `6.3.0` | ❌ |
| `net.bytebuddy:byte-buddy` | not declared → transitively `1.15.11` | `1.17.6` explicit | ❌ |
| `de.tum.in.ase:artemis-java-test-sandbox` | `1.15.0` | `1.15.0` | ✅ |
| `org.apache.commons:commons-lang3` | `3.18.0` | `3.18.0` | ✅ |
| `pmd` `toolVersion` | `7.16.0` | `7.16.0` | ✅ |

Because Gradle resolves the `plugins { }` block at configuration time, this surfaces in the **`compile` phase** (`./gradlew clean compileJava compileTestJava`, from `templates/phases/java/plain_gradle.yaml`) before anything is actually compiled:

```
* Where:
Plugin [id: 'com.teamscale', version: '34.2.1'] was not found in any of the following sources:
Searched in the following repositories:
Gradle Central Plugin Repository
BUILD FAILED in 23s
```

Once that is resolved, the next failure is `net.bytebuddy:byte-buddy:1.15.11`, which `assertj-core` pulls in transitively via `artemis-java-test-sandbox` and which is likewise absent from the cache.

The versions appear to have diverged in #11374, which updated the generated template to match the image update from two days earlier (Ares `1.13.0`→`1.15.0`, PMD `7.2.0`→`7.16.0`, Gradle `8.12`→`9.0.0`) but did not carry over `com.teamscale`, `com.github.spotbugs`, or the byte-buddy pin.

The explicit byte-buddy pin is not new — it mirrors the same fix already present in the bundled template, added in [`artemis-maven-docker@4ffd2ee`](https://github.com/ls1intum/artemis-maven-docker/commit/4ffd2ee) titled *"include byte buddy explicitly to avoid download issues on build agents"*. That fix was simply never mirrored into the generated exercise template.

### Description

One file changed, `src/main/resources/templates/java/test/gradle/projectTemplate/build.gradle`:

- `com.teamscale` `34.2.1` → `35.2.1`
- `com.github.spotbugs` `6.1.0` → `6.3.0`
- added an explicit `testImplementation 'net.bytebuddy:byte-buddy:1.17.6'`, with a comment explaining why the pin must stay in sync with the image

`repositories { mavenCentral(); mavenLocal() }` already matches the bundled template and is unchanged.

### Steps for Testing

Prerequisites:
- 1 Instructor
- A test server on the **integrated lifecycle setup** (LocalVC + LocalCI), using `ls1tum/artemis-maven-template:java17-25`

1. Log in as an instructor and navigate to Course Administration
2. Create a new **Java** programming exercise with **Gradle** as the build tool
3. Wait for the template and solution builds to be triggered on creation
4. Both builds should now pass. On `develop` they fail in the `compile` phase with `Plugin [id: 'com.teamscale', version: '34.2.1'] was not found`
5. Repeat with **static code analysis enabled** to cover the `com.github.spotbugs` bump

### Review notes

Two things worth a maintainer's judgement, neither of which I wanted to decide unilaterally in this PR:

- **`com.teamscale` is declared but never configured** in this template — there is no `teamscale { }` block and no report upload task. It may well be vestigial, in which case removing it outright would be preferable to version-bumping it, since it would remove this failure mode permanently. I went with the bump because I cannot tell whether anything downstream relies on the plugin being applied. Happy to switch this to a removal if you confirm it is unused.
- **`checkstyle` does not pin `toolVersion`** here, so it falls back to the Gradle default, whereas the image bakes checkstyle `11.0.1`. If those differ, SCA-enabled exercises would hit the same class of failure. I have not reproduced this (my exercise had SCA disabled) so I left it out of scope.

Separately, `src/main/resources/templates/kotlin/test/maven/projectTemplate/pom.xml` also declares `<teamscale.version>34.2.1</teamscale.version>`. I have not reproduced anything on the Kotlin path, so it is not touched here, but it may be worth a look.

More generally: nothing currently enforces that this template and the bundled `artemis-java-template` stay in version lockstep, so this drift can silently recur. Some form of sync check between the two repositories might be worth considering.

### Testserver States

I do not have access to a test server, so I was not able to run the checklist item above. What I can report is that the equivalent change was verified empirically against **production `artemis.tum.de` LocalCI builds**: applying these same coordinates to the `-tests` repository of a failing exercise took its build from red to green, across three successive rounds of real build logs (teamscale → byte-buddy). A maintainer verification on a test server is still needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static-analysis tooling in the Gradle project template.
  * Added a pinned Byte Buddy test dependency to support builds using the offline dependency cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->