### PR TITLE
`Exam mode`: Fix latest-result lookup failing for test-run programming participations

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseParticipationResource.java
@@ -599,11 +599,17 @@ public class ProgrammingExerciseParticipationResource {
 
     /**
      * Checks if the results should be hidden for the given participation.
+     * Test-run participations are exempt: their conductor always sees the results.
      *
      * @param participation the participation to check
      * @return true if the results should be hidden, false otherwise
      */
     private boolean shouldHideExamExerciseResults(ProgrammingExerciseStudentParticipation participation) {
+        if (participation.isTestRun()) {
+            // A test run is conducted by an instructor on their own test-run student exam, which the lookup below
+            // excludes by design (testRun = FALSE). Results are never hidden from the conductor.
+            return false;
+        }
         if (participation.getProgrammingExercise().isExamExercise() && !participation.getProgrammingExercise().isTestExamExercise()) {
             var examApi = this.examApi.orElseThrow(() -> new ExamApiNotPresentException(ExamApi.class));
             var studentExamApi = this.studentExamApi.orElseThrow(() -> new ExamApiNotPresentException(StudentExamApi.class));

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
@@ -336,14 +336,6 @@ public class ParticipationUtilService {
     }
 
     /**
-     * Creates and saves a ProgrammingExerciseStudentParticipation for the given ProgrammingExercise given the Participant's login. If an existing
-     * ProgrammingExerciseStudentParticipation exists for the given ProgrammingExercise and Participant, it will be returned instead.
-     *
-     * @param exercise The ProgrammingExercise the ProgrammingExerciseStudentParticipation belongs to
-     * @param login    The login of the Participant the ProgrammingExerciseStudentParticipation belongs to
-     * @return The created or existing ProgrammingExerciseStudentParticipation with eagerly loaded submissions, results and assessors
-     */
-    /**
      * Creates (or reuses) a programming participation for the given login and marks it as a test-run participation.
      *
      * @param exercise the programming exercise the participation belongs to
@@ -356,6 +348,14 @@ public class ParticipationUtilService {
         return programmingExerciseStudentParticipationRepo.save(participation);
     }
 
+    /**
+     * Creates and saves a ProgrammingExerciseStudentParticipation for the given ProgrammingExercise given the Participant's login. If an existing
+     * ProgrammingExerciseStudentParticipation exists for the given ProgrammingExercise and Participant, it will be returned instead.
+     *
+     * @param exercise The ProgrammingExercise the ProgrammingExerciseStudentParticipation belongs to
+     * @param login    The login of the Participant the ProgrammingExerciseStudentParticipation belongs to
+     * @return The created or existing ProgrammingExerciseStudentParticipation with eagerly loaded submissions, results and assessors
+     */
     public ProgrammingExerciseStudentParticipation addStudentParticipationForProgrammingExercise(ProgrammingExercise exercise, String login) {
         final var existingParticipation = programmingExerciseStudentParticipationRepo.findByExerciseIdAndStudentLogin(exercise.getId(), login);
         if (existingParticipation.isPresent()) {

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
@@ -343,6 +343,19 @@ public class ParticipationUtilService {
      * @param login    The login of the Participant the ProgrammingExerciseStudentParticipation belongs to
      * @return The created or existing ProgrammingExerciseStudentParticipation with eagerly loaded submissions, results and assessors
      */
+    /**
+     * Creates (or reuses) a programming participation for the given login and marks it as a test-run participation.
+     *
+     * @param exercise the programming exercise the participation belongs to
+     * @param login    the login of the user conducting the test run
+     * @return the persisted test-run participation
+     */
+    public ProgrammingExerciseStudentParticipation addTestRunParticipationForProgrammingExercise(ProgrammingExercise exercise, String login) {
+        var participation = addStudentParticipationForProgrammingExercise(exercise, login);
+        participation.setTestRun(true);
+        return programmingExerciseStudentParticipationRepo.save(participation);
+    }
+
     public ProgrammingExerciseStudentParticipation addStudentParticipationForProgrammingExercise(ProgrammingExercise exercise, String login) {
         final var existingParticipation = programmingExerciseStudentParticipationRepo.findByExerciseIdAndStudentLogin(exercise.getId(), login);
         if (existingParticipation.isPresent()) {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseParticipationIntegrationTest.java
@@ -272,6 +272,15 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractProgrammin
         assertThat(participationUtilService.getResultsForParticipation(requestedParticipation)).hasSize(1);
     }
 
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testGetParticipationWithLatestResult_testRunParticipationWithoutResult_returnsParticipationWithoutResults() throws Exception {
+        var participation = setupExamExerciseWithTestRunParticipation();
+        var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-latest-result-and-feedbacks", HttpStatus.OK,
+                ProgrammingExerciseStudentParticipation.class);
+        assertThat(participationUtilService.getResultsForParticipation(requestedParticipation)).isEmpty();
+    }
+
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @MethodSource("argumentsForGetParticipationResults")
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
@@ -1292,15 +1301,14 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractProgrammin
         var workingTime = 120 * 60;
         programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(visibilityDate, startDate, endDate, publishResultsDate,
                 TEST_PREFIX + "student1", workingTime);
-        var participation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, TEST_PREFIX + "instructor1");
-        participation.setTestRun(true);
-        return programmingExerciseStudentParticipationRepository.save(participation);
+        return participationUtilService.addTestRunParticipationForProgrammingExercise(programmingExercise, TEST_PREFIX + "instructor1");
     }
 
     private Result addTestRunParticipationResult() {
+        var now = ZonedDateTime.now();
         var submission = ParticipationFactory.generateProgrammingSubmission(true);
         Result result = programmingExerciseUtilService.addProgrammingSubmissionWithResult(programmingExercise, submission, TEST_PREFIX + "instructor1");
-        result.successful(true).rated(true).score(100D).assessmentType(AssessmentType.AUTOMATIC).completionDate(ZonedDateTime.now().minusMinutes(30));
+        result.successful(true).rated(true).score(100D).assessmentType(AssessmentType.AUTOMATIC).completionDate(now.minusMinutes(30));
 
         return participationUtilService.addVariousVisibilityFeedbackToResult(result);
     }

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseParticipationIntegrationTest.java
@@ -262,6 +262,16 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractProgrammin
         assertThat(participationUtilService.getResultsForParticipation(requestedParticipation)).hasSize(1);
     }
 
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testGetParticipationWithLatestResult_testRunParticipation_showsResultsBeforeExamResultsPublished() throws Exception {
+        var participation = setupExamExerciseWithTestRunParticipation();
+        addTestRunParticipationResult();
+        var requestedParticipation = request.get(participationsBaseUrl + participation.getId() + "/student-participation-with-latest-result-and-feedbacks", HttpStatus.OK,
+                ProgrammingExerciseStudentParticipation.class);
+        assertThat(participationUtilService.getResultsForParticipation(requestedParticipation)).hasSize(1);
+    }
+
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @MethodSource("argumentsForGetParticipationResults")
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
@@ -447,6 +457,25 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractProgrammin
     void testGetLatestResultWithFeedbacksAsStudent_showsResultAfterExamResultsPublished() throws Exception {
         var result = setupExamExerciseWithParticipationAndResult(10, TEST_PREFIX + "student1");
         StudentParticipation participation = (StudentParticipation) result.getSubmission().getParticipation();
+        var requestedResult = request.get(participationsBaseUrl + participation.getId() + "/latest-result-with-feedbacks", HttpStatus.OK, Result.class);
+
+        assertThat(requestedResult).isNotNull();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testGetLatestResultWithFeedbacks_testRunParticipationWithoutResult_returnsOk() throws Exception {
+        var participation = setupExamExerciseWithTestRunParticipation();
+        var requestedResult = request.get(participationsBaseUrl + participation.getId() + "/latest-result-with-feedbacks", HttpStatus.OK, Result.class);
+
+        assertThat(requestedResult).isNull();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testGetLatestResultWithFeedbacks_testRunParticipationWithResult_returnsResult() throws Exception {
+        var participation = setupExamExerciseWithTestRunParticipation();
+        addTestRunParticipationResult();
         var requestedResult = request.get(participationsBaseUrl + participation.getId() + "/latest-result-with-feedbacks", HttpStatus.OK, Result.class);
 
         assertThat(requestedResult).isNotNull();
@@ -1245,6 +1274,35 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractProgrammin
                 userLogin, workingTime);
         programmingExerciseParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, userLogin);
         return addStudentParticipationWithResult(AssessmentType.AUTOMATIC, startDate.plusMinutes(2));
+    }
+
+    /**
+     * Sets up an exam programming exercise whose exam has ended but whose results are not yet published, together with a
+     * test-run participation owned by instructor1. In this window a regular student participation would have its results
+     * hidden; a test run must not.
+     *
+     * @return the test-run participation
+     */
+    private ProgrammingExerciseStudentParticipation setupExamExerciseWithTestRunParticipation() {
+        var now = ZonedDateTime.now();
+        var startDate = now.minusHours(4);
+        var endDate = startDate.plusHours(1);
+        var visibilityDate = startDate.minusHours(1);
+        var publishResultsDate = startDate.plusHours(10);
+        var workingTime = 120 * 60;
+        programmingExercise = programmingExerciseUtilService.addCourseExamExerciseGroupWithProgrammingExerciseAndExamDates(visibilityDate, startDate, endDate, publishResultsDate,
+                TEST_PREFIX + "student1", workingTime);
+        var participation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, TEST_PREFIX + "instructor1");
+        participation.setTestRun(true);
+        return programmingExerciseStudentParticipationRepository.save(participation);
+    }
+
+    private Result addTestRunParticipationResult() {
+        var submission = ParticipationFactory.generateProgrammingSubmission(true);
+        Result result = programmingExerciseUtilService.addProgrammingSubmissionWithResult(programmingExercise, submission, TEST_PREFIX + "instructor1");
+        result.successful(true).rated(true).score(100D).assessmentType(AssessmentType.AUTOMATIC).completionDate(ZonedDateTime.now().minusMinutes(30));
+
+        return participationUtilService.addVariousVisibilityFeedbackToResult(result);
     }
 
 }


### PR DESCRIPTION
Fixes #13316

### Checklist

#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server. **Only local, helios not available at the time of writing**
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

`ProgrammingExerciseParticipationResource.shouldHideExamExerciseResults` resolves the student exam for an exam programming participation through `StudentExamApi.findByExerciseIdAndUserId`, whose query filters `studentExam.testRun = FALSE`. A test-run participation can therefore never resolve a student exam, and the method throws `EntityNotFoundException("Participation X does not have a student exam!")` instead of deciding visibility.

The throw fires **before** the result lookup, so both endpoints that use the check fail for every test-run programming participation:

- `GET .../latest-result-with-feedbacks` answers 404 — even when a build result exists. The client's polling fallback swallows the 404, so during a test run the instructor gets build results only over the websocket; if that delivery is missed, the result never appears without a full reload.
- `GET .../student-participation-with-latest-result-and-feedbacks` fails the same way.

On top of the broken fetches, every occurrence writes an error-level stack trace to the server log for a state that is by design — test runs deliberately have no non-test-run student exam. Present since #9152 (Aug 2024); the `testRun = FALSE` filter predates it. Reported during a #13186 testing session (participation 419) and reproduced on `develop` (participation 5; recording and log excerpt attached to the linked issue).

### Description

`shouldHideExamExerciseResults` now short-circuits for test-run participations before any exam or student-exam lookup:

```java
if (participation.isTestRun()) {
    // A test run is conducted by an instructor on their own test-run student exam, which the lookup below
    // excludes by design (testRun = FALSE). Results are never hidden from the conductor.
    return false;
}
```

This is the semantics `ExamService.shouldStudentSeeResult` already applies to real student exams — test runs are exempt from result hiding — expressed one layer earlier so the lookup that cannot succeed is never attempted. Both callers (`latest-result-with-feedbacks`, `student-participation-with-latest-result-and-feedbacks`) are covered by the single guard. Non-test-run participations are unaffected: the lookup and the throw remain for genuinely orphaned participations, and the publish-gate for real student exams is untouched.

One new integration test per endpoint: an instructor test-run programming participation returns 200 (empty body while no result exists, the result once one exists) instead of 404, and the student-exam lookup is never invoked for it. The pre-publish hiding behavior for a real student exam is asserted unchanged alongside.

### Steps for Testing

Prerequisites: instructor in a course; an exam with a programming exercise (online editor enabled).

1. As instructor, create a test run for the exam (Exam management → Test runs), start conducting it, and open the programming exercise before any build result exists.
2. Open the browser network tab: `latest-result-with-feedbacks` returns **200**, not 404. The server log stays free of `EntityNotFoundException: Participation ... does not have a student exam!` — before this fix, every such click produced the stack trace.
3. Submit code in the test run and wait for the build: the result appears on the exercise.
4. Regression check with a real student: conduct the exam as a registered student, open the programming exercise before results are published — scores stay hidden exactly as before; after publishing, they show.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2

#### Exam Mode Test
- [ ] Test run: programming exercise opens without server error, result arrives (steps 1–3)
- [ ] Real student exam: result hiding before publish unchanged (step 4)

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/30519125737) did not pass (`failure`). Coverage below may be partial.

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| ProgrammingExerciseParticipationResource.java | not found (modified) | 419 |

_Last updated: 2026-07-30 07:25:53 UTC_


### Screenshots

(Repro recording and failing-state captures are attached to the linked issue; the fix changes no UI.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Test-run programming exercise results are now exempt from exam-result hiding logic, keeping them visible to instructors.
  * Instructor views now handle test-run participations correctly when a result exists or is missing.

* **Tests**
  * Added instructor-focused integration tests to verify visible results and expected API responses across unpublished-exam scenarios.

* **Documentation**
  * Updated documentation to clarify that test-run conductors/instructors always see test-run results.

* **Chores**
  * Added a test helper to create/persist test-run participations for programming exercises.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->