### PR TITLE
`General`: Redesign documentation homepage

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,6 +5,12 @@
         { "files": ["**/*.scss"], "customSyntax": "postcss-scss" },
         { "files": ["**/*.html"], "customSyntax": "postcss-html" },
         {
+            "files": ["documentation/**/*.module.css"],
+            "rules": {
+                "selector-pseudo-class-no-unknown": [true, { "ignorePseudoClasses": ["global"] }]
+            }
+        },
+        {
             "files": [
                 "src/main/webapp/app/admin/**/*.scss",
                 "src/main/webapp/app/course/request/**/*.scss",

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -67,7 +67,7 @@ const config: Config = {
         [
             require.resolve('@easyops-cn/docusaurus-search-local'),
             /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */
-            ({
+            {
                 hashed: true,
                 language: ['en'],
                 indexDocs: true,
@@ -76,23 +76,23 @@ const config: Config = {
                 searchContextByPaths: [
                     {
                         label: 'Student Guide',
-                        path: 'student'
+                        path: 'student',
                     },
                     {
                         label: 'Instructor Guide',
-                        path: 'instructor'
+                        path: 'instructor',
                     },
                     {
                         label: 'Developer Guide',
-                        path: 'developer'
+                        path: 'developer',
                     },
                     {
                         label: 'Admin Guide',
-                        path: 'admin'
-                    }
+                        path: 'admin',
+                    },
                 ],
-                hideSearchBarWithNoSearchContext: true,
-            }),
+                useAllContextsWithNoSearchContext: true,
+            },
         ],
     ],
 
@@ -156,7 +156,8 @@ const config: Config = {
             title: PAGE_TITLE,
             logo: {
                 alt: 'TUM Logo',
-                src: 'img/artemis-favicon.svg',
+                src: 'img/tum-logo-blue.svg',
+                srcDark: 'img/tum-logo-blue.svg',
             },
             items: [
                 {

--- a/documentation/src/components/HomepageAudienceIcon/index.tsx
+++ b/documentation/src/components/HomepageAudienceIcon/index.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+
+export type AudienceRole = 'student' | 'instructor' | 'developer' | 'administrator';
+
+interface HomepageAudienceIconProps {
+    role: AudienceRole;
+}
+
+const iconPaths: Record<AudienceRole, ReactNode> = {
+    student: (
+        <>
+            <path d="m2 10 10-5 10 5-10 5Z" />
+            <path d="M6 12.5V17c3.3 2.7 8.7 2.7 12 0v-4.5" />
+            <path d="M22 10v6" />
+        </>
+    ),
+    instructor: (
+        <>
+            <rect x="3" y="3" width="18" height="14" rx="2" />
+            <path d="M8 8h8M8 12h5M12 17v4M8 21h8" />
+        </>
+    ),
+    developer: <path d="m8 8-4 4 4 4M16 8l4 4-4 4M14 5l-4 14" />,
+    administrator: (
+        <>
+            <rect x="3" y="4" width="18" height="6" rx="2" />
+            <rect x="3" y="14" width="18" height="6" rx="2" />
+            <path d="M7 7h.01M7 17h.01M11 7h6M11 17h6" />
+        </>
+    ),
+};
+
+export default function HomepageAudienceIcon({ role }: HomepageAudienceIconProps): ReactNode {
+    return (
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            {iconPaths[role]}
+        </svg>
+    );
+}

--- a/documentation/src/components/SearchModal/index.tsx
+++ b/documentation/src/components/SearchModal/index.tsx
@@ -199,7 +199,7 @@ export function SearchModalProvider({ children }: SearchModalProviderProps): Rea
                         </button>
                     </div>
                     <div className={styles.modalSearch}>
-                        <SearchBar />
+                        <SearchBar key={locationKey} />
                     </div>
                 </div>
             </dialog>

--- a/documentation/src/components/SearchModal/index.tsx
+++ b/documentation/src/components/SearchModal/index.tsx
@@ -1,0 +1,241 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from 'react';
+import { useLocation } from '@docusaurus/router';
+import SearchBar from '@theme/SearchBar';
+
+import styles from './styles.module.css';
+
+type SearchDialogState = 'closed' | 'opening' | 'open' | 'closing';
+type SearchTriggerVariant = 'hero' | 'navbar';
+type ShortcutModifier = '⌘' | 'Ctrl';
+
+interface SearchModalContextValue {
+    dialogState: SearchDialogState;
+    openSearch: () => void;
+    shortcutModifier: ShortcutModifier | undefined;
+}
+
+interface SearchModalProviderProps {
+    children: ReactNode;
+}
+
+interface SearchModalTriggerProps {
+    variant: SearchTriggerVariant;
+}
+
+const SEARCH_DIALOG_CLOSE_FALLBACK_MS = 300;
+const SearchModalContext = createContext<SearchModalContextValue | undefined>(undefined);
+
+function isAppleUserAgent(): boolean {
+    return /Macintosh|Mac OS X|iPhone|iPad|iPod/.test(navigator.userAgent);
+}
+
+function SearchIcon(): ReactNode {
+    return (
+        <svg viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+            <circle cx="8.5" cy="8.5" r="5.5" />
+            <path d="m12.5 12.5 4 4" />
+        </svg>
+    );
+}
+
+export function SearchModalProvider({ children }: SearchModalProviderProps): ReactNode {
+    const location = useLocation();
+    const locationKey = `${location.pathname}${location.search}${location.hash}`;
+    const dialogRef = useRef<HTMLDialogElement>(null);
+    const previousLocationRef = useRef(locationKey);
+    const dialogStateRef = useRef<SearchDialogState>('closed');
+    const openingFrameRef = useRef<number | undefined>(undefined);
+    const closeTimerRef = useRef<number | undefined>(undefined);
+    const [dialogState, setDialogState] = useState<SearchDialogState>('closed');
+    const [shortcutModifier, setShortcutModifier] = useState<ShortcutModifier>();
+
+    const updateDialogState = useCallback((state: SearchDialogState) => {
+        dialogStateRef.current = state;
+        setDialogState(state);
+    }, []);
+
+    const finishClose = useCallback(() => {
+        const dialog = dialogRef.current;
+        if (!dialog?.open || dialogStateRef.current !== 'closing') {
+            return;
+        }
+
+        window.clearTimeout(closeTimerRef.current);
+        dialog.close();
+        updateDialogState('closed');
+    }, [updateDialogState]);
+
+    const openSearch = useCallback(() => {
+        const dialog = dialogRef.current;
+        if (!dialog) {
+            return;
+        }
+
+        if (dialogStateRef.current === 'open' || dialogStateRef.current === 'opening') {
+            dialog.querySelector<HTMLInputElement>('.navbar__search-input')?.focus();
+            return;
+        }
+
+        window.clearTimeout(closeTimerRef.current);
+        cancelAnimationFrame(openingFrameRef.current ?? 0);
+
+        const searchInput = dialog.querySelector<HTMLInputElement>('.navbar__search-input');
+        if (!dialog.open) {
+            searchInput?.setAttribute('autofocus', '');
+            dialog.showModal();
+            searchInput?.removeAttribute('autofocus');
+        } else {
+            searchInput?.focus();
+        }
+
+        updateDialogState('opening');
+        openingFrameRef.current = requestAnimationFrame(() => {
+            openingFrameRef.current = requestAnimationFrame(() => updateDialogState('open'));
+        });
+    }, [updateDialogState]);
+
+    const closeSearch = useCallback(() => {
+        const dialog = dialogRef.current;
+        if (!dialog?.open || dialogStateRef.current === 'closing') {
+            return;
+        }
+
+        const shouldAnimate = dialogStateRef.current === 'open' && !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        cancelAnimationFrame(openingFrameRef.current ?? 0);
+        updateDialogState('closing');
+
+        if (!shouldAnimate) {
+            finishClose();
+            return;
+        }
+
+        closeTimerRef.current = window.setTimeout(finishClose, SEARCH_DIALOG_CLOSE_FALLBACK_MS);
+    }, [finishClose, updateDialogState]);
+
+    useEffect(() => {
+        setShortcutModifier(isAppleUserAgent() ? '⌘' : 'Ctrl');
+
+        const handleShortcut = (event: KeyboardEvent) => {
+            const platformModifierPressed = isAppleUserAgent() ? event.metaKey : event.ctrlKey;
+            if (!platformModifierPressed || event.altKey || event.shiftKey || event.key.toLowerCase() !== 'k') {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            if (dialogStateRef.current === 'open' || dialogStateRef.current === 'opening') {
+                closeSearch();
+            } else {
+                openSearch();
+            }
+        };
+
+        document.addEventListener('keydown', handleShortcut, true);
+        return () => document.removeEventListener('keydown', handleShortcut, true);
+    }, [closeSearch, openSearch]);
+
+    useEffect(() => {
+        if (previousLocationRef.current !== locationKey) {
+            previousLocationRef.current = locationKey;
+            closeSearch();
+        }
+    }, [closeSearch, locationKey]);
+
+    useEffect(
+        () => () => {
+            cancelAnimationFrame(openingFrameRef.current ?? 0);
+            window.clearTimeout(closeTimerRef.current);
+        },
+        [],
+    );
+
+    const closeOnBackdrop = (event: MouseEvent<HTMLDialogElement>) => {
+        if (event.target === dialogRef.current) {
+            closeSearch();
+        }
+    };
+
+    const dialogClassName = [styles.searchDialog, dialogState === 'open' && styles.searchDialogOpen, dialogState === 'closing' && styles.searchDialogClosing]
+        .filter(Boolean)
+        .join(' ');
+    const contextValue = useMemo(() => ({ dialogState, openSearch, shortcutModifier }), [dialogState, openSearch, shortcutModifier]);
+
+    return (
+        <SearchModalContext.Provider value={contextValue}>
+            {children}
+            <dialog
+                ref={dialogRef}
+                id="documentation-search-dialog"
+                className={dialogClassName}
+                aria-label="Search documentation"
+                onCancel={(event) => {
+                    event.preventDefault();
+                    closeSearch();
+                }}
+                onClose={() => {
+                    const dialog = dialogRef.current;
+                    if (!dialog || dialog.open) {
+                        return;
+                    }
+
+                    cancelAnimationFrame(openingFrameRef.current ?? 0);
+                    window.clearTimeout(closeTimerRef.current);
+                    updateDialogState('closed');
+                }}
+                onClick={closeOnBackdrop}
+            >
+                <div
+                    className={styles.searchDialogPanel}
+                    onTransitionEnd={(event) => {
+                        if (event.target === event.currentTarget && event.propertyName === 'opacity') {
+                            finishClose();
+                        }
+                    }}
+                >
+                    <div className={styles.searchDialogHeader}>
+                        <strong>Search documentation</strong>
+                        <button type="button" onClick={closeSearch} aria-label="Close search">
+                            ×
+                        </button>
+                    </div>
+                    <div className={styles.modalSearch}>
+                        <SearchBar />
+                    </div>
+                </div>
+            </dialog>
+        </SearchModalContext.Provider>
+    );
+}
+
+export function SearchModalTrigger({ variant }: SearchModalTriggerProps): ReactNode {
+    const context = useContext(SearchModalContext);
+    if (!context) {
+        throw new Error('SearchModalTrigger must be rendered inside SearchModalProvider');
+    }
+
+    const { dialogState, openSearch, shortcutModifier } = context;
+    const className = variant === 'hero' ? styles.heroTrigger : styles.navbarTrigger;
+
+    return (
+        <button
+            type="button"
+            className={className}
+            onClick={openSearch}
+            aria-label="Search documentation"
+            aria-haspopup="dialog"
+            aria-controls="documentation-search-dialog"
+            aria-expanded={dialogState !== 'closed'}
+        >
+            <span className={styles.triggerLabel}>
+                <SearchIcon />
+                <span className={styles.triggerText}>Search</span>
+            </span>
+            {shortcutModifier && (
+                <span className={styles.triggerShortcut} aria-hidden="true">
+                    <kbd>{shortcutModifier}</kbd>
+                    <kbd>K</kbd>
+                </span>
+            )}
+        </button>
+    );
+}

--- a/documentation/src/components/SearchModal/styles.module.css
+++ b/documentation/src/components/SearchModal/styles.module.css
@@ -79,7 +79,7 @@
 .navbarTrigger .triggerLabel svg {
     width: 1rem;
     height: 1rem;
-    stroke: currentColor;
+    stroke: currentcolor;
 }
 
 .triggerShortcut {
@@ -101,6 +101,7 @@
     --search-ink: #102a3d;
     --search-navy: #003c69;
     --search-blue: #0065bd;
+
     width: min(52rem, calc(100vw - 2rem));
     max-width: none;
     max-height: calc(100vh - 2rem);
@@ -174,7 +175,7 @@
     height: 2rem;
     padding: 0;
     place-items: center;
-    color: currentColor;
+    color: currentcolor;
     font: inherit;
     font-size: 1.5rem;
     line-height: 1;
@@ -204,6 +205,7 @@
     --search-local-hit-active-color: #fff;
     --search-local-highlight-color: var(--search-blue);
     --search-local-muted-color: #607887;
+
     width: 100%;
 }
 

--- a/documentation/src/components/SearchModal/styles.module.css
+++ b/documentation/src/components/SearchModal/styles.module.css
@@ -294,6 +294,10 @@
     }
 }
 
+:global([data-theme='dark']) .navbarTrigger {
+    color: #b8ccd8;
+}
+
 :global([data-theme='dark']) .heroTrigger {
     color: #b8ccd8;
     border-color: rgba(152, 198, 234, 0.28);

--- a/documentation/src/components/SearchModal/styles.module.css
+++ b/documentation/src/components/SearchModal/styles.module.css
@@ -1,0 +1,370 @@
+.heroTrigger,
+.navbarTrigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    color: #617886;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+}
+
+.heroTrigger {
+    width: 100%;
+    max-width: 35rem;
+    min-height: 3.1rem;
+    margin-top: 1.6rem;
+    padding: 0 0.75rem 0 1rem;
+    border: 1px solid rgba(0, 82, 147, 0.22);
+    border-radius: 0.5rem;
+    background: rgba(255, 255, 255, 0.94);
+    box-shadow:
+        0 3px 9px rgba(0, 60, 105, 0.1),
+        0 14px 30px rgba(0, 60, 105, 0.11);
+    transition:
+        transform 180ms ease,
+        box-shadow 180ms ease,
+        border-color 180ms ease;
+}
+
+.heroTrigger:focus-visible {
+    border-color: rgba(0, 101, 189, 0.46);
+    outline: 3px solid #0065bd;
+    outline-offset: 3px;
+    box-shadow:
+        0 4px 11px rgba(0, 60, 105, 0.13),
+        0 18px 38px rgba(0, 60, 105, 0.16);
+}
+
+.navbarTrigger {
+    width: 12.5rem;
+    height: 2rem;
+    margin-left: 0.5em;
+    padding: 0 0.5rem 0 0.75rem;
+    border: 0;
+    border-radius: var(--ifm-global-radius);
+    background: var(--ifm-navbar-search-input-background-color);
+}
+
+.navbarTrigger:focus-visible {
+    outline: 2px solid var(--ifm-color-primary);
+    outline-offset: 2px;
+}
+
+.triggerLabel,
+.triggerShortcut {
+    display: flex;
+    align-items: center;
+}
+
+.triggerLabel {
+    gap: 0.8rem;
+}
+
+.triggerLabel svg {
+    width: 1.15rem;
+    height: 1.15rem;
+    flex: 0 0 auto;
+    fill: none;
+    stroke: #003c69;
+    stroke-linecap: round;
+    stroke-width: 1.8;
+}
+
+.navbarTrigger .triggerLabel {
+    gap: 0.5rem;
+}
+
+.navbarTrigger .triggerLabel svg {
+    width: 1rem;
+    height: 1rem;
+    stroke: currentColor;
+}
+
+.triggerShortcut {
+    gap: 0.25rem;
+}
+
+.triggerShortcut kbd {
+    color: #537183;
+    background: rgba(234, 244, 251, 0.9);
+}
+
+.navbarTrigger .triggerShortcut kbd {
+    color: var(--ifm-navbar-search-input-placeholder-color);
+    border-color: var(--ifm-color-emphasis-500);
+    background: var(--ifm-navbar-search-input-background-color);
+}
+
+.searchDialog {
+    --search-ink: #102a3d;
+    --search-navy: #003c69;
+    --search-blue: #0065bd;
+    width: min(52rem, calc(100vw - 2rem));
+    max-width: none;
+    max-height: calc(100vh - 2rem);
+    margin: clamp(1rem, 8vh, 5rem) auto auto;
+    padding: 0;
+    overflow: visible;
+    color: var(--search-ink);
+    border: 0;
+    background: transparent;
+}
+
+.searchDialog::backdrop {
+    background: rgba(4, 18, 28, 0);
+    backdrop-filter: blur(0);
+    transition:
+        background-color 220ms ease,
+        backdrop-filter 220ms ease;
+}
+
+.searchDialogOpen::backdrop {
+    background: rgba(4, 18, 28, 0.68);
+    backdrop-filter: blur(5px);
+}
+
+.searchDialogClosing::backdrop {
+    background: rgba(4, 18, 28, 0);
+    backdrop-filter: blur(0);
+    transition-duration: 150ms;
+    transition-timing-function: ease-in;
+}
+
+.searchDialogPanel {
+    padding: 1.25rem;
+    opacity: 0;
+    border: 1px solid rgba(0, 82, 147, 0.24);
+    border-radius: 0.75rem;
+    background: #f6fbfe;
+    box-shadow: 0 24px 70px rgba(0, 35, 62, 0.34);
+    transform: translateY(-10px) scale(0.985);
+    transform-origin: top center;
+    transition:
+        opacity 220ms ease,
+        transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+    will-change: opacity, transform;
+}
+
+.searchDialogOpen .searchDialogPanel {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+}
+
+.searchDialogClosing .searchDialogPanel {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.99);
+    transition-duration: 150ms;
+    transition-timing-function: ease-in;
+}
+
+.searchDialogHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.85rem;
+    color: var(--search-navy);
+}
+
+.searchDialogHeader button {
+    display: grid;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    place-items: center;
+    color: currentColor;
+    font: inherit;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    border: 0;
+    border-radius: 0.35rem;
+    background: transparent;
+}
+
+.searchDialogHeader button:hover {
+    background: rgba(152, 198, 234, 0.3);
+}
+
+.searchDialogHeader button:focus-visible {
+    outline: 3px solid var(--search-blue);
+    outline-offset: 2px;
+}
+
+.modalSearch {
+    --search-local-modal-width: 100%;
+    --search-local-modal-width-sm: 100%;
+    --search-local-modal-background: #f6fbfe;
+    --search-local-modal-shadow: none;
+    --search-local-hit-background: #fff;
+    --search-local-hit-shadow: 0 1px 4px rgba(0, 60, 105, 0.12);
+    --search-local-hit-color: var(--search-ink);
+    --search-local-hit-active-color: #fff;
+    --search-local-highlight-color: var(--search-blue);
+    --search-local-muted-color: #607887;
+    width: 100%;
+}
+
+.modalSearch :global(.navbar__search) {
+    width: 100%;
+    margin-left: 0;
+}
+
+.modalSearch :global(.navbar__search > span) {
+    display: block !important;
+    width: 100%;
+}
+
+.modalSearch :global(.navbar__search-input),
+.modalSearch :global(.navbar__search-input:not(:focus)) {
+    width: 100%;
+    height: 3.5rem;
+    padding: 0 2.75rem;
+    color: var(--search-ink);
+    border-radius: 0.5rem;
+}
+
+.modalSearch :global(.navbar__search-input + div) {
+    top: 50% !important;
+    transform: translateY(-50%) !important;
+}
+
+.modalSearch :global(.navbar__search-input::placeholder) {
+    color: #617886;
+    opacity: 1;
+}
+
+.modalSearch :global(.navbar__search > button) {
+    color: var(--search-navy);
+}
+
+.modalSearch :global(.navbar__search kbd) {
+    display: none;
+}
+
+.modalSearch :global([role='listbox']) {
+    max-height: min(34rem, calc(100dvh - 13rem));
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    animation: searchResultsIn 140ms ease-out;
+    transform-origin: top center;
+}
+
+@keyframes searchResultsIn {
+    from {
+        opacity: 0;
+        transform: translateY(-4px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .heroTrigger:hover {
+        transform: translateY(-1px);
+    }
+}
+
+@media screen and (max-width: 996px) {
+    .heroTrigger {
+        max-width: none;
+    }
+}
+
+@media screen and (max-width: 576px) {
+    .navbarTrigger {
+        width: 2rem;
+        padding: 0;
+        justify-content: center;
+    }
+
+    .navbarTrigger .triggerText,
+    .navbarTrigger .triggerShortcut {
+        display: none;
+    }
+
+    .modalSearch :global(.navbar__search-input),
+    .modalSearch :global(.navbar__search-input:not(:focus)) {
+        width: 100%;
+    }
+}
+
+:global([data-theme='dark']) .heroTrigger {
+    color: #b8ccd8;
+    border-color: rgba(152, 198, 234, 0.28);
+    background: rgba(19, 42, 58, 0.94);
+    box-shadow:
+        0 4px 11px rgba(0, 0, 0, 0.25),
+        0 18px 38px rgba(0, 0, 0, 0.28);
+}
+
+:global([data-theme='dark']) .heroTrigger .triggerLabel svg {
+    stroke: #b8ccd8;
+}
+
+:global([data-theme='dark']) .heroTrigger .triggerShortcut kbd {
+    color: #c5d9e6;
+    background: rgba(27, 62, 85, 0.92);
+}
+
+:global([data-theme='dark']) .searchDialog {
+    --search-ink: #edf6fc;
+    --search-navy: #d8ebf8;
+    --search-blue: #98c6ea;
+}
+
+:global([data-theme='dark']) .searchDialogPanel {
+    color: #edf6fc;
+    border-color: rgba(152, 198, 234, 0.28);
+    background: #162a39;
+    box-shadow: 0 24px 70px rgba(0, 0, 0, 0.52);
+}
+
+:global([data-theme='dark']) .searchDialogHeader button:hover {
+    background: rgba(48, 112, 179, 0.35);
+}
+
+:global([data-theme='dark']) .modalSearch {
+    --ifm-navbar-search-input-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='%23b8ccd8' d='M6.02945 10.20327a4.17382 4.17382 0 1 1 4.17382-4.17382 4.15609 4.15609 0 0 1-4.17382 4.17382Zm9.69195 4.2199-4.8225-4.82338A5.88021 5.88021 0 0 0 12.058 6.02856 6.00467 6.00467 0 1 0 9.59979 10.8989l4.82338 4.82338a.89729.89729 0 0 0 1.29912 0 .89749.89749 0 0 0-.00087-1.29909Z'/%3E%3C/svg%3E");
+    --search-local-modal-background: #162a39;
+    --search-local-hit-background: #203949;
+    --search-local-hit-shadow: none;
+    --search-local-hit-color: #edf6fc;
+    --search-local-hit-active-color: #fff;
+    --search-local-highlight-color: #98c6ea;
+    --search-local-muted-color: #b1c7d5;
+}
+
+:global([data-theme='dark']) .modalSearch :global(.navbar__search-input) {
+    color: #edf6fc;
+}
+
+:global([data-theme='dark']) .modalSearch :global(.navbar__search-input::placeholder) {
+    color: #b8ccd8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .heroTrigger,
+    .searchDialogPanel,
+    .searchDialog::backdrop {
+        transition: none;
+    }
+
+    .modalSearch :global([role='listbox']) {
+        animation: none;
+    }
+
+    .searchDialogPanel,
+    .searchDialogClosing .searchDialogPanel {
+        transform: none;
+    }
+
+    .heroTrigger:hover {
+        transform: none;
+    }
+}

--- a/documentation/src/css/custom.css
+++ b/documentation/src/css/custom.css
@@ -16,7 +16,7 @@
     --docusaurus-highlighted-code-line-bg: var(--tum-gray-20);
 
     /* TUM Primary Colors */
-    --tum-color-blue: #0065BD;
+    --tum-color-blue: #0065bd;
     --tum-color-black: #000000;
     --tum-color-white: #ffffff;
 
@@ -25,14 +25,18 @@
     --tum-color-blue-darker: #003359;
     --tum-gray-80: #333333;
     --tum-gray-50: #808080;
-    --tum-gray-20: #CCCCCC;
+    --tum-gray-20: #cccccc;
 
     /* TUM Accent Colors */
-    --tum-accent-beige: #DAD7CB;
-    --tum-accent-orange: #E37222;
-    --tum-accent-green: #A2AD00;
-    --tum-accent-light-blue: #98C6EA;
-    --tum-accent-blue: #64A0C8;
+    --tum-accent-beige: #dad7cb;
+    --tum-accent-orange: #e37222;
+    --tum-accent-green: #a2ad00;
+    --tum-accent-light-blue: #98c6ea;
+    --tum-accent-blue: #64a0c8;
+}
+
+.navbar__logo {
+    margin-right: 1.5em;
 }
 
 /* Dark mode: use Artemis blue tones */

--- a/documentation/src/pages/index.module.css
+++ b/documentation/src/pages/index.module.css
@@ -149,13 +149,14 @@
     overflow: hidden;
     color: var(--home-ink);
     text-decoration: none;
-    border: 1px solid rgba(0, 60, 105, 0.16);
+    border: 1px solid rgba(0, 82, 147, 0.2);
     border-radius: 0.65rem;
-    background: rgba(255, 255, 255, 0.92);
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.8), rgba(239, 248, 253, 0.68));
     box-shadow:
-        0 4px 10px rgba(0, 60, 105, 0.12),
-        0 18px 38px rgba(0, 60, 105, 0.16);
-    backdrop-filter: blur(13px);
+        inset 0 1px 0 rgba(255, 255, 255, 0.9),
+        0 6px 16px rgba(0, 60, 105, 0.13),
+        0 24px 50px rgba(0, 60, 105, 0.18);
+    backdrop-filter: blur(16px) saturate(1.12);
     transition:
         transform 180ms ease,
         box-shadow 180ms ease,
@@ -347,8 +348,9 @@
     .audienceCard:hover {
         border-color: rgba(0, 101, 189, 0.34);
         box-shadow:
-            0 6px 14px rgba(0, 60, 105, 0.14),
-            0 22px 44px rgba(0, 60, 105, 0.2);
+            inset 0 1px 0 rgba(255, 255, 255, 0.94),
+            0 8px 20px rgba(0, 60, 105, 0.15),
+            0 28px 56px rgba(0, 60, 105, 0.21);
         transform: translateY(-4px);
     }
 
@@ -489,6 +491,7 @@
     box-shadow:
         0 4px 10px rgba(0, 0, 0, 0.28),
         0 18px 38px rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(13px);
 }
 
 :global([data-theme='dark']) .audienceCard:hover {

--- a/documentation/src/pages/index.module.css
+++ b/documentation/src/pages/index.module.css
@@ -1,116 +1,534 @@
-/**
- * CSS files with the .module.css suffix will be treated as CSS modules
- * and scoped locally.
- */
+.homepage {
+    --home-logo-navy: #003c69;
+    --home-logo-blue: #3070b3;
+    --home-tum-blue: #0065bd;
+    --home-sky: #98c6ea;
+    --home-ice: #eaf4fb;
+    --home-ink: #102a3d;
+    --home-secondary-hover: rgba(152, 198, 234, 0.34);
+    display: flex;
+    min-height: 100vh;
+    min-height: 100dvh;
+    flex-direction: column;
+    color: var(--home-ink);
+    background: linear-gradient(108deg, #fff 0 32%, rgba(247, 251, 254, 0.97) 48%, rgba(225, 240, 250, 0.92) 70%, rgba(152, 198, 234, 0.62) 100%);
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
 
-.heroBanner {
-  padding: 2rem 0 1.5rem 0;
-  text-align: center;
-  position: relative;
-  overflow: hidden;
-  height: 100%;
+:global(body:has(.homepage-landing) .navbar) {
+    position: absolute;
+    inset: 0 0 auto;
+    width: 100%;
+    background: transparent;
+    box-shadow: none;
+}
+
+:global(body:has(.homepage-landing) .navbar a[href='/compare']) {
+    display: none;
+}
+
+.hero {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    min-height: 0;
+    flex: 1 0 auto;
+    align-items: center;
+    overflow: visible;
+    isolation: isolate;
+    padding: clamp(4rem, 7vw, 6.5rem) 0 clamp(3.25rem, 5vw, 4.75rem);
+    background: transparent;
+}
+
+.hero > :global(.container) {
+    width: 100%;
+}
+
+.heroDecoration {
+    position: absolute;
+    z-index: 0;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+}
+
+.mark {
+    position: absolute;
+    top: 5%;
+    right: 0;
+    width: auto;
+    height: 90%;
+    opacity: 0.52;
+    transform: translateX(min(2vw, 5.8%));
+    filter: blur(1.2px) drop-shadow(0 20px 30px rgba(0, 60, 105, 0.12));
+}
+
+.markEdge {
+    fill: none;
+    stroke: rgba(0, 60, 105, 0.14);
+    stroke-width: 0.7;
+    vector-effect: non-scaling-stroke;
+}
+
+.heroContent {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: minmax(0, 0.92fr) minmax(28rem, 1.08fr);
+    gap: clamp(2.5rem, 5vw, 5.5rem);
+    align-items: stretch;
+}
+
+.introduction,
+.audienceGrid,
+.audienceCard,
+.cardCopy {
+    min-width: 0;
+}
+
+.introduction {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--home-logo-blue);
+    font-size: 0.78rem;
+    font-weight: 750;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.eyebrow::before {
+    width: 1.75rem;
+    height: 2px;
+    background: currentColor;
+    content: '';
+}
+
+.headline {
+    max-width: 39rem;
+    margin: 1rem 0 0.9rem;
+    color: var(--home-logo-navy);
+    font-size: clamp(3rem, 5vw, 4.75rem);
+    font-weight: 750;
+    letter-spacing: -0.055em;
+    line-height: 0.98;
+}
+
+.headline em {
+    color: var(--home-tum-blue);
+    font-style: normal;
+}
+
+.lead {
+    max-width: 34rem;
+    margin: 0;
+    color: #4e6676;
+    font-size: clamp(1rem, 1.4vw, 1.15rem);
+    line-height: 1.6;
+}
+
+.audienceGrid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-rows: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.audienceCard {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 1.25rem;
+    overflow: hidden;
+    color: var(--home-ink);
+    text-decoration: none;
+    border: 1px solid rgba(0, 60, 105, 0.16);
+    border-radius: 0.65rem;
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow:
+        0 4px 10px rgba(0, 60, 105, 0.12),
+        0 18px 38px rgba(0, 60, 105, 0.16);
+    backdrop-filter: blur(13px);
+    transition:
+        transform 180ms ease,
+        box-shadow 180ms ease,
+        border-color 180ms ease;
+}
+
+.audienceCard:hover {
+    color: var(--home-ink);
+    text-decoration: none;
+}
+
+.audienceCard:focus-visible,
+.researchLink:focus-visible {
+    outline: 3px solid var(--home-tum-blue);
+    outline-offset: 3px;
+}
+
+.cardTop {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.iconChip {
+    display: grid;
+    width: 2.15rem;
+    height: 2.15rem;
+    flex: 0 0 auto;
+    place-items: center;
+    color: var(--home-logo-blue);
+    border: 1px solid rgba(48, 112, 179, 0.18);
+    border-radius: 0.4rem;
+    background: rgba(152, 198, 234, 0.42);
+}
+
+.iconChip svg {
+    width: 1.05rem;
+    height: 1.05rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.8;
+}
+
+.cardArrow {
+    display: grid;
+    width: 1.35rem;
+    height: 1.35rem;
+    flex: 0 0 auto;
+    place-items: center;
+    color: var(--home-tum-blue);
+    transition: transform 180ms ease;
+}
+
+.cardArrow svg,
+.secondaryAction svg {
+    width: 100%;
+    height: 100%;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.65;
+}
+
+.cardCopy {
+    display: block;
+    margin-top: 1.1rem;
+}
+
+.cardTitle {
+    margin: 0;
+    color: var(--home-logo-navy);
+    font-size: 1.05rem;
+    font-weight: 750;
+    line-height: 1.2;
+}
+
+.cardDescription {
+    display: block;
+    margin-top: 0.35rem;
+    color: #5b7180;
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+
+.secondaryStrip {
+    position: relative;
+    z-index: 0;
+    overflow-x: clip;
+    border-top: 1px solid rgba(0, 60, 105, 0.14);
+    background: rgba(255, 255, 255, 0.68);
+    box-shadow: 0 -10px 30px rgba(0, 60, 105, 0.06);
+    backdrop-filter: blur(13px);
+}
+
+.secondaryGrid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.secondaryLink {
+    position: relative;
+    display: flex;
+    min-width: 0;
+    isolation: isolate;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    padding: 1.45rem 2rem 1.65rem 0;
+    color: #526a79;
+    text-decoration: none;
+}
+
+.secondaryLink::before {
+    position: absolute;
+    z-index: -1;
+    inset: 0;
+    background: var(--home-secondary-hover);
+    content: '';
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 180ms ease;
+}
+
+.secondaryLink:first-child::before {
+    left: calc(100% - 50vw);
+}
+
+.secondaryLink:last-child::before {
+    right: calc(100% - 50vw);
+}
+
+.secondaryLink + .secondaryLink {
+    padding-right: 0;
+    padding-left: 2rem;
+    border-left: 1px solid #dce7ee;
+}
+
+.secondaryLink:hover {
+    color: #526a79;
+    text-decoration: none;
+}
+
+.secondaryLink:focus-visible {
+    outline: 3px solid var(--home-tum-blue);
+    outline-offset: -3px;
+}
+
+.secondaryCopy {
+    min-width: 0;
+}
+
+.secondaryCopy strong,
+.secondaryCopy > span {
+    display: block;
+}
+
+.secondaryCopy strong {
+    color: var(--home-logo-navy);
+    font-size: 1rem;
+}
+
+.secondaryCopy > span {
+    margin-top: 0.2rem;
+    font-size: 0.9rem;
+    line-height: 1.4;
+}
+
+.secondaryAction {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    gap: 0.55rem;
+    color: var(--home-tum-blue);
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.secondaryAction svg {
+    width: 1.2rem;
+    height: 1.2rem;
+    transition: transform 180ms ease;
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .audienceCard:hover {
+        border-color: rgba(0, 101, 189, 0.34);
+        box-shadow:
+            0 6px 14px rgba(0, 60, 105, 0.14),
+            0 22px 44px rgba(0, 60, 105, 0.2);
+        transform: translateY(-4px);
+    }
+
+    .secondaryLink:hover::before {
+        opacity: 1;
+    }
+
+    .audienceCard:hover .cardArrow,
+    .secondaryLink:hover .secondaryAction svg {
+        transform: translate(2px, -2px);
+    }
 }
 
 @media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 1.5rem;
-  }
-}
+    .hero {
+        padding: 3.75rem 0 3.25rem;
+    }
 
-.tilesContainer {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1.25rem;
-  margin-top: 1.5rem;
-  margin-bottom: 0;
-  padding-bottom: 0;
-  max-width: 700px;
-  margin-left: auto;
-  margin-right: auto;
-}
+    .heroContent {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 2.5rem;
+    }
 
-@media screen and (max-width: 768px) {
-  .tilesContainer {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-    margin-top: 1.25rem;
-  }
-}
+    .introduction {
+        max-width: none;
+    }
 
-.tile {
-  text-decoration: none;
-  transition: all 0.2s ease;
-  width: 100%;
-  border-radius: 8px;
-}
+    .headline {
+        font-size: clamp(3rem, 8vw, 4.25rem);
+    }
 
-.tile:hover {
-  background-color: var(--ifm-color-primary-lightest);
-  text-decoration: none;
-  transform: translateY(-2px);
-}
+    .audienceGrid {
+        grid-template-rows: none;
+    }
 
-.tile .card__body {
-  text-align: center;
-  padding: 1.25rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-}
+    .audienceCard {
+        min-height: 10rem;
+    }
 
-.tileIcon {
-  color: var(--ifm-color-primary);
-  margin-bottom: 0.25rem;
-  transition: color 0.2s ease;
-}
-
-.tileTitle {
-  font-size: 1.35rem;
-  font-weight: bold;
-  margin: 0;
-  color: var(--ifm-color-emphasis-900);
-  transition: color 0.2s ease;
-}
-
-/* Dark mode tile styling */
-/* stylelint-disable selector-pseudo-class-no-unknown */
-:global([data-theme='dark']) .tile {
-  background-color: #3a3d42;
-  border: 1px solid #4a4d52;
-}
-
-:global([data-theme='dark']) .tile:hover {
-  background-color: #454850;
-  border-color: #5a9ed6;
-  box-shadow: 0 4px 12px rgba(90, 158, 214, 0.2);
-}
-
-:global([data-theme='dark']) .tileIcon {
-  color: #76b2e0;
-}
-
-:global([data-theme='dark']) .tile:hover .tileIcon {
-  color: #98c6ea;
-}
-
-:global([data-theme='dark']) .tileTitle {
-  color: #fff;
-}
-/* stylelint-enable selector-pseudo-class-no-unknown */
-
-/* Publications section styling */
-.publicationsSection {
-  display: flex;
-  justify-content: center;
-  margin-top: 3rem;
-  max-width: 350px;
-  margin-left: auto;
-  margin-right: auto;
+    .mark {
+        top: 16%;
+        height: 68%;
+        opacity: 0.42;
+    }
 }
 
 @media screen and (max-width: 768px) {
-  .publicationsSection {
-    max-width: 100%;
-  }
+    .secondaryGrid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .secondaryLink,
+    .secondaryLink + .secondaryLink {
+        padding: 1.25rem 0 1.4rem;
+        border-left: 0;
+    }
+
+    .secondaryLink + .secondaryLink {
+        border-top: 1px solid #dce7ee;
+    }
+
+    .secondaryLink:first-child::before,
+    .secondaryLink:last-child::before {
+        right: calc((100vw - 100%) / -2);
+        left: calc((100vw - 100%) / -2);
+    }
+}
+
+@media screen and (max-width: 576px) {
+    .hero {
+        padding: 2.75rem 0 2.5rem;
+    }
+
+    .heroContent {
+        gap: 2rem;
+    }
+
+    .headline {
+        margin-top: 0.85rem;
+        font-size: clamp(2.75rem, 14vw, 3.6rem);
+    }
+
+    .lead {
+        font-size: 1rem;
+    }
+
+    .audienceGrid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .audienceCard {
+        min-height: 9rem;
+    }
+
+    .mark {
+        top: 31%;
+        height: 50%;
+        opacity: 0.3;
+    }
+}
+
+:global([data-theme='dark']) .homepage {
+    --home-logo-navy: #d8ebf8;
+    --home-logo-blue: #76b2e0;
+    --home-tum-blue: #98c6ea;
+    --home-ink: #edf6fc;
+    --home-secondary-hover: rgba(152, 198, 234, 0.1);
+    background: linear-gradient(108deg, #101b24 0 32%, rgba(18, 36, 50, 0.98) 50%, rgba(23, 57, 80, 0.96) 72%, rgba(34, 84, 120, 0.88) 100%);
+}
+
+:global([data-theme='dark'] body:has(.homepage-landing) .navbar) {
+    --ifm-navbar-link-color: #d8ebf8;
+    --ifm-navbar-link-hover-color: #98c6ea;
+    background: transparent;
+}
+
+:global([data-theme='dark']) .hero {
+    background: transparent;
+}
+
+:global([data-theme='dark']) .mark {
+    opacity: 0.28;
+    filter: blur(1.2px) drop-shadow(0 20px 30px rgba(0, 0, 0, 0.32));
+}
+
+:global([data-theme='dark']) .markEdge {
+    stroke: rgba(152, 198, 234, 0.2);
+}
+
+:global([data-theme='dark']) .lead {
+    color: #bdd0dc;
+}
+
+:global([data-theme='dark']) .audienceCard {
+    color: #edf6fc;
+    border-color: rgba(152, 198, 234, 0.22);
+    background: rgba(19, 42, 58, 0.9);
+    box-shadow:
+        0 4px 10px rgba(0, 0, 0, 0.28),
+        0 18px 38px rgba(0, 0, 0, 0.3);
+}
+
+:global([data-theme='dark']) .audienceCard:hover {
+    color: #edf6fc;
+}
+
+:global([data-theme='dark']) .iconChip {
+    color: #98c6ea;
+    border-color: rgba(152, 198, 234, 0.35);
+    background: rgba(48, 112, 179, 0.42);
+}
+
+:global([data-theme='dark']) .cardDescription {
+    color: #b9ccd8;
+}
+
+:global([data-theme='dark']) .secondaryStrip {
+    border-color: rgba(152, 198, 234, 0.22);
+    background: rgba(16, 27, 36, 0.68);
+    box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.14);
+}
+
+:global([data-theme='dark']) .secondaryLink + .secondaryLink {
+    border-color: rgba(152, 198, 234, 0.22);
+}
+
+:global([data-theme='dark']) .secondaryLink,
+:global([data-theme='dark']) .secondaryLink:hover {
+    color: #b9ccd8;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .audienceCard,
+    .cardArrow,
+    .secondaryLink::before,
+    .secondaryAction svg {
+        transition: none;
+    }
+
+    .audienceCard:hover {
+        transform: none;
+    }
 }

--- a/documentation/src/pages/index.module.css
+++ b/documentation/src/pages/index.module.css
@@ -419,7 +419,7 @@
 
 @media screen and (max-width: 576px) {
     .hero {
-        padding: 2.75rem 0 2.5rem;
+        padding: calc(var(--ifm-navbar-height) + 1.5rem) 0 2.5rem;
     }
 
     .heroContent {

--- a/documentation/src/pages/index.module.css
+++ b/documentation/src/pages/index.module.css
@@ -6,6 +6,7 @@
     --home-ice: #eaf4fb;
     --home-ink: #102a3d;
     --home-secondary-hover: rgba(152, 198, 234, 0.34);
+
     display: flex;
     min-height: 100vh;
     min-height: 100dvh;
@@ -106,7 +107,7 @@
 .eyebrow::before {
     width: 1.75rem;
     height: 2px;
-    background: currentColor;
+    background: currentcolor;
     content: '';
 }
 
@@ -168,8 +169,7 @@
     text-decoration: none;
 }
 
-.audienceCard:focus-visible,
-.researchLink:focus-visible {
+.audienceCard:focus-visible {
     outline: 3px solid var(--home-tum-blue);
     outline-offset: 3px;
 }
@@ -197,7 +197,7 @@
     width: 1.05rem;
     height: 1.05rem;
     fill: none;
-    stroke: currentColor;
+    stroke: currentcolor;
     stroke-linecap: round;
     stroke-linejoin: round;
     stroke-width: 1.8;
@@ -218,7 +218,7 @@
     width: 100%;
     height: 100%;
     fill: none;
-    stroke: currentColor;
+    stroke: currentcolor;
     stroke-linecap: round;
     stroke-linejoin: round;
     stroke-width: 1.65;
@@ -458,12 +458,14 @@
     --home-tum-blue: #98c6ea;
     --home-ink: #edf6fc;
     --home-secondary-hover: rgba(152, 198, 234, 0.1);
+
     background: linear-gradient(108deg, #101b24 0 32%, rgba(18, 36, 50, 0.98) 50%, rgba(23, 57, 80, 0.96) 72%, rgba(34, 84, 120, 0.88) 100%);
 }
 
 :global([data-theme='dark'] body:has(.homepage-landing) .navbar) {
     --ifm-navbar-link-color: #d8ebf8;
     --ifm-navbar-link-hover-color: #98c6ea;
+
     background: transparent;
 }
 

--- a/documentation/src/pages/index.tsx
+++ b/documentation/src/pages/index.tsx
@@ -1,85 +1,142 @@
 import type { ReactNode } from 'react';
-import clsx from 'clsx';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import Layout from '@theme/Layout';
-import Heading from '@theme/Heading';
 import Link from '@docusaurus/Link';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faGraduationCap, faChalkboardTeacher, faCode, faUserShield, faBook } from '@fortawesome/free-solid-svg-icons';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Heading from '@theme/Heading';
+import Layout from '@theme/Layout';
+import HomepageAudienceIcon, { type AudienceRole } from '../components/HomepageAudienceIcon';
+import { SearchModalTrigger } from '../components/SearchModal';
 
 import styles from './index.module.css';
 
-interface TileProps {
+interface AudienceDestination {
+    role: AudienceRole;
     title: string;
-    link: string;
-    icon: any;
+    description: string;
+    to: string;
 }
 
-function Tile({ title, link, icon }: TileProps) {
+const audienceDestinations: AudienceDestination[] = [
+    { role: 'student', title: 'Student', description: 'Learn with Artemis', to: '/student/intro' },
+    { role: 'instructor', title: 'Instructor', description: 'Teach with Artemis', to: '/instructor/intro' },
+    { role: 'developer', title: 'Developer', description: 'Build Artemis', to: '/developer/intro' },
+    { role: 'administrator', title: 'Administrator', description: 'Run Artemis', to: '/admin/intro' },
+];
+
+function ArrowIcon(): ReactNode {
     return (
-        <Link to={link} className={clsx('card', styles.tile)}>
-            <div className="card__body">
-                <div className={styles.tileIcon}>
-                    <FontAwesomeIcon icon={icon} size="3x" />
-                </div>
-                <Heading as="h3" className={styles.tileTitle}>
-                    {title}
+        <svg viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+            <path d="M5 15 15 5M7 5h8v8" />
+        </svg>
+    );
+}
+
+function AudienceCard({ destination }: { destination: AudienceDestination }): ReactNode {
+    return (
+        <Link to={destination.to} className={styles.audienceCard}>
+            <span className={styles.cardTop}>
+                <span className={styles.iconChip}>
+                    <HomepageAudienceIcon role={destination.role} />
+                </span>
+                <span className={styles.cardArrow}>
+                    <ArrowIcon />
+                </span>
+            </span>
+            <span className={styles.cardCopy}>
+                <Heading as="h2" className={styles.cardTitle}>
+                    {destination.title}
                 </Heading>
-            </div>
+                <span className={styles.cardDescription}>{destination.description}</span>
+            </span>
         </Link>
     );
 }
 
-function HomepageHeader() {
-    const { siteConfig } = useDocusaurusContext();
+function ArtemisMark(): ReactNode {
     return (
-        <header className={clsx('hero hero--primary', styles.heroBanner)}>
-            <div className="container">
-                <Heading as="h1" className="hero__title">
-                    {siteConfig.title}
-                </Heading>
-                <p className="hero__subtitle">{siteConfig.tagline}</p>
-                <div className={styles.tilesContainer}>
-                    <Tile
-                        title="Student"
-                        link="/student/intro"
-                        icon={faGraduationCap}
-                    />
-                    <Tile
-                        title="Instructor"
-                        link="/instructor/intro"
-                        icon={faChalkboardTeacher}
-                    />
-                    <Tile
-                        title="Developer"
-                        link="/developer/intro"
-                        icon={faCode}
-                    />
-                    <Tile
-                        title="Admin"
-                        link="/admin/intro"
-                        icon={faUserShield}
-                    />
+        <svg className={styles.mark} viewBox="72 58 135 112" aria-hidden="true" focusable="false">
+            <defs>
+                <linearGradient id="homepage-mark-blue" x1="72" y1="170" x2="156" y2="58" gradientUnits="userSpaceOnUse">
+                    <stop offset="0" stopColor="#0065bd" />
+                    <stop offset="0.58" stopColor="#3070b3" />
+                    <stop offset="1" stopColor="#4c8ac6" />
+                </linearGradient>
+                <linearGradient id="homepage-mark-light" x1="135" y1="115" x2="199" y2="170" gradientUnits="userSpaceOnUse">
+                    <stop offset="0" stopColor="#fffffc" />
+                    <stop offset="0.62" stopColor="#f5fbff" />
+                    <stop offset="1" stopColor="#d9edf9" />
+                </linearGradient>
+            </defs>
+            <path d="M135 58 L72 170 L135 115 L156 95 Z" fill="url(#homepage-mark-blue)" />
+            <path d="M156 95 L199 170 L135 115 Z" fill="url(#homepage-mark-light)" />
+            <path className={styles.markEdge} d="M135 58 L72 170 L135 115 L199 170 L156 95 Z" />
+            <path className={styles.markEdge} d="M135 115 L156 95" />
+        </svg>
+    );
+}
+
+function HomepageContent(): ReactNode {
+    return (
+        <main className={`${styles.homepage} homepage-landing`}>
+            <section className={styles.hero} aria-labelledby="homepage-title">
+                <div className={styles.heroDecoration} aria-hidden="true">
+                    <ArtemisMark />
                 </div>
-                <div className={styles.publicationsSection}>
-                    <Tile
-                        title="Publications"
-                        link="/publications"
-                        icon={faBook}
-                    />
+                <div className="container">
+                    <div className={styles.heroContent}>
+                        <div className={styles.introduction}>
+                            <div className={styles.eyebrow}>Artemis documentation</div>
+                            <Heading as="h1" id="homepage-title" className={styles.headline}>
+                                Find your way through <em>Artemis.</em>
+                            </Heading>
+                            <p className={styles.lead}>Guides for learning, teaching, developing, and operating the platform.</p>
+                            <SearchModalTrigger variant="hero" />
+                        </div>
+
+                        <nav className={styles.audienceGrid} aria-label="Documentation by audience">
+                            {audienceDestinations.map((destination) => (
+                                <AudienceCard key={destination.role} destination={destination} />
+                            ))}
+                        </nav>
+                    </div>
+                </div>
+            </section>
+
+            <div className={styles.secondaryStrip}>
+                <div className="container">
+                    <nav className={styles.secondaryGrid} aria-label="Additional resources">
+                        <Link to="/compare" className={styles.secondaryLink}>
+                            <span className={styles.secondaryCopy}>
+                                <strong>Compare Artemis</strong>
+                                <span>See how Artemis compares with other learning platforms</span>
+                            </span>
+                            <span className={styles.secondaryAction}>
+                                Explore comparison
+                                <ArrowIcon />
+                            </span>
+                        </Link>
+                        <Link to="/publications" className={styles.secondaryLink}>
+                            <span className={styles.secondaryCopy}>
+                                <strong>Research &amp; publications</strong>
+                                <span>The evidence behind the platform</span>
+                            </span>
+                            <span className={styles.secondaryAction}>
+                                Explore research
+                                <ArrowIcon />
+                            </span>
+                        </Link>
+                    </nav>
                 </div>
             </div>
-        </header>
+        </main>
     );
 }
 
 export default function Home(): ReactNode {
     const { siteConfig } = useDocusaurusContext();
+
     return (
-        <Layout
-            title={String(siteConfig.customFields?.pageTitle ?? '')}
-            description={siteConfig.tagline}>
-            <HomepageHeader />
+        <Layout title={String(siteConfig.customFields?.pageTitle ?? '')} description={siteConfig.tagline}>
+            <HomepageContent />
         </Layout>
     );
 }

--- a/documentation/src/theme/Navbar/Search/index.tsx
+++ b/documentation/src/theme/Navbar/Search/index.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+import { useLocation } from '@docusaurus/router';
+import { SearchModalTrigger } from '../../../components/SearchModal';
+
+export default function NavbarSearchWrapper(): ReactNode {
+    const { pathname } = useLocation();
+
+    if (pathname === '/') {
+        return null;
+    }
+
+    return <SearchModalTrigger variant="navbar" />;
+}

--- a/documentation/src/theme/Root.js
+++ b/documentation/src/theme/Root.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import { SearchModalProvider } from '../components/SearchModal';
 import { openDetailsOnHash, handleLinkClick } from '../utils/detailsScrollHelper';
 
 /**
@@ -7,26 +8,26 @@ import { openDetailsOnHash, handleLinkClick } from '../utils/detailsScrollHelper
  * Sets up global event listeners for handling collapsed details elements during navigation.
  */
 export default function Root({ children }) {
-  useEffect(() => {
-    if (!ExecutionEnvironment.canUseDOM) {
-      return;
-    }
+    useEffect(() => {
+        if (!ExecutionEnvironment.canUseDOM) {
+            return;
+        }
 
-    // Run on initial load
-    openDetailsOnHash();
+        // Run on initial load
+        openDetailsOnHash();
 
-    // Listen to navigation events
-    window.addEventListener('hashchange', openDetailsOnHash);
-    window.addEventListener('popstate', openDetailsOnHash);
-    document.addEventListener('click', handleLinkClick, true);
+        // Listen to navigation events
+        window.addEventListener('hashchange', openDetailsOnHash);
+        window.addEventListener('popstate', openDetailsOnHash);
+        document.addEventListener('click', handleLinkClick, true);
 
-    // Cleanup event listeners on unmount
-    return () => {
-      window.removeEventListener('hashchange', openDetailsOnHash);
-      window.removeEventListener('popstate', openDetailsOnHash);
-      document.removeEventListener('click', handleLinkClick, true);
-    };
-  }, []);
+        // Cleanup event listeners on unmount
+        return () => {
+            window.removeEventListener('hashchange', openDetailsOnHash);
+            window.removeEventListener('popstate', openDetailsOnHash);
+            document.removeEventListener('click', handleLinkClick, true);
+        };
+    }, []);
 
-  return <>{children}</>;
+    return <SearchModalProvider>{children}</SearchModalProvider>;
 }


### PR DESCRIPTION
### Summary

Redesign the Artemis documentation homepage as an audience-first gateway and provide a shared command-palette search experience across the documentation site.

### Checklist

#### General

- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client

- [x] **Important**: I implemented the changes with a very good performance, prevented too many unnecessary requests, and made sure that the UI is responsive.
- [x] I **strictly** followed the principle of **data economy** for all client-server requests.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

The previous landing page did not provide a strong entry point for the four documentation audiences and exposed limited space for local-search results. The redesign helps students, instructors, developers, and administrators reach their guide directly while retaining secondary access to platform comparisons and research.

### Description

- Replace the generic landing page with a responsive audience-first homepage.
- Add dedicated audience cards for Student, Instructor, Developer, and Administrator documentation.
- Add a continuous Artemis/TUM blue visual treatment with light and dark variants.
- Add a glass-style Compare and Research resource band with keyboard and hover states.
- Replace inline homepage and navbar search fields with semantic launchers backed by one shared native-dialog search experience.
- Search across all four documentation contexts from contextless pages while retaining guide-specific search contexts.
- Add platform-specific keyboard shortcut labels and shortcut toggling.
- Preserve reduced-motion behavior, visible keyboard focus, responsive layouts, and route-aware modal dismissal.
- Correct the TUM navbar logo and shared navbar spacing.

### Steps for Testing

1. Build and serve the documentation site:
   ```bash
   cd documentation
   corepack pnpm build
   corepack pnpm serve --host 127.0.0.1
   ```
2. Open `/` and verify the four audience destinations plus the Compare and Research resource links.
3. Verify the homepage at desktop, tablet, and mobile widths in both light and dark mode.
4. Open search from the homepage launcher and verify results from Student, Instructor, Developer, and Administrator guides.
5. Close and reopen search using `Command+K` on Apple platforms or `Ctrl+K` elsewhere.
6. Open a guide page and verify that its navbar contains Compare and the search launcher while the homepage does not duplicate those controls.
7. Navigate from a search result and confirm that the dialog closes.
8. Enable reduced motion and verify that modal and hover transforms are disabled while focus indicators remain visible.

### Testserver States

No Artemis application test-server deployment is required. The change affects only the standalone Docusaurus documentation site and was verified against its production build.

### Review Progress

#### Performance Review

- [ ] I (as a reviewer) confirm that the client changes are implemented with very good performance.

#### Code Review

- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests

- [ ] Responsive layout and both themes
- [ ] Search, keyboard, and navigation behavior

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-28 14:45:59 UTC_


### Screenshots

The homepage was validated locally at `1600×1200`, `996×1024`, and `390×844` in light and dark mode. Screenshots captured from the production build:
![Desktop homepage, light mode](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/d08bacb0-d1c9-4da1-b746-ac84baabf211.png)

![Shared documentation search](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/3269f674-606d-4208-a5fa-71990e929099.png)

![Mobile homepage, light mode](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/5ba18d38-a918-4045-a1af-68cb9b2ab01e.png)

![Mobile homepage, dark mode](https://raw.githubusercontent.com/Claudia-Anthropica/pr-screenshots/main/c852eaea-be43-4a19-8098-bfc88593fb85.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a modal-based documentation search with Ctrl/⌘+K, animated open/close, backdrop dismissal, route-change closing, and reduced-motion support.
  * Added role-based audience icons and rebuilt the homepage with interactive student/instructor/developer/administrator audience cards.
* **Improvements**
  * Updated navbar search behavior so it only appears on appropriate pages, and refreshed the navbar logo for light/dark mode.
  * Refined local search plugin configuration and improved search UI integration.
* **Style**
  * Updated homepage and global styling, including refreshed color variables and responsive layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
