### PR TITLE
`Programming exercises`: Stop AddressSanitizer stalling on its exit-time leak scan

### DIFF
--- a/src/main/resources/templates/c/gcc/test/Tests.py
+++ b/src/main/resources/templates/c/gcc/test/Tests.py
@@ -1,3 +1,5 @@
+import os
+
 from tests.TestASan import TestASan
 from tests.TestCompile import TestCompile
 from tests.TestLSan import TestLSan
@@ -6,7 +8,27 @@ from tests.TestUBSan import TestUBSan
 from testUtils.Tester import Tester
 
 
+def configureSanitizerRuntime():
+    """
+    Disables AddressSanitizer's exit-time leak scan for the programs started by this tester.
+
+    GCC's AddressSanitizer runs LeakSanitizer when an instrumented program exits. That leak scan
+    stops the world via ptrace, which Docker's default seccomp profile denies (the build containers
+    intentionally do not get CAP_SYS_PTRACE, because they execute untrusted student code). Without
+    ptrace the scan does not fail fast: it stalls, so a correct `asan.out` never reaches exit and the
+    test is reported as a timeout. That is why `TestOutputASan` was flaky while `TestOutputUBSan` --
+    same instrumentation cost, no leak scan -- always passed.
+
+    Leak coverage is not lost: leaks are checked by the dedicated `-fsanitize=leak` test, which reads
+    LSAN_OPTIONS rather than ASAN_OPTIONS and is unaffected by this setting. `setdefault` keeps an
+    explicit ASAN_OPTIONS from the environment authoritative.
+    """
+    os.environ.setdefault("ASAN_OPTIONS", "detect_leaks=0")
+
+
 def main():
+    configureSanitizerRuntime()
+
     # Makefile location:
     # Artemis expects it to be located in ../assignment
     makefileLocation: str = "../assignment"

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIDockerImageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIDockerImageIntegrationTest.java
@@ -214,9 +214,13 @@ class LocalCIDockerImageIntegrationTest extends AbstractProgrammingIntegrationLo
                 baseRepositories.solutionRepository());
         programmingExerciseStudentParticipationRepository.saveAndFlush(participation);
 
-        // Sanitizer-based test cases (especially in the GCC variant) can flake intermittently
-        // in Docker due to ASLR / sanitizer interactions on CI runners. Retry the build once
-        // before failing — a real configuration regression will fail twice.
+        // Retry the build once before failing — a real configuration regression fails twice.
+        // The GCC variant used to flake here with `TestOutputASan [FAIL]: timeout`, which was not a
+        // load or ASLR effect: AddressSanitizer runs LeakSanitizer at exit, that scan stops the world
+        // via ptrace, and the build containers deliberately have no CAP_SYS_PTRACE (they run untrusted
+        // student code), so a correct `asan.out` stalled instead of exiting. The C template now sets
+        // ASAN_OPTIONS=detect_leaks=0 for the tester's child processes, so the stall is gone at the
+        // source. This retry is kept as cheap insurance and can be dropped once that has held.
         AssertionError lastFailure = null;
         for (int attempt = 1; attempt <= MAX_BUILD_ATTEMPTS; attempt++) {
             String triggerFileName = "trigger-attempt-" + attempt + ".txt";


### PR DESCRIPTION
### Problem

`LocalCIDockerImageIntegrationTest.setupCExerciseWithGcc_usesConfiguredDockerImage` keeps failing with:

```
expected: 100.0 but was: 83.3
  - TestCompile      [PASS]
  - TestCompileASan  [PASS]
  - TestCompileUBSan [PASS]
  - TestOutput       [PASS]
  - TestOutputASan   [FAIL]: timeout
  - TestOutputUBSan  [PASS]
```

This is not a per-PR problem — it is red on **develop** itself, and it has taken down unrelated PRs including a one-file Docker change that cannot touch server tests. Because `Test / Server Tests (PostgreSQL)` feeds the required `All required CI Passed` gate, this single test currently makes merging a lottery for every open PR.

### Cause

Not runner load and not ASLR, which is what the existing comments assumed.

GCC's AddressSanitizer runs **LeakSanitizer when an instrumented program exits**. That leak scan stops the world via `ptrace`. The build containers deliberately do **not** get `CAP_SYS_PTRACE` — they execute untrusted student code. Without `ptrace` the scan does not fail fast, it **stalls**, so a correct `asan.out` never reaches exit and the case is reported as a timeout.

Three things corroborate this:

1. `TestOutputUBSan` always passes — same instrumentation overhead, but UBSan performs no leak scan.
2. The failure is a *timeout*, not a startup error. An ASan shadow-memory/ASLR problem fails loudly at startup instead.
3. The LSan cases are already quietly excluded from `GCC_TEST_CASE_NAMES` even though `Tests.py` registers them — consistent with leak-scanning being broken in these containers all along.

Note that raising timeouts has already been tried twice here (`5s → 30s`, `10s → 30s`, `3s → 15s`) and the test still fails. You cannot wait out a stall.

### Fix

The C template sets `ASAN_OPTIONS=detect_leaks=0` for the tester's child processes, removing the stall at the source.

Leak coverage is **not** lost: leaks are checked by the dedicated `-fsanitize=leak` test, which reads `LSAN_OPTIONS` and is unaffected. `setdefault` keeps an explicit `ASAN_OPTIONS` from the environment authoritative.

### Deliberate non-changes

Both are safe to revisit once this has held for a while, and both are intentionally *not* bundled here:

- The build-retry loop in the Java test stays as cheap insurance.
- The previously inflated timeouts stay put rather than being reverted in the same change.

I also corrected the Java test comment, which attributed the flake to ASLR.

### Verification

**This is verified by CI, not locally, and I want to be explicit about why.** The failure only manifests inside the Linux build container: Docker is unavailable in my environment, and on macOS LeakSanitizer does not apply at all, so there is no way for me to reproduce it here. The reasoning above is derived from the failure signature plus the ASan/UBSan asymmetry and the pre-existing LSan exclusion.

If `TestOutputASan` still times out after this, the hypothesis is wrong and the next candidate is the ASan shadow-mapping/`vm.mmap_rnd_bits` interaction — but that should present as a startup error rather than a timeout.

Also worth flagging separately: `lsan.out` presumably stalls for the same reason. Its results are not asserted, so it does not fail the build, but it may be burning up to ~30s of every C build. Disabling leak detection in the leak test would be nonsense, so that needs its own decision (drop the LSan cases from the container template, or grant the capability — which I would not do for untrusted code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C test execution reliability by preventing AddressSanitizer leak checks from stalling or failing test runs.
  * Updated test guidance to clarify sanitizer behavior during build retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->