### PR TITLE
Development: Replace the TUM UI kit styleClass shim with native class

### DIFF
--- a/documentation/docs/developer/guidelines/tum-ui-kit.mdx
+++ b/documentation/docs/developer/guidelines/tum-ui-kit.mdx
@@ -108,8 +108,14 @@ apps in the fleet mirror the same concepts with their own primitive stack.
 - **Token-only styling** — only semantic Tailwind tokens (see [Design tokens](#design-tokens)).
   Never raw palette colors, `--p-*` primitives, or Bootstrap classes.
 - **Native `class`, not `styleClass`** — a component styles its own host via a `host` `class` / `[class]`
-  binding, and Angular merges that with whatever `class` the consumer writes on the element. So pass extra
-  classes with plain `class="w-full"`; do not add a PrimeNG-style `styleClass` input to a new component.
+  binding, and Angular merges that with whatever `class` the consumer writes on the element. Both the static
+  form (`class="w-full"`) and a bound one (`[class]="extraClasses()"`) merge, and a bound value can change
+  freely without dropping the component's own classes. So pass extra classes natively; do not add a
+  PrimeNG-style `styleClass` input to a new component.
+  The exception is a component that wraps a **native element it cannot hoist onto the host** — `tum-ui-button`
+  (inner `<button>`) and `tum-ui-input-number` (inner `<input>`). There the host is a custom element, a
+  consumer `class` lands on the wrapper rather than the control, and a targeted `styleClass` /
+  `inputStyleClass` input is the correct design, not a shim.
 - **Accessibility is part of the contract** — correct roles and `aria-*`, keyboard support, and focus
   management, all verified in tests.
 - **`@angular/cdk` is the only UI _component-library_ dependency** — no PrimeNG / Bootstrap /

--- a/documentation/docs/developer/guidelines/tum-ui-kit.mdx
+++ b/documentation/docs/developer/guidelines/tum-ui-kit.mdx
@@ -112,10 +112,14 @@ apps in the fleet mirror the same concepts with their own primitive stack.
   form (`class="w-full"`) and a bound one (`[class]="extraClasses()"`) merge, and a bound value can change
   freely without dropping the component's own classes. So pass extra classes natively; do not add a
   PrimeNG-style `styleClass` input to a new component.
-  The exception is a component that wraps a **native element it cannot hoist onto the host** — `tum-ui-button`
-  (inner `<button>`) and `tum-ui-input-number` (inner `<input>`). There the host is a custom element, a
-  consumer `class` lands on the wrapper rather than the control, and a targeted `styleClass` /
-  `inputStyleClass` input is the correct design, not a shim.
+  The one exception is a component that wraps a **native element it cannot hoist onto the host**, because the
+  host is a custom element and a consumer `class` would land on the wrapper rather than the control.
+  `tum-ui-button` is that case: it keeps a `styleClass` input targeting its inner `<button>`, and that is the
+  correct design there, not a shim. (`<button tumUiButton>` — the attribute form — has no such input, because
+  its host _is_ the button.) `tum-ui-tag` also still has one; its pill is a plain inner `<span>` that _could_
+  be hoisted onto the host, but its severity styling is keyed to `:host span[data-severity=…]` selectors, so
+  the move is deferred rather than structurally required. Only add a targeted class input when a consumer
+  actually needs to reach such an inner element; do not add one pre-emptively.
 - **Accessibility is part of the contract** — correct roles and `aria-*`, keyboard support, and focus
   management, all verified in tests.
 - **`@angular/cdk` is the only UI _component-library_ dependency** — no PrimeNG / Bootstrap /
@@ -592,7 +596,6 @@ A numeric input — the drop-in for `p-inputnumber` (integer values). A token-st
 | `inputId`            | `string`     | unique per instance | `id` of the inner `<input>`, for an external `<label for>`.                                                         |
 | `name`               | `string`     | –                   | `name` forwarded onto the inner `<input>`.                                                                          |
 | `ariaLabel`          | `string`     | –                   | Accessible name when there is no visible label.                                                                     |
-| `inputStyleClass`    | `string`     | `''`                | Classes forwarded onto the inner `<input>`.                                                                         |
 | `onBlur` / `onFocus` | `FocusEvent` | –                   | Emitted on the inner input's blur (after clamping) / focus.                                                         |
 
 Public methods `focus()`, `blur()`, and `select()` operate on the inner native input (e.g. for a page-navigation field that selects its text on focus).
@@ -720,7 +723,6 @@ A rounded pill with a text `[label]` (or projected content) and an optional keyb
 | `removable`         | `boolean` | `false`    | Renders the accessible remove (×) button.                                                |
 | `size`              | `'small'` | –          | `'small'` renders the compact in-field chip; omit for the default size.                  |
 | `removeAriaLabel`   | `string`  | `'Remove'` | Accessible name for the remove button; override for i18n.                                |
-| `styleClass`        | `string`  | `''`       | Classes forwarded onto the pill.                                                         |
 | `onRemove` (output) | `Event`   | –          | The remove control was activated (click, Enter/Space, or Backspace/Delete when focused). |
 
 ```html

--- a/documentation/docs/developer/guidelines/tum-ui-kit.mdx
+++ b/documentation/docs/developer/guidelines/tum-ui-kit.mdx
@@ -107,6 +107,9 @@ apps in the fleet mirror the same concepts with their own primitive stack.
 - **Standalone + `ChangeDetectionStrategy.OnPush`**, zoneless-safe.
 - **Token-only styling** — only semantic Tailwind tokens (see [Design tokens](#design-tokens)).
   Never raw palette colors, `--p-*` primitives, or Bootstrap classes.
+- **Native `class`, not `styleClass`** — a component styles its own host via a `host` `class` / `[class]`
+  binding, and Angular merges that with whatever `class` the consumer writes on the element. So pass extra
+  classes with plain `class="w-full"`; do not add a PrimeNG-style `styleClass` input to a new component.
 - **Accessibility is part of the contract** — correct roles and `aria-*`, keyboard support, and focus
   management, all verified in tests.
 - **`@angular/cdk` is the only UI _component-library_ dependency** — no PrimeNG / Bootstrap /
@@ -506,7 +509,6 @@ A single-select dropdown on the CDK overlay — the drop-in for `p-select`. A `r
 | `disabled`          | `boolean`            | `false`                  | Merged with the reactive-forms disabled state.                                                                                                                   |
 | `showClear`         | `boolean`            | `false`                  | Renders a clear (×) button once a value is selected.                                                                                                             |
 | `size`              | `'small' \| 'large'` | –                        | Omit for the default size.                                                                                                                                       |
-| `styleClass`        | `string`             | `''`                     | Classes forwarded onto the host (e.g. `w-full`).                                                                                                                 |
 | `inputId`           | `string`             | unique per instance      | `id` of the trigger; set it for a stable `<label for>` target.                                                                                                   |
 | `ariaLabel`         | `string`             | –                        | Accessible name when there is no visible label.                                                                                                                  |
 | `name`              | `string`             | –                        | Forwarded onto the trigger for template-driven-form parity.                                                                                                      |
@@ -518,10 +520,10 @@ A single-select dropdown on the CDK overlay — the drop-in for `p-select`. A `r
 
 ```html
 <!-- Reactive form, object options -->
-<tum-ui-select inputId="langKey" formControlName="langKey" styleClass="w-full" [options]="languageOptions()" optionLabel="label" optionValue="value" />
+<tum-ui-select inputId="langKey" formControlName="langKey" class="w-full" [options]="languageOptions()" optionLabel="label" optionValue="value" />
 
 <!-- Two-way binding + change handler -->
-<tum-ui-select [(ngModel)]="selectedNodeId" [options]="nodeOptions()" optionLabel="label" optionValue="value" (onChange)="onNodeChange()" size="small" styleClass="w-auto" />
+<tum-ui-select [(ngModel)]="selectedNodeId" [options]="nodeOptions()" optionLabel="label" optionValue="value" (onChange)="onNodeChange()" size="small" class="w-auto" />
 ```
 
 ### Autocomplete — `tum-ui-autocomplete`
@@ -540,7 +542,6 @@ An autocomplete / combobox on the CDK overlay — the drop-in for `p-autocomplet
 | `minLength`             | `number`                    | `1`                  | Minimum typed characters before `completeMethod` fires.                                    |
 | `delay`                 | `number`                    | `300`                | Debounce (ms) before `completeMethod` fires.                                               |
 | `completeOnFocus`       | `boolean`                   | `false`              | Fire `completeMethod` (even empty) and open the panel on focus.                            |
-| `styleClass`            | `string`                    | `''`                 | Classes forwarded onto the host (e.g. `w-full`).                                           |
 | `emptyMessage`          | `string`                    | `'No results found'` | Panel text when a search returns nothing.                                                  |
 | `inputId`               | `string`                    | unique per instance  | `id` of the text input, for a stable `<label for>` target.                                 |
 | `name`                  | `string`                    | –                    | Forwarded onto the input for template-driven-form parity.                                  |
@@ -552,7 +553,7 @@ An autocomplete / combobox on the CDK overlay — the drop-in for `p-autocomplet
 
 ```html
 <tum-ui-autocomplete
-    styleClass="w-full"
+    class="w-full"
     [multiple]="true"
     [ngModel]="user().groups ?? []"
     [ngModelOptions]="{ standalone: true }"
@@ -585,7 +586,6 @@ A numeric input — the drop-in for `p-inputnumber` (integer values). A token-st
 | `inputId`            | `string`     | unique per instance | `id` of the inner `<input>`, for an external `<label for>`.                                                         |
 | `name`               | `string`     | –                   | `name` forwarded onto the inner `<input>`.                                                                          |
 | `ariaLabel`          | `string`     | –                   | Accessible name when there is no visible label.                                                                     |
-| `styleClass`         | `string`     | `''`                | Classes forwarded onto the host.                                                                                    |
 | `inputStyleClass`    | `string`     | `''`                | Classes forwarded onto the inner `<input>`.                                                                         |
 | `onBlur` / `onFocus` | `FocusEvent` | –                   | Emitted on the inner input's blur (after clamping) / focus.                                                         |
 
@@ -727,11 +727,10 @@ A content card with a surface, rounded corners, and a soft shadow — the drop-i
 
 <Shots light={TumuiCardLight} dark={TumuiCardDark} alt="tum-ui-card with a header, subheader and body" />
 
-| Input        | Type     | Default | Notes                                                     |
-| ------------ | -------- | ------- | --------------------------------------------------------- |
-| `header`     | `string` | –       | Optional title, rendered in the caption.                  |
-| `subheader`  | `string` | –       | Optional subtitle under the title, in the muted color.    |
-| `styleClass` | `string` | `''`    | Classes forwarded onto the card root (e.g. a hook class). |
+| Input       | Type     | Default | Notes                                                  |
+| ----------- | -------- | ------- | ------------------------------------------------------ |
+| `header`    | `string` | –       | Optional title, rendered in the caption.               |
+| `subheader` | `string` | –       | Optional subtitle under the title, in the muted color. |
 
 ```html
 <tum-ui-card header="Statistics" subheader="Last 30 days">
@@ -750,7 +749,6 @@ A titled, bordered content panel with an optional collapse toggle — the drop-i
 | `header`              | `string`  | `''`    | Header title text.                                                                       |
 | `toggleable`          | `boolean` | `false` | Whether the header toggle can collapse the body.                                         |
 | `collapsed` (`model`) | `boolean` | `false` | Two-way bindable as `[(collapsed)]` (or one-way `[collapsed]`). Emits `collapsedChange`. |
-| `styleClass`          | `string`  | `''`    | Classes forwarded onto the panel root.                                                   |
 
 ```html
 <tum-ui-panel [header]="'…config' | artemisTranslate" [toggleable]="true" [collapsed]="true">
@@ -791,9 +789,8 @@ A presentational wrapper — the drop-in for `p-buttongroup` — that welds proj
 
 <Shots light={TumuiButtonGroupLight} dark={TumuiButtonGroupDark} alt="tum-ui-button-group welding three buttons" />
 
-| Input        | Type     | Default | Notes                                  |
-| ------------ | -------- | ------- | -------------------------------------- |
-| `styleClass` | `string` | `''`    | Classes forwarded onto the group root. |
+| Input | Type | Default | Notes |
+| ----- | ---- | ------- | ----- |
 
 ```html
 <tum-ui-button-group>
@@ -809,16 +806,15 @@ An inline message / alert box — the drop-in for `p-message`. Colored severitie
 
 <Shots light={TumuiMessageLight} dark={TumuiMessageDark} alt="tum-ui-message in info, success, warn and error severities" />
 
-| Input        | Type                                                                    | Default  | Notes                                                                     |
-| ------------ | ----------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------- |
-| `severity`   | `'info' \| 'success' \| 'warn' \| 'error' \| 'secondary' \| 'contrast'` | `'info'` |                                                                           |
-| `text`       | `string`                                                                | –        | Plain-text message; when set it renders **instead of** projected content. |
-| `icon`       | `IconProp`                                                              | –        | Optional leading FontAwesome icon; none shown by default.                 |
-| `styleClass` | `string`                                                                | `''`     | Classes forwarded onto the box (e.g. `mb-3 w-full`).                      |
+| Input      | Type                                                                    | Default  | Notes                                                                     |
+| ---------- | ----------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------- |
+| `severity` | `'info' \| 'success' \| 'warn' \| 'error' \| 'secondary' \| 'contrast'` | `'info'` |                                                                           |
+| `text`     | `string`                                                                | –        | Plain-text message; when set it renders **instead of** projected content. |
+| `icon`     | `IconProp`                                                              | –        | Optional leading FontAwesome icon; none shown by default.                 |
 
 ```html
 <!-- Plain text via the input -->
-<tum-ui-message severity="error" [text]="error" styleClass="mb-3 w-full" aria-live="assertive" />
+<tum-ui-message severity="error" [text]="error" class="mb-3 w-full" aria-live="assertive" />
 
 <!-- Projected content -->
 <tum-ui-message severity="warn"><fa-icon [icon]="faTriangleExclamation" /> This action needs your attention.</tum-ui-message>
@@ -924,13 +920,12 @@ A determinate progress bar — the drop-in for `p-progressbar`. A `bg-primary` f
 
 <Shots light={TumuiProgressBarLight} dark={TumuiProgressBarDark} alt="tum-ui-progress-bar at 65%" />
 
-| Input        | Type      | Default | Notes                                                                     |
-| ------------ | --------- | ------- | ------------------------------------------------------------------------- |
-| `value`      | `number`  | `0`     | Current progress 0–100; drives the fill width and `aria-valuenow`.        |
-| `showValue`  | `boolean` | `true`  | Render the default `{value}{unit}` label (ignored for projected content). |
-| `color`      | `string`  | –       | CSS color for the fill, overriding the default `bg-primary`.              |
-| `unit`       | `string`  | `'%'`   | Unit appended to the default value label.                                 |
-| `styleClass` | `string`  | `''`    | Classes forwarded onto the bar (e.g. `mb-2`).                             |
+| Input       | Type      | Default | Notes                                                                     |
+| ----------- | --------- | ------- | ------------------------------------------------------------------------- |
+| `value`     | `number`  | `0`     | Current progress 0–100; drives the fill width and `aria-valuenow`.        |
+| `showValue` | `boolean` | `true`  | Render the default `{value}{unit}` label (ignored for projected content). |
+| `color`     | `string`  | –       | CSS color for the fill, overriding the default `bg-primary`.              |
+| `unit`      | `string`  | `'%'`   | Unit appended to the default value label.                                 |
 
 ```html
 <!-- Labelled percentage -->
@@ -946,16 +941,15 @@ An indeterminate loading spinner — the drop-in for `p-progressspinner`. A rota
 
 <Shots light={TumuiProgressSpinnerLight} dark={TumuiProgressSpinnerDark} alt="tum-ui-progress-spinner" />
 
-| Input               | Type               | Default  | Notes                                                   |
-| ------------------- | ------------------ | -------- | ------------------------------------------------------- |
-| `strokeWidth`       | `string \| number` | `'2'`    | Width of the circle stroke.                             |
-| `fill`              | `string`           | `'none'` | Fill of the circle interior.                            |
-| `animationDuration` | `string`           | `'2s'`   | Duration of one full rotation.                          |
-| `ariaLabel`         | `string`           | –        | Accessible label describing what is loading.            |
-| `styleClass`        | `string`           | `''`     | Classes forwarded onto the spinner (e.g. to resize it). |
+| Input               | Type               | Default  | Notes                                        |
+| ------------------- | ------------------ | -------- | -------------------------------------------- |
+| `strokeWidth`       | `string \| number` | `'2'`    | Width of the circle stroke.                  |
+| `fill`              | `string`           | `'none'` | Fill of the circle interior.                 |
+| `animationDuration` | `string`           | `'2s'`   | Duration of one full rotation.               |
+| `ariaLabel`         | `string`           | –        | Accessible label describing what is loading. |
 
 ```html
-<tum-ui-progress-spinner [ariaLabel]="'loading' | artemisTranslate" styleClass="w-16 h-16" />
+<tum-ui-progress-spinner [ariaLabel]="'loading' | artemisTranslate" class="w-16 h-16" />
 ```
 
 <Callout variant={CalloutVariant.info}>The visible spinner carries no text, so `ariaLabel` is the only description a screen reader gets — set it to say what is loading.</Callout>
@@ -972,7 +966,6 @@ The **low-level, hand-templated** table primitive — the drop-in for using `p-t
 | `striped`                     | `boolean`                          | `false`    | Zebra-stripe body rows.                                                                                               |
 | `scrollable`                  | `boolean`                          | `false`    | Pin the header while a bounded ancestor container scrolls.                                                            |
 | `rowHover`                    | `boolean`                          | `false`    | Tint body rows on hover.                                                                                              |
-| `styleClass`                  | `string`                           | `''`       | Classes forwarded onto the table (e.g. `mt-3`).                                                                       |
 | `sortField`                   | `string`                           | –          | Active sort field (**controlled**); drives icons + `aria-sort`.                                                       |
 | `sortOrder`                   | `number`                           | `1`        | Active sort order: `1` ascending, `-1` descending.                                                                    |
 | `defaultSortOrder`            | `number`                           | `1`        | Order applied when a previously-unsorted column is first clicked.                                                     |

--- a/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.html
+++ b/src/main/webapp/app/admin/cleanup-service/cleanup-operation-modal.component.html
@@ -10,7 +10,7 @@
     [header]="'cleanupService.operation.' + operation().name | artemisTranslate"
 >
     @if (dialogError(); as error) {
-        <tum-ui-message severity="error" [text]="error" styleClass="mb-3 w-full" aria-live="assertive" data-testid="cleanup-error-message" />
+        <tum-ui-message severity="error" [text]="error" class="mb-3 w-full" aria-live="assertive" data-testid="cleanup-error-message" />
     }
     @if (operation().name === 'deleteOrphans') {
         <p

--- a/src/main/webapp/app/admin/features/admin-feature-toggle.component.html
+++ b/src/main/webapp/app/admin/features/admin-feature-toggle.component.html
@@ -147,7 +147,7 @@
                     </div>
                     <p class="mb-2 text-sm leading-snug text-muted-color">{{ getFeatureDescriptionKey(featureInfo.feature) | artemisTranslate }}</p>
                     @if (!featureInfo.isActive) {
-                        <tum-ui-message severity="warn" styleClass="w-full" data-testid="feature-warning">{{
+                        <tum-ui-message severity="warn" class="w-full" data-testid="feature-warning">{{
                             getFeatureWarningKey(featureInfo.feature) | artemisTranslate
                         }}</tum-ui-message>
                     }

--- a/src/main/webapp/app/admin/iris-dashboard/iris-dashboard.component.html
+++ b/src/main/webapp/app/admin/iris-dashboard/iris-dashboard.component.html
@@ -11,7 +11,7 @@
                 optionLabel="label"
                 (ngModelChange)="onTimeSpanChange($event)"
                 size="small"
-                styleClass="w-auto"
+                class="w-auto"
             />
             <tum-ui-button
                 severity="secondary"
@@ -31,7 +31,7 @@
     }
 
     @if (error()) {
-        <tum-ui-message severity="error" styleClass="w-full">{{ 'artemisApp.irisDashboard.error' | artemisTranslate }}</tum-ui-message>
+        <tum-ui-message severity="error" class="w-full">{{ 'artemisApp.irisDashboard.error' | artemisTranslate }}</tum-ui-message>
     }
 
     @if (overview()) {

--- a/src/main/webapp/app/admin/iris-dashboard/iris-kpi-card/iris-kpi-card.component.html
+++ b/src/main/webapp/app/admin/iris-dashboard/iris-kpi-card/iris-kpi-card.component.html
@@ -1,4 +1,4 @@
-<tum-ui-card styleClass="iris-kpi-card">
+<tum-ui-card class="iris-kpi-card">
     <div class="iris-kpi-card__header">
         <span class="iris-kpi-card__title" [jhiTranslate]="titleKey()"></span>
         <jhi-help-icon [text]="helpKey()" />

--- a/src/main/webapp/app/admin/lti-configuration/edit/edit-lti-configuration.component.html
+++ b/src/main/webapp/app/admin/lti-configuration/edit/edit-lti-configuration.component.html
@@ -7,11 +7,11 @@
             jhiTranslate="{{ !platform()?.id ? 'artemisApp.lti.addLtiPlatform' : 'artemisApp.lti.editLtiPlatform' }}"
         ></h5>
         @if (loadFailed()) {
-            <tum-ui-message severity="error" styleClass="mt-3 w-full" data-testid="lti-load-error">
+            <tum-ui-message severity="error" class="mt-3 w-full" data-testid="lti-load-error">
                 <span jhiTranslate="artemisApp.lti.editConfiguration.loadError"></span>
             </tum-ui-message>
         } @else {
-            <tum-ui-message severity="info" styleClass="mt-3 w-full" data-testid="lti-documentation-message">
+            <tum-ui-message severity="info" class="mt-3 w-full" data-testid="lti-documentation-message">
                 <span jhiTranslate="artemisApp.lti.edit.documentationLink"></span>
                 <a
                     href="https://docs.artemis.tum.de/instructor/lti-configuration/"

--- a/src/main/webapp/app/admin/lti-configuration/lti-configuration.component.html
+++ b/src/main/webapp/app/admin/lti-configuration/lti-configuration.component.html
@@ -1,6 +1,6 @@
 <form name="editForm" role="form" novalidate>
     <h5 *adminTitleBarTitle id="lti-configuration-heading" class="mb-0" jhiTranslate="artemisApp.lti.version13Configuration"></h5>
-    <tum-ui-message severity="info" styleClass="mt-3 w-full" data-testid="lti-documentation-message">
+    <tum-ui-message severity="info" class="mt-3 w-full" data-testid="lti-documentation-message">
         <span jhiTranslate="artemisApp.lti.edit.documentationLink"></span>
         <a
             href="https://docs.artemis.tum.de/instructor/lti-configuration/"

--- a/src/main/webapp/app/admin/metrics/metrics.component.html
+++ b/src/main/webapp/app/admin/metrics/metrics.component.html
@@ -11,15 +11,7 @@
             >Datasource</tum-ui-button
         >
         @if (nodeOptions().length > 1) {
-            <tum-ui-select
-                [(ngModel)]="selectedNodeId"
-                [options]="nodeOptions()"
-                optionLabel="label"
-                optionValue="value"
-                (onChange)="onNodeChange()"
-                size="small"
-                styleClass="w-auto"
-            />
+            <tum-ui-select [(ngModel)]="selectedNodeId" [options]="nodeOptions()" optionLabel="label" optionValue="value" (onChange)="onNodeChange()" size="small" class="w-auto" />
         }
         <tum-ui-button severity="secondary" size="small" variant="outlined" [icon]="faSync" [loading]="isRefreshing()" (clicked)="refresh()" data-testid="refresh-button">
             <span jhiTranslate="metrics.refresh.button"></span>

--- a/src/main/webapp/app/admin/standardized-competencies/import/admin-import-standardized-competencies.component.html
+++ b/src/main/webapp/app/admin/standardized-competencies/import/admin-import-standardized-competencies.component.html
@@ -55,7 +55,7 @@
         <span jhiTranslate="artemisApp.standardizedCompetency.manage.import.preview.empty"></span>
     }
     @if (validationErrors().length) {
-        <tum-ui-message severity="error" styleClass="mt-2 w-full" aria-live="assertive" data-testid="validation-errors">
+        <tum-ui-message severity="error" class="mt-2 w-full" aria-live="assertive" data-testid="validation-errors">
             <div class="flex flex-col">
                 <strong jhiTranslate="artemisApp.standardizedCompetency.manage.import.error.fileValidation" [translateValues]="{ count: validationErrors().length }"></strong>
                 <ul class="mb-0 mt-1">

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management-update.component.html
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management-update.component.html
@@ -13,7 +13,7 @@
                 </div>
                 <div class="mb-3 flex flex-col gap-2">
                     <label for="type" class="font-bold" jhiTranslate="artemisApp.systemNotification.type"></label>
-                    <tum-ui-select inputId="type" [options]="systemNotificationTypes" optionLabel="name" optionValue="value" formControlName="type" styleClass="w-full" />
+                    <tum-ui-select inputId="type" [options]="systemNotificationTypes" optionLabel="name" optionValue="value" formControlName="type" class="w-full" />
                 </div>
                 <div class="mb-3">
                     <jhi-date-time-picker

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.html
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.html
@@ -13,7 +13,7 @@
             [sortOrder]="reverse() ? 1 : -1"
             (sortChange)="onTableSort($event)"
             size="small"
-            styleClass="mt-3"
+            class="mt-3"
             aria-describedby="system-notification-management-page-heading"
             data-testid="system-notification-table"
         >

--- a/src/main/webapp/app/admin/user-management/update/user-management-update.component.html
+++ b/src/main/webapp/app/admin/user-management/update/user-management-update.component.html
@@ -128,7 +128,6 @@
                     <label jhiTranslate="artemisApp.userManagement.groups"></label>
                     <tum-ui-autocomplete
                         class="w-full"
-                        styleClass="w-full"
                         [multiple]="true"
                         [ngModel]="user().groups ?? []"
                         [ngModelOptions]="{ standalone: true }"
@@ -222,7 +221,7 @@
                             inputId="langKey"
                             name="langKey"
                             formControlName="langKey"
-                            styleClass="w-full"
+                            class="w-full"
                             [options]="languageOptions()"
                             optionLabel="label"
                             optionValue="value"

--- a/src/main/webapp/app/localci/build-agent-details/build-agent-details.component.html
+++ b/src/main/webapp/app/localci/build-agent-details/build-agent-details.component.html
@@ -89,7 +89,7 @@
         </div>
     }
     @if (agentNotFound()) {
-        <tum-ui-message severity="warn" styleClass="mb-4 block">
+        <tum-ui-message severity="warn" class="mb-4 block">
             <div>
                 <span jhiTranslate="artemisApp.buildAgents.notFound" [translateValues]="{ agentName: agentName() }"></span>
                 <br />

--- a/src/main/webapp/app/localci/build-queue/build-job-detail/build-job-detail.component.html
+++ b/src/main/webapp/app/localci/build-queue/build-job-detail/build-job-detail.component.html
@@ -10,7 +10,7 @@
     }
 
     @if (notFound()) {
-        <tum-ui-message severity="warn" styleClass="mb-3 block" jhiTranslate="artemisApp.buildQueue.detail.notFound" />
+        <tum-ui-message severity="warn" class="mb-3 block" jhiTranslate="artemisApp.buildQueue.detail.notFound" />
     }
 
     @if (buildJob()) {

--- a/src/main/webapp/app/localci/build-queue/finished-builds-filter-modal/finished-builds-filter-modal.component.html
+++ b/src/main/webapp/app/localci/build-queue/finished-builds-filter-modal/finished-builds-filter-modal.component.html
@@ -55,7 +55,7 @@
                 </div>
                 <div class="finished-build-jobs-filter-background-accent px-3 my-0 py-2">
                     <tum-ui-autocomplete
-                        styleClass="w-full"
+                        class="w-full"
                         [placeholder]="'artemisApp.buildQueue.filter.buildAgentAddress' | artemisTranslate"
                         [(ngModel)]="finishedBuildJobFilter.buildAgentAddress"
                         [suggestions]="buildAgentAddressSuggestions()"

--- a/src/main/webapp/app/shared-ui/tum-ui/autocomplete/tum-ui-autocomplete.component.scss
+++ b/src/main/webapp/app/shared-ui/tum-ui/autocomplete/tum-ui-autocomplete.component.scss
@@ -1,6 +1,6 @@
 // Structural styling only; colors come from the token utility classes in the template. Metrics are the exact
 // Aura `autocomplete` tokens (multi-container border / radius / focus, overlay panel, option states). The host
-// is a block so a forwarded `w-full` styleClass (and the always-`w-full` inner field) fills its column.
+// is a block so a consumer `w-full` class (and the always-`w-full` inner field) fills its column.
 :host {
     display: block;
     max-width: 100%;

--- a/src/main/webapp/app/shared-ui/tum-ui/autocomplete/tum-ui-autocomplete.component.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/autocomplete/tum-ui-autocomplete.component.ts
@@ -59,9 +59,6 @@ let nextAutoCompleteId = 0;
     templateUrl: './tum-ui-autocomplete.component.html',
     styleUrl: './tum-ui-autocomplete.component.scss',
     imports: [A11yModule, TumUiChipComponent],
-    host: {
-        '[class]': 'styleClass()',
-    },
     providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => TumUiAutoCompleteComponent), multi: true }],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -97,8 +94,6 @@ export class TumUiAutoCompleteComponent implements ControlValueAccessor {
     readonly ariaLabel = input<string>();
     /** Accessible name for each chip's remove button; overridable for i18n. */
     readonly removeAriaLabel = input<string>('Remove');
-    /** Extra classes forwarded onto the host (drop-in for `p-autocomplete styleClass`, e.g. `w-full`). */
-    readonly styleClass = input<string>('');
     /** Text shown in the panel when a search returned no suggestions. */
     readonly emptyMessage = input<string>('No results found');
 

--- a/src/main/webapp/app/shared-ui/tum-ui/button-group/tum-ui-button-group.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/button-group/tum-ui-button-group.component.spec.ts
@@ -26,12 +26,6 @@ describe('TumUiButtonGroupComponent', () => {
     it('renders as an inline-flex group', () => {
         expect(host.className).toContain('tum-ui-button-group');
     });
-
-    it('forwards styleClass onto the group', () => {
-        fixture.componentRef.setInput('styleClass', 'ms-1');
-        fixture.detectChanges();
-        expect(host.className).toContain('ms-1');
-    });
 });
 
 @Component({

--- a/src/main/webapp/app/shared-ui/tum-ui/button-group/tum-ui-button-group.component.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/button-group/tum-ui-button-group.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 /**
  * Owned button group, part of the tum-aet-ui kit (future @tumaet/ui-angular).
@@ -14,13 +14,8 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
     template: '<ng-content />',
     styleUrl: './tum-ui-button-group.component.scss',
     host: {
-        '[class]': 'hostClasses()',
+        class: 'tum-ui-button-group',
     },
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TumUiButtonGroupComponent {
-    /** Extra classes forwarded onto the group (drop-in for p-buttongroup `styleClass`). */
-    readonly styleClass = input<string>('');
-
-    protected readonly hostClasses = computed(() => `tum-ui-button-group ${this.styleClass()}`.trim());
-}
+export class TumUiButtonGroupComponent {}

--- a/src/main/webapp/app/shared-ui/tum-ui/card/tum-ui-card.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/card/tum-ui-card.component.spec.ts
@@ -40,17 +40,11 @@ describe('TumUiCardComponent', () => {
         expect(subtitle.textContent?.trim()).toBe('last 30 days');
         expect(subtitle.className).toContain('text-muted-color');
     });
-
-    it('forwards styleClass onto the card root', () => {
-        fixture.componentRef.setInput('styleClass', 'iris-kpi-card');
-        fixture.detectChanges();
-        expect(host.className).toContain('iris-kpi-card');
-    });
 });
 
 @Component({
     template: `
-        <tum-ui-card styleClass="iris-kpi-card">
+        <tum-ui-card class="iris-kpi-card">
             <div tumUiCardHeader class="header-slot">Header</div>
             <span class="body-slot">Body content</span>
             <div tumUiCardFooter class="footer-slot">Footer</div>
@@ -75,6 +69,12 @@ describe('TumUiCardComponent (projection)', () => {
         const body = fixture.debugElement.query(By.css('.tum-ui-card-content .body-slot'));
         expect(body).not.toBeNull();
         expect(body.nativeElement.textContent.trim()).toBe('Body content');
+    });
+
+    it('merges a consumer class on the host with the card own classes', () => {
+        const card = fixture.debugElement.query(By.css('tum-ui-card')).nativeElement as HTMLElement;
+        expect(card.className).toContain('iris-kpi-card');
+        expect(card.className).toContain('tum-ui-card');
     });
 
     it('projects header and footer into their dedicated slots', () => {

--- a/src/main/webapp/app/shared-ui/tum-ui/card/tum-ui-card.component.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/card/tum-ui-card.component.ts
@@ -1,12 +1,12 @@
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 /**
  * Owned content card, part of the tum-aet-ui kit (future @tumaet/ui-angular).
  *
  * A content card with a surface, rounded corners and a soft shadow. Content projects into the body via the
  * default slot; an optional `header` / `subheader` render a caption (title + muted subtitle), and dedicated
- * `[tumUiCardHeader]` / `[tumUiCardFooter]` slots cover the remaining regions. `styleClass` is forwarded onto
- * the card root so callers can keep their own hook class (e.g. `iris-kpi-card`).
+ * `[tumUiCardHeader]` / `[tumUiCardFooter]` slots cover the remaining regions. A native `class` on the host
+ * merges with the card's own classes, so callers can keep their own hook class (e.g. `iris-kpi-card`).
  *
  * Styled entirely with the design-token utilities (surface / radius / shadow / spacing / typography); no
  * component stylesheet.
@@ -14,8 +14,10 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
 @Component({
     selector: 'tum-ui-card',
     templateUrl: './tum-ui-card.component.html',
+    // Surface (surface.0 light / surface.900 dark) + content text color, laid out as a column with a rounded,
+    // soft-shadowed edge — all via the shared design-token utilities.
     host: {
-        '[class]': 'hostClasses()',
+        class: 'tum-ui-card flex flex-col rounded-xl shadow-sm bg-surface-0 dark:bg-surface-900 text-color',
     },
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -24,10 +26,4 @@ export class TumUiCardComponent {
     readonly header = input<string>();
     /** Optional card subtitle, rendered under the title in the muted color (parity with p-card `[subheader]`). */
     readonly subheader = input<string>();
-    /** Extra classes forwarded onto the card root (drop-in for p-card `styleClass`). */
-    readonly styleClass = input<string>('');
-
-    // Surface (surface.0 light / surface.900 dark) + content text color, laid out as a column with a rounded,
-    // soft-shadowed edge — all via the shared design-token utilities.
-    protected readonly hostClasses = computed(() => `tum-ui-card flex flex-col rounded-xl shadow-sm bg-surface-0 dark:bg-surface-900 text-color ${this.styleClass()}`.trim());
 }

--- a/src/main/webapp/app/shared-ui/tum-ui/chip/tum-ui-chip.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/chip/tum-ui-chip.component.spec.ts
@@ -81,13 +81,6 @@ describe('TumUiChipComponent', () => {
         expect(chip.className).toContain('text-sm');
         expect(chip.className).toContain('px-2');
     });
-
-    it('forwards styleClass onto the pill', () => {
-        fixture.componentRef.setInput('styleClass', 'mr-2');
-        fixture.detectChanges();
-        const chip = fixture.debugElement.query(By.css('[data-testid="tum-ui-chip"]')).nativeElement as HTMLElement;
-        expect(chip.className).toContain('mr-2');
-    });
 });
 
 @Component({

--- a/src/main/webapp/app/shared-ui/tum-ui/chip/tum-ui-chip.component.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/chip/tum-ui-chip.component.ts
@@ -34,8 +34,6 @@ export class TumUiChipComponent {
     readonly size = input<TumUiChipSize>();
     /** Accessible name for the remove button; overridable for i18n. */
     readonly removeAriaLabel = input<string>('Remove');
-    /** Extra classes forwarded onto the pill (drop-in for `p-chip styleClass`). */
-    readonly styleClass = input<string>('');
 
     /** Emitted when the remove control is activated (mouse / Enter / Space / Backspace). Parity with `p-chip (onRemove)`. */
     readonly onRemove = output<Event>();
@@ -48,7 +46,7 @@ export class TumUiChipComponent {
         // Aura `chip:has(.p-chip-remove-icon)` shrinks the trailing padding to `paddingY`; keep the leading padding.
         const padding = small ? (this.removable() ? 'py-1 pl-2 pr-1' : 'px-2 py-1') : this.removable() ? 'py-2 pl-3 pr-2' : 'px-3 py-2';
         const base = 'inline-flex items-center rounded-2xl bg-surface-100 text-surface-800 dark:bg-surface-800 dark:text-surface-0';
-        return `${base} ${type} ${padding} ${this.styleClass()}`.trim();
+        return `${base} ${type} ${padding}`;
     });
 
     protected remove(event: Event): void {

--- a/src/main/webapp/app/shared-ui/tum-ui/input-number/tum-ui-input-number.component.html
+++ b/src/main/webapp/app/shared-ui/tum-ui/input-number/tum-ui-input-number.component.html
@@ -3,7 +3,7 @@
     tumUiInput
     type="text"
     inputmode="numeric"
-    class="tum-ui-input-number-input {{ inputStyleClass() }}"
+    class="tum-ui-input-number-input"
     role="spinbutton"
     [id]="inputId()"
     [attr.name]="name()"

--- a/src/main/webapp/app/shared-ui/tum-ui/input-number/tum-ui-input-number.component.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/input-number/tum-ui-input-number.component.ts
@@ -60,8 +60,6 @@ export class TumUiInputNumberComponent implements ControlValueAccessor {
     readonly name = input<string>();
     /** Accessible name for the inner `<input>` when there is no visible `<label>`. */
     readonly ariaLabel = input<string>();
-    /** Extra classes forwarded onto the inner `<input>` (drop-in for `inputStyleClass`). */
-    readonly inputStyleClass = input('');
 
     /** Fires on the inner input's blur, after the value is clamped / reformatted (parity with `(onBlur)`). */
     readonly onBlur = output<FocusEvent>();

--- a/src/main/webapp/app/shared-ui/tum-ui/input-number/tum-ui-input-number.component.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/input-number/tum-ui-input-number.component.ts
@@ -60,8 +60,6 @@ export class TumUiInputNumberComponent implements ControlValueAccessor {
     readonly name = input<string>();
     /** Accessible name for the inner `<input>` when there is no visible `<label>`. */
     readonly ariaLabel = input<string>();
-    /** Extra classes forwarded onto the host (drop-in for `styleClass`). */
-    readonly styleClass = input('');
     /** Extra classes forwarded onto the inner `<input>` (drop-in for `inputStyleClass`). */
     readonly inputStyleClass = input('');
 
@@ -91,8 +89,7 @@ export class TumUiInputNumberComponent implements ControlValueAccessor {
         if (this.showButtons()) {
             parts.push('tum-ui-input-number-buttons');
         }
-        const style = this.styleClass();
-        return style ? `${parts.join(' ')} ${style}` : parts.join(' ');
+        return parts.join(' ');
     });
 
     // WAI-ARIA spinbutton semantics: the input announces its numeric value + range and is adjusted with the arrow

--- a/src/main/webapp/app/shared-ui/tum-ui/message/tum-ui-message.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/message/tum-ui-message.component.spec.ts
@@ -53,13 +53,6 @@ describe('TumUiMessageComponent', () => {
         expect(text().textContent?.trim()).toBe('Something went wrong');
     });
 
-    it('forwards styleClass onto the message box', () => {
-        fixture.componentRef.setInput('styleClass', 'mb-3 w-full');
-        fixture.detectChanges();
-        expect(host.className).toContain('mb-3');
-        expect(host.className).toContain('w-full');
-    });
-
     it('renders a leading icon only when one is provided', () => {
         expect(fixture.debugElement.query(By.css('.tum-ui-message-icon'))).toBeNull();
         fixture.componentRef.setInput('icon', faCircleInfo);

--- a/src/main/webapp/app/shared-ui/tum-ui/message/tum-ui-message.component.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/message/tum-ui-message.component.ts
@@ -45,8 +45,6 @@ export class TumUiMessageComponent {
     readonly text = input<string>();
     /** Optional leading FontAwesome icon; none is shown by default, exactly like p-message. */
     readonly icon = input<IconProp>();
-    /** Extra classes forwarded onto the message box (drop-in for p-message `styleClass`, e.g. `mb-3 w-full`). */
-    readonly styleClass = input<string>('');
 
-    protected readonly hostClasses = computed(() => `${MESSAGE_BASE} ${MESSAGE_SEVERITY[this.severity()]} ${this.styleClass()}`.trim());
+    protected readonly hostClasses = computed(() => `${MESSAGE_BASE} ${MESSAGE_SEVERITY[this.severity()]}`);
 }

--- a/src/main/webapp/app/shared-ui/tum-ui/panel/tum-ui-panel.component.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/panel/tum-ui-panel.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, input, model } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, model } from '@angular/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 
@@ -20,8 +20,10 @@ let nextPanelId = 0;
     templateUrl: './tum-ui-panel.component.html',
     styleUrl: './tum-ui-panel.component.scss',
     imports: [FaIconComponent],
+    // Panel surface = Aura content.background/border (surface.0/border light, surface.900/border dark via the
+    // Artemis theme override). `block` + radius + internal paddings live in the stylesheet.
     host: {
-        '[class]': 'hostClasses()',
+        class: 'tum-ui-panel border border-surface rounded-md bg-surface-0 dark:bg-surface-900 text-color',
         '[attr.data-collapsed]': 'toggleable() && collapsed()',
     },
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -33,17 +35,11 @@ export class TumUiPanelComponent {
     readonly toggleable = input(false);
     /** Collapsed state; two-way so `[collapsed]` and `[(collapsed)]` both work (parity with p-panel `[(collapsed)]`). */
     readonly collapsed = model(false);
-    /** Extra classes forwarded onto the panel root (drop-in for p-panel `styleClass`). */
-    readonly styleClass = input<string>('');
 
     /** Stable id linking the toggle's `aria-controls` to the collapsible region. */
     protected readonly contentId = `tum-ui-panel-content-${nextPanelId++}`;
     protected readonly faChevronDown = faChevronDown;
     protected readonly faChevronUp = faChevronUp;
-
-    // Panel surface = Aura content.background/border (surface.0/border light, surface.900/border dark via the
-    // Artemis theme override). `block` + radius + internal paddings live in the stylesheet.
-    protected readonly hostClasses = computed(() => `tum-ui-panel border border-surface rounded-md bg-surface-0 dark:bg-surface-900 text-color ${this.styleClass()}`.trim());
 
     protected toggle(): void {
         if (this.toggleable()) {

--- a/src/main/webapp/app/shared-ui/tum-ui/progress-bar/tum-ui-progress-bar.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/progress-bar/tum-ui-progress-bar.component.spec.ts
@@ -75,13 +75,6 @@ describe('TumUiProgressBarComponent', () => {
         fixture.detectChanges();
         expect(fill().style.background).toBe('var(--success)');
     });
-
-    it('forwards styleClass onto the bar', () => {
-        fixture.componentRef.setInput('styleClass', 'mb-2 w-full');
-        fixture.detectChanges();
-        expect(host.className).toContain('mb-2');
-        expect(host.className).toContain('w-full');
-    });
 });
 
 @Component({

--- a/src/main/webapp/app/shared-ui/tum-ui/progress-bar/tum-ui-progress-bar.component.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/progress-bar/tum-ui-progress-bar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 /**
  * Owned determinate progress bar, part of the tum-aet-ui kit (future @tumaet/ui-angular).
@@ -15,8 +15,10 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
     selector: 'tum-ui-progress-bar',
     templateUrl: './tum-ui-progress-bar.component.html',
     styleUrl: './tum-ui-progress-bar.component.scss',
+    // Track background = Aura's content.border.color (surface.200 light / surface.800 dark, matching the
+    // Artemis theme override); the fill is bg-primary on the value element unless `color` overrides it inline.
     host: {
-        '[class]': 'hostClasses()',
+        class: 'tum-ui-progress-bar bg-surface-200 dark:bg-surface-800',
         role: 'progressbar',
         '[attr.aria-valuemin]': '0',
         '[attr.aria-valuemax]': '100',
@@ -33,10 +35,4 @@ export class TumUiProgressBarComponent {
     readonly color = input<string>();
     /** Unit appended to the default value label (parity with p-progressbar `[unit]`). */
     readonly unit = input<string>('%');
-    /** Extra classes forwarded onto the bar (drop-in for p-progressbar `styleClass`, e.g. `mb-2`). */
-    readonly styleClass = input<string>('');
-
-    // Track background = Aura's content.border.color (surface.200 light / surface.800 dark, matching the
-    // Artemis theme override); the fill is bg-primary on the value element unless `color` overrides it inline.
-    protected readonly hostClasses = computed(() => `tum-ui-progress-bar bg-surface-200 dark:bg-surface-800 ${this.styleClass()}`.trim());
 }

--- a/src/main/webapp/app/shared-ui/tum-ui/progress-spinner/tum-ui-progress-spinner.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/progress-spinner/tum-ui-progress-spinner.component.spec.ts
@@ -56,11 +56,4 @@ describe('TumUiProgressSpinnerComponent', () => {
         const spin = fixture.debugElement.query(By.css('.tum-ui-progress-spinner-spin')).nativeElement as SVGElement;
         expect(spin.style.animationDuration).toBe('1s');
     });
-
-    it('forwards styleClass onto the spinner', () => {
-        fixture.componentRef.setInput('styleClass', 'w-8 h-8');
-        fixture.detectChanges();
-        expect(host.className).toContain('w-8');
-        expect(host.className).toContain('h-8');
-    });
 });

--- a/src/main/webapp/app/shared-ui/tum-ui/progress-spinner/tum-ui-progress-spinner.component.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/progress-spinner/tum-ui-progress-spinner.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 /**
  * Owned indeterminate loading spinner, part of the tum-aet-ui kit (future @tumaet/ui-angular).
@@ -15,7 +15,7 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
     templateUrl: './tum-ui-progress-spinner.component.html',
     styleUrl: './tum-ui-progress-spinner.component.scss',
     host: {
-        '[class]': 'hostClasses()',
+        class: 'tum-ui-progress-spinner',
         role: 'status',
         'aria-busy': 'true',
         '[attr.aria-label]': 'ariaLabel()',
@@ -31,8 +31,4 @@ export class TumUiProgressSpinnerComponent {
     readonly animationDuration = input<string>('2s');
     /** Accessible label describing what is loading (parity with p-progressspinner `[ariaLabel]`). */
     readonly ariaLabel = input<string>();
-    /** Extra classes forwarded onto the spinner (drop-in for p-progressspinner `styleClass`, e.g. to resize). */
-    readonly styleClass = input<string>('');
-
-    protected readonly hostClasses = computed(() => `tum-ui-progress-spinner ${this.styleClass()}`.trim());
 }

--- a/src/main/webapp/app/shared-ui/tum-ui/select/tum-ui-select.component.spec.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/select/tum-ui-select.component.spec.ts
@@ -175,11 +175,9 @@ describe('TumUiSelectComponent', () => {
         expect((document.querySelector('[data-testid="tum-ui-select-empty"]') as HTMLElement).textContent?.trim()).toBe('Nothing here');
     });
 
-    it('forwards styleClass onto the host and sizing to the trigger', () => {
-        fixture.componentRef.setInput('styleClass', 'w-full');
+    it('forwards sizing to the trigger', () => {
         fixture.componentRef.setInput('size', 'small');
         fixture.detectChanges();
-        expect((fixture.nativeElement as HTMLElement).classList.contains('w-full')).toBe(true);
         expect(triggerButton().className).toContain('text-sm');
     });
 });

--- a/src/main/webapp/app/shared-ui/tum-ui/select/tum-ui-select.component.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/select/tum-ui-select.component.ts
@@ -58,9 +58,6 @@ let nextSelectId = 0;
     templateUrl: './tum-ui-select.component.html',
     styleUrl: './tum-ui-select.component.scss',
     imports: [A11yModule, FaIconComponent],
-    host: {
-        '[class]': 'styleClass()',
-    },
     providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => TumUiSelectComponent), multi: true }],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -88,8 +85,6 @@ export class TumUiSelectComponent implements ControlValueAccessor {
     readonly appendTo = input<string>();
     /** `small` / `large`, matching the Aura form-field sizes; omit for the default size. */
     readonly size = input<TumUiSelectSize>();
-    /** Extra classes forwarded onto the host (drop-in for `p-select styleClass`, e.g. `w-full` / `w-auto`). */
-    readonly styleClass = input<string>('');
     /** `id` of the trigger `<button>` (the target of an external `<label for>`). Defaults to a unique per-instance id. */
     readonly inputId = input(`tum-ui-select-${nextSelectId++}`);
     /** Forwarded onto the trigger for template-driven-form parity; the CVA itself does not need it. */

--- a/src/main/webapp/app/shared-ui/tum-ui/table-directive/tum-ui-table.directive.spec.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/table-directive/tum-ui-table.directive.spec.ts
@@ -13,7 +13,7 @@ import { TumUiTableDirective, TumUiTableSize, TumUiTableSortEvent } from 'app/sh
             [striped]="striped()"
             [scrollable]="scrollable()"
             [rowHover]="rowHover()"
-            [styleClass]="styleClass()"
+            class="mt-3 shadow"
             [sortField]="sortField()"
             [sortOrder]="sortOrder()"
             (sortChange)="events.push($event)"
@@ -37,7 +37,6 @@ class HostComponent {
     readonly striped = signal(false);
     readonly scrollable = signal(false);
     readonly rowHover = signal(false);
-    readonly styleClass = signal('');
     readonly sortField = signal<string | undefined>(undefined);
     readonly sortOrder = signal(1);
     events: TumUiTableSortEvent[] = [];
@@ -113,11 +112,10 @@ describe('TumUiTableDirective', () => {
         expect(tableClass()).toContain('[&_tbody_tr:hover]:bg-surface-100');
     });
 
-    it('forwards styleClass onto the table', () => {
-        host.styleClass.set('mt-3 shadow');
-        fixture.detectChanges();
+    it('merges the consumer static class with its own host classes', () => {
         expect(tableClass()).toContain('mt-3');
         expect(tableClass()).toContain('shadow');
+        expect(tableClass()).toContain('tum-ui-table');
     });
 
     it('toggles the order when re-sorting the active field (parity with p-table single sort)', () => {

--- a/src/main/webapp/app/shared-ui/tum-ui/table-directive/tum-ui-table.directive.spec.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/table-directive/tum-ui-table.directive.spec.ts
@@ -13,7 +13,8 @@ import { TumUiTableDirective, TumUiTableSize, TumUiTableSortEvent } from 'app/sh
             [striped]="striped()"
             [scrollable]="scrollable()"
             [rowHover]="rowHover()"
-            class="mt-3 shadow"
+            class="mt-3"
+            [class]="extraClasses()"
             [sortField]="sortField()"
             [sortOrder]="sortOrder()"
             (sortChange)="events.push($event)"
@@ -37,6 +38,7 @@ class HostComponent {
     readonly striped = signal(false);
     readonly scrollable = signal(false);
     readonly rowHover = signal(false);
+    readonly extraClasses = signal('shadow');
     readonly sortField = signal<string | undefined>(undefined);
     readonly sortOrder = signal(1);
     events: TumUiTableSortEvent[] = [];
@@ -112,9 +114,18 @@ describe('TumUiTableDirective', () => {
         expect(tableClass()).toContain('[&_tbody_tr:hover]:bg-surface-100');
     });
 
-    it('merges the consumer static class with its own host classes', () => {
+    it('merges both a static and a bound consumer class with its own host classes', () => {
         expect(tableClass()).toContain('mt-3');
         expect(tableClass()).toContain('shadow');
+        expect(tableClass()).toContain('tum-ui-table');
+    });
+
+    it('keeps its own host classes when a bound consumer class changes', () => {
+        host.extraClasses.set('ring-2');
+        fixture.detectChanges();
+        expect(tableClass()).toContain('ring-2');
+        expect(tableClass()).not.toContain('shadow');
+        expect(tableClass()).toContain('mt-3');
         expect(tableClass()).toContain('tum-ui-table');
     });
 

--- a/src/main/webapp/app/shared-ui/tum-ui/table-directive/tum-ui-table.directive.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui/table-directive/tum-ui-table.directive.ts
@@ -82,8 +82,6 @@ export class TumUiTableDirective {
     readonly scrollable = input(false, { transform: booleanAttribute });
     /** Tint body rows on hover (parity with p-table `[rowHover]`). */
     readonly rowHover = input(false, { transform: booleanAttribute });
-    /** Extra classes forwarded onto the table (drop-in for p-table `styleClass`, e.g. `mt-3`). */
-    readonly styleClass = input('');
 
     /**
      * Active sort field (controlled, parity with p-table `[sortField]`). Drives the sortable-column
@@ -108,10 +106,6 @@ export class TumUiTableDirective {
         }
         if (this.scrollable()) {
             parts.push(SCROLLABLE_CLASSES);
-        }
-        const styleClass = this.styleClass();
-        if (styleClass) {
-            parts.push(styleClass);
         }
         return parts.join(' ');
     });


### PR DESCRIPTION
### Summary

The TUM UI kit carried a `styleClass` input on 13 components — a shim inherited from PrimeNG, where it was the only way to get extra classes onto a component root. Angular does not need it: a component's host `class` / `[class]` binding already merges with whatever `class` the consumer writes on the element (something the kit already relies on and tests for in `tum-ui-input.directive.spec.ts`). This PR removes the shim from 12 of those components and migrates the 17 call sites to plain `class`, deleting ~100 lines net.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

PrimeNG components expose `styleClass` because their host element is not the styled element, so `class` on the tag would land on the wrong node. The kit copied that convention during the PrimeNG migration for API parity, so screens could be ported without touching bindings.

For most kit components that reason does not hold — they *do* style their own host. `styleClass` there is pure indirection: an extra input, an extra signal read, and a second way of doing something the framework already does. It also forces every new component author to decide whether to add the input, which is how it spread to 13 components.

Removing it is the last cleanup before the kit is extracted into `@tumaet/ui-angular`, where a redundant input becomes a public API commitment that is expensive to retract.

### Description

**Kit — 10 redundant inputs removed.** Three shapes, depending on how the input was consumed:

- **`select`, `autocomplete`** — their entire `host` block was `'[class]': 'styleClass()'` and nothing else. Block and input both deleted; a consumer `class` now lands on the host natively.
- **`card`, `panel`, `progress-bar`, `progress-spinner`, `button-group`** — with `styleClass` gone their `hostClasses` `computed()` evaluated to a constant, so it collapses into a static `host: { class: '...' }`. This removes a signal, a `computed` import, and the indirection. `button-group` becomes an empty class.
- **`message`, `input-number`, `table-directive`** — genuinely dynamic (severity / size / striped / scrollable), so the `computed()` stays; only the concatenated `styleClass` is dropped.

**Consumers — 17 call sites across 12 templates**, `styleClass="X"` → `class="X"`. One site (`user-management-update.component.html`) already carried `class="w-full"` *and* `styleClass="w-full"`; those are merged and deduplicated.

**Tests.** Seven tests asserted an input that no longer exists and were removed. Two were converted into genuine merge tests (`card`, `table-directive`) asserting that a consumer class and the component's own classes coexist. The `table-directive` host binds **both** a static `class` and a bound `[class]`, with a test that flips the bound signal and asserts the old value is dropped while the static class and the directive's own classes survive — verified behaviour that the previous `[styleClass]` test did not cover.

**Docs.** `tum-ui-kit.mdx` loses 12 `styleClass` rows and its snippets are rewritten. A new Principles bullet states the rule so the shim does not come back:

> **Native `class`, not `styleClass`** — a component styles its own host via a `host` `class` / `[class]` binding, and Angular merges that with whatever `class` the consumer writes on the element.

**Two further inputs deleted as dead code.** `chip`'s `styleClass` and `input-number`'s `inputStyleClass` target an *inner* element, so unlike the ten above they are not redundant with a native `class`. But nothing passes them — no consumer, and not the kit's own `tum-ui-autocomplete`, which renders chips without one. Deleting beats restructuring: if a consumer ever needs to reach those inner elements, the input can come back with a caller to justify it.

**Deliberately out of scope.** `button` and `tag` keep their `styleClass`:

- `button` is a **structural** exception. Its host is `<tum-ui-button>`, a custom element that cannot become a native `<button>` — and the inner `<button>` must stay real for focus, `type="submit"` and disabled semantics. `:host` is `inline-flex`, so a consumer `class="w-full"` widens the wrapper while the inner button stays content-width. `styleClass` is the only way to reach the control, so it is correct design rather than a shim. The kit already offers the host-styled alternative: `<button tumUiButton>`, whose host *is* the button and which has no such input.
- `tag` is a **pragmatic** deferral. Its pill is a plain `<span>` that could be hoisted onto the host, but the severity styling is keyed to eight `:host span[data-severity='…']` SCSS selectors, and exactly one call site passes `styleClass`. Rewriting all eight for one caller is a bad trade today.

Both are now documented as such so the next cleanup pass does not silently break button widths.

### Steps for Testing

This is an appearance-neutral refactor: the same class strings reach the same elements, only via `class` instead of `styleClass`. Testing is therefore a visual no-diff check on the screens that used it.

Prerequisites:
- 1 Admin

1. Log in as an admin and open **Admin → System Notifications**. The table should keep its `mt-3` top margin and the notification form's type dropdown should stay full-width.
2. Open **Admin → User Management → edit a user**. The *Groups* autocomplete and the *Language* select should both still be full-width; add and remove a group to confirm the chips still work.
3. Open **Admin → Metrics**. The node-selection dropdown should stay auto-width (not stretched).
4. Open **Admin → LTI Configuration** and **Admin → Cleanup Service**. The info/error messages should keep their full width and top/bottom margins.
5. Open **Admin → Iris Dashboard**. The KPI cards keep their `iris-kpi-card` hook class (rounded card, correct padding) and the error message stays full-width.
6. Open **Build Queue → a build job's details** and **Build Agent details**. Messages should be unchanged.
7. Repeat a couple of the above in **dark theme** to confirm the surface tokens still resolve.

#### Exam Mode Testing

Not applicable. Every migrated call site is under `app/admin/**` or `app/localci/**`; no exam-mode component is touched. The kit components themselves are unchanged in appearance and their public API only loses an input that no exam-mode template used.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/30381052349) did not pass (`failure`). Coverage below may be partial.

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| tum-ui-autocomplete.component.ts | 89.41% | 309 | 45 | 14.6 |
| tum-ui-button-group.component.ts | not found (modified) | 11 | 4 | 36.4 |
| tum-ui-card.component.ts | 100.00% | 13 | 14 | 107.7 |
| tum-ui-chip.component.ts | 100.00% | 35 | 11 | 31.4 |
| tum-ui-input-number.component.ts | 95.77% | 217 | 45 | 20.7 |
| tum-ui-message.component.ts | 100.00% | 30 | 10 | 33.3 |
| tum-ui-panel.component.ts | 100.00% | 28 | 19 | 67.9 |
| tum-ui-progress-bar.component.ts | 100.00% | 20 | 14 | 70.0 |
| tum-ui-progress-spinner.component.ts | 100.00% | 19 | 10 | 52.6 |
| tum-ui-select.component.ts | 83.73% | 297 | 37 | 12.5 |
| tum-ui-table.directive.ts | 100.00% | 54 | 34 | 63.0 |

_Last updated: 2026-07-28 17:52:07 UTC_


### Screenshots

No screenshots: the change is appearance-neutral by construction — the identical class strings are delivered to the identical elements, only through `class` rather than `styleClass`. `pnpm run webapp:build` type-checks every template binding and passes, which proves no call site was missed. A reviewer's visual no-diff pass on the screens in *Steps for Testing* is the intended confirmation.

---

#### Verification run locally

| Check | Result |
|---|---|
| `eslint` (kit + touched consumers) | clean |
| `vitest` — tum-ui kit | **324 passed** / 37 files |
| `vitest` — touched consumer modules | **717 passed** / 52 files |
| `pnpm run webapp:build` | **succeeded** |
| `pnpm run test:rules` (Tailwind `@source` / lock lists) | 7 passed |

The build is the load-bearing check here: admin specs blank their templates via `overrideTemplate`, so a stale `styleClass` binding would pass Vitest and only fail at compile time.
