### PR TITLE
fix: surface underlying export errors instead of generic "noSubmissions" (#13054)

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionExportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionExportService.java
@@ -71,8 +71,15 @@ public abstract class SubmissionExportService {
      * @return the path to the zipped file with the exported submissions
      */
     public Path exportStudentSubmissionsElseThrow(Long exerciseId, SubmissionExportOptionsDTO submissionExportOptions) {
-        var zippedSubmissionsPaths = exportStudentSubmissions(exerciseId, submissionExportOptions);
+        List<String> exportErrors = new ArrayList<>();
+        var zippedSubmissionsPaths = exportStudentSubmissions(exerciseId, submissionExportOptions, true,
+                fileService.getTemporaryUniqueSubfolderPath(submissionExportPath, EXPORTED_SUBMISSIONS_DELETION_DELAY_IN_MINUTES),
+                exportErrors, new ArrayList<>());
         if (zippedSubmissionsPaths.isEmpty()) {
+            if (!exportErrors.isEmpty()) {
+                String errorDetails = String.join("; ", exportErrors);
+                throw new BadRequestAlertException("Failed to export student submissions: " + errorDetails, "SubmissionExport", "exportError");
+            }
             throw new BadRequestAlertException("Failed to export student submissions.", "SubmissionExport", "noSubmissions");
         }
         return zippedSubmissionsPaths.getFirst();


### PR DESCRIPTION
### Description

Fixes #13054

When exporting student submissions, if the export produces no files (e.g. due to an I/O error), the `exportStudentSubmissionsElseThrow` method throws a generic "noSubmissions" error message, hiding the actual cause.

This change:
1. Collects export errors from the underlying `exportStudentSubmissions` method
2. Surfaces those errors in the exception message when the result is empty but errors exist
3. Falls back to the original "noSubmissions" message only when there are genuinely no errors

### Changes

- `SubmissionExportService.java`: Modified `exportStudentSubmissionsElseThrow` to pass an `exportErrors` list and surface actual errors instead of the generic "noSubmissions" message