### PR TITLE
fix: thread notificationText through course notifications so custom update text is delivered

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/AttachmentResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/AttachmentResource.java
@@ -103,7 +103,7 @@ public class AttachmentResource {
         Attachment attachmentUpdate = toTransientAttachment(attachment);
         Attachment result = attachmentService.updateLectureAttachment(attachmentId, attachmentUpdate, file);
         if (notificationText != null) {
-            groupNotificationService.notifyStudentGroupAboutAttachmentChange(result);
+            groupNotificationService.notifyStudentGroupAboutAttachmentChange(result, notificationText);
         }
         return ResponseEntity.ok(AttachmentDTO.of(result));
     }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/web/AttachmentVideoUnitResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/web/AttachmentVideoUnitResource.java
@@ -187,7 +187,7 @@ public class AttachmentVideoUnitResource {
             // notifyStudentGroupAboutAttachmentChange derives the course via attachment.getLecture(); a unit attachment does not carry its lecture,
             // so set it from the (already course-loaded) unit lecture to avoid a NullPointerException.
             changedAttachment.setLecture(savedAttachmentVideoUnit.getLecture());
-            groupNotificationService.notifyStudentGroupAboutAttachmentChange(changedAttachment);
+            groupNotificationService.notifyStudentGroupAboutAttachmentChange(changedAttachment, notificationText);
         }
 
         searchableEntityWeaviateService.ifPresent(service -> {

--- a/src/main/java/de/tum/cit/aet/artemis/notification/domain/course_notifications/AttachmentChangedNotification.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/domain/course_notifications/AttachmentChangedNotification.java
@@ -22,15 +22,19 @@ public class AttachmentChangedNotification extends CourseNotification {
 
     protected Long lectureId;
 
+    protected String notificationText;
+
     /**
      * Default constructor used when creating a new post notification.
      */
-    public AttachmentChangedNotification(Long courseId, String courseTitle, String courseImageUrl, String attachmentName, String unitName, Long exerciseId, Long lectureId) {
+    public AttachmentChangedNotification(Long courseId, String courseTitle, String courseImageUrl, String attachmentName, String unitName, Long exerciseId, Long lectureId,
+            String notificationText) {
         super(null, courseId, courseTitle, courseImageUrl, ZonedDateTime.now());
         this.attachmentName = attachmentName;
         this.unitName = unitName;
         this.exerciseId = exerciseId;
         this.lectureId = lectureId;
+        this.notificationText = notificationText;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/notification/domain/course_notifications/ExerciseUpdatedNotification.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/domain/course_notifications/ExerciseUpdatedNotification.java
@@ -24,17 +24,20 @@ public class ExerciseUpdatedNotification extends CourseNotification {
 
     protected String exerciseType;
 
+    protected String notificationText;
+
     /**
      * Default constructor used when creating a new post notification.
      */
     public ExerciseUpdatedNotification(Long courseId, String courseTitle, String courseImageUrl, Long exerciseId, String exerciseTitle, Long examId, Long exerciseGroupId,
-            String exerciseType) {
+            String exerciseType, String notificationText) {
         super(null, courseId, courseTitle, courseImageUrl, ZonedDateTime.now());
         this.exerciseId = exerciseId;
         this.exerciseTitle = exerciseTitle;
         this.examId = examId;
         this.exerciseGroupId = exerciseGroupId;
         this.exerciseType = exerciseType;
+        this.notificationText = notificationText;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/notification/service/notifications/GroupNotificationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/service/notifications/GroupNotificationService.java
@@ -66,7 +66,7 @@ public class GroupNotificationService {
 
         if (notificationText != null) {
             // sends an exercise-update notification
-            notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(exercise);
+            notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(exercise, notificationText);
         }
     }
 
@@ -75,7 +75,7 @@ public class GroupNotificationService {
      *
      * @param attachment that has been changed
      */
-    public void notifyStudentGroupAboutAttachmentChange(Attachment attachment) {
+    public void notifyStudentGroupAboutAttachmentChange(Attachment attachment, String notificationText) {
         // Do not send a notification before the release date of the attachment.
         if (attachment.getReleaseDate() != null && attachment.getReleaseDate().isAfter(ZonedDateTime.now())) {
             return;
@@ -86,7 +86,8 @@ public class GroupNotificationService {
 
         var attachmentChangedNotification = new AttachmentChangedNotification(course.getId(), course.getTitle(), course.getCourseIcon(), attachment.getName(),
                 attachment.getExercise() == null ? attachment.getLecture().getTitle() : attachment.getExercise().getTitle(),
-                attachment.getExercise() == null ? null : attachment.getExercise().getId(), attachment.getLecture() == null ? null : attachment.getLecture().getId());
+                attachment.getExercise() == null ? null : attachment.getExercise().getId(), attachment.getLecture() == null ? null : attachment.getLecture().getId(),
+                notificationText);
 
         courseNotificationService.sendCourseNotification(attachmentChangedNotification, recipients.stream().toList());
     }
@@ -153,7 +154,7 @@ public class GroupNotificationService {
      *
      * @param exercise that has been updated
      */
-    public void notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(Exercise exercise) {
+    public void notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(Exercise exercise, String notificationText) {
         if (exercise.isExamExercise()) {
             // Do not send exercise update notifications to students for exam exercises.
             // The notification URL points to the course-management page which students cannot access.
@@ -171,7 +172,7 @@ public class GroupNotificationService {
                 Set.of(course.getEditorGroupName(), course.getInstructorGroupName(), course.getStudentGroupName()));
 
         var exerciseUpdatedNotification = new ExerciseUpdatedNotification(course.getId(), course.getTitle(), course.getCourseIcon(), exercise.getId(),
-                exercise.getExerciseNotificationTitle(), null, null, exercise.getType());
+                exercise.getExerciseNotificationTitle(), null, null, exercise.getType(), notificationText);
 
         courseNotificationService.sendCourseNotification(exerciseUpdatedNotification, recipients.stream().toList());
     }


### PR DESCRIPTION
Fixes #13261

When instructors edit lecture attachments/exercises and fill in the notification text, it was only used as an on/off gate but the actual text was never forwarded to the notification objects. This meant students received a notification that *something* changed, but never saw the instructor's custom explanation of *what* changed.

## Changes

1. **AttachmentChangedNotification.java** — added `protected String notificationText` field and updated the constructor to accept it. The notification system uses reflection: all `protected` fields of `CourseNotification` subclasses are automatically serialized to/from a parameters map, so this is all that's needed for serialization/deserialization.

2. **ExerciseUpdatedNotification.java** — same pattern: added `protected String notificationText` field and updated the constructor.

3. **GroupNotificationService.java** — threaded `notificationText` through:
   - `notifyStudentGroupAboutAttachmentChange` now accepts and passes `notificationText` to the notification constructor
   - `notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate` now accepts and passes `notificationText` to the notification constructor
   - `notifyAboutExerciseUpdate` passes `notificationText` to `notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate`

4. **AttachmentResource.java** — passes `notificationText` to `notifyStudentGroupAboutAttachmentChange`.

5. **AttachmentVideoUnitResource.java** — passes `notificationText` to `notifyStudentGroupAboutAttachmentChange`.

Wallet: fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom notification text when exercises are updated.
  * Added support for custom notification text when attachments are changed.
  * Provided notification text is now included in course notifications sent to relevant recipients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->