### PR TITLE
`Development`: Serialize the submission overview publication date for exam conduction

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExamForConductionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExamForConductionDTO.java
@@ -28,9 +28,14 @@ import de.tum.cit.aet.artemis.exam.domain.Exam;
  * <p>
  * {@code examSummaryPublicationDate} and {@code publishResultsDate} are required by the client-side summary gate
  * ({@code isExamSummaryPublished} in {@code exam.utils.ts}), which the exam-participation component evaluates against the exam
- * it takes from this projection after a hand-in. That helper treats a missing {@code examSummaryPublicationDate} as
- * "published", so omitting either field here silently opens the gate and shows the submission overview even while it is
- * supposed to be withheld.
+ * it takes from this projection after a hand-in. Omitting them breaks the gate in opposite directions, so neither may be
+ * dropped:
+ * <ul>
+ * <li>Without {@code examSummaryPublicationDate} the gate reads the absent value as "published" and opens the submission
+ * overview immediately, defeating a configured delay.</li>
+ * <li>Without {@code publishResultsDate} the results-published fallback can never fire, so a configured future publication
+ * date keeps the overview withheld even after the grades are out.</li>
+ * </ul>
  *
  * @param id                         the id of the exam
  * @param title                      the title shown on the exam cover

--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExamForConductionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/ExamForConductionDTO.java
@@ -25,32 +25,41 @@ import de.tum.cit.aet.artemis.exam.domain.Exam;
  * A dedicated projection (rather than enriching {@link ExamForStudentExamDTO}) keeps the management/test-run endpoints that
  * nest the slim exam from newly serializing the exam cover texts — those consumers read only {@code exam.course}, so folding
  * the conduction fields into the shared slim projection would leak the markdown cover content onto the student-exams list.
+ * <p>
+ * {@code examSummaryPublicationDate} and {@code publishResultsDate} are required by the client-side summary gate
+ * ({@code isExamSummaryPublished} in {@code exam.utils.ts}), which the exam-participation component evaluates against the exam
+ * it takes from this projection after a hand-in. That helper treats a missing {@code examSummaryPublicationDate} as
+ * "published", so omitting either field here silently opens the gate and shows the submission overview even while it is
+ * supposed to be withheld.
  *
- * @param id                      the id of the exam
- * @param title                   the title shown on the exam cover
- * @param testExam                whether this is a test exam (drives the test-exam conduction branch)
- * @param examWithAttendanceCheck whether an attendance check is enabled (the cover renders the attendance confirmation)
- * @param visibleDate             the date the exam becomes visible
- * @param startDate               the exam start date (individual end date + waiting-for-start are computed from it)
- * @param endDate                 the exam end date
- * @param gracePeriod             the grace period in seconds
- * @param workingTime             the regular working time in seconds
- * @param startText               the markdown start text
- * @param endText                 the markdown end text
- * @param confirmationStartText   the markdown confirmation start text (start consent)
- * @param confirmationEndText     the markdown confirmation end text (end consent)
- * @param examMaxPoints           the maximum achievable points (exam-start information box)
- * @param numberOfExercisesInExam the number of exercises drawn per student exam (exam-start information box)
- * @param examiner                the examiner (exam-start information box)
- * @param moduleNumber            the module number (exam-start information box)
- * @param courseName              the course name shown on the exam cover (exam-start information box)
- * @param course                  the slim student-facing course projection (only {@code id} is read)
+ * @param id                         the id of the exam
+ * @param title                      the title shown on the exam cover
+ * @param testExam                   whether this is a test exam (drives the test-exam conduction branch)
+ * @param examWithAttendanceCheck    whether an attendance check is enabled (the cover renders the attendance confirmation)
+ * @param visibleDate                the date the exam becomes visible
+ * @param startDate                  the exam start date (individual end date + waiting-for-start are computed from it)
+ * @param endDate                    the exam end date
+ * @param gracePeriod                the grace period in seconds
+ * @param workingTime                the regular working time in seconds
+ * @param startText                  the markdown start text
+ * @param endText                    the markdown end text
+ * @param confirmationStartText      the markdown confirmation start text (start consent)
+ * @param confirmationEndText        the markdown confirmation end text (end consent)
+ * @param examMaxPoints              the maximum achievable points (exam-start information box)
+ * @param numberOfExercisesInExam    the number of exercises drawn per student exam (exam-start information box)
+ * @param examiner                   the examiner (exam-start information box)
+ * @param moduleNumber               the module number (exam-start information box)
+ * @param courseName                 the course name shown on the exam cover (exam-start information box)
+ * @param examSummaryPublicationDate the date the submission overview becomes visible, or {@code null} when it is not delayed
+ * @param publishResultsDate         the date the results are published (the summary gate also opens once results are out)
+ * @param course                     the slim student-facing course projection (only {@code id} is read)
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ExamForConductionDTO(long id, @Nullable String title, boolean testExam, boolean examWithAttendanceCheck, @Nullable ZonedDateTime visibleDate,
         @Nullable ZonedDateTime startDate, @Nullable ZonedDateTime endDate, @Nullable Integer gracePeriod, int workingTime, @Nullable String startText, @Nullable String endText,
         @Nullable String confirmationStartText, @Nullable String confirmationEndText, int examMaxPoints, @Nullable Integer numberOfExercisesInExam, @Nullable String examiner,
-        @Nullable String moduleNumber, @Nullable String courseName, @Nullable CourseForStudentExamDTO course) {
+        @Nullable String moduleNumber, @Nullable String courseName, @Nullable ZonedDateTime examSummaryPublicationDate, @Nullable ZonedDateTime publishResultsDate,
+        @Nullable CourseForStudentExamDTO course) {
 
     /**
      * Converts an Exam into an ExamForConductionDTO.
@@ -70,6 +79,6 @@ public record ExamForConductionDTO(long id, @Nullable String title, boolean test
         return new ExamForConductionDTO(exam.getId(), exam.getTitle(), exam.isTestExam(), exam.isExamWithAttendanceCheck(), exam.getVisibleDate(), exam.getStartDate(),
                 exam.getEndDate(), exam.getGracePeriod(), exam.getWorkingTime(), exam.getStartText(), exam.getEndText(), exam.getConfirmationStartText(),
                 exam.getConfirmationEndText(), exam.getExamMaxPoints(), exam.getNumberOfExercisesInExam(), exam.getExaminer(), exam.getModuleNumber(), exam.getCourseName(),
-                courseDTO);
+                exam.getExamSummaryPublicationDate(), exam.getPublishResultsDate(), courseDTO);
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExamIntegrationTest.java
@@ -1570,6 +1570,12 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         exam.setConfirmationStartText("I-confirm-start");
         exam.setConfirmationEndText("I-confirm-submit");
         exam.setExamMaxPoints(42);
+        exam.setExaminer("Prof. Examiner");
+        exam.setModuleNumber("IN0000");
+        exam.setCourseName("Conduction Course");
+        exam.setNumberOfExercisesInExam(3);
+        exam.setGracePeriod(180);
+        exam.setExamWithAttendanceCheck(true);
         // a delayed submission overview, so the summary-gate fields below are asserted against real values and not against null
         ZonedDateTime summaryPublicationDate = ZonedDateTime.now().plusDays(1);
         ZonedDateTime publishResultsDate = ZonedDateTime.now().plusDays(2);
@@ -1597,6 +1603,18 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         assertThat(examDTO.confirmationStartText()).isEqualTo("I-confirm-start");
         assertThat(examDTO.confirmationEndText()).isEqualTo("I-confirm-submit");
         assertThat(examDTO.examMaxPoints()).isEqualTo(42);
+        // the exam-start information box
+        assertThat(examDTO.examiner()).isEqualTo("Prof. Examiner");
+        assertThat(examDTO.moduleNumber()).isEqualTo("IN0000");
+        assertThat(examDTO.courseName()).isEqualTo("Conduction Course");
+        assertThat(examDTO.numberOfExercisesInExam()).isEqualTo(3);
+        assertThat(examDTO.title()).isEqualTo(exam.getTitle());
+        // the participation component computes the individual end date and the waiting-for-start state from these
+        assertThat(examDTO.visibleDate()).isNotNull();
+        assertThat(examDTO.endDate()).isNotNull();
+        assertThat(examDTO.gracePeriod()).isEqualTo(180);
+        assertThat(examDTO.workingTime()).isEqualTo(exam.getWorkingTime());
+        assertThat(examDTO.examWithAttendanceCheck()).isTrue();
         // the client-side summary gate (isExamSummaryPublished) evaluates these two off this projection after a hand-in and
         // treats a missing examSummaryPublicationDate as "published", so both have to survive the DTO conversion
         assertThat(examDTO.examSummaryPublicationDate()).isNotNull();
@@ -1606,6 +1624,10 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         // exam-cover reads exam.course.id for the attendance-check / conduction links
         assertThat(examDTO.course()).isNotNull();
         assertThat(examDTO.course().id()).isEqualTo(course1.getId());
+        // Guards the whole projection rather than the fields above one by one: every record component the conduction flow
+        // reads must be populated here, so a future refactor that drops one fails this test instead of silently shipping a
+        // client that reads undefined. That is exactly how examSummaryPublicationDate and publishResultsDate went missing.
+        assertThat(examDTO).hasNoNullFieldsOrProperties();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")

--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExamIntegrationTest.java
@@ -1570,6 +1570,11 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         exam.setConfirmationStartText("I-confirm-start");
         exam.setConfirmationEndText("I-confirm-submit");
         exam.setExamMaxPoints(42);
+        // a delayed submission overview, so the summary-gate fields below are asserted against real values and not against null
+        ZonedDateTime summaryPublicationDate = ZonedDateTime.now().plusDays(1);
+        ZonedDateTime publishResultsDate = ZonedDateTime.now().plusDays(2);
+        exam.setExamSummaryPublicationDate(summaryPublicationDate);
+        exam.setPublishResultsDate(publishResultsDate);
         examRepository.save(exam);
 
         StudentExamForConductionDTO response = request.get("/api/exam/courses/" + course1.getId() + "/exams/" + exam.getId() + "/own-student-exam", HttpStatus.OK,
@@ -1592,6 +1597,12 @@ class ExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCBatchTe
         assertThat(examDTO.confirmationStartText()).isEqualTo("I-confirm-start");
         assertThat(examDTO.confirmationEndText()).isEqualTo("I-confirm-submit");
         assertThat(examDTO.examMaxPoints()).isEqualTo(42);
+        // the client-side summary gate (isExamSummaryPublished) evaluates these two off this projection after a hand-in and
+        // treats a missing examSummaryPublicationDate as "published", so both have to survive the DTO conversion
+        assertThat(examDTO.examSummaryPublicationDate()).isNotNull();
+        assertThat(examDTO.examSummaryPublicationDate().toInstant()).isCloseTo(summaryPublicationDate.toInstant(), within(1, ChronoUnit.SECONDS));
+        assertThat(examDTO.publishResultsDate()).isNotNull();
+        assertThat(examDTO.publishResultsDate().toInstant()).isCloseTo(publishResultsDate.toInstant(), within(1, ChronoUnit.SECONDS));
         // exam-cover reads exam.course.id for the attendance-check / conduction links
         assertThat(examDTO.course()).isNotNull();
         assertThat(examDTO.course().id()).isEqualTo(course1.getId());

--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExamSummaryPublicationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExamSummaryPublicationTest.java
@@ -1,0 +1,63 @@
+package de.tum.cit.aet.artemis.exam;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import de.tum.cit.aet.artemis.exam.domain.Exam;
+
+/**
+ * Unit tests for {@link Exam#isExamSummaryPublished()}, the server-side gate that decides whether a student may fetch the
+ * submission overview.
+ * <p>
+ * The safeguard branch (a publication date still in the future, but the results are already out) cannot be reached through
+ * the REST API: {@code ExamResource#checkExamForDatesConflictsElseThrow} rejects an exam whose summary date is after its
+ * publish-results date, so neither an integration test nor
+ * {@code ExamSummaryPublicationDate.spec.ts} can construct it. It is reachable for exams stored before that validation
+ * existed and for direct database edits, which is exactly why it exists, so it is pinned here instead.
+ */
+class ExamSummaryPublicationTest {
+
+    private static Exam examWith(ZonedDateTime summaryPublicationDate, ZonedDateTime publishResultsDate) {
+        Exam exam = new Exam();
+        exam.setExamSummaryPublicationDate(summaryPublicationDate);
+        exam.setPublishResultsDate(publishResultsDate);
+        return exam;
+    }
+
+    @Test
+    void isExamSummaryPublished_noPublicationDate_availableImmediately() {
+        assertThat(examWith(null, null).isExamSummaryPublished()).isTrue();
+    }
+
+    @Test
+    void isExamSummaryPublished_publicationDateInTheFuture_withheld() {
+        assertThat(examWith(ZonedDateTime.now().plusDays(1), null).isExamSummaryPublished()).isFalse();
+    }
+
+    @Test
+    void isExamSummaryPublished_publicationDateInThePast_available() {
+        assertThat(examWith(ZonedDateTime.now().minusMinutes(1), null).isExamSummaryPublished()).isTrue();
+    }
+
+    @Test
+    void isExamSummaryPublished_resultsAlreadyPublished_availableDespiteFuturePublicationDate() {
+        // the safeguard: a misconfigured date must never hide the overview once the grades are out
+        assertThat(examWith(ZonedDateTime.now().plusDays(1), ZonedDateTime.now().minusMinutes(1)).isExamSummaryPublished()).isTrue();
+    }
+
+    @Test
+    void isExamSummaryPublished_resultsNotYetPublished_staysWithheld() {
+        assertThat(examWith(ZonedDateTime.now().plusDays(1), ZonedDateTime.now().plusDays(2)).isExamSummaryPublished()).isFalse();
+    }
+
+    @Test
+    void isExamSummaryPublished_testExam_neverGated() {
+        Exam testExam = examWith(ZonedDateTime.now().plusDays(1), null);
+        testExam.setTestExam(true);
+
+        assertThat(testExam.isExamSummaryPublished()).isTrue();
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExamSummaryPublicationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExamSummaryPublicationTest.java
@@ -20,6 +20,16 @@ import de.tum.cit.aet.artemis.exam.domain.Exam;
  */
 class ExamSummaryPublicationTest {
 
+    /**
+     * The gate compares against {@code ZonedDateTime.now()}, so the fixtures only have to sit far enough on either side of it
+     * to stay unambiguous. Fixed instants keep the assertions independent of the wall clock and of the machine's time zone.
+     */
+    private static final ZonedDateTime PAST = ZonedDateTime.parse("2000-01-01T00:00:00Z");
+
+    private static final ZonedDateTime FUTURE = ZonedDateTime.parse("2999-01-01T00:00:00Z");
+
+    private static final ZonedDateTime FURTHER_FUTURE = ZonedDateTime.parse("2999-06-01T00:00:00Z");
+
     private static Exam examWith(ZonedDateTime summaryPublicationDate, ZonedDateTime publishResultsDate) {
         Exam exam = new Exam();
         exam.setExamSummaryPublicationDate(summaryPublicationDate);
@@ -34,28 +44,29 @@ class ExamSummaryPublicationTest {
 
     @Test
     void isExamSummaryPublished_publicationDateInTheFuture_withheld() {
-        assertThat(examWith(ZonedDateTime.now().plusDays(1), null).isExamSummaryPublished()).isFalse();
+        assertThat(examWith(FUTURE, null).isExamSummaryPublished()).isFalse();
     }
 
     @Test
     void isExamSummaryPublished_publicationDateInThePast_available() {
-        assertThat(examWith(ZonedDateTime.now().minusMinutes(1), null).isExamSummaryPublished()).isTrue();
+        assertThat(examWith(PAST, null).isExamSummaryPublished()).isTrue();
     }
 
     @Test
     void isExamSummaryPublished_resultsAlreadyPublished_availableDespiteFuturePublicationDate() {
         // the safeguard: a misconfigured date must never hide the overview once the grades are out
-        assertThat(examWith(ZonedDateTime.now().plusDays(1), ZonedDateTime.now().minusMinutes(1)).isExamSummaryPublished()).isTrue();
+        assertThat(examWith(FUTURE, PAST).isExamSummaryPublished()).isTrue();
     }
 
     @Test
     void isExamSummaryPublished_resultsNotYetPublished_staysWithheld() {
-        assertThat(examWith(ZonedDateTime.now().plusDays(1), ZonedDateTime.now().plusDays(2)).isExamSummaryPublished()).isFalse();
+        // the results are published even later than the summary, which is the ordering ExamResource's validation enforces
+        assertThat(examWith(FUTURE, FURTHER_FUTURE).isExamSummaryPublished()).isFalse();
     }
 
     @Test
     void isExamSummaryPublished_testExam_neverGated() {
-        Exam testExam = examWith(ZonedDateTime.now().plusDays(1), null);
+        Exam testExam = examWith(FUTURE, null);
         testExam.setTestExam(true);
 
         assertThat(testExam.isExamSummaryPublished()).isTrue();

--- a/src/test/playwright/e2e/exam/ExamSummaryPublicationDate.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamSummaryPublicationDate.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '../../support/fixtures';
+import { ArtemisCommands, ArtemisRequests, test } from '../../support/fixtures';
 import { Exam } from 'app/exam/shared/entities/exam.model';
 import { expect } from '@playwright/test';
 import { admin, studentTwo } from '../../support/users';
@@ -15,6 +15,20 @@ import textExerciseTemplate from '../../fixtures/exercise/text/template.json';
  *
  * This guards the staggered/multi-shift exam use case where early submitters must not be able to re-download and leak the
  * exam content to later shifts before every shift has finished.
+ *
+ * Both states are covered: gated (a publication date in the future) and the default (no publication date at all, which is
+ * what nearly every exam uses). The default case matters because the gate fails open on a missing value, so the server
+ * omitting the field is indistinguishable from "not configured". That is exactly how the field went missing from
+ * ExamForConductionDTO once the exam response endpoints were ported to DTOs.
+ *
+ * Two further branches of the gate are deliberately NOT covered here, because the API's own validation
+ * (ExamResource#checkExamForDatesConflictsElseThrow) makes them unreachable through it:
+ * - A publication date already in the past requires an exam that has ended (the date must be after the end date), and a
+ *   student cannot sit an exam that is over. Reaching it needs a wall-clock wait for the date to pass mid-test, which is
+ *   the shape of the flakiest specs in this suite, so it is covered by unit tests instead.
+ * - The publishResultsDate safeguard needs a future publication date together with already-published results, but the
+ *   summary date may never be after the results date. It is defensive only, so it is covered by unit tests on both
+ *   Exam#isExamSummaryPublished and its client counterpart in exam.utils.ts.
  */
 
 const course = { id: SEED_COURSES.examParticipation.id } as any;
@@ -25,7 +39,18 @@ test.describe('Exam submission overview publication date', { tag: '@slow' }, () 
     let groupTitle: string;
     let studentExamId: number;
 
-    test.beforeEach('Create exam with a future summary publication date', async ({ login, examAPIRequests, exerciseAPIRequests }) => {
+    /**
+     * Creates an active exam with a single text exercise, registers studentTwo and prepares the exercise start.
+     *
+     * @param summaryPublicationDate when the submission overview becomes visible, or undefined for the default
+     *                               (immediately available after submission)
+     */
+    async function createExamWithOneTextExercise(
+        login: ArtemisCommands['login'],
+        examAPIRequests: ArtemisRequests['examAPIRequests'],
+        exerciseAPIRequests: ArtemisRequests['exerciseAPIRequests'],
+        summaryPublicationDate?: dayjs.Dayjs,
+    ) {
         await login(admin);
 
         exam = await examAPIRequests.createExam({
@@ -35,8 +60,7 @@ test.describe('Exam submission overview publication date', { tag: '@slow' }, () 
             visibleDate: dayjs().subtract(3, 'minutes'),
             startDate: dayjs().subtract(2, 'minutes'),
             endDate: dayjs().add(1, 'hour'),
-            // the submission overview must only become visible far in the future (after the last shift)
-            examSummaryPublicationDate: dayjs().add(1, 'day'),
+            examSummaryPublicationDate: summaryPublicationDate,
             examMaxPoints: 10,
             numberOfExercisesInExam: 1,
         });
@@ -50,9 +74,20 @@ test.describe('Exam submission overview publication date', { tag: '@slow' }, () 
         const studentExams = await examAPIRequests.getAllStudentExams(exam);
         studentExamId = studentExams[0].id!;
         await examAPIRequests.prepareExerciseStartForExam(exam);
-    });
+    }
 
-    test('withholds the submission overview until the publication date', async ({ page, examParticipation, examNavigation, examStartEnd, textExerciseEditor }) => {
+    test('withholds the submission overview until the publication date', async ({
+        page,
+        login,
+        examAPIRequests,
+        exerciseAPIRequests,
+        examParticipation,
+        examNavigation,
+        textExerciseEditor,
+    }) => {
+        // the submission overview must only become visible far in the future (after the last shift)
+        await createExamWithOneTextExercise(login, examAPIRequests, exerciseAPIRequests, dayjs().add(1, 'day'));
+
         await examParticipation.startParticipation(studentTwo, course, exam);
         await examNavigation.openOrSaveExerciseByTitle(groupTitle);
         await textExerciseEditor.typeSubmission(exercise.id!, 'my answer to the exercise.');
@@ -67,6 +102,32 @@ test.describe('Exam submission overview publication date', { tag: '@slow' }, () 
         // The server rejects the summary request while the publication date is still in the future.
         const summaryResponse = await page.request.get(`api/exam/courses/${course.id}/exams/${exam.id}/student-exams/${studentExamId}/summary`);
         expect(summaryResponse.status()).toBe(403);
+    });
+
+    test('offers the submission overview right away when no publication date is set', async ({
+        page,
+        login,
+        examAPIRequests,
+        exerciseAPIRequests,
+        examParticipation,
+        examNavigation,
+        textExerciseEditor,
+    }) => {
+        await createExamWithOneTextExercise(login, examAPIRequests, exerciseAPIRequests, undefined);
+
+        await examParticipation.startParticipation(studentTwo, course, exam);
+        await examNavigation.openOrSaveExerciseByTitle(groupTitle);
+        await textExerciseEditor.typeSubmission(exercise.id!, 'my answer to the exercise.');
+
+        await examParticipation.handInEarly();
+
+        // Default behaviour: the overview is offered as soon as the submission is in, and no release hint is shown.
+        await expect(page.locator('#showExamSummaryButton')).toBeVisible({ timeout: 20000 });
+        await expect(page.locator('#examSummaryUnavailableHint')).toBeHidden();
+
+        // The server serves the summary, so the gate is open on both sides and not just visually.
+        const summaryResponse = await page.request.get(`api/exam/courses/${course.id}/exams/${exam.id}/student-exams/${studentExamId}/summary`);
+        expect(summaryResponse.status()).toBe(200);
     });
 
     test.afterEach('Delete exam', async ({ login, examAPIRequests }) => {


### PR DESCRIPTION
### Summary

`ExamForConductionDTO` does not carry `examSummaryPublicationDate` or `publishResultsDate`, so the client-side summary gate added in #13293 never sees them and always opens. The student submission overview is therefore shown immediately after hand-in, even when an instructor delayed it. This also makes `ExamSummaryPublicationDate.spec.ts` fail deterministically on `develop`, which turns the required `All required CI Passed` gate red on every PR that runs the full E2E suite.

### Checklist

#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).
- [x] I extended the existing integration test that pins the own-student-exam wire contract.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

Two PRs merged into `develop` on 2026-07-28 collide semantically, which no textual merge could detect:

| PR | Merged | What it did |
|---|---|---|
| #13199 | 10:50 | Introduced `ExamForConductionDTO`, returned by `GET courses/{courseId}/exams/{examId}/own-student-exam` nested in `StudentExamForConductionDTO` |
| #13293 | 20:39 | Added `exam.examSummaryPublicationDate` and the client gate that withholds the submission overview until it passes |

`ExamForConductionDTO` was written before the new field existed, so it could not have included it. #13293's E2E test passed on its own branch, which did not yet contain the DTO refactor. Neither PR is at fault on its own.

The client gate fails open:

```ts
// exam.utils.ts
export function isExamSummaryPublished(isTestRun: boolean, exam: Exam | undefined, serverDateService: ServerDateService): boolean {
    if (isTestRun || exam?.testExam) {
        return true;
    }
    if (!exam?.examSummaryPublicationDate) {
        return true;                    // <-- absent field reads as "published"
    }
    return dayjs(exam.examSummaryPublicationDate).isBefore(serverDateService.now()) || !!isExamResultPublished(isTestRun, exam, serverDateService);
}
```

`exam-participation.component.ts:708` sets `this.exam.set(studentExam.exam!)` from that DTO and then evaluates the gate, so `examSummaryPublicationDate` is `undefined`, `isExamSummaryVisible()` returns `true`, and the template renders `#showExamSummaryButton` instead of `#examSummaryUnavailableHint`.

The server-side gate in `StudentExamResource` is unaffected: it reads `studentExam.getExam().isExamSummaryPublished()` off the entity, so the `/summary` endpoint still returns 403. Only the client display is wrong, which is precisely what the E2E test asserts.

### Description

Added both missing dates to `ExamForConductionDTO` (record component plus the `of()` mapping):

- `examSummaryPublicationDate`, the field the gate reads directly.
- `publishResultsDate`, needed for the `|| isExamResultPublished(...)` branch of the same helper. Without it, the summary would stay withheld even after results are published, which is a second latent gap in the same gate.

The component names deliberately match the client `Exam` model field names, so the JSON keys line up.

The class JavaDoc now records why these two fields are part of this projection, so a future DTO refactor does not drop them again for the same reason.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Student
- 1 Exam with a text exercise

1. As instructor, create an exam and set the submission overview publication date to a future point in time.
2. Register the student, generate the student exams, and prepare exercise start.
3. As the student, participate and hand in early.
4. The submission confirmation must show the "summary available from" hint, and neither the "Show summary" button nor the PDF export may be visible.
5. Set the publication date to the past and reload. The summary must now be reachable.

Automated coverage:
- `ExamIntegrationTest.testGetOwnStudentExam_returnsConductionDTOWithCoverFields` now sets both dates on the exam and asserts they survive the DTO conversion.
- `ExamSummaryPublicationDate.spec.ts` (added by #13293) passes again.

### Why a server-only change is sufficient

No client change is needed, and this was checked rather than assumed:

- Both gate helpers wrap the value before comparing (`dayjs(exam.examSummaryPublicationDate).isBefore(...)`), so they work whether the field arrives as a `dayjs` object or a raw ISO string. There is no string-versus-`dayjs` hazard.
- `@JsonInclude(NON_EMPTY)` keeps the key absent when no delay is configured, which the gate correctly reads as "published". The default behaviour is unchanged.
- I audited every field the conduction flow reads off this exam (`exam-participation`, `exam-participation-cover`, `exam-bar`, `exam-start-information`) against the projection. The union is exactly the 21 components the DTO now has, so nothing else is missing.
- `examStudentReviewStart` / `examStudentReviewEnd` look like a similar gap at first glance, but the only component reading them (`exam-general-information`) is rendered by `exam-result-summary`, which sources its exam from the `/summary` endpoint in `StudentExamResource`. That endpoint still returns the entity and was not touched by #13199.

`publishResultsDate` is a genuine regression rather than a new field: before #13199, `getOwnStudentExam` returned the `StudentExam` entity, and `Exam.publishResultsDate` carries no `@JsonIgnore`, so it was on the wire. `examSummaryPublicationDate` never reached that endpoint at all, since it was added after the DTO refactor. That is why the E2E test has failed 100% of the time since #13293 merged.

### Note for reviewers

Verification, in the order it was done:

1. **A/B on one local stack** (Postgres + server + Angular dev server + Playwright), `ExamSummaryPublicationDate.spec.ts`: **1 failed** against the current `develop` DTO, at the same locator and with the same error as CI, then **1 passed** with this change. This also confirms the local stack reproduces the CI failure, so the green run means something.
2. **Removing a component breaks compilation.** Revert only `ExamForConductionDTO` to its `develop` state and the test no longer compiles, because none of the accessors exist.
3. **Forgetting to map a component trips the null guard.** Mapping `examSummaryPublicationDate` to `null` in `of()` while keeping the record component makes the test fail. Verified by deliberately doing it.

The second commit exists because asserting only the two restored dates would catch this regression and no other. The test now populates every field the conduction flow reads and closes with `hasNoNullFieldsOrProperties()` on the projection, so the next dropped field fails CI instead of silently shipping a client that reads `undefined`. That is the actual root cause worth guarding, since an absent JSON key and a null value are indistinguishable on the client.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exam conduction now includes optional scheduled timestamps for exam summary publication and publish-results timing.

* **Bug Fixes**
  * Improved exam summary availability logic using the configured publication and results dates (including edge cases where publication or results are still pending).

* **Tests**
  * Added unit tests and expanded integration and end-to-end coverage to verify gated vs open behavior, UI visibility (hints/buttons), and correct HTTP responses (e.g., 403 vs 200).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->