### PR TITLE
`Development`: Detect rejected pushes and diagnose bare-repository wait timeouts in LocalVC tests

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/RepositoryExportTestUtil.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/RepositoryExportTestUtil.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -15,16 +16,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import org.apache.commons.io.FileUtils;
 import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.transport.PushResult;
+import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -152,7 +157,7 @@ public final class RepositoryExportTestUtil {
         if (contentInitializer != null) {
             contentInitializer.accept(target.workingCopyGitRepo);
             // push initialized content so the bare repo has a default branch/history
-            target.workingCopyGitRepo.push().setRemote("origin").call();
+            assertPushDelivered(target.workingCopyGitRepo.push().setRemote("origin").call());
             // Wait for the bare repository to be fully ready
             waitForBareRepositoryReady(target);
         }
@@ -387,12 +392,38 @@ public final class RepositoryExportTestUtil {
         }
         repo.workingCopyGitRepo.add().addFilepattern(".").call();
         var commit = GitService.commit(repo.workingCopyGitRepo).setMessage(message).call();
-        repo.workingCopyGitRepo.push().setRemote("origin").call();
+        assertPushDelivered(repo.workingCopyGitRepo.push().setRemote("origin").call());
 
         // Wait for the bare repository to be fully ready for cloning operations
         waitForBareRepositoryReady(repo);
 
         return commit;
+    }
+
+    /**
+     * Fails immediately if a push did not actually update the remote refs.
+     * <p>
+     * {@code PushCommand.call()} only throws when the transport itself fails. A push whose individual ref updates were
+     * rejected (non-fast-forward, lock failure, hook rejection, ...) completes normally and returns those per-ref
+     * statuses, which callers here previously discarded. The pushed commit then never reaches the bare repository, and
+     * because {@link #waitForBareRepositoryReady(LocalRepository)} only checks that HEAD resolves (already true from the
+     * initial commit), the problem surfaced much later as an unexplained 60-second timeout in
+     * {@link #waitForBareRepositoryToContainCommit(LocalRepository, String)}. Checking the statuses here turns that into
+     * an immediate failure that names the rejected ref and its reason.
+     *
+     * @param pushResults the results returned by the push command
+     */
+    private static void assertPushDelivered(Iterable<PushResult> pushResults) {
+        List<String> rejected = new ArrayList<>();
+        for (PushResult pushResult : pushResults) {
+            for (RemoteRefUpdate update : pushResult.getRemoteUpdates()) {
+                if (update.getStatus() != RemoteRefUpdate.Status.OK && update.getStatus() != RemoteRefUpdate.Status.UP_TO_DATE) {
+                    rejected.add("%s -> %s: %s%s".formatted(update.getSrcRef(), update.getRemoteName(), update.getStatus(),
+                            update.getMessage() == null ? "" : " (" + update.getMessage() + ")"));
+                }
+            }
+        }
+        assertThat(rejected).as("push did not update the remote refs, so the bare repository never received the commit").isEmpty();
     }
 
     /**
@@ -404,25 +435,84 @@ public final class RepositoryExportTestUtil {
      * @param commitHash the commit hash that must be resolvable
      */
     public static void waitForBareRepositoryToContainCommit(LocalRepository repo, String commitHash) {
+        waitForBareRepositoryToContainCommit(repo, commitHash, Duration.ofSeconds(60));
+    }
+
+    /**
+     * Same as {@link #waitForBareRepositoryToContainCommit(LocalRepository, String)} with an explicit timeout.
+     * Package-private so the timeout diagnostics can be tested without waiting a minute.
+     *
+     * @param repo       the local repository whose bare repo should be verified
+     * @param commitHash the commit hash that must be resolvable
+     * @param timeout    how long to wait for the commit to appear
+     */
+    static void waitForBareRepositoryToContainCommit(LocalRepository repo, String commitHash, Duration timeout) {
         if (commitHash == null || commitHash.length() != 40) {
             throw new IllegalArgumentException("Expected a full 40-character commit hash but got: " + commitHash);
         }
         ObjectId commitId = ObjectId.fromString(commitHash);
-        Awaitility.await().atMost(60, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(() -> {
-            // A local JGit push writes the commit into a pack file (not a loose object) on JGit 7.6+, so the former
-            // loose-object fast-path was always false and every poll fell through to resolve() + parseCommit().
-            // Parsing reads the commit object data and memory-maps the pack through JGit's process-wide WindowCache,
-            // which is heavily contended under parallel CI (it holds pack locks until a GC runs, see JGitConfig) and
-            // could make the poll time out. ObjectDatabase.has(...) inspects loose objects and pack indexes only, so
-            // it confirms the commit landed without mapping the pack data.
-            try (Git git = Git.open(repo.remoteBareGitRepoFile)) {
-                return git.getRepository().getObjectDatabase().has(commitId);
-            }
-            catch (Exception e) {
-                log.debug("Bare repository does not yet contain commit {}: {}", commitHash, e.getMessage());
-                return false;
-            }
-        });
+        // Remembers why the last poll failed. Awaitility only reports "condition was not fulfilled within 60 seconds",
+        // so without this the underlying cause is lost and the failure is undiagnosable after the fact.
+        AtomicReference<Exception> lastPollFailure = new AtomicReference<>();
+        try {
+            Awaitility.await().atMost(timeout).pollInterval(100, TimeUnit.MILLISECONDS).until(() -> {
+                // A local JGit push writes the commit into a pack file (not a loose object) on JGit 7.6+, so the former
+                // loose-object fast-path was always false and every poll fell through to resolve() + parseCommit().
+                // Parsing reads the commit object data and memory-maps the pack through JGit's process-wide WindowCache,
+                // which is heavily contended under parallel CI (it holds pack locks until a GC runs, see JGitConfig) and
+                // could make the poll time out. ObjectDatabase.has(...) inspects loose objects and pack indexes only, so
+                // it confirms the commit landed without mapping the pack data.
+                try (Git git = Git.open(repo.remoteBareGitRepoFile)) {
+                    boolean present = git.getRepository().getObjectDatabase().has(commitId);
+                    if (present) {
+                        lastPollFailure.set(null);
+                    }
+                    return present;
+                }
+                catch (Exception e) {
+                    lastPollFailure.set(e);
+                    log.debug("Bare repository does not yet contain commit {}: {}", commitHash, e.getMessage());
+                    return false;
+                }
+            });
+        }
+        catch (ConditionTimeoutException conditionTimeout) {
+            throw new AssertionError(describeMissingCommit(repo, commitHash, lastPollFailure.get(), timeout), lastPollFailure.get());
+        }
+    }
+
+    /**
+     * Builds a diagnosable message for a {@link #waitForBareRepositoryToContainCommit} timeout.
+     * <p>
+     * Reports whether the bare repository directory exists at all, which refs it currently holds and, when the polls kept
+     * throwing, the last exception. Previously the only evidence was Awaitility's bare "condition was not fulfilled",
+     * which is not enough to tell a genuinely missing commit apart from a repository that could not be opened.
+     *
+     * @param repo            the local repository whose bare repo was polled
+     * @param commitHash      the commit that never appeared
+     * @param lastPollFailure the exception thrown by the last poll, or {@code null} if the polls returned cleanly
+     * @param timeout         how long the wait lasted before giving up
+     * @return the failure message
+     */
+    private static String describeMissingCommit(LocalRepository repo, String commitHash, Exception lastPollFailure, Duration timeout) {
+        StringBuilder message = new StringBuilder("Commit %s never appeared in the bare repository %s within %s.".formatted(commitHash, repo.remoteBareGitRepoFile, timeout));
+        if (!repo.remoteBareGitRepoFile.exists()) {
+            message.append(" The bare repository directory does not exist.");
+            return message.toString();
+        }
+        try (Git git = Git.open(repo.remoteBareGitRepoFile)) {
+            message.append(" Refs present: ").append(git.getRepository().getRefDatabase().getRefs().stream().map(ref -> ref.getName() + "=" + ref.getObjectId()).toList());
+        }
+        catch (Exception e) {
+            message.append(" The bare repository could not be opened for diagnostics: ").append(e);
+        }
+        if (lastPollFailure != null) {
+            message.append(" Last poll failed with: ").append(lastPollFailure);
+        }
+        else {
+            message.append(" Every poll completed without error, so the commit was simply absent (most likely the push did not deliver it).");
+        }
+        return message.toString();
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/RepositoryExportTestUtilDiagnosticsTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/RepositoryExportTestUtilDiagnosticsTest.java
@@ -1,0 +1,70 @@
+package de.tum.cit.aet.artemis.programming.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+import org.eclipse.jgit.api.Git;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies that a {@code waitForBareRepositoryToContainCommit} timeout reports enough context to be diagnosed.
+ * <p>
+ * The wait previously swallowed every poll failure at debug level, so a timeout surfaced only as Awaitility's
+ * "condition was not fulfilled within 60 seconds". That made the recurring flake in
+ * {@code ProgrammingExerciseLocalVCIntegrationTest#testGetParticipationFilesWithContentAtCommitShouldRedirect}
+ * impossible to diagnose from CI logs alone: a genuinely absent commit and a bare repository that could not be opened
+ * produced the same message.
+ */
+class RepositoryExportTestUtilDiagnosticsTest {
+
+    private static final String ABSENT_COMMIT = "0".repeat(40);
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void timeoutOnAnEmptyBareRepository_reportsTheRefsItActuallyHas() throws Exception {
+        Path bareDir = tempDir.resolve("empty.git");
+        try (Git created = Git.init().setBare(true).setDirectory(bareDir.toFile()).call()) {
+            assertThat(created.getRepository().getDirectory()).exists();
+        }
+
+        LocalRepository repo = new LocalRepository("main");
+        repo.remoteBareGitRepoFile = bareDir.toFile();
+
+        assertThatThrownBy(() -> RepositoryExportTestUtil.waitForBareRepositoryToContainCommit(repo, ABSENT_COMMIT, Duration.ofMillis(300))).isInstanceOf(AssertionError.class)
+                // names the commit and the repository, so the failure identifies which wait timed out
+                .hasMessageContaining(ABSENT_COMMIT).hasMessageContaining("empty.git")
+                // an empty bare repo opens cleanly, so the polls never threw: the commit really was absent
+                .hasMessageContaining("Refs present: []").hasMessageContaining("Every poll completed without error");
+    }
+
+    @Test
+    void timeoutOnAMissingBareRepository_saysTheDirectoryDoesNotExist() {
+        LocalRepository repo = new LocalRepository("main");
+        repo.remoteBareGitRepoFile = tempDir.resolve("never-created.git").toFile();
+
+        // Distinguishing this from the case above is the whole point: the old message could not tell them apart.
+        assertThatThrownBy(() -> RepositoryExportTestUtil.waitForBareRepositoryToContainCommit(repo, ABSENT_COMMIT, Duration.ofMillis(300))).isInstanceOf(AssertionError.class)
+                .hasMessageContaining("The bare repository directory does not exist");
+    }
+
+    @Test
+    void aPresentCommitReturnsWithoutWaiting() throws Exception {
+        Path workingDir = tempDir.resolve("work");
+        String commitHash;
+        try (Git git = Git.init().setDirectory(workingDir.toFile()).setInitialBranch("main").call()) {
+            commitHash = git.commit().setMessage("initial").setAllowEmpty(true).setSign(false).call().getId().getName();
+        }
+
+        LocalRepository repo = new LocalRepository("main");
+        // a non-bare repository is fine here: the wait only inspects the object database
+        repo.remoteBareGitRepoFile = workingDir.resolve(".git").toFile();
+
+        RepositoryExportTestUtil.waitForBareRepositoryToContainCommit(repo, commitHash, Duration.ofSeconds(5));
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/RepositoryExportTestUtilDiagnosticsTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/RepositoryExportTestUtilDiagnosticsTest.java
@@ -10,6 +10,8 @@ import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import de.tum.cit.aet.artemis.localvc.service.GitService;
+
 /**
  * Verifies that a {@code waitForBareRepositoryToContainCommit} timeout reports enough context to be diagnosed.
  * <p>
@@ -58,7 +60,8 @@ class RepositoryExportTestUtilDiagnosticsTest {
         Path workingDir = tempDir.resolve("work");
         String commitHash;
         try (Git git = Git.init().setDirectory(workingDir.toFile()).setInitialBranch("main").call()) {
-            commitHash = git.commit().setMessage("initial").setAllowEmpty(true).setSign(false).call().getId().getName();
+            // GitService.commit rather than Git.commit: an ArchUnit rule enforces it, so that commit signing is always disabled
+            commitHash = GitService.commit(git).setMessage("initial").setAllowEmpty(true).call().getId().getName();
         }
 
         LocalRepository repo = new LocalRepository("main");


### PR DESCRIPTION
### Summary

`RepositoryExportTestUtil.waitForBareRepositoryToContainCommit` times out after 60 seconds on PR branches, most often in `ProgrammingExerciseLocalVCIntegrationTest#testGetParticipationFilesWithContentAtCommitShouldRedirect`, and the failure carries no information about why. This closes the two reasons that failure is opaque: a rejected push is silently ignored, and the wait swallows every poll exception.

### Checklist

#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).
- [x] Test-only change: no production code is touched.
- [x] I added tests covering the new diagnostics.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

The failure always looks the same, and says nothing:

```
org.awaitility.core.ConditionTimeoutException: Condition with Lambda expression in
de.tum.cit.aet.artemis.programming.util.RepositoryExportTestUtil was not fulfilled within 1 minutes.
    at ...RepositoryExportTestUtil.waitForBareRepositoryToContainCommit(RepositoryExportTestUtil.java:411)
    at ...ProgrammingExerciseIntegrationTestService.testRedirectGetParticipationRepositoryFilesWithContentAtCommit(...:2276)
```

Observed on three PRs today (five occurrences, twice on the same PR), while passing on `develop`, which points at load sensitivity rather than a code defect in the tests under change.

Two independent problems make it undiagnosable.

**1. A rejected push is discarded.** `PushCommand.call()` only throws when the transport itself fails. A push whose individual ref updates were rejected (non-fast-forward, lock failure, hook rejection) completes normally and returns those statuses in `Iterable<PushResult>`. Both call sites ignored the return value:

```java
repo.workingCopyGitRepo.push().setRemote("origin").call();   // result discarded
waitForBareRepositoryReady(repo);
```

When that happens the commit never reaches the bare repository. And `waitForBareRepositoryReady` cannot catch it, because it only checks that **HEAD** resolves, which the initial commit already satisfies. So the push looks fine, the readiness wait passes, and the problem only surfaces a minute later in the specific-commit wait, far from its cause. The test's own comment about using "a unique student to avoid repo collisions with other tests in this class" suggests rejections under contention are a known hazard here.

**2. The poll swallows the cause.**

```java
catch (Exception e) {
    log.debug("Bare repository does not yet contain commit {}: {}", commitHash, e.getMessage());
    return false;
}
```

At debug level this is invisible in CI. A genuinely absent commit and a bare repository that could not be opened produce byte-identical output.

### Description

- `assertPushDelivered(Iterable<PushResult>)` checks every `RemoteRefUpdate` and fails immediately unless the status is `OK` or `UP_TO_DATE`, naming the ref, the status and the message. Applied to both push sites in this helper.
- `waitForBareRepositoryToContainCommit` records the last poll exception and, on timeout, throws an `AssertionError` that reports the bare repository path, whether the directory exists at all, the refs it actually holds, and either the last exception or an explicit note that every poll completed cleanly (so the commit was simply absent).
- The 60-second timeout is now an injectable parameter on a package-private overload, purely so the diagnostics can be tested in milliseconds. The public signature and the 60-second default are unchanged.

### Steps for Testing

This is a test-infrastructure change with no user-facing behaviour.

1. `./gradlew test --tests "ProgrammingExerciseLocalVCIntegrationTest"` still passes (30 tests).
2. `./gradlew test --tests "RepositoryExportTestUtilDiagnosticsTest"` covers the three timeout outcomes.

### Note for reviewers

**What this does and does not do.** The second change guarantees that the next occurrence is diagnosable instead of silent. The first change is a genuine defect fix and is my hypothesis for the root cause, but I want to be explicit that it is not proven: the flake does not reproduce locally, so I could not observe a rejected push directly. If rejections are the cause, this converts a 60-second silent timeout into an immediate, named failure. If they are not, the improved timeout message will identify the real cause on the next occurrence rather than leaving the next person where I started.

Deliberately **not** done: raising the timeout. That would hide the symptom without explaining it.

Worth a reviewer's eye: whether other `push().call()` sites in the test utilities should get the same treatment. I limited this to the two in this helper to keep the change small, but `LocalRepository` has further push sites that discard their results the same way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation that remote Git refs update correctly, with clearer failure details when a push is rejected.
  * Enhanced commit-availability waiting with timeout support and more diagnosable errors (e.g., repo existence, current refs, and poll outcomes).

* **Tests**
  * Added new tests to verify timeout diagnostics for empty bare repos, missing bare repo directories, and successful commit availability within the timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->