### PR TITLE
`Development`: Fix flaky plagiarism notification assertions in the single user notification test

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/notification/notification/SingleUserNotificationServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/notification/SingleUserNotificationServiceTest.java
@@ -184,10 +184,12 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationIndepen
         singleUserNotificationService.notifyUserAboutNewContinuousPlagiarismControlPlagiarismCase(plagiarismCase, user);
 
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-            List<CourseNotification> notifications = courseNotificationRepository.findAll();
+            // Scope to this test's course: the embedded database is shared by concurrently executing test classes,
+            // so findAll() also returns notifications of the same type created elsewhere.
+            List<CourseNotification> notifications = courseNotificationRepository.findAll().stream().filter(notification -> notification.getCourse().getId().equals(course.getId()))
+                    .toList();
 
-            var hasNewCpcPlagiarismCaseNotification = notifications.stream().filter(notification -> notification.getCourse().getId().equals(course.getId()))
-                    .anyMatch(notification -> notification.getType() == 13);
+            var hasNewCpcPlagiarismCaseNotification = notifications.stream().anyMatch(notification -> notification.getType() == 13);
 
             assertThat(hasNewCpcPlagiarismCaseNotification).isTrue();
 
@@ -207,10 +209,12 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationIndepen
         singleUserNotificationService.notifyUserAboutNewPlagiarismCase(plagiarismCase, user);
 
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-            List<CourseNotification> notifications = courseNotificationRepository.findAll();
+            // Scope to this test's course: the embedded database is shared by concurrently executing test classes,
+            // so findAll() also returns notifications of the same type created elsewhere.
+            List<CourseNotification> notifications = courseNotificationRepository.findAll().stream().filter(notification -> notification.getCourse().getId().equals(course.getId()))
+                    .toList();
 
-            var hasNewPlagiarismCaseNotification = notifications.stream().filter(notification -> notification.getCourse().getId().equals(course.getId()))
-                    .anyMatch(notification -> notification.getType() == 14);
+            var hasNewPlagiarismCaseNotification = notifications.stream().anyMatch(notification -> notification.getType() == 14);
 
             assertThat(hasNewPlagiarismCaseNotification).isTrue();
 
@@ -232,10 +236,12 @@ class SingleUserNotificationServiceTest extends AbstractSpringIntegrationIndepen
         singleUserNotificationService.notifyUserAboutPlagiarismCaseVerdict(plagiarismCase, user);
 
         await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
-            List<CourseNotification> notifications = courseNotificationRepository.findAll();
+            // Scope to this test's course: the embedded database is shared by concurrently executing test classes,
+            // so findAll() also returns notifications of the same type created elsewhere.
+            List<CourseNotification> notifications = courseNotificationRepository.findAll().stream().filter(notification -> notification.getCourse().getId().equals(course.getId()))
+                    .toList();
 
-            var hasNewPlagiarismVerdictNotification = notifications.stream().filter(notification -> notification.getCourse().getId().equals(course.getId()))
-                    .anyMatch(notification -> notification.getType() == 17);
+            var hasNewPlagiarismVerdictNotification = notifications.stream().anyMatch(notification -> notification.getType() == 17);
 
             assertThat(hasNewPlagiarismVerdictNotification).isTrue();
 


### PR DESCRIPTION
### Summary
The three plagiarism tests in `SingleUserNotificationServiceTest` select the notification they assert on by type alone, while the preceding existence check filters by course. Because the embedded database is shared by concurrently executing test classes, they can pick up a notification created by a different test and fail.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
Seen on CI as an intermittent failure that reads like a timing problem but is not:

```
SingleUserNotificationServiceTest > shouldCreatePlagiarismCaseVerdictNotificationWhenCourseSpecificNotificationsEnabled() FAILED
  org.opentest4j.AssertionFailedError:
  Expecting value to be true but was false
    at SingleUserNotificationServiceTest.lambda$...$0(SingleUserNotificationServiceTest.java:245)
```

Line 245 is the `wasNotificationSentOnlyToUser` assertion, so the two assertions before it had already passed: the notification for this course **was** created and found. The problem is which notification the test then picks:

```java
// existence check — correctly scoped to this test's course
notifications.stream().filter(n -> n.getCourse().getId().equals(course.getId())).anyMatch(n -> n.getType() == 17)

// the notification actually asserted on — scoped by type only
notifications.stream().filter(n -> n.getType() == 17).findFirst()
```

`AbstractArtemisIntegrationTest` uses `@AutoConfigureEmbeddedDatabase` without a refresh mode, so the database is created once per Spring context, and it is annotated `@Execution(ExecutionMode.CONCURRENT)`. Test classes therefore share one database. `PlagiarismCaseService.savePlagiarismCaseVerdict` calls `notifyUserAboutPlagiarismCaseVerdict`, so `PlagiarismCaseIntegrationTest` produces type 17 notifications through the same production path. When `findFirst()` returns one of those, `wasNotificationSentOnlyToUser` is false because that notification's single status row belongs to a different student.

Retrying cannot help: the awaitility block re-runs the same selection and keeps choosing the same wrong row, which is why the test burns the full 5 seconds and why raising the timeout would not fix it. `size() > 1` is impossible here, since `notifyUserAboutPlagiarismCaseVerdict` always passes exactly one recipient.

The same defect is present in the type 13 and type 14 tests in this class, so all three are fixed.

### Description
Scope the notification list to the test's own course once, so the existence check and the selected notification always refer to the same notification. The per-assertion course filter becomes redundant and is removed.

No production code and no assertion semantics changed.

### Steps for Testing
Verified by reproducing the failure deterministically before fixing it:

1. Added a temporary block to the verdict test that creates a type 17 notification for a *different* course with a status row for a *different* student, simulating the concurrent test class.
2. Ran the class on unmodified `develop`: the verdict test **failed** with the exact CI assertion error at the `wasNotificationSentOnlyToUser` line.
3. Applied this fix, leaving the simulated foreign notification in place: the test **passed**.
4. Removed the temporary block and re-ran: `./gradlew test --tests "de.tum.cit.aet.artemis.notification.notification.SingleUserNotificationServiceTest"` is green, and `./gradlew spotlessCheck` passes.

### Review Progress
- [x] Code review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved notification test reliability by isolating assertions to notifications from the relevant course.
  * Prevented concurrently running tests from affecting notification verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->