### PR TITLE
`Development`: Document deepClone as the required way to copy objects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,13 @@ Organized by feature module:
     - **Prefer `computed()`/`effect()` over `ngOnChanges` for signal-based components.** Note: in Angular 21 `ngOnChanges` _does_ fire for signal inputs (it is NOT dead code — that was only true in v17–18), so do not treat it as a bug or auto-convert it. But `computed` (derived state) / `effect` (side effects, used sparingly) are the idiomatic, consistent choice. `ngOnChanges` is still valid when you need `SimpleChanges.previousValue`/`isFirstChange()` or logic that must run before child init. A warn-level rule (`prefer-signal-reactivity-over-ngonchanges`) warns on `ngOnChanges` in clean-baseline Angular client files; known migration-backlog files are temporarily excluded in `eslint.config.mjs`. The goal is to remove it entirely (migrate to `computed`/`effect`); rare genuinely-unavoidable cases need a detailed comment and a justified line-level disable. `ngOnInit`/`ngOnDestroy` are unaffected by signals. See `documentation/docs/developer/guidelines/client-development.mdx`.
 - **Angular template control flow: use `@if`, `@for`, `@switch`; never use `*ngIf`, `*ngFor`, `*ngSwitch`**
 - Avoid `null`, use `undefined` where possible
-- Avoid spread operator for objects
+- **Copy objects with `deepClone`, never with object spread, `Object.assign`, or `structuredClone`**
+    - Use `deepClone` from `app/foundation/util/deep-clone.util` (a thin wrapper over lodash `cloneDeep`) whenever you copy an entity-like object — anything that may hold a `dayjs` date, a nested object, a `Map`/`Set`, or a circular reference
+    - `structuredClone()` is the worst option: it does not preserve prototypes, so a cloned `dayjs` date comes back as a plain object without its methods
+    - Object spread (`{ ...obj }`) and `Object.assign({}, obj)` only copy one level deep, so nested objects and arrays stay shared with the original and later edits mutate both
+    - This is why signal updates need care: a signal only notifies when the reference changes, so replace the object rather than mutating it — `const updated = deepClone(current); updated.field = value; return updated;` See `AccountService.setImageUrl` for the canonical pattern
+    - Array spread stays fine: `items.update((items) => [...items, newItem])` is the documented way to append immutably
+    - Full rationale and examples: `documentation/docs/developer/guidelines/client-development.mdx` (### Cloning objects)
 - Prefer 100% type safety
 - **UI components: Use PrimeNG instead of Bootstrap components**
     - All new UI elements must be implemented using PrimeNG components

--- a/documentation/docs/developer/guidelines/client-development.mdx
+++ b/documentation/docs/developer/guidelines/client-development.mdx
@@ -517,6 +517,57 @@ Do one of these:
 - `else` goes on the same line from the closing curly brace.
 - Use 4 spaces per indentation.
 
+### Cloning objects
+
+Copy objects with `deepClone` from `app/foundation/util/deep-clone.util` (a thin wrapper over lodash `cloneDeep`). **Never** use `structuredClone()`, object spread (`{ ...obj }`), or `Object.assign({}, obj)` to copy an entity-like object — anything that may hold a `dayjs` date, a nested object, a `Map`/`Set`, or a circular reference.
+
+```ts
+import { deepClone } from 'app/foundation/util/deep-clone.util';
+
+// Don't - structuredClone() does not preserve prototypes, so `startDate` loses every dayjs
+// method and `copy.startDate.format(...)` throws at runtime. Worse, `dayjs.isDayjs(copy.startDate)`
+// still returns true (an internal data flag survives the clone), so a guard does not catch it.
+const copy = structuredClone(lecture);
+
+// Don't - shallow: `copy.course` is the SAME object as `lecture.course`, so editing the copy
+// silently edits the original too.
+const copy = { ...lecture };
+const copy = Object.assign({}, lecture);
+
+// Do
+const copy = deepClone(lecture);
+copy.title = 'New title';
+```
+
+Why each alternative fails:
+
+| Approach                 | Problem                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `structuredClone()`      | Drops prototypes — `dayjs` dates (and other class instances) lose their methods, while `isDayjs()` still says true |
+| `{ ...obj }`             | One level deep only — nested objects/arrays stay shared with the original                                          |
+| `Object.assign({}, obj)` | Same shallow-copy problem, and it reads as if the result were independent when it is not                           |
+
+This matters most for **signals**, which only notify when the reference changes (see [Zoneless change detection & signal-based state](#zoneless-change-detection--signal-based-state)). Replace the object instead of mutating it:
+
+```ts
+// Do - a new reference, with the nested state safely detached
+this.userIdentity.update((current) => {
+    if (!current) {
+        return current;
+    }
+    const updated = deepClone(current);
+    updated.imageUrl = url;
+    return updated;
+});
+```
+
+`AccountService.setImageUrl` and `AccountService.setUserEnabledMemiris` are the canonical examples.
+
+Two things this rule does **not** cover:
+
+- **Arrays.** Array spread is the documented way to append immutably: `this.items.update((items) => [...items, newItem])`. Reach for `deepClone` only when you need the array's _elements_ detached as well.
+- **Merging a couple of primitive fields onto a fresh literal.** Writing the literal out is clearer than cloning; the rule targets copies of existing entity objects.
+
 ### Prettier and ESLint
 
 - We use `prettier` to style code automatically and `eslint` to find additional issues.


### PR DESCRIPTION
### Summary

`deep-clone.util.ts` already tells you to use `deepClone` "instead of spread operator, `Object.assign()`, or `structuredClone()` when cloning objects that may contain Day.js dates" — but that rule lived **only** in the utility's own JSDoc, where you find it after you have already written the wrong thing. Call sites kept reaching for `Object.assign` as a result (including one I just had to correct in #13340). This records the convention where developers and AI agents actually look: the client development guidelines and `CLAUDE.md`.

Documentation only — no production code changes.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

The convention was effectively invisible. `Object.assign` currently appears in **125** client files and `cloneDeep`/`deepClone` in **47**, and nothing in the guidelines, `CLAUDE.md`, or ESLint mentioned the preference — so a developer had no way to know the rule existed unless they happened to open `deep-clone.util.ts`.

It matters because the alternatives fail in ways that are easy to miss in review. I verified each claim rather than paraphrasing the JSDoc:

```
structuredClone -> isDayjs: true | typeof format: undefined
spread          -> nested shared: true
Object.assign   -> nested shared: true
deepClone       -> isDayjs: true | nested shared: false | format: 2026-07-30
```

The `structuredClone` result is the nastiest: the clone **passes** a `dayjs.isDayjs()` guard (an internal data flag survives) while every method is gone, so it fails later at the call site rather than at the clone. That detail was not written down anywhere, so the new section states it explicitly.

### Description

**`documentation/docs/developer/guidelines/client-development.mdx`** — new `### Cloning objects` section under *Code Style & Quality*:

- The rule, with a do/don't code example.
- A table giving the specific failure mode of `structuredClone()`, `{ ...obj }`, and `Object.assign({}, obj)`.
- Why it matters most for signals (they only notify when the reference changes), cross-linked to the existing *Zoneless change detection & signal-based state* section, with `AccountService.setImageUrl` / `setUserEnabledMemiris` named as the canonical patterns.
- Two explicit **non**-scopes, so the rule does not get cargo-culted: **array spread stays correct** (`items.update((items) => [...items, newItem])` is the documented immutable append), and building a fresh literal from a couple of primitives does not need a clone.

**`CLAUDE.md`** — replaced the bare `Avoid spread operator for objects` bullet with the actual rule, the reason, the signal-update pattern, the array carve-out, and a pointer to the new section.

### Steps for Testing

Documentation only; nothing to exercise at runtime.

1. Open the [client guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development) preview and check the new *Cloning objects* section renders, including the table and the anchor link to *Zoneless change detection & signal-based state*.
2. Confirm `CLAUDE.md` reads consistently with it.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Notes for reviewers

- I deliberately did **not** run Prettier over the whole guidelines file. It is already non-conforming on `develop` (14 diff lines around the Bootstrap-migration paragraph and some `@Component({/* ... */})` blocks), so reformatting would have buried this change in unrelated churn. The lines I added are Prettier-clean.
- Optional follow-up, not included here: a lint rule would enforce this rather than rely on discipline — e.g. `no-restricted-syntax` against `Object.assign({}, …)` and `structuredClone(` in `src/main/webapp/**`. It needs a decision on how to handle the 125 existing `Object.assign` files (warn-level, or an allowlist baseline like the `ngOnChanges` rule uses), so it seemed better to agree the written convention first.
