### PR TITLE
`Development`: Fix flaky slide splitting assertions by unserializing async tests

### DIFF
--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -203,7 +203,15 @@ spring:
         execution:
             thread-name-prefix: artemis-task-
             pool:
-                core-size: 1
+                # core-size must stay >= the number of test classes that run in parallel (junit-platform.properties enables
+                # parallel execution with the default strategy, i.e. one thread per core).
+                #
+                # ThreadPoolExecutor only grows past core-size once the queue is FULL, so with a 10000-deep queue max-size
+                # below is unreachable and core-size alone is the effective pool size. At 1, every @Async task of every
+                # test sharing a Spring context was serialized on one thread: a test awaiting its own background work
+                # could sit behind unrelated tests' tasks far longer than Awaitility's 10s default while the runner idled
+                # at ~67%. That is what made slide-splitting assertions flaky under suite load (#13341).
+                core-size: 8
                 max-size: 50
                 queue-capacity: 10000
         scheduling:


### PR DESCRIPTION
### Summary

`AttachmentVideoUnitIntegrationTest::updateAttachmentVideoUnit_withByteDifferentFileAndChangedHiddenPages_shouldApplyHiddenAndBumpVersion` fails intermittently in the full server suite. The cause is not the assertion or its timeout: the test profile ran **every** `@Async` task on a **single thread**, so a test awaiting its own background work queued behind unrelated tests' tasks. One line of test configuration fixes it, and it should stabilise every other async assertion in the suite too.

No timeout was changed and no test code was touched.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).

### Motivation and Context

The test blocked unrelated PRs (it failed on #13340, which contains no Java at all). It only ever failed in the full suite, never in isolation — the signature of a load-dependent problem rather than a wrong assertion.

**Root cause.** `src/test/resources/config/application.yml` configured the shared `@Async` executor as:

```yaml
core-size: 1
max-size: 50
queue-capacity: 10000
```

`ThreadPoolExecutor` only creates threads beyond `core-size` **once the queue is full**. With a 10000-deep queue, `max-size: 50` is unreachable, so `core-size` is the effective pool size. Verified rather than assumed — 20 blocking tasks submitted to each configuration:

```
core-size=1 -> live threads=1, queued=19
core-size=8 -> live threads=8, queued=12
```

So in the test profile every `@Async` task of every test sharing a Spring context was serialized onto one thread. `junit-platform.properties` enables parallel execution with the default strategy (one thread per core), so several test classes submit work concurrently to that single thread. `SlideSplitterService.splitAttachmentVideoUnitIntoSingleSlides` is `@Async` and CPU-heavy (it renders PDF pages), so the hidden-slide metadata this test awaits could still be unwritten when Awaitility's 10s default expired.

The failing CI run's own telemetry confirms queueing rather than CPU starvation:

```
Avg CPU used:    32.6% system (~2.0 of 6 cores)
Parallelization: ✓ Significant headroom (67% idle on average)
```

The runner sat **idle** while the assertion timed out — a single-threaded pool starving work that the machine had capacity for.

### Description

Raise `core-size` from 1 to 8 in the **test** profile only, so the pool is at least as wide as the number of test classes running in parallel. Production configuration is untouched.

The comment records both constraints so this cannot be quietly reverted: `core-size` must stay `>= ` the parallel test-class count, and `max-size` is not the effective bound while the queue is this deep.

Deliberately **not** done:

- **Raising the Awaitility timeout.** It would hide the queueing rather than remove it, and would leave every other async assertion equally exposed.
- **Making the test executor synchronous.** `AsyncConfiguration` already does this for the mail executor, but the shared `taskExecutor` is different: `splitAttachmentVideoUnitIntoSingleSlides` is `@Async` **and** `@Transactional` and self-locks via `findByIdForUpdate`, so running it on the caller's thread would change transaction and locking semantics rather than just timing.
- **Shrinking `queue-capacity`** so `max-size` becomes reachable. That would also work, but it makes pool growth depend on a queue overflowing under load — less predictable than sizing the core pool directly.

### Steps for Testing

This is test-infrastructure only; there is nothing to exercise in the UI.

1. Confirm CI's `Test / Server Tests (PostgreSQL)` is green.
2. Optionally reproduce the analysis locally:

```bash
./gradlew test -x webapp --tests "de.tum.cit.aet.artemis.lecture.AttachmentVideoUnitIntegrationTest"
```

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-30 13:03:51 UTC_


### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Notes for reviewers

- Production still uses `core-size: 2`, and has the same `max-size`-unreachable property. I left it alone deliberately: this PR is scoped to the test flake, and changing production async concurrency deserves its own discussion. Worth a look separately if 2 effective threads is not what was intended there either.
