### PR TITLE
`Development`: Fix stale LocalVC test repositories causing commit lookup timeouts

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
@@ -116,6 +116,7 @@ import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseParticipationU
 import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseUtilService;
 import de.tum.cit.aet.artemis.programming.util.ProgrammingUtilTestService;
 import de.tum.cit.aet.artemis.programming.util.RepositoryExportTestUtil;
+import de.tum.cit.aet.artemis.programming.util.ShortNameGenerator;
 import de.tum.cit.aet.artemis.programming.util.TestFileUtil;
 import de.tum.cit.aet.artemis.text.util.TextExerciseUtilService;
 
@@ -2250,6 +2251,8 @@ public class ProgrammingExerciseIntegrationTestService {
     // Legacy BiFunction-based helper is no longer needed after LocalVC conversion; removed to simplify the suite.
 
     void testRedirectGetParticipationRepositoryFilesWithContentAtCommit(String testPrefix) throws Exception {
+        programmingExercise = createProgrammingExerciseWithUniqueProjectKey("Commit Lookup Test", "CLT");
+
         // Ensure base repositories (template, solution, tests) exist and URIs are wired for this exercise
         RepositoryExportTestUtil.createAndWireBaseRepositories(localVCLocalCITestService, programmingExercise);
         programmingExercise = programmingExerciseRepository.save(programmingExercise);
@@ -2271,9 +2274,6 @@ public class ProgrammingExerciseIntegrationTestService {
             Map.entry("C.java", "efg")
         ), "seed student files");
         // @formatter:on
-        // The endpoint under test resolves the bare repo by commit hash; ensure that specific
-        // hash is visible in the bare repo (not just HEAD) before issuing the request.
-        RepositoryExportTestUtil.waitForBareRepositoryToContainCommit(repo, commit.getId().getName());
 
         // Persist submission with commit hash
         var submission = new ProgrammingSubmission();
@@ -2299,10 +2299,13 @@ public class ProgrammingExerciseIntegrationTestService {
     }
 
     void testRedirectGetParticipationRepositoryFilesWithContentAtCommitForbidden(String testPrefix) throws Exception {
-        // Seed LocalVC repo for existing participation1 and create a submission for its latest commit
-        var studentLogin = participation1.getParticipantIdentifier();
-        var repo = RepositoryExportTestUtil.seedStudentRepositoryForParticipation(localVCLocalCITestService, participation1);
-        programmingExerciseStudentParticipationRepository.save(participation1);
+        programmingExercise = createProgrammingExerciseWithUniqueProjectKey("Commit Lookup Forbidden Test", "CLF");
+
+        // Seed LocalVC repo for a dedicated participation and create a submission for its latest commit
+        var studentLogin = testPrefix + "student1";
+        var studentParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, studentLogin);
+        var repo = RepositoryExportTestUtil.seedStudentRepositoryForParticipation(localVCLocalCITestService, studentParticipation);
+        programmingExerciseStudentParticipationRepository.save(studentParticipation);
 
         // Write files, commit, and push via util
         var commit = RepositoryExportTestUtil.writeFilesAndPush(repo, Map.of("README.md", "Initial commit", "A.java", "abc", "B.java", "cde", "C.java", "efg"),
@@ -2315,8 +2318,15 @@ public class ProgrammingExerciseIntegrationTestService {
         programmingExerciseUtilService.addProgrammingSubmission(programmingExercise, submission, studentLogin);
 
         // Expect forbidden for current user
-        request.get("/api/programming/programming-exercise-participations/" + participation1.getId() + "/files-content?commitId=" + submission.getCommitHash(),
+        request.get("/api/programming/programming-exercise-participations/" + studentParticipation.getId() + "/files-content?commitId=" + submission.getCommitHash(),
                 HttpStatus.FORBIDDEN, Map.class);
+    }
+
+    private ProgrammingExercise createProgrammingExerciseWithUniqueProjectKey(String title, String shortNamePrefix) {
+        var uniqueShortName = shortNamePrefix + ShortNameGenerator.generateRandomShortName(6);
+        var course = programmingExerciseUtilService.addCourseWithOneProgrammingExercise(false, title, uniqueShortName);
+        return programmingExerciseRepository.findWithTemplateAndSolutionParticipationById(ExerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class).getId())
+                .orElseThrow();
     }
 
     private long getMaxProgrammingExerciseId() {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
@@ -2257,11 +2257,10 @@ public class ProgrammingExerciseIntegrationTestService {
         RepositoryExportTestUtil.createAndWireBaseRepositories(localVCLocalCITestService, programmingExercise);
         programmingExercise = programmingExerciseRepository.save(programmingExercise);
 
-        // Create student participation with LocalVC repo
-        // Use a unique student to avoid repo collisions with other tests in this class
         String studentLogin = testPrefix + "student3";
         var studentParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, studentLogin);
-        var repo = RepositoryExportTestUtil.seedStudentRepositoryForParticipation(localVCLocalCITestService, studentParticipation);
+        // The participation helper creates and seeds the bare LocalVC repository; clone it here instead of creating a second root commit.
+        var repo = RepositoryExportTestUtil.getOrCreateWorkingCopyForParticipation(localVCLocalCITestService, studentParticipation, localVCBasePath);
         programmingExerciseStudentParticipationRepository.save(studentParticipation);
 
         // Write files in one commit and push to origin to ensure the commit exists remotely
@@ -2301,10 +2300,10 @@ public class ProgrammingExerciseIntegrationTestService {
     void testRedirectGetParticipationRepositoryFilesWithContentAtCommitForbidden(String testPrefix) throws Exception {
         programmingExercise = createProgrammingExerciseWithUniqueProjectKey("Commit Lookup Forbidden Test", "CLF");
 
-        // Seed LocalVC repo for a dedicated participation and create a submission for its latest commit
         var studentLogin = testPrefix + "student1";
         var studentParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, studentLogin);
-        var repo = RepositoryExportTestUtil.seedStudentRepositoryForParticipation(localVCLocalCITestService, studentParticipation);
+        // The participation helper creates and seeds the bare LocalVC repository; clone it here instead of creating a second root commit.
+        var repo = RepositoryExportTestUtil.getOrCreateWorkingCopyForParticipation(localVCLocalCITestService, studentParticipation, localVCBasePath);
         programmingExerciseStudentParticipationRepository.save(studentParticipation);
 
         // Write files, commit, and push via util

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/RepositoryExportTestUtil.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/RepositoryExportTestUtil.java
@@ -25,6 +25,7 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -152,9 +153,7 @@ public final class RepositoryExportTestUtil {
         if (contentInitializer != null) {
             contentInitializer.accept(target.workingCopyGitRepo);
             // push initialized content so the bare repo has a default branch/history
-            target.workingCopyGitRepo.push().setRemote("origin").call();
-            // Wait for the bare repository to be fully ready
-            waitForBareRepositoryReady(target);
+            pushToOrigin(target.workingCopyGitRepo);
         }
 
         return trackRepository(target);
@@ -377,7 +376,7 @@ public final class RepositoryExportTestUtil {
     /**
      * Writes a set of files into the repo working copy, commits them with the provided message, and pushes to origin.
      * Returns the created commit for callers that need the hash.
-     * After pushing, waits for the bare repository to be fully ready to prevent race conditions on slow CI systems.
+     * The local file push is synchronous; once JGit reports a successful remote ref update, the bare repository can be read by follow-up code.
      */
     public static RevCommit writeFilesAndPush(LocalRepository repo, Map<String, String> files, String message) throws Exception {
         for (Map.Entry<String, String> e : files.entrySet()) {
@@ -387,12 +386,23 @@ public final class RepositoryExportTestUtil {
         }
         repo.workingCopyGitRepo.add().addFilepattern(".").call();
         var commit = GitService.commit(repo.workingCopyGitRepo).setMessage(message).call();
-        repo.workingCopyGitRepo.push().setRemote("origin").call();
-
-        // Wait for the bare repository to be fully ready for cloning operations
-        waitForBareRepositoryReady(repo);
+        pushToOrigin(repo.workingCopyGitRepo);
 
         return commit;
+    }
+
+    private static void pushToOrigin(Git git) throws GitAPIException {
+        var pushResults = git.push().setRemote("origin").call();
+        List<String> failedUpdates = new ArrayList<>();
+        for (var pushResult : pushResults) {
+            for (RemoteRefUpdate update : pushResult.getRemoteUpdates()) {
+                var status = update.getStatus();
+                if (status != RemoteRefUpdate.Status.OK && status != RemoteRefUpdate.Status.UP_TO_DATE) {
+                    failedUpdates.add(update.getRemoteName() + " -> " + status + (update.getMessage() == null ? "" : ": " + update.getMessage()));
+                }
+            }
+        }
+        assertThat(failedUpdates).as("push to origin should update all refs").isEmpty();
     }
 
     /**


### PR DESCRIPTION
### Summary

Fixes a flaky LocalVC integration test setup where reused bare repositories could reject test pushes silently, causing commit lookup awaits to time out.

### Checklist
#### General
- [x] This is a small test-only issue that I tested locally.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).

### Motivation and Context

`ProgrammingExerciseLocalVCIntegrationTest > testGetParticipationFilesWithContentAtCommitShouldRedirect()` was timing out in CI while waiting for a commit to become visible in the bare LocalVC repository.

The underlying issue was that the affected tests used the shared default programming exercise project key and standard repository slugs. If such a LocalVC repository already contained unrelated history, JGit could reject a test push with a non-fast-forward update. The previous test utilities ignored push results, so the test later waited for a commit that had never reached the bare repository.

### Description

- Use dedicated programming exercises with unique project keys for the affected commit-lookup test paths.
- Validate JGit push results and fail immediately on rejected ref updates.
- Remove the redundant post-push commit visibility await from the affected participation file test flow.

### Steps for Testing

Run the affected server tests:

```bash
./gradlew test --tests ProgrammingExerciseLocalVCIntegrationTest.testGetParticipationFilesWithContentAtCommitShouldRedirect -x webapp
./gradlew test --tests ProgrammingExerciseLocalVCIntegrationTest -x webapp
./gradlew test --tests LocalVCIntegrationTest.testInstructorTriesToForcePushOverHttp -x webapp
```

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-30 14:00:01 UTC_

