### PR TITLE
`Development`: Reuse LocalVC participation repositories in submission tests

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionIntegrationTest.java
@@ -766,7 +766,7 @@ class ProgrammingSubmissionIntegrationTest extends AbstractProgrammingIntegratio
     }
 
     private void seedRepositoryForParticipation(ProgrammingExerciseStudentParticipation participation, String filename) throws Exception {
-        LocalRepository repo = RepositoryExportTestUtil.seedStudentRepositoryForParticipation(localVCLocalCITestService, participation);
+        LocalRepository repo = RepositoryExportTestUtil.getOrCreateWorkingCopyForParticipation(localVCLocalCITestService, participation, localVCBasePath);
         createdRepos.add(repo);
         RepositoryExportTestUtil.writeFilesAndPush(repo, Map.of(filename, "class %s {}".formatted(filename.replace('.', '_'))), "seed " + filename);
         participationRepository.save(participation);


### PR DESCRIPTION
### Summary

Follow-up to #13350. This fixes the remaining CI failures in `ProgrammingSubmissionIntegrationTest` by reusing the LocalVC repository that the participation helper already creates.

### Checklist
#### General
- [x] This is a small issue that I tested locally.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server
- [x] I strictly followed the server coding and design guidelines.
- [x] I verified the affected integration test class locally.

### Motivation and Context

PR #13350 was merged before the final follow-up fix made it into the PR. The server CI then failed several `ProgrammingSubmissionIntegrationTest` methods with non-fast-forward push failures.

The underlying issue is the same LocalVC repository lifecycle problem addressed in #13350: the test creates participations through helpers that already initialize the bare LocalVC repository, then the local seeding helper initialized the same repository again. With push-result validation enabled, this surfaces immediately as `REJECTED_NONFASTFORWARD`.

### Description

`ProgrammingSubmissionIntegrationTest.seedRepositoryForParticipation(...)` now uses `RepositoryExportTestUtil.getOrCreateWorkingCopyForParticipation(...)` instead of `seedStudentRepositoryForParticipation(...)`.

This clones/reuses the existing participation repository and avoids creating a second independent root commit for the same bare repository.

### Steps for Testing

Run:

```bash
./gradlew test --tests ProgrammingSubmissionIntegrationTest -x webapp
```

Expected result:

- 38 tests pass
- 0 failures
- 0 skipped

### Testserver States

Not deployed. This is a test-only server change verified locally.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-30 14:43:59 UTC_

