### PR TITLE
`Development`: Fix flaky server tests caused by JGit configuration races and LocalVC repository seeding

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/GlobalCleanupListener.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/GlobalCleanupListener.java
@@ -10,25 +10,29 @@ import org.junit.platform.launcher.TestPlan;
 import de.tum.cit.aet.artemis.programming.util.RepositoryExportTestUtil;
 
 /**
- * GlobalCleanupListener performs a single
+ * GlobalCleanupListener performs setup that has to happen exactly once before all server integration tests, and a single
  * cleanup operation of local server-integration-test directories after all server integration tests have completed.
  *
  * <p>
- * This listener registers with the JUnit Platform Launcher to receive a callback
- * in {@link #testPlanExecutionFinished(TestPlan)} once the entire test plan has
- * executed. Unlike JUnit Jupiter {@link org.junit.jupiter.api.AfterAll} methods and
+ * This listener registers with the JUnit Platform Launcher to receive callbacks in {@link #testPlanExecutionStarted(TestPlan)} and
+ * in {@link #testPlanExecutionFinished(TestPlan)}, i.e. before and after the entire test plan has
+ * executed. Unlike JUnit Jupiter {@link org.junit.jupiter.api.BeforeAll} / {@link org.junit.jupiter.api.AfterAll} methods and
  * {@link org.junit.jupiter.api.extension.AfterAllCallback} extensions, which are scoped
  * per test container and may run multiple times (once per class), this listener ensures
- * cleanup logic is executed exactly once per test run. Running the cleanup once per class caused issues with parallel test execution.
+ * the logic is executed exactly once per test run, while the JVM is still single-threaded. Running it once per class caused issues with parallel test execution,
+ * both for the cleanup and for the JGit {@link JGitSystemReaderInitializer configuration}.
  *
  * <p>
- * If you want to keep the directory for debugging purposes, you can either comment out the method below or remove the listener from
- * {@code  src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener}.
+ * If you want to keep the directory for debugging purposes, comment out {@link #testPlanExecutionFinished(TestPlan)}. Do not remove the listener from
+ * {@code src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener}, because the JGit setup would be lost as well.
  */
 public class GlobalCleanupListener implements TestExecutionListener {
 
     @Override
     public void testPlanExecutionStarted(TestPlan testPlan) {
+        // Must happen here and not in a @BeforeAll: installing a JGit SystemReader resets JGit's static platform detection caches,
+        // which makes git operations of already running test classes fail. See JGitSystemReaderInitializer.
+        JGitSystemReaderInitializer.configureOnce();
         CpuUsageMonitor.start();
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/JGitSystemReaderInitializer.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/JGitSystemReaderInitializer.java
@@ -1,0 +1,110 @@
+package de.tum.cit.aet.artemis.core.util.junit_extensions;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jgit.lib.Config;
+import org.eclipse.jgit.storage.file.FileBasedConfig;
+import org.eclipse.jgit.util.FS;
+import org.eclipse.jgit.util.SystemReader;
+
+/**
+ * Installs a {@link SystemReader} that makes JGit skip system-level git config files.
+ * This is necessary because system gitconfig files (e.g. {@code /opt/homebrew/etc/gitconfig}) can exceed JGit's default 5 MB file size limit,
+ * which makes every git operation fail with "File is too large".
+ * <p>
+ * The reader must be installed <b>exactly once per JVM</b>. {@link SystemReader#setInstance(SystemReader)} first resets JGit's static platform detection caches
+ * ({@code isWindows}, {@code isMacOS}, {@code isLinux}) to {@code null} and only afterwards re-derives them via {@code init() -> setPlatformChecker()}.
+ * Since {@code SystemReader#isWindows()} re-reads the static field after assigning it, a concurrent {@code setInstance(...)} nulls the field between the
+ * assignment and the read, which throws {@code NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because
+ * "org.eclipse.jgit.util.SystemReader.isWindows" is null}. Calling {@code setInstance} from {@code @BeforeAll} of a base test class means one call per test
+ * class, and test classes run in parallel, so those calls collide with each other and with git operations of tests that are already running.
+ * <p>
+ * {@link #configureOnce()} is therefore idempotent, and {@link GlobalCleanupListener#testPlanExecutionStarted} calls it before the test plan starts executing,
+ * i.e. while the JVM is still single-threaded.
+ */
+public final class JGitSystemReaderInitializer {
+
+    private static final AtomicBoolean CONFIGURED = new AtomicBoolean(false);
+
+    private JGitSystemReaderInitializer() {
+    }
+
+    /**
+     * Installs the custom {@link SystemReader} the first time it is called and does nothing on every subsequent call.
+     */
+    public static void configureOnce() {
+        if (!CONFIGURED.compareAndSet(false, true)) {
+            return;
+        }
+        final SystemReader defaultReader = SystemReader.getInstance();
+
+        SystemReader.setInstance(new SystemReader() {
+
+            @Override
+            public String getHostname() {
+                return defaultReader.getHostname();
+            }
+
+            @Override
+            public String getenv(String variable) {
+                return defaultReader.getenv(variable);
+            }
+
+            @Override
+            public String getProperty(String key) {
+                return defaultReader.getProperty(key);
+            }
+
+            @Override
+            public FileBasedConfig openUserConfig(Config parent, FS fs) {
+                return defaultReader.openUserConfig(parent, fs);
+            }
+
+            @Override
+            public FileBasedConfig openSystemConfig(Config parent, FS fs) {
+                // Return an empty config instead of reading the potentially large system gitconfig
+                return new FileBasedConfig(parent, null, fs) {
+
+                    @Override
+                    public void load() {
+                        // Don't load anything - skip system config
+                    }
+
+                    @Override
+                    public boolean isOutdated() {
+                        return false;
+                    }
+                };
+            }
+
+            @Override
+            public FileBasedConfig openJGitConfig(Config parent, FS fs) {
+                return defaultReader.openJGitConfig(parent, fs);
+            }
+
+            @Override
+            public Instant now() {
+                return defaultReader.now();
+            }
+
+            @Override
+            public ZoneOffset getTimeZoneAt(Instant when) {
+                return defaultReader.getTimeZoneAt(when);
+            }
+
+            @SuppressWarnings("deprecation")
+            @Override
+            public long getCurrentTime() {
+                return defaultReader.getCurrentTime();
+            }
+
+            @SuppressWarnings("deprecation")
+            @Override
+            public int getTimezone(long when) {
+                return defaultReader.getTimezone(when);
+            }
+        });
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/JGitSystemReaderInitializer.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/JGitSystemReaderInitializer.java
@@ -32,6 +32,17 @@ public final class JGitSystemReaderInitializer {
     }
 
     /**
+     * Whether the custom {@link SystemReader} has already been installed in this JVM.
+     * Tests assert this to detect the regression where the up-front installation is dropped and the first
+     * {@link SystemReader#setInstance(SystemReader)} call happens lazily, while other test classes already run git operations.
+     *
+     * @return true once {@link #configureOnce()} has installed the reader
+     */
+    public static boolean isConfigured() {
+        return CONFIGURED.get();
+    }
+
+    /**
      * Installs the custom {@link SystemReader} the first time it is called and does nothing on every subsequent call.
      */
     public static void configureOnce() {

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/JGitSystemReaderInitializerTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/JGitSystemReaderInitializerTest.java
@@ -32,6 +32,10 @@ class JGitSystemReaderInitializerTest {
 
     private static final int THREAD_COUNT = 16;
 
+    /**
+     * Covers the second race ingredient: the reader has to be installed before any test executes. Fails if the
+     * {@link GlobalCleanupListener#testPlanExecutionStarted} call is ever dropped, which would move the installation back into a running, parallel test plan.
+     */
     @Test
     void shouldBeConfiguredBeforeAnyTestRuns() {
         assertThat(JGitSystemReaderInitializer.isConfigured())
@@ -40,6 +44,9 @@ class JGitSystemReaderInitializerTest {
                 .isTrue();
     }
 
+    /**
+     * Covers the first race ingredient: only a single {@code setInstance} call may ever happen, so no later call can null the static platform caches again.
+     */
     @Test
     void shouldInstallSystemReaderOnlyOnce() throws Exception {
         JGitSystemReaderInitializer.configureOnce();

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/JGitSystemReaderInitializerTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/JGitSystemReaderInitializerTest.java
@@ -12,15 +12,33 @@ import org.eclipse.jgit.util.SystemReader;
 import org.junit.jupiter.api.Test;
 
 /**
- * Guards the invariant that JGit's {@link SystemReader} is installed exactly once per JVM.
+ * Guards the two invariants that keep JGit's {@link SystemReader} from breaking parallel tests.
  * <p>
  * {@link SystemReader#setInstance(SystemReader)} nulls JGit's static platform detection caches before re-deriving them. Calling it while other threads run git
  * operations makes {@code SystemReader#isWindows()} throw a {@link NullPointerException}, which is what happened when the reader was installed from a
  * {@code @BeforeAll} of the integration test base class (once per test class, with test classes running in parallel).
+ * <p>
+ * The race therefore has two ingredients, and each is covered by one invariant:
+ * <ol>
+ * <li>more than one {@code setInstance} call: prevented by the guard in {@link JGitSystemReaderInitializer#configureOnce()},</li>
+ * <li>a {@code setInstance} call concurrent with git work: prevented by installing the reader in
+ * {@link GlobalCleanupListener#testPlanExecutionStarted} before any test runs.</li>
+ * </ol>
+ * Note that the second ingredient cannot be reproduced from within a test: every test already runs inside the test plan, so by then the reader is installed and
+ * {@code configureOnce()} is a no-op. It is asserted structurally instead, via {@link JGitSystemReaderInitializer#isConfigured()}, plus the ArchUnit rule
+ * {@code ArchitectureTest#testNoJGitSystemReaderConfigurationOutsideInitializer}.
  */
 class JGitSystemReaderInitializerTest {
 
     private static final int THREAD_COUNT = 16;
+
+    @Test
+    void shouldBeConfiguredBeforeAnyTestRuns() {
+        assertThat(JGitSystemReaderInitializer.isConfigured())
+                .as("the SystemReader must already be installed before the first test runs, otherwise the first installation resets JGit's platform caches "
+                        + "while other test classes are already executing git operations")
+                .isTrue();
+    }
 
     @Test
     void shouldInstallSystemReaderOnlyOnce() throws Exception {
@@ -32,6 +50,10 @@ class JGitSystemReaderInitializerTest {
         assertThat(SystemReader.getInstance()).as("repeated configuration must not replace the installed SystemReader").isSameAs(installedReader);
     }
 
+    /**
+     * Exercises the idempotent path that every test class hits: concurrent {@code configureOnce()} calls must stay no-ops and must not disturb git platform
+     * detection running in parallel.
+     */
     @Test
     void shouldKeepPlatformDetectionUsableWhileConfiguringConcurrently() throws Exception {
         List<Throwable> failures = new CopyOnWriteArrayList<>();

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/JGitSystemReaderInitializerTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/junit_extensions/JGitSystemReaderInitializerTest.java
@@ -1,0 +1,85 @@
+package de.tum.cit.aet.artemis.core.util.junit_extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jgit.util.SystemReader;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the invariant that JGit's {@link SystemReader} is installed exactly once per JVM.
+ * <p>
+ * {@link SystemReader#setInstance(SystemReader)} nulls JGit's static platform detection caches before re-deriving them. Calling it while other threads run git
+ * operations makes {@code SystemReader#isWindows()} throw a {@link NullPointerException}, which is what happened when the reader was installed from a
+ * {@code @BeforeAll} of the integration test base class (once per test class, with test classes running in parallel).
+ */
+class JGitSystemReaderInitializerTest {
+
+    private static final int THREAD_COUNT = 16;
+
+    @Test
+    void shouldInstallSystemReaderOnlyOnce() throws Exception {
+        JGitSystemReaderInitializer.configureOnce();
+        SystemReader installedReader = SystemReader.getInstance();
+
+        runConcurrently(JGitSystemReaderInitializer::configureOnce);
+
+        assertThat(SystemReader.getInstance()).as("repeated configuration must not replace the installed SystemReader").isSameAs(installedReader);
+    }
+
+    @Test
+    void shouldKeepPlatformDetectionUsableWhileConfiguringConcurrently() throws Exception {
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+
+        runConcurrently(() -> {
+            try {
+                JGitSystemReaderInitializer.configureOnce();
+                for (int i = 0; i < 500; i++) {
+                    SystemReader reader = SystemReader.getInstance();
+                    reader.isWindows();
+                    reader.isMacOS();
+                    reader.isLinux();
+                }
+            }
+            catch (Throwable throwable) {
+                failures.add(throwable);
+            }
+        });
+
+        assertThat(failures).as("JGit platform detection must not fail while the SystemReader is configured").isEmpty();
+    }
+
+    private static void runConcurrently(Runnable action) throws InterruptedException {
+        CountDownLatch startSignal = new CountDownLatch(1);
+        CountDownLatch doneSignal = new CountDownLatch(THREAD_COUNT);
+        List<Thread> threads = new ArrayList<>(THREAD_COUNT);
+
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    startSignal.await();
+                    action.run();
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                finally {
+                    doneSignal.countDown();
+                }
+            });
+            threads.add(thread);
+            thread.start();
+        }
+
+        startSignal.countDown();
+        assertThat(doneSignal.await(30, TimeUnit.SECONDS)).as("all threads should finish").isTrue();
+        for (Thread thread : threads) {
+            thread.join();
+        }
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/LocalRepository.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/LocalRepository.java
@@ -11,6 +11,7 @@ import java.util.stream.StreamSupport;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ResetCommand.ResetType;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ConfigConstants;
 import org.eclipse.jgit.lib.Constants;
@@ -138,6 +139,7 @@ public class LocalRepository {
 
     /**
      * Configures the local and origin repositories instantiating the origin repository as a bare repository and making sure the default branch name is set correctly.
+     * If the origin repository already contains commits, the working copy continues that history instead of starting a new one.
      *
      * @param repoBasePath           The base path where the repositories will be created
      * @param localRepoFileName      name of the local repository to be used as the prefix for the folder
@@ -153,7 +155,8 @@ public class LocalRepository {
         workingCopyGitRepo = initialize(localRepoPath, defaultBranch, false);
 
         remoteBareGitRepoFile = originRepositoryFolder.toAbsolutePath().toFile();
-        // Create a bare remote repository.
+        boolean originHasHistory = hasCommits(originRepositoryFolder);
+        // Create a bare remote repository. This is a no-op for an origin repository that already exists.
         remoteBareGitRepo = initialize(remoteBareGitRepoFile.toPath(), defaultBranch, true);
 
         workingCopyGitRepo.remoteAdd().setName("origin").setUri(new URIish(remoteBareGitRepoFile.toURI().toString())).call();
@@ -164,6 +167,15 @@ public class LocalRepository {
         refUpdate.setForceUpdate(true);
         refUpdate.link("refs/heads/" + defaultBranch);
 
+        if (originHasHistory) {
+            // The origin repository was already created and filled elsewhere, e.g. when the participation was created
+            // (see ParticipationUtilService#ensureLocalVcRepositoryExists). Adopt its history: an unrelated initial commit could only be pushed as a
+            // non-fast-forward, and JGit reports that in the push result instead of throwing, so the working copy would silently diverge from the origin.
+            workingCopyGitRepo.fetch().setRemote("origin").call();
+            workingCopyGitRepo.reset().setMode(ResetType.HARD).setRef("origin/" + defaultBranch).call();
+            return;
+        }
+
         // Push a file to the remote repository to create the default branch there.
         // This is needed because the local CI system only considers pushes that update the existing default branch.
         Path filePath = localRepoPath.resolve("test.txt");
@@ -171,6 +183,22 @@ public class LocalRepository {
         workingCopyGitRepo.add().addFilepattern("test.txt").call();
         GitService.commit(workingCopyGitRepo).setMessage("Initial commit").call();
         workingCopyGitRepo.push().setRemote("origin").call();
+    }
+
+    /**
+     * Checks whether the given folder already holds a git repository that has at least one commit on its current branch.
+     *
+     * @param repositoryFolder the folder of the (bare) repository to inspect
+     * @return true if the repository exists and is not empty, false otherwise
+     * @throws IOException if reading the repository fails
+     */
+    private static boolean hasCommits(Path repositoryFolder) throws IOException {
+        if (!Files.exists(repositoryFolder.resolve(Constants.HEAD))) {
+            return false;
+        }
+        try (Repository repository = new FileRepositoryBuilder().setGitDir(repositoryFolder.toFile()).build()) {
+            return repository.resolve(Constants.HEAD) != null;
+        }
     }
 
     // This method tries to build a valid, but unique (random) LocalVCRepositoryUri from the given base path and local repository file name.

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/LocalRepositoryTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/LocalRepositoryTest.java
@@ -67,6 +67,10 @@ class LocalRepositoryTest {
                 pushResult -> assertThat(pushResult.getRemoteUpdates()).isNotEmpty().allSatisfy(update -> assertThat(update.getStatus()).isEqualTo(RemoteRefUpdate.Status.OK)));
     }
 
+    /**
+     * The complementary case: for an origin repository that does not exist yet, the helper still has to create the default branch with an initial commit, so
+     * LocalCI sees an existing branch to update.
+     */
     @Test
     void shouldCreateInitialHistoryWhenOriginRepositoryDoesNotExist() throws Exception {
         Path originRepositoryFolder = repositoryBasePath.resolve("TESTPROJECT").resolve("testproject-student2.git");

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/LocalRepositoryTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/LocalRepositoryTest.java
@@ -1,0 +1,92 @@
+package de.tum.cit.aet.artemis.programming.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import org.apache.commons.io.FileUtils;
+import org.eclipse.jgit.transport.RemoteRefUpdate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import de.tum.cit.aet.artemis.localvc.service.GitService;
+
+/**
+ * Tests for {@link LocalRepository}, in particular that configuring a working copy against an origin repository that already exists continues the existing
+ * history instead of starting an unrelated one.
+ */
+class LocalRepositoryTest {
+
+    private static final String DEFAULT_BRANCH = "main";
+
+    @TempDir
+    Path repositoryBasePath;
+
+    private LocalRepository firstRepository;
+
+    private LocalRepository secondRepository;
+
+    @AfterEach
+    void closeRepositories() {
+        closeQuietly(firstRepository);
+        closeQuietly(secondRepository);
+    }
+
+    /**
+     * The LocalVC bare repository of a participation is created as soon as the participation is created (see
+     * {@code ParticipationUtilService#ensureLocalVcRepositoryExists}). Test helpers that seed content into that repository afterwards configure a second working
+     * copy for the very same bare repository. That working copy has to continue the existing history: a fresh unrelated root commit can only be pushed as a
+     * non-fast-forward, which JGit reports in the push result instead of throwing, so the working copy would silently diverge from the bare repository.
+     */
+    @Test
+    void shouldContinueHistoryWhenOriginRepositoryAlreadyExists() throws Exception {
+        Path originRepositoryFolder = repositoryBasePath.resolve("TESTPROJECT").resolve("testproject-student1.git");
+
+        firstRepository = new LocalRepository(DEFAULT_BRANCH);
+        firstRepository.configureRepos(repositoryBasePath, "localRepo", originRepositoryFolder);
+        // Mirrors LocalVCLocalCITestService#createAndConfigureLocalRepository, which pushes another commit on top of the initial one
+        GitService.commit(firstRepository.workingCopyGitRepo).setMessage("Initial commit").setAllowEmpty(true).call();
+        firstRepository.workingCopyGitRepo.push().call();
+
+        secondRepository = new LocalRepository(DEFAULT_BRANCH);
+        secondRepository.configureRepos(repositoryBasePath, "localRepo", originRepositoryFolder);
+
+        assertThat(secondRepository.getAllLocalCommits()).as("the second working copy should start from the existing history")
+                .containsExactlyElementsOf(firstRepository.getAllOriginCommits());
+
+        Path seededFile = secondRepository.workingCopyGitRepoFile.toPath().resolve("Seed.java");
+        FileUtils.writeStringToFile(seededFile.toFile(), "class Seed {}", StandardCharsets.UTF_8);
+        secondRepository.workingCopyGitRepo.add().addFilepattern(".").call();
+        GitService.commit(secondRepository.workingCopyGitRepo).setMessage("seed").call();
+
+        var pushResults = secondRepository.workingCopyGitRepo.push().setRemote("origin").call();
+
+        assertThat(pushResults).isNotEmpty().allSatisfy(
+                pushResult -> assertThat(pushResult.getRemoteUpdates()).isNotEmpty().allSatisfy(update -> assertThat(update.getStatus()).isEqualTo(RemoteRefUpdate.Status.OK)));
+    }
+
+    @Test
+    void shouldCreateInitialHistoryWhenOriginRepositoryDoesNotExist() throws Exception {
+        Path originRepositoryFolder = repositoryBasePath.resolve("TESTPROJECT").resolve("testproject-student2.git");
+
+        firstRepository = new LocalRepository(DEFAULT_BRANCH);
+        firstRepository.configureRepos(repositoryBasePath, "localRepo", originRepositoryFolder);
+
+        assertThat(firstRepository.getAllOriginCommits()).as("the bare repository should have the default branch with an initial commit").hasSize(1);
+        assertThat(firstRepository.getAllLocalCommits()).containsExactlyElementsOf(firstRepository.getAllOriginCommits());
+    }
+
+    private static void closeQuietly(LocalRepository repository) {
+        if (repository == null) {
+            return;
+        }
+        if (repository.workingCopyGitRepo != null) {
+            repository.workingCopyGitRepo.close();
+        }
+        if (repository.remoteBareGitRepo != null) {
+            repository.remoteBareGitRepo.close();
+        }
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/shared/architecture/ArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/architecture/ArchitectureTest.java
@@ -44,6 +44,7 @@ import jakarta.persistence.OrderColumn;
 
 import org.awaitility.Awaitility;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -98,6 +99,7 @@ import de.tum.cit.aet.artemis.core.config.ConditionalMetricsExclusionConfigurati
 import de.tum.cit.aet.artemis.core.config.StaticResourcesConfiguration;
 import de.tum.cit.aet.artemis.core.repository.base.RepositoryImpl;
 import de.tum.cit.aet.artemis.core.service.TitleCacheEvictionService;
+import de.tum.cit.aet.artemis.core.util.junit_extensions.JGitSystemReaderInitializer;
 import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnit;
 import de.tum.cit.aet.artemis.localvc.service.GitService;
@@ -159,6 +161,16 @@ class ArchitectureTest extends AbstractArchitectureTest {
 
         stringUtils.check(allClasses);
         randomStringUtils.check(allClasses);
+    }
+
+    @Test
+    void testNoJGitSystemReaderConfigurationOutsideInitializer() {
+        ArchRule setInstanceUsage = noClasses().that().doNotHaveFullyQualifiedName(JGitSystemReaderInitializer.class.getName()).should()
+                .callMethod(SystemReader.class, "setInstance", SystemReader.class)
+                .because("SystemReader#setInstance resets JGit's static platform detection caches (isWindows, isMacOS, isLinux) before re-deriving them, so calling it while "
+                        + "other threads run git operations makes those fail with a NullPointerException. Installing it from a @BeforeAll means one call per test class, and test "
+                        + "classes run in parallel. Use JGitSystemReaderInitializer#configureOnce instead, which GlobalCleanupListener invokes before the test plan starts.");
+        setInstanceUsage.check(allClasses);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
@@ -8,18 +8,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
 import jakarta.mail.internet.MimeMessage;
 
-import org.eclipse.jgit.storage.file.FileBasedConfig;
-import org.eclipse.jgit.util.FS;
-import org.eclipse.jgit.util.SystemReader;
-import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -209,14 +203,6 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
 
     private static volatile boolean fileUploadPathInitialized = false;
 
-    @BeforeAll
-    static void setup() {
-        // Configure JGit to skip reading system-level git config files.
-        // This prevents "File is too large" errors when system gitconfig files (e.g., /opt/homebrew/etc/gitconfig)
-        // exceed JGit's default 5MB file size limit.
-        configureJGitSystemReader();
-    }
-
     @BeforeEach
     void initFileUploadPath() {
         // Set the file upload path from configuration (only once across all tests)
@@ -224,95 +210,6 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
             FilePathConverter.setFileUploadPath(fileUploadPath);
             fileUploadPathInitialized = true;
         }
-    }
-
-    /**
-     * Configures JGit to use a custom SystemReader that skips system-level git config files.
-     * This is necessary because system gitconfig files can exceed JGit's default file size limit,
-     * causing test failures on some machines.
-     */
-    private static void configureJGitSystemReader() {
-        final var defaultReader = getSystemReader();
-
-        SystemReader.setInstance(new SystemReader() {
-
-            @Override
-            public String getHostname() {
-                return defaultReader.getHostname();
-            }
-
-            @Override
-            public String getenv(String variable) {
-                return defaultReader.getenv(variable);
-            }
-
-            @Override
-            public String getProperty(String key) {
-                return defaultReader.getProperty(key);
-            }
-
-            @Override
-            public FileBasedConfig openUserConfig(org.eclipse.jgit.lib.Config parent, FS fs) {
-                return defaultReader.openUserConfig(parent, fs);
-            }
-
-            @Override
-            public FileBasedConfig openSystemConfig(org.eclipse.jgit.lib.Config parent, FS fs) {
-                // Return an empty config instead of reading the potentially large system gitconfig
-                return new FileBasedConfig(parent, null, fs) {
-
-                    @Override
-                    public void load() {
-                        // Don't load anything - skip system config
-                    }
-
-                    @Override
-                    public boolean isOutdated() {
-                        return false;
-                    }
-                };
-            }
-
-            @Override
-            public FileBasedConfig openJGitConfig(org.eclipse.jgit.lib.Config parent, FS fs) {
-                return defaultReader.openJGitConfig(parent, fs);
-            }
-
-            @Override
-            public Instant now() {
-                return defaultReader.now();
-            }
-
-            @Override
-            public ZoneOffset getTimeZoneAt(Instant when) {
-                return defaultReader.getTimeZoneAt(when);
-            }
-
-            @SuppressWarnings("deprecation")
-            @Override
-            public long getCurrentTime() {
-                return defaultReader.getCurrentTime();
-            }
-
-            @SuppressWarnings("deprecation")
-            @Override
-            public int getTimezone(long when) {
-                return defaultReader.getTimezone(when);
-            }
-        });
-    }
-
-    private static @NonNull SystemReader getSystemReader() {
-        SystemReader defaultReader = SystemReader.getInstance();
-
-        // Force initialization of static platform detection fields before calling setInstance().
-        // This prevents a race condition where setInstance() -> init() -> setPlatformChecker()
-        // accesses static fields (isMacOS, isWindows) that haven't been initialized yet
-        // during parallel test execution, causing NullPointerException.
-        defaultReader.isMacOS();
-        defaultReader.isWindows();
-        defaultReader.isLinux();
-        return defaultReader;
     }
 
     @BeforeEach


### PR DESCRIPTION
### Summary
Two independent root causes made 18 server tests fail on `develop` (CI run [30549683108](https://github.com/ls1intum/Artemis/actions/runs/30549683108)): a JGit configuration race that broke `UserSaml2IntegrationTest`, and a LocalVC test-repository seeding bug that made 17 `ProgrammingSubmissionIntegrationTest` tests fail with `refs/heads/main -> REJECTED_NONFASTFORWARD`. Both are fixed at the root, with regression tests that fail without the fix and an ArchUnit rule that prevents the JGit problem from coming back.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
The server test suite on `develop` is intermittently red. Two failure signatures kept appearing, and both are real bugs in the test infrastructure rather than timing problems, so they cannot be fixed by raising timeouts.

**1. `UserSaml2IntegrationTest > initializationError`**

```
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()"
  because "org.eclipse.jgit.util.SystemReader.isWindows" is null
    at org.eclipse.jgit.util.SystemReader.isWindows(SystemReader.java:735)
    at org.eclipse.jgit.util.SystemReader.setPlatformChecker(SystemReader.java:311)
    at org.eclipse.jgit.util.SystemReader.init(SystemReader.java:301)
    at org.eclipse.jgit.util.SystemReader.setInstance(SystemReader.java:282)
    at AbstractArtemisIntegrationTest.configureJGitSystemReader(AbstractArtemisIntegrationTest.java:237)
    at AbstractArtemisIntegrationTest.setup(AbstractArtemisIntegrationTest.java:217)
```

`SystemReader.setInstance(...)` first resets JGit's **static** platform detection caches and only afterwards re-derives them, while `SystemReader#isWindows()` re-reads the static field after assigning it:

```java
public static void setInstance(SystemReader newReader) { isMacOS = null; isWindows = null; isLinux = null; ... newReader.init(); }
public boolean isWindows() { if (isWindows == null) { ... isWindows = Boolean.valueOf(...); } return isWindows.booleanValue(); }
```

Because `configureJGitSystemReader()` was called from `@BeforeAll` of the integration test base class, it ran **once per test class**, and test classes run in parallel (`@Execution(CONCURRENT)`). Those calls wiped the cache under each other and under git operations of tests that were already running. The pre-warming that was in place (`defaultReader.isWindows()` before `setInstance`) could not help, because `setInstance` nulls exactly those fields immediately afterwards.

**2. 17x `ProgrammingSubmissionIntegrationTest ... REJECTED_NONFASTFORWARD`**

`LocalRepository#configureRepos(repoBasePath, localRepoFileName, originRepositoryFolder)` assumed the origin bare repository did not exist yet. It does exist in most cases: `ParticipationUtilService#ensureLocalVcRepositoryExists` creates it when the participation is created. `Git.init()` then re-initialised the already populated bare repository (keeping its refs) while the freshly created working copy started an **unrelated root commit**. Pushing that can only be a non-fast-forward, and JGit reports a rejection in the `PushResult` instead of throwing, so the rejection was swallowed: the working copy silently diverged from the origin. The first push that actually asserts its result (`RepositoryExportTestUtil#pushToOrigin`, introduced in #13350) then failed.

This means #13350 did not introduce the bug, it made a long-standing silent bug visible; #13353 worked around it for one call site. `seedStudentRepositoryForParticipation` is still used from about ten other places that were silently pushing into diverged repositories.

### Description
**JGit SystemReader**
- New `JGitSystemReaderInitializer#configureOnce()` holds the reader that skips oversized system git config files. It is idempotent (`AtomicBoolean#compareAndSet`), so `setInstance` is called at most once per JVM.
- `GlobalCleanupListener#testPlanExecutionStarted` invokes it before the test plan starts executing, i.e. while the JVM is still single-threaded. This also covers `AbstractArtemisBuildAgentTest`, which never got the custom reader before.
- The `@BeforeAll` installation in `AbstractArtemisIntegrationTest` is removed (103 lines).
- New ArchUnit rule `testNoJGitSystemReaderConfigurationOutsideInitializer` forbids `SystemReader.setInstance` anywhere except the initializer, so a per-class installation cannot be reintroduced unnoticed.

**LocalVC repository seeding**
- `LocalRepository#configureRepos` now detects an origin repository that already has commits and adopts its history (`fetch` + `reset --hard origin/<defaultBranch>`) instead of starting an unrelated one. Behaviour for a not-yet-existing origin is unchanged.

**Regression tests**
- `LocalRepositoryTest` covers both branches. `shouldContinueHistoryWhenOriginRepositoryAlreadyExists` fails with exactly the `REJECTED_NONFASTFORWARD` divergence without the fix.
- `JGitSystemReaderInitializerTest` asserts that repeated and concurrent configuration never replaces the installed reader, and that JGit platform detection stays usable while it happens. Without the up-front installation this reproduces the production `NullPointerException` locally.

### Steps for Testing
This PR only touches test code, so it is verified by running the suite. No production code and no user-visible behaviour changes.

```bash
# The two classes that were failing
./gradlew test --tests ProgrammingSubmissionIntegrationTest --tests UserSaml2IntegrationTest -x webapp

# The new regression tests (both fail if the corresponding fix is reverted)
./gradlew test --tests LocalRepositoryTest --tests JGitSystemReaderInitializerTest -x webapp

# Everything that touches LocalRepository / JGit, under real parallel load
./gradlew test -DincludeModules="programming,localvc,localci,exercise" -x webapp

# Code style gates
./gradlew spotlessCheck && ./gradlew checkstyleMain -x webapp && ./gradlew test -DincludeTags='ArchitectureTest' -x webapp
```

Local results:

| Check | Result |
|---|---|
| `ProgrammingSubmissionIntegrationTest` + `UserSaml2IntegrationTest` | 47 tests, 0 failures |
| New regression tests | red before the fix, green after |
| All 41 test classes touching `LocalRepository` / JGit | 1404 tests, 0 failures |
| `programming,localvc,localci,exercise,shared` modules | 4590 tests, 0 related failures |
| Full ArchUnit suite | 1179 tests, 0 failures |
| `spotlessCheck`, `checkstyleMain` | clean |

### Testserver States
Not required: this PR changes only test sources, so there is nothing to deploy or verify on a test server. The CI server test job is the relevant gate.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-07-31 10:29:31 UTC_


### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Server test suite is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test repository setup when working with repositories that already contain commit history.
  * Prevented oversized system Git configuration files from interfering with automated Git operations.

* **Tests**
  * Added coverage for repository initialization, history preservation, concurrent setup, and platform detection.
  * Added safeguards to ensure Git configuration is initialized consistently and only once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->