### PR TITLE
`Development`: Fix flaky server tests caused by async and order-column races

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisEventService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisEventService.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.iris.service.pyris;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
@@ -37,14 +39,20 @@ public class PyrisEventService {
     /**
      * Validates and republishes the given {@link PyrisEvent} as a Spring application event so that
      * registered {@code @EventListener}s can react to it.
+     * <p>
+     * Runs asynchronously. Production callers use this fire-and-forget and ignore the returned future; it exists so
+     * that callers which must observe the effect of the dispatch (notably tests) can wait for the publication to have
+     * finished instead of polling for its side effects with an arbitrary deadline. Failures are logged here, so an
+     * ignored future never hides an error.
      *
      * @param event The event object received to trigger the matching action
+     * @return a future that completes once the event has been published (exceptionally if the event is not supported)
      * @throws UnsupportedPyrisEventException if the event is not supported
      *
      * @see PyrisEvent
      */
     @Async
-    public void trigger(PyrisEvent<?> event) {
+    public CompletableFuture<Void> trigger(PyrisEvent<?> event) {
         log.debug("Starting to process event of type: {}", event.getClass().getSimpleName());
         try {
             switch (event) {
@@ -60,5 +68,6 @@ public class PyrisEventService {
             log.error("Failed to process event: {}", event, e);
             throw e;
         }
+        return CompletableFuture.completedFuture(null);
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -709,6 +709,15 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         PostResponseDTO createdPost1 = request.postWithResponseBody("/api/communication/courses/" + courseId + "/messages", postDTOToSave1, PostResponseDTO.class,
                 HttpStatus.CREATED);
 
+        // Wait for the post-creation @Async increment to settle: the count must reach 1 before student2 reads the
+        // conversation. Both the increment (ConversationMessagingService#notifyAboutMessageCreation) and the read reset
+        // (ConversationParticipantRepository#updateLastReadAsync) run asynchronously, so without this gate the increment
+        // can land after the reset and leave the count permanently at 1.
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            SecurityUtils.setAuthorizationObject();
+            assertThat(getUnreadMessagesCount(createdPost1.conversation().id(), student2)).isEqualTo(1);
+        });
+
         userUtilService.changeUser(TEST_PREFIX + "student2");
         // we read the messages by "getting" them from the server as student
         var params = new LinkedMultiValueMap<String, String>();

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
@@ -1610,16 +1610,25 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
     void getParticipationWithLatestResult() throws Exception {
         var participation = participationUtilService.createAndSaveParticipationForExercise(textExercise, TEST_PREFIX + "student1");
         var submission = participationUtilService.addSubmission(participation, ParticipationFactory.generateTextSubmission("text", Language.ENGLISH, true));
-        participationUtilService.addResultToSubmission(null, null, participation.findLatestSubmission().orElseThrow());
-        var result = ParticipationFactory.generateResult(true, 70D);
-        result.submission(submission).setCompletionDate(ZonedDateTime.now().minusHours(2));
-        result.setExerciseId(textExercise.getId());
-        resultRepository.save(result);
+        var firstResult = participationUtilService.addResultToSubmission(null, ZonedDateTime.now().minusHours(2), participation.findLatestSubmission().orElseThrow());
+        var latestResult = ParticipationFactory.generateResult(true, 70D);
+        latestResult.submission(submission).setCompletionDate(ZonedDateTime.now().minusHours(1));
+        latestResult.setExerciseId(textExercise.getId());
+        latestResult = resultRepository.save(latestResult);
+        // Attach the second result to the submission and save the submission as well: Submission#results is a list with
+        // an @OrderColumn, and that column is only written when the collection itself is flushed. Persisting a result
+        // through the result repository alone leaves results_order at its database default (0), which collides with the
+        // first result, and Hibernate then reconstructs the list by overwriting index 0 with whichever row the database
+        // happens to return last. That made this test fail non-deterministically.
+        submission.addResult(latestResult);
+        submissionRepository.save(submission);
+
         var actualParticipation = request.get("/api/exercise/participations/" + participation.getId() + "/with-latest-result", HttpStatus.OK, StudentParticipation.class);
 
         assertThat(actualParticipation).isNotNull();
         assertThat(actualParticipation.getSubmissions()).as("Only latest submission is returned").containsExactly(submission);
-        assertThat(participationUtilService.getResultsForParticipation(actualParticipation)).as("Only latest result is returned").containsExactly(result);
+        assertThat(participationUtilService.getResultsForParticipation(actualParticipation)).as("All results of the latest submission are returned")
+                .containsExactlyInAnyOrder(firstResult, latestResult);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -229,10 +228,12 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         });
 
         var event = new NewResultEvent(result);
-        pyrisEventService.trigger(event);
+        // Joining the returned future waits for the asynchronous dispatch itself instead of polling for its side
+        // effect with a fixed deadline, which timed out whenever the shared task executor was saturated on a loaded
+        // CI runner. The event listener runs inside that async task, so the verification below cannot race it.
+        pyrisEventService.trigger(event).join();
 
-        // Wrap the following code into await() to ensure that the pipeline is executed before the test finishes.
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> verify(irisChatSessionService, times(1)).handleNewResultEvent(eq(event)));
+        verify(irisChatSessionService, times(1)).handleNewResultEvent(eq(event));
 
         await().atMost(5, TimeUnit.SECONDS).until(() -> pipelineDone.get());
 
@@ -252,14 +253,13 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         });
 
         var event = new NewResultEvent(result);
-        pyrisEventService.trigger(event);
+        pyrisEventService.trigger(event).join();
 
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> verify(irisChatSessionService, times(1)).handleNewResultEvent(eq(event)));
+        verify(irisChatSessionService, times(1)).handleNewResultEvent(eq(event));
 
         await().atMost(2, TimeUnit.SECONDS).until(() -> pipelineDone.get());
 
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted(
-                () -> verify(pyrisPipelineService, times(1)).executeChatPipeline(eq("default"), eq("moderate"), eq(irisSession), eq(Optional.of("build_failed")), any()));
+        verify(pyrisPipelineService, times(1)).executeChatPipeline(eq("default"), eq("moderate"), eq(irisSession), eq(Optional.of("build_failed")), any());
     }
 
     @Test
@@ -275,14 +275,13 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         });
 
         var event = new NewResultEvent(result);
-        pyrisEventService.trigger(event);
+        pyrisEventService.trigger(event).join();
 
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> verify(irisChatSessionService, times(1)).handleNewResultEvent(eq(event)));
+        verify(irisChatSessionService, times(1)).handleNewResultEvent(eq(event));
 
         await().atMost(2, TimeUnit.SECONDS).until(() -> pipelineDone.get());
 
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted(
-                () -> verify(pyrisPipelineService, times(1)).executeChatPipeline(eq("default"), eq("moderate"), eq(irisSession), eq(Optional.of("build_failed")), any()));
+        verify(pyrisPipelineService, times(1)).executeChatPipeline(eq("default"), eq("moderate"), eq(irisSession), eq(Optional.of("build_failed")), any());
     }
 
     @Test
@@ -298,17 +297,16 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         });
 
         var event = new NewResultEvent(result);
-        pyrisEventService.trigger(event);
+        pyrisEventService.trigger(event).join();
 
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> verify(irisChatSessionService, times(1)).handleNewResultEvent(eq(event)));
+        verify(irisChatSessionService, times(1)).handleNewResultEvent(eq(event));
         // No pre-existing session here (unlike the sibling tests above), so the handler first creates the fallback
         // course session and applies the exercise context before the pipeline runs; allow the same 5s budget used
         // for the slower progress-stalled case above instead of the 2s used where a session is already prepared.
         await().atMost(5, TimeUnit.SECONDS).until(() -> pipelineDone.get());
 
         ArgumentCaptor<IrisChatSession> sessionCaptor = ArgumentCaptor.forClass(IrisChatSession.class);
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted(
-                () -> verify(pyrisPipelineService, times(1)).executeChatPipeline(eq("default"), eq("moderate"), sessionCaptor.capture(), eq(Optional.of("build_failed")), any()));
+        verify(pyrisPipelineService, times(1)).executeChatPipeline(eq("default"), eq("moderate"), sessionCaptor.capture(), eq(Optional.of("build_failed")), any());
 
         IrisChatSession usedSession = sessionCaptor.getValue();
         assertThat(usedSession.getMode()).isEqualTo(IrisChatMode.PROGRAMMING_EXERCISE_CHAT);
@@ -347,19 +345,14 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         createSubmissionWithScore(studentParticipation, 100);
         Result result = createSubmissionWithScore(studentParticipation, 50);
 
-        pyrisEventService.trigger(new NewResultEvent(result));
-
-        await().atMost(2, TimeUnit.SECONDS);
+        pyrisEventService.trigger(new NewResultEvent(result)).join();
 
         result = createSubmissionWithScore(studentParticipation, 50);
 
-        pyrisEventService.trigger(new NewResultEvent(result));
-        await().atMost(2, TimeUnit.SECONDS);
+        pyrisEventService.trigger(new NewResultEvent(result)).join();
 
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
-            verify(irisChatSessionService, times(2)).handleNewResultEvent(any(NewResultEvent.class));
-            verify(pyrisPipelineService, never()).executeChatPipeline(any(), any(), any(), any(), any());
-        });
+        verify(irisChatSessionService, times(2)).handleNewResultEvent(any(NewResultEvent.class));
+        verify(pyrisPipelineService, after(2000).never()).executeChatPipeline(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -370,9 +363,9 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         createSubmissionWithScore(studentParticipation, 20);
         var result = createSubmissionWithScore(studentParticipation, 20);
 
-        pyrisEventService.trigger(new NewResultEvent(result));
+        pyrisEventService.trigger(new NewResultEvent(result)).join();
 
-        verify(irisChatSessionService, timeout(2000).times(1)).handleNewResultEvent(any(NewResultEvent.class));
+        verify(irisChatSessionService, times(1)).handleNewResultEvent(any(NewResultEvent.class));
         verify(pyrisPipelineService, after(2000).never()).executeChatPipeline(any(), any(), any(), any(), any());
     }
 
@@ -386,9 +379,9 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         Result result = createSubmissionWithScore(studentParticipation, 40);
 
         var event = new NewResultEvent(result);
-        pyrisEventService.trigger(event);
+        pyrisEventService.trigger(event).join();
 
-        verify(irisChatSessionService, timeout(2000).times(1)).handleNewResultEvent(event);
+        verify(irisChatSessionService, times(1)).handleNewResultEvent(event);
         verify(pyrisPipelineService, after(2000).never()).executeChatPipeline(any(), any(), any(), any(), any());
     }
 
@@ -401,9 +394,9 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         Result result = createFailingSubmission(teamParticipation);
         var event = new NewResultEvent(result);
 
-        pyrisEventService.trigger(event);
+        pyrisEventService.trigger(event).join();
 
-        verify(irisChatSessionService, timeout(2000).times(1)).handleNewResultEvent(event);
+        verify(irisChatSessionService, times(1)).handleNewResultEvent(event);
         verify(pyrisPipelineService, after(2000).never()).executeChatPipeline(any(), any(), any(), any(), any());
     }
 
@@ -439,14 +432,13 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         });
 
         var event = new NewResultEvent(result);
-        pyrisEventService.trigger(event);
+        pyrisEventService.trigger(event).join();
 
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> verify(irisChatSessionService, times(1)).handleNewResultEvent(eq(event)));
+        verify(irisChatSessionService, times(1)).handleNewResultEvent(eq(event));
 
         await().atMost(2, TimeUnit.SECONDS).until(() -> pipelineDone.get());
 
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted(
-                () -> verify(pyrisPipelineService, times(1)).executeChatPipeline(eq("default"), eq("moderate"), eq(irisSession), eq(Optional.of("build_failed")), any()));
+        verify(pyrisPipelineService, times(1)).executeChatPipeline(eq("default"), eq("moderate"), eq(irisSession), eq(Optional.of("build_failed")), any());
     }
 
 }


### PR DESCRIPTION
### Summary

Three server tests failed or flaked on `develop` because they asserted on asynchronous side effects with a fixed deadline, or because a test fixture relied on undefined `@OrderColumn` behaviour. This PR removes the races at their source instead of raising any timeout. Two of them are the reason `Test / Server Tests (PostgreSQL)` was red on develop's own runs.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

`Test / Server Tests (PostgreSQL)` failed on four of the last six `develop` pushes, which keeps the required `All required CI Passed` gate red for every open PR. The failures looked like unrelated one-off flakes, but each has a concrete, explainable cause.

Run [30632968298](https://github.com/ls1intum/Artemis/actions/runs/30632968298) (commit 42507d3f9a) failed on:

- `MessageIntegrationTest.testDecreaseUnreadMessageCountAfterMessageRead` — `expected: 0L but was: 1L` (also failed in the preceding run 30632920251)
- `ParticipationIntegrationTest.getParticipationWithLatestResult` — the endpoint returned the wrong one of two results

Run [30576488918](https://github.com/ls1intum/Artemis/actions/runs/30576488918) failed on:

- `PyrisEventSystemIntegrationTest.testCustomInstructionsPassedToExerciseChatPipeline` — `ConditionTimeoutException` after 2 seconds

### Description

**1. Unread message count (`MessageIntegrationTest`)**

Creating a message returns as soon as the post is saved. The unread counter for the other participants is incremented at the very end of `ConversationMessagingService#notifyAboutMessageCreation`, which is `@Async`. Reading the conversation resets that counter through `ConversationParticipantRepository#updateLastReadAsync`, which is also `@Async`. The test posted a message and immediately read it as the second student, so when the increment landed after the reset, the counter stayed at 1 forever and the assertion could never become true.

The test now waits until the counter has actually reached 1 before the second student reads. That is the precondition the test already assumes ("decrease after read" presupposes an increase), so this is a barrier rather than a longer deadline. The sibling test `testMarkMessageAsUnread` already contains the same gate with the same reasoning.

**2. Two results on one submission (`ParticipationIntegrationTest`)**

`Submission.results` is a `List<Result>` with `@OrderColumn(name = "results_order")` on the `mappedBy` side, and Hibernate writes that column only when the collection itself is flushed. The fixture persisted its second result through `ResultRepository` alone, so the result kept the schema default `results_order = 0` and collided with the first result. On read, Hibernate rebuilds the list by index, so whichever row PostgreSQL happened to return last silently overwrote the other — and PostgreSQL does not guarantee an order for equal sort keys.

The fixture now attaches the second result through `submission.addResult(...)` plus `submissionRepository.save(submission)`, which is what every production write path does (`AssessmentService`, `SubmissionService`, `ProgrammingExerciseGradingService`, `TextAssessmentService`, the quiz services), so the two indices are distinct and the read is deterministic.

Making it deterministic also revealed that the old assertion was passing by accident: with distinct order values, `GET /api/exercise/participations/{id}/with-latest-result` returns **both** results, because `findWithEagerResultsById` eagerly fetches all submissions and all results. It no longer restricts the response to the latest result despite the endpoint name — the participation-to-results relation was removed in #10549 / #10983. The assertion was therefore corrected to describe what the endpoint really returns. Whether the endpoint should filter to the latest result again is a product decision and deliberately left out of this PR.

**3. Awaiting the Pyris event dispatch (`PyrisEventService`, `PyrisEventSystemIntegrationTest`)**

`PyrisEventService#trigger` is `@Async` and returned `void`, so a test had no way to wait for the dispatch itself and could only poll for its side effects on a 2 second budget. On a loaded CI runner the shared task executor is saturated and 2 seconds is not enough, so the test failed even though nothing was wrong.

`trigger` now returns `CompletableFuture<Void>`. Production keeps using it fire-and-forget: the single caller, `PyrisEventApi#trigger`, stays `void` and ignores the future, and failures are still logged inside the method, so an ignored future cannot hide an error. The dispatch still runs on the task executor, so the security-context and threading behaviour is unchanged. The tests now `join()` that future and assert directly, which removes the deadline entirely instead of extending it.

The remaining `await(... pipelineDone)` waits in that test class were left at their original budgets on purpose. They cover a second asynchronous hop, the `CompletableFuture.runAsync(...)` inside `IrisChatSessionService#onBuildFailure`, which a test cannot join without adding a new seam to production code.

### Steps for Testing

This PR only touches tests plus one method signature, so it is verified by running the affected tests rather than by clicking through the UI.

```bash
./gradlew test -x webapp \
  --tests "de.tum.cit.aet.artemis.communication.MessageIntegrationTest" \
  --tests "de.tum.cit.aet.artemis.exercise.participation.ParticipationIntegrationTest" \
  --tests "de.tum.cit.aet.artemis.iris.PyrisEventSystemIntegrationTest"
```

Result locally (PostgreSQL via Testcontainers): 88 tests, 88 passed, 0 failed. `./gradlew spotlessCheck checkstyleMain -x webapp` is clean.

To see that the second fix is real rather than cosmetic, revert only the `submission.addResult(...)` / `submissionRepository.save(...)` lines in `getParticipationWithLatestResult` and inspect the response: the participation comes back with a single result, and which of the two it is depends on the query plan.

### Testserver States

Not deployed to a test server: the change is limited to test code plus a return type that production ignores.

### Review Progress

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| PyrisEventService.java | 76.47% | 42 |

_Last updated: 2026-07-31 23:57:42 UTC_

