### PR TITLE
`Development`: Fix the failing exam assessment availability tests on develop

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/exercise/ExamAssessmentAvailabilityIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/ExamAssessmentAvailabilityIntegrationTest.java
@@ -78,7 +78,9 @@ class ExamAssessmentAvailabilityIntegrationTest extends AbstractSpringIntegratio
     @BeforeEach
     void initTestCase() {
         userUtilService.addUsers(TEST_PREFIX, 1, 1, 0, 1);
-        Course course = courseUtilService.addEmptyCourse();
+        // addUsers clears every user_course_role, so the course has to be one that enrolls this test's users again:
+        // course access is a role now, and an empty course would leave the tutor without one (plain 403, no gate).
+        Course course = courseUtilService.createEnrolledCourse(TEST_PREFIX);
         exam = examUtilService.addExamWithModellingAndTextAndFileUploadAndQuizAndProgramming(course);
         // the exam is still running: it started an hour ago and the last student can hand in in another hour
         setExamWorkingPeriod(ZonedDateTime.now().minusHours(1), ZonedDateTime.now().plusHours(1));
@@ -251,7 +253,7 @@ class ExamAssessmentAvailabilityIntegrationTest extends AbstractSpringIntegratio
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void testTheAssessmentDashboardSendsNoSuchDatesForCourseExercises() throws Exception {
-        Course course = textExerciseUtilService.addCourseWithOneReleasedTextExercise();
+        Course course = textExerciseUtilService.addEnrolledCourseWithOneReleasedTextExercise("Text", TEST_PREFIX);
         TextExercise textExercise = ExerciseUtilService.findTextExerciseWithTitle(course.getExercises(), "Text");
         textExercise.setAssessmentType(AssessmentType.SEMI_AUTOMATIC);
         exerciseRepository.save(textExercise);


### PR DESCRIPTION
### Summary

All nine tests of `ExamAssessmentAvailabilityIntegrationTest` currently fail on develop, so every branch that merges develop inherits the failure. It is already blocking unrelated PRs (#13181 and #13267 both show exactly these nine failures and nothing else).

Each failure is a plain `You are not allowed to access the Course` 403, raised **before** the gate the test is about.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context

The class came in with #13365 and was written against the group-name membership model. #12788 landed just before it and replaced course group strings with `UserCourseRole`:

- `UserUtilService.addUsers` now deletes every `user_course_role` row, so no stale role survives into the next test.
- The enrolling course helpers (`createEnrolledCourse`, `addEnrolledCourseWith…`) are what put the roles back.

`courseUtilService.addEmptyCourse()` enrolls nobody, so the tutor held no role in the exam course and never reached the availability gate. Under the old model the shared `tutor`/`instructor` group names made this work implicitly, which is why both PRs were green on their own heads: #13365's head did not contain #12788, and the merge commit that did (`9637d68c35`) was the first run to fail.

This is a test-only defect. The gate itself is fine and is still asserted exactly as before.

### Description

- `initTestCase` builds the exam course with `createEnrolledCourse(TEST_PREFIX)` instead of `addEmptyCourse()`.
- `testTheAssessmentDashboardSendsNoSuchDatesForCourseExercises` builds its second, course-exercise course with `addEnrolledCourseWithOneReleasedTextExercise("Text", TEST_PREFIX)`.

No production code changes, no assertion changes, and no `@Execution(SAME_THREAD)`: the tests keep running concurrently, so there is no wall-clock cost.

### Steps for Testing

This is a test-only change; CI is the test. Locally:

```
./gradlew test --tests ExamAssessmentAvailabilityIntegrationTest -x webapp
```

Fails 9/9 on develop, passes 9/9 with this change — verified over four consecutive runs.

### Testserver States

Not applicable, test-only change.

### Review Progress

#### Code Review
- [x] Code Review 1

#### Manual Tests
- [x] Test 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated assessment availability test setup to use enrolled courses and released exercises.
  * Improved coverage of dashboard behavior for configured users with course roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->