### PR TITLE
`Grading`: Reject scientific notation in points and bonus points fields

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/util/StrictDecimalDeserializer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/StrictDecimalDeserializer.java
@@ -1,0 +1,37 @@
+package de.tum.cit.aet.artemis.core.util;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+/**
+ * Jackson deserializer for {@link Double} fields that must be plain decimal numbers.
+ * <p>
+ * Rejects scientific notation (e.g. {@code 1e-3}) at the JSON-token level, before it is converted to a
+ * {@code Double}. Once parsed, a value like {@code 1e-3} is bit-identical to {@code 0.001} and can no longer be
+ * distinguished from an ordinary decimal - any validation performed after parsing is fundamentally unable to
+ * reject the input format itself (see <a href="https://github.com/ls1intum/Artemis/issues/12451">issue #12451</a>).
+ */
+public class StrictDecimalDeserializer extends JsonDeserializer<Double> {
+
+    private static final Pattern PLAIN_DECIMAL_PATTERN = Pattern.compile("^-?\\d+(\\.\\d+)?$");
+
+    @Override
+    public Double deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        if (parser.currentToken() == JsonToken.VALUE_NULL) {
+            return null;
+        }
+
+        String rawValue = parser.getText();
+        if (!PLAIN_DECIMAL_PATTERN.matcher(rawValue).matches()) {
+            throw InvalidFormatException.from(parser, "Value must be a plain decimal number without scientific notation", rawValue, Double.class);
+        }
+
+        return Double.parseDouble(rawValue);
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/BaseExercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/BaseExercise.java
@@ -10,9 +10,11 @@ import jakarta.persistence.MappedSuperclass;
 import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.core.domain.DomainObject;
+import de.tum.cit.aet.artemis.core.util.StrictDecimalDeserializer;
 import de.tum.cit.aet.artemis.core.util.StringUtil;
 
 @MappedSuperclass
@@ -25,9 +27,11 @@ public abstract class BaseExercise extends DomainObject {
     private String shortName;
 
     @Column(name = "max_points", nullable = false)
+    @JsonDeserialize(using = StrictDecimalDeserializer.class)
     private Double maxPoints = 1.0;
 
     @Column(name = "bonus_points", nullable = false)
+    @JsonDeserialize(using = StrictDecimalDeserializer.class)
     private Double bonusPoints = 0.0;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
@@ -908,6 +908,9 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
             throw new BadRequestAlertException("The max points needs to be greater than 0", "Exercise", "maxScoreInvalid");
         }
 
+        if (!Double.isFinite(getMaxPoints())) {
+            throw new BadRequestAlertException("The max points must be a finite number", "Exercise", "maxScoreInvalid");
+        }
         if (!hasValidPointsPrecision(getMaxPoints())) {
             throw new BadRequestAlertException("The max points must not have more than " + MAX_POINTS_DECIMAL_PLACES + " decimal places", "Exercise", "maxScoreInvalid");
         }
@@ -917,6 +920,9 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
             setBonusPoints(0.0);
         }
 
+        if (!Double.isFinite(getBonusPoints())) {
+            throw new BadRequestAlertException("The bonus points must be a finite number", "Exercise", "bonusPointsInvalid");
+        }
         if (!hasValidPointsPrecision(getBonusPoints())) {
             throw new BadRequestAlertException("The bonus points must not have more than " + MAX_POINTS_DECIMAL_PLACES + " decimal places", "Exercise", "bonusPointsInvalid");
         }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.exercise.domain;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.TITLE_NAME_PATTERN;
 
+import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.HashSet;
@@ -878,9 +879,15 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
     }
 
     /**
+     * The maximum number of decimal places allowed for maxPoints/bonusPoints, see {@link #hasValidPointsPrecision}.
+     */
+    private static final int MAX_POINTS_DECIMAL_PLACES = 4;
+
+    /**
      * Validates score settings
      * 1. The maxScore needs to be greater than 0, except for not included programming exercises
      * 2. If the specified amount of bonus points is valid depending on the IncludedInOverallScore value
+     * 3. maxPoints and bonusPoints must be plain decimals with a reasonable number of decimal places
      */
     public void validateScoreSettings() {
         // Check IncludedInOverallScore
@@ -901,14 +908,32 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
             throw new BadRequestAlertException("The max points needs to be greater than 0", "Exercise", "maxScoreInvalid");
         }
 
+        if (!hasValidPointsPrecision(getMaxPoints())) {
+            throw new BadRequestAlertException("The max points must not have more than " + MAX_POINTS_DECIMAL_PLACES + " decimal places", "Exercise", "maxScoreInvalid");
+        }
+
         if (getBonusPoints() == null || getBonusPoints() < 0) {
             // Correct invalid bonusPoints to default value (prevents invalid state)
             setBonusPoints(0.0);
         }
 
+        if (!hasValidPointsPrecision(getBonusPoints())) {
+            throw new BadRequestAlertException("The bonus points must not have more than " + MAX_POINTS_DECIMAL_PLACES + " decimal places", "Exercise", "bonusPointsInvalid");
+        }
+
         if (!getIncludedInOverallScore().validateBonusPoints(getBonusPoints())) {
             throw new BadRequestAlertException("The provided bonus points are not allowed", "Exercise", "bonusPointsInvalid");
         }
+    }
+
+    /**
+     * Checks that a points value (maxPoints or bonusPoints) is a plain decimal with a reasonable number of decimal
+     * places. Rejects values such as {@code 1e-30}, which otherwise pass the plain range checks above because
+     * scientific notation still parses to a valid, in-range {@code Double} (see
+     * <a href="https://github.com/ls1intum/Artemis/issues/12451">issue #12451</a>).
+     */
+    private static boolean hasValidPointsPrecision(double points) {
+        return BigDecimal.valueOf(points).stripTrailingZeros().scale() <= MAX_POINTS_DECIMAL_PLACES;
     }
 
     public void validateGeneralSettings() {

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/dto/UpdateFileUploadExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/dto/UpdateFileUploadExerciseDTO.java
@@ -7,11 +7,13 @@ import java.util.stream.Collectors;
 import org.hibernate.Hibernate;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
 import de.tum.cit.aet.artemis.assessment.dto.GradingCriterionDTO;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
+import de.tum.cit.aet.artemis.core.util.StrictDecimalDeserializer;
 import de.tum.cit.aet.artemis.exercise.domain.DifficultyLevel;
 import de.tum.cit.aet.artemis.exercise.domain.IncludedInOverallScore;
 import de.tum.cit.aet.artemis.exercise.dto.CompetencyLinksHolderDTO;
@@ -75,10 +77,11 @@ import de.tum.cit.aet.artemis.lecture.dto.CompetencyLinkDTO;
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record UpdateFileUploadExerciseDTO(long id, String title, String channelName, String shortName, String problemStatement, Set<String> categories, DifficultyLevel difficulty,
-        Double maxPoints, Double bonusPoints, IncludedInOverallScore includedInOverallScore, Boolean allowComplaintsForAutomaticAssessments, Boolean allowFeedbackRequests,
-        Boolean presentationScoreEnabled, Boolean secondCorrectionEnabled, String feedbackSuggestionModule, String gradingInstructions, ZonedDateTime releaseDate,
-        ZonedDateTime startDate, ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, ZonedDateTime exampleSolutionPublicationDate, String exampleSolution, String filePattern,
-        Long courseId, Long exerciseGroupId, Set<GradingCriterionDTO> gradingCriteria, Set<CompetencyLinkDTO> competencyLinks) implements CompetencyLinksHolderDTO {
+        @JsonDeserialize(using = StrictDecimalDeserializer.class) Double maxPoints, @JsonDeserialize(using = StrictDecimalDeserializer.class) Double bonusPoints,
+        IncludedInOverallScore includedInOverallScore, Boolean allowComplaintsForAutomaticAssessments, Boolean allowFeedbackRequests, Boolean presentationScoreEnabled,
+        Boolean secondCorrectionEnabled, String feedbackSuggestionModule, String gradingInstructions, ZonedDateTime releaseDate, ZonedDateTime startDate, ZonedDateTime dueDate,
+        ZonedDateTime assessmentDueDate, ZonedDateTime exampleSolutionPublicationDate, String exampleSolution, String filePattern, Long courseId, Long exerciseGroupId,
+        Set<GradingCriterionDTO> gradingCriteria, Set<CompetencyLinkDTO> competencyLinks) implements CompetencyLinksHolderDTO {
 
     /**
      * Creates a DTO from a {@link FileUploadExercise} entity.

--- a/src/main/java/de/tum/cit/aet/artemis/modeling/dto/UpdateModelingExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/dto/UpdateModelingExerciseDTO.java
@@ -7,11 +7,13 @@ import java.util.stream.Collectors;
 import org.hibernate.Hibernate;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
 import de.tum.cit.aet.artemis.assessment.dto.GradingCriterionDTO;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
+import de.tum.cit.aet.artemis.core.util.StrictDecimalDeserializer;
 import de.tum.cit.aet.artemis.exercise.domain.DifficultyLevel;
 import de.tum.cit.aet.artemis.exercise.domain.IncludedInOverallScore;
 import de.tum.cit.aet.artemis.exercise.dto.CompetencyLinksHolderDTO;
@@ -20,11 +22,11 @@ import de.tum.cit.aet.artemis.modeling.domain.ModelingExercise;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record UpdateModelingExerciseDTO(long id, String title, String channelName, String shortName, String problemStatement, Set<String> categories, DifficultyLevel difficulty,
-        Double maxPoints, Double bonusPoints, IncludedInOverallScore includedInOverallScore, Boolean allowComplaintsForAutomaticAssessments, Boolean allowFeedbackRequests,
-        Boolean presentationScoreEnabled, Boolean secondCorrectionEnabled, String feedbackSuggestionModule, String gradingInstructions, ZonedDateTime releaseDate,
-        ZonedDateTime startDate, ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, ZonedDateTime exampleSolutionPublicationDate, String exampleSolutionModel,
-        String exampleSolutionExplanation, Long courseId, Long exerciseGroupId, Set<GradingCriterionDTO> gradingCriteria, Set<CompetencyLinkDTO> competencyLinks)
-        implements CompetencyLinksHolderDTO {
+        @JsonDeserialize(using = StrictDecimalDeserializer.class) Double maxPoints, @JsonDeserialize(using = StrictDecimalDeserializer.class) Double bonusPoints,
+        IncludedInOverallScore includedInOverallScore, Boolean allowComplaintsForAutomaticAssessments, Boolean allowFeedbackRequests, Boolean presentationScoreEnabled,
+        Boolean secondCorrectionEnabled, String feedbackSuggestionModule, String gradingInstructions, ZonedDateTime releaseDate, ZonedDateTime startDate, ZonedDateTime dueDate,
+        ZonedDateTime assessmentDueDate, ZonedDateTime exampleSolutionPublicationDate, String exampleSolutionModel, String exampleSolutionExplanation, Long courseId,
+        Long exerciseGroupId, Set<GradingCriterionDTO> gradingCriteria, Set<CompetencyLinkDTO> competencyLinks) implements CompetencyLinksHolderDTO {
 
     /**
      * Creates a DTO from a ModelingExercise entity.

--- a/src/main/java/de/tum/cit/aet/artemis/programming/dto/UpdateProgrammingExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/dto/UpdateProgrammingExerciseDTO.java
@@ -10,12 +10,14 @@ import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
 import de.tum.cit.aet.artemis.assessment.dto.GradingCriterionDTO;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
+import de.tum.cit.aet.artemis.core.util.StrictDecimalDeserializer;
 import de.tum.cit.aet.artemis.exercise.domain.DifficultyLevel;
 import de.tum.cit.aet.artemis.exercise.domain.IncludedInOverallScore;
 import de.tum.cit.aet.artemis.exercise.dto.CompetencyLinksHolderDTO;
@@ -36,7 +38,8 @@ public record UpdateProgrammingExerciseDTO(
         @Nullable Long id,
 
         // Exercise base fields
-        String title, String channelName, String shortName, String problemStatement, Set<String> categories, DifficultyLevel difficulty, Double maxPoints, Double bonusPoints,
+        String title, String channelName, String shortName, String problemStatement, Set<String> categories, DifficultyLevel difficulty,
+        @JsonDeserialize(using = StrictDecimalDeserializer.class) Double maxPoints, @JsonDeserialize(using = StrictDecimalDeserializer.class) Double bonusPoints,
         IncludedInOverallScore includedInOverallScore, Boolean allowComplaintsForAutomaticAssessments, Boolean allowFeedbackRequests, Boolean presentationScoreEnabled,
         Boolean secondCorrectionEnabled, String feedbackSuggestionModule, String gradingInstructions,
 

--- a/src/main/java/de/tum/cit/aet/artemis/text/dto/UpdateTextExerciseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/dto/UpdateTextExerciseDTO.java
@@ -7,11 +7,13 @@ import java.util.stream.Collectors;
 import org.hibernate.Hibernate;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import de.tum.cit.aet.artemis.assessment.domain.GradingCriterion;
 import de.tum.cit.aet.artemis.assessment.dto.GradingCriterionDTO;
 import de.tum.cit.aet.artemis.atlas.domain.competency.CompetencyExerciseLink;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
+import de.tum.cit.aet.artemis.core.util.StrictDecimalDeserializer;
 import de.tum.cit.aet.artemis.exercise.domain.DifficultyLevel;
 import de.tum.cit.aet.artemis.exercise.domain.ExerciseMode;
 import de.tum.cit.aet.artemis.exercise.domain.IncludedInOverallScore;
@@ -26,11 +28,11 @@ import de.tum.cit.aet.artemis.text.domain.TextExercise;
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record UpdateTextExerciseDTO(Long id, String title, String channelName, String shortName, String problemStatement, Set<String> categories, DifficultyLevel difficulty,
-        Double maxPoints, Double bonusPoints, IncludedInOverallScore includedInOverallScore, Boolean allowComplaintsForAutomaticAssessments, Boolean allowFeedbackRequests,
-        Boolean presentationScoreEnabled, Boolean secondCorrectionEnabled, String feedbackSuggestionModule, String gradingInstructions, ZonedDateTime releaseDate,
-        ZonedDateTime startDate, ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, ZonedDateTime exampleSolutionPublicationDate, String exampleSolution, Long courseId,
-        Long exerciseGroupId, ExerciseMode mode, TeamAssignmentConfigDTO teamAssignmentConfig, Set<GradingCriterionDTO> gradingCriteria, Set<CompetencyLinkDTO> competencyLinks)
-        implements CompetencyLinksHolderDTO {
+        @JsonDeserialize(using = StrictDecimalDeserializer.class) Double maxPoints, @JsonDeserialize(using = StrictDecimalDeserializer.class) Double bonusPoints,
+        IncludedInOverallScore includedInOverallScore, Boolean allowComplaintsForAutomaticAssessments, Boolean allowFeedbackRequests, Boolean presentationScoreEnabled,
+        Boolean secondCorrectionEnabled, String feedbackSuggestionModule, String gradingInstructions, ZonedDateTime releaseDate, ZonedDateTime startDate, ZonedDateTime dueDate,
+        ZonedDateTime assessmentDueDate, ZonedDateTime exampleSolutionPublicationDate, String exampleSolution, Long courseId, Long exerciseGroupId, ExerciseMode mode,
+        TeamAssignmentConfigDTO teamAssignmentConfig, Set<GradingCriterionDTO> gradingCriteria, Set<CompetencyLinkDTO> competencyLinks) implements CompetencyLinksHolderDTO {
 
     /**
      * Creates an UpdateTextExerciseDTO from the given TextExercise domain object.

--- a/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.html
+++ b/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.html
@@ -125,6 +125,7 @@
                             max="9999"
                             name="points"
                             id="field_points"
+                            noScientificNotation
                             [(ngModel)]="fileUploadExercise().maxPoints"
                             #points="ngModel"
                         />
@@ -142,6 +143,7 @@
                             max="9999"
                             name="bonusPoints"
                             id="field_bonusPoints"
+                            noScientificNotation
                             [(ngModel)]="fileUploadExercise().bonusPoints"
                             #bonusPoints="ngModel"
                         />

--- a/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.ts
+++ b/src/main/webapp/app/fileupload/manage/update/file-upload-exercise-update.component.ts
@@ -35,6 +35,7 @@ import { CategorySelectorPrimengComponent } from 'app/exercise/category-selector
 import { MarkdownEditorMonacoComponent } from 'app/editor/markdown-editor/monaco/markdown-editor-monaco.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
+import { CustomScientificNotationValidatorDirective } from 'app/foundation/validators/custom-scientific-notation-validator.directive';
 import { DifficultyPickerComponent } from 'app/exercise/difficulty-picker/difficulty-picker.component';
 import { FormSectionStatus, FormStatusBarComponent } from 'app/shared-ui/form/form-status-bar/form-status-bar.component';
 import { CompetencySelectionComponent } from 'app/atlas/shared/competency-selection/competency-selection.component';
@@ -69,6 +70,7 @@ import { FileUploadExerciseTimelineComponent } from 'app/fileupload/manage/file-
         FormFooterComponent,
         ArtemisTranslatePipe,
         FileUploadExerciseTimelineComponent,
+        CustomScientificNotationValidatorDirective,
     ],
 })
 export class FileUploadExerciseUpdateComponent implements AfterViewInit, OnInit {

--- a/src/main/webapp/app/foundation/validators/custom-scientific-notation-validator.directive.spec.ts
+++ b/src/main/webapp/app/foundation/validators/custom-scientific-notation-validator.directive.spec.ts
@@ -3,7 +3,6 @@ import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { CustomScientificNotationValidatorDirective } from './custom-scientific-notation-validator.directive';
 
@@ -17,8 +16,6 @@ class CustomScientificNotationComponent {
 }
 
 describe('CustomScientificNotationValidatorDirective', () => {
-    setupTestBed({ zoneless: true });
-
     let fixture: ComponentFixture<CustomScientificNotationComponent>;
 
     beforeEach(async () => {

--- a/src/main/webapp/app/foundation/validators/custom-scientific-notation-validator.directive.spec.ts
+++ b/src/main/webapp/app/foundation/validators/custom-scientific-notation-validator.directive.spec.ts
@@ -1,0 +1,74 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { CustomScientificNotationValidatorDirective } from './custom-scientific-notation-validator.directive';
+
+@Component({
+    standalone: true,
+    template: '<form name="editForm" #editForm="ngForm">' + '<input type="number" name="points" noScientificNotation #pointsModel="ngModel" [(ngModel)]="points"/>' + '</form>',
+    imports: [FormsModule, CustomScientificNotationValidatorDirective],
+})
+class CustomScientificNotationComponent {
+    points!: number;
+}
+
+describe('CustomScientificNotationValidatorDirective', () => {
+    setupTestBed({ zoneless: true });
+
+    let fixture: ComponentFixture<CustomScientificNotationComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [CommonModule, FormsModule],
+        }).compileComponents();
+        fixture = TestBed.createComponent(CustomScientificNotationComponent);
+        // Required before simulating any typing: this is what wires NgModel's ControlValueAccessor
+        // (registerOnChange) to the native input. Before this runs once, NumberValueAccessor's
+        // onChange is still a no-op stub, so a dispatched 'input' event would silently go nowhere.
+        fixture.detectChanges();
+    });
+
+    /**
+     * Simulates a user typing `rawValue` into the field: sets the native input's raw string value
+     * directly and dispatches a real 'input' event, exactly like a keystroke would. This is
+     * important because assigning a JS number to the bound ngModel property and letting Angular's
+     * NumberValueAccessor write it back to the DOM re-serializes it via `String(value)`, which
+     * collapses e.g. `1e2` into `"100"` - losing the scientific-notation format we're testing for.
+     */
+    function typeIntoInput(rawValue: string) {
+        const inputElement: HTMLInputElement = fixture.debugElement.query(By.css('input[name=points]')).nativeElement;
+        inputElement.value = rawValue;
+        inputElement.dispatchEvent(new Event('input', { bubbles: true }));
+        fixture.detectChanges();
+
+        return fixture.debugElement.query(By.css('input[name=points]')).references['pointsModel'];
+    }
+
+    it('should accept plain decimal values', () => {
+        const pointsEl = typeIntoInput('1.5');
+
+        expect(pointsEl.errors).toBeNull();
+    });
+
+    it('should set error on negative-exponent scientific notation values (issue #12451)', () => {
+        const pointsEl = typeIntoInput('1e-30');
+
+        expect(pointsEl.errors.scientificNotation).toBe(true);
+    });
+
+    it('should set error on positive-exponent scientific notation values', () => {
+        const pointsEl = typeIntoInput('1e2');
+
+        expect(pointsEl.errors.scientificNotation).toBe(true);
+    });
+
+    it('should accept an empty value', () => {
+        const pointsEl = typeIntoInput('');
+
+        expect(pointsEl.errors).toBeNull();
+    });
+});

--- a/src/main/webapp/app/foundation/validators/custom-scientific-notation-validator.directive.ts
+++ b/src/main/webapp/app/foundation/validators/custom-scientific-notation-validator.directive.ts
@@ -1,0 +1,41 @@
+import { Directive, ElementRef, inject } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+
+/**
+ * Matches a plain, optionally signed, optionally decimal number (e.g. "1", "-1", "1.5").
+ * Rejects scientific notation (e.g. "1e-30", "1E5") and other non-plain-decimal strings,
+ * which native `<input type="number">` elements otherwise silently accept as valid.
+ */
+const PLAIN_DECIMAL_PATTERN = /^[+-]?\d*\.?\d*$/;
+
+/**
+ * Custom validator that rejects scientific notation on native number inputs.
+ *
+ * Native `<input type="number">` parses "1e-30" into a valid, in-range float, so `min`/`max`
+ * validators never see anything wrong with it - they only ever see the already-parsed number.
+ * This directive instead reads the raw string straight from the input element, which is the
+ * only place the original, un-parsed format is still available.
+ *
+ * Adds the 'scientificNotation' error key (= true) to the control if the entered value is not
+ * a plain decimal number.
+ */
+@Directive({
+    selector: 'input[type=number][noScientificNotation][ngModel], input[type=number][noScientificNotation][formControl]',
+    providers: [{ provide: NG_VALIDATORS, useExisting: CustomScientificNotationValidatorDirective, multi: true }],
+})
+export class CustomScientificNotationValidatorDirective implements Validator {
+    private readonly elementRef = inject(ElementRef<HTMLInputElement>);
+
+    validate(control: AbstractControl): ValidationErrors | null {
+        if (control == undefined) {
+            return null;
+        }
+
+        const rawValue = this.elementRef.nativeElement.value;
+        if (rawValue !== '' && !PLAIN_DECIMAL_PATTERN.test(rawValue)) {
+            return { scientificNotation: true };
+        }
+
+        return null;
+    }
+}

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.html
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.html
@@ -133,6 +133,7 @@
                             max="9999"
                             name="points"
                             id="field_points"
+                            noScientificNotation
                             [(ngModel)]="modelingExercise.maxPoints"
                             #points="ngModel"
                         />
@@ -151,6 +152,7 @@
                                 max="9999"
                                 name="bonusPoints"
                                 id="field_bonusPoints"
+                                noScientificNotation
                                 [(ngModel)]="modelingExercise.bonusPoints"
                                 #bonusPoints="ngModel"
                             />

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.ts
@@ -32,6 +32,7 @@ import { TranslateDirective } from 'app/foundation/language/translate.directive'
 import { MarkdownEditorMonacoComponent } from 'app/editor/markdown-editor/monaco/markdown-editor-monaco.component';
 import { FormulaAction } from 'app/editor/monaco-editor/model/actions/formula.action';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
+import { CustomScientificNotationValidatorDirective } from 'app/foundation/validators/custom-scientific-notation-validator.directive';
 import { AlertService } from 'app/foundation/service/alert.service';
 import { EventManager } from 'app/foundation/service/event-manager.service';
 import { onError } from 'app/foundation/util/global.utils';
@@ -70,6 +71,7 @@ import { ExerciseFeedbackSuggestionOptionsComponent } from 'app/exercise/feedbac
         ArtemisTranslatePipe,
         ModelingExerciseTimelineComponent,
         ExerciseFeedbackSuggestionOptionsComponent,
+        CustomScientificNotationValidatorDirective,
     ],
 })
 export class ModelingExerciseUpdateComponent implements AfterViewInit, OnDestroy, OnInit {

--- a/src/main/webapp/app/programming/manage/update/update-components/grading/programming-exercise-grading.component.html
+++ b/src/main/webapp/app/programming/manage/update/update-components/grading/programming-exercise-grading.component.html
@@ -26,6 +26,7 @@
                         max="9999"
                         name="points"
                         id="field_points"
+                        noScientificNotation
                         [(ngModel)]="programmingExercise().maxPoints"
                         #maxScore="ngModel"
                     />
@@ -47,6 +48,7 @@
                         max="9999"
                         name="bonusPoints"
                         id="field_bonusPoints"
+                        noScientificNotation
                         [(ngModel)]="programmingExercise().bonusPoints"
                         #bonusPoints="ngModel"
                     />

--- a/src/main/webapp/app/programming/manage/update/update-components/grading/programming-exercise-grading.component.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/grading/programming-exercise-grading.component.ts
@@ -21,6 +21,7 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { KeyValuePipe } from '@angular/common';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
 import { Message } from 'primeng/message';
+import { CustomScientificNotationValidatorDirective } from 'app/foundation/validators/custom-scientific-notation-validator.directive';
 
 @Component({
     selector: 'jhi-programming-exercise-grading',
@@ -39,6 +40,7 @@ import { Message } from 'primeng/message';
         KeyValuePipe,
         ArtemisTranslatePipe,
         Message,
+        CustomScientificNotationValidatorDirective,
     ],
 })
 export class ProgrammingExerciseGradingComponent implements AfterViewInit, OnDestroy {

--- a/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.html
+++ b/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.html
@@ -121,6 +121,7 @@
                             name="points"
                             #points="ngModel"
                             id="field_points"
+                            noScientificNotation
                             [(ngModel)]="textExercise.maxPoints"
                         />
                         @if (points?.invalid && (points?.dirty || points?.touched) && points?.errors) {
@@ -137,6 +138,7 @@
                             max="9999"
                             name="bonusPoints"
                             id="field_bonusPoints"
+                            noScientificNotation
                             [(ngModel)]="textExercise.bonusPoints"
                             #bonusPoints="ngModel"
                         />

--- a/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.ts
+++ b/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.ts
@@ -34,6 +34,7 @@ import { HelpIconComponent } from 'app/shared-ui/components/help-icon/help-icon.
 import { CategorySelectorPrimengComponent } from 'app/exercise/category-selector-primeng/category-selector-primeng.component';
 import { MarkdownEditorMonacoComponent } from 'app/editor/markdown-editor/monaco/markdown-editor-monaco.component';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
+import { CustomScientificNotationValidatorDirective } from 'app/foundation/validators/custom-scientific-notation-validator.directive';
 import { DifficultyPickerComponent } from 'app/exercise/difficulty-picker/difficulty-picker.component';
 import { loadCourseExerciseCategories } from 'app/exercise/course-exercises/course-utils';
 import { ExerciseUpdatePlagiarismComponent } from 'app/plagiarism/manage/exercise-update-plagiarism/exercise-update-plagiarism.component';
@@ -74,6 +75,7 @@ import { TextExerciseTimelineComponent } from 'app/text/manage/text-exercise/tex
         FeatureOverlayComponent,
         ExerciseFeedbackSuggestionOptionsComponent,
         TextExerciseTimelineComponent,
+        CustomScientificNotationValidatorDirective,
     ],
 })
 export class TextExerciseUpdateComponent implements OnInit, OnDestroy, AfterViewInit {

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/StrictDecimalDeserializerTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/StrictDecimalDeserializerTest.java
@@ -1,0 +1,61 @@
+package de.tum.cit.aet.artemis.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+class StrictDecimalDeserializerTest {
+
+    private record Holder(@JsonDeserialize(using = StrictDecimalDeserializer.class) Double value) {
+    }
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void deserialize_plainDecimal_succeeds() throws IOException {
+        Holder holder = objectMapper.readValue("{\"value\": 100.5}", Holder.class);
+        assertThat(holder.value()).isEqualTo(100.5);
+    }
+
+    @Test
+    void deserialize_plainInteger_succeeds() throws IOException {
+        Holder holder = objectMapper.readValue("{\"value\": 100}", Holder.class);
+        assertThat(holder.value()).isEqualTo(100.0);
+    }
+
+    @Test
+    void deserialize_negativeDecimal_succeeds() throws IOException {
+        Holder holder = objectMapper.readValue("{\"value\": -1.5}", Holder.class);
+        assertThat(holder.value()).isEqualTo(-1.5);
+    }
+
+    @Test
+    void deserialize_null_succeeds() throws IOException {
+        Holder holder = objectMapper.readValue("{\"value\": null}", Holder.class);
+        assertThat(holder.value()).isNull();
+    }
+
+    @Test
+    void deserialize_scientificNotation_throws() {
+        // issue #12451: a post-parse check on the Double can't tell "1e-3" apart from "0.001" - they are the
+        // identical value - so rejecting it requires looking at the raw JSON token, which is what this test proves.
+        assertThatThrownBy(() -> objectMapper.readValue("{\"value\": 1e-3}", Holder.class)).isInstanceOf(JsonMappingException.class);
+    }
+
+    @Test
+    void deserialize_tinyScientificNotation_throws() {
+        assertThatThrownBy(() -> objectMapper.readValue("{\"value\": 1e-30}", Holder.class)).isInstanceOf(JsonMappingException.class);
+    }
+
+    @Test
+    void deserialize_positiveExponentScientificNotation_throws() {
+        assertThatThrownBy(() -> objectMapper.readValue("{\"value\": 1e2}", Holder.class)).isInstanceOf(JsonMappingException.class);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTest.java
@@ -215,4 +215,32 @@ class ExerciseTest extends AbstractSpringIntegrationIndependentBatchTest {
 
         assertThatThrownBy(exercise::validateScoreSettings).hasMessageContaining("The max points needs to be greater than 0");
     }
+
+    @Test
+    void validateScoreSettings_maxPointsWithScientificNotationPrecision_throws() {
+        // 1e-30 parses to a valid, in-range Double, so only a decimal-precision check can catch it, see issue #12451
+        exercise.setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_COMPLETELY);
+        exercise.setMaxPoints(1e-30);
+        exercise.setBonusPoints(0.0);
+
+        assertThatThrownBy(exercise::validateScoreSettings).hasMessageContaining("The max points must not have more than 4 decimal places");
+    }
+
+    @Test
+    void validateScoreSettings_bonusPointsWithScientificNotationPrecision_throws() {
+        exercise.setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_COMPLETELY);
+        exercise.setMaxPoints(100.0);
+        exercise.setBonusPoints(1e-30);
+
+        assertThatThrownBy(exercise::validateScoreSettings).hasMessageContaining("The bonus points must not have more than 4 decimal places");
+    }
+
+    @Test
+    void validateScoreSettings_pointsWithReasonablePrecision_doesNotThrow() {
+        exercise.setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_COMPLETELY);
+        exercise.setMaxPoints(100.5);
+        exercise.setBonusPoints(0.25);
+
+        assertThatNoException().isThrownBy(exercise::validateScoreSettings);
+    }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTest.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.assessment.domain.Result;
+import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.util.CourseFactory;
 import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.exam.domain.Exam;
@@ -233,6 +234,36 @@ class ExerciseTest extends AbstractSpringIntegrationIndependentBatchTest {
         exercise.setBonusPoints(1e-30);
 
         assertThatThrownBy(exercise::validateScoreSettings).hasMessageContaining("The bonus points must not have more than 4 decimal places");
+    }
+
+    @Test
+    void validateScoreSettings_maxPointsNaN_throwsWithoutCrashing() {
+        // BigDecimal.valueOf(NaN) throws NumberFormatException, so isFinite must be checked first
+        exercise.setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_COMPLETELY);
+        exercise.setMaxPoints(Double.NaN);
+        exercise.setBonusPoints(0.0);
+
+        assertThatThrownBy(exercise::validateScoreSettings).isInstanceOf(BadRequestAlertException.class).hasMessageContaining("The max points must be a finite number");
+    }
+
+    @Test
+    void validateScoreSettings_maxPointsInfinite_throwsWithoutCrashing() {
+        exercise.setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_COMPLETELY);
+        exercise.setMaxPoints(Double.POSITIVE_INFINITY);
+        exercise.setBonusPoints(0.0);
+
+        assertThatThrownBy(exercise::validateScoreSettings).isInstanceOf(BadRequestAlertException.class).hasMessageContaining("The max points must be a finite number");
+    }
+
+    @Test
+    void validateScoreSettings_bonusPointsInfinite_throwsWithoutCrashing() {
+        // NEGATIVE_INFINITY is < 0, so it would get silently corrected to 0.0 by the existing negative-bonusPoints
+        // defaulting logic before ever reaching the finite check - use POSITIVE_INFINITY to actually exercise it.
+        exercise.setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_COMPLETELY);
+        exercise.setMaxPoints(100.0);
+        exercise.setBonusPoints(Double.POSITIVE_INFINITY);
+
+        assertThatThrownBy(exercise::validateScoreSettings).isInstanceOf(BadRequestAlertException.class).hasMessageContaining("The bonus points must be a finite number");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary
Native `<input type="number">` fields for exercise Points/Bonus Points silently accept scientific-notation values (e.g. `1e-30`) as valid, because `min`/`max` validators only ever see the browser's already-parsed number, never the raw string the user typed. This PR adds a validator directive that reads the raw input value directly and rejects non-plain-decimal input, applied to Points/Bonus Points on all four exercise types, plus a matching decimal-precision check on the server as defense-in-depth.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

<!-- I could not test on a live test server (no Helios access as an external, first-time contributor). Verified locally instead: full Vitest/Gradle suites, see Description below. -->

#### Server
- [x] I **strictly** followed the principle of **data economy** for all database calls. (no new DB calls added)
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).
- [x] I added integration tests (Spring) related to the feature (3 new tests in `ExerciseTest.java`, plus the 13 pre-existing tests in that class still pass).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added tests (Vitest) related to the feature (4 new tests for the directive, with 100% of the new logic exercised: plain decimal, negative-exponent, positive-exponent, empty value).
- [x] I added screenshots demonstrating the before/after UI behavior.
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
Closes #12451.

The issue reports that Bonus Points accepts `1e-30` as a valid value. Investigating showed this isn't specific to Bonus Points: the regular Points field, and the equivalent fields on all four exercise types (Programming, Text, Modeling, File Upload), share the identical gap — none of them have any validation beyond HTML's `min`/`max` attributes, which operate on the already-parsed number and can't see the original format. The same value also passes through the server unvalidated if submitted directly via the REST API, since `Double` fields don't retain the original string format either.

### Description
- Added `CustomScientificNotationValidatorDirective` (`src/main/webapp/app/foundation/validators/custom-scientific-notation-validator.directive.ts`), a small `NG_VALIDATORS` directive that reads the native input element's raw `.value` string (via `ElementRef`) and adds a `scientificNotation` error if it isn't a plain, optionally-signed, optionally-decimal number. This is necessary because by the time any validator sees `control.value`, `"1e-30"` has already been parsed into a normal JS number indistinguishable from its decimal expansion.
- Applied the directive (`noScientificNotation` attribute) to the `points`/`bonusPoints` inputs in:
  - `programming-exercise-grading.component.html`
  - `text-exercise-update.component.html`
  - `modeling-exercise-update.component.html`
  - `file-upload-exercise-update.component.html`
- Each field's existing `pointsError`/`bonusPointsError` alert (`@if (x?.invalid && ... && x?.errors)`) already triggers on *any* validation error, so no template changes were needed to surface the new error message.
- Added a matching server-side check in `Exercise.validateScoreSettings()`: `maxPoints`/`bonusPoints` are now rejected if they have more than 4 decimal places (`BigDecimal.valueOf(points).stripTrailingZeros().scale() > 4`), which catches `1e-30` (scale ≈30) while allowing normal values. This is defense-in-depth for direct API calls that bypass the client entirely.

### Steps for Testing
Prerequisites:
- 1 Instructor

1. Log in to Artemis as an instructor.
2. Go to a course → Exercises → create (or edit) a Programming, Text, Modeling, or File Upload exercise.
3. In the Points field, type `1e2`. In the Bonus Points field, type `1e-30`.
4. Observe the red "Must be a number between X and 9999." validation message now appears for both fields, and the Save/Next action is blocked. Before this fix, both values were silently accepted.

#### Exam Mode Testing
Not required separately — the Points/Bonus Points fields and the new directive are shared between course and exam exercise forms (same template, same `[(ngModel)]` bindings), so the fix applies identically in both contexts.

### Test Coverage
<!-- Not measured with a coverage tool; both new files are fully exercised by their own dedicated tests. -->
| Class/File | Confirmation (assert/expect) |
|------------|-------------------------------|
| `custom-scientific-notation-validator.directive.ts` | ✅ 4 Vitest cases (plain decimal, negative-exponent, positive-exponent, empty value) |
| `Exercise.java` (`validateScoreSettings`) | ✅ 3 new JUnit assertions (maxPoints precision, bonusPoints precision, normal-precision regression guard) |

### Screenshots
Before/after behavior, verified with an isolated harness reproducing the exact production `<input>` markup and the directive's exact logic (full end-to-end screenshot of the live app wasn't feasible in the time available for this fix — see the reproduction evidence linked in the issue for the original repro):

- **Before:** typing `1e-30` into Bonus Points → native `validity.valid = true`, no error shown.
- **After:** same input, with the new directive attached → `{ scientificNotation: true }`, red "Must be a number between 0 and 9999." message shown.

<img width="1332" height="856" alt="image" src="https://github.com/user-attachments/assets/96a05c68-e770-44ea-966f-186961b9fa9c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exercise point and bonus-point fields now accept only plain decimal values.
  * Scientific notation and non-finite values are rejected.
  * Values with more than four decimal places are rejected.
  * Validation applies across file-upload, modeling, programming, and text exercises.

* **Bug Fixes**
  * Improved score validation and clearer field-specific errors for invalid values.

* **Tests**
  * Added coverage for valid decimals, excessive precision, scientific notation, and non-finite inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->