### PR TITLE
`Development`: Fix the nightly Iris e2e monitor failing on a too-tight timeout budget

### DIFF
--- a/src/test/playwright/e2e/iris/IrisActivityFeed.spec.ts
+++ b/src/test/playwright/e2e/iris/IrisActivityFeed.spec.ts
@@ -27,8 +27,13 @@ const course = { id: SEED_COURSES.lectureManagement.id, title: SEED_COURSES.lect
  *
  * Run with: RUN_IRIS=true ./run-e2e-tests-local-fast.sh --skip-db --filter "Iris"
  * Skips itself when the Iris module feature is not active.
+ *
+ * Tagged `@slow`, not `@fast`: this test waits out a full two-round Pyris agent run (tool call plus
+ * follow-up answer, each relayed back over the status callback) and its assertions already budget
+ * 60s per wait — more than the `@fast` project's whole per-test cap (45s in the nightly runner).
+ * See the same note in IrisChatbotWidget.spec.ts and issue #13383.
  */
-test.describe('Iris activity visibility (real Pyris)', { tag: '@fast' }, () => {
+test.describe('Iris activity visibility (real Pyris)', { tag: '@slow' }, () => {
     let lecture: Lecture;
 
     test.beforeAll(async ({ browser }) => {
@@ -40,7 +45,10 @@ test.describe('Iris activity visibility (real Pyris)', { tag: '@fast' }, () => {
     });
 
     test.beforeEach(async ({ courseManagementAPIRequests, page }) => {
-        await Commands.login(page, instructor, '/');
+        // No target URL: the calls below only need the instructor JWT cookie, and the test navigates
+        // as the student right after. See IrisChatbotWidget.spec.ts for why the discarded `/` bootstrap
+        // this used to do was the nightly's timeout hot spot (issue #13383).
+        await Commands.login(page, instructor);
         await page.request.put(`api/iris/courses/${course.id}/iris-settings`, { data: { enabled: true, variant: 'default' } });
         lecture = await courseManagementAPIRequests.createLecture(course);
         expect(lecture.id, 'lecture should be created with an id').toBeDefined();

--- a/src/test/playwright/e2e/iris/IrisChatbotWidget.spec.ts
+++ b/src/test/playwright/e2e/iris/IrisChatbotWidget.spec.ts
@@ -36,8 +36,15 @@ const course = { id: SEED_COURSES.lectureManagement.id, title: SEED_COURSES.lect
  *
  * When Iris is NOT enabled (the default), the suite skips itself rather than failing, so
  * it is a no-op in normal CI runs.
+ *
+ * Tagged `@slow`, not `@fast`: a single test here drives a real Pyris pipeline run (Weaviate
+ * lookup, mock-LLM call, status callback back into Artemis) on top of a cold Angular dev-server
+ * route, and the assertions below already budget 60s for that round trip — which the `@fast`
+ * project's per-test cap (45s in the nightly runner) can never honour. Measured first-attempt
+ * durations on the nightly's 4-core runner were 28-45s against that 45s cap, so the monitor was
+ * only ever green when its single retry rescued it (issue #13383).
  */
-test.describe('Iris chatbot widget (real Pyris)', { tag: '@fast' }, () => {
+test.describe('Iris chatbot widget (real Pyris)', { tag: '@slow' }, () => {
     let lecture: Lecture;
 
     test.beforeAll(async ({ browser }) => {
@@ -51,7 +58,12 @@ test.describe('Iris chatbot widget (real Pyris)', { tag: '@fast' }, () => {
 
     test.beforeEach(async ({ courseManagementAPIRequests, page }) => {
         // Create the lecture as instructor via API (faster and more robust than the UI).
-        await Commands.login(page, instructor, '/');
+        // Authenticate WITHOUT a target URL: the two calls below only need the JWT cookie, and the
+        // test's own `login(student, lectureUrl)` navigates anyway. Passing a URL here would add a
+        // full Angular bootstrap of `/` (goto + load event + navbar identity check, each with a
+        // reload fallback) whose rendered page is then thrown away — on the nightly runner that
+        // discarded navigation is exactly where the beforeEach hook timed out (issue #13383).
+        await Commands.login(page, instructor);
         // Defensively ensure the course-level Iris settings are enabled (they default to
         // enabled when no override row exists, but this is idempotent and robust to a
         // future default flip). Instructors may toggle `enabled`.

--- a/src/test/playwright/support/baseFixtures.ts
+++ b/src/test/playwright/support/baseFixtures.ts
@@ -56,9 +56,11 @@ function readAdminJwt(): string | undefined {
 }
 
 /**
- * Visit each lazy-loaded route once with an authenticated browser context so Chromium
- * caches the JS chunks on disk. Subsequent tests in the same worker hit the cache
- * instead of refetching, eliminating the chunk-fetch race under load.
+ * Visit each lazy-loaded route once with an authenticated browser context so the Angular dev
+ * server has already built and cached each route's chunks. Subsequent tests in the same worker
+ * still refetch them over HTTP (see the note above), but the server answers from its transform
+ * cache instead of compiling while a test waits, which is what eliminates the chunk-fetch race
+ * under load.
  *
  * Best-effort: every navigation is `.catch`ed so a single slow route never breaks the
  * worker. Runs only once per worker (gated by the module-level `chunksWarmedOnThisWorker`
@@ -76,7 +78,7 @@ async function prewarmChunks(browser: Browser): Promise<void> {
     }
 
     // serviceWorkers: 'block' mirrors the global `use` option (manually created contexts don't inherit
-    // it) so the warm-up populates the same HTTP/disk caches the SW-free test contexts read from.
+    // it) so the warm-up exercises the same request path as the SW-free test contexts.
     const ctx = await browser.newContext({ ignoreHTTPSErrors: true, serviceWorkers: 'block' });
     try {
         const url = new URL(baseURL);

--- a/src/test/playwright/support/baseFixtures.ts
+++ b/src/test/playwright/support/baseFixtures.ts
@@ -7,9 +7,17 @@ import { addE2EInitScript, installApiResponseCapture } from './utils';
 
 /**
  * Lazy-loaded Angular routes that e2e tests commonly hit. Pre-warming these on each
- * Playwright worker downloads the route chunks into Chromium's per-worker disk cache,
- * so subsequent test navigations don't race the chunk fetch (which under heavy
+ * Playwright worker makes the *server* side of the fetch cheap — the Angular dev server
+ * transforms and caches each module once instead of while a test is waiting on it — so
+ * subsequent test navigations don't race a cold chunk build (which under heavy
  * multi-node load occasionally fails and drops the user on `/courses`).
+ *
+ * Note it does NOT populate a browser cache, despite what this comment used to claim:
+ * `installApiResponseCapture` registers request interception on every context, and
+ * Playwright disables Chromium's HTTP cache whenever interception is active. Measured over
+ * 12 Iris attempts, every navigation re-downloads the `immutable` `vite/deps/*` bundles
+ * (24x for 199 unique URLs). Only the dev server's own transform cache is being warmed
+ * here (issue #13383).
  *
  * The list deliberately picks ONE representative URL per distinct lazy module: leaf
  * components like course-detail, course-update, iris-settings etc. are loaded

--- a/src/test/playwright/support/utils.ts
+++ b/src/test/playwright/support/utils.ts
@@ -158,8 +158,10 @@ function captureBodyWithoutReplaying(request: Request): void {
  * /api fetches — Playwright routing never sees service-worker-handled requests, which is what
  * defeated an earlier page-scoped version of this capture.
  *
- * Scope guards: GETs are never intercepted (SSE — GET text/event-stream, e.g. Iris — must not be
- * fetched from Node, and GET evictions are recoverable read-side by replay), and multipart bodies
+ * Scope guards: only `/api/` URLs are routed at all (see the glob below — this matters for the
+ * browser HTTP cache, not just for tidiness), GETs are continued untouched (SSE — GET
+ * text/event-stream, e.g. Iris — must not be fetched from Node, and GET evictions are recoverable
+ * read-side by replay), and multipart bodies
  * are only captured up to {@link MAX_CAPTURED_MULTIPART_BODY_BYTES} inclusive **and** only when
  * Playwright's copy of the body is byte-complete (see {@link isBodyFaithfullyReplayable}). Multipart
  * was previously skipped outright, which left course create/update (Angular posts them as `FormData`)
@@ -176,10 +178,28 @@ function captureBodyWithoutReplaying(request: Request): void {
  */
 export async function installApiResponseCapture(context: BrowserContext): Promise<void> {
     await context.route(
-        (url) => url.pathname.includes('/api/'),
+        // A STRING GLOB, deliberately — not the equivalent `(url) => url.pathname.includes('/api/')`
+        // predicate. Playwright can only push a URL pattern down to the browser when EVERY matcher
+        // registered on the context is a string: `RouteHandler.prepareInterceptionPatterns` sets
+        // `all = true` for any function/RegExp matcher and then returns `[{ glob: '**/*' }]`. With the
+        // predicate, every request in every E2E context therefore round-tripped through this handler
+        // just to be waved through — measured over 12 Iris test attempts: 20334 `route.continue()`
+        // calls with `**/*` versus 326 with this glob, i.e. ~1700 driver round-trips per attempt of
+        // pure overhead. That is dead weight everywhere and it is not free on a CPU-saturated CI
+        // runner (issue #13383).
+        //
+        // What this does NOT buy: HTTP caching. Playwright disables Chromium's cache whenever any
+        // interception is registered at all (`_updateProtocolRequestInterceptionForSession` sends
+        // `Network.setCacheDisabled: <interception enabled>`), so narrowing the pattern changes
+        // nothing there — the same 12 attempts re-fetched the `max-age=31536000,immutable`
+        // `vite/deps/*` bundles 24x either way. Restoring cacheability would mean not routing these
+        // contexts at all, which is a separate question from this pattern.
+        '**/api/**',
         async (route) => {
             const request = route.request();
-            if (request.method() === 'GET') {
+            // The glob above is the browser-side filter; this is the exact predicate it approximates,
+            // so a URL that merely resembles an API path can never take the capture path below.
+            if (request.method() === 'GET' || !new URL(request.url()).pathname.includes('/api/')) {
                 await route.continue();
                 return;
             }

--- a/src/test/playwright/support/utils.ts
+++ b/src/test/playwright/support/utils.ts
@@ -158,8 +158,8 @@ function captureBodyWithoutReplaying(request: Request): void {
  * /api fetches — Playwright routing never sees service-worker-handled requests, which is what
  * defeated an earlier page-scoped version of this capture.
  *
- * Scope guards: only `/api/` URLs are routed at all (see the glob below — this matters for the
- * browser HTTP cache, not just for tidiness), GETs are continued untouched (SSE — GET
+ * Scope guards: only `/api/` URLs are routed at all (see the glob below — it must stay a string so
+ * Playwright does not widen interception to every request), GETs are continued untouched (SSE — GET
  * text/event-stream, e.g. Iris — must not be fetched from Node, and GET evictions are recoverable
  * read-side by replay), and multipart bodies
  * are only captured up to {@link MAX_CAPTURED_MULTIPART_BODY_BYTES} inclusive **and** only when


### PR DESCRIPTION
### Summary

The nightly `Nightly Iris E2E` monitor — which guards the Artemis ↔ Pyris wire contract — went red on 2026-07-31 and 2026-08-03 and filed #13383. **The contract had not drifted.** No Iris assertion ever reached a verdict on either night: all six attempts died on infrastructure timeouts. The specs were tagged `@fast`, capping every test at 45 s in the nightly runner, while their own assertions budget 60 s for the real-Pyris round trip. This PR fixes the budget, removes a wasted page bootstrap that consumed it, and cuts ~1700 Playwright driver round-trips per test attempt across the whole e2e suite.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

Fixes #13383.

The monitor had been riding its timeout wall for weeks. First-attempt durations across the last nine nightlies, against a 45 s cap:

| Night | first-attempt durations | outcome |
|---|---|---|
| 07-26 … 07-30 | 28-45 s, at least one test over the cap every night | green **only** because of the single retry |
| 08-01 | 40.8 / 42.4 / 44.4 s | green at 91-99 % of budget |
| 08-02 | 39.9 / 43.1 / fail → retry | green via retry |
| **07-31** | 45.0 / 45.0 / 45.1 s | **red** |
| **08-03** | 45.3 / 45.2 / 45.7 s | **red** |

It went red whenever all three tests hit the wall at once. A monitor that only passes because of its retry is not a monitor, and a red night that says "the contract may have drifted" when it has not costs real investigation time.

### Description

Four changes, all confined to the e2e harness. No production code.

**1. `@fast` → `@slow` on both Iris describes.** They land in the `slow-tests` project (90 s in the nightly runner, 300 s in Docker CI). The nightly already passes `--project=fast-tests --project=slow-tests`, so they keep running unchanged. This also resolves an internal contradiction: the specs contain `{ timeout: 60_000 }` waits that a 45 s test cap can never honour. Per the repo's own guidance, `@slow` is for tests "polling for background jobs" — a real Pyris pipeline run, Weaviate lookup, mock-LLM call and status callback qualifies.

**2. Drop the `'/'` from the `beforeEach` instructor login.** The two API calls that follow only need the JWT cookie, and each test navigates as the student immediately afterwards, discarding the instructor page. The action timeline from a failing attempt's trace spends the entire budget inside that discarded navigation:

```
goto('/') 7.1s → navbar probe FAILS → reload 6.5s → probe 2.4s
→ goto 5.2s (drift re-goto) → probe 2.0s → goto 5.8s → probe FAILS
→ reload 5.6s → probe 1.9s → 45s cap hit
```

Three `goto`s, two recovery reloads, five navbar probes — and the API calls never ran. These were the only two call sites in the entire suite passing a URL to `Commands.login` for API-only setup; every other one uses the no-URL form (~0.3 s).

**3. Give `installApiResponseCapture` a string glob instead of an equivalent predicate.** Playwright's `RouteHandler.prepareInterceptionPatterns` sets `all = true` for *any* function or RegExp matcher on a context and then returns `[{ glob: '**/*' }]`. The predicate `(url) => url.pathname.includes('/api/')` therefore made **every** request in **every** e2e context round-trip through the Node handler just to be waved through. Measured over 12 Iris attempts:

| | `**/*` (before) | `**/api/**` (after) |
|---|---|---|
| `route.continue()` calls | 20334 | **326** |

That is ~1700 driver round-trips per attempt of pure overhead, suite-wide, and it is not free on a CPU-saturated 4-core CI runner.

**4. Correct the `prewarmChunks` docstring.** It claimed to download route chunks "into Chromium's per-worker disk cache". That is false: Playwright sends `Network.setCacheDisabled: <interception enabled>`, so while `installApiResponseCapture` is registered on every context, **no** e2e navigation can hit the browser cache. I expected change 3 to restore caching and measured that it does not — the `max-age=31536000,immutable` `vite/deps/*` bundles are re-fetched 24× either way. Only the dev server's transform cache is being warmed. Comment now says so rather than leaving a claim the measurement disproves.

**Deliberately out of scope**, noted here so the findings are not lost:
- Making non-API contexts cacheable means not routing them at all, which trades away the body-capture robustness #13339 added. That is a design decision, not a drive-by fix.
- `IrisChatbotWidget.openWidget()` races two *rejecting* 5 s `waitFor`s through `Promise.race`, so a slow-but-fine render rejects at 5 s carrying the modal's timeout error.
- `ExamSubmissionRecovery.spec.ts` uses a RegExp `page.route` matcher, re-triggering the `**/*` fallback for that one spec's page.
- The runner's `/management/health` "server ready" gate fires ~45 s before `DeferredEagerBeanInitializer` finishes, so tests start into a CPU-contended JVM. Systematic in green runs too, so not the trigger.
- First-attempt durations also stepped from ~35 s to ~44 s exactly at the Angular 22.1 / Vite 8 move (#13349, #13363), which shifted dep pre-bundling from esbuild to rolldown. Correlation across four consecutive nights; given the cache finding above, the dev server is on the critical path of every navigation.

### Steps for Testing

This is a test-infrastructure change; it is verified by running the affected suites rather than through the UI.

Prerequisites:
- Docker running
- The Pyris image: `docker pull ghcr.io/ls1intum/edutelligence/iris:latest && docker tag ghcr.io/ls1intum/edutelligence/iris:latest pyris-e2e:local`

1. Run the Iris suite against a real Pyris: `RUN_IRIS=true ./run-e2e-tests-local-fast.sh --filter "Iris"`
2. Confirm all three tests are reported under `[slow-tests]` (not `[fast-tests]`) and pass.
3. Confirm the multipart body capture still works after the glob change — these are the specs #13339 fixed: `./run-e2e-tests-local-fast.sh --filter "CourseManagement|QuizExerciseParticipation"`
4. Optionally re-run the nightly workflow directly via `workflow_dispatch` on this branch (Actions → Nightly Iris E2E → Run workflow).

What I ran locally, all green:
- 21 Iris test runs against real Pyris with retries disabled (`--repeat-each`, `TEST_RETRIES=0`).
- `CourseManagement` + `QuizExerciseParticipation` + `QuizExerciseDropLocation`: 22 passed, 0 failed.
- `pnpm exec eslint`, `prettier --check` clean on all four files.

### Testserver States

Not applicable — this PR only changes Playwright e2e test code and has no effect on a deployed server.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reclassified Iris activity feed and chatbot end-to-end tests as slow-running.
  * Simplified instructor authentication setup for more reliable test execution.
  * Improved API response interception to scope handling to relevant requests while preserving normal GET behavior.

* **Documentation**
  * Clarified lazy-route prewarming, caching behavior, and request interception details in test guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->