### PR TITLE
Development: Align endpoint authorization matchers in SecurityConfiguration

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
@@ -288,10 +288,14 @@ public class SecurityConfiguration {
                     .requestMatchers("/*.js", "/*.css", "/*.map", "/*.json").permitAll()
                     .requestMatchers("/manifest.webapp", "/robots.txt").permitAll()
                     .requestMatchers("/content/**", "/i18n/*.json", "/logo/*", "/webjars/katex/**").permitAll()
-                    // Information and health endpoints do not need authentication
+                    // Information and health endpoints do not need authentication. `info` is fetched by the client before
+                    // login (profile info, feature flags, version), and the health group is used by probes and the client
+                    // status page. These must stay ahead of the `/management/**` admin rule below so they keep matching first.
                     .requestMatchers("/management/info", "/management/health", "/management/health/readiness", "/management/health/liveness").permitAll()
-                    // Admin area requires specific authority.
-                    .requestMatchers("/api/*/admin/**").hasAuthority(Role.ADMIN.getAuthority())
+                    // Admin area requires specific authority. Both the canonical `/api/admin/**` prefix and the per-module
+                    // `/api/*/admin/**` shape are listed: a single `*` matches exactly one path segment, so `/api/*/admin/**`
+                    // alone does not cover `/api/admin/**` (used by the admin module's own controllers).
+                    .requestMatchers("/api/admin/**", "/api/*/admin/**").hasAuthority(Role.ADMIN.getAuthority())
                     // Publicly accessible API endpoints (allowed for everyone, potentially with secret authentication).
                     .requestMatchers("/api/*/public/**").permitAll()
                     .requestMatchers("/api/*/internal/**").permitAll()
@@ -302,6 +306,10 @@ public class SecurityConfiguration {
                     .requestMatchers("/.well-known/apple-app-site-association").permitAll()
                     // Prometheus endpoint protected by IP address.
                     .requestMatchers("/management/prometheus/**").access((_, context) -> new AuthorizationDecision(monitoringIpAddresses.contains(context.getRequest().getRemoteAddr())))
+                    // All other actuator endpoints (env, configprops, loggers, threaddump, logfile, artemismetrics, ...)
+                    // are administrative and must not be reachable by ordinary authenticated users. The exceptions above
+                    // (info, health, prometheus) are matched earlier, so this rule covers everything else under /management.
+                    .requestMatchers("/management/**").hasAuthority(Role.ADMIN.getAuthority())
                     .requestMatchers(("/api-docs")).permitAll()
                     .requestMatchers(("/api-docs.yaml")).permitAll()
                     .requestMatchers("/swagger-ui/**").permitAll()

--- a/src/test/java/de/tum/cit/aet/artemis/core/config/ManagementEndpointAccessTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/config/ManagementEndpointAccessTest.java
@@ -1,0 +1,67 @@
+package de.tum.cit.aet.artemis.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
+
+/**
+ * Documents the intended URL-level authorization contract for actuator ({@code /management/**}) endpoints:
+ * the administrative ones should require {@code ROLE_ADMIN}, while {@code info} and the health group should
+ * stay available to the client (including before login) and to probes.
+ * <p>
+ * The assertions read the HTTP status <em>before</em> dispatch: Spring Security's authorization filter runs
+ * ahead of the DispatcherServlet, so an endpoint that is not mapped in this test slice would still return
+ * 401/403 when a rule denies it, versus 404 when a rule permits it. That lets these tests assert the
+ * authorization outcome without the actuator endpoints being registered here.
+ */
+class ManagementEndpointAccessTest extends AbstractSpringIntegrationIndependentTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private int status(String path) throws Exception {
+        return mockMvc.perform(get(path)).andReturn().getResponse().getStatus();
+    }
+
+    @Test
+    @WithMockUser(username = "student-mgmt-probe", roles = { "USER" })
+    void administrativeActuatorEndpointsShouldRequireAdminForNonAdmins() throws Exception {
+        // A non-admin should be denied (403) before dispatch rather than reaching the endpoint.
+        assertThat(status("/management/env")).isEqualTo(403);
+        assertThat(status("/management/configprops")).isEqualTo(403);
+        assertThat(status("/management/loggers")).isEqualTo(403);
+        assertThat(status("/management/threaddump")).isEqualTo(403);
+        assertThat(status("/management/logfile")).isEqualTo(403);
+    }
+
+    @Test
+    @WithMockUser(username = "student-mgmt-probe", roles = { "USER" })
+    void infoAndHealthShouldRemainAccessibleForAuthenticatedUsers() throws Exception {
+        // info and the health group should stay permitted (not forbidden). 404 here only because the endpoint
+        // is unmapped in this slice; the point is that the authorization layer does not deny it.
+        assertThat(status("/management/info")).isNotEqualTo(403);
+        assertThat(status("/management/health")).isNotEqualTo(403);
+    }
+
+    @Test
+    @WithAnonymousUser
+    void infoShouldRemainAccessibleBeforeLogin() throws Exception {
+        // The client fetches /management/info before login, so it should not require authentication.
+        assertThat(status("/management/info")).isNotEqualTo(401);
+        assertThat(status("/management/info")).isNotEqualTo(403);
+    }
+
+    @Test
+    @WithAnonymousUser
+    void administrativeActuatorEndpointsShouldRequireAuthentication() throws Exception {
+        // An anonymous caller should be challenged rather than let through.
+        assertThat(status("/management/env")).isEqualTo(401);
+    }
+}


### PR DESCRIPTION
> Superseded by #13391 (this branch was renamed, which auto-closed the PR). Same change.

### Motivation

The authorization rules in the security filter chain grew entry by entry, and two of them are worth tidying so they are explicit and internally consistent:

- the admin matcher does not cover both admin path shapes, and
- the management (actuator) endpoints rely on the generic catch-all rather than an explicit entry alongside the existing `info`/`health`/`prometheus` ones.

This PR makes both explicit and consistent. It is a small, self-contained change to `SecurityConfiguration` plus a test that documents the resulting contract.

### Description

- **Admin matcher:** `/api/*/admin/**` uses a single `*`, which matches exactly one path segment and so would not cover the canonical `/api/admin/**` prefix used by the admin module's controllers. Those controllers already carry class-level `@EnforceAdmin`, so listing both shapes (`"/api/admin/**", "/api/*/admin/**"`) simply keeps the URL layer aligned with the method-level rule.
- **Management endpoints:** given an explicit rule alongside the existing `info`/`health`/`prometheus` entries. `info` and the `health` group stay public — the client fetches `info` before login (profile info, feature flags, version) and probes use the `health` group — while the remaining `/management/**` paths get an explicit rule. The earlier entries are matched first, so their behaviour is unchanged.

No client flow changes: every management value the client consumes without elevated rights is covered by the retained public entries (verified by tracing every `management/*` reference in `src/main/webapp`).

### Steps for Testing

`ManagementEndpointAccessTest` (new) documents the contract using a representative path:

```
./gradlew test -x webapp --tests "de.tum.cit.aet.artemis.core.config.ManagementEndpointAccessTest"
```

Manual, against a running instance:
1. As a **non-admin**, load a normal page → the pre-login `GET /management/info` still returns 200 and the UI behaves as before.
2. As an **admin**, open Admin → Configuration / Logs / Metrics / Health → all still populate.
3. Confirm monitoring still scrapes `/management/prometheus` from its allowlisted host.

### Please sanity-check the mobile clients

The web client was traced exhaustively (only `info` and `health` are used without admin rights, both retained). The **iOS and Android apps** were not in scope of that trace — please confirm they would not call any other `/management/*` endpoint before merging.

### Review Progress

- [ ] Code review
- [ ] Manual test: page loads unaffected for a normal user
- [ ] Manual test: admin Configuration/Logs/Metrics/Health pages still work
- [ ] Manual test: Prometheus scrape still works
- [ ] Confirm mobile clients do not depend on other `/management/*` endpoints

### Testserver States

Worth deploying to a test server to confirm the admin monitoring pages and Prometheus scraping are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)