### PR TITLE
`Development`: Align endpoint authorization matchers in SecurityConfiguration

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
@@ -288,10 +288,14 @@ public class SecurityConfiguration {
                     .requestMatchers("/*.js", "/*.css", "/*.map", "/*.json").permitAll()
                     .requestMatchers("/manifest.webapp", "/robots.txt").permitAll()
                     .requestMatchers("/content/**", "/i18n/*.json", "/logo/*", "/webjars/katex/**").permitAll()
-                    // Information and health endpoints do not need authentication
+                    // Information and health endpoints do not need authentication. `info` is fetched by the client before
+                    // login (profile info, feature flags, version), and the health group is used by probes and the client
+                    // status page. These must stay ahead of the `/management/**` admin rule below so they keep matching first.
                     .requestMatchers("/management/info", "/management/health", "/management/health/readiness", "/management/health/liveness").permitAll()
-                    // Admin area requires specific authority.
-                    .requestMatchers("/api/*/admin/**").hasAuthority(Role.ADMIN.getAuthority())
+                    // Admin area requires specific authority. Both the canonical `/api/admin/**` prefix and the per-module
+                    // `/api/*/admin/**` shape are listed: a single `*` matches exactly one path segment, so `/api/*/admin/**`
+                    // alone does not cover `/api/admin/**` (used by the admin module's own controllers).
+                    .requestMatchers("/api/admin/**", "/api/*/admin/**").hasAuthority(Role.ADMIN.getAuthority())
                     // Publicly accessible API endpoints (allowed for everyone, potentially with secret authentication).
                     .requestMatchers("/api/*/public/**").permitAll()
                     .requestMatchers("/api/*/internal/**").permitAll()
@@ -302,6 +306,10 @@ public class SecurityConfiguration {
                     .requestMatchers("/.well-known/apple-app-site-association").permitAll()
                     // Prometheus endpoint protected by IP address.
                     .requestMatchers("/management/prometheus/**").access((_, context) -> new AuthorizationDecision(monitoringIpAddresses.contains(context.getRequest().getRemoteAddr())))
+                    // The remaining /management/** paths are administrative and require ROLE_ADMIN. The public
+                    // exceptions (info, health) and the IP-gated prometheus rule are matched earlier, so this rule
+                    // covers the rest.
+                    .requestMatchers("/management/**").hasAuthority(Role.ADMIN.getAuthority())
                     .requestMatchers(("/api-docs")).permitAll()
                     .requestMatchers(("/api-docs.yaml")).permitAll()
                     .requestMatchers("/swagger-ui/**").permitAll()

--- a/src/test/java/de/tum/cit/aet/artemis/core/config/ManagementEndpointAccessTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/config/ManagementEndpointAccessTest.java
@@ -1,0 +1,64 @@
+package de.tum.cit.aet.artemis.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
+
+/**
+ * Documents the URL-level authorization contract for actuator ({@code /management/**}) endpoints: the general
+ * {@code /management/**} rule should require {@code ROLE_ADMIN}, while {@code info} and the health group should
+ * stay available to the client (including before login) and to probes. {@code /management/env} is used below as
+ * a representative path for the general rule; all administrative endpoints share the same matcher.
+ * <p>
+ * The assertions read the HTTP status <em>before</em> dispatch: Spring Security's authorization filter runs
+ * ahead of the DispatcherServlet, so an endpoint that is not mapped in this test slice would still return
+ * 401/403 when a rule denies it, versus 404 when a rule permits it. That lets these tests assert the
+ * authorization outcome without the actuator endpoints being registered here.
+ */
+class ManagementEndpointAccessTest extends AbstractSpringIntegrationIndependentTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private int status(String path) throws Exception {
+        return mockMvc.perform(get(path)).andReturn().getResponse().getStatus();
+    }
+
+    @Test
+    @WithMockUser(username = "management-contract-user", roles = { "USER" })
+    void generalManagementRuleShouldRequireAdminForNonAdmins() throws Exception {
+        // Representative of the general /management/** rule: a non-admin should be denied (403) before dispatch.
+        assertThat(status("/management/env")).isEqualTo(403);
+    }
+
+    @Test
+    @WithMockUser(username = "management-contract-user", roles = { "USER" })
+    void infoAndHealthShouldRemainAccessibleForAuthenticatedUsers() throws Exception {
+        // info and the health group should stay permitted (not forbidden). 404 here only because the endpoint
+        // is unmapped in this slice; the point is that the authorization layer does not deny it.
+        assertThat(status("/management/info")).isNotEqualTo(403);
+        assertThat(status("/management/health")).isNotEqualTo(403);
+    }
+
+    @Test
+    @WithAnonymousUser
+    void infoShouldRemainAccessibleBeforeLogin() throws Exception {
+        // The client fetches /management/info before login, so it should not require authentication.
+        assertThat(status("/management/info")).isNotEqualTo(401);
+        assertThat(status("/management/info")).isNotEqualTo(403);
+    }
+
+    @Test
+    @WithAnonymousUser
+    void generalManagementRuleShouldRequireAuthentication() throws Exception {
+        // An anonymous caller should be challenged rather than let through.
+        assertThat(status("/management/env")).isEqualTo(401);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/config/ManagementEndpointAccessTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/config/ManagementEndpointAccessTest.java
@@ -57,6 +57,18 @@ class ManagementEndpointAccessTest extends AbstractSpringIntegrationIndependentT
 
     @Test
     @WithAnonymousUser
+    void healthGroupShouldRemainAccessibleBeforeLogin() throws Exception {
+        // Kubernetes/monitoring probes and the status page hit the health group without a session, so it must stay
+        // reachable anonymously. Asserting anonymously (not just for an authenticated user) guards against a regression
+        // that silently changes the rule from permitAll() to authenticated().
+        for (String path : new String[] { "/management/health", "/management/health/readiness", "/management/health/liveness" }) {
+            assertThat(status(path)).isNotEqualTo(401);
+            assertThat(status(path)).isNotEqualTo(403);
+        }
+    }
+
+    @Test
+    @WithAnonymousUser
     void generalManagementRuleShouldRequireAuthentication() throws Exception {
         // An anonymous caller should be challenged rather than let through.
         assertThat(status("/management/env")).isEqualTo(401);


### PR DESCRIPTION
### Motivation and Context

The authorization rules in the security filter chain grew entry by entry, and two of them are worth tidying so they are explicit and internally consistent: the admin matcher does not cover both admin path shapes, and the actuator (`/management/**`) endpoints rely on the generic catch-all rather than an explicit entry alongside the existing `info`/`health`/`prometheus` ones. This makes both explicit and consistent.

### Description

- **Admin matcher:** `/api/*/admin/**` uses a single `*`, which matches exactly one path segment and so would not cover the canonical `/api/admin/**` prefix used by the admin module's controllers. Those controllers already carry class-level `@EnforceAdmin`, so listing both shapes (`"/api/admin/**", "/api/*/admin/**"`) keeps the URL layer aligned with the method-level rule.
- **Management endpoints:** given an explicit rule alongside the existing `info`/`health`/`prometheus` entries. `info` and the `health` group stay public — the client fetches `info` before login and probes use the `health` group — while the remaining `/management/**` paths get an explicit rule. The earlier entries are matched first, so their behaviour is unchanged.

No client flow changes: every management value the client consumes without elevated rights is covered by the retained public entries (verified by tracing every `management/*` reference in `src/main/webapp`).

### Steps for Testing

`ManagementEndpointAccessTest` documents the contract:

```
./gradlew test -x webapp --tests "de.tum.cit.aet.artemis.core.config.ManagementEndpointAccessTest"
```

Manual, against a running instance:
1. As a non-admin, load a normal page → the pre-login `GET /management/info` still returns 200 and the UI behaves as before.
2. As an admin, open Admin → Configuration / Logs / Metrics / Health → all still populate.
3. Confirm monitoring still scrapes `/management/prometheus` from its allow-listed host.

### Checklist

#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server
- [x] I implemented the changes with a very good performance and prevented too many (unnecessary) and too complex database calls (this change adds no database calls).
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the server coding and design guidelines and the REST API guidelines.
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added pre-authorization annotations according to the guidelines and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.

_No client changes in this PR._

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [x] Non-admin limited to info/health; page loads unaffected
- [x] Admin Configuration/Logs/Metrics/Health pages still work
- [x] Prometheus scrape still works
- [x] Confirm mobile clients do not depend on other `/management/*` endpoints


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access control for management endpoints.
  * Restricted administrative management endpoints to authorized administrators.
  * Preserved public access to health and information endpoints.
  * Added support for the canonical admin API path while retaining existing access rules.
  * Ensured unauthorized requests receive appropriate access responses.

* **Tests**
  * Added coverage for authenticated, anonymous, administrator, and non-administrator access scenarios.
  * Verified accessibility of health and information endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->