### PR TITLE
`Assessment`: Show info when no submissions remain

### DIFF
--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.spec.ts
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.spec.ts
@@ -282,11 +282,12 @@ describe('FileUploadAssessmentComponent', () => {
             routeParams$.next({ exerciseId: 20, courseId: 123, submissionId: 'new' });
             vi.spyOn(fileUploadSubmissionService, 'getSubmissionWithoutAssessment').mockReturnValue(of(undefined));
             const alertSpy = vi.spyOn(alertService, 'info');
-            vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+            const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
 
             component.exercise.set(createExercise());
             component.ngOnInit();
 
+            expect(navigateSpy).toHaveBeenCalledWith('/course-management/123/assessment-dashboard/20');
             expect(alertSpy).toHaveBeenCalledWith('artemisApp.exerciseAssessmentDashboard.noSubmissions');
         });
 
@@ -728,12 +729,15 @@ describe('FileUploadAssessmentComponent', () => {
             expect(component.isLoading()).toBe(false);
         });
 
-        it('should clear submission when no next submission is available', () => {
+        it('should navigate back and show an info alert when no next submission is available', () => {
             vi.spyOn(fileUploadSubmissionService, 'getSubmissionWithoutAssessment').mockReturnValue(of(undefined));
+            const navigateSpy = vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+            const alertInfoSpy = vi.spyOn(alertService, 'info');
 
             component.assessNext();
 
-            expect(component.submission()).toBeUndefined();
+            expect(navigateSpy).toHaveBeenCalledExactlyOnceWith('/course-management/123/assessment-dashboard/20');
+            expect(alertInfoSpy).toHaveBeenCalledExactlyOnceWith('artemisApp.exerciseAssessmentDashboard.noSubmissions');
         });
 
         it('should show error alert on fetch failure', () => {
@@ -748,6 +752,7 @@ describe('FileUploadAssessmentComponent', () => {
         it('should reset unreferencedFeedback when loading next assessment', () => {
             component.unreferencedFeedback.set([createFeedback()]);
             vi.spyOn(fileUploadSubmissionService, 'getSubmissionWithoutAssessment').mockReturnValue(of(undefined));
+            vi.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
 
             component.assessNext();
 

--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
@@ -339,7 +339,8 @@ export class FileUploadAssessmentComponent implements OnInit {
                 this.unassessedSubmission = submission;
                 if (!submission) {
                     // there are no unassessed submissions
-                    this.submission.set(undefined);
+                    this.navigateBack();
+                    this.alertService.info('artemisApp.exerciseAssessmentDashboard.noSubmissions');
                     return;
                 }
 


### PR DESCRIPTION
### Summary

When **Assess Next Submission** reaches an empty file-upload assessment queue, Artemis now returns the assessor to the exercise assessment dashboard and shows the existing informational "no submissions" message instead of leaving the assessment view in a misleading state.

### Checklist

#### General

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).
- [x] I have read and followed the [coding guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/).

#### Client

- [x] I implemented the changes without additional REST calls and kept the existing assessment request flow.
- [x] I followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added focused Vitest assertions for the empty assessment queue behavior.

### Motivation and Context

Closes #13067

After the final file-upload submission has been assessed, the next-submission lookup legitimately returns no submission. The client previously cleared the current submission in place. The exhaustion case should be communicated as normal assessment progress rather than as an error or ambiguous assessment state.

### Description

- Navigate back to the exercise assessment dashboard when the next-submission response is empty.
- Show the existing `artemisApp.exerciseAssessmentDashboard.noSubmissions` informational alert.
- Keep genuine HTTP failures on the existing error-handling path.
- Verify both `/new` and **Assess Next Submission** exhaustion paths navigate to the dashboard and display the informational message.

### Steps for Testing

Prerequisites:

- 1 Instructor
- 1 Student
- 1 Exam with a File Upload Exercise

1. Participate in the exam as the student and upload a file.
2. After the exam, open the file-upload exercise assessment as the instructor.
3. Assess and submit the only submission.
4. Click **Assess Next Submission**.
5. Verify that Artemis navigates to the exercise assessment dashboard and displays an informational message that there are no submissions left to assess.
6. Verify that no authorization error is shown.

#### Exam Mode Testing

The testing steps above exercise the affected exam-mode flow directly.

### Tests

- `pnpm exec vitest run src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.spec.ts` — 61 tests passed
- ESLint passed for both changed files
- Prettier passed for both changed files
- `git diff --check` passed

### Screenshots

Manual before/after screenshots are needed from a configured Artemis test server. This headless implementation run did not produce a test-server screenshot; the change reuses the existing assessment-dashboard view and informational alert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When no unassessed submissions remain, the assessment view now returns to the dashboard and displays an informational alert.
  * Improved navigation behavior when moving to the next assessment or resetting feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->