### PR TITLE
`Usability`: Restore the spacing on the user settings pages

### DIFF
--- a/src/main/webapp/tailwind.css
+++ b/src/main/webapp/tailwind.css
@@ -82,6 +82,7 @@
 @source './app/localci/build-job-statistics';
 @source './app/shared-ui/components/buttons/copy-to-clipboard-button';
 @source './app/shared-ui/tum-ui';
+@source './app/account/user/settings/user-settings-container/user-settings-container.component.html';
 
 /*
  * Exclude test files: their prose ("should collapse the sidebar", "renders a table") would trip the same name


### PR DESCRIPTION
### Summary

The user settings pages lost all separation between the settings menu and the page content in 9.8. The Tailwind layout utilities the container relies on were never compiled, because the template was not added to the `@source` allowlist. One line fixes it.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).

> The test-server checkbox is deliberately left off: I verified this by compiling `tailwind.css` and diffing the emitted selectors, not on a test server. @krusche please tick it once you have seen the settings pages there, since this is a hotfix candidate.

### Motivation and Context

Fixes #13395. Reported on 9.8.

9.8 replaced the Bootstrap grid in `user-settings-container.component.html` with Tailwind flex utilities:

```diff
-    <div class="row">
-        <div class="col-lg-3 col-sm-12">
+    <div class="flex flex-col md:flex-row md:gap-4">
+        <div class="md:w-1/3 md:shrink-0 lg:w-1/4">
...
-        <div class="col-lg-8 col-sm-12">
+        <div class="mt-4 md:mt-0 md:min-w-0 md:flex-1">
```

but did not add the template to the `@source` allowlist in `tailwind.css`. That list exists because `tailwind.css` uses `source(none)`, so Tailwind only emits utilities it finds in scanned files. Our own guidelines call out this exact trap:

> A missing `@source` entry fails **silently** (the module's utilities simply never generate).

The result is a partially applied layout, which is worse than either alternative. I checked each class against the scanned paths:

| class | emitted? | why |
|---|---|---|
| `flex`, `flex-col`, `md:flex-row` | yes | other scanned modules happen to use them |
| `md:gap-4`, `md:w-1/3`, `md:shrink-0`, `lg:w-1/4`, `md:mt-0`, `md:min-w-0`, `md:flex-1` | **no** | used only here, and here was not scanned |

So from `md` upwards the container did become a flex **row**, but with no gap, no column widths and no `flex-1` on the content. The two columns end up flush against each other, which is the reported near-overlap, and it affects every settings subpage because the container wraps them all.

### Description

Added the template to the `@source` allowlist. It is listed as an individual file, the way `global-search-modal.component.html` already is, because all seven missing classes come from this one template — I verified no other file under `app/account` uses any of them.

I compiled `tailwind.css` before and after and diffed the emitted selectors, so the blast radius is measured rather than assumed:

```
=== NEWLY EMITTED ===
.lg\:w-1\/4  .md\:flex-1  .md\:gap-4  .md\:min-w-0  .md\:mt-0  .md\:shrink-0  .md\:w-1\/3
=== REMOVED ===
(none)
```

Exactly the seven missing utilities, nothing incidental, nothing removed. For comparison, scanning the whole `app/account/user/settings` directory would also have emitted ten Bootstrap-named collisions (`col-3`, `col-4`, `col-9`, `col-auto`, `ms-4`, `pb-3`, …); those would have lost the cascade to unlayered Bootstrap and been harmless, but the single-file entry avoids the question entirely, which seemed the better trade for a hotfix candidate.

`rules/migration-source-coverage.spec.mjs` and the rest of `rules/` still pass (20 tests).

### Steps for Testing

Prerequisites:
- 1 User

1. Log in to Artemis
2. Click your username in the top right, go to **User Settings**
3. Confirm there is clear separation between the settings menu on the left and the content on the right
4. Check a few subpages (Account information, SSH, Passkeys, Notifications) — the container is shared, so all of them are affected
5. Narrow the browser below 768px and confirm the menu stacks above the content

### Review Progress

#### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-03 20:41:52 UTC_


### Screenshots

The bug is a missing gap; a screenshot of the fix is best taken on a test server. The before state is in #13395.