### PR TITLE
`Text exercises`: Fix deleting feedback on a line of a text submission

### DIFF
--- a/src/main/webapp/app/text/manage/assess/textblock-assessment-card/text-block-assessment-card.component.spec.ts
+++ b/src/main/webapp/app/text/manage/assess/textblock-assessment-card/text-block-assessment-card.component.spec.ts
@@ -8,7 +8,7 @@ import { MockProvider } from 'ng-mocks';
 import { GradingInstruction } from 'app/exercise/structured-grading-criterion/grading-instruction.model';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { FeedbackType } from 'app/assessment/shared/entities/feedback.model';
-import { TextBlockType } from 'app/text/shared/entities/text-block.model';
+import { TextBlock, TextBlockType } from 'app/text/shared/entities/text-block.model';
 import { TextAssessmentEventType } from 'app/text/shared/entities/text-assesment-event.model';
 import { StructuredGradingCriterionService } from 'app/exercise/structured-grading-criterion/structured-grading-criterion.service';
 import { TextAssessmentAnalytics } from 'app/text/manage/assess/analytics/text-assessment-analytics.service';
@@ -152,6 +152,34 @@ describe('TextblockAssessmentCardComponent', () => {
         component.select();
         fixture.changeDetectorRef.detectChanges();
         expect(sendAssessmentEvent).toHaveBeenCalledWith(TextAssessmentEventType.ADD_FEEDBACK_AUTOMATICALLY_SELECTED_BLOCK, FeedbackType.MANUAL, TextBlockType.AUTOMATIC);
+    });
+
+    /**
+     * Deleting feedback from an automatic text block, i.e. a line of the submission, used to be impossible: the click on the
+     * close control bubbled to the editor host, whose `(click)="select(false)"` calls `TextBlockRef.initFeedback()` and
+     * re-created the feedback that `unselect()` had just removed. A manual block hid the problem, because it is additionally
+     * removed from the list via `didDelete`.
+     *
+     * The click has to go through the DOM: calling `dismiss()` on the editor directly never bubbles, which is why the
+     * existing tests above did not catch this.
+     */
+    it('should delete the feedback of an automatic text block when the close control is clicked', () => {
+        const block = new TextBlock();
+        block.type = TextBlockType.AUTOMATIC;
+        block.text = 'a line of the submission';
+        const textBlockRef = new TextBlockRef(block, { type: FeedbackType.MANUAL, credits: 0, detailText: '' });
+        fixture.componentRef.setInput('textBlockRef', textBlockRef);
+        fixture.changeDetectorRef.detectChanges();
+
+        const dismissIcon = fixture.debugElement.query(By.css('#dismiss-icon'));
+        expect(dismissIcon).toBeTruthy();
+
+        // No change detection afterwards on purpose: the click handlers run synchronously, and in the real page the parent
+        // destroys this editor in response to didSelect(undefined). Re-rendering it here instead would only exercise the
+        // test's own missing parent wiring.
+        dismissIcon.nativeElement.click();
+
+        expect(textBlockRef.feedback).toBeUndefined();
     });
 
     it('should not send assessment event when selecting text block that is unselectable', () => {

--- a/src/main/webapp/app/text/manage/assess/textblock-feedback-editor/text-block-feedback-editor.component.html
+++ b/src/main/webapp/app/text/manage/assess/textblock-feedback-editor/text-block-feedback-editor.component.html
@@ -3,7 +3,10 @@
         <jhi-feedback-suggestion-badge [feedback]="feedback()" [useDefaultText]="true" />
     }
     @if (!readOnly()) {
-        <div class="close">
+        <!-- Deleting is not selecting: the host of this editor treats any click as "select this text block", and selecting
+             re-creates the feedback that was just removed (TextBlockRef.initFeedback). Keep the close control's clicks,
+             including the confirm-icon's two-step click, from reaching it. -->
+        <div class="close" (click)="$event.stopPropagation()">
             @if (canDismiss) {
                 <fa-icon [icon]="faTimes" [ngbTooltip]="'artemisApp.textAssessment.feedbackEditor.dismissFeedback' | artemisTranslate" (click)="dismiss()" id="dismiss-icon" />
             } @else {


### PR DESCRIPTION
### Summary

Deleting a feedback item on a line of a text submission did nothing: the click deleted the feedback and then, still bubbling, immediately re-created it. One `stopPropagation` on the close control fixes it.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).

> The test-server checkbox is deliberately left off: I verified this with a red-green client test locally, not on a test server. @krusche please tick it once a tutor flow has been checked there, since this is a hotfix candidate.

### Motivation and Context

Fixes #13385. Reported on 9.8 while correcting an exam, and it blocks giving feedback on *parts* of a line, because the existing whole-line feedback cannot be removed.

The close control lives inside the feedback editor, and the editor's host reacts to any click by selecting the block:

```html
<jhi-text-block-feedback-editor
    (click)="select(false)"     <!-- host -->
    (onClose)="unselect()"
```

So clicking the "x" runs two handlers in sequence:

1. the icon's own handler → `dismiss()` → `onClose` → `unselect()`, which does `delete textBlockRef.feedback`
2. the same click bubbles to the host → `select(false)` → `textBlockRef.initFeedback()`, which **re-creates the feedback it just deleted**

Net effect: nothing is deleted.

This explains why the reporter saw it on a line and why it was never noticed elsewhere. `unselect()` only emits `didDelete` for **manual** blocks, and the parent then drops the ref from the list entirely, so a manual block disappears regardless of the re-created feedback. An **automatic** block, which is what a line of the submission is and what tutors click to add feedback, stays in the list, so the re-created feedback is plainly visible and the delete looks broken.

Not a 9.8 regression: the two handlers have coexisted since #10492. The reporter simply hit the automatic-block case.

### Description

The close control now stops its clicks from reaching the host. It is placed on the wrapping `div.close` rather than on the icon, so it covers both branches: the direct dismiss icon and the two-step confirm icon that appears once the feedback has text or a score.

### Steps for Testing

Prerequisites:
- 1 Instructor, 1 Tutor, 1 Student
- 1 Text exercise with a non-empty student submission

1. Log in as tutor and start assessing the submission
2. Click a line to add a feedback
3. Click the "x" on the feedback → it is removed and stays removed
4. Add a feedback, type a comment or set a score, then click "x" twice (the confirm step) → it is removed
5. Select a part of a line to create a manual block, add feedback, click "x" → the block disappears, as before
6. Confirm the assessment can still be saved and submitted

Worth repeating inside an exam exercise, since that is where it was reported.

### Review Progress

#### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-03 21:00:32 UTC_


### Test Coverage Notes

The existing `should delete feedback` tests called `dismiss()` on the editor component **directly**, which never produces a DOM event and therefore never bubbles — that is why this shipped. The added test clicks the real element and asserts the feedback stays gone. I verified it fails against the unfixed template and passes with the fix; all 103 tests under `app/text/manage/assess` pass.
