### PR TITLE
`Assessment`: Fix the second correction round collapsing into the first on save

### DIFF
--- a/src/main/webapp/app/assessment/manage/assessment-header/assessment-header.component.html
+++ b/src/main/webapp/app/assessment/manage/assessment-header/assessment-header.component.html
@@ -104,6 +104,7 @@
             <div class="d-flex flex-wrap flex-lg-nowrap">
                 @if (!result()?.completionDate) {
                     <button
+                        id="save"
                         class="btn m-1 btn-primary"
                         (click)="save.emit()"
                         [disabled]="saveDisabled"

--- a/src/main/webapp/app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component.html
+++ b/src/main/webapp/app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component.html
@@ -9,7 +9,7 @@
         ) {
             <div class="d-flex align-items-center gap-1">
                 <a
-                    [routerLink]="getAssessmentLink(correctionRound)"
+                    [routerLink]="getAssessmentLink()"
                     [queryParams]="{ 'correction-round': getCorrectionRoundForAssessmentLink(correctionRound) }"
                     class="btn btn-sm"
                     [class.btn-success]="

--- a/src/main/webapp/app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import dayjs from 'dayjs/esm';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ManageAssessmentButtonsComponent } from 'app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component';
 import { MockProvider } from 'ng-mocks';
@@ -133,6 +134,36 @@ describe('ManageAssessmentButtonsComponent', () => {
             const result = comp.getAssessmentLink();
 
             expect(result).toBeDefined();
+        });
+    });
+
+    describe('getAssessmentLink with two correction rounds', () => {
+        /**
+         * The scores overview builds its participation from a DTO carrying a single result, so the result array cannot
+         * identify a correction round. The link must therefore not contain a result id for any round, otherwise round 0
+         * opens whichever result the DTO happens to carry (issue #13396).
+         */
+        it('should not put a result id in the link for either correction round', () => {
+            fixture.componentRef.setInput('exercise', {
+                id: 1,
+                type: ExerciseType.TEXT,
+                exerciseGroup: { id: 3, exam: { id: 2, numberOfCorrectionRoundsInExam: 2 } },
+            } as Exercise);
+            fixture.componentRef.setInput('participation', {
+                id: 1,
+                // The single result the DTO provides is the newest round, not round 0.
+                submissions: [{ id: 1, results: [{ id: 99, completionDate: dayjs() }] } as Submission],
+            } as Participation);
+
+            const firstRoundLink = comp.getAssessmentLink();
+            const secondRoundLink = comp.getAssessmentLink();
+
+            expect(firstRoundLink).toBeDefined();
+            expect(secondRoundLink).toBeDefined();
+            expect(firstRoundLink).not.toContain('99');
+            expect(secondRoundLink).not.toContain('99');
+            // Both rounds address the same submission and are distinguished only by the correction-round parameter.
+            expect(firstRoundLink).toEqual(secondRoundLink);
         });
     });
 

--- a/src/main/webapp/app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component.ts
+++ b/src/main/webapp/app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component.ts
@@ -61,7 +61,11 @@ export class ManageAssessmentButtonsComponent implements OnInit {
         this.correctionRoundIndices.set([...Array(this.exercise().exerciseGroup?.exam?.numberOfCorrectionRoundsInExam ?? 1).keys()]);
     }
 
-    getAssessmentLink(correctionRound = 0) {
+    /**
+     * The route to the assessment editor. The correction round is not part of it: the template supplies it as the
+     * correction-round query parameter via {@link getCorrectionRoundForAssessmentLink}.
+     */
+    getAssessmentLink() {
         const exercise = this.exercise();
         const course = this.course();
         const participation = this.participation();
@@ -69,19 +73,12 @@ export class ManageAssessmentButtonsComponent implements OnInit {
         if (!exercise.type || !exercise.id || !course.id || !submission?.id) {
             return;
         }
-        correctionRound = this.getCorrectionRoundForAssessmentLink(correctionRound);
-
-        return getLinkToSubmissionAssessment(
-            exercise.type,
-            course.id,
-            exercise.id,
-            participation.id,
-            submission.id,
-            exercise.exerciseGroup?.exam?.id,
-            exercise.exerciseGroup?.id,
-            // TODO do we need to handle this differently for programming exercises?
-            submission.results?.[correctionRound]?.id,
-        );
+        // Navigate by correction round only. The scores overview builds its participation from a DTO that carries a
+        // single result (ExerciseScoresComponent#toParticipation), so indexing that array by correction round cannot
+        // identify the round's result: round 0 would hand over whichever result the DTO happens to carry and any later
+        // round has none at all. The editor resolves the round from the correction-round query parameter, which is
+        // authoritative, and passing no result id also stops the server from reducing the submission to one result.
+        return getLinkToSubmissionAssessment(exercise.type, course.id, exercise.id, participation.id, submission.id, exercise.exerciseGroup?.exam?.id, exercise.exerciseGroup?.id);
     }
 
     getCorrectionRoundForAssessmentLink(correctionRound = 0): number {

--- a/src/main/webapp/app/exercise/shared/entities/submission/submission.model.spec.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission.model.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import {
+    Submission,
+    getCorrectionRoundOfResult,
+    getSubmissionResultByCorrectionRound,
+    setSubmissionResultByCorrectionRound,
+} from 'app/exercise/shared/entities/submission/submission.model';
+import { Result } from 'app/exercise/shared/entities/result/result.model';
+import { AssessmentType } from 'app/assessment/shared/entities/assessment-type.model';
+
+/**
+ * A correction round is an index into the submission's results, but Athena results are not correction rounds and are
+ * skipped. Reading and writing therefore have to agree on that index space, otherwise saving an assessment lands in the
+ * wrong slot and silently rewrites another round's result.
+ */
+describe('Submission model correction round accessors', () => {
+    const resultWith = (id: number, assessmentType: AssessmentType): Result => ({ id, assessmentType }) as Result;
+
+    /**
+     * @param results the results in the order the server returned them
+     * @returns a submission carrying those results
+     */
+    function submissionWith(results: Result[]): Submission {
+        return { id: 1, results } as Submission;
+    }
+
+    it('should read the correction round result skipping an Athena result', () => {
+        const athena = resultWith(10, AssessmentType.AUTOMATIC_ATHENA);
+        const firstRound = resultWith(11, AssessmentType.MANUAL);
+        const secondRound = resultWith(12, AssessmentType.MANUAL);
+        const submission = submissionWith([athena, firstRound, secondRound]);
+
+        expect(getSubmissionResultByCorrectionRound(submission, 0)).toBe(firstRound);
+        expect(getSubmissionResultByCorrectionRound(submission, 1)).toBe(secondRound);
+    });
+
+    it('should write the correction round result into the slot it is read from when an Athena result is present', () => {
+        const athena = resultWith(10, AssessmentType.AUTOMATIC_ATHENA);
+        const firstRound = resultWith(11, AssessmentType.MANUAL);
+        const secondRound = resultWith(12, AssessmentType.MANUAL);
+        const submission = submissionWith([athena, firstRound, secondRound]);
+        const savedSecondRound = resultWith(12, AssessmentType.MANUAL);
+
+        setSubmissionResultByCorrectionRound(submission, savedSecondRound, 1);
+
+        // The first correction round must be untouched: overwriting it is what made a saved second-round assessment
+        // reappear as the first round's result.
+        expect(getSubmissionResultByCorrectionRound(submission, 0)).toBe(firstRound);
+        expect(getSubmissionResultByCorrectionRound(submission, 1)).toBe(savedSecondRound);
+        expect(submission.results).toContain(athena);
+    });
+
+    it('should report the correction round of a result skipping an Athena result', () => {
+        const athena = resultWith(10, AssessmentType.AUTOMATIC_ATHENA);
+        const firstRound = resultWith(11, AssessmentType.MANUAL);
+        const secondRound = resultWith(12, AssessmentType.MANUAL);
+        const submission = submissionWith([athena, firstRound, secondRound]);
+
+        // The raw positions are 1 and 2; as correction rounds they are 0 and 1.
+        expect(getCorrectionRoundOfResult(submission, 11)).toBe(0);
+        expect(getCorrectionRoundOfResult(submission, 12)).toBe(1);
+    });
+
+    it('should report no correction round for an unknown or Athena result', () => {
+        const athena = resultWith(10, AssessmentType.AUTOMATIC_ATHENA);
+        const firstRound = resultWith(11, AssessmentType.MANUAL);
+        const submission = submissionWith([athena, firstRound]);
+
+        expect(getCorrectionRoundOfResult(submission, 10)).toBeUndefined();
+        expect(getCorrectionRoundOfResult(submission, 999)).toBeUndefined();
+        expect(getCorrectionRoundOfResult(undefined, 11)).toBeUndefined();
+    });
+
+    it('should stay symmetric without Athena results', () => {
+        const firstRound = resultWith(11, AssessmentType.MANUAL);
+        const secondRound = resultWith(12, AssessmentType.MANUAL);
+        const submission = submissionWith([firstRound, secondRound]);
+        const savedSecondRound = resultWith(12, AssessmentType.MANUAL);
+
+        setSubmissionResultByCorrectionRound(submission, savedSecondRound, 1);
+
+        expect(getSubmissionResultByCorrectionRound(submission, 0)).toBe(firstRound);
+        expect(getSubmissionResultByCorrectionRound(submission, 1)).toBe(savedSecondRound);
+        expect(submission.latestResult).toBe(savedSecondRound);
+    });
+
+    it('should mark the newest correction round as the latest result even behind an Athena result', () => {
+        const athena = resultWith(10, AssessmentType.AUTOMATIC_ATHENA);
+        const firstRound = resultWith(11, AssessmentType.MANUAL);
+        const submission = submissionWith([athena, firstRound]);
+        const savedFirstRound = resultWith(11, AssessmentType.MANUAL);
+
+        setSubmissionResultByCorrectionRound(submission, savedFirstRound, 0);
+
+        expect(submission.latestResult).toBe(savedFirstRound);
+    });
+});

--- a/src/main/webapp/app/exercise/shared/entities/submission/submission.model.spec.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission.model.spec.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-    Submission,
-    getCorrectionRoundOfResult,
-    getSubmissionResultByCorrectionRound,
-    setSubmissionResultByCorrectionRound,
-} from 'app/exercise/shared/entities/submission/submission.model';
+import { Submission, getSubmissionResultByCorrectionRound, setSubmissionResultByCorrectionRound } from 'app/exercise/shared/entities/submission/submission.model';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { AssessmentType } from 'app/assessment/shared/entities/assessment-type.model';
 
@@ -48,27 +43,6 @@ describe('Submission model correction round accessors', () => {
         expect(getSubmissionResultByCorrectionRound(submission, 0)).toBe(firstRound);
         expect(getSubmissionResultByCorrectionRound(submission, 1)).toBe(savedSecondRound);
         expect(submission.results).toContain(athena);
-    });
-
-    it('should report the correction round of a result skipping an Athena result', () => {
-        const athena = resultWith(10, AssessmentType.AUTOMATIC_ATHENA);
-        const firstRound = resultWith(11, AssessmentType.MANUAL);
-        const secondRound = resultWith(12, AssessmentType.MANUAL);
-        const submission = submissionWith([athena, firstRound, secondRound]);
-
-        // The raw positions are 1 and 2; as correction rounds they are 0 and 1.
-        expect(getCorrectionRoundOfResult(submission, 11)).toBe(0);
-        expect(getCorrectionRoundOfResult(submission, 12)).toBe(1);
-    });
-
-    it('should report no correction round for an unknown or Athena result', () => {
-        const athena = resultWith(10, AssessmentType.AUTOMATIC_ATHENA);
-        const firstRound = resultWith(11, AssessmentType.MANUAL);
-        const submission = submissionWith([athena, firstRound]);
-
-        expect(getCorrectionRoundOfResult(submission, 10)).toBeUndefined();
-        expect(getCorrectionRoundOfResult(submission, 999)).toBeUndefined();
-        expect(getCorrectionRoundOfResult(undefined, 11)).toBeUndefined();
     });
 
     it('should stay symmetric without Athena results', () => {

--- a/src/main/webapp/app/exercise/shared/entities/submission/submission.model.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission.model.ts
@@ -62,6 +62,20 @@ export function getLatestSubmissionResult(submission: Submission | undefined): R
 }
 
 /**
+ * A correction round indexes only the results that are correction rounds. Automatic results, whether from continuous
+ * integration or from Athena, are not correction rounds and are skipped, matching the server's
+ * {@code Submission#filterNonAutomaticResults}. Filtering only Athena results here made the client disagree with the
+ * server as soon as a plain automatic result was present, for example [AUTOMATIC, SEMI_AUTOMATIC] on a programming
+ * exercise, where the server calls the manual result round 0 and the client called it round 1.
+ *
+ * @param results the results in the order the server returned them
+ * @returns the results that are correction rounds, in order
+ */
+function correctionRoundResults(results: Result[]): Result[] {
+    return results.filter((result) => result?.assessmentType !== AssessmentType.AUTOMATIC && result?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA);
+}
+
+/**
  * Used to access a submissions result for a specific correctionRound
  * Athena Results need to be excluded to avoid an assessment being locked by null
  * @param submission
@@ -69,10 +83,10 @@ export function getLatestSubmissionResult(submission: Submission | undefined): R
  * @returns the results or undefined if submission or the result for the requested correctionRound is undefined
  */
 export function getSubmissionResultByCorrectionRound(submission: Submission | undefined, correctionRound: number): Result | undefined {
-    if (submission?.results && submission?.results.filter((result) => result?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA).length >= correctionRound) {
-        return submission.results.filter((result) => result?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA)[correctionRound];
+    if (!submission?.results || correctionRound < 0) {
+        return undefined;
     }
-    return undefined;
+    return correctionRoundResults(submission.results)[correctionRound];
 }
 
 /**
@@ -126,7 +140,7 @@ export function setSubmissionResultByCorrectionRound(submission: Submission, res
     }
     const correctionRoundIndices = submission.results
         .map((existingResult, index) => ({ existingResult, index }))
-        .filter(({ existingResult }) => existingResult?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA)
+        .filter(({ existingResult }) => correctionRoundResults([existingResult]).length > 0)
         .map(({ index }) => index);
 
     // A round beyond the known ones is appended rather than written over an unrelated slot.

--- a/src/main/webapp/app/exercise/shared/entities/submission/submission.model.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission.model.ts
@@ -87,6 +87,23 @@ export function getSubmissionResultById(submission: Submission | undefined, resu
 }
 
 /**
+ * Determines which correction round a result belongs to.
+ * <p>
+ * Counts only the results that are correction rounds, so Athena results are skipped exactly as
+ * {@link getSubmissionResultByCorrectionRound} and {@link setSubmissionResultByCorrectionRound} skip them. Using the raw
+ * position in {@link Submission#results} instead would report a round that is too high as soon as an Athena result
+ * precedes, which then reads and writes the wrong round.
+ *
+ * @param submission the submission the result belongs to
+ * @param resultId   the id of the result whose correction round is wanted
+ * @returns the zero-based correction round, or undefined if the submission has no such result
+ */
+export function getCorrectionRoundOfResult(submission: Submission | undefined, resultId: number): number | undefined {
+    const correctionRoundIndex = submission?.results?.filter((result) => result?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA).findIndex((result) => result.id === resultId);
+    return correctionRoundIndex === undefined || correctionRoundIndex < 0 ? undefined : correctionRoundIndex;
+}
+
+/**
  * Used to set / override the latest result in the results list, and set / override the
  * var latestResult
  *
@@ -108,13 +125,32 @@ export function setLatestSubmissionResult(submission: Submission | undefined, re
     submission.latestResult = result;
 }
 
+/**
+ * Used to set / override the result of a specific correctionRound, and to keep {@link Submission#latestResult} in sync.
+ * <p>
+ * A correction round indexes only the results that are correction rounds, so Athena results are skipped exactly as
+ * {@link getSubmissionResultByCorrectionRound} skips them when reading. Writing into the raw list at the same index
+ * would land in the wrong slot as soon as an Athena result precedes, silently replacing another round's result: saving a
+ * second-round assessment then made it reappear as the first round's result.
+ *
+ * @param submission      the submission whose result list is updated
+ * @param result          the result to store for the given round
+ * @param correctionRound the correction round the result belongs to
+ */
 export function setSubmissionResultByCorrectionRound(submission: Submission, result: Result, correctionRound: number) {
-    if (!submission || !result || !submission.results) {
+    if (!submission || !result || !submission.results || correctionRound < 0) {
         return;
     }
-    submission.results[correctionRound] = result;
+    const correctionRoundIndices = submission.results
+        .map((existingResult, index) => ({ existingResult, index }))
+        .filter(({ existingResult }) => existingResult?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA)
+        .map(({ index }) => index);
 
-    if (submission.results.length === correctionRound + 1) {
+    // A round beyond the known ones is appended rather than written over an unrelated slot.
+    submission.results[correctionRoundIndices[correctionRound] ?? submission.results.length] = result;
+
+    const numberOfCorrectionRounds = Math.max(correctionRoundIndices.length, correctionRound + 1);
+    if (correctionRound === numberOfCorrectionRounds - 1) {
         submission.latestResult = result;
     }
 }

--- a/src/main/webapp/app/exercise/shared/entities/submission/submission.model.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission.model.ts
@@ -87,23 +87,6 @@ export function getSubmissionResultById(submission: Submission | undefined, resu
 }
 
 /**
- * Determines which correction round a result belongs to.
- * <p>
- * Counts only the results that are correction rounds, so Athena results are skipped exactly as
- * {@link getSubmissionResultByCorrectionRound} and {@link setSubmissionResultByCorrectionRound} skip them. Using the raw
- * position in {@link Submission#results} instead would report a round that is too high as soon as an Athena result
- * precedes, which then reads and writes the wrong round.
- *
- * @param submission the submission the result belongs to
- * @param resultId   the id of the result whose correction round is wanted
- * @returns the zero-based correction round, or undefined if the submission has no such result
- */
-export function getCorrectionRoundOfResult(submission: Submission | undefined, resultId: number): number | undefined {
-    const correctionRoundIndex = submission?.results?.filter((result) => result?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA).findIndex((result) => result.id === resultId);
-    return correctionRoundIndex === undefined || correctionRoundIndex < 0 ? undefined : correctionRoundIndex;
-}
-
-/**
  * Used to set / override the latest result in the results list, and set / override the
  * var latestResult
  *

--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
@@ -363,8 +363,9 @@ export class FileUploadAssessmentComponent implements OnInit {
                     this.exerciseGroupId,
                 );
                 // Carry the correction round: the component reads it from the URL, so dropping it here sent the next
-                // submission into the first correction round.
-                void this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() } });
+                // submission into the first correction round. Merge rather than replace, otherwise a supplied
+                // queryParams object drops every other parameter, testRun among them.
+                void this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() }, queryParamsHandling: 'merge' });
             },
             error: (error: HttpErrorResponse) => {
                 this.isLoading.set(false);

--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
@@ -17,7 +17,7 @@ import { FileUploadExercise } from 'app/fileupload/shared/entities/file-upload-e
 import { FileUploadSubmission } from 'app/fileupload/shared/entities/file-upload-submission.model';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
-import { getCorrectionRoundOfResult, getLatestSubmissionResult, getSubmissionResultById } from 'app/exercise/shared/entities/submission/submission.model';
+import { getLatestSubmissionResult, getSubmissionResultById } from 'app/exercise/shared/entities/submission/submission.model';
 import { FileUploadAssessmentService } from 'app/fileupload/manage/assess/file-upload-assessment.service';
 import { FileUploadSubmissionService } from 'app/fileupload/overview/file-upload-submission.service';
 import { getPositiveAndCappedTotalScore, getTotalMaxPoints } from 'app/exercise/util/exercise.utils';
@@ -276,7 +276,8 @@ export class FileUploadAssessmentComponent implements OnInit {
         this.course.set(getCourseFromExercise(exercise));
         this.hasAssessmentDueDatePassed.set(!!exercise.assessmentDueDate && dayjs(exercise.assessmentDueDate).isBefore(dayjs()));
         if (this.resultId > 0) {
-            this.correctionRound.set(getCorrectionRoundOfResult(submission, this.resultId) ?? 0);
+            // The correction round stays as read from the URL rather than being looked up in the results list: the
+            // list can be reduced to the requested result, which would report every reopened assessment as round 1.
             this.result.set(getSubmissionResultById(submission, this.resultId));
         } else {
             this.result.set(getLatestSubmissionResult(submission));

--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
@@ -17,7 +17,7 @@ import { FileUploadExercise } from 'app/fileupload/shared/entities/file-upload-e
 import { FileUploadSubmission } from 'app/fileupload/shared/entities/file-upload-submission.model';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
-import { getLatestSubmissionResult, getSubmissionResultById } from 'app/exercise/shared/entities/submission/submission.model';
+import { getCorrectionRoundOfResult, getLatestSubmissionResult, getSubmissionResultById } from 'app/exercise/shared/entities/submission/submission.model';
 import { FileUploadAssessmentService } from 'app/fileupload/manage/assess/file-upload-assessment.service';
 import { FileUploadSubmissionService } from 'app/fileupload/overview/file-upload-submission.service';
 import { getPositiveAndCappedTotalScore, getTotalMaxPoints } from 'app/exercise/util/exercise.utils';
@@ -276,8 +276,7 @@ export class FileUploadAssessmentComponent implements OnInit {
         this.course.set(getCourseFromExercise(exercise));
         this.hasAssessmentDueDatePassed.set(!!exercise.assessmentDueDate && dayjs(exercise.assessmentDueDate).isBefore(dayjs()));
         if (this.resultId > 0) {
-            const foundIndex = submission.results?.findIndex((result) => result.id === this.resultId);
-            this.correctionRound.set(foundIndex !== undefined && foundIndex >= 0 ? foundIndex : 0);
+            this.correctionRound.set(getCorrectionRoundOfResult(submission, this.resultId) ?? 0);
             this.result.set(getSubmissionResultById(submission, this.resultId));
         } else {
             this.result.set(getLatestSubmissionResult(submission));

--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
@@ -133,11 +133,12 @@ export class FileUploadAssessmentComponent implements OnInit {
         });
         this.route.queryParamMap.subscribe((queryParams) => {
             this.isTestRun.set(queryParams.get('testRun') === 'true');
-            // Only override when the parameter is present and sane: Number(null) is 0, which silently means the first
-            // correction round, and an arbitrary query string could otherwise put NaN or a fraction into the round.
-            const correctionRoundParam = Number(queryParams.get('correction-round'));
-            if (Number.isSafeInteger(correctionRoundParam) && correctionRoundParam >= 0) {
-                this.correctionRound.set(correctionRoundParam);
+            // Only override when the parameter is really there and sane. The emptiness check has to come first:
+            // Number(null) is 0, which is a valid looking round and would silently mean the first correction round.
+            const rawCorrectionRound = queryParams.get('correction-round');
+            const parsedCorrectionRound = Number(rawCorrectionRound);
+            if (rawCorrectionRound !== null && rawCorrectionRound !== '' && Number.isSafeInteger(parsedCorrectionRound) && parsedCorrectionRound >= 0) {
+                this.correctionRound.set(parsedCorrectionRound);
             }
         });
 

--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
@@ -133,9 +133,11 @@ export class FileUploadAssessmentComponent implements OnInit {
         });
         this.route.queryParamMap.subscribe((queryParams) => {
             this.isTestRun.set(queryParams.get('testRun') === 'true');
-            const correctionRoundParam = queryParams.get('correction-round');
-            if (correctionRoundParam) {
-                this.correctionRound.set(parseInt(correctionRoundParam, 10));
+            // Only override when the parameter is present and sane: Number(null) is 0, which silently means the first
+            // correction round, and an arbitrary query string could otherwise put NaN or a fraction into the round.
+            const correctionRoundParam = Number(queryParams.get('correction-round'));
+            if (Number.isSafeInteger(correctionRoundParam) && correctionRoundParam >= 0) {
+                this.correctionRound.set(correctionRoundParam);
             }
         });
 
@@ -360,7 +362,9 @@ export class FileUploadAssessmentComponent implements OnInit {
                     this.examId,
                     this.exerciseGroupId,
                 );
-                void this.router.navigate(url);
+                // Carry the correction round: the component reads it from the URL, so dropping it here sent the next
+                // submission into the first correction round.
+                void this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() } });
             },
             error: (error: HttpErrorResponse) => {
                 this.isLoading.set(false);

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
@@ -584,7 +584,7 @@ describe('ModelingAssessmentEditorComponent', () => {
             component.modelingExercise.set({ id: exerciseId } as Exercise);
             component.exerciseId = exerciseId;
             const url = ['/course-management', courseId.toString(), 'modeling-exercises', exerciseId.toString(), 'submissions', modelingSubmission.id!.toString(), 'assessment'];
-            const queryParams = { queryParams: { 'correction-round': correctionRound } };
+            const queryParams = { queryParams: { 'correction-round': correctionRound }, queryParamsHandling: 'merge' };
 
             await fixture.whenStable();
             component.assessNext();

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -21,7 +21,7 @@ import { Complaint, ComplaintType } from 'app/assessment/shared/entities/complai
 import { ModelingAssessmentService } from 'app/modeling/manage/assess/modeling-assessment.service';
 import { assessmentNavigateBack } from 'app/foundation/util/navigate-back.util';
 import { StructuredGradingCriterionService } from 'app/exercise/structured-grading-criterion/structured-grading-criterion.service';
-import { Submission, getCorrectionRoundOfResult, getSubmissionResultByCorrectionRound, getSubmissionResultById } from 'app/exercise/shared/entities/submission/submission.model';
+import { Submission, getSubmissionResultByCorrectionRound, getSubmissionResultById } from 'app/exercise/shared/entities/submission/submission.model';
 import { getExerciseDashboardLink, getLinkToSubmissionAssessment } from 'app/foundation/util/navigation.utils';
 import { ExerciseType, getCourseFromExercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { SubmissionService } from 'app/exercise/submission/submission.service';
@@ -150,7 +150,11 @@ export class ModelingAssessmentEditorComponent implements OnInit {
 
         this.route.queryParamMap.subscribe((queryParams) => {
             this.isTestRun.set(queryParams.get('testRun') === 'true');
-            this.correctionRound.set(Number(queryParams.get('correction-round')));
+            // Only override when the parameter is present: Number(null) is 0 and would silently mean round 1.
+            const correctionRoundParam = queryParams.get('correction-round');
+            if (correctionRoundParam) {
+                this.correctionRound.set(Number(correctionRoundParam));
+            }
         });
         this.route.paramMap.subscribe((params) => {
             // this component is reused for param-only navigations (e.g. to the next submission), so a blocked state from
@@ -235,7 +239,8 @@ export class ModelingAssessmentEditorComponent implements OnInit {
         this.course.set(getCourseFromExercise(this.modelingExercise()));
         if (this.resultId() > 0) {
             this.result.set(getSubmissionResultById(submission, this.resultId()));
-            this.correctionRound.set(getCorrectionRoundOfResult(submission, this.resultId()) ?? 0);
+            // The correction round stays as read from the URL rather than being looked up in the results list: the
+            // list can be reduced to the requested result, which would report every reopened assessment as round 1.
         } else {
             this.result.set(getSubmissionResultByCorrectionRound(this.submission(), this.correctionRound()));
         }

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -21,7 +21,7 @@ import { Complaint, ComplaintType } from 'app/assessment/shared/entities/complai
 import { ModelingAssessmentService } from 'app/modeling/manage/assess/modeling-assessment.service';
 import { assessmentNavigateBack } from 'app/foundation/util/navigate-back.util';
 import { StructuredGradingCriterionService } from 'app/exercise/structured-grading-criterion/structured-grading-criterion.service';
-import { Submission, getSubmissionResultByCorrectionRound, getSubmissionResultById } from 'app/exercise/shared/entities/submission/submission.model';
+import { Submission, getCorrectionRoundOfResult, getSubmissionResultByCorrectionRound, getSubmissionResultById } from 'app/exercise/shared/entities/submission/submission.model';
 import { getExerciseDashboardLink, getLinkToSubmissionAssessment } from 'app/foundation/util/navigation.utils';
 import { ExerciseType, getCourseFromExercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { SubmissionService } from 'app/exercise/submission/submission.service';
@@ -235,8 +235,7 @@ export class ModelingAssessmentEditorComponent implements OnInit {
         this.course.set(getCourseFromExercise(this.modelingExercise()));
         if (this.resultId() > 0) {
             this.result.set(getSubmissionResultById(submission, this.resultId()));
-            // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-            this.correctionRound.set(submission.results?.findIndex((result) => result.id === this.resultId())!);
+            this.correctionRound.set(getCorrectionRoundOfResult(submission, this.resultId()) ?? 0);
         } else {
             this.result.set(getSubmissionResultByCorrectionRound(this.submission(), this.correctionRound()));
         }

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -594,7 +594,8 @@ export class ModelingAssessmentEditorComponent implements OnInit {
                 this.isLoading.set(false);
 
                 const url = getLinkToSubmissionAssessment(ExerciseType.MODELING, this.courseId, this.exerciseId, undefined, submission.id!, this.examId, this.exerciseGroupId);
-                void this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() } });
+                // Merge rather than replace: a supplied queryParams object drops every other parameter, testRun among them.
+                void this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() }, queryParamsHandling: 'merge' });
             },
             error: (error: HttpErrorResponse) => {
                 this.nextSubmissionBusy.set(false);

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -150,10 +150,11 @@ export class ModelingAssessmentEditorComponent implements OnInit {
 
         this.route.queryParamMap.subscribe((queryParams) => {
             this.isTestRun.set(queryParams.get('testRun') === 'true');
-            // Only override when the parameter is present: Number(null) is 0 and would silently mean round 1.
-            const correctionRoundParam = queryParams.get('correction-round');
-            if (correctionRoundParam) {
-                this.correctionRound.set(Number(correctionRoundParam));
+            // Only override when the parameter is present and sane: Number(null) is 0, which silently means the first
+            // correction round, and an arbitrary query string could otherwise put NaN or a fraction into the round.
+            const correctionRoundParam = Number(queryParams.get('correction-round'));
+            if (Number.isSafeInteger(correctionRoundParam) && correctionRoundParam >= 0) {
+                this.correctionRound.set(correctionRoundParam);
             }
         });
         this.route.paramMap.subscribe((params) => {

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -150,11 +150,12 @@ export class ModelingAssessmentEditorComponent implements OnInit {
 
         this.route.queryParamMap.subscribe((queryParams) => {
             this.isTestRun.set(queryParams.get('testRun') === 'true');
-            // Only override when the parameter is present and sane: Number(null) is 0, which silently means the first
-            // correction round, and an arbitrary query string could otherwise put NaN or a fraction into the round.
-            const correctionRoundParam = Number(queryParams.get('correction-round'));
-            if (Number.isSafeInteger(correctionRoundParam) && correctionRoundParam >= 0) {
-                this.correctionRound.set(correctionRoundParam);
+            // Only override when the parameter is really there and sane. The emptiness check has to come first:
+            // Number(null) is 0, which is a valid looking round and would silently mean the first correction round.
+            const rawCorrectionRound = queryParams.get('correction-round');
+            const parsedCorrectionRound = Number(rawCorrectionRound);
+            if (rawCorrectionRound !== null && rawCorrectionRound !== '' && Number.isSafeInteger(parsedCorrectionRound) && parsedCorrectionRound >= 0) {
+                this.correctionRound.set(parsedCorrectionRound);
             }
         });
         this.route.paramMap.subscribe((params) => {

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
@@ -14,7 +14,7 @@ import { LocalStorageService } from 'app/foundation/service/local-storage.servic
 import { SessionStorageService } from 'app/foundation/service/session-storage.service';
 import { TextSubmissionAssessmentComponent } from 'app/text/manage/assess/submission-assessment/text-submission-assessment.component';
 import { By } from '@angular/platform-browser';
-import { of, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { AssessmentLayoutComponent } from 'app/assessment/manage/assessment-layout/assessment-layout.component';
 import { TextAssessmentAreaComponent } from 'app/text/manage/assess/text-assessment-area/text-assessment-area.component';
 import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
@@ -29,7 +29,7 @@ import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
 import dayjs from 'dayjs/esm';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
-import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
+import { ActivatedRoute, ParamMap, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { Location } from '@angular/common';
 import { NEW_ASSESSMENT_PATH } from 'app/text/manage/assess/text-submission-assessment.route';
 import { ConfirmIconComponent } from 'app/shared-ui/confirm-icon/confirm-icon.component';
@@ -247,7 +247,8 @@ describe('TextSubmissionAssessmentComponent', () => {
         component.correctionRound.set(1);
 
         const queryParams = convertToParamMap(param === undefined ? {} : { 'correction-round': param });
-        component['route'].queryParamMap = of(queryParams);
+        // queryParamMap is declared readonly on ActivatedRoute, so the mock is reached through a writable view.
+        (component['route'] as unknown as { queryParamMap: Observable<ParamMap> }).queryParamMap = of(queryParams);
         // ngOnInit is async and subscribes after its first await, so the assertion has to wait for it.
         await component.ngOnInit();
 

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
@@ -236,6 +236,24 @@ describe('TextSubmissionAssessmentComponent', () => {
         expect(sharedLayout).not.toBeNull();
     });
 
+    it.each([
+        { param: undefined, description: 'absent' },
+        { param: '', description: 'empty' },
+        { param: 'abc', description: 'not a number' },
+        { param: '1.5', description: 'fractional' },
+    ])('should not treat a $description correction-round parameter as the first round', async ({ param }) => {
+        // Number(null) is 0, so parsing before checking for emptiness silently means the first correction round, which
+        // is exactly how a second-round assessment collapsed into the first one (issue #13396).
+        component.correctionRound.set(1);
+
+        const queryParams = convertToParamMap(param === undefined ? {} : { 'correction-round': param });
+        component['route'].queryParamMap = of(queryParams);
+        // ngOnInit is async and subscribes after its first await, so the assertion has to wait for it.
+        await component.ngOnInit();
+
+        expect(component.correctionRound()).toBe(1);
+    });
+
     it('should keep the query parameters when rewriting the new-assessment url', () => {
         // The correction round lives only in the URL. Rebuilding it without the query parameters turned a second-round
         // assessment into a first-round one on the next reload, which is the core of issue #13396.

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
@@ -30,6 +30,8 @@ import { Result } from 'app/exercise/shared/entities/result/result.model';
 import dayjs from 'dayjs/esm';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
+import { Location } from '@angular/common';
+import { NEW_ASSESSMENT_PATH } from 'app/text/manage/assess/text-submission-assessment.route';
 import { ConfirmIconComponent } from 'app/shared-ui/confirm-icon/confirm-icon.component';
 import { Course } from 'app/course/shared/entities/course.model';
 import { ManualTextblockSelectionComponent } from 'app/text/manage/assess/manual-textblock-selection/manual-textblock-selection.component';
@@ -232,6 +234,21 @@ describe('TextSubmissionAssessmentComponent', () => {
     it('should use jhi-assessment-layout', () => {
         const sharedLayout = fixture.debugElement.query(By.directive(AssessmentLayoutComponent));
         expect(sharedLayout).not.toBeNull();
+    });
+
+    it('should keep the query parameters when rewriting the new-assessment url', () => {
+        // The correction round lives only in the URL. Rebuilding it without the query parameters turned a second-round
+        // assessment into a first-round one on the next reload, which is the core of issue #13396.
+        const router = TestBed.inject(Router);
+        const createUrlTreeSpy = vi.spyOn(router, 'createUrlTree').mockReturnValue({ toString: () => '/rewritten' } as any);
+        const goSpy = vi.spyOn(TestBed.inject(Location), 'go').mockImplementation(() => {});
+        component['activatedRoute'] = { routeConfig: { path: NEW_ASSESSMENT_PATH } } as any;
+        component['route'] = { snapshot: { queryParams: { 'correction-round': '1', testRun: 'false' } } } as any;
+
+        component['updateUrlIfNeeded']();
+
+        expect(createUrlTreeSpy).toHaveBeenCalledExactlyOnceWith(expect.anything(), { queryParams: { 'correction-round': '1', testRun: 'false' } });
+        expect(goSpy).toHaveBeenCalledExactlyOnceWith('/rewritten');
     });
 
     describe('when assessment is not possible yet', () => {

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
@@ -484,7 +484,7 @@ describe('TextSubmissionAssessmentComponent', () => {
             'new',
             'assessment',
         ];
-        const queryParams = { queryParams: { 'correction-round': 0 } };
+        const queryParams = { queryParams: { 'correction-round': 0 }, queryParamsHandling: 'merge' };
 
         component.nextSubmission();
         expect(routerSpy).toHaveBeenCalledOnce();

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
@@ -16,6 +16,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { NEW_ASSESSMENT_PATH } from 'app/text/manage/assess/text-submission-assessment.route';
 import { assessmentNavigateBack } from 'app/foundation/util/navigate-back.util';
 import {
+    getCorrectionRoundOfResult,
     getLatestSubmissionResult,
     getSubmissionResultByCorrectionRound,
     getSubmissionResultById,
@@ -222,8 +223,7 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
 
         if (this.resultId() > 0) {
             this.result.set(getSubmissionResultById(this.submission, this.resultId()));
-            // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-            this.correctionRound.set(this.submission!.results?.findIndex((result) => result.id === this.resultId())!);
+            this.correctionRound.set(getCorrectionRoundOfResult(this.submission, this.resultId()) ?? 0);
         } else {
             this.result.set(getSubmissionResultByCorrectionRound(this.submission, this.correctionRound()));
         }

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
@@ -177,11 +177,12 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
         await super.ngOnInit();
         this.route.queryParamMap.subscribe((queryParams) => {
             this.isTestRun.set(queryParams.get('testRun') === 'true');
-            // Only override when the parameter is present and sane: Number(null) is 0, which silently means the first
-            // correction round, and an arbitrary query string could otherwise put NaN or a fraction into the round.
-            const correctionRoundParam = Number(queryParams.get('correction-round'));
-            if (Number.isSafeInteger(correctionRoundParam) && correctionRoundParam >= 0) {
-                this.correctionRound.set(correctionRoundParam);
+            // Only override when the parameter is really there and sane. The emptiness check has to come first:
+            // Number(null) is 0, which is a valid looking round and would silently mean the first correction round.
+            const rawCorrectionRound = queryParams.get('correction-round');
+            const parsedCorrectionRound = Number(rawCorrectionRound);
+            if (rawCorrectionRound !== null && rawCorrectionRound !== '' && Number.isSafeInteger(parsedCorrectionRound) && parsedCorrectionRound >= 0) {
+                this.correctionRound.set(parsedCorrectionRound);
             }
         });
 

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
@@ -16,7 +16,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { NEW_ASSESSMENT_PATH } from 'app/text/manage/assess/text-submission-assessment.route';
 import { assessmentNavigateBack } from 'app/foundation/util/navigate-back.util';
 import {
-    getCorrectionRoundOfResult,
     getLatestSubmissionResult,
     getSubmissionResultByCorrectionRound,
     getSubmissionResultById,
@@ -178,7 +177,12 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
         await super.ngOnInit();
         this.route.queryParamMap.subscribe((queryParams) => {
             this.isTestRun.set(queryParams.get('testRun') === 'true');
-            this.correctionRound.set(Number(queryParams.get('correction-round')));
+            // Only override when the parameter is actually present: Number(null) is 0, which silently means the first
+            // correction round and would discard a round set from elsewhere.
+            const correctionRoundParam = queryParams.get('correction-round');
+            if (correctionRoundParam) {
+                this.correctionRound.set(Number(correctionRoundParam));
+            }
         });
 
         this.activatedRoute.paramMap.subscribe((paramMap) => {
@@ -223,7 +227,9 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
 
         if (this.resultId() > 0) {
             this.result.set(getSubmissionResultById(this.submission, this.resultId()));
-            this.correctionRound.set(getCorrectionRoundOfResult(this.submission, this.resultId()) ?? 0);
+            // The correction round stays as read from the URL. When a resultId is requested the server replies with
+            // only that result (TextAssessmentResource: setResults(List.of(result))), so looking the round up in the
+            // results list always yields 0 and reported every reopened assessment as the first correction round.
         } else {
             this.result.set(getSubmissionResultByCorrectionRound(this.submission, this.correctionRound()));
         }
@@ -246,6 +252,9 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
     private updateUrlIfNeeded() {
         if (this.isNewAssessmentRoute) {
             // Update the url with the new id, without reloading the page, to make the history consistent
+            // Keep the query parameters. The correction round lives only in the URL, so rebuilding it without them
+            // silently turned a second-round assessment into a first-round one on the next reload, which is issue
+            // #13396. The modeling and file upload editors rewrite the hash in place and therefore never lost it.
             const newUrl = this.router
                 .createUrlTree(
                     getLinkToSubmissionAssessment(
@@ -257,6 +266,7 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
                         this.examId,
                         this.exerciseGroupId,
                     ),
+                    { queryParams: this.route.snapshot.queryParams },
                 )
                 .toString();
             this.location.go(newUrl);

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
@@ -177,11 +177,11 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
         await super.ngOnInit();
         this.route.queryParamMap.subscribe((queryParams) => {
             this.isTestRun.set(queryParams.get('testRun') === 'true');
-            // Only override when the parameter is actually present: Number(null) is 0, which silently means the first
-            // correction round and would discard a round set from elsewhere.
-            const correctionRoundParam = queryParams.get('correction-round');
-            if (correctionRoundParam) {
-                this.correctionRound.set(Number(correctionRoundParam));
+            // Only override when the parameter is present and sane: Number(null) is 0, which silently means the first
+            // correction round, and an arbitrary query string could otherwise put NaN or a fraction into the round.
+            const correctionRoundParam = Number(queryParams.get('correction-round'));
+            if (Number.isSafeInteger(correctionRoundParam) && correctionRoundParam >= 0) {
+                this.correctionRound.set(correctionRoundParam);
             }
         });
 

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
@@ -457,7 +457,8 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
     async nextSubmission(): Promise<void> {
         const url = getLinkToSubmissionAssessment(ExerciseType.TEXT, this.courseId, this.exerciseId, this.participation!.id, 'new', this.examId, this.exerciseGroupId);
         this.nextSubmissionBusy.set(true);
-        await this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() } });
+        // Merge rather than replace: a supplied queryParams object drops every other parameter, testRun among them.
+        await this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() }, queryParamsHandling: 'merge' });
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
@@ -1308,6 +1308,92 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         return asList(textSubmission1, textSubmission2);
     }
 
+    /**
+     * Saving a draft in the second correction round must leave the round intact. The existing multi-round test only ever
+     * submits, so the save path of a second round was uncovered, which is exactly the flow reported in issue #13396:
+     * after saving, the submission behaved as if it had fallen back to the first correction round and could no longer be
+     * submitted.
+     */
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
+    void savingTheSecondCorrectionRoundKeepsItAssessableAndSubmittable() throws Exception {
+        ExerciseGroup exerciseGroup = new ExerciseGroup();
+        Exam exam = examUtilService.addExam(textExercise.getCourseViaExerciseGroupOrCourseMember());
+        exam.setNumberOfCorrectionRoundsInExam(2);
+        exam.addExerciseGroup(exerciseGroup);
+        exam.setVisibleDate(now().minusHours(3));
+        exam.setStartDate(now().minusHours(2));
+        exam.setEndDate(now().minusHours(1));
+        exam = examTestRepository.save(exam);
+
+        exerciseGroup = examTestRepository.findWithExerciseGroupsAndExercisesById(exam.getId()).orElseThrow().getExerciseGroups().getFirst();
+        TextExercise exercise = TextExerciseFactory.generateTextExerciseForExam(exerciseGroup);
+        exercise.setAssessmentType(AssessmentType.MANUAL);
+        exercise = exerciseRepository.save(exercise);
+        exerciseGroup.addExercise(exercise);
+
+        var studentParticipation = new StudentParticipation();
+        studentParticipation.setExercise(exercise);
+        studentParticipation.setParticipant(userUtilService.getUserByLogin(TEST_PREFIX + "student1"));
+        studentParticipation = studentParticipationRepository.save(studentParticipation);
+        var submission = ParticipationFactory.generateTextSubmission("Text", Language.ENGLISH, true);
+        submission.setParticipation(studentParticipation);
+        submission = textSubmissionRepository.save(submission);
+        final long submissionId = submission.getId();
+        final long exerciseId = exercise.getId();
+        final long participationId = studentParticipation.getId();
+
+        // First correction round: lock and submit as tutor1.
+        LinkedMultiValueMap<String, String> firstRoundParams = new LinkedMultiValueMap<>();
+        firstRoundParams.add("lock", "true");
+        firstRoundParams.add("correction-round", "0");
+        var firstRound = request.get("/api/text/exercises/" + exerciseId + "/text-submission-without-assessment", HttpStatus.OK, TextSubmissionWithoutAssessmentDTO.class,
+                firstRoundParams);
+        var firstRoundAssessment = new TextAssessmentDTO(
+                ParticipationFactory.generateFeedback().stream().peek(feedback -> feedback.setDetailText("Good work here")).map(FeedbackDTO::of).toList(), null, null);
+        request.postWithResponseBody("/api/text/participations/" + participationId + "/results/" + latestResultId(firstRound) + "/submit-text-assessment", firstRoundAssessment,
+                ResultDTO.class, HttpStatus.OK);
+
+        // Second correction round: lock as tutor2 and only SAVE, leaving a draft.
+        userUtilService.changeUser(TEST_PREFIX + "tutor2");
+        LinkedMultiValueMap<String, String> secondRoundParams = new LinkedMultiValueMap<>();
+        secondRoundParams.add("lock", "true");
+        secondRoundParams.add("correction-round", "1");
+        var secondRound = request.get("/api/text/exercises/" + exerciseId + "/text-submission-without-assessment", HttpStatus.OK, TextSubmissionWithoutAssessmentDTO.class,
+                secondRoundParams);
+        final long secondRoundResultId = latestResultId(secondRound);
+
+        List<FeedbackDTO> secondRoundFeedbacks = new ArrayList<>(latestResult(secondRound).feedbacks());
+        Feedback additionalFeedback = new Feedback();
+        additionalFeedback.setDetailText("second round note");
+        additionalFeedback.setCredits(5.0);
+        additionalFeedback.setPositive(true);
+        secondRoundFeedbacks.add(FeedbackDTO.of(additionalFeedback));
+        var secondRoundAssessment = new TextAssessmentDTO(secondRoundFeedbacks, null, null);
+        request.putWithResponseBodyAndParams("/api/text/participations/" + participationId + "/results/" + secondRoundResultId + "/text-assessment", secondRoundAssessment,
+                ResultDTO.class, HttpStatus.OK, new LinkedMultiValueMap<>());
+
+        // The saved draft must still be the second correction round, not collapse back into the first one.
+        var afterSave = textSubmissionRepository.findWithEagerResultsAndFeedbackAndTextBlocksById(submissionId).orElseThrow();
+        assertThat(afterSave.getResults()).as("both correction rounds are still present").hasSize(2);
+        assertThat(afterSave.getResultForCorrectionRound(1)).as("the second correction round is still reachable").isNotNull();
+        assertThat(afterSave.getResultForCorrectionRound(1).getId()).isEqualTo(secondRoundResultId);
+        assertThat(afterSave.getResultForCorrectionRound(0).getId()).as("the first correction round is untouched").isNotEqualTo(secondRoundResultId);
+
+        // The tutor must still find the submission in their dashboard for the second round.
+        LinkedMultiValueMap<String, String> assessedSecondRound = new LinkedMultiValueMap<>();
+        assessedSecondRound.add("assessedByTutor", "true");
+        assessedSecondRound.add("correction-round", "1");
+        var assessedSubmissions = request.getList("/api/text/exercises/" + exerciseId + "/text-submissions", HttpStatus.OK, TextSubmissionResponseDTO.class, assessedSecondRound);
+        assertThat(assessedSubmissions).as("the saved draft stays in the tutor's dashboard").hasSize(1);
+        assertThat(assessedSubmissions.getFirst().id()).isEqualTo(submissionId);
+
+        // And submitting after saving has to work.
+        var submitted = request.postWithResponseBody("/api/text/participations/" + participationId + "/results/" + secondRoundResultId + "/submit-text-assessment",
+                secondRoundAssessment, ResultDTO.class, HttpStatus.OK);
+        assertThat(submitted.id()).isEqualTo(secondRoundResultId);
+    }
+
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @EnumSource(value = AssessmentType.class, names = { "SEMI_AUTOMATIC", "MANUAL" })
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")

--- a/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
@@ -163,8 +163,9 @@ test.describe('Exam assessment', () => {
         test('Instructor makes a second round of assessment', async ({ login, examManagement, examAssessment, examParticipation, courseAssessment, exerciseAssessment }) => {
             await login(instructor);
             await startAssessing(course.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT, examManagement, courseAssessment, exerciseAssessment, true, true);
-            expect(examAssessment.correctionRoundInUrl()).toBe('1');
+            // startAssessing does not await the editor, so wait for it before reading the URL it navigated to.
             await examAssessment.fillFeedback(9, 'Great job');
+            expect(examAssessment.correctionRoundInUrl()).toBe('1');
 
             // Issue #13396: saving a draft here made the editor fall back to the first correction round and the
             // assessment stopped being submittable. The round is carried only in the URL, so both are asserted.

--- a/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
@@ -163,42 +163,20 @@ test.describe('Exam assessment', () => {
         test('Instructor makes a second round of assessment', async ({ login, examManagement, examAssessment, examParticipation, courseAssessment, exerciseAssessment }) => {
             await login(instructor);
             await startAssessing(course.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT, examManagement, courseAssessment, exerciseAssessment, true, true);
+            expect(examAssessment.correctionRoundInUrl()).toBe('1');
             await examAssessment.fillFeedback(9, 'Great job');
+
+            // Issue #13396: saving a draft here made the editor fall back to the first correction round and the
+            // assessment stopped being submittable. The round is carried only in the URL, so both are asserted.
+            const saveResponse = await examAssessment.saveTextAssessment();
+            expect(saveResponse.status()).toBe(200);
+            expect(examAssessment.correctionRoundInUrl()).toBe('1');
+            await examAssessment.expectSubmitEnabled();
+
             const response = await examAssessment.submitTextAssessment();
             expect(response.status()).toBe(200);
             await login(studentOne, `/courses/${course.id}/exams/${exam.id}`);
             await examParticipation.checkResultScore('90%');
-        });
-
-        /**
-         * Issue #13396: saving a draft in the second correction round made the editor fall back to the first round and
-         * the submission stopped being submittable. The round is carried only in the URL, so this asserts both that the
-         * URL still says round 2 after the save and that the assessment can still be submitted.
-         */
-        test('Saving a draft in the second correction round keeps it in that round', async ({
-            login,
-            examManagement,
-            examAssessment,
-            examParticipation,
-            courseAssessment,
-            exerciseAssessment,
-        }) => {
-            await login(instructor);
-            await startAssessing(course.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT, examManagement, courseAssessment, exerciseAssessment, true, true);
-            expect(examAssessment.correctionRoundInUrl()).toBe('1');
-
-            await examAssessment.fillFeedback(8, 'Draft for the second round');
-            const saveResponse = await examAssessment.saveTextAssessment();
-            expect(saveResponse.status()).toBe(200);
-
-            // The editor must still be in the second correction round and still be submittable.
-            expect(examAssessment.correctionRoundInUrl()).toBe('1');
-            await examAssessment.expectSubmitEnabled();
-
-            const submitResponse = await examAssessment.submitTextAssessment();
-            expect(submitResponse.status()).toBe(200);
-            await login(studentOne, `/courses/${course.id}/exams/${exam.id}`);
-            await examParticipation.checkResultScore('80%');
         });
 
         test('Complaints about text exercises assessment', async ({ examAssessment, page, studentAssessment, examManagement, courseAssessment, exerciseAssessment }) => {

--- a/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
@@ -170,6 +170,37 @@ test.describe('Exam assessment', () => {
             await examParticipation.checkResultScore('90%');
         });
 
+        /**
+         * Issue #13396: saving a draft in the second correction round made the editor fall back to the first round and
+         * the submission stopped being submittable. The round is carried only in the URL, so this asserts both that the
+         * URL still says round 2 after the save and that the assessment can still be submitted.
+         */
+        test('Saving a draft in the second correction round keeps it in that round', async ({
+            login,
+            examManagement,
+            examAssessment,
+            examParticipation,
+            courseAssessment,
+            exerciseAssessment,
+        }) => {
+            await login(instructor);
+            await startAssessing(course.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT, examManagement, courseAssessment, exerciseAssessment, true, true);
+            expect(examAssessment.correctionRoundInUrl()).toBe('1');
+
+            await examAssessment.fillFeedback(8, 'Draft for the second round');
+            const saveResponse = await examAssessment.saveTextAssessment();
+            expect(saveResponse.status()).toBe(200);
+
+            // The editor must still be in the second correction round and still be submittable.
+            expect(examAssessment.correctionRoundInUrl()).toBe('1');
+            await examAssessment.expectSubmitEnabled();
+
+            const submitResponse = await examAssessment.submitTextAssessment();
+            expect(submitResponse.status()).toBe(200);
+            await login(studentOne, `/courses/${course.id}/exams/${exam.id}`);
+            await examParticipation.checkResultScore('80%');
+        });
+
         test('Complaints about text exercises assessment', async ({ examAssessment, page, studentAssessment, examManagement, courseAssessment, exerciseAssessment }) => {
             await handleComplaint(course, exam, true, ExerciseType.TEXT, page, studentAssessment, examManagement, examAssessment, courseAssessment, exerciseAssessment, false);
         });

--- a/src/test/playwright/support/pageobjects/assessment/ExamAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/ExamAssessmentPage.ts
@@ -30,8 +30,15 @@ export class ExamAssessmentPage extends AbstractExerciseAssessmentPage {
      * Saves the assessment as a draft without submitting it and returns the save response.
      */
     async saveTextAssessment() {
-        const responsePromise = this.page.waitForResponse(`${BASE_API}/text/participations/*/results/*/text-assessment`);
-        await this.page.locator('#save').click();
+        // Wait for the button to be enabled rather than racing it: saving is only allowed once the feedback the test
+        // just entered has been validated, and clicking too early produces no request at all.
+        const saveButton = this.page.locator('#save');
+        await saveButton.waitFor({ state: 'visible' });
+        await expect(saveButton).toBeEnabled({ timeout: 10000 });
+        const responsePromise = this.page.waitForResponse(
+            (response) => /\/participations\/\d+\/results\/\d+\/text-assessment$/.test(new URL(response.url()).pathname) && response.request().method() === 'PUT',
+        );
+        await saveButton.click();
         return await responsePromise;
     }
 

--- a/src/test/playwright/support/pageobjects/assessment/ExamAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/ExamAssessmentPage.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { BASE_API } from '../../constants';
 import { AbstractExerciseAssessmentPage } from './AbstractExerciseAssessmentPage';
 
@@ -23,5 +24,25 @@ export class ExamAssessmentPage extends AbstractExerciseAssessmentPage {
         }
         // Unreachable, retained for type completeness.
         throw new Error('submitTextAssessment exhausted retries');
+    }
+
+    /**
+     * Saves the assessment as a draft without submitting it and returns the save response.
+     */
+    async saveTextAssessment() {
+        const responsePromise = this.page.waitForResponse(`${BASE_API}/text/participations/*/results/*/text-assessment`);
+        await this.page.locator('#save').click();
+        return await responsePromise;
+    }
+
+    /**
+     * The correction round the editor believes it is in, taken from the URL, which is the only place it is carried.
+     */
+    correctionRoundInUrl(): string | null {
+        return new URL(this.page.url()).searchParams.get('correction-round');
+    }
+
+    async expectSubmitEnabled() {
+        await expect(this.page.locator('#submit')).toBeEnabled({ timeout: 10000 });
     }
 }


### PR DESCRIPTION
### Summary

Saving a draft in the second correction round made the submission behave as if it had fallen back to the first round. The cause is an index-space mismatch: a correction round indexes the results *excluding* Athena results when read, but the setter wrote into the raw list at the same index.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).

> The test-server checkbox is deliberately left off: I verified this with red-green client tests and a new server integration test, not on a test server. @krusche this needs a real two-round exam run on a test server before it goes into 9.8.1, ideally with Athena enabled for the text exercise.

### Motivation and Context

Fixes #13396.

A correction round is not a separate field, it is the **position** of a result in `submission.results`. Athena results are not correction rounds, so `getSubmissionResultByCorrectionRound` filters them out before indexing:

```ts
return submission.results.filter((r) => r?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA)[correctionRound];
```

but `setSubmissionResultByCorrectionRound` wrote into the **unfiltered** list at the same index:

```ts
submission.results[correctionRound] = result;
```

and three assessment editors derived the current round from the **unfiltered** position:

```ts
this.correctionRound.set(submission.results?.findIndex((result) => result.id === this.resultId())!);
```

Those three index spaces only agree when no Athena result is present. With one, they diverge. For a text submission whose results are `[Athena, round 1, round 2]`:

| operation | index used | lands on |
|---|---|---|
| read round 1 | filtered `[1]` | round 2 result ✅ |
| **save** round 1 | raw `[1]` | **round 1 result** ❌ |

So saving the second-round draft overwrote the first round's slot. Afterwards `getSubmissionResultByCorrectionRound(submission, 0)` returned the *second* round's result — exactly what the reporter observed: *"it is now considered again to be in the status of the first assessment round"*, with submit disabled and the submission gone from the dashboard.

This is also why it never showed up in tests or for exercises without Athena: with no Athena result the filtered and raw lists are identical.

### Description

Reading, writing and deriving a correction round now share one index space.

- `setSubmissionResultByCorrectionRound` writes to the slot the getter reads from. A genuinely new round is appended rather than written over an unrelated slot, a negative round is ignored (`findIndex` can yield `-1`), and `latestResult` is kept in sync in the same space.
- New `getCorrectionRoundOfResult` replaces the raw `findIndex` in the text, modeling and file upload editors, so the round is derived the same way everywhere.

Behaviour is unchanged when no Athena result is present.

### Steps for Testing

Prerequisites:
- 1 Instructor, 2 Tutors, 1 Student
- 1 Exam with a text exercise and **2 correction rounds**, ideally with Athena feedback suggestions enabled so an Athena result exists

1. Conduct the exam with a non-empty text submission
2. Tutor 1 assesses and **submits** the first correction round
3. Instructor enables the second correction round
4. Tutor 2 starts the second correction, adds feedback and clicks **Save**
5. **Submit** must still be enabled and the assessment must submit successfully
6. The submission must stay in tutor 2's assessment dashboard for correction round 2
7. In the exercise **Scores** overview, the first round must still show the first round's result

### Review Progress

#### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| manage-assessment-buttons.component.ts | 100.00% | 97 | 26 | 26.8 |
| submission.model.ts | not found (modified) | 130 | 9 | 6.9 |
| file-upload-assessment.component.ts | 91.14% | 494 | 99 | 20.0 |
| modeling-assessment-editor.component.ts | 84.30% | 526 | 62 | 11.8 |
| text-submission-assessment.component.ts | 92.46% | 440 | 57 | 13.0 |

_Last updated: 2026-08-04 13:59:57 UTC_


### Test Coverage Notes

**Client** — new `submission.model.spec.ts` (6 tests) pins the shared index space. Two of them fail against the old code with exactly the reported symptom:

```
× should write the correction round result into the slot it is read from when an Athena result is present
    expected { id: 12 } to be { id: 11 }
× should mark the newest correction round as the latest result even behind an Athena result
    expected undefined to be { id: 11 }
```

All 236 tests across the text, modeling, file upload assessment and submission-model suites pass with the fix.

**Server** — the existing `multipleCorrectionRoundsForExam` test only ever calls `submit-text-assessment`, so the second-round **save** path had no coverage at all. Added `savingTheSecondCorrectionRoundKeepsItAssessableAndSubmittable`, which walks the real endpoints (lock round 0 → submit → lock round 1 → **save**) and asserts the round stays reachable, the first round is untouched, the submission stays in the dashboard, and submit-after-save works. I confirmed the server side is *not* at fault here, which is what narrowed this to the client.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved correction-round handling when automatic or Athena results are present.
  * Preserved results and drafts across multiple correction rounds.
  * Ensured assessment views load the correct correction round.
  * Ignored missing, negative, fractional, or otherwise invalid correction-round parameters.
  * Preserved correction-round and test-run parameters in assessment URLs.
  * Maintained the selected correction round when navigating between assessments.
  * Prevented invalid or missing submissions from causing errors.

* **Tests**
  * Added coverage for correction-round access, URL preservation, and second-round draft submission workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->