### PR TITLE
`Development`: Correct the exercise group query budget

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExerciseGroupIntegrationJenkinsLocalVCTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExerciseGroupIntegrationJenkinsLocalVCTest.java
@@ -266,9 +266,12 @@ class ExerciseGroupIntegrationJenkinsLocalVCTest extends AbstractSpringIntegrati
     @Test
     @WithMockUser(username = TEST_PREFIX + "editor1", roles = "EDITOR")
     void testGetExerciseGroupsForExam_asEditor() throws Exception {
+        // Six is the count the endpoint actually performs: the editor access check resolves user, course and exam, and
+        // the group fetch adds one more. The budget guards that fixed cost - it cannot detect a per-row N+1, because the
+        // fixture holds a single group with a single exercise.
         List<ExerciseGroupDTO> result = assertThatDb(
                 () -> request.getList("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/exercise-groups", HttpStatus.OK, ExerciseGroupDTO.class))
-                .hasBeenCalledAtMostTimes(5);
+                .hasBeenCalledAtMostTimes(6);
         verify(examAccessService).checkCourseAndExamAccessForEditorElseThrow(course1.getId(), exam1.getId());
         assertThat(result).hasSize(1);
         // The list response embeds the exercise summaries. The previously serialized exam of each group is deliberately


### PR DESCRIPTION
### Summary

`ExerciseGroupIntegrationJenkinsLocalVCTest.testGetExerciseGroupsForExam_asEditor` fails on `develop` with `Expected at most <5> queries, but <6> were performed.` This raises the budget to the count the endpoint actually performs.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the server coding and design guidelines and the REST API guidelines.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

The budget was introduced in #13097 (commit 72430054c7) and **never passed**: that PR's own `Test / Server Tests (PostgreSQL)` job failed on this exact assertion with this exact message, and it was merged red. So `develop` has been failing it ever since, which reddens the `All required CI Passed` gate on unrelated PRs.

The endpoint itself is fine - it returns `200` with the correct payload. Only the assertion's number is wrong.

### Description

`GET /api/exam/courses/{courseId}/exams/{examId}/exercise-groups` performs six queries: `examAccessService.checkCourseAndExamAccessForEditorElseThrow` resolves user, course and exam, and `exerciseGroupRepository.findWithExamAndExercisesByExamId` adds one more. Verified by the interceptor's own log line, which reports `result.callCount: 6`.

Raise `hasBeenCalledAtMostTimes(5)` to `hasBeenCalledAtMostTimes(6)` and record where the six come from.

I did not try to remove a query instead. The sixth is not an avoidable lazy load: the list path drops the nested exam and maps only exercises the fetch join already loaded. The residual cost sits in the access check, and trimming that is a behaviour change well beyond a red-test fix. Worth noting the assertion cannot detect a per-row N+1 at this fixture size either way, since the fixture holds one exercise group with one exercise - it guards fixed cost only.

### Steps for Testing

No functional change; this is a test-only fix.

1. `./gradlew test --tests "de.tum.cit.aet.artemis.exam.ExerciseGroupIntegrationJenkinsLocalVCTest" -x webapp`
2. The class is green (24 tests, 0 failures). On `develop` without this change the same command fails 1 of 24.

### Testserver States

<!-- Testserver states are updated automatically -->

### Review Progress

- [x] Code is readable and maintainable
- [x] Code follows the coding guidelines

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-04 06:37:33 UTC_

