### PR TITLE
`Development`: Serve the client's KaTeX copy and remove the version range that broke the server tests

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -98,6 +98,16 @@
                                 "glob": "pdfium.wasm",
                                 "input": "./node_modules/@embedpdf/pdfium/dist",
                                 "output": "assets/embedpdf"
+                            },
+                            {
+                                "glob": "{katex.min.js,katex.min.css}",
+                                "input": "./node_modules/katex/dist",
+                                "output": "assets/katex"
+                            },
+                            {
+                                "glob": "**/*.woff2",
+                                "input": "./node_modules/katex/dist/fonts",
+                                "output": "assets/katex/fonts"
                             }
                         ],
                         "styles": [

--- a/build.gradle
+++ b/build.gradle
@@ -550,7 +550,14 @@ dependencies {
     implementation "org.apache.pdfbox:pdfbox:3.0.7"
     implementation "org.apache.commons:commons-csv:1.14.1"
     implementation "org.commonmark:commonmark:0.29.0"
-    implementation "org.webjars.npm:katex:0.16.47"
+    // Only the served browser assets are used (ProblemStatementRenderingService serves /webjars/katex/dist). The npm
+    // package additionally declares commander for its command line tool, and declares it as a version range
+    // ("[8.3.0,9.0.0-0)"). A range forces Gradle to ask the repository for the list of available versions on every
+    // resolution, which cannot be answered from the dependency cache - so an unreachable Maven Central fails the build
+    // even though every artifact it needs is already cached. Excluding it removes both the unused jar and the range.
+    implementation("org.webjars.npm:katex:0.16.47") {
+        exclude group: "org.webjars.npm", module: "commander"
+    }
     implementation "org.commonmark:commonmark-ext-gfm-tables:0.29.0"
     implementation "org.commonmark:commonmark-ext-gfm-strikethrough:0.29.0"
 
@@ -676,6 +683,16 @@ configurations.matching { it.name != 'mockitoAgent' }.configureEach {
             details.because("Patched OpenTelemetry release; pre-${opentelemetry_version} contains GHSA-rcgg-9c38-7xpx.")
         }
     }
+}
+
+// Refuse version ranges on the classpaths CI builds from.
+//
+// A range ("[8.3.0,9.0.0-0)") cannot be resolved from the dependency cache: Gradle has to ask the repository which
+// versions exist, on every resolution. A single range therefore makes the whole build depend on Maven Central being
+// reachable, even when every artifact it needs is already cached - which is how one transitive webjar dependency took
+// the server tests down on develop. Failing here points at the offending dependency instead.
+configurations.matching { it.name in ["compileClasspath", "runtimeClasspath", "testCompileClasspath", "testRuntimeClasspath"] }.configureEach {
+    resolutionStrategy.failOnDynamicVersions()
 }
 
 // Testcontainers 2.0 renamed modules with a "testcontainers-" prefix.

--- a/build.gradle
+++ b/build.gradle
@@ -550,14 +550,6 @@ dependencies {
     implementation "org.apache.pdfbox:pdfbox:3.0.7"
     implementation "org.apache.commons:commons-csv:1.14.1"
     implementation "org.commonmark:commonmark:0.29.0"
-    // Only the served browser assets are used (ProblemStatementRenderingService serves /webjars/katex/dist). The npm
-    // package additionally declares commander for its command line tool, and declares it as a version range
-    // ("[8.3.0,9.0.0-0)"). A range forces Gradle to ask the repository for the list of available versions on every
-    // resolution, which cannot be answered from the dependency cache - so an unreachable Maven Central fails the build
-    // even though every artifact it needs is already cached. Excluding it removes both the unused jar and the range.
-    implementation("org.webjars.npm:katex:0.16.47") {
-        exclude group: "org.webjars.npm", module: "commander"
-    }
     implementation "org.commonmark:commonmark-ext-gfm-tables:0.29.0"
     implementation "org.commonmark:commonmark-ext-gfm-strikethrough:0.29.0"
 

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
@@ -287,7 +287,7 @@ public class SecurityConfiguration {
                     .requestMatchers("/", "/index.html", "/public/**").permitAll()
                     .requestMatchers("/*.js", "/*.css", "/*.map", "/*.json").permitAll()
                     .requestMatchers("/manifest.webapp", "/robots.txt").permitAll()
-                    .requestMatchers("/content/**", "/i18n/*.json", "/logo/*", "/webjars/katex/**").permitAll()
+                    .requestMatchers("/content/**", "/i18n/*.json", "/logo/*", "/assets/katex/**").permitAll()
                     // Information and health endpoints do not need authentication. `info` is fetched by the client before
                     // login (profile info, feature flags, version), and the health group is used by probes and the client
                     // status page. These must stay ahead of the `/management/**` admin rule below so they keep matching first.

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ProblemStatementRenderingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ProblemStatementRenderingService.java
@@ -78,7 +78,13 @@ public class ProblemStatementRenderingService {
 
     private static final String RENDERER_VERSION = "1.0.0";
 
-    private static final String KATEX_BASE_PATH = "/webjars/katex/dist";
+    /**
+     * KaTeX is served from the client's own copy, the one declared in {@code package.json} and copied out of
+     * {@code node_modules} by the Angular build. The server used to pull a second copy as a webjar, which meant shipping
+     * two versions of the same library - and the webjar's generated POM carried an npm version range, which Gradle cannot
+     * resolve without asking the repository for a version list on every build.
+     */
+    private static final String KATEX_BASE_PATH = "/assets/katex";
 
     private static final int MAX_PLANTUML_DIAGRAMS = 10;
 

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/ProblemStatementRenderingIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/ProblemStatementRenderingIntegrationTest.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.exercise;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -383,8 +384,8 @@ class ProblemStatementRenderingIntegrationTest extends AbstractSpringIntegration
         assertThat(result.html()).contains("data-formula=\"E = mc^2\"");
         assertThat(result.html()).contains("data-display-mode=\"false\"");
         assertThat(result.html()).contains("data-display-mode=\"true\"");
-        assertThat(result.html()).contains("/webjars/katex/dist/katex.min.css");
-        assertThat(result.html()).contains("/webjars/katex/dist/katex.min.js");
+        assertThat(result.html()).contains("/assets/katex/katex.min.css");
+        assertThat(result.html()).contains("/assets/katex/katex.min.js");
     }
 
     @Test
@@ -401,7 +402,15 @@ class ProblemStatementRenderingIntegrationTest extends AbstractSpringIntegration
 
     @Test
     void shouldServeKatexResourcesAnonymously() throws Exception {
-        request.get("/webjars/katex/dist/katex.min.css", HttpStatus.OK, String.class);
+        // The rendered document is loaded in a WebView that does not authenticate for the asset requests, so this path has
+        // to stay outside the security rules.
+        //
+        // Only that is asserted here, not that the file exists: KaTeX now comes from the client's own copy, which the
+        // Angular build copies out of node_modules, and server tests run with the client build skipped. So 404 ("not built
+        // in this run") is an acceptable outcome while 401 or 403 ("behind authentication") is not.
+        int status = request.performMvcRequest(get("/assets/katex/katex.min.css")).andReturn().getResponse().getStatus();
+
+        assertThat(status).as("the KaTeX assets must not be behind authentication").isIn(HttpStatus.OK.value(), HttpStatus.NOT_FOUND.value());
     }
 
     // --- Interactive toggle ---


### PR DESCRIPTION
### Motivation

Two problems with one cause.

**1. Two versions of KaTeX shipped.** The client declares `katex 0.18.1` in `package.json`; the server pulled `org.webjars.npm:katex:0.16.47` as a separate Maven dependency. The web client rendered math with one version, and the server-rendered problem statement linked the other.

**2. `Test / Server Tests (PostgreSQL)` failed on develop on every run**, at about 50 seconds, before a single test executed:

```
Execution failed for task ':compileJava'
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not resolve org.webjars.npm:commander:[8.3.0,9.0.0-0).
      Required by: root project 'Artemis' > org.webjars.npm:katex:0.16.47
      > Repository MavenRepo is disabled due to earlier error below:
BUILD FAILED in 16s
```

A webjar's POM is generated from the npm `package.json`, so KaTeX's npm range for `commander` — the dependency of its command line tool — arrived as a Maven **version range**. A range is the one thing Gradle cannot answer from the dependency cache: it has to ask the repository which versions exist, on every resolution. `dependencyInsight` shows the listing being performed:

```
org.webjars.npm:commander:[8.3.0,9.0.0-0) -> 8.3.0
   Selection reasons:
      - Was requested: didn't match versions 14.0.1, 14.0.0, 13.1.0, 12.0.0-0, ...
```

So one transitive range made every build depend on Maven Central being reachable *even with a warm cache*, and one failed request disabled the repository for the rest of the build. That matches the failure exactly: consistent rather than occasional, dying in `:compileJava`, with the misleading downstream "No test report files were found" because no JUnit XML was ever produced.

### Description

The webjar is removed and the server serves **the client's own copy**. The Angular build copies `katex.min.js`, `katex.min.css` and the `woff2` fonts out of `node_modules` into `assets/katex` — the same mechanism already used for `monaco-editor` and `@embedpdf/pdfium` — and `ProblemStatementRenderingService` points at `/assets/katex`. One version, declared in one place.

Dropping the dependency removes the range with it. It was the **only** dynamic version in the graph, verified across `compileClasspath`, `runtimeClasspath`, `testCompileClasspath` and `testRuntimeClasspath`, and with `-Pprod`: one before, zero after. Those four classpaths now `failOnDynamicVersions()`, so a dependency that reintroduces a range fails immediately and names itself instead of becoming an intermittent network failure months later.

Only `woff2` fonts are copied, not the `woff` and `ttf` fallbacks the CSS also lists, because `woff2` is listed **first** in every `@font-face` and is what any current engine selects — the fallbacks are never requested.

### One behavioural change worth knowing

The assets now come from the client build rather than from the classpath, so they are **absent when the client build is skipped**:

- **Production and the Docker images are unaffected** — the WAR always contains the built client. Verified with `pnpm run webapp:prod`, not just the dev build.
- **`bootRun -x webapp` with a separate `pnpm start`** serves the rendered document from the server, whose static directory then has no KaTeX. Math in that endpoint will not typeset until the client has been built once. This is a deliberate trade for having a single version.

That is also why `shouldServeKatexResourcesAnonymously` no longer asserts `200`. It was quietly checking two things — that the path is public *and* that the file exists. It now asserts the part that must hold at that level: an anonymous request must not be rejected, so `404` ("not built in this run") passes and `401`/`403` ("behind authentication") fails.

`org.webjars:swagger-ui` is still on the classpath via springdoc, so webjars remain in use in the project; it is reachable through its own `/swagger-ui/**` rule and is untouched here.

### Steps for testing

1. `./gradlew --offline compileJava compileTestJava -x webapp` succeeds with no repository access at all.
2. `./gradlew dependencies --configuration compileClasspath | grep -E ":[^ ]*\["` returns nothing.
3. Build the client, start the server, and render a problem statement containing math: the document links `/assets/katex/katex.min.css` and `katex.min.js`, both load, and the formulas typeset with the fonts applied.
4. Confirm the served file is the client's version: `grep -o 'version:"[0-9.]*"' build/resources/main/static/assets/katex/katex.min.js` reports `0.18.1`.

### Testserver states

<!-- Testserver states are updated automatically -->

### Server tests

- [x] `*ProblemStatementRendering*` — 53 tests green
- [x] Proved the URL really resolves: with the assets built, the anonymous request returns **200** (asserted strictly in a scratch run, then relaxed so the suite does not depend on the client build)
- [x] `--offline compileJava compileTestJava` green, i.e. resolution no longer needs the network
- [x] Zero dynamic versions on all four classpaths, including `-Pprod` (one before)
- [x] The guard rejects a reintroduced range, verified by putting the webjar back: `commander:[8.3.0,9.0.0-0) FAILED`
- [x] Both `webapp:build` and `webapp:prod` emit `katex.min.js`, `katex.min.css` and 20 `woff2` fonts
- [x] `autoLintGradle`, `spotlessCheck`, `checkstyleMain` green

### Client tests

- [x] No client behaviour changes: the client keeps importing `katex` from `node_modules` as before. The only client-side change is two asset copy rules in `angular.json`.

### Code review

- [x] Code is readable and maintainable
- [x] Code follows the coding guidelines
