### PR TITLE
`Development`: Exempt the e2e stacks from the nginx request rate limits

### DIFF
--- a/docker/nginx/artemis-nginx.conf
+++ b/docker/nginx/artemis-nginx.conf
@@ -11,12 +11,34 @@ server_tokens off;
 # application-level limiter returns (RateLimitExceededException -> 429).
 limit_req_status 429;
 
+# Clients exempt from the request rate limits below. Empty in production and in the dev stack: the
+# glob matches nothing and every client is limited (nginx does not fail on a mask that matches no
+# file, unlike a plain `include`).
+#
+# The Playwright compose files mount an exemption drop-in here, because an E2E run drives hundreds of
+# logins and git operations from a single source address and would otherwise be throttled to a halt:
+# `loginlimit` alone budgets 30 requests per minute per address, while `Commands.login` issues one
+# POST /api/core/public/authenticate per test across 5 parallel workers. The E2E stack is a throwaway
+# environment, so the drop-in exempts everything rather than trying to pin down the Playwright source
+# address, which differs between the host-run and containerised runners.
+geo $rate_limit_exempt {
+    default 0;
+    include rate-limit-exempt/*.conf;
+}
+
+# An empty key is not accounted by nginx, which is how an exempt client bypasses a zone. Every zone
+# keyed on the client address below uses this variable rather than $binary_remote_addr directly.
+map $rate_limit_exempt $rate_limit_key {
+    1       "";
+    default $binary_remote_addr;
+}
+
 # Rate limit for the login REST call, at most one request every two seconds
-limit_req_zone $binary_remote_addr zone=loginlimit:10m rate=30r/m;
+limit_req_zone $rate_limit_key zone=loginlimit:10m rate=30r/m;
 # Rate limit for account recovery and registration (password reset init/finish, register).
 # Stricter than the login zone: these endpoints send mail and mutate credentials, and no
 # legitimate client calls them repeatedly.
-limit_req_zone $binary_remote_addr zone=accountrecoverylimit:10m rate=5r/m;
+limit_req_zone $rate_limit_key zone=accountrecoverylimit:10m rate=5r/m;
 # Rate limit for the git credential handshake (/info/refs), bounded separately from the bulk transfer
 # below - which has to stay generous for real clones and pushes.
 #
@@ -29,13 +51,19 @@ limit_req_zone $binary_remote_addr zone=accountrecoverylimit:10m rate=5r/m;
 # Charging both would halve the budget (60r/m would allow only ~30 operations and burst=10 only ~5
 # concurrent ones), so the credential-free probe maps to an empty key, which nginx does not account.
 # The probe is not left unbounded: the location applies the general git zone alongside this one.
-map $http_authorization $git_credential_attempt_key {
-    ""      "";
-    default $binary_remote_addr;
+map $http_authorization $git_credential_present {
+    ""      0;
+    default 1;
+}
+# Only a non-exempt client presenting credentials is accounted; every other combination maps to the
+# empty key.
+map $rate_limit_exempt$git_credential_present $git_credential_attempt_key {
+    "01"    $binary_remote_addr;
+    default "";
 }
 limit_req_zone $git_credential_attempt_key zone=gitauthlimit:10m rate=60r/m;
 # Rate limit for git data transfer, at most 5 requests per second
-limit_req_zone $binary_remote_addr zone=gitlimit:10m rate=5r/s;
+limit_req_zone $rate_limit_key zone=gitlimit:10m rate=5r/s;
 
 server {
     listen 80 default_server;

--- a/docker/nginx/artemis-rate-limit-exempt-e2e.conf
+++ b/docker/nginx/artemis-rate-limit-exempt-e2e.conf
@@ -1,0 +1,15 @@
+# Rate limit exemption drop-in for the Playwright E2E stacks.
+#
+# Mounted into /etc/nginx/rate-limit-exempt/ by the docker/playwright-E2E-tests-*.yml compose files
+# and read by the `geo $rate_limit_exempt` block in artemis-nginx.conf. It is NOT mounted by
+# docker/nginx.yml alone, so production and the dev stack keep the real limits.
+#
+# An E2E run drives hundreds of logins and git operations from one source address in a few minutes,
+# which is exactly the traffic shape the limits exist to stop. Without this exemption the run fails
+# en masse with 429 (Commands.login treats a 4xx as a permanent failure and does not retry).
+#
+# Everything is exempted rather than a specific address: the Playwright source differs between the
+# host-run runners (docker bridge gateway) and the containerised ones (a bridge address), and the
+# whole stack is throwaway.
+0.0.0.0/0 1;
+::/0 1;

--- a/docker/playwright-E2E-tests-multi-node-fast.yml
+++ b/docker/playwright-E2E-tests-multi-node-fast.yml
@@ -68,6 +68,9 @@ services:
       - ./nginx/artemis-upstream-multi-node-fast.conf:/etc/nginx/includes/artemis-upstream.conf:ro
       - ./nginx/artemis-ssh-upstream-multi-node-fast.conf:/etc/nginx/includes/artemis-ssh-upstream.conf:ro
       - ./nginx/artemis-nginx-playwright.conf:/etc/nginx/conf.d/artemis-nginx-playwright.conf:ro
+      # Lift the nginx request rate limits for the E2E run (see the geo block in artemis-nginx.conf):
+      # a full suite drives hundreds of logins and git operations from one source address.
+      - ./nginx/artemis-rate-limit-exempt-e2e.conf:/etc/nginx/rate-limit-exempt/e2e.conf:ro
       - type: bind
         source: ${NGINX_PROXY_SSL_CERTIFICATE_PATH:-../src/test/playwright/certs/artemis-nginx+4.pem}
         target: "/certs/fullchain.pem"

--- a/docker/playwright-E2E-tests-multi-node.yml
+++ b/docker/playwright-E2E-tests-multi-node.yml
@@ -95,6 +95,9 @@ services:
       - ./nginx/artemis-upstream-multi-node.conf:/etc/nginx/includes/artemis-upstream.conf:ro
       - ./nginx/artemis-ssh-upstream-multi-node.conf:/etc/nginx/includes/artemis-ssh-upstream.conf:ro
       - ./nginx/artemis-nginx-playwright.conf:/etc/nginx/conf.d/artemis-nginx-playwright.conf:ro
+      # Lift the nginx request rate limits for the E2E run (see the geo block in artemis-nginx.conf):
+      # a full suite drives hundreds of logins and git operations from one source address.
+      - ./nginx/artemis-rate-limit-exempt-e2e.conf:/etc/nginx/rate-limit-exempt/e2e.conf:ro
       - type: bind
         source: ${NGINX_PROXY_SSL_CERTIFICATE_PATH:-../src/test/playwright/certs/artemis-nginx+4.pem}
         target: "/certs/fullchain.pem"

--- a/docker/playwright-E2E-tests-mysql-localci.yml
+++ b/docker/playwright-E2E-tests-mysql-localci.yml
@@ -38,6 +38,9 @@ services:
                 condition: service_started
         volumes:
             - ./nginx/artemis-nginx-playwright.conf:/etc/nginx/conf.d/artemis-nginx-playwright.conf:ro
+            # Lift the nginx request rate limits for the E2E run (see the geo block in artemis-nginx.conf):
+            # a full suite drives hundreds of logins and git operations from one source address.
+            - ./nginx/artemis-rate-limit-exempt-e2e.conf:/etc/nginx/rate-limit-exempt/e2e.conf:ro
         ports:
             - '80:80'
             - '443:443'

--- a/docker/playwright-E2E-tests-mysql.yml
+++ b/docker/playwright-E2E-tests-mysql.yml
@@ -29,6 +29,9 @@ services:
                 condition: service_started
         volumes:
             - ./nginx/artemis-nginx-playwright.conf:/etc/nginx/conf.d/artemis-nginx-playwright.conf:ro
+            # Lift the nginx request rate limits for the E2E run (see the geo block in artemis-nginx.conf):
+            # a full suite drives hundreds of logins and git operations from one source address.
+            - ./nginx/artemis-rate-limit-exempt-e2e.conf:/etc/nginx/rate-limit-exempt/e2e.conf:ro
         ports:
             - '80:80'
             - '443:443'

--- a/docker/playwright-E2E-tests-postgres-localci.yml
+++ b/docker/playwright-E2E-tests-postgres-localci.yml
@@ -39,6 +39,9 @@ services:
                 condition: service_started
         volumes:
             - ./nginx/artemis-nginx-playwright.conf:/etc/nginx/conf.d/artemis-nginx-playwright.conf:ro
+            # Lift the nginx request rate limits for the E2E run (see the geo block in artemis-nginx.conf):
+            # a full suite drives hundreds of logins and git operations from one source address.
+            - ./nginx/artemis-rate-limit-exempt-e2e.conf:/etc/nginx/rate-limit-exempt/e2e.conf:ro
         ports:
             - '80:80'
             - '443:443'

--- a/docker/playwright-E2E-tests-postgres.yml
+++ b/docker/playwright-E2E-tests-postgres.yml
@@ -30,6 +30,9 @@ services:
                 condition: service_started
         volumes:
             - ./nginx/artemis-nginx-playwright.conf:/etc/nginx/conf.d/artemis-nginx-playwright.conf:ro
+            # Lift the nginx request rate limits for the E2E run (see the geo block in artemis-nginx.conf):
+            # a full suite drives hundreds of logins and git operations from one source address.
+            - ./nginx/artemis-rate-limit-exempt-e2e.conf:/etc/nginx/rate-limit-exempt/e2e.conf:ro
         ports:
             - '80:80'
             - '443:443'


### PR DESCRIPTION
### Summary

The nginx auth rate limits from #13387 now also throttle Playwright. Every E2E stack routes through nginx and the whole run arrives from a single source address, so the entire suite shares one 30-requests-per-minute login budget. A full run fails en masse with 429. This PR exempts the E2E stacks from the limits while leaving production and the dev stack fully limited.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).
- [x] This is an infrastructure-only change that I verified locally: `nginx -t` in both modes, a live nginx behaviour comparison, and a full multi-node E2E run.

### Motivation and Context

Before #13387 the login limiter sat on `location /api/authenticate`, a path no controller serves, so it throttled nothing. #13387 correctly moved it to `/api/core/public/authenticate`. That is also the path `Commands.login` posts to on every single test (`src/test/playwright/support/commands.ts:29`), and the same PR tightened `gitlimit` (15r/s to 5r/s), added `gitauthlimit` (60r/m) and switched throttled responses from 503 to 429.

Every zone keys on `$binary_remote_addr`, and a Playwright run has exactly one of those. With `loginlimit` at 30r/m, `burst=3 delay=2`, and 5 parallel workers each logging in per test, the budget is exhausted within seconds. `Commands.login` retries only 5xx (`commands.ts:40`), so a 429 fails the test immediately rather than backing off. A local `run-e2e-tests-local-multinode-fast.sh` run produced 195 failures, nearly all 429.

This affects CI too: `.ci/E2E-tests/execute.sh` uses `playwright-E2E-tests-postgres.yml`, `playwright-E2E-tests-postgres-localci.yml` and `playwright-E2E-tests-multi-node.yml`, all of which run nginx. `run-e2e-tests-local-fast.sh` is the exception, because it talks to the Angular dev server on `:9000` and never goes through nginx.

Not involved: the application-level bucket4j limiter. `artemis.rate-limiting.enabled` defaults to `false` and no E2E env file enables it.

### Description

`docker/nginx/artemis-nginx.conf`:
- A `geo $rate_limit_exempt` block reading an **optional** glob include, `rate-limit-exempt/*.conf`. nginx does not fail on a mask that matches no file, unlike a plain `include`, so production and the dev stack need no new mount and stay fully limited.
- A `map` turning that into `$rate_limit_key`: the empty string for exempt clients, `$binary_remote_addr` otherwise. An empty key is not accounted by nginx, which is how a zone is bypassed. `loginlimit`, `accountrecoverylimit` and `gitlimit` now key on it.
- The git-credential map is chained rather than replaced, so `gitauthlimit` keeps accounting exactly the credential-bearing `/info/refs` retry and nothing else.

`docker/nginx/artemis-rate-limit-exempt-e2e.conf` (new) is mounted at `/etc/nginx/rate-limit-exempt/e2e.conf` by all six `docker/playwright-E2E-tests-*.yml` files. It is a fresh mount target, so it composes cleanly with the `extends: nginx.yml` base instead of colliding with the parent's volume list.

Everything is exempted rather than a specific address: the Playwright source differs between the host-run runners (docker bridge gateway) and the containerised ones, and the E2E stack is throwaway.

### Steps for Testing

`nginx -t` passes with and without the drop-in. Behaviour measured against a live nginx with a stub upstream, 20/30 parallel requests per row:

| | login | `/info/refs` with credentials | `/info/refs` no credentials |
|---|---|---|---|
| config at `develop` | 429 = 16/20 | 429 = 19/30 | 429 = 10/30 |
| this PR, no drop-in | 429 = 16/20 | 429 = 19/30 | 429 = 10/30 |
| this PR + drop-in | **0/20** | **0/30** | **0/30** |

The middle row is the important one: production behaviour is bit-for-bit unchanged.

Sequential probes do **not** reproduce the throttle. `burst=3 delay=2` queues a serial client instead of rejecting it, so reproducing this needs concurrency, which is exactly what the Playwright workers provide.

To verify end to end, run `./run-e2e-tests-local-multinode-fast.sh` before and after.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [x] E2E suite passes on a multi-node stack
- [x] Rate limits still apply on a stack without the drop-in

### Test Coverage

Not applicable: infrastructure configuration only, no Java or TypeScript changed.
