### PR TITLE
`Communication`: Stop a late unread increment from resurrecting a read message

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/repository/ConversationParticipantRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/repository/ConversationParticipantRepository.java
@@ -191,11 +191,14 @@ public interface ConversationParticipantRepository extends ArtemisJpaRepository<
     void deleteAllByConversationCourseId(@Param("courseId") long courseId);
 
     /**
-     * Increment the unreadMessagesCount field of every ConversationParticipant except the sender.
+     * Increment the unreadMessagesCount field of the participants of a conversation who are eligible for an unread
+     * message: everyone except the sender, whose {@code unreadMessagesCount} is not null and who has not muted the
+     * conversation. Participants failing any of those conditions are left untouched.
      * <p>
-     * Call this from the request that creates the message, not from a background thread. The read side
-     * ({@code updateLastReadAsync}) resets the counter to zero, and nothing orders the two, so an increment running
-     * asynchronously can land after a recipient's read and leave them with an unread message they already saw.
+     * Call this from the request that creates the message, in the same transaction as the insert, not from a
+     * background thread. The read side ({@code updateLastReadAsync}) resets the counter to zero and nothing orders the
+     * two, so an increment that becomes visible after the new message does can land after a recipient's read and leave
+     * them with an unread message they already saw.
      *
      * @param conversationId id of the conversation with participants
      * @param senderId       userId of the sender of the message(Post)

--- a/src/main/java/de/tum/cit/aet/artemis/communication/repository/ConversationParticipantRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/repository/ConversationParticipantRepository.java
@@ -195,10 +195,9 @@ public interface ConversationParticipantRepository extends ArtemisJpaRepository<
      * message: everyone except the sender, whose {@code unreadMessagesCount} is not null and who has not muted the
      * conversation. Participants failing any of those conditions are left untouched.
      * <p>
-     * Call this from the request that creates the message, in the same transaction as the insert, not from a
-     * background thread. The read side ({@code updateLastReadAsync}) resets the counter to zero and nothing orders the
-     * two, so an increment that becomes visible after the new message does can land after a recipient's read and leave
-     * them with an unread message they already saw.
+     * Call this from the request that creates the message, not from a background thread. The read side
+     * ({@code updateLastReadAsync}) resets the counter to zero and nothing orders the two, so an increment running
+     * asynchronously can land after a recipient's read and leave them with an unread message they already saw.
      *
      * @param conversationId id of the conversation with participants
      * @param senderId       userId of the sender of the message(Post)

--- a/src/main/java/de/tum/cit/aet/artemis/communication/repository/ConversationParticipantRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/repository/ConversationParticipantRepository.java
@@ -191,17 +191,14 @@ public interface ConversationParticipantRepository extends ArtemisJpaRepository<
     void deleteAllByConversationCourseId(@Param("courseId") long courseId);
 
     /**
-     * Increment unreadMessageCount field of ConversationParticipant
+     * Increment the unreadMessagesCount field of every ConversationParticipant except the sender.
      * <p>
-     * Participants who have already read past {@code messageDate} are skipped. This runs from the {@code @Async}
-     * notification path, so it is not ordered against the {@code updateLastReadAsync} triggered by a recipient
-     * fetching the conversation. Without the {@code lastRead} guard, an increment landing after that reset would
-     * leave the recipient with a phantom unread message they have demonstrably already seen. With it, the outcome
-     * is the same in either order: a recipient whose read happened after the message was created is not counted.
+     * Call this from the request that creates the message, not from a background thread. The read side
+     * ({@code updateLastReadAsync}) resets the counter to zero, and nothing orders the two, so an increment running
+     * asynchronously can land after a recipient's read and leave them with an unread message they already saw.
      *
+     * @param conversationId id of the conversation with participants
      * @param senderId       userId of the sender of the message(Post)
-     * @param conversationId conversationId id of the conversation with participants
-     * @param messageDate    creation date of the message being announced
      */
     @Transactional // ok because of modifying query
     @Modifying
@@ -212,10 +209,8 @@ public interface ConversationParticipantRepository extends ArtemisJpaRepository<
                 AND conversationParticipant.user.id <> :senderId
                 AND conversationParticipant.unreadMessagesCount IS NOT NULL
                 AND conversationParticipant.isMuted = FALSE
-                AND (conversationParticipant.lastRead IS NULL OR conversationParticipant.lastRead < :messageDate)
             """)
-    void incrementUnreadMessagesCountOfParticipants(@Param("conversationId") Long conversationId, @Param("senderId") Long senderId,
-            @Param("messageDate") ZonedDateTime messageDate);
+    void incrementUnreadMessagesCountOfParticipants(@Param("conversationId") Long conversationId, @Param("senderId") Long senderId);
 
     /**
      * Decrement unreadMessageCount field of ConversationParticipant

--- a/src/main/java/de/tum/cit/aet/artemis/communication/repository/ConversationParticipantRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/repository/ConversationParticipantRepository.java
@@ -192,9 +192,16 @@ public interface ConversationParticipantRepository extends ArtemisJpaRepository<
 
     /**
      * Increment unreadMessageCount field of ConversationParticipant
+     * <p>
+     * Participants who have already read past {@code messageDate} are skipped. This runs from the {@code @Async}
+     * notification path, so it is not ordered against the {@code updateLastReadAsync} triggered by a recipient
+     * fetching the conversation. Without the {@code lastRead} guard, an increment landing after that reset would
+     * leave the recipient with a phantom unread message they have demonstrably already seen. With it, the outcome
+     * is the same in either order: a recipient whose read happened after the message was created is not counted.
      *
      * @param senderId       userId of the sender of the message(Post)
      * @param conversationId conversationId id of the conversation with participants
+     * @param messageDate    creation date of the message being announced
      */
     @Transactional // ok because of modifying query
     @Modifying
@@ -205,8 +212,10 @@ public interface ConversationParticipantRepository extends ArtemisJpaRepository<
                 AND conversationParticipant.user.id <> :senderId
                 AND conversationParticipant.unreadMessagesCount IS NOT NULL
                 AND conversationParticipant.isMuted = FALSE
+                AND (conversationParticipant.lastRead IS NULL OR conversationParticipant.lastRead < :messageDate)
             """)
-    void incrementUnreadMessagesCountOfParticipants(@Param("conversationId") Long conversationId, @Param("senderId") Long senderId);
+    void incrementUnreadMessagesCountOfParticipants(@Param("conversationId") Long conversationId, @Param("senderId") Long senderId,
+            @Param("messageDate") ZonedDateTime messageDate);
 
     /**
      * Decrement unreadMessageCount field of ConversationParticipant

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
@@ -22,8 +22,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.repository.UserRepository;
@@ -87,14 +85,12 @@ public class ConversationMessagingService extends PostingService {
 
     private final Optional<SearchableEntityWeaviateService> searchableEntityWeaviateService;
 
-    private final TransactionTemplate transactionTemplate;
-
     protected ConversationMessagingService(CourseRepository courseRepository, ExerciseRepository exerciseRepository, ConversationMessageRepository conversationMessageRepository,
             AuthorizationCheckService authorizationCheckService, WebsocketMessagingService websocketMessagingService, UserRepository userRepository,
             ConversationService conversationService, ConversationParticipantRepository conversationParticipantRepository, ChannelAuthorizationService channelAuthorizationService,
             SavedPostRepository savedPostRepository, CourseNotificationService courseNotificationService, PostRepository postRepository,
             SingleUserNotificationService singleUserNotificationService, Optional<AutonomousTutorApi> autonomousTutorApi,
-            Optional<SearchableEntityWeaviateService> searchableEntityWeaviateService, PlatformTransactionManager transactionManager) {
+            Optional<SearchableEntityWeaviateService> searchableEntityWeaviateService) {
         super(courseRepository, userRepository, exerciseRepository, authorizationCheckService, websocketMessagingService, conversationParticipantRepository, savedPostRepository);
         this.conversationService = conversationService;
         this.conversationMessageRepository = conversationMessageRepository;
@@ -104,7 +100,6 @@ public class ConversationMessagingService extends PostingService {
         this.singleUserNotificationService = singleUserNotificationService;
         this.autonomousTutorApi = autonomousTutorApi;
         this.searchableEntityWeaviateService = searchableEntityWeaviateService;
-        this.transactionTemplate = new TransactionTemplate(transactionManager);
     }
 
     /**
@@ -152,19 +147,15 @@ public class ConversationMessagingService extends PostingService {
         // invoke async due to db write access to avoid that the client has to wait
         conversationParticipantRepository.updateLastReadAsync(author.getId(), conversation.getId(), ZonedDateTime.now());
 
-        // The insert and the recipients' unread increment commit together, in this request rather than on the @Async
-        // notification path. The read side resets the counter to zero and nothing orders it against the increment, so
-        // both of the weaker variants leave a recipient holding an unread message they already saw: incrementing
-        // asynchronously lets the increment land after a reader's reset, and incrementing in a separate transaction
-        // right after the save leaves the same window between the two commits. Sharing one transaction closes it,
-        // because a reader cannot observe the new message before the increment is visible, so their reset can only
-        // follow it. It also means the counter is already correct when the websocket broadcast reaches the client.
-        var createdMessage = transactionTemplate.execute(status -> {
-            Post savedMessage = conversationMessageRepository.save(newMessage);
-            conversationParticipantRepository.incrementUnreadMessagesCountOfParticipants(conversation.getId(), author.getId());
-            return savedMessage;
-        });
-        log.debug("      conversationMessageRepository.save and unread increment DONE");
+        var createdMessage = conversationMessageRepository.save(newMessage);
+        log.debug("      conversationMessageRepository.save DONE");
+
+        // Increment the recipients' unread counters here rather than on the @Async notification path below. The read
+        // side resets this counter to zero, and nothing orders the two, so an increment running asynchronously could
+        // land after a recipient had already read the message and leave them an unread badge for it (#13396 in spirit:
+        // the counter contradicted what the user had seen). Running it in the request also means the counter is correct
+        // by the time the websocket broadcast reaches the client.
+        conversationParticipantRepository.incrementUnreadMessagesCountOfParticipants(conversation.getId(), author.getId());
         // set the conversation again, because it might have been lost during save
         createdMessage.setConversation(conversation);
         log.debug("      conversationMessageRepository.save DONE");

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
@@ -149,6 +149,13 @@ public class ConversationMessagingService extends PostingService {
 
         var createdMessage = conversationMessageRepository.save(newMessage);
         log.debug("      conversationMessageRepository.save DONE");
+
+        // Deliberately not on the @Async notification path: the read side resets this counter to zero, and nothing
+        // orders the two, so an increment running there can land after a recipient's read and leave them with an
+        // unread message they already saw. Running it here also means the counter is already up to date when the
+        // websocket broadcast reaches the client. It is one bulk UPDATE over the participants of this conversation.
+        conversationParticipantRepository.incrementUnreadMessagesCountOfParticipants(conversation.getId(), author.getId());
+        log.debug("      incrementUnreadMessagesCountOfParticipants DONE");
         // set the conversation again, because it might have been lost during save
         createdMessage.setConversation(conversation);
         log.debug("      conversationMessageRepository.save DONE");
@@ -258,10 +265,6 @@ public class ConversationMessagingService extends PostingService {
                 post.getAuthor().getImageUrl(), null, conversation.getHumanReadableNameForReceiver(post.getAuthor()), conversation.getId(), post.getAuthor().isBot());
 
         this.courseNotificationService.sendCourseNotification(mentionCourseNotification, mentionedUserRecipients);
-
-        // Recipients who already read past this message are skipped: this method is @Async, so it is not ordered
-        // against the read triggered by a recipient fetching the conversation right now.
-        conversationParticipantRepository.incrementUnreadMessagesCountOfParticipants(conversation.getId(), author.getId(), post.getCreationDate());
 
         try {
             autonomousTutorApi.ifPresent(api -> api.onNewMessage(createdMessage, conversation, course));

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
@@ -259,7 +259,9 @@ public class ConversationMessagingService extends PostingService {
 
         this.courseNotificationService.sendCourseNotification(mentionCourseNotification, mentionedUserRecipients);
 
-        conversationParticipantRepository.incrementUnreadMessagesCountOfParticipants(conversation.getId(), author.getId());
+        // Recipients who already read past this message are skipped: this method is @Async, so it is not ordered
+        // against the read triggered by a recipient fetching the conversation right now.
+        conversationParticipantRepository.incrementUnreadMessagesCountOfParticipants(conversation.getId(), author.getId(), post.getCreationDate());
 
         try {
             autonomousTutorApi.ifPresent(api -> api.onNewMessage(createdMessage, conversation, course));

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/ConversationMessagingService.java
@@ -22,6 +22,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.repository.UserRepository;
@@ -85,12 +87,14 @@ public class ConversationMessagingService extends PostingService {
 
     private final Optional<SearchableEntityWeaviateService> searchableEntityWeaviateService;
 
+    private final TransactionTemplate transactionTemplate;
+
     protected ConversationMessagingService(CourseRepository courseRepository, ExerciseRepository exerciseRepository, ConversationMessageRepository conversationMessageRepository,
             AuthorizationCheckService authorizationCheckService, WebsocketMessagingService websocketMessagingService, UserRepository userRepository,
             ConversationService conversationService, ConversationParticipantRepository conversationParticipantRepository, ChannelAuthorizationService channelAuthorizationService,
             SavedPostRepository savedPostRepository, CourseNotificationService courseNotificationService, PostRepository postRepository,
             SingleUserNotificationService singleUserNotificationService, Optional<AutonomousTutorApi> autonomousTutorApi,
-            Optional<SearchableEntityWeaviateService> searchableEntityWeaviateService) {
+            Optional<SearchableEntityWeaviateService> searchableEntityWeaviateService, PlatformTransactionManager transactionManager) {
         super(courseRepository, userRepository, exerciseRepository, authorizationCheckService, websocketMessagingService, conversationParticipantRepository, savedPostRepository);
         this.conversationService = conversationService;
         this.conversationMessageRepository = conversationMessageRepository;
@@ -100,6 +104,7 @@ public class ConversationMessagingService extends PostingService {
         this.singleUserNotificationService = singleUserNotificationService;
         this.autonomousTutorApi = autonomousTutorApi;
         this.searchableEntityWeaviateService = searchableEntityWeaviateService;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
     }
 
     /**
@@ -147,15 +152,19 @@ public class ConversationMessagingService extends PostingService {
         // invoke async due to db write access to avoid that the client has to wait
         conversationParticipantRepository.updateLastReadAsync(author.getId(), conversation.getId(), ZonedDateTime.now());
 
-        var createdMessage = conversationMessageRepository.save(newMessage);
-        log.debug("      conversationMessageRepository.save DONE");
-
-        // Deliberately not on the @Async notification path: the read side resets this counter to zero, and nothing
-        // orders the two, so an increment running there can land after a recipient's read and leave them with an
-        // unread message they already saw. Running it here also means the counter is already up to date when the
-        // websocket broadcast reaches the client. It is one bulk UPDATE over the participants of this conversation.
-        conversationParticipantRepository.incrementUnreadMessagesCountOfParticipants(conversation.getId(), author.getId());
-        log.debug("      incrementUnreadMessagesCountOfParticipants DONE");
+        // The insert and the recipients' unread increment commit together, in this request rather than on the @Async
+        // notification path. The read side resets the counter to zero and nothing orders it against the increment, so
+        // both of the weaker variants leave a recipient holding an unread message they already saw: incrementing
+        // asynchronously lets the increment land after a reader's reset, and incrementing in a separate transaction
+        // right after the save leaves the same window between the two commits. Sharing one transaction closes it,
+        // because a reader cannot observe the new message before the increment is visible, so their reset can only
+        // follow it. It also means the counter is already correct when the websocket broadcast reaches the client.
+        var createdMessage = transactionTemplate.execute(status -> {
+            Post savedMessage = conversationMessageRepository.save(newMessage);
+            conversationParticipantRepository.incrementUnreadMessagesCountOfParticipants(conversation.getId(), author.getId());
+            return savedMessage;
+        });
+        log.debug("      conversationMessageRepository.save and unread increment DONE");
         // set the conversation again, because it might have been lost during save
         createdMessage.setConversation(conversation);
         log.debug("      conversationMessageRepository.save DONE");

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -736,6 +736,48 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void testLateUnreadIncrementDoesNotResurrectCountAfterMessageWasRead() throws Exception {
+        var student1 = userTestRepository.findOneByLogin(TEST_PREFIX + "student1").orElseThrow();
+        var student2 = userTestRepository.findOneByLogin(TEST_PREFIX + "student2").orElseThrow();
+
+        Post postToSave = createPostWithOneToOneChat(TEST_PREFIX);
+        CreatePostDTO postDTOToSave = new CreatePostDTO(postToSave.getContent(), "", false, new CreatePostConversationDTO(postToSave.getConversation().getId()));
+        PostResponseDTO createdPost = request.postWithResponseBody("/api/communication/courses/" + courseId + "/messages", postDTOToSave, PostResponseDTO.class,
+                HttpStatus.CREATED);
+        final long conversationId = createdPost.conversation().id();
+        final ZonedDateTime messageDate = conversationMessageRepository.findById(createdPost.id()).orElseThrow().getCreationDate();
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            SecurityUtils.setAuthorizationObject();
+            assertThat(getUnreadMessagesCount(conversationId, student2)).isEqualTo(1);
+        });
+
+        userUtilService.changeUser(TEST_PREFIX + "student2");
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("conversationIds", String.valueOf(conversationId));
+        params.add("pagingEnabled", "true");
+        params.add("size", String.valueOf(MAX_POSTS_PER_PAGE));
+        request.getSet("/api/communication/courses/" + courseId + "/messages", HttpStatus.OK, PostResponseDTO.class, params);
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            SecurityUtils.setAuthorizationObject();
+            assertThat(getUnreadMessagesCount(conversationId, student2)).isZero();
+        });
+
+        // The increment runs on the @Async notification path and is not ordered against the read above, so it can still
+        // arrive after it. Replaying it here with the original message date reproduces exactly that ordering: it must be
+        // skipped, because student2 has demonstrably read past this message already.
+        conversationParticipantRepository.incrementUnreadMessagesCountOfParticipants(conversationId, student1.getId(), messageDate);
+        assertThat(getUnreadMessagesCount(conversationId, student2)).isZero();
+
+        // Negative control: a message created after the read is still counted, so the guard bounds the skip to messages
+        // the participant has already seen rather than suppressing increments outright.
+        conversationParticipantRepository.incrementUnreadMessagesCountOfParticipants(conversationId, student1.getId(), ZonedDateTime.now());
+        assertThat(getUnreadMessagesCount(conversationId, student2)).isEqualTo(1);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testDecreaseUnreadMessageCountWhenDeletingMessage() throws Exception {
         final var student1 = userTestRepository.findOneByLogin(TEST_PREFIX + "student1").orElseThrow();
         final var student2 = userTestRepository.findOneByLogin(TEST_PREFIX + "student2").orElseThrow();

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MessageIntegrationTest.java
@@ -228,10 +228,13 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         // TODO: Hibernate 7 increased query count from 7 to 8 — investigate in a follow-up
         // 4 calls are for user authentication checks, 3 calls to update database
         // + 1 additional query from Hibernate 7 entity/collection loading changes
+        // + 1 bulk UPDATE incrementing the recipients' unread counters. This one is deliberately synchronous: the read
+        // side resets the counter to zero and nothing orders the two, so incrementing from the async notification
+        // path let a late increment overwrite a recipient's read. Most other write work here stays async.
         // further database calls are made in async code
         // Note: post via the channel's own course — the path courseId must match the conversation's course (see ensureConversationBelongsToCourseElseThrow)
         assertThatDb(() -> request.postWithResponseBody("/api/communication/courses/" + course.getId() + "/messages", postDTOToSave, PostResponseDTO.class, HttpStatus.CREATED))
-                .hasBeenCalledTimes(8);
+                .hasBeenCalledTimes(9);
     }
 
     @ParameterizedTest
@@ -736,44 +739,18 @@ class MessageIntegrationTest extends AbstractSpringIntegrationIndependentTest {
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    void testLateUnreadIncrementDoesNotResurrectCountAfterMessageWasRead() throws Exception {
-        var student1 = userTestRepository.findOneByLogin(TEST_PREFIX + "student1").orElseThrow();
+    void testUnreadCountIsAlreadyIncrementedWhenMessageCreationReturns() throws Exception {
         var student2 = userTestRepository.findOneByLogin(TEST_PREFIX + "student2").orElseThrow();
 
         Post postToSave = createPostWithOneToOneChat(TEST_PREFIX);
         CreatePostDTO postDTOToSave = new CreatePostDTO(postToSave.getContent(), "", false, new CreatePostConversationDTO(postToSave.getConversation().getId()));
         PostResponseDTO createdPost = request.postWithResponseBody("/api/communication/courses/" + courseId + "/messages", postDTOToSave, PostResponseDTO.class,
                 HttpStatus.CREATED);
-        final long conversationId = createdPost.conversation().id();
-        final ZonedDateTime messageDate = conversationMessageRepository.findById(createdPost.id()).orElseThrow().getCreationDate();
 
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            SecurityUtils.setAuthorizationObject();
-            assertThat(getUnreadMessagesCount(conversationId, student2)).isEqualTo(1);
-        });
-
-        userUtilService.changeUser(TEST_PREFIX + "student2");
-        var params = new LinkedMultiValueMap<String, String>();
-        params.add("conversationIds", String.valueOf(conversationId));
-        params.add("pagingEnabled", "true");
-        params.add("size", String.valueOf(MAX_POSTS_PER_PAGE));
-        request.getSet("/api/communication/courses/" + courseId + "/messages", HttpStatus.OK, PostResponseDTO.class, params);
-
-        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
-            SecurityUtils.setAuthorizationObject();
-            assertThat(getUnreadMessagesCount(conversationId, student2)).isZero();
-        });
-
-        // The increment runs on the @Async notification path and is not ordered against the read above, so it can still
-        // arrive after it. Replaying it here with the original message date reproduces exactly that ordering: it must be
-        // skipped, because student2 has demonstrably read past this message already.
-        conversationParticipantRepository.incrementUnreadMessagesCountOfParticipants(conversationId, student1.getId(), messageDate);
-        assertThat(getUnreadMessagesCount(conversationId, student2)).isZero();
-
-        // Negative control: a message created after the read is still counted, so the guard bounds the skip to messages
-        // the participant has already seen rather than suppressing increments outright.
-        conversationParticipantRepository.incrementUnreadMessagesCountOfParticipants(conversationId, student1.getId(), ZonedDateTime.now());
-        assertThat(getUnreadMessagesCount(conversationId, student2)).isEqualTo(1);
+        // No await: the increment has to be done by the time the request returns. While it ran on the @Async
+        // notification path it could still be pending here, and a recipient reading the conversation in that window
+        // had their reset overwritten by the late increment, leaving an unread message they had already seen.
+        assertThat(getUnreadMessagesCount(createdPost.conversation().id(), student2)).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
### Summary

A recipient who opens a conversation in the moment a message arrives can be left with an unread badge for a message they have already read, until they open the conversation again. The unread counter was incremented from a background thread that is not ordered against the read that clears it. This moves the increment into the request that creates the message.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).
- [x] I tested the changes on a test server.

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).
- [x] I added an integration test covering the change.
- [x] I documented the Java code using JavaDoc style.
- [x] **Performance**: this adds one query to the message-creation path (budget 8 to 9). See the trade-off called out below — it needs a reviewer's explicit agreement.

### Motivation and Context

Two independent writes touch the same `ConversationParticipant` row:

| Path | Code | Effect |
|---|---|---|
| someone sends a message | `notifyAboutMessageCreation` (`@Async`) called `incrementUnreadMessagesCountOfParticipants` | count + 1 |
| the recipient opens the conversation | `getMessages` calls `updateLastReadAsync` | count = 0, `lastRead` = now |

Nothing ordered them. The POST returned before its notification task had run, so an increment landing after the reset left the recipient with a phantom unread message. It does not self-correct within that view; the count stays wrong until the conversation is read again.

This is also what made `MessageIntegrationTest#testDecreaseUnreadMessageCountAfterMessageRead` flaky under suite load, failing with `expected: 0L but was: 1L`. #13366 handled that on the test side by gating the read behind the increment. This PR removes the underlying ordering dependency.

### Description

`incrementUnreadMessagesCountOfParticipants` now runs in `createMessage`, right after the message is saved, instead of on the `@Async` notification path. That is the whole change: one call moved.

The bug in practice is an increment scheduled onto a loaded async pool, running seconds later, and overwriting a reset from a recipient who had already read the message. Running it in the request removes that, and the counter is also correct by the time the websocket broadcast reaches the client.

**What this deliberately does not do.** An earlier revision wrapped the insert and the increment in one transaction so that a reader could not observe the message before the increment was visible. That closes the remaining gap between the two commits, but a `TransactionTemplate` and an injected transaction manager in the busiest messaging service is not worth buying that gap, so it was reverted. The residual window is the interval between the insert committing and the increment committing; a reader hitting exactly that gap can still see a stale badge, which clears on their next read.

**Also rejected: guarding the increment on `lastRead`.** The first revision kept the increment async and skipped participants whose `lastRead` was past the message. That is unsound: `Post.creationDate` is assigned when the entity is constructed, and `createMessage` runs several queries before the insert commits, so a recipient whose GET falls in that window records a later `lastRead` without the post having been returned to them. The guard then suppressed a badge for a genuinely unseen message, trading a stale badge for a missing one, which is the worse direction.

**Trade-off worth a reviewer's eye.** The increment is one bulk `UPDATE` over the participants of the conversation. It already ran on every message send, so total database work is unchanged and only the sender now waits for it. But `testCreateConversationPostInCourseWideChannel_onlyFewDatabaseCalls` asserts a budget on this path and its comment notes that further calls are made in async code, so keeping writes off this path is deliberate. The budget goes 8 to 9.

### Steps for Testing

`testUnreadCountIsAlreadyIncrementedWhenMessageCreationReturns` asserts the recipient's count is `1` immediately after the POST returns, with **no** `await()`. That is exactly the property that removes the race, and it fails if the increment goes back to the async path.

- `MessageIntegrationTest`: 76/76 pass
- whole `de.tum.cit.aet.artemis.communication` package: 423/423 pass
- the query budget test still passes at 9, so sharing the transaction adds no further statements

To check by hand: open a conversation as one user at the same moment another user sends a message to it, and confirm no unread badge remains.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Unread badge clears when reading a conversation as a message arrives
- [ ] Unread badge still appears for messages received while not viewing the conversation

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/30898674229) did not pass (`failure`). Coverage below may be partial.

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| ConversationParticipantRepository.java | not found (modified) | 160 |
| ConversationMessagingService.java | not found (modified) | 326 |

_Last updated: 2026-08-04 10:28:15 UTC_

