### PR TITLE
`Development`: Avoid a second course query when listing an exam's exercise groups

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exam/repository/ExerciseGroupRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/repository/ExerciseGroupRepository.java
@@ -36,13 +36,12 @@ public interface ExerciseGroupRepository extends ArtemisJpaRepository<ExerciseGr
      * course that is immediately discarded (the list DTO sets the exam to null).
      *
      * @param examId the exam whose exercise groups are returned
-     * @return the exercise groups of the exam, ordered as stored; a single null element for an exam without any groups,
-     *         because the groups are left-joined off the exam
+     * @return the exercise groups of the exam, ordered as stored, or an empty list if it has none
      */
     @Query("""
             SELECT eg
             FROM Exam exam
-                LEFT JOIN exam.exerciseGroups eg
+                JOIN exam.exerciseGroups eg
                 LEFT JOIN FETCH eg.exercises
                 LEFT JOIN FETCH eg.exam eagerExam
                 LEFT JOIN FETCH eagerExam.course

--- a/src/main/java/de/tum/cit/aet/artemis/exam/repository/ExerciseGroupRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/repository/ExerciseGroupRepository.java
@@ -28,12 +28,24 @@ public interface ExerciseGroupRepository extends ArtemisJpaRepository<ExerciseGr
     @EntityGraph(type = LOAD, attributePaths = { "exercises" })
     Optional<ExerciseGroup> findWithExercisesById(Long exerciseGroupId);
 
+    /**
+     * Finds the exercise groups of an exam, in their stored order, with their exercises.
+     * <p>
+     * The course is fetch-joined even though no caller reads it: {@code Exam.course} is a {@code @ManyToOne} without an
+     * explicit fetch type, so it is EAGER, and hydrating the fetched exam would otherwise cost a second round trip for a
+     * course that is immediately discarded (the list DTO sets the exam to null).
+     *
+     * @param examId the exam whose exercise groups are returned
+     * @return the exercise groups of the exam, ordered as stored; a single null element for an exam without any groups,
+     *         because the groups are left-joined off the exam
+     */
     @Query("""
             SELECT eg
             FROM Exam exam
                 LEFT JOIN exam.exerciseGroups eg
                 LEFT JOIN FETCH eg.exercises
-                LEFT JOIN FETCH eg.exam
+                LEFT JOIN FETCH eg.exam eagerExam
+                LEFT JOIN FETCH eagerExam.course
             WHERE exam.id = :examId
             ORDER BY INDEX(eg)
             """)

--- a/src/main/java/de/tum/cit/aet/artemis/exam/web/ExerciseGroupResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/web/ExerciseGroupResource.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -224,9 +223,7 @@ public class ExerciseGroupResource {
         examAccessService.checkCourseAndExamAccessForEditorElseThrow(courseId, examId);
 
         List<ExerciseGroup> exerciseGroupList = exerciseGroupRepository.findWithExamAndExercisesByExamId(examId);
-        // The query left-joins the groups off the exam, so an exam without any exercise groups yields a single null row;
-        // filter it out so the endpoint returns the documented empty list instead of failing to map.
-        List<ExerciseGroupDTO> exerciseGroupDTOs = exerciseGroupList.stream().filter(Objects::nonNull).map(ExerciseGroupDTO::ofWithExercises).toList();
+        List<ExerciseGroupDTO> exerciseGroupDTOs = exerciseGroupList.stream().map(ExerciseGroupDTO::ofWithExercises).toList();
         return ResponseEntity.ok(exerciseGroupDTOs);
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/exam/ExerciseGroupIntegrationJenkinsLocalVCTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/ExerciseGroupIntegrationJenkinsLocalVCTest.java
@@ -203,8 +203,8 @@ class ExerciseGroupIntegrationJenkinsLocalVCTest extends AbstractSpringIntegrati
     @Test
     @WithMockUser(username = TEST_PREFIX + "editor1", roles = "EDITOR")
     void testGetExerciseGroupsForExam_withoutGroups_returnsEmptyList() throws Exception {
-        // The repository query left-joins the groups off the exam, so an exam without groups yields a single null row;
-        // the endpoint must filter it and return the documented empty list instead of failing to map.
+        // The repository query inner-joins the groups off the exam, so an exam without groups yields no rows at all and
+        // the endpoint returns the documented empty list.
         Exam emptyExam = examUtilService.addExam(course1);
         List<ExerciseGroupDTO> result = request.getList("/api/exam/courses/" + course1.getId() + "/exams/" + emptyExam.getId() + "/exercise-groups", HttpStatus.OK,
                 ExerciseGroupDTO.class);


### PR DESCRIPTION
### Motivation

`GET courses/{courseId}/exams/{examId}/exercise-groups` issues **six** queries where its test budgets five, so `ExerciseGroupIntegrationJenkinsLocalVCTest.testGetExerciseGroupsForExam_asEditor` fails:

```
org.opentest4j.AssertionFailedError: Expected at most <5> queries, but <6> were performed.
```

This has been failing on `develop` and is invisible: the server tests could not get past `:compileJava` (see #13411), so nothing ran. Verified against unmodified `develop` in a clean worktree, so it is not caused by that PR.

### Is the sixth query legitimate?

No. Logging each statement with its call site answers it directly:

| # | query | issued from |
| --- | --- | --- |
| 1 | course | `ExamAccessService.checkCourseAccessForEditor` |
| 2 | user + authorities | `AuthorizationCheckService.loadUserIfNeeded` |
| 3 | `exists` on user_course_role | `AuthorizationCheckService.hasCourseRoleAtLeast` |
| 4 | exam | `ExamAccessService.checkExamBelongsToCourseElseThrow` |
| 5 | exercise groups + exercises + exam | `ExerciseGroupResource:226` |
| 6 | **course again** | **`ExerciseGroupResource:226`** — the same line |

Queries 1-4 are the access check and 5 is the endpoint's own fetch. The sixth is a *second* course select triggered by that same fetch, and nothing asks for it:

- `Exam.course` is a `@ManyToOne` with no explicit fetch type, so it is **EAGER**.
- The query fetch-joins `eg.exam` but not the exam's course, so hydrating that exam costs another round trip.
- The result is then thrown away: `ExerciseGroupDTO.ofWithExercises` passes `null` for the exam, so neither the exam nor its course reaches the response.

So this is not a DTO that needs an extra query — it is an eager association being satisfied separately and discarded.

### Description

The course is fetch-joined in the same query. The count drops from six to five, so the budget stays at five instead of being raised to accommodate avoidable work.

**On whether it was worth optimising rather than accepting:** the endpoint is `@EnforceAtLeastEditor` and the web client does not call it at all (only a Playwright helper reads it), so it is not a hot path and the query is a fast primary-key lookup. Raising the budget to six would have been defensible on those grounds. It is fixed instead because the query buys nothing — the argument for keeping it would have to be that the data is used, and it is not.

I also checked the student-facing side, since that is where the cost would matter with thousands of concurrent users: `StudentExamRepository` already fetches `exam.course` alongside `se.exam` in the queries those paths use, so they do not have this problem.

### Also in this PR

The same query left-joined the groups off the exam, so an exam without any exercise groups produced a single row whose group was `null` — filtered out by the resource, and documented as such. A repository method returning a list with a null element is a trap for the next caller, so the join is now an inner join: no rows for that case, and the list is simply empty. The null filter and the warning in the javadoc are gone with it.

`ORDER BY INDEX(eg)` still works, because it needs the collection join rather than specifically an outer one, and the endpoint's contract is unchanged — `testGetExerciseGroupsForExam_withoutGroups_returnsEmptyList` already covered it and still passes.

### Steps for testing

1. `./gradlew test --tests "de.tum.cit.aet.artemis.exam.ExerciseGroupIntegrationJenkinsLocalVCTest" -x webapp` passes; on `develop` it fails.
2. Open an exam's exercise groups as an editor and confirm the list is unchanged — same groups, same order, same embedded exercise summaries.

### Testserver states

<!-- Testserver states are updated automatically -->

### Server tests

- [x] `ExerciseGroupIntegrationJenkinsLocalVCTest` green (was failing on develop)
- [x] Query count measured as **exactly 5** with `hasBeenCalledTimes(5)`, not merely under the at-most bound
- [x] Whole exam module: 678 tests across 35 classes green
- [x] Query count re-measured as exactly 5 *after* switching to the inner join, so the join change did not reintroduce a round trip
- [x] `checkstyleMain`, `spotlessCheck`, `autoLintGradle` green

### Code review

- [x] Code is readable and maintainable
- [x] Code follows the coding guidelines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exercise-group loading so associated exams and courses are available immediately.
  * Preserved existing exercise retrieval and ordering behavior.
  * Corrected handling of empty exercise-group results, returning an empty list as expected.

* **Documentation**
  * Added documentation describing query behavior and data-fetching details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
