### PR TITLE
`Development`: Keep the correction round in the text assessment URL

### DIFF
--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.spec.ts
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.spec.ts
@@ -722,10 +722,16 @@ describe('FileUploadAssessmentComponent', () => {
             nextSubmission.participation = nextParticipation;
             vi.spyOn(fileUploadSubmissionService, 'getSubmissionWithoutAssessment').mockReturnValue(of(nextSubmission));
             const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+            component.correctionRound.set(1);
 
             component.assessNext();
 
-            expect(navigateSpy).toHaveBeenCalled();
+            // Assert the exact navigation contract: the correction round has to travel with the next submission, and it
+            // has to be merged rather than replace the query string, otherwise testRun is dropped on the way.
+            expect(navigateSpy).toHaveBeenCalledExactlyOnceWith(['/course-management', '123', 'file-upload-exercises', '20', 'submissions', '999', 'assessment'], {
+                queryParams: { 'correction-round': 1 },
+                queryParamsHandling: 'merge',
+            });
             expect(component.isLoading()).toBe(false);
         });
 

--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
@@ -360,7 +360,9 @@ export class FileUploadAssessmentComponent implements OnInit {
                     this.examId,
                     this.exerciseGroupId,
                 );
-                void this.router.navigate(url);
+                // Carry the correction round and keep the other parameters: the component reads the round from the URL,
+                // so dropping it sent the next submission into the first correction round.
+                void this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() }, queryParamsHandling: 'merge' });
             },
             error: (error: HttpErrorResponse) => {
                 this.isLoading.set(false);

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
@@ -584,7 +584,7 @@ describe('ModelingAssessmentEditorComponent', () => {
             component.modelingExercise.set({ id: exerciseId } as Exercise);
             component.exerciseId = exerciseId;
             const url = ['/course-management', courseId.toString(), 'modeling-exercises', exerciseId.toString(), 'submissions', modelingSubmission.id!.toString(), 'assessment'];
-            const queryParams = { queryParams: { 'correction-round': correctionRound } };
+            const queryParams = { queryParams: { 'correction-round': correctionRound }, queryParamsHandling: 'merge' };
 
             await fixture.whenStable();
             component.assessNext();

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -589,7 +589,8 @@ export class ModelingAssessmentEditorComponent implements OnInit {
                 this.isLoading.set(false);
 
                 const url = getLinkToSubmissionAssessment(ExerciseType.MODELING, this.courseId, this.exerciseId, undefined, submission.id!, this.examId, this.exerciseGroupId);
-                void this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() } });
+                // Merge rather than replace: a supplied queryParams object drops every other parameter, testRun among them.
+                void this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() }, queryParamsHandling: 'merge' });
             },
             error: (error: HttpErrorResponse) => {
                 this.nextSubmissionBusy.set(false);

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
@@ -30,6 +30,8 @@ import { Result } from 'app/exercise/shared/entities/result/result.model';
 import dayjs from 'dayjs/esm';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
+import { Location } from '@angular/common';
+import { NEW_ASSESSMENT_PATH } from 'app/text/manage/assess/text-submission-assessment.route';
 import { ConfirmIconComponent } from 'app/shared-ui/confirm-icon/confirm-icon.component';
 import { Course } from 'app/course/shared/entities/course.model';
 import { ManualTextblockSelectionComponent } from 'app/text/manage/assess/manual-textblock-selection/manual-textblock-selection.component';
@@ -232,6 +234,21 @@ describe('TextSubmissionAssessmentComponent', () => {
     it('should use jhi-assessment-layout', () => {
         const sharedLayout = fixture.debugElement.query(By.directive(AssessmentLayoutComponent));
         expect(sharedLayout).not.toBeNull();
+    });
+
+    it('should keep the query parameters when rewriting the new-assessment url', () => {
+        // The correction round lives only in the URL. Rebuilding it without the query parameters turned a second-round
+        // assessment into a first-round one on the next reload, which is the core of issue #13396.
+        const router = TestBed.inject(Router);
+        const createUrlTreeSpy = vi.spyOn(router, 'createUrlTree').mockReturnValue({ toString: () => '/rewritten' } as any);
+        const goSpy = vi.spyOn(TestBed.inject(Location), 'go').mockImplementation(() => {});
+        component['activatedRoute'] = { routeConfig: { path: NEW_ASSESSMENT_PATH } } as any;
+        component['route'] = { snapshot: { queryParams: { 'correction-round': '1', testRun: 'false' } } } as any;
+
+        component['updateUrlIfNeeded']();
+
+        expect(createUrlTreeSpy).toHaveBeenCalledExactlyOnceWith(expect.anything(), { queryParams: { 'correction-round': '1', testRun: 'false' } });
+        expect(goSpy).toHaveBeenCalledExactlyOnceWith('/rewritten');
     });
 
     describe('when assessment is not possible yet', () => {

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
@@ -484,7 +484,7 @@ describe('TextSubmissionAssessmentComponent', () => {
             'new',
             'assessment',
         ];
-        const queryParams = { queryParams: { 'correction-round': 0 } };
+        const queryParams = { queryParams: { 'correction-round': 0 }, queryParamsHandling: 'merge' };
 
         component.nextSubmission();
         expect(routerSpy).toHaveBeenCalledOnce();

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
@@ -452,7 +452,8 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
     async nextSubmission(): Promise<void> {
         const url = getLinkToSubmissionAssessment(ExerciseType.TEXT, this.courseId, this.exerciseId, this.participation!.id, 'new', this.examId, this.exerciseGroupId);
         this.nextSubmissionBusy.set(true);
-        await this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() } });
+        // Merge rather than replace: a supplied queryParams object drops every other parameter, testRun among them.
+        await this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound() }, queryParamsHandling: 'merge' });
     }
 
     /**

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
@@ -246,6 +246,10 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
     private updateUrlIfNeeded() {
         if (this.isNewAssessmentRoute) {
             // Update the url with the new id, without reloading the page, to make the history consistent
+            // Keep the query parameters. The correction round is carried only in the URL, so rebuilding the URL from
+            // the route commands alone dropped it and the next load of this page started the second correction round
+            // as the first one (#13396). The modeling and file upload editors rewrite the hash in place and therefore
+            // never lost it.
             const newUrl = this.router
                 .createUrlTree(
                     getLinkToSubmissionAssessment(
@@ -257,6 +261,7 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
                         this.examId,
                         this.exerciseGroupId,
                     ),
+                    { queryParams: this.route.snapshot.queryParams },
                 )
                 .toString();
             this.location.go(newUrl);


### PR DESCRIPTION
### Summary

Starting a new text assessment opens `/submissions/**new**/assessment`, and the editor then rewrites the URL to the real submission id so the browser history stays usable. It rebuilt that URL from the route commands alone, which **drops the query string** — and the correction round is carried only there. After the rewrite the URL no longer says which round is being assessed, so the next load of that page starts the second correction round as the **first** one.

Text editor only. No Athena, no automatic results.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).
- [x] I tested the changes on a test server.

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added a test covering the change.

### Motivation and Context

Part of #13396, reported for a **text** exercise in an exam with two correction rounds.

`TextSubmissionAssessmentComponent#updateUrlIfNeeded`:

```ts
const newUrl = this.router.createUrlTree(getLinkToSubmissionAssessment(...)).toString();
this.location.go(newUrl);
```

`getLinkToSubmissionAssessment` returns route segments only, so the resulting URL has no query string and `correction-round=1` is gone. Nothing else stores the round, so it cannot be recovered afterwards.

This is why the report is specific to text exercises. The modeling and file upload editors do the same rewrite with `window.location.hash.replace('new', id)`, which preserves everything after the `?`, so they never lose it.

### Description

The rewrite now carries the current query parameters over:

```ts
this.router.createUrlTree(getLinkToSubmissionAssessment(...), { queryParams: this.route.snapshot.queryParams })
```

That is the whole change. `testRun` benefits for the same reason.

### Steps for Testing

Prerequisites:
- 1 exam with a **text** exercise and **2 correction rounds**
- 1 student with a non-empty submission
- 1 tutor, 1 instructor
- no Athena anywhere

1. As the tutor, assess the submission in correction round 1 and **submit** it.
2. As the instructor, enable the second correction round.
3. Start assessing correction round **2**. You arrive at a URL like
   `/course-management/1/exams/2/exercise-groups/3/text-exercises/4/submissions/new/assessment?correction-round=1`.
4. Watch the address bar. The editor replaces `new` with the real submission id.
   - **Before this change:** the URL becomes `.../submissions/1234/assessment` — `?correction-round=1` has disappeared.
   - **After this change:** it becomes `.../submissions/1234/assessment?correction-round=1`.
5. Now press **F5** to reload that page.
   - **Before:** the editor opens correction round **1**, showing the first tutor's assessment, and the header says the first correction round.
   - **After:** the editor stays in correction round 2.

Step 5 is the user-visible symptom: a tutor who reloads, or returns via browser history, silently ends up in the wrong round.

Automated: `text-submission-assessment.component.spec.ts` asserts `createUrlTree` receives the query parameters and that `location.go` is called with the result. It fails without this change, which I verified by removing the option and re-running (1 failed / 39 passed).

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] The correction round survives the URL rewrite and a reload

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| file-upload-assessment.component.ts | 90.44% | 495 | 99 | 20.0 |
| modeling-assessment-editor.component.ts | 84.19% | 523 | 62 | 11.9 |
| text-submission-assessment.component.ts | 91.98% | 437 | 56 | 12.8 |

_Last updated: 2026-08-04 21:09:08 UTC_

