### PR TITLE
`Assessment`: Fix missing text assessments in the second correction round

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/text/dto/TextSubmissionResponseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/dto/TextSubmissionResponseDTO.java
@@ -5,6 +5,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.hibernate.Hibernate;
+import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -19,12 +20,13 @@ import de.tum.cit.aet.artemis.text.domain.TextSubmission;
  * Read DTO for a {@link TextSubmission} returned to the client.
  * <p>
  * Lazy associations (results, blocks, participation) are guarded with {@link Hibernate#isInitialized} so uninitialized
- * proxies map to {@code null}/empty rather than triggering a lazy load. The caller is expected to have trimmed/filtered
- * the entity (e.g. removed null results) before invoking the factory.
+ * proxies map to {@code null}/empty rather than triggering a lazy load. Null result entries are preserved because they
+ * encode correction-round positions for assessor-filtered exam submissions.
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record TextSubmissionResponseDTO(Long id, String submissionExerciseType, String text, Language language, Boolean submitted, ZonedDateTime submissionDate,
-        SubmissionType type, Boolean exampleSubmission, StudentParticipationDTO participation, List<ResultDTO> results, List<TextBlockDTO> blocks) implements Serializable {
+        SubmissionType type, Boolean exampleSubmission, StudentParticipationDTO participation, List<@Nullable ResultDTO> results, List<TextBlockDTO> blocks)
+        implements Serializable {
 
     /**
      * Converts a {@link TextSubmission} into a {@link TextSubmissionResponseDTO} without the participation's student.
@@ -48,9 +50,9 @@ public record TextSubmissionResponseDTO(Long id, String submissionExerciseType, 
             return null;
         }
 
-        List<ResultDTO> results = null;
+        List<@Nullable ResultDTO> results = null;
         if (Hibernate.isInitialized(submission.getResults()) && submission.getResults() != null) {
-            results = submission.getResults().stream().filter(java.util.Objects::nonNull).map(ResultDTO::of).toList();
+            results = submission.getResults().stream().map(result -> result == null ? null : ResultDTO.of(result)).toList();
         }
 
         List<TextBlockDTO> blocks = null;

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
@@ -1487,7 +1487,9 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         assertThat(assessedSubmissionList).hasSize(1);
         assertThat(assessedSubmissionList.getFirst().id()).isEqualTo(submissionId(submissionWithoutSecondAssessment));
         // result for correction round 1 corresponds to the just-submitted second manual result
-        assertThat(assessedSubmissionList.getFirst().results()).extracting(ResultDTO::id).contains(secondSubmittedManualResult.id());
+        assertThat(assessedSubmissionList.getFirst().results()).hasSize(2);
+        assertThat(assessedSubmissionList.getFirst().results().getFirst()).isNull();
+        assertThat(assessedSubmissionList.getFirst().results().get(1).id()).isEqualTo(secondSubmittedManualResult.id());
 
         // make sure that they do not appear for the first correction round as the tutor only assessed the second correction round
         LinkedMultiValueMap<String, String> paramsGetAssessedCR1 = new LinkedMultiValueMap<>();

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
@@ -1489,7 +1489,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         // result for correction round 1 corresponds to the just-submitted second manual result
         assertThat(assessedSubmissionList.getFirst().results()).hasSize(2);
         assertThat(assessedSubmissionList.getFirst().results().getFirst()).isNull();
-        assertThat(assessedSubmissionList.getFirst().results().get(1).id()).isEqualTo(secondSubmittedManualResult.id());
+        assertThat(assessedSubmissionList.getFirst().results().get(1)).isNotNull().extracting(ResultDTO::id).isEqualTo(secondSubmittedManualResult.id());
 
         // make sure that they do not appear for the first correction round as the tutor only assessed the second correction round
         LinkedMultiValueMap<String, String> paramsGetAssessedCR1 = new LinkedMultiValueMap<>();


### PR DESCRIPTION
### Summary

Preserve correction-round result positions in text submission responses so that tutors can continue their locked text assessments from the exercise assessment dashboard during the second correction round.

### Checklist

#### General

- [x] This is a small issue that I tested locally.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server

- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I extended the existing integration test for multiple exam correction rounds with assertions covering the regression.
- [x] I documented the correction-round result mapping using JavaDoc style.

### Motivation and Context

In an exam with multiple correction rounds, a tutor who started and saved a text assessment in the second correction round could not see that locked submission on the exercise assessment dashboard. The same submission was still available through the exercise scores page.

The server deliberately uses the result list position to represent the correction round. When the current tutor owns the second-round result but not the first-round result, the assessor-filtered query can produce a list such as `[null, secondRoundResult]`. The null entry is significant: it preserves index 1 for the second correction round, which the shared assessment dashboard reads.

The regression was introduced by #12922 (`Development: Use DTOs at the REST boundary for exercise, submission, and assessment endpoints`). During that migration, `TextSubmissionResponseDTO` filtered null entries while mapping results. This compacted `[null, secondRoundResult]` to `[secondRoundResult]`; consequently, the dashboard found no result at index 1 and discarded the submission. Modeling submissions retain the entity list, and the file-upload DTO already preserves null entries, so those paths were not affected.

### Description

- Preserve null entries while mapping text submission results to `ResultDTO`.
- Mark result list elements as nullable to document the response contract.
- Strengthen the existing multiple-correction-round integration test to verify the exact `[null, secondRoundResult]` structure.

The change does not add database queries, REST calls, or client-side logic.

### Steps for Testing

Prerequisites:

- 1 exam with two correction rounds
- 1 text exercise in the exam
- 1 student submission
- 2 tutors

1. Complete the first correction-round assessment with tutor 1.
2. Start the second correction-round assessment with tutor 2 and save it without submitting it.
3. Navigate back to the exercise assessment dashboard as tutor 2.
4. Verify that the locked submission is listed for correction round 2 and can be continued from the dashboard.
5. Verify that tutor 2 does not see the submission as their assessment in correction round 1.

#### Exam Mode Testing

The testing steps above exercise the affected exam-mode flow directly.

Automated checks:

- `./gradlew test --tests 'de.tum.cit.aet.artemis.text.TextAssessmentIntegrationTest' --tests 'de.tum.cit.aet.artemis.text.TextSubmissionIntegrationTest' --tests 'de.tum.cit.aet.artemis.text.TextExerciseIntegrationTest' -x webapp` (214 tests)
- `./gradlew test --tests 'de.tum.cit.aet.artemis.assessment.ExampleSubmissionIntegrationTest' -x webapp` (26 tests)
- `npm run vitest -- src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.spec.ts src/main/webapp/app/text/overview/service/text-submission.service.spec.ts` (48 tests)
- `./gradlew spotlessCheck checkstyleMain -x webapp`
- `git diff --check`

### Review Progress

#### Code Review

- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests

- [x] Verify the second correction-round text assessment on a test server

#### Exam Mode Test

- [x] Verify the affected exam flow

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| TextSubmissionResponseDTO.java | 93.33% | 40 |

_Last updated: 2026-08-04 20:41:26 UTC_

