### PR TITLE
`Development`: Answer a refused login with 401 rather than 500

### DIFF
--- a/documentation/docs/admin/production-setup/security.mdx
+++ b/documentation/docs/admin/production-setup/security.mdx
@@ -36,8 +36,9 @@ jhipster:
     directory. Artemis owns that account: it sets the configured password and the administrator authorities on every startup
     and marks the account as internally managed. An internally managed account authenticates against Artemis rather than
     against the directory, and it is eligible for the e-mail password reset - so pointing this property at a directory login
-    moves that account out of your directory's control. Artemis logs a warning when it has to do so to an account that
-    existed as an externally managed one.
+    moves that account out of your directory's control, and the flag cannot be changed back through the admin UI, which
+    offers it only while a user is being created. Artemis logs a warning when it has to mark an account that existed as an
+    externally managed one.
 </Callout>
 
 <Callout variant={CalloutVariant.info}>

--- a/documentation/docs/admin/production-setup/security.mdx
+++ b/documentation/docs/admin/production-setup/security.mdx
@@ -31,6 +31,15 @@ jhipster:
     Always replace default credentials before deploying. Failing to do so exposes your system to serious security risks.
 </Callout>
 
+<Callout variant={CalloutVariant.warning}>
+    `artemis.user-management.internal-admin.username` has to name a dedicated local account, not a login from your external
+    directory. Artemis owns that account: it sets the configured password and the administrator authorities on every startup
+    and marks the account as internally managed. An internally managed account authenticates against Artemis rather than
+    against the directory, and it is eligible for the e-mail password reset - so pointing this property at a directory login
+    moves that account out of your directory's control. Artemis logs a warning when it has to do so to an account that
+    existed as an externally managed one.
+</Callout>
+
 <Callout variant={CalloutVariant.info}>
     Always restrict read access to configuration files for the minimum required set of users (usually only the system user that runs the Artemis service) only.
 </Callout>

--- a/src/main/java/de/tum/cit/aet/artemis/account/security/ArtemisInternalAuthenticationProvider.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/ArtemisInternalAuthenticationProvider.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -61,7 +60,9 @@ public class ArtemisInternalAuthenticationProvider implements ArtemisAuthenticat
         }
         final var user = optionalUser.get();
         if (user.isBot()) {
-            throw new AuthenticationServiceException("Bot users cannot authenticate interactively");
+            // A refusal, not a system problem: AuthenticationServiceException means the request could not be processed, and
+            // the login endpoint answers that with a 500 on purpose.
+            throw new BadCredentialsException("Bot users cannot authenticate interactively");
         }
         if (!user.getActivated()) {
             throw new UserNotActivatedException("User " + user.getLogin() + " was not activated");

--- a/src/main/java/de/tum/cit/aet/artemis/account/security/ArtemisInternalAuthenticationProvider.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/ArtemisInternalAuthenticationProvider.java
@@ -70,7 +70,9 @@ public class ArtemisInternalAuthenticationProvider implements ArtemisAuthenticat
         if (!passwordService.checkPasswordMatch(authentication.getCredentials().toString(), user.getPassword())) {
             // BadCredentialsException rather than AuthenticationServiceException: the request is rejected, nothing failed.
             // The distinction decides the status code the caller sees, and it keeps the login out of the message, which
-            // callers are free to propagate. The attempt itself is logged once by whoever called the authentication manager.
+            // callers are free to propagate. The attempt is logged by the caller - PublicUserJwtResource for the web login
+            // and LocalVCFetchFilter for a git fetch, which also writes a VCS access log entry. LocalVCPushFilter does not
+            // log it, which is unchanged by this class and left as it is here.
             throw new BadCredentialsException("Invalid credentials");
         }
         return new UsernamePasswordAuthenticationToken(user.getLogin(), user.getPassword(), user.getGrantedAuthorities());

--- a/src/main/java/de/tum/cit/aet/artemis/account/security/ArtemisInternalAuthenticationProvider.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/ArtemisInternalAuthenticationProvider.java
@@ -68,8 +68,8 @@ public class ArtemisInternalAuthenticationProvider implements ArtemisAuthenticat
         }
         if (!passwordService.checkPasswordMatch(authentication.getCredentials().toString(), user.getPassword())) {
             // BadCredentialsException rather than AuthenticationServiceException: the request is rejected, nothing failed.
-            // The distinction decides the status code the caller sees, and it keeps the login out of the message.
-            log.warn("Wrong password for user {}", user.getLogin());
+            // The distinction decides the status code the caller sees, and it keeps the login out of the message, which
+            // callers are free to propagate. The attempt itself is logged once by whoever called the authentication manager.
             throw new BadCredentialsException("Invalid credentials");
         }
         return new UsernamePasswordAuthenticationToken(user.getLogin(), user.getPassword(), user.getGrantedAuthorities());

--- a/src/main/java/de/tum/cit/aet/artemis/account/security/ArtemisInternalAuthenticationProvider.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/ArtemisInternalAuthenticationProvider.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -66,7 +67,10 @@ public class ArtemisInternalAuthenticationProvider implements ArtemisAuthenticat
             throw new UserNotActivatedException("User " + user.getLogin() + " was not activated");
         }
         if (!passwordService.checkPasswordMatch(authentication.getCredentials().toString(), user.getPassword())) {
-            throw new AuthenticationServiceException("Invalid password for user " + user.getLogin());
+            // BadCredentialsException rather than AuthenticationServiceException: the request is rejected, nothing failed.
+            // The distinction decides the status code the caller sees, and it keeps the login out of the message.
+            log.warn("Wrong password for user {}", user.getLogin());
+            throw new BadCredentialsException("Invalid credentials");
         }
         return new UsernamePasswordAuthenticationToken(user.getLogin(), user.getPassword(), user.getGrantedAuthorities());
     }

--- a/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserService.java
@@ -202,7 +202,8 @@ public class UserService {
                 // password reset. For the dedicated local admin this property is meant for, all of that is intended. An
                 // operator who pointed it at a directory account instead needs to see it.
                 log.warn("The configured internal admin {} exists as an externally managed account and is now marked internal: it will authenticate with the "
-                        + "configured password instead of the external directory, and it becomes eligible for the Artemis password reset. Point "
+                        + "configured password instead of the external directory, and it becomes eligible for the Artemis password reset. The flag cannot be "
+                        + "changed back through the admin UI, which offers it only while creating a user. Point "
                         + "artemis.user-management.internal-admin.username at a dedicated local account if that is not what you want.", internalAdminUsername);
                 internalAdmin.setInternal(true);
             }

--- a/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserService.java
@@ -188,11 +188,20 @@ public class UserService {
         Optional<User> existingInternalAdmin = userRepository.findOneWithAuthoritiesByLogin(internalAdminUsername);
         if (existingInternalAdmin.isPresent()) {
             log.info("Update internal admin user {}", internalAdminUsername);
-            existingInternalAdmin.get().setActivated(true);
-            existingInternalAdmin.get().setPassword(passwordService.hashPassword(internalAdminPassword));
+            User internalAdmin = existingInternalAdmin.get();
+            if (!internalAdmin.isInternal()) {
+                // An instance that ran a version which created this account as external keeps an admin that cannot use the
+                // password configured for it, and an upgrade alone would not repair it. The account belongs to Artemis by
+                // configuration and its password is set right here on every startup, so owning the flag as well is what makes
+                // that configuration mean something. Logged, because it changes how an existing account authenticates.
+                log.info("Marking the configured internal admin {} as an internal user so that the configured password applies", internalAdminUsername);
+                internalAdmin.setInternal(true);
+            }
+            internalAdmin.setActivated(true);
+            internalAdmin.setPassword(passwordService.hashPassword(internalAdminPassword));
             // needs to be mutable --> new HashSet<>(Set.of(...))
-            existingInternalAdmin.get().setAuthorities(new HashSet<>(Set.of(SUPER_ADMIN_AUTHORITY, new Authority(STUDENT.getAuthority()))));
-            saveUser(existingInternalAdmin.get());
+            internalAdmin.setAuthorities(new HashSet<>(Set.of(SUPER_ADMIN_AUTHORITY, new Authority(STUDENT.getAuthority()))));
+            saveUser(internalAdmin);
         }
         else {
             log.info("Create internal admin user {}", internalAdminUsername);
@@ -208,8 +217,7 @@ public class UserService {
         userDto.setActivated(true);
         // UserDTO defaults this to false, which would store the admin as an externally managed account and make the password
         // configured right here unusable: ArtemisInternalAuthenticationProvider only ever looks for internal users. The
-        // update branch of ensureInternalAdminExists leaves the flag alone, so this only ever went wrong where the account
-        // had to be created - a new instance, or a test stack whose admin is not part of the seed data.
+        // update branch above repairs an account that a previous version created that way.
         userDto.setInternal(true);
         userDto.setFirstName("Administrator");
         userDto.setLastName("Administrator");

--- a/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserService.java
@@ -206,6 +206,11 @@ public class UserService {
         userDto.setLogin(login);
         userDto.setPassword(password);
         userDto.setActivated(true);
+        // UserDTO defaults this to false, which would store the admin as an externally managed account and make the password
+        // configured right here unusable: ArtemisInternalAuthenticationProvider only ever looks for internal users. The
+        // update branch of ensureInternalAdminExists leaves the flag alone, so this only ever went wrong where the account
+        // had to be created - a new instance, or a test stack whose admin is not part of the seed data.
+        userDto.setInternal(true);
         userDto.setFirstName("Administrator");
         userDto.setLastName("Administrator");
         userDto.setEmail(artemisInternalAdminEmail.orElse("admin@localhost"));

--- a/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserService.java
@@ -190,11 +190,20 @@ public class UserService {
             log.info("Update internal admin user {}", internalAdminUsername);
             User internalAdmin = existingInternalAdmin.get();
             if (!internalAdmin.isInternal()) {
-                // An instance that ran a version which created this account as external keeps an admin that cannot use the
-                // password configured for it, and an upgrade alone would not repair it. The account belongs to Artemis by
-                // configuration and its password is set right here on every startup, so owning the flag as well is what makes
-                // that configuration mean something. Logged, because it changes how an existing account authenticates.
-                log.info("Marking the configured internal admin {} as an internal user so that the configured password applies", internalAdminUsername);
+                // An instance that started up between #13394 and this change has an admin that was created as an externally
+                // managed account and therefore cannot use the password configured for it. Creating it correctly is not
+                // enough for those instances: the account exists, so only this branch is reached. The account belongs to
+                // Artemis by configuration and its password is set right here on every startup, so owning the flag as well
+                // is what makes that configuration mean something.
+                //
+                // Warned rather than logged quietly, and spelled out, because the flag decides more than the password check:
+                // LdapAuthenticationProvider skips internal users, so this account stops authenticating against the
+                // directory, and prepareUserForPasswordReset accepts internal users, so it becomes eligible for the e-mail
+                // password reset. For the dedicated local admin this property is meant for, all of that is intended. An
+                // operator who pointed it at a directory account instead needs to see it.
+                log.warn("The configured internal admin {} exists as an externally managed account and is now marked internal: it will authenticate with the "
+                        + "configured password instead of the external directory, and it becomes eligible for the Artemis password reset. Point "
+                        + "artemis.user-management.internal-admin.username at a dedicated local account if that is not what you want.", internalAdminUsername);
                 internalAdmin.setInternal(true);
             }
             internalAdmin.setActivated(true);
@@ -215,9 +224,11 @@ public class UserService {
         userDto.setLogin(login);
         userDto.setPassword(password);
         userDto.setActivated(true);
-        // UserDTO defaults this to false, which would store the admin as an externally managed account and make the password
-        // configured right here unusable: ArtemisInternalAuthenticationProvider only ever looks for internal users. The
-        // update branch above repairs an account that a previous version created that way.
+        // Set explicitly because #13394 made the flag caller-controlled - UserCreationService.createUser used to force
+        // internal = true for everyone - and UserDTO defaults it to false. Without this the admin is stored as an externally
+        // managed account and the password configured right here is unusable, because
+        // ArtemisInternalAuthenticationProvider only ever looks for internal users. The update branch above repairs an
+        // account that was created in between.
         userDto.setInternal(true);
         userDto.setFirstName("Administrator");
         userDto.setLastName("Administrator");

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResource.java
@@ -20,11 +20,12 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AccountStatusException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.ProviderNotFoundException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -114,15 +115,19 @@ public class PublicUserJwtResource {
             log.warn("Wrong credentials during login for user {}", loginVM.getUsername());
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
-        catch (AuthenticationException ex) {
-            // Every other way the authentication manager can refuse a login: an account that is not activated, a bot
-            // account, or no provider producing a result at all (ProviderNotFoundException, which is what an unknown login
-            // ends in, because a provider that does not know the user returns null so the next one can try).
+        catch (UserNotActivatedException | ProviderNotFoundException | AccountStatusException ex) {
+            // The other ways a login can be refused. ProviderNotFoundException is what an unknown login ends in, because a
+            // provider that does not know the user returns null so that the next one can try, and then none produced a
+            // result. UserNotActivatedException and the account-status exceptions speak for themselves.
             //
-            // Without this, all of those reached the generic exception handler and the caller got a 500. A rejected login is
-            // not a server fault, and answering it with a server error tells an operator to go looking for an outage while
-            // telling the client nothing it can act on. The reason is logged; the response says no more than "unauthorized",
-            // so it stays a single answer for "these credentials do not work" and reveals nothing about which part failed.
+            // Without this, all of them reached the generic exception handler and the caller got a 500. A refused login is
+            // not a server fault, and answering it with a server error sends an operator looking for an outage while telling
+            // the client nothing it can act on. The reason is logged; the response says no more than "unauthorized", the
+            // same as for a wrong password, so it does not become an oracle for which part refused.
+            //
+            // AuthenticationServiceException is deliberately not caught here: by its contract it means the request could not
+            // be processed - a directory that is unreachable, a repository that failed - and answering that with 401 would
+            // hide an outage behind "wrong credentials". It stays a 500, which is what it is.
             log.warn("Login for user {} was refused ({}): {}", loginVM.getUsername(), ex.getClass().getSimpleName(), ex.getMessage());
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResource.java
@@ -84,8 +84,11 @@ public class PublicUserJwtResource {
      * @param tool      optional Tool Token Type to define the scope of the token
      * @param request   HTTP request object, used to get the client environment information
      * @param response  HTTP response object, used to set the JWT cookie
-     * @return if successful a map with the access_token information and status 200 (ok), and otherwise an empty body with
-     *         status 401 (unauthorized) - for every reason a login can be refused, so that the response does not say which
+     * @return if successful a map with the access_token information and status 200 (ok). Every credential that the
+     *         authentication manager refuses answers an empty body with status 401 (unauthorized) - the same status for all
+     *         of them, so that the response does not say which check refused. A malformed request still answers 400 and an
+     *         exhausted rate limit 429, both before the credentials are looked at, and a system problem behind
+     *         authentication (an unreachable directory, for instance) stays a 500.
      */
     @PostMapping("authenticate")
     @EnforceNothing
@@ -112,7 +115,10 @@ public class PublicUserJwtResource {
             return ResponseEntity.ok(Map.of("access_token", responseCookie.getValue()));
         }
         catch (BadCredentialsException ex) {
-            log.warn("Wrong credentials during login for user {}", loginVM.getUsername());
+            // The message is logged as well: the providers raise this for more than a wrong password - a bot account is
+            // refused with it too, and on an LDAP instance so is a login the directory does not know - and without the
+            // message those cases are indistinguishable in the log.
+            log.warn("Wrong credentials during login for user {}: {}", loginVM.getUsername(), ex.getMessage());
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         catch (UserNotActivatedException | ProviderNotFoundException | AccountStatusException ex) {

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResource.java
@@ -24,6 +24,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -82,7 +83,8 @@ public class PublicUserJwtResource {
      * @param tool      optional Tool Token Type to define the scope of the token
      * @param request   HTTP request object, used to get the client environment information
      * @param response  HTTP response object, used to set the JWT cookie
-     * @return if successful a map with the access_token information and status 200 (ok), if not successful an empty body with status 401 (unauthorized)
+     * @return if successful a map with the access_token information and status 200 (ok), and otherwise an empty body with
+     *         status 401 (unauthorized) - for every reason a login can be refused, so that the response does not say which
      */
     @PostMapping("authenticate")
     @EnforceNothing
@@ -110,6 +112,18 @@ public class PublicUserJwtResource {
         }
         catch (BadCredentialsException ex) {
             log.warn("Wrong credentials during login for user {}", loginVM.getUsername());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        catch (AuthenticationException ex) {
+            // Every other way the authentication manager can refuse a login: an account that is not activated, a bot
+            // account, or no provider producing a result at all (ProviderNotFoundException, which is what an unknown login
+            // ends in, because a provider that does not know the user returns null so the next one can try).
+            //
+            // Without this, all of those reached the generic exception handler and the caller got a 500. A rejected login is
+            // not a server fault, and answering it with a server error tells an operator to go looking for an outage while
+            // telling the client nothing it can act on. The reason is logged; the response says no more than "unauthorized",
+            // so it stays a single answer for "these credentials do not work" and reveals nothing about which part failed.
+            log.warn("Login for user {} was refused: {}", loginVM.getUsername(), ex.getMessage());
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
     }

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResource.java
@@ -123,7 +123,7 @@ public class PublicUserJwtResource {
             // not a server fault, and answering it with a server error tells an operator to go looking for an outage while
             // telling the client nothing it can act on. The reason is logged; the response says no more than "unauthorized",
             // so it stays a single answer for "these credentials do not work" and reveals nothing about which part failed.
-            log.warn("Login for user {} was refused: {}", loginVM.getUsername(), ex.getMessage());
+            log.warn("Login for user {} was refused ({}): {}", loginVM.getUsername(), ex.getClass().getSimpleName(), ex.getMessage());
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
     }

--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/InternalAuthenticationIntegrationTest.java
@@ -21,6 +21,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -33,6 +34,7 @@ import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.repository.AuthorityRepository;
 import de.tum.cit.aet.artemis.account.security.ArtemisInternalAuthenticationProvider;
 import de.tum.cit.aet.artemis.account.service.user.PasswordService;
+import de.tum.cit.aet.artemis.account.service.user.UserService;
 import de.tum.cit.aet.artemis.core.domain.CourseRole;
 import de.tum.cit.aet.artemis.core.dto.vm.LoginVM;
 import de.tum.cit.aet.artemis.core.dto.vm.ManagedUserVM;
@@ -50,6 +52,9 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
 
     @Autowired
     private PasswordService passwordService;
+
+    @Autowired
+    private UserService userService;
 
     @Autowired
     private TokenProvider tokenProvider;
@@ -99,6 +104,70 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
         // enroll endpoint returns Void; verify enrollment via UCR
         request.postWithoutLocation("/api/course/courses/" + course1.getId() + "/enroll", null, HttpStatus.OK, null);
         assertThat(userTestRepository.countByCourseIdAndRole(course1.getId(), CourseRole.STUDENT)).as("User is registered for course as STUDENT").isGreaterThan(0);
+    }
+
+    private static LoginVM loginVM(String username, String password) {
+        LoginVM loginVM = new LoginVM();
+        loginVM.setUsername(username);
+        loginVM.setPassword(password);
+        loginVM.setRememberMe(false);
+        return loginVM;
+    }
+
+    private static HttpHeaders browserHeaders() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36");
+        return httpHeaders;
+    }
+
+    /**
+     * A refused login has to be answered with 401. Each of the cases below used to end in a 500, because the endpoint only
+     * caught {@code BadCredentialsException} while the internal provider signals the others differently: an unknown login
+     * ends in a {@code ProviderNotFoundException} (a provider that does not know the user returns null so that the next one
+     * can try, and no provider produced a result), a wrong password used to raise an
+     * {@code AuthenticationServiceException}, and a deactivated account raises a {@code UserNotActivatedException}.
+     */
+    @Test
+    @WithAnonymousUser
+    void testUnknownUserIsRefusedRatherThanCausingAServerError() throws Exception {
+        request.postWithoutResponseBody("/api/core/public/authenticate", loginVM(TEST_PREFIX + "nosuchuser", "any-password"), HttpStatus.UNAUTHORIZED, browserHeaders());
+    }
+
+    @Test
+    @WithAnonymousUser
+    void testWrongPasswordIsRefusedRatherThanCausingAServerError() throws Exception {
+        request.postWithoutResponseBody("/api/core/public/authenticate", loginVM(USERNAME, "definitely-the-wrong-password"), HttpStatus.UNAUTHORIZED, browserHeaders());
+    }
+
+    @Test
+    @WithAnonymousUser
+    void testDeactivatedUserIsRefusedRatherThanCausingAServerError() throws Exception {
+        User user = userTestRepository.getUserByLoginElseThrow(USERNAME);
+        user.setActivated(false);
+        userTestRepository.save(user);
+
+        try {
+            request.postWithoutResponseBody("/api/core/public/authenticate", loginVM(USERNAME, USER_PASSWORD), HttpStatus.UNAUTHORIZED, browserHeaders());
+        }
+        finally {
+            user.setActivated(true);
+            userTestRepository.save(user);
+        }
+    }
+
+    /**
+     * The account the server creates for itself at startup has to be able to log in with the password it was configured
+     * with. It could not: the account was stored as external, and the internal provider only authenticates internal users,
+     * so the first login on an instance whose admin did not exist yet was refused - with a 500, at that.
+     */
+    @Test
+    @WithAnonymousUser
+    void testAFreshlyCreatedInternalAdminCanAuthenticate() throws Exception {
+        String adminLogin = TEST_PREFIX + "freshadmin";
+        String adminPassword = "a-password-for-the-fresh-admin";
+        userService.ensureInternalAdminExists(adminLogin, adminPassword);
+
+        request.postWithoutResponseBody("/api/core/public/authenticate", loginVM(adminLogin, adminPassword), HttpStatus.OK, browserHeaders());
     }
 
     @Test
@@ -236,7 +305,10 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
     void testAuthenticateWithWrongPassword() {
         var authentication = new UsernamePasswordAuthenticationToken(USERNAME, "wrongPassword");
 
-        assertThatThrownBy(() -> artemisInternalAuthenticationProvider.authenticate(authentication)).hasMessageContaining("Invalid password");
+        // The type is what matters: BadCredentialsException is the one the login endpoint answers with 401, where an
+        // AuthenticationServiceException reads as "the service broke" and reached the caller as a 500. The message
+        // deliberately no longer names the account.
+        assertThatThrownBy(() -> artemisInternalAuthenticationProvider.authenticate(authentication)).isInstanceOf(BadCredentialsException.class);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/InternalAuthenticationIntegrationTest.java
@@ -35,6 +35,7 @@ import de.tum.cit.aet.artemis.account.repository.AuthorityRepository;
 import de.tum.cit.aet.artemis.account.security.ArtemisInternalAuthenticationProvider;
 import de.tum.cit.aet.artemis.account.service.user.PasswordService;
 import de.tum.cit.aet.artemis.account.service.user.UserService;
+import de.tum.cit.aet.artemis.account.util.UserFactory;
 import de.tum.cit.aet.artemis.core.domain.CourseRole;
 import de.tum.cit.aet.artemis.core.dto.vm.LoginVM;
 import de.tum.cit.aet.artemis.core.dto.vm.ManagedUserVM;
@@ -167,6 +168,27 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
         String adminPassword = "a-password-for-the-fresh-admin";
         userService.ensureInternalAdminExists(adminLogin, adminPassword);
 
+        request.postWithoutResponseBody("/api/core/public/authenticate", loginVM(adminLogin, adminPassword), HttpStatus.OK, browserHeaders());
+    }
+
+    /**
+     * An instance that ran a version which created the admin as an external account keeps an admin whose configured password
+     * does not work, and starting the new version alone would not repair it: the account exists, so the update branch runs.
+     * The flag is therefore corrected there as well.
+     */
+    @Test
+    @WithAnonymousUser
+    void testAnExistingExternalAdminIsRepairedSoItsConfiguredPasswordWorks() throws Exception {
+        String adminLogin = TEST_PREFIX + "externaladmin";
+        String adminPassword = "a-password-for-the-repaired-admin";
+        User externalAdmin = UserFactory.generateActivatedUser(adminLogin);
+        externalAdmin.setInternal(false);
+        externalAdmin.setPassword(passwordService.hashPassword("some-other-password"));
+        userTestRepository.save(externalAdmin);
+
+        userService.ensureInternalAdminExists(adminLogin, adminPassword);
+
+        assertThat(userTestRepository.getUserByLoginElseThrow(adminLogin).isInternal()).isTrue();
         request.postWithoutResponseBody("/api/core/public/authenticate", loginVM(adminLogin, adminPassword), HttpStatus.OK, browserHeaders());
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/InternalAuthenticationIntegrationTest.java
@@ -320,7 +320,10 @@ class InternalAuthenticationIntegrationTest extends AbstractSpringIntegrationJen
 
         var authentication = new UsernamePasswordAuthenticationToken(botUsername, USER_PASSWORD);
 
-        assertThatThrownBy(() -> artemisInternalAuthenticationProvider.authenticate(authentication)).hasMessageContaining("Bot users cannot authenticate interactively");
+        // The type carries the meaning: a bot is refused, which the login endpoint answers with 401. As an
+        // AuthenticationServiceException - "the request could not be processed" - it reached the caller as a 500 instead.
+        assertThatThrownBy(() -> artemisInternalAuthenticationProvider.authenticate(authentication)).isInstanceOf(BadCredentialsException.class)
+                .hasMessageContaining("Bot users cannot authenticate interactively");
     }
 
     @Test


### PR DESCRIPTION
### Checklist

#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).
- [x] I added integration tests related to the change.
- [x] I documented the Java code using JavaDoc style.

### Motivation

Two defects on the password login path, found while tracking down an E2E failure where the admin could not log in.

**A new instance cannot log in its own admin.** The account the server creates for itself at startup was stored as an externally managed user, so the password that same configuration had just set was unusable. The origin is #13394, which made `UserCreationService` respect `UserDTO.isInternal()` where it previously forced `internal = true` for every user it created; the internal-admin bootstrap was a caller that relied on the old behaviour. **No released version is affected** - only instances started from `develop` between that change and this one, which is also the population the repair branch below exists for. The E2E fallout of the same origin was fixed separately in #13427.

**Every refused login answered 500.** On an instance with internal authentication, a wrong password or an unknown username produced an internal server error rather than a rejection. That sends an operator looking for an outage and tells the client nothing it can act on — and it hid the first defect, which is how it stayed unnoticed.

### Description

Three small changes, one per cause:

- **`UserService.createManagedUserVm`** now sets `internal`. `UserDTO` defaults it to `false`, and `ArtemisInternalAuthenticationProvider` looks a login up with `findOneWithAuthoritiesByLoginAndInternal(login, true)`, so an externally-flagged account is skipped entirely. The *update* branch of `ensureInternalAdminExists` leaves the flag alone, which is why this only went wrong where the account had to be created: a new instance, or a test stack whose admin is not part of the seed data.
- **`PublicUserJwtResource.authenticate`** answers 401 for a refused login instead of catching only `BadCredentialsException`: `UserNotActivatedException`, `ProviderNotFoundException` — which is what an unknown login ends in, because a provider that does not know the user returns `null` so the next one can try, and then none produced a result — and the account-status exceptions. All of those reached the generic exception handler before. The reason and the refusing type are logged; the response stays a single "unauthorized" for every case, so it does not become an oracle for which part refused.
  `AuthenticationServiceException` is deliberately **not** caught: by its contract it means the request could not be processed — an unreachable directory, a failed repository — and answering that with 401 would hide an outage behind "wrong credentials". It stays a 500.
- **`ArtemisInternalAuthenticationProvider`** signals a wrong password and a bot account as `BadCredentialsException`, which is what they are — `AuthenticationServiceException` reads as "the service broke", and that difference is what the split above rests on. The wrong-password message no longer names the account.
- **`ensureInternalAdminExists`** also repairs an existing admin stored as external, because for those instances the account already exists and only the update branch runs. It **warns** when it does, and says what changes: the flag decides more than the password check - `LdapAuthenticationProvider` skips internal users, so the account stops authenticating against the directory, and `prepareUserForPasswordReset` accepts internal users, so it becomes eligible for the e-mail password reset, on an account that also gets `SUPER_ADMIN` here. For the dedicated local admin this property is meant for that is all intended; `security.mdx` now states that the property has to name a local account, not a directory login.

Measured against a running instance seeded with `prod,e2e` data, before → after:

| case | before | after |
|---|---|---|
| created admin, correct password | 500 | **200** |
| unknown user | 500 | **401** |
| known user, wrong password | 500 | **401** |
| known user, correct password | 200 | 200 |

### Steps for Testing

The four cases are covered by integration tests, which is the fastest way to see it:

```
./gradlew test --tests "de.tum.cit.aet.artemis.account.authentication.InternalAuthenticationIntegrationTest" -x webapp
```

End to end against a real instance, which is how the numbers above were produced:

```bash
java -jar build/libs/Artemis-*.jar \
  --spring.profiles.active="dev,artemis,scheduling,core" \
  --spring.datasource.url="jdbc:h2:mem:probe;DB_CLOSE_DELAY=-1" --spring.datasource.username=sa --spring.datasource.password= \
  --spring.liquibase.contexts=prod,e2e --artemis.user-management.use-external=false \
  --artemis.user-management.internal-admin.username=fresh_admin \
  --artemis.user-management.internal-admin.password=a-password-for-the-fresh-admin \
  --eureka.client.enabled=false

# the admin the server just created for itself
curl -si -XPOST localhost:8080/api/core/public/authenticate -H 'Content-Type: application/json' \
  -d '{"username":"fresh_admin","password":"a-password-for-the-fresh-admin","rememberMe":false}' | head -1
# a login that must be refused, not blamed on the server
curl -so /dev/null -w '%{http_code}\n' -XPOST localhost:8080/api/core/public/authenticate -H 'Content-Type: application/json' \
  -d '{"username":"nobody","password":"whatever","rememberMe":false}'
```

### Review Progress

- [x] Code review
- [x] Manual test: the admin of a fresh instance can log in
- [x] Manual test: a wrong password and an unknown user both answer 401
- [x] Manual test: an instance whose admin already exists as an external account can log that admin in after the upgrade

### Testserver States

Not deployed to a test server: the paths are covered by integration tests and by the manual recipe above, which needs a fresh database rather than a deployed instance to show the created-admin case at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Failed login attempts now consistently return an unauthorized response instead of a server error.
* Authentication errors use generic messages without revealing account-specific details.
* Unknown, deactivated, bot, and incorrect credentials are handled consistently.
* Newly created or repaired internal administrator accounts can authenticate successfully.

## Documentation

* Clarified that internal administrator accounts must be locally managed, including authentication and password-reset behavior.

## Tests

* Added coverage for refused logins and internal administrator authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->