### PR TITLE
`Development`: Fix the Docker image build and its missing client styles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-# https://docs.docker.com/engine/reference/builder/#dockerignore-file
 classes/
 generated-sources/
 generated-test-sources/
@@ -13,51 +12,33 @@ www/
 !*.jar
 !*.war
 
-# exclude hidden directories like .idea, .gradle, .cache, .github
+# Deny-all: a build input reaches the image only if a `!` line below re-admits it. An omission is
+# silent — a tool that cannot find its config falls back to its defaults and still exits 0.
 .*
-# do not exclude .git as it's necessary to insert the commit id into the build
+# supplies the commit id stamped into the build
 !.git
-# do not exclude .eslint files as they are required in the build process
-!.eslintrc
-# do not exclude .npmrc as it's required in the build process for setting the correct node options
+# raises the Node heap the client build needs; pnpm reads nothing else from this file
 !.npmrc
-# exclude node_modules if installed locally
-node_modules
-# exclude build binaries except a pre-built .war file
+# registers @tailwindcss/postcss; nothing else in the repo ties Tailwind to the build
+!.postcssrc.json
+!.browserslistrc
+# `**/` is load-bearing: unlike .gitignore, a bare `node_modules` matches only the root one, and a
+# host install would shadow the one the image builds for its own platform
+**/node_modules
+# the .war exception feeds the external_builder stage, which packages a WAR built outside Docker
 build/*
 !build/libs/*.war
-# exlude the .cache of angular
-.cache
-# exclude the .gradle cache
-.gradle
 
-#########################
-# exclude Artemis configs
-#########################
+# local config and private keys; never re-admit
 /src/main/resources/config/application-local*.yml
 /src/main/resources/id_*
 /src/main/resources/known_hosts
 
-# exclude the docker files and the /docker/.docker-data folders
+# holds this Dockerfile, which `docker build -f` reads from the host rather than from the context
 docker/
 
-######################
-# Artemis resources
-######################
-/src/main/resources/config/application-local*.yml
-/src/main/resources/id_*
-/src/main/resources/known_hosts
-
-# files inside of the root directory not needed
 CITATION.cff
 CODE_OF_CONDUCT.md
 LICENSE
 README.md
 SECURITY.md
-
-######################
-# Artemis resources
-######################
-/src/main/resources/config/application-local*.yml
-/src/main/resources/id_*
-/src/main/resources/known_hosts

--- a/docker/artemis/Dockerfile
+++ b/docker/artemis/Dockerfile
@@ -62,7 +62,7 @@ COPY . .
 #
 # `-Psbom` includes the server + client Software Bill of Materials inside the WAR.
 # This Dockerfile is the production image build path (used by the `docker-release`
-# job in .github/workflows/build.yml, which only fires on push to develop / main /
+# job in .github/workflows/ci-build.yml, which only fires on push to develop / main /
 # release/* / version tags and on release events). Always emitting the SBOM here
 # guarantees that deployed images expose the dependency inventory via
 # AdminSbomResource and the weekly vulnerability scan finds something to scan.
@@ -137,6 +137,10 @@ WORKDIR /opt/artemis
 
 COPY --chown=artemis:artemis --from=war_file ${WAR_FILE_PATH}/*.war Artemis.war
 
+# The directive list is a denylist: revisit it whenever Tailwind gains one. The same invariant is
+# asserted for the package stylesheet in packages/tum-ui/check-styles.mjs.
+# `jar` prefix-matches entry names, so every stylesheet arrives together with its .css.map, and that
+# map embeds the original source, directives and all. Only the .css files are scanned.
 RUN set -eu; \
   war_entries="$(jar tf Artemis.war)"; \
   if ! printf '%s\n' "$war_entries" | grep -qx 'WEB-INF/classes/static/index.html'; then \
@@ -145,6 +149,26 @@ RUN set -eu; \
   fi; \
   if ! printf '%s\n' "$war_entries" | grep -Eq '^WEB-INF/classes/static/main-.*\.js$'; then \
     echo "Artemis.war does not contain a WEB-INF/classes/static/main-*.js bundle. The Angular client build is incomplete."; \
+    exit 1; \
+  fi; \
+  stylesheets="$(printf '%s\n' "$war_entries" | grep -E '^WEB-INF/classes/static/[^/]+\.css$' || true)"; \
+  if [ -z "$stylesheets" ]; then \
+    echo "Artemis.war contains no WEB-INF/classes/static/*.css bundle. The Angular client build is incomplete."; \
+    exit 1; \
+  fi; \
+  extracted="$(mktemp -d)"; \
+  printf '%s\n' "$stylesheets" | while read -r stylesheet; do jar xf Artemis.war -C "$extracted" "$stylesheet"; done; \
+  if [ "$(find "$extracted" -name '*.css' | wc -l)" -ne "$(printf '%s\n' "$stylesheets" | wc -l)" ]; then \
+    echo "Could not extract the stylesheet bundles from Artemis.war; the Tailwind check did not run."; \
+    rm -rf "$extracted"; \
+    exit 1; \
+  fi; \
+  uncompiled="$(find "$extracted" -name '*.css' -exec grep -hoE '@(tailwind|source|theme|plugin|custom-variant|utility|variant|apply|reference|config)[[:space:]("{]' {} + | sed 's/.$//' | sort -u | paste -sd' ' - || true)"; \
+  rm -rf "$extracted"; \
+  if [ -n "$uncompiled" ]; then \
+    echo "Artemis.war ships a client stylesheet that still contains Tailwind source directives: ${uncompiled}."; \
+    echo "The Tailwind PostCSS plugin did not transform it, so no utility class in the templates resolves to a rule and the application renders unstyled."; \
+    echo "Check that a PostCSS config at the repository root names the plugin and that the build which produced this WAR could read it; for an in-Docker build that means .dockerignore."; \
     exit 1; \
   fi
 

--- a/docker/artemis/Dockerfile
+++ b/docker/artemis/Dockerfile
@@ -39,6 +39,10 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 # be present at install time (pnpm applies patches during resolution, not via a
 # postinstall hook like patch-package did).
 COPY patches patches/
+# pnpm resolves the `workspace:*` dependencies while installing, so every workspace member's
+# manifest has to exist by then. Manifests only: copying sources here would invalidate the cached
+# install layer on every package edit. A new member without its own COPY aborts the install.
+COPY packages/tum-ui/package.json packages/tum-ui/
 
 # One Gradle invocation does both the cache config and the pnpm install. The
 # BuildKit pnpm-store cache mount below is reused on warm builds; pnpm's


### PR DESCRIPTION
### Summary

The Dockerfile's in-Docker WAR build is broken in two independent ways, and this PR fixes both.

Since the TUM UI component library moved into `packages/tum-ui`, the build fails outright — every `Build and Push Docker Image` job on `develop` has been red, so no image has been published from the branch. Before that it succeeded, but shipped an Angular client with **no Tailwind CSS compiled into it**. That is what left `artemis-test2` rendering without layout or semantic colours.

A third change stops the silent variant from happening again: an image whose WAR carries an uncompiled stylesheet is now rejected instead of published.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

Pages on `artemis-test2` rendered unstyled — spacing, flex/grid layout and the semantic state colours were all missing, while the older Bootstrap-derived styling still applied. The stylesheet it served contained Tailwind's **source directives as literal text** rather than compiled utilities:

```css
@plugin 'tailwindcss-primeui';
@theme inline{ --color-state-danger: var(--danger); … }
@source "./app/admin";
@media source(none){@layer utilities{@tailwind utilities;}}
```

Tailwind is compiled by `@tailwindcss/postcss`, which Angular loads through `.postcssrc.json`. `.dockerignore` excluded every root dotfile with `.*` and re-admitted only `.git`, `.eslintrc` and `.npmrc`, so that file never entered the build context. Angular reads a missing PostCSS config as "no plugins", esbuild then resolves `@import "tailwindcss"` by itself and inlines the framework's source stylesheets verbatim. The build succeeds, emits no warning, and every utility class in our templates matches nothing.

This only affected images whose WAR was built **inside** the Dockerfile (`builder` stage, which starts from `COPY . .`). Servers running a WAR built in CI and packaged through `external_builder` were never affected, which is why the breakage looked server-specific rather than systemic.

`.postcssrc.json` was added on 2026-07-07 with the admin Bootstrap → Tailwind migration (#12963). `.dockerignore` was last touched in 2024 and never learned about it. `gradle/profile_prod.gradle` already declares both `.postcssrc.json` and `.browserslistrc` as inputs of the `webapp` task — the knowledge existed, it just never reached the ignore file.

### Description

**1. `.dockerignore` — let the client build inputs through**

Re-admits `.postcssrc.json` and `.browserslistrc`, and drops the `!.eslintrc` negation, dead since ESLint moved to `eslint.config.mjs`. Without `.browserslistrc` the client is compiled for browserslist's own defaults instead of ours; the resolved target set genuinely differs (`ios_saf 18.0`–`18.4`, `chrome 142`, `edge 142`/`143` and `firefox 144`–`146` drop out, mobile-only engines come in).

`node_modules` matched only the **root** directory, so `packages/tum-ui/node_modules`, `documentation/node_modules` and `src/test/playwright/node_modules` were copied in from the contributor's machine — on macOS that means darwin-native binaries landing in a Linux image, on top of the install the image builds for itself. `**/node_modules` matches them at any depth. This matters more once the workspace fix below lands, because the install layer now creates `packages/tum-ui/node_modules` inside the image.

Two pieces of dead weight go with it: `.cache` and `.gradle`, both already covered by `.*`, and three byte-identical copies of the local-configuration excludes. Sorting the non-comment patterns before and after shows the only behavioural changes are the intended ones.

**2. `docker/artemis/Dockerfile` — restore the workspace install**

The install layer copies `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.npmrc` and `patches/`, but the root manifest now depends on `"@tumaet/ui-angular": "workspace:*"` and that workspace member's manifest was not among them:

```
[ERR_PNPM_WORKSPACE_PKG_NOT_FOUND] In : "@tumaet/ui-angular@workspace:*" is in the
dependencies but no package named "@tumaet/ui-angular" is present in the workspace
Packages found in the workspace: artemis
> Task :pnpmInstall FAILED
```

Copying `packages/tum-ui/package.json` before the install resolves it. Only the manifest, so edits under `packages/tum-ui` do not invalidate the cached install layer. It also gives the workspace member its own `node_modules`, which `build-styles.mjs` needs for `chokidar` — a dependency of that package alone, absent from the root install.

**3. `docker/artemis/Dockerfile` — reject an uncompiled stylesheet**

The runtime stage already refuses a WAR with no `index.html` or no `main-*.js`. It could not tell a compiled stylesheet from one still carrying Tailwind's source directives, which is exactly how the unstyled client reached a test server unnoticed. It now fails on any Tailwind directive — `@tailwind`, `@source`, `@theme`, `@plugin`, `@custom-variant`, `@utility`, `@variant`, `@apply`, `@reference`, `@config` — and names the plugin responsible. The full set was checked against a real known-good WAR and produces no false positives, so covering the directives we do not use today costs nothing and stops the guard failing open when a refactor starts using one.

It checks every top-level `WEB-INF/classes/static/*.css` entry rather than one bundle by name, so the second global bundle (`theme-dark`) is covered and a third could not quietly fall outside it. The scan is deliberately limited to `.css`: `jar` prefix-matches entry names, so extracting `styles-<hash>.css` also pulls `styles-<hash>.css.map`, and that source map embeds the original stylesheet — directives and all.

One known false-positive channel remains: production minification keeps `content:` string literals, so `content: "@apply foo"` would trip it. Nothing in the tree does that, and it fails closed — a red build naming the directives, never a silent pass.

#### A note for reviewers on merge order

If these are ever split, **`.dockerignore` must land first**. On its own it is harmless — the image build still fails loudly at `pnpmInstall`. The workspace fix on its own would make the build succeed again and publish a silently unstyled image, which is worse than a red build.

### Steps for Testing

Prerequisites:
- Docker
- No Artemis instance needed; this is entirely a build-path change

1. Check out this branch and build the image through the path that was broken:
   ```bash
   docker build . -f ./docker/artemis/Dockerfile -t artemis-local --no-cache
   ```
   It should complete. On `develop` the same command fails at `> Task :pnpmInstall FAILED`.

2. Confirm the shipped stylesheet is actually compiled — this should print utilities and no source directives:
   ```bash
   id=$(docker create artemis-local) && docker cp "$id:/opt/artemis/Artemis.war" /tmp/Artemis.war && docker rm "$id"
   css=$(unzip -Z1 /tmp/Artemis.war 'WEB-INF/classes/static/styles-*.css' | head -1)
   unzip -p /tmp/Artemis.war "$css" > /tmp/styles.css
   grep -c '\.items-center'          /tmp/styles.css   # expect ≥ 1
   grep -cE '@(tailwind|source|theme)' /tmp/styles.css  # expect 0
   ```

3. Confirm the new guard actually fires. Temporarily comment out `!.postcssrc.json` in `.dockerignore` and rebuild — the build must now fail with:
   ```
   Artemis.war ships a stylesheet that still contains Tailwind source directives: …
   ```

4. Confirm the build context is right:
   ```bash
   printf 'FROM alpine\nWORKDIR /ctx\nCOPY . .\nRUN ls -a1 /ctx | grep "^\\." && find /ctx -name node_modules | wc -l\n' > /tmp/probe.Dockerfile
   docker build --no-cache --progress=plain -f /tmp/probe.Dockerfile .
   ```
   Expect `.browserslistrc`, `.git`, `.npmrc`, `.postcssrc.json`, and `0` `node_modules` directories.

### What was verified, and what was not

Verified locally and against CI:

| Check | Result |
|---|---|
| Building the client with `.postcssrc.json` removed | Reproduces the deployed artifact: 28 `@source`, `@tailwind utilities`, `@plugin`, `@custom-variant`, 3 `@theme`, and **0** `.items-center` / `.text-state-danger`. The deployed bundle had 27 `@source` — the difference is two entries added to `tailwind.css` since that server was built, not a difference in mechanism |
| The same build with the file present | 0 source directives, utilities present |
| Does the broken build warn? | No — exit `0`, nothing matching `postcss\|tailwind\|warn\|error` in the log |
| `docker build` context probe, before → after | dotfiles `.git`/`.npmrc` → `+.postcssrc.json`/`+.browserslistrc`; `node_modules` dirs 4 → 0; `packages/tum-ui/src` still present |
| `pnpm install` with the Dockerfile's exact first-layer file set | Fails with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`; succeeds once `packages/tum-ui/package.json` is copied, and then provides `chokidar` |
| The new WAR guard, on real good and broken stylesheets | good → exit 0 silent; broken → exit 1 with the message; no stylesheet → exit 1. Identical under `sh` and `bash -o pipefail`; leaves no extracted files |
| Guard false positives | 0 across three known-good stylesheets (local production build, `artemis-test1`, `artemis-test3`); catches both known-bad ones |
| hadolint | Finding set identical to `develop`'s baseline — no new warnings |
| **Full `docker build` through the `builder` stage** | **`pnpmInstall` BUILD SUCCESSFUL (1m39s), `bootWar` BUILD SUCCESSFUL (9m30s), stylesheet guard passed, image built.** The same command on `develop` dies at `Task :pnpmInstall FAILED`. |
| The stylesheet inside that image | `0` raw `@source`, `0` raw `@tailwind`, `.items-center` and `.text-state-danger` both present |

Not done: **no deployment to a test server through the repaired path yet.** A test-server deploy of this branch reuses the `docker-pr` image (`external_builder`), because `conditional-build` only builds on the fly for a branch with no open PR — so it would not exercise these fixes. Deploying the commits from a PR-less branch is the way to validate them on a server. The first checklist box is left unticked for that reason.

One limitation worth stating precisely. The guard runs on every image, pull requests included — `docker-pr` builds the final stage, which is where it lives. But it cannot catch a **`.dockerignore` regression** at PR time, because `docker-pr` passes `WAR_FILE_STAGE=external_builder` and so validates a CI-built WAR, which always has the config files. Only `testserver-deployment.yml` and the release build exercise the `builder` stage. So a future PR that re-broke `.dockerignore` would still go green, and the failure would surface at deploy time. Asserting that `.dockerignore` admits everything declared as `client-build-config` in `gradle/profile_prod.gradle` would make the two lists structurally unable to drift; that is one natural follow-up.

The better one, and the reason this PR does not attempt it: **Angular's builder looks for `postcss.config.json` before `.postcssrc.json`** (`@angular/build/src/utils/postcss-configuration.js`). `postcss.config.json` is not a dotfile, so `.*` could never strip it — renaming the file deletes this failure class rather than guarding it. I left it out because that same config is read by Vitest's and Docusaurus's PostCSS pipelines (`vitest.config.ts`, `documentation/postcss.config.js`), so the rename needs verification well beyond this PR's blast radius. It deserves its own change.

#### Why `.env` is not re-admitted

It is read at Gradle configuration time (`gradle/env.gradle`, applied from `build.gradle`), so it is a fair question. Two things make its absence harmless rather than merely untested: the only consumer of a resulting property, `build.gradle`'s `postgres_version`, has an explicit fallback; and `gradle/test.gradle`'s `weaviate_server_version` is also defined in `gradle.properties`, so `findProperty` resolves without `.env` — and that task is never realised during `bootWar` anyway. Re-admitting it would change which versions the Docker build resolves, for no current benefit.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
