### PR TITLE
`Exercises`: Use primary color for exercise and group accents

### DIFF
--- a/src/main/webapp/app/course/manage/exercises/create-modal/exercise-add-modal.component.html
+++ b/src/main/webapp/app/course/manage/exercises/create-modal/exercise-add-modal.component.html
@@ -22,7 +22,7 @@
         <p class="text-muted small mb-3" jhiTranslate="artemisApp.exerciseManagement.addModal.createHint"></p>
         <div class="exercise-grid">
             @for (card of exerciseTypeCards(); track card.type) {
-                <button class="exercise-card {{ card.accentClass }}" [attr.data-testid]="'create-' + card.type + '-exercise'" (click)="navigateToCreate(card)" type="button">
+                <button class="exercise-card" [attr.data-testid]="'create-' + card.type + '-exercise'" (click)="navigateToCreate(card)" type="button">
                     <div class="card-icon-wrapper">
                         <fa-icon [icon]="card.icon" />
                     </div>
@@ -34,7 +34,7 @@
                     </span>
                 </button>
             }
-            <button class="exercise-card card--group" (click)="createGroup()" type="button">
+            <button class="exercise-card" (click)="createGroup()" type="button">
                 <div class="card-icon-wrapper">
                     <fa-icon [icon]="faLayerGroup" />
                 </div>
@@ -53,7 +53,7 @@
         <p class="text-muted small mb-3" jhiTranslate="artemisApp.exerciseManagement.addModal.importHint"></p>
         <div class="exercise-grid">
             @for (card of exerciseTypeCards(); track card.type) {
-                <button class="exercise-card {{ card.accentClass }}" [attr.data-testid]="'import-' + card.type + '-exercise'" (click)="startImport(card.type)" type="button">
+                <button class="exercise-card" [attr.data-testid]="'import-' + card.type + '-exercise'" (click)="startImport(card.type)" type="button">
                     <div class="card-icon-wrapper">
                         <fa-icon [icon]="card.icon" />
                     </div>

--- a/src/main/webapp/app/course/manage/exercises/create-modal/exercise-add-modal.component.scss
+++ b/src/main/webapp/app/course/manage/exercises/create-modal/exercise-add-modal.component.scss
@@ -57,7 +57,7 @@
         left: 0;
         right: 0;
         height: 3px;
-        background: var(--card-accent, var(--primary));
+        background: var(--tumaet-ui-primary-color);
         opacity: 0;
         transition: opacity 0.2s ease;
     }
@@ -87,30 +87,6 @@
     }
 }
 
-.card--programming {
-    --card-accent: var(--exercise-accent-programming);
-}
-
-.card--quiz {
-    --card-accent: var(--exercise-accent-quiz);
-}
-
-.card--modeling {
-    --card-accent: var(--exercise-accent-modeling);
-}
-
-.card--text {
-    --card-accent: var(--exercise-accent-text);
-}
-
-.card--fileupload {
-    --card-accent: var(--exercise-accent-fileupload);
-}
-
-.card--group {
-    --card-accent: var(--exercise-accent-group);
-}
-
 .card-icon-wrapper {
     width: 44px;
     height: 44px;
@@ -119,16 +95,17 @@
     align-items: center;
     justify-content: center;
     margin-bottom: 0.75rem;
-    color: var(--white);
-    background: var(--card-accent, var(--primary));
+    color: var(--tumaet-ui-primary-contrast-color);
+    background: var(--tumaet-ui-primary-color);
     box-shadow: 0 3px 8px color-mix(in srgb, var(--black) 12%, transparent);
     font-size: 1.1rem;
 }
 
+// Uses the accessible brand foreground (light: --primary-dark); plain --primary would miss WCAG AA at this size.
 .card-cta {
     font-weight: 600;
     font-size: 0.8rem;
-    color: var(--card-accent, var(--primary));
+    color: var(--tumaet-ui-accent-color);
     display: inline-flex;
     align-items: center;
 }

--- a/src/main/webapp/app/course/manage/exercises/create-modal/exercise-add-modal.component.ts
+++ b/src/main/webapp/app/course/manage/exercises/create-modal/exercise-add-modal.component.ts
@@ -23,7 +23,6 @@ interface ExerciseTypeCard {
     labelKey: string;
     descriptionKey: string;
     icon: typeof faKeyboard;
-    accentClass: string;
     routeSegment: string;
 }
 
@@ -33,7 +32,6 @@ const EXERCISE_TYPE_CARDS: ExerciseTypeCard[] = [
         labelKey: 'artemisApp.exerciseManagement.type.PROGRAMMING',
         descriptionKey: 'artemisApp.exerciseManagement.addModal.cardDescription.PROGRAMMING',
         icon: faKeyboard,
-        accentClass: 'card--programming',
         routeSegment: 'programming-exercises/new',
     },
     {
@@ -41,7 +39,6 @@ const EXERCISE_TYPE_CARDS: ExerciseTypeCard[] = [
         labelKey: 'artemisApp.exerciseManagement.type.QUIZ',
         descriptionKey: 'artemisApp.exerciseManagement.addModal.cardDescription.QUIZ',
         icon: faCheckDouble,
-        accentClass: 'card--quiz',
         routeSegment: 'quiz-exercises/new',
     },
     {
@@ -49,7 +46,6 @@ const EXERCISE_TYPE_CARDS: ExerciseTypeCard[] = [
         labelKey: 'artemisApp.exerciseManagement.type.MODELING',
         descriptionKey: 'artemisApp.exerciseManagement.addModal.cardDescription.MODELING',
         icon: faProjectDiagram,
-        accentClass: 'card--modeling',
         routeSegment: 'modeling-exercises/new',
     },
     {
@@ -57,7 +53,6 @@ const EXERCISE_TYPE_CARDS: ExerciseTypeCard[] = [
         labelKey: 'artemisApp.exerciseManagement.type.TEXT',
         descriptionKey: 'artemisApp.exerciseManagement.addModal.cardDescription.TEXT',
         icon: faFont,
-        accentClass: 'card--text',
         routeSegment: 'text-exercises/new',
     },
     {
@@ -65,7 +60,6 @@ const EXERCISE_TYPE_CARDS: ExerciseTypeCard[] = [
         labelKey: 'artemisApp.exerciseManagement.type.FILE_UPLOAD',
         descriptionKey: 'artemisApp.exerciseManagement.addModal.cardDescription.FILE_UPLOAD',
         icon: faFileUpload,
-        accentClass: 'card--fileupload',
         routeSegment: 'file-upload-exercises/new',
     },
 ];

--- a/src/main/webapp/app/course/sidebar/sidebar-accordion/sidebar-accordion.component.scss
+++ b/src/main/webapp/app/course/sidebar/sidebar-accordion/sidebar-accordion.component.scss
@@ -99,7 +99,7 @@ hr {
 .sidebar-group--connected {
     padding: 0;
     overflow: hidden;
-    border-top: 5px solid var(--purple);
+    border-top: 5px solid var(--primary);
 
     .sidebar-group-content {
         margin-top: 0;

--- a/src/main/webapp/app/course/sidebar/sidebar-card-medium/sidebar-card-medium.component.scss
+++ b/src/main/webapp/app/course/sidebar/sidebar-card-medium/sidebar-card-medium.component.scss
@@ -50,10 +50,10 @@
 // Header of a connected variant group; the difficulty stripe is hidden so its text aligns with the nested tiles.
 .group-header {
     border-left-color: transparent !important;
-    background-color: color-mix(in srgb, var(--purple) 4%, var(--module-bg)) !important;
-    background-image: linear-gradient(to bottom, color-mix(in srgb, var(--purple) 12%, var(--module-bg)), var(--module-bg)) !important;
+    background-color: color-mix(in srgb, var(--primary) 4%, var(--module-bg)) !important;
+    background-image: linear-gradient(to bottom, color-mix(in srgb, var(--primary) 12%, var(--module-bg)), var(--module-bg)) !important;
 
     &:hover {
-        background-image: linear-gradient(to bottom, color-mix(in srgb, var(--purple) 20%, var(--module-bg)), color-mix(in srgb, var(--purple) 5%, var(--module-bg))) !important;
+        background-image: linear-gradient(to bottom, color-mix(in srgb, var(--primary) 20%, var(--module-bg)), color-mix(in srgb, var(--primary) 5%, var(--module-bg))) !important;
     }
 }

--- a/src/main/webapp/content/scss/themes/_dark-variables.scss
+++ b/src/main/webapp/content/scss/themes/_dark-variables.scss
@@ -125,14 +125,6 @@ $table-color: $body-color;
 $artemis-dark: #353d47;
 $link-color: #3e8acc;
 
-// Per-exercise-type accent colors: the light theme's hues, lightened to stay legible on the dark $body-bg.
-$exercise-accent-programming: #818cf8;
-$exercise-accent-quiz: #fbbf24;
-$exercise-accent-modeling: #38bdf8;
-$exercise-accent-text: #34d399;
-$exercise-accent-fileupload: #f472b6;
-$exercise-accent-group: #a78bfa;
-
 // Border
 $border-color: lighten($body-bg, 10);
 

--- a/src/main/webapp/content/scss/themes/_default-variables.scss
+++ b/src/main/webapp/content/scss/themes/_default-variables.scss
@@ -48,14 +48,6 @@ $navbar-dark-hover-color: $white;
 $artemis-dark: #353d47;
 $link-color: $primary;
 
-// Per-exercise-type accent colors
-$exercise-accent-programming: #6366f1;
-$exercise-accent-quiz: #f59e0b;
-$exercise-accent-modeling: #0ea5e9;
-$exercise-accent-text: #10b981;
-$exercise-accent-fileupload: #ec4899;
-$exercise-accent-group: #8b5cf6;
-
 // Border
 $border-color: #dee2e6;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 
The exercise-type cards in the "Add exercise" dialog and the variant group highlighting in the student
sidebar used accent colors that the course onboarding wizard already uses for unrelated concepts, so the
same hue meant different things depending on where you were. The icon and the label already identify the
exercise type, so the color added no information and only created the collision. Everything now uses the
primary brand accent. Client-only change; no behavior or routing is affected.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer locally.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The dialog's per-type card accents and the sidebar's `var(--purple)` variant-group highlighting both came from the
palette that the onboarding wizard, quick actions and course management cards use for unrelated concepts —
#6366f1 was both "Programming exercise" and the "General" onboarding step.

### Description
<!-- Describe your changes in detail -->
- **Dialog** — the six `.card--*` blocks and the `--card-accent` indirection removed; icon tile and hover bar use
  `var(--tumaet-ui-primary-color)`, the CTA `var(--tumaet-ui-accent-color)`. `accentClass` dropped from
  `ExerciseTypeCard` and the template; `data-testid` bindings untouched.
- **Sidebar** — `var(--purple)` → `var(--primary)` for the connected group's top stripe, header tint and hover.
- **Theme variables** — the twelve `$exercise-accent-*` declarations deleted; the dialog was their only consumer.
- **Dark-mode fix** — the icon glyph was hardcoded `var(--white)` over the lightened fills (≈1.7:1 on the amber
  quiz tile); it now uses `--tumaet-ui-primary-contrast-color`.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Course containing at least one exercise variant group, so the student sidebar renders a connected group

1. As **instructor**: Course Management → Exercises → **Create**. On both the **Create** and **Import** tabs every
   card should show a primary icon tile
2. As **student**: open Exercises. The variant group in the sidebar should show a primary top stripe and header tint (both were purple), with selection and navigation unchanged.
3. Toggle **light and dark theme** on both views. The dialog's icon must stay legible on the tile

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
#### Manual Tests
- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/31167495818) did not pass (`failure`). Coverage below may be partial.

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| exercise-add-modal.component.ts | 100.00% | 178 | 24 | 13.5 |

_Last updated: 2026-08-07 10:27:44 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**Before:** Add exercise dialog
<img width="1502" height="886" alt="image" src="https://github.com/user-attachments/assets/2e0775da-ebc7-4f09-b1de-52522f9f0acd" />

**Now:** Add exercise dialog
<img width="1065" height="822" alt="image" src="https://github.com/user-attachments/assets/95d1cce1-e516-4ffd-9d4d-d4d907b4df37" />

**Before:** Student sidebar, exercise variant group
<img width="305" height="322" alt="image" src="https://github.com/user-attachments/assets/7181d9e9-27fc-44ed-9eb3-71d608cb8966" />

**Now:** Student sidebar, exercise variant group
<img width="303" height="322" alt="image" src="https://github.com/user-attachments/assets/5d02f820-a4ea-4d7d-8c31-b2a767c2ae4f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized exercise creation cards on the shared primary theme color.
  * Updated card icons, call-to-action text, and contrast colors for improved visual consistency and accessibility.
  * Aligned connected sidebar borders and hover backgrounds with the primary theme color.
  * Removed distinct per-exercise accent colors across light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->