### PR TITLE
`Development`: Update docker images and upgrade the monitoring stack

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ COMPOSE_PROJECT_NAME=artemis
 # Docker image versions (single source of truth for Docker Compose, tests, and build dependencies)
 
 # Databases
-MYSQL_VERSION=9.7.0
+MYSQL_VERSION=9.7.2
 # Full Docker image reference for MySQL. Override for custom registries or images (e.g. database-migration tester).
 MYSQL_IMAGE=docker.io/library/mysql:${MYSQL_VERSION}
 POSTGRES_VERSION=18.4
@@ -20,41 +20,41 @@ POSTGRES_IMAGE_VARIANT=-alpine
 # Caching and middleware
 # Note: This is redis-stack-server, not standard Redis. Uses different version tags.
 REDIS_STACK_VERSION=7.4.0-v8
-VALKEY_VERSION=8.1.5
+VALKEY_VERSION=8.1.9
 
 # Search
 # Weaviate must be compatible with the Java client: https://docs.weaviate.io/weaviate/release-notes
-WEAVIATE_SERVER_VERSION=1.37.9
+WEAVIATE_SERVER_VERSION=1.37.14
 
 # Web & proxy
-NGINX_VERSION=1.31.1
+NGINX_VERSION=1.31.3
 NGINX_IMAGE_VARIANT=-alpine-slim
 
 # Testing
-ALPINE_VERSION=3.23.4
+ALPINE_VERSION=3.23.5
 # Used for both the Docker image and @playwright/test in src/test/playwright/package.json
 PLAYWRIGHT_VERSION=v1.62.1
 
 # Monitoring
-# TODO: Upgrade Prometheus to v3.x (breaking config changes, v2 is EOL). See https://prometheus.io/docs/prometheus/latest/migration/
-PROMETHEUS_VERSION=v2.55.1
-# TODO: Upgrade Grafana to 11.x or 12.x (10.x is EOL). See https://grafana.com/docs/grafana/latest/upgrade-guide/
-GRAFANA_VERSION=10.4.14
+PROMETHEUS_VERSION=v3.13.2
+# Kept in sync with the AET production Grafana (https://monitoring.aet.cit.tum.de) so dashboards are
+# developed against the version that renders them in production.
+GRAFANA_VERSION=12.4.2
 
 # Messaging & registry
-ACTIVEMQ_VERSION=2.54.0
+ACTIVEMQ_VERSION=2.55.0
 ACTIVEMQ_IMAGE_VARIANT=-alpine
 # TODO: JHipster Registry is dormant (last release 2022). Evaluate alternatives or removal.
 JHIPSTER_REGISTRY_VERSION=v7.5.0
 
 # Mail
-MAILPIT_VERSION=v1.30.1
+MAILPIT_VERSION=v1.30.6
 
 # LTI / Moodle
 MOODLE_VERSION=5.0.2-debian-12-r2
 
 # SAML2 Testing
-KEYCLOAK_VERSION=26.6
+KEYCLOAK_VERSION=26.7
 
 # Client dependency versions synced into package.json by `supporting_scripts/sync-client-versions.mjs`
 # Run `node supporting_scripts/sync-client-versions.mjs` after changing these.

--- a/build.gradle
+++ b/build.gradle
@@ -653,7 +653,7 @@ dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${spring_cloud_version}"
         // BOM uses 3-part versions (e.g. 18.1.0); POSTGRES_VERSION from .env may be 2-part (e.g. 18.1)
-        def pgVersion = findProperty('postgres_version') ?: '18.1'
+        def pgVersion = findProperty('postgres_version') ?: '18.4'
         def bomVersion = pgVersion.count('.') < 2 ? "${pgVersion}.0" : pgVersion
         mavenBom "io.zonky.test.postgres:embedded-postgres-binaries-bom:${bomVersion}"
         mavenBom "org.testcontainers:testcontainers-bom:${testcontainers_version}"

--- a/docker/artemis/Dockerfile
+++ b/docker/artemis/Dockerfile
@@ -77,7 +77,7 @@ RUN \
 #-----------------------------------------------------------------------------------------------------------------------
 # external build stage
 #-----------------------------------------------------------------------------------------------------------------------
-FROM docker.io/library/alpine:3.23.4 AS external_builder
+FROM docker.io/library/alpine:3.23.5 AS external_builder
 
 #default path of the built .war files
 ARG WAR_FILE_PATH="/opt/artemis/build/libs"

--- a/docker/monitoring.yml
+++ b/docker/monitoring.yml
@@ -9,7 +9,6 @@
 services:
   prometheus:
     container_name: artemis-prometheus
-    # TODO: check if we can upgrade to 3.x
     image: docker.io/prom/prometheus:${PROMETHEUS_VERSION}
     pull_policy: missing
     volumes:
@@ -26,15 +25,17 @@ services:
     network_mode: 'host' # to test locally running service
   grafana:
     container_name: artemis-grafana
-    # TODO: check if we can upgrade to 11.x
     image: docker.io/grafana/grafana:${GRAFANA_VERSION}
     pull_policy: missing
+    # Mount the two provisioning subdirectories individually rather than the whole provisioning
+    # directory: mounting the parent hides the image's own (empty) alerting/, plugins/, notifiers/
+    # and access-control/ directories, which Grafana then logs as read errors on every startup.
     volumes:
-      - ./monitoring/grafana/provisioning/:/etc/grafana/provisioning/
+      - ./monitoring/grafana/provisioning/datasources/:/etc/grafana/provisioning/datasources/
+      - ./monitoring/grafana/provisioning/dashboards/:/etc/grafana/provisioning/dashboards/
     environment:
       GF_SECURITY_ADMIN_PASSWORD: "admin"
       GF_USERS_ALLOW_SIGN_UP: "false"
-      GF_INSTALL_PLUGINS: "grafana-piechart-panel"
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:

--- a/docker/monitoring/grafana/provisioning/dashboards/artemis/artemis_public.json
+++ b/docker/monitoring/grafana/provisioning/dashboards/artemis/artemis_public.json
@@ -1,4 +1,5 @@
 {
+    "uid": "hsG-aUQ4k",
     "annotations": {
         "list": [
             {
@@ -24,8 +25,6 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 3,
-    "iteration": 1686231801578,
     "links": [],
     "liveNow": false,
     "panels": [
@@ -57,8 +56,7 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "green",
-                                "value": null
+                                "color": "green"
                             },
                             {
                                 "color": "red",
@@ -123,8 +121,7 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "green",
-                                "value": null
+                                "color": "green"
                             },
                             {
                                 "color": "red",
@@ -189,8 +186,7 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "green",
-                                "value": null
+                                "color": "green"
                             },
                             {
                                 "color": "red",
@@ -255,8 +251,7 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "green",
-                                "value": null
+                                "color": "green"
                             },
                             {
                                 "color": "red",
@@ -321,8 +316,7 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "green",
-                                "value": null
+                                "color": "green"
                             },
                             {
                                 "color": "red",
@@ -417,8 +411,7 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "green",
-                                "value": null
+                                "color": "green"
                             },
                             {
                                 "color": "red",
@@ -521,7 +514,8 @@
                         "last"
                     ],
                     "displayMode": "list",
-                    "placement": "right"
+                    "placement": "right",
+                    "showLegend": true
                 },
                 "orientation": "auto",
                 "showValue": "always",
@@ -589,8 +583,7 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "green",
-                                "value": null
+                                "color": "green"
                             },
                             {
                                 "color": "red",
@@ -693,7 +686,8 @@
                         "last"
                     ],
                     "displayMode": "list",
-                    "placement": "right"
+                    "placement": "right",
+                    "showLegend": true
                 },
                 "orientation": "auto",
                 "showValue": "always",
@@ -755,7 +749,9 @@
                     },
                     "custom": {
                         "align": "auto",
-                        "displayMode": "auto",
+                        "cellOptions": {
+                            "type": "auto"
+                        },
                         "inspect": false
                     },
                     "mappings": [],
@@ -763,8 +759,7 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "green",
-                                "value": null
+                                "color": "green"
                             },
                             {
                                 "color": "red",
@@ -856,7 +851,9 @@
                     },
                     "custom": {
                         "align": "auto",
-                        "displayMode": "auto",
+                        "cellOptions": {
+                            "type": "auto"
+                        },
                         "inspect": false
                     },
                     "mappings": [],
@@ -864,8 +861,7 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "green",
-                                "value": null
+                                "color": "green"
                             },
                             {
                                 "color": "red",
@@ -970,7 +966,9 @@
                     },
                     "custom": {
                         "align": "auto",
-                        "displayMode": "auto",
+                        "cellOptions": {
+                            "type": "auto"
+                        },
                         "inspect": false
                     },
                     "mappings": [],
@@ -978,8 +976,7 @@
                         "mode": "absolute",
                         "steps": [
                             {
-                                "color": "green",
-                                "value": null
+                                "color": "green"
                             },
                             {
                                 "color": "red",
@@ -1058,8 +1055,8 @@
             "type": "table"
         }
     ],
-    "schemaVersion": 36,
-    "style": "dark",
+    "refresh": "",
+    "schemaVersion": 42,
     "tags": [],
     "templating": {
         "list": [
@@ -1099,7 +1096,6 @@
     "timepicker": {},
     "timezone": "",
     "title": "Artemis Public Statistics",
-    "uid": "hsG-aUQ4k",
-    "version": 7,
-    "weekStart": ""
+    "weekStart": "",
+    "version": 8
 }

--- a/docker/monitoring/grafana/provisioning/dashboards/artemis/artemis_public.json
+++ b/docker/monitoring/grafana/provisioning/dashboards/artemis/artemis_public.json
@@ -97,7 +97,7 @@
                     },
                     "editorMode": "code",
                     "exemplar": false,
-                    "expr": "artemis_instance_websocket_users",
+                    "expr": "max(artemis_global_websocket_users)",
                     "instant": true,
                     "range": false,
                     "refId": "A"

--- a/docker/monitoring/grafana/provisioning/dashboards/artemis/artemis_statistics.json
+++ b/docker/monitoring/grafana/provisioning/dashboards/artemis/artemis_statistics.json
@@ -1,9 +1,12 @@
 {
+    "uid": "d9vRDInMz",
     "annotations": {
         "list": [
             {
                 "builtIn": 1,
-                "datasource": "-- Grafana --",
+                "datasource": {
+                    "uid": "-- Grafana --"
+                },
                 "enable": true,
                 "hide": true,
                 "iconColor": "rgba(0, 211, 255, 1)",
@@ -26,9 +29,14 @@
     "panels": [
         {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus_default"
+            },
             "fieldConfig": {
                 "defaults": {
                     "links": []
@@ -71,6 +79,10 @@
             "steppedLine": false,
             "targets": [
                 {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus_default"
+                    },
                     "expr": "sum(artemis_instance_websocket_users)",
                     "instant": false,
                     "interval": "",
@@ -86,7 +98,7 @@
                 "sort": 0,
                 "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                 "mode": "time",
                 "show": true,
@@ -113,9 +125,14 @@
         },
         {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus_default"
+            },
             "fieldConfig": {
                 "defaults": {
                     "links": []
@@ -158,6 +175,10 @@
             "steppedLine": false,
             "targets": [
                 {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus_default"
+                    },
                     "expr": "artemis_instance_websocket_users",
                     "instant": false,
                     "interval": "",
@@ -173,7 +194,7 @@
                 "sort": 0,
                 "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                 "mode": "time",
                 "show": true,
@@ -200,9 +221,14 @@
         },
         {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus_default"
+            },
             "fieldConfig": {
                 "defaults": {
                     "links": []
@@ -245,6 +271,10 @@
             "steppedLine": false,
             "targets": [
                 {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus_default"
+                    },
                     "expr": "sum by (instance_name) (artemis_health)",
                     "interval": "",
                     "legendFormat": "{{instance_name}}",
@@ -259,7 +289,7 @@
                 "sort": 0,
                 "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                 "mode": "time",
                 "show": true,
@@ -285,9 +315,14 @@
         },
         {
             "aliasColors": {},
+            "autoMigrateFrom": "graph",
             "bars": false,
             "dashLength": 10,
             "dashes": false,
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus_default"
+            },
             "fill": 1,
             "fillGradient": 0,
             "gridPos": {
@@ -324,6 +359,10 @@
             "steppedLine": false,
             "targets": [
                 {
+                    "datasource": {
+                        "type": "prometheus",
+                        "uid": "prometheus_default"
+                    },
                     "expr": "sum by (healthindicator) (artemis_health)",
                     "interval": "",
                     "legendFormat": "{{healthindicator}}",
@@ -338,7 +377,7 @@
                 "sort": 0,
                 "value_type": "individual"
             },
-            "type": "graph",
+            "type": "timeseries",
             "xaxis": {
                 "mode": "time",
                 "show": true,
@@ -364,8 +403,7 @@
         }
     ],
     "refresh": "30s",
-    "schemaVersion": 34,
-    "style": "dark",
+    "schemaVersion": 42,
     "tags": [],
     "templating": {
         "list": []
@@ -389,7 +427,6 @@
     },
     "timezone": "",
     "title": "Artemis Statistics",
-    "uid": "d9vRDInMz",
-    "version": 1,
-    "weekStart": ""
+    "weekStart": "",
+    "version": 2
 }

--- a/docker/monitoring/grafana/provisioning/dashboards/artemis/artemis_statistics.json
+++ b/docker/monitoring/grafana/provisioning/dashboards/artemis/artemis_statistics.json
@@ -83,7 +83,7 @@
                         "type": "prometheus",
                         "uid": "prometheus_default"
                     },
-                    "expr": "sum(artemis_instance_websocket_users)",
+                    "expr": "max(artemis_global_websocket_users)",
                     "instant": false,
                     "interval": "",
                     "legendFormat": "",
@@ -92,7 +92,7 @@
             ],
             "thresholds": [],
             "timeRegions": [],
-            "title": "Artemis User - Sum",
+            "title": "Connected Users (all instances)",
             "tooltip": {
                 "shared": true,
                 "sort": 0,
@@ -179,7 +179,7 @@
                         "type": "prometheus",
                         "uid": "prometheus_default"
                     },
-                    "expr": "artemis_instance_websocket_users",
+                    "expr": "artemis_instance_websocket_sessions",
                     "instant": false,
                     "interval": "",
                     "legendFormat": "{{instance_name}}",
@@ -188,7 +188,7 @@
             ],
             "thresholds": [],
             "timeRegions": [],
-            "title": "Artemis User",
+            "title": "Websocket Sessions per Instance",
             "tooltip": {
                 "shared": true,
                 "sort": 0,

--- a/docker/oidc-test.yml
+++ b/docker/oidc-test.yml
@@ -19,7 +19,7 @@ name: artemis
 services:
     keycloak-oidc:
         container_name: artemis-keycloak-oidc
-        image: quay.io/keycloak/keycloak:${KEYCLOAK_VERSION:-26.6}
+        image: quay.io/keycloak/keycloak:${KEYCLOAK_VERSION:-26.7}
         pull_policy: missing
         command: start-dev --import-realm
         environment:

--- a/docker/weaviate-embeddings.yml
+++ b/docker/weaviate-embeddings.yml
@@ -19,7 +19,7 @@ services:
       - --scheme
       - http
     # Must be compatible with the Java client: https://docs.weaviate.io/weaviate/release-notes
-    image: cr.weaviate.io/semitechnologies/weaviate:${WEAVIATE_SERVER_VERSION:-1.37.9}
+    image: cr.weaviate.io/semitechnologies/weaviate:${WEAVIATE_SERVER_VERSION:-1.37.14}
     expose:
       - 8001
       - 50051

--- a/docker/weaviate.yml
+++ b/docker/weaviate.yml
@@ -10,7 +10,7 @@ services:
       - --scheme
       - http
     # Must be compatible with the Java client: https://docs.weaviate.io/weaviate/release-notes
-    image: cr.weaviate.io/semitechnologies/weaviate:${WEAVIATE_SERVER_VERSION:-1.37.9}
+    image: cr.weaviate.io/semitechnologies/weaviate:${WEAVIATE_SERVER_VERSION:-1.37.14}
     expose:
       - 8001
       - 50051

--- a/documentation/docs/admin/database-tips.mdx
+++ b/documentation/docs/admin/database-tips.mdx
@@ -44,9 +44,11 @@ and run the following commands to convert the `Artemis.sql` dump into `Artemis.p
 
   The temporary MySQL helper below is deliberately pinned to **8.0** and is *not* kept in sync with the
   MySQL version Artemis itself runs on. `pgloader` only implements the `mysql_native_password`
-  authentication plugin, which MySQL removed in 8.4. Against any MySQL 8.4 or 9.x container, the
-  `pgloader` step below fails with `Condition QMYND:MYSQL-UNSUPPORTED-AUTHENTICATION was signalled`,
-  and neither `caching_sha2_password` (the default) nor `sha256_password` is a usable alternative.
+  authentication plugin, which MySQL **disabled by default in 8.4** and **removed in 9.0**. So the
+  `pgloader` step below fails with `Condition QMYND:MYSQL-UNSUPPORTED-AUTHENTICATION was signalled`
+  against a default MySQL 8.4 (where the plugin can still be switched back on with
+  `--mysql-native-password=ON`) and against any MySQL 9.x (where it is gone for good), and neither
+  `caching_sha2_password` (the default) nor `sha256_password` is a usable alternative.
   This container is a throwaway format converter that only ever talks to `pgloader` on a local Docker
   network, so running an older MySQL here is safe — but do not copy this snippet as a template for a
   real Artemis deployment.
@@ -60,8 +62,10 @@ and run the following commands to convert the `Artemis.sql` dump into `Artemis.p
            environment:
                - MYSQL_DATABASE=Artemis
                - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+           # Bind to localhost only: this helper runs with an empty root password and TLS disabled,
+           # so it must never be reachable from outside the host.
            ports:
-               - 3306:3306
+               - 127.0.0.1:3306:3306
            command: >
                mysqld
                    --lower_case_table_names=1 --skip-ssl
@@ -78,8 +82,10 @@ and run the following commands to convert the `Artemis.sql` dump into `Artemis.p
                - POSTGRES_USER=root
                - POSTGRES_DB=Artemis
                - POSTGRES_HOST_AUTH_METHOD=trust
+           # Bind to localhost only: POSTGRES_HOST_AUTH_METHOD=trust accepts any connection without
+           # a password, so this must never be reachable from outside the host.
            ports:
-               - 5432:5432
+               - 127.0.0.1:5432:5432
            networks:
                - db-migration
 

--- a/documentation/docs/admin/database-tips.mdx
+++ b/documentation/docs/admin/database-tips.mdx
@@ -39,10 +39,24 @@ This dump is called `Artemis.sql` in the following steps.
 and run the following commands to convert the `Artemis.sql` dump into `Artemis.pg.sql` that is usable by PostgreSQL.
 
 **docker-compose.yml with helper containers for MySQL and PostgreSQL:**
+
+<Callout variant={CalloutVariant.warning}>
+
+  The temporary MySQL helper below is deliberately pinned to **8.0** and is *not* kept in sync with the
+  MySQL version Artemis itself runs on. `pgloader` only implements the `mysql_native_password`
+  authentication plugin, which MySQL removed in 8.4. Against any MySQL 8.4 or 9.x container, the
+  `pgloader` step below fails with `Condition QMYND:MYSQL-UNSUPPORTED-AUTHENTICATION was signalled`,
+  and neither `caching_sha2_password` (the default) nor `sha256_password` is a usable alternative.
+  This container is a throwaway format converter that only ever talks to `pgloader` on a local Docker
+  network, so running an older MySQL here is safe — but do not copy this snippet as a template for a
+  real Artemis deployment.
+
+</Callout>
+
 ```yaml
    services:
        mysql:
-           image: docker.io/library/mysql:9.7.2
+           image: docker.io/library/mysql:8.0.46
            environment:
                - MYSQL_DATABASE=Artemis
                - MYSQL_ALLOW_EMPTY_PASSWORD=yes
@@ -50,10 +64,11 @@ and run the following commands to convert the `Artemis.sql` dump into `Artemis.p
                - 3306:3306
            command: >
                mysqld
-                   --lower_case_table_names=1 --tls-version=''
+                   --lower_case_table_names=1 --skip-ssl
                    --character_set_server=utf8mb4
                    --collation-server=utf8mb4_unicode_ci
                    --explicit_defaults_for_timestamp
+                   --default-authentication-plugin=mysql_native_password
            networks:
                - db-migration
 

--- a/documentation/docs/admin/database-tips.mdx
+++ b/documentation/docs/admin/database-tips.mdx
@@ -42,7 +42,7 @@ and run the following commands to convert the `Artemis.sql` dump into `Artemis.p
 ```yaml
    services:
        mysql:
-           image: docker.io/library/mysql:9.5.0
+           image: docker.io/library/mysql:9.7.2
            environment:
                - MYSQL_DATABASE=Artemis
                - MYSQL_ALLOW_EMPTY_PASSWORD=yes
@@ -50,16 +50,15 @@ and run the following commands to convert the `Artemis.sql` dump into `Artemis.p
                - 3306:3306
            command: >
                mysqld
-                   --lower_case_table_names=1 --skip-ssl
+                   --lower_case_table_names=1 --tls-version=''
                    --character_set_server=utf8mb4
                    --collation-server=utf8mb4_unicode_ci
                    --explicit_defaults_for_timestamp
-                   --default-authentication-plugin=mysql_native_password
            networks:
                - db-migration
 
        postgres:
-           image: docker.io/library/postgres:18.3-alpine
+           image: docker.io/library/postgres:18.4-alpine
            environment:
                - POSTGRES_USER=root
                - POSTGRES_DB=Artemis

--- a/documentation/docs/admin/global-search-weaviate.mdx
+++ b/documentation/docs/admin/global-search-weaviate.mdx
@@ -70,7 +70,7 @@ docker compose -f docker/weaviate-embeddings.yml build
 docker compose -f docker/weaviate-embeddings.yml up -d
 ```
 
-The shipped image is pinned to **Weaviate 1.37.9** (`cr.weaviate.io/semitechnologies/weaviate:1.37.9`).
+The shipped image is pinned to **Weaviate 1.37.14** (`cr.weaviate.io/semitechnologies/weaviate:1.37.14`).
 
 **Ports exposed by both files:**
 

--- a/documentation/docs/developer/docker-compose.mdx
+++ b/documentation/docs/developer/docker-compose.mdx
@@ -331,7 +331,7 @@ services:
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=Artemis
-    command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8mb4 --collation-server=utf8mb4_unicode_ci --explicit_defaults_for_timestamp
+    command: mysqld --lower_case_table_names=1 --tls-version='' --character_set_server=utf8mb4 --collation-server=utf8mb4_unicode_ci --explicit_defaults_for_timestamp
     networks:
       - artemis-net
     cap_add:

--- a/documentation/docs/developer/docker-compose.mdx
+++ b/documentation/docs/developer/docker-compose.mdx
@@ -323,7 +323,7 @@ services:
       - "traefik.http.services.artemis.loadbalancer.server.port=8080"
 
   artemis-db:
-    image: mysql:9.5.0
+    image: mysql:9.7.2
     container_name: "mysql"
     restart: unless-stopped
     volumes:

--- a/documentation/docs/developer/weaviate-setup.mdx
+++ b/documentation/docs/developer/weaviate-setup.mdx
@@ -491,7 +491,7 @@ You can also define a custom Weaviate version if needed, but make sure to use a 
 ```bash
 WEAVIATE_REST_PORT=8002
 WEAVIATE_GRPC_PORT=50052
-WEAVIATE_SERVER_VERSION=1.37.9
+WEAVIATE_SERVER_VERSION=1.37.14
 ```
 
 If you also run Pyris against the same Weaviate instance, remember to update the Pyris configuration accordingly.

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ netty_version=4.2.16.Final
 bucket4j_version=8.19.0
 weaviate_client_version=6.2.1
 # Must be compatible with the Java client: https://docs.weaviate.io/weaviate/release-notes
-weaviate_server_version=1.37.9
+weaviate_server_version=1.37.14
 commons_lang3_version=3.20.0
 commons_text_version=1.15.0
 redisson_version=4.6.1

--- a/src/test/playwright/support/iris-stack/README.md
+++ b/src/test/playwright/support/iris-stack/README.md
@@ -20,7 +20,7 @@ Components (see `docker-compose.yml`):
 | Service     | Image                                             | Purpose                                                            |
 | ----------- | ------------------------------------------------- | ------------------------------------------------------------------ |
 | `pyris-app` | `pyris-e2e:local` (built, see below)              | Real Pyris. Reads the mounted config; calls back to Artemis on the host. |
-| `weaviate`  | `cr.weaviate.io/semitechnologies/weaviate:1.34.10`| Vector DB. Required for Pyris `/health` to be UP and for chat to run. |
+| `weaviate`  | `cr.weaviate.io/semitechnologies/weaviate:1.37.14`| Vector DB. Required for Pyris `/health` to be UP and for chat to run. Kept in sync with `WEAVIATE_SERVER_VERSION` in the root `.env`. |
 | `mock-llm`  | `iris-mock-llm:local` (built from `../iris-mock-llm`) | Deterministic OpenAI-compatible LLM. Canned reply contains `mock-llm`. |
 
 ## Why this is the high-fidelity version

--- a/src/test/playwright/support/iris-stack/docker-compose.yml
+++ b/src/test/playwright/support/iris-stack/docker-compose.yml
@@ -43,7 +43,10 @@ services:
     restart: unless-stopped
 
   weaviate:
-    image: cr.weaviate.io/semitechnologies/weaviate:1.34.10
+    # Consumed by Pyris's Weaviate client only (Artemis never talks to this instance), but kept in
+    # sync with WEAVIATE_SERVER_VERSION in the repo root .env so the E2E stack and the Artemis dev
+    # stack run the same server. When bumping, re-check it against edutelligence's weaviate-client.
+    image: cr.weaviate.io/semitechnologies/weaviate:1.37.14
     container_name: iris-e2e-weaviate
     command:
       - --host


### PR DESCRIPTION
### Summary

All container images referenced in the repository were audited against their registries. About half were behind, and the monitoring stack was running two end-of-life versions. This PR bumps every image where a newer release exists and compatibility is not at risk, upgrades Prometheus and Grafana off EOL, and fixes the config and dashboard queries that were broken so `docker compose -f docker/monitoring.yml up` works out of the box again.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

Two problems.

First, the pinned image versions had drifted. Nine of them were behind on patch or minor releases, which means we develop and test against containers that no longer match what is published, and we miss the bug and security fixes in those patch releases. Several versions were also pinned in more than one place, so they would silently diverge on the next bump.

Second, and more importantly, the monitoring stack was unusable on a current setup. Prometheus was on v2.55.1 and Grafana on 10.4.14, both end-of-life, each carrying a stale `TODO` asking whether an upgrade was possible. Meanwhile AET production (https://monitoring.aet.cit.tum.de) already runs Grafana 12.4.2, so dashboards were being developed against a version two majors behind the one that actually renders them. Grafana 11 disabled AngularJS plugin support and Grafana 12 removed it, which breaks two things in our config: the `grafana-piechart-panel` plugin we install, and the four AngularJS `graph` panels in the Artemis Statistics dashboard. Running the upgraded stack against a real Artemis also surfaced three dashboard panels that had been silently showing *No data*.

### Description

**Image bumps** (`.env`, the single source of truth for Compose and tests) — all within the same major, so no breaking-change surface: MySQL 9.7.0 → 9.7.2, Valkey 8.1.5 → 8.1.9, Weaviate 1.37.9 → 1.37.14, nginx 1.31.1 → 1.31.3, Alpine 3.23.4 → 3.23.5, ActiveMQ Artemis 2.54.0 → 2.55.0, Mailpit v1.30.1 → v1.30.6, Keycloak 26.6 → 26.7.

**Duplicate pins brought back in sync**, so they cannot drift apart on the next bump:
- `gradle.properties` `weaviate_server_version` (used by the Testcontainers-based Weaviate tests)
- the hardcoded `alpine:3.23.4` in `docker/artemis/Dockerfile`, which bypassed `ALPINE_VERSION`
- the inline `:-` fallbacks in `docker/weaviate.yml`, `docker/weaviate-embeddings.yml` and `docker/oidc-test.yml`
- the `embedded-postgres-binaries-bom` fallback in `build.gradle`, still on 18.1 while `.env` is on 18.4
- the Weaviate version documented in `weaviate-setup.mdx` and `global-search-weaviate.mdx`

**Monitoring upgrade**: Prometheus v2.55.1 → v3.13.2 (the newest release, and what `prom/prometheus:latest` resolves to) and Grafana 10.4.14 → 12.4.2, deliberately matching AET production rather than the newest 13.x so dashboards are developed against the version that renders them. Both stale `TODO` comments are gone. Config changes that make it work out of the box:
- Removed `GF_INSTALL_PLUGINS: "grafana-piechart-panel"`. Grafana 12 downloads it and then logs `Refusing to initialize plugin because it's using Angular, which has been disabled`. Neither dashboard uses a pie chart, so it was dead config.
- Migrated the dashboards off the AngularJS `graph` panel. `artemis_statistics.json` goes from schemaVersion 34 with 4 × `graph` to schemaVersion 42 with 4 × `timeseries`; `artemis_public.json` goes 36 → 42 with its panel set unchanged. The migration was produced by Grafana 12.4.2's own schema conversion API rather than hand-edited, and the dashboard UIDs, panel titles and all PromQL queries were preserved verbatim, so existing links keep working.
- Split the Grafana provisioning mount into `datasources/` and `dashboards/`. Mounting the whole `provisioning/` parent hid the image's own empty `alerting/`, `plugins/`, `notifiers/` and `access-control/` directories, which Grafana logged as errors on every startup.

**Dead dashboard metric fixed.** Three panels queried `artemis_instance_websocket_users`, which #7459 (`babc1bc38c`) removed. It was fed by `extractWebsocketSessionCount` — the same extractor now behind `artemis.instance.websocket.sessions` — so it was effectively a rename and no data is lost:
- Artemis Statistics *"Artemis User - Sum"* → **"Connected Users (all instances)"** using `max(artemis_global_websocket_users)`. That gauge reads `SimpUserRegistry.getUserCount()` and `WebsocketConfiguration` calls `setUserRegistryBroadcast`, so the value is already cluster-wide and identical on every node — `max`, not `sum`, which would multiply it by the node count.
- Artemis Statistics *"Artemis User"* → **"Websocket Sessions per Instance"** using `artemis_instance_websocket_sessions`, the per-instance successor. Retitled because it counts sessions, not users.
- Public *"Current connected users"* → `max(artemis_global_websocket_users)`, which matches the panel title semantically.

**Iris E2E stack**: its separate Weaviate pin was three minors behind at 1.34.10; it now tracks `.env` at 1.37.14, with a comment recording that Pyris (not Artemis) is the client so future bumps need checking against edutelligence.

**Documentation**, where two snippets were already broken before this PR:
- The **production** Compose examples in `docker-compose.mdx` and the MySQL helper in `database-tips.mdx` passed `--skip-ssl` and `--default-authentication-plugin`, both unusable on MySQL 9.x, so neither could start the container it pinned. The production example now uses `--tls-version=''`, matching `docker/mysql.yml`.
- The **temporary MySQL helper** in the migration guide is a different case and is now pinned to `mysql:8.0.46` with `mysql_native_password`, *deliberately not* tracking the Artemis MySQL version. `pgloader` implements only the `mysql_native_password` auth plugin, which MySQL disabled by default in 8.4 and removed in 9.0, so against 9.x it aborts with `QMYND:MYSQL-UNSUPPORTED-AUTHENTICATION`; neither `caching_sha2_password` nor `sha256_password` is a usable substitute, and no published `dimitri/pgloader` build supports them. A callout explains why this one container stays behind and warns against copying it as a deployment template.
- Both migration helpers published their ports on all interfaces while running without credentials (MySQL with an empty root password and TLS off, PostgreSQL with `POSTGRES_HOST_AUTH_METHOD=trust`, which accepts any connection with no password). Both are now bound to `127.0.0.1`, as `docker/mysql.yml` already does.

**Deliberately not bumped**, to keep this a maintenance change: the Swift build agent (`swift5.9.2` → `swift6.2` is a language major that would break student templates), MATLAB (`r2024b` → `r2026a`), the DejaGnu blackbox image (its tag tracks the JDK, so `:25` matches our Java 25), `ubuntu:24.04` (still supported LTS), and the floating tags `jenkins:lts`, `golang:alpine`, `alpine:3`, `python:3.13-slim`. Grafana 13.1.3 was also skipped in favour of matching production.

### Verification already performed locally

The monitoring upgrade was verified end to end against a **real running Artemis** (a multi-node dev instance on `:8080`), not just a started container:

- **Prometheus v3.13.2 scrapes Artemis successfully**: target `health=UP`, `lastError` empty, `up = 1`, 76 `artemis_*` series ingested. This was the main upgrade risk, because Prometheus v3 requires scrape targets to send a valid `Content-Type`. Artemis's Actuator endpoint returns `text/plain;version=0.0.4;charset=utf-8`, which v3 accepts, so **no `fallback_scrape_protocol` is needed**.
- `promtool check config` on v3.13.2 accepts the existing `prometheus.yml` unchanged. None of the v3 breaking changes apply: no removed CLI flags are used (the compose file passes no `command:`), and the dashboard queries use no histograms, no `le=`/`quantile=` matchers, no regex and no `holt_winters`.
- **Grafana 12.4.2 renders both dashboards with live data**: the two `artemis_health` panels plot all 13 health indicators, the public dashboard's stat and bar chart panels show real values, and after the metric fix the three previously-empty websocket panels return a series (value `0` with nobody connected) where the old query returned none.
- Grafana → Prometheus datasource `Save & test` returns `Successfully queried the Prometheus API.`
- Both containers start with **zero `level=error` log lines**, where previously there was the Angular plugin refusal plus two provisioning read errors.
- Weaviate 1.37.14 against the Java client 6.2.1: `WeaviateClientIntegrationTest` passes 3/3, none skipped.
- The MySQL → PostgreSQL migration guide was run end to end on the new pin: dump imports, `pgloader` reports `Total import time ✓`, rows verified present in PostgreSQL. The MySQL auth lifecycle was checked against the images directly (8.4.11: plugin present but `DISABLED`, re-enablable with `--mysql-native-password=ON`; 9.7.2: absent entirely).
- MySQL 9.7.2, Valkey 8.1.9, ActiveMQ 2.55.0 (STOMP acceptors up), Mailpit v1.30.6, Keycloak 26.7 (realm imports, OIDC discovery serves 200) and Alpine 3.23.5 were each started and checked; nginx 1.31.3-alpine-slim passes `nginx -t` against the full Artemis config set.

**Note on the `course_students` / `exam_students` table panels**: these are *not* broken and are intentionally untouched. Both metrics are registered `MultiGauge`s in `MetricsBean` carrying `courseId`, `courseName` and `semester` tags, populated only on the scheduling node; they emit no series purely because a dev instance has no active courses or exams, so the panels will populate on a real deployment.

### Steps for Testing

No Artemis application code changed, so this is verified by running the containers.

Prerequisites: Docker, and a running Artemis on `:8080` for the scrape check.

1. **Monitoring stack works out of the box** — the main thing to check:
   ```
   docker compose --env-file .env -f docker/monitoring.yml up -d
   ```
   - `docker logs artemis-prometheus` and `docker logs artemis-grafana` should contain **no** `level=error` lines. In particular no `Refusing to initialize plugin` and no `Failed to read plugin provisioning files`.
   - Prometheus reports v3.13.2 and is ready: `curl localhost:9090/api/v1/status/buildinfo` and `curl localhost:9090/-/ready`.
   - Grafana reports 12.4.2: `curl localhost:3000/api/health`.
   - With Artemis running, `curl localhost:9090/api/v1/targets` must show the `prometheus` job as `"health": "up"` with an empty `lastError`. Note `/management/prometheus` is IP-gated to `spring.prometheus.monitoringIp` (default `127.0.0.1`), which is why the compose file uses `network_mode: host`.
   - In Grafana (`localhost:3000`, admin/admin) open **Artemis → Artemis Statistics**. All four panels must render as time series charts, not as a `Panel plugin not found: graph` error. "Connected Users (all instances)" and "Websocket Sessions per Instance" must show a value (`0` if nobody is connected), **not** *No data*. The two health panels should plot the health indicators.
   - Open **Artemis Public Statistics** and confirm "Current connected users" shows a value, plus the rows and the `Semester` dropdown work.
   - Under Connections → Data sources → Prometheus, **Save & test** must succeed.
   - On macOS this needs the tweak already documented in `docker/monitoring.yml` (drop `network_mode: host` and use `host.docker.internal`), since host networking is not exposed there.

2. **Weaviate still matches the Java client** (the one bump with a documented compatibility constraint):
   ```
   ./gradlew test --tests WeaviateClientIntegrationTest -x webapp
   ```
   All 3 tests must pass and must not be skipped.

3. **Databases and middleware start** — bring up a normal dev stack (e.g. `docker compose -f docker/artemis-dev-postgres.yml up`) and confirm Postgres/MySQL, the ActiveMQ broker and nginx come up healthy.

4. **Iris E2E stack** (optional, needs the Pyris image):
   ```
   docker compose -f src/test/playwright/support/iris-stack/docker-compose.yml up -d
   curl -s -H "Authorization: iris-e2e-secret-token" http://localhost:8000/api/v1/health/
   ```
   Must return `"isHealthy": true` with the Weaviate module `UP`.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-07 15:32:30 UTC_

