### PR TITLE
`Development`: Fix the vulnerable Python dependencies of the coverage table script

### DIFF
--- a/supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt
+++ b/supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt
@@ -1,7 +1,8 @@
 requests==2.34.2
 urllib3>=2.7.0
 gitpython==3.1.55
-beautifulsoup4==4.14.3
+beautifulsoup4==4.15.0
+soupsieve>=2.8.4
 pyperclip==1.11.0
 python-dotenv==1.2.2
 tqdm==4.67.3

--- a/supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt
+++ b/supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.34.2
 urllib3>=2.7.0
-gitpython==3.1.55
+gitpython==3.1.58
 beautifulsoup4==4.15.0
 soupsieve>=2.8.4
 pyperclip==1.11.0


### PR DESCRIPTION
### Summary

Clears every dependency vulnerability reported against `supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt`: nine Dependabot alerts for `GitPython` and the Mend report for `soupsieve` (reached transitively through `beautifulsoup4`). Ten alerts, three changed lines, one file.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

Closes #13188.

**`GitPython` 3.1.55 to 3.1.58** — nine open Dependabot alerts, six high and three medium:

| GHSA | Severity | Patched | Issue |
| --- | --- | --- | --- |
| GHSA-hmq2-w58f-27jc | high | 3.1.58 | Repository creation outside the working tree via unvalidated `.gitmodules` submodule name |
| GHSA-jm78-9fvv-mhgr | high | 3.1.58 | git-config option-name injection forging `core.sshCommand` / `hooksPath` (RCE) |
| GHSA-wvpp-8hx9-p66j | high | 3.1.58 | Guard bypass via `split_single_char_options=False` short-option smuggling |
| GHSA-9rj7-rf2p-w77r | high | 3.1.58 | `Repo.init` option forwarding enables command execution via `--template` clone hooks |
| GHSA-4gmw-gg2m-w46p | high | 3.1.58 | `IndexFile.from_tree` / `reset` / `merge_tree` option forwarding enables file overwrite |
| GHSA-3f7w-8rr8-f37f | high | 3.1.57 | `IndexFile.checkout()` / `TagReference.create()` option forwarding |
| GHSA-hh9p-6wh2-4mfc | medium | 3.1.58 | Arbitrary file read via `--pathspec-from-file` in `IndexFile.remove()` / `Head.checkout()` |
| GHSA-539m-9xh6-q6rr | medium | 3.1.57 | Incomplete `unsafe_git_archive_options` denylist omits `--add-file` |
| GHSA-p538-c434-8v24 | medium | 3.1.56 | File truncation via `git rev-list --output` injection in `Commit.count` |

3.1.58 covers all nine. They share one root pattern — unguarded forwarding of caller-supplied git options — and **the script calls none of the affected APIs**. Its entire use of GitPython is `git.Repo(repo_path, search_parent_directories=True)`, `repo.active_branch.name`, `repo.commit(...)` and catching `git.exc.InvalidGitRepositoryError`. No `checkout`, `archive`, `from_tree`, `merge_tree`, `reset`, `init`, `remove`, `TagReference`, submodule or config-writer call anywhere in the file.

**`soupsieve` via `beautifulsoup4`** — CVE-2026-49476 and CVE-2026-49477, denial of service in the CSS selector parser. The important detail here is that **the scanner's suggested remediation would not have fixed anything**: it recommends bumping `beautifulsoup4` to 4.15.0, but 4.14.3 and 4.15.0 declare the same floor, `soupsieve>=1.6.1`. Nothing in the current pin set prevents the vulnerable `soupsieve` 2.8.3 from resolving; a fresh install merely happens to pick the newest version today. Verified with pip dry-runs:

| Constraints | Resolves to |
| --- | --- |
| `beautifulsoup4==4.14.3` | `soupsieve 2.9.2` (patched, but only by luck) |
| `beautifulsoup4==4.14.3` + `soupsieve==2.8.3` | resolves fine — vulnerable version is permitted |
| `beautifulsoup4==4.15.0` + `soupsieve>=2.8.4` + `soupsieve==2.8.3` | `ResolutionImpossible` — correctly rejected |

Only the explicit floor makes the outcome deterministic. Those two CVEs are also unreachable: they live in soupsieve's CSS selector parser, entered only through `.select()`, `.select_one()` or `soupsieve.compile()`, and this script uses only `find` / `find_all` with `html.parser` (`generate_code_cov_table.py:216-244`).

So none of the ten alerts is exploitable here — the script is developer-run, not referenced by any workflow under `.github/`, and its only inputs are the developer's own git checkout and coverage HTML from our own CI artifacts. This is dependency hygiene to get the alert count back to zero, which is why it stays a one-file change.

### Description

`supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt`:

- `gitpython` 3.1.55 to 3.1.58.
- `beautifulsoup4` 4.14.3 to 4.15.0, so the direct-dependency version the scanner keys its alert to is clear.
- Added `soupsieve>=2.8.4`, the constraint that actually enforces the patched parser. This follows the precedent already in this file: `urllib3>=2.7.0` pins a transitive dependency of `requests` the same way.

### Steps for Testing

Prerequisites:
- Python 3 and a GitHub token, per `supporting_scripts/code-coverage/generate_code_cov_table/README.md`

1. Create a fresh virtual environment and run `pip install -r supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt`.
2. Confirm via `pip list` that the resolved versions are `GitPython 3.1.58`, `beautifulsoup4 4.15.0` and `soupsieve` 2.8.4 or newer.
3. Run `python3 generate_code_cov_table.py` against a PR following the README. Confirm it still detects the branch and changed files, and that the generated table reports client and server line coverage rather than `not found`.

Verification I ran locally in a clean virtual environment:

- Resolved set: `GitPython 3.1.58`, `gitdb 4.0.12`, `beautifulsoup4 4.15.0`, `soupsieve 2.9.2`, `requests 2.34.2`, `urllib3 2.7.0`.
- Exercised the script's exact GitPython surface against this repository on 3.1.58: `git.Repo(..., search_parent_directories=True)`, `active_branch.name`, `head.commit.hexsha`, and `InvalidGitRepositoryError` raised for a non-repository path. All behave as the script expects.
- Exercised both BeautifulSoup parsing paths against `beautifulsoup4 4.15.0` / `soupsieve 2.9.2` with fixtures replicating the istanbul and JaCoCo report structures; client extraction returned `87.5%` and server extraction returned `91%`.

### Testserver States

> [!NOTE]
> These changes affect a developer-run supporting script only. No test server is involved.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-10 08:09:12 UTC_

