### PR TITLE
`Development`: Bump jsoup, dompurify, hono, and fast-uri to patched releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -373,7 +373,7 @@ dependencies {
     implementation "ch.qos.logback:logback-classic"
     implementation "ch.qos.logback:logback-core"
 
-    implementation "org.jsoup:jsoup:1.22.2"
+    implementation "org.jsoup:jsoup:1.23.1"
     // needed by e.g. spring security saml2, we explicitly use the newest version to avoid security vulnerabilities
     implementation "commons-codec:commons-codec:1.22.0"
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "d3-shape": "3.2.0",
         "dayjs": "catalog:",
         "diff-match-patch-typescript": "1.1.3",
-        "dompurify": "3.4.12",
+        "dompurify": "3.4.13",
         "fflate": "0.8.3",
         "highlight.js": "11.11.1",
         "hls.js": "1.6.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,9 +188,9 @@ overrides:
   dompurify: 3.4.13
   esbuild: 0.28.1
   express: 5.2.1
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
   globals: 17.8.0
-  hono: 4.12.32
+  hono: 4.12.34
   '@hono/node-server': 2.0.12
   http-proxy-middleware: 3.0.7
   immutable: 5.1.9
@@ -2185,7 +2185,7 @@ packages:
     resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: 4.12.32
+      hono: 4.12.34
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -5566,8 +5566,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -5782,8 +5782,8 @@ packages:
   hls.js@1.6.16:
     resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hookified@1.15.1:
@@ -10056,9 +10056,9 @@ snapshots:
   '@harperfast/extended-iterable@1.0.3':
     optional: true
 
-  '@hono/node-server@2.0.12(hono@4.12.32)':
+  '@hono/node-server@2.0.12(hono@4.12.34)':
     dependencies:
-      hono: 4.12.32
+      hono: 4.12.34
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -10403,7 +10403,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.32)
+      '@hono/node-server': 2.0.12(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -10413,7 +10413,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1(supports-color@10.2.2)
       express-rate-limit: 8.5.2(express@5.2.1(supports-color@10.2.2))
-      hono: 4.12.32
+      hono: 4.12.34
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -12280,7 +12280,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13268,7 +13268,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -13474,7 +13474,7 @@ snapshots:
 
   hls.js@1.6.16: {}
 
-  hono@4.12.32: {}
+  hono@4.12.34: {}
 
   hookified@1.15.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,7 +185,7 @@ overrides:
   cookie: 1.1.1
   debug: 4.4.3
   diff: 9.0.0
-  dompurify: 3.4.12
+  dompurify: 3.4.13
   esbuild: 0.28.1
   express: 5.2.1
   fast-uri: 3.1.4
@@ -343,8 +343,8 @@ importers:
         specifier: 1.1.3
         version: 1.1.3
       dompurify:
-        specifier: 3.4.12
-        version: 3.4.12
+        specifier: 3.4.13
+        version: 3.4.13
       fflate:
         specifier: 0.8.3
         version: 0.8.3
@@ -2725,6 +2725,7 @@ packages:
   '@ngtools/webpack@22.1.2':
     resolution: {integrity: sha512-5o3zbOdEHv5+wjRCMN+t6RBou28dbPkio5/rxEJBsQ9iEq11K+atsSKEaZXBMUhYr9nLYR8Pckm5Cqx2FP9R2Q==}
     engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+    deprecated: Angular's Webpack support is deprecated. Use the esbuild and Vite-based "@angular/build" package instead.
     peerDependencies:
       '@angular/compiler-cli': ^22.0.0
       typescript: '>=6.0 <6.1'
@@ -5290,8 +5291,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -12953,7 +12954,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -13819,7 +13820,7 @@ snapshots:
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.49.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       html2canvas: 1.4.1
     optional: true
 
@@ -14232,7 +14233,7 @@ snapshots:
 
   monaco-editor@0.56.0:
     dependencies:
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       marked: 14.0.0
 
   moo-color@1.0.3:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -145,10 +145,10 @@ overrides:
   esbuild: '0.28.1'
   express: '5.2.1'
   # Kept on the 3.x line (ajv/fast-json-stringify require ^3).
-  fast-uri: '3.1.4'
+  fast-uri: '3.1.5'
   globals: '17.8.0'
   # Only reached dev-side via @modelcontextprotocol/sdk -> @angular/cli (never run by Artemis).
-  hono: '4.12.32'
+  hono: '4.12.34'
   '@hono/node-server': '2.0.12'
   http-proxy-middleware: '3.0.7'
   immutable: '5.1.9'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -141,7 +141,7 @@ overrides:
   cookie: '1.1.1'
   debug: '4.4.3'
   diff: '9.0.0'
-  dompurify: '3.4.12'
+  dompurify: '3.4.13'
   esbuild: '0.28.1'
   express: '5.2.1'
   # Kept on the 3.x line (ajv/fast-json-stringify require ^3).


### PR DESCRIPTION
### Summary

Clears every dependency vulnerability reported against the server dependencies and the root client lockfile: six open Dependabot alerts plus the weekly Mend report. Four files, six changed version pins, no functional changes.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).

### Motivation and Context

| Package | From | To | Advisory | Severity |
| --- | --- | --- | --- | --- |
| `org.jsoup:jsoup` | 1.22.2 | 1.23.1 | GHSA-pmhh-3w7g-xqp8 / CVE-2026-71497 — Cleaner may expose markup with custom raw-text elements | medium |
| `dompurify` | 3.4.12 | 3.4.13 | GHSA-55q2-fjhq-7xh7 — `IN_PLACE` hook removal leaves a detached subtree executable | medium |
| `fast-uri` | 3.1.4 | 3.1.5 | GHSA-7p8r-x3mc-p8w7 — host confusion via backslash authority introducer | high |
| `hono` | 4.12.32 | 4.12.34 | GHSA-f23p-vx2j-j53r — `memo()` retains SSR output across requests | medium |
| `hono` | | | GHSA-54fx-42gc-7vw4 — algorithmic complexity DoS in Language middleware | medium |
| `hono` | | | GHSA-79qm-7rj5-m7r9 — Proxy helper does not strip headers listed in `Connection` | low |

I checked reachability for each before bumping. None is exploitable in Artemis today, so this is hygiene to get the alert count back to zero rather than an incident:

**jsoup.** The flaw needs a *custom* `Safelist` that permits raw-text elements; the advisory states built-in Safelists are unaffected. Artemis builds two custom Safelists and neither permits a raw-text element (`script`, `style`, `textarea`, `title`, `xmp`, `noembed`, `noframes`, `noscript`, `iframe`, `plaintext`): `ProblemStatementRenderingService.buildSafelist()` starts from `Safelist.relaxed()` and only ever calls `addAttributes`, never `addTags`; `CourseNotificationEmailService` builds `new Safelist().addTags("p", "br", "b", "i", "em", "strong", "a", "code", "pre", "img")`, all normal elements. `SvgSanitizer` does not use `Cleaner` at all — it walks nodes itself via the XML parser.

**dompurify.** Requires `IN_PLACE: true` combined with a `beforeSanitizeElements` / `uponSanitizeElement` hook that detaches a node. Artemis registers no DOMPurify hooks and never enables `IN_PLACE` — there is no occurrence of `IN_PLACE`, `addHook` or `RETURN_DOM` anywhere in the client. Every call site uses the plain string form `DOMPurify.sanitize(value)` (`markdown.conversion.util.ts`, `safe-html.pipe.ts`, `translate.directive.ts`, `programming-exercise-plant-uml.extension.ts`).

**hono and fast-uri.** Both are dev-side only in the root lockfile; Dependabot classifies them as `development` scope. `hono` is reached solely through `@modelcontextprotocol/sdk` under `@angular/cli`, as the existing comment in `pnpm-workspace.yaml` records — Artemis never runs a Hono server, so no `memo()`, Language middleware or proxy helper is involved. `fast-uri` is reached through `ajv`, which the Angular build tooling uses for schema validation of its own configuration files, not for untrusted URIs.

### Description

- `build.gradle`: `org.jsoup:jsoup` 1.22.2 to 1.23.1. Confirmed via `dependencyInsight` that the runtime classpath resolves to 1.23.1 and that no `resolutionStrategy.force` rule pins jsoup separately.
- `package.json` and `pnpm-workspace.yaml`: `dompurify` 3.4.12 to 3.4.13. It is pinned in **two** places — as a direct dependency and as a pnpm override — so both needed the bump; otherwise the transitive consumers would stay behind. The lockfile shows the override correctly carrying the patched version into `monaco-editor` and `jspdf`.
- `pnpm-workspace.yaml`: `fast-uri` 3.1.4 to 3.1.5 and `hono` 4.12.32 to 4.12.34. `fast-uri` stays on the 3.x line that `ajv` / `fast-json-stringify` require, so the existing comment above the pin still holds.
- `pnpm-lock.yaml`: regenerated. Worth one note for the reviewer — a plain `pnpm install` updated the resolved versions but left `@hono/node-server`'s peer-resolution key stale as `(hono@4.12.32)`, because `preferFrozenLockfile` makes pnpm skip the resolution pass. Neither `--no-frozen-lockfile` nor `--fix-lockfile` re-derived it. I forced a clean re-derivation by dropping the two `hono` overrides, installing, then restoring them at the new version. The lockfile now contains **zero** occurrences of `4.12.32`, `3.1.4` and `3.4.12`, and the diff is confined to exactly those pins. This matters beyond tidiness: Dependabot parses the lockfile, so a leftover stale version string would have kept the alert open.

While doing that I noticed something worth recording: without the `hono` override, the natural resolution is already `hono@4.12.34`, and `@hono/node-server` naturally resolves to 1.19.17 rather than the overridden 2.0.12. The overrides are therefore no longer doing any work for `hono` itself. I left them in place rather than widening this PR, but they are a candidate for removal in a follow-up.

The lockfile also picked up one unrelated registry metadata refresh — a `deprecated:` note on the already-present `@ngtools/webpack@22.1.2` — which any install would have written.

### Steps for Testing

Prerequisites:
- 1 Instructor, 1 Student
- 1 Programming Exercise with a problem statement containing markdown, a task, a test-case reference and a PlantUML diagram
- 1 Lecture with an online unit

Since the shipped changes are sanitizers, the meaningful check is that sanitized HTML still renders rather than being stripped:

1. Open the programming exercise as a student and confirm the problem statement renders fully: formatted markdown, task badges with test-case status, KaTeX formulas and the PlantUML diagram.
2. Edit the problem statement as an instructor, save, and confirm the rendered output is unchanged.
3. Open a lecture attachment and a lecture with an online unit; confirm the online unit still resolves its title and description from the linked page.
4. Post a message with markdown and a link in a course channel; confirm the link preview and the rendered markdown both appear.
5. Trigger a course notification email (for example a new announcement) and confirm the email body keeps its formatting and links.

Verification I ran locally:

- Server: `./gradlew test -x webapp --tests SvgSanitizerTest --tests ProblemStatementRenderingIntegrationTest --tests CourseNotificationEmailServiceTest --tests LinkPreviewIntegrationTest --tests OnlineUnitIntegrationTest` — **117 tests, 117 passed**. These cover every `Jsoup.clean`, `Jsoup.parse` and `Safelist` call site on the server.
- Client: full Vitest suite — **1263 test files, 16452 tests, all passed**.
- Client production build: `pnpm run webapp:prod` succeeded in 44 s. This is the relevant gate for the `fast-uri` bump, since that is what `ajv` validates the build configuration with.
- `pnpm run check:vite-override` passes.

### Testserver States

> [!NOTE]
> Dependency bumps only; no functional changes. Worth a quick look on a test server for problem statement and email rendering.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-10 08:23:16 UTC_

