### PR TITLE
`Development`: Bump the documentation fast-uri override to 3.1.5

### DIFF
--- a/documentation/pnpm-lock.yaml
+++ b/documentation/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@babel/plugin-transform-modules-systemjs': 7.29.7
   body-parser: 1.20.6
   brace-expansion: 5.0.9
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
   follow-redirects: 1.16.0
   http-proxy-middleware: 3.0.7
   joi: 17.13.4
@@ -3311,8 +3311,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -9360,7 +9360,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10360,7 +10360,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:

--- a/documentation/pnpm-workspace.yaml
+++ b/documentation/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ overrides:
   body-parser: '1.20.6'
   brace-expansion: '5.0.9'
   # Kept on the 3.x line (consumers require ^3).
-  fast-uri: '3.1.4'
+  fast-uri: '3.1.5'
   follow-redirects: '1.16.0'
   http-proxy-middleware: '3.0.7'
   joi: '17.13.4'


### PR DESCRIPTION
### Summary

Clears the one open Dependabot alert against `documentation/pnpm-lock.yaml`: `fast-uri` 3.1.4 is vulnerable to host confusion via a backslash authority introducer (GHSA-7p8r-x3mc-p8w7, high). Two lines in the documentation project, no functional change.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

GHSA-7p8r-x3mc-p8w7 (high), affecting `fast-uri` `>= 3.0.0, < 3.1.5`, patched in 3.1.5.

`fast-uri` is not a declared dependency of the documentation project; it is pinned as an override because it arrives transitively through `ajv`, which Docusaurus uses to validate its own configuration and plugin options at build time. No untrusted URI is parsed with it, so the host-confusion flaw is not reachable here — this bump is to get the alert count back to zero.

The root project carries the same override and is bumped separately in #13455. They live in different pnpm projects with independent lockfiles, so they are kept as separate PRs to keep each one trivially reviewable.

### Description

- `documentation/pnpm-workspace.yaml`: `fast-uri` 3.1.4 to 3.1.5. This stays on the 3.x line the existing comment above the pin calls for, since its consumers require `^3`.
- `documentation/pnpm-lock.yaml`: regenerated. `fast-uri` has no peer dependencies, so all four occurrences updated cleanly and no stale `3.1.4` string remains — which matters because Dependabot parses the lockfile.

### Steps for Testing

Prerequisites:
- Node and pnpm per the repository setup

1. Run `pnpm --dir documentation install`.
2. Run `pnpm --dir documentation run build` and confirm it completes without schema or configuration validation errors.
3. Run `pnpm --dir documentation run serve` and click through a few documentation pages to confirm the site renders.

Verification I ran locally: `pnpm --dir documentation run build` completes with `[SUCCESS] Generated static files in "build"`. That build is the meaningful gate here, because it is exactly the `ajv` schema validation path that pulls `fast-uri` in.

### Testserver States

> [!NOTE]
> Documentation build dependency only. No test server is involved.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage

Not applicable. No production code changed; this touches only the documentation project's dependency pins.