### PR TITLE
`Development`: Bump json to 2.21.2 in the Ruby SCA exercise templates

### DIFF
--- a/src/main/resources/templates/ruby/staticCodeAnalysis/exercise/Gemfile.lock
+++ b/src/main/resources/templates/ruby/staticCodeAnalysis/exercise/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     ast (2.4.2)
     date (3.4.1)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.4)
     parallel (1.26.3)
     parser (3.3.7.0)

--- a/src/main/resources/templates/ruby/staticCodeAnalysis/solution/Gemfile.lock
+++ b/src/main/resources/templates/ruby/staticCodeAnalysis/solution/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     ast (2.4.2)
     date (3.4.1)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.4)
     parallel (1.26.3)
     parser (3.3.7.0)

--- a/src/main/resources/templates/ruby/staticCodeAnalysis/test/Gemfile.lock
+++ b/src/main/resources/templates/ruby/staticCodeAnalysis/test/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     code-scanning-rubocop (0.6.1)
       rubocop (~> 1.0)
     date (3.4.1)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.4)
     minitest (5.25.4)
     minitest-junit (2.1.0)


### PR DESCRIPTION
### Summary

Clears the three open Dependabot alerts against the Ruby static code analysis exercise templates: `json` 2.21.1 has a use-after-free in `JSON::ResumableParser#partial_value` (GHSA-9hj4-r449-hfvc / CVE-2026-71847, low). One version line in each of the three `Gemfile.lock` files.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context

GHSA-9hj4-r449-hfvc (low), affecting `json` `>= 2.20.0, <= 2.21.1`, patched in 2.21.2. Ruby's JSON C extension clears the consumed `JSON::ResumableParser` input buffer but leaves `state.start`, `state.cursor` and `state.end` pointing into released storage; reconstructing an incomplete object with duplicate keys then dereferences those stale pointers and can terminate the process.

Dependabot raises it once per template — `exercise`, `solution` and `test`. `json` is not a declared dependency in any of them; it arrives transitively through `rubocop`, which requires `json (~> 2.3)`. Nothing in these templates uses `JSON::ResumableParser`, so the flaw is not reachable; the templates only run `rubocop` and `minitest` against student code.

### Description

Bumped `json (2.21.1)` to `json (2.21.2)` in the `GEM` section of:

- `src/main/resources/templates/ruby/staticCodeAnalysis/exercise/Gemfile.lock`
- `src/main/resources/templates/ruby/staticCodeAnalysis/solution/Gemfile.lock`
- `src/main/resources/templates/ruby/staticCodeAnalysis/test/Gemfile.lock`

`2.21.2` satisfies rubocop's `json (~> 2.3)` requirement (`>= 2.3, < 3.0`), and it is published for the generic `ruby` platform, which is how the lock records `json` — so no platform-specific entry is needed. There is no `CHECKSUMS` section in these lockfiles, so the version line is the only thing that changes.

I deliberately edited the version line rather than running `bundle lock --update json`. The locks declare `BUNDLED WITH 2.6.2`, and regenerating them with a newer bundler would rewrite that field and risk churning the lock format for files that are handed to students and executed in the `ghcr.io/ls1intum/artemis-ruby-docker` build container. A single transitive leaf-gem version line is exactly what Dependabot itself would change.

### Steps for Testing

Prerequisites:
- 1 Instructor, 1 Student
- A test server with the integrated lifecycle setup (LocalVC and LocalCI)

1. As an instructor, create a Ruby programming exercise with static code analysis enabled.
2. Confirm the template and solution builds both succeed and that the static code analysis (rubocop) results are reported.
3. As a student, participate, push a commit that deliberately violates a rubocop rule, and confirm the build completes and the code analysis feedback appears.

Verification I ran locally, and its limit stated plainly:

- Confirmed `json 2.21.2` downloads for the generic `ruby` platform via `gem fetch json -v 2.21.2`, matching how the lock records it.
- Ran `BUNDLE_FROZEN=true bundle install` against a scratch copy of the `test` template. Bundler honoured the lockfile's `BUNDLED WITH` by auto-installing 2.6.2, resolved the full graph including `json 2.21.2` without complaint, and left the lockfile byte-identical.
- That install then stopped short of completing, but for a reason unrelated to this change: `unicode-emoji 4.0.4` requires `ruby < 4.0` and my local Ruby is 4.0.6. The templates run on the older Ruby in `ghcr.io/ls1intum/artemis-ruby-docker:v1.0.1`, so **the end-to-end build check above is still worth running on a test server** — I could not complete it locally.

### Testserver States

> [!NOTE]
> Needs a test server with the integrated lifecycle setup to confirm the Ruby exercise build and rubocop reporting, since the templates cannot be fully installed on a Ruby 4.x host.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-10 08:28:33 UTC_

