### PR TITLE
`Development`: Bump js-yaml and nanoid to patched releases

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,10 +195,11 @@ overrides:
   http-proxy-middleware: 3.0.7
   immutable: 5.1.9
   ip-address: 10.3.1
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   jsdom: 30.0.1
   katex: 0.18.1
   minimatch: 10.2.6
+  nanoid: 3.3.17
   piscina: 5.3.0
   postcss: 8.5.25
   punycode: 2.3.1
@@ -6099,8 +6100,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -6618,8 +6619,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -12769,7 +12770,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -13760,7 +13761,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -14276,7 +14277,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -14766,7 +14767,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -154,10 +154,12 @@ overrides:
   immutable: '5.1.9'
   ip-address: '10.3.1'
   # Kept on the 4.x line (consumers require ^4; 5.x is an API break).
-  js-yaml: '4.3.0'
+  js-yaml: '4.3.1'
   jsdom: '30.0.1'
   katex: '0.18.1'
   minimatch: '10.2.6'
+  # Reached dev-side via postcss, whose range allows the patched 3.3.17.
+  nanoid: '3.3.17'
   piscina: '5.3.0'
   postcss: '8.5.25'
   punycode: '2.3.1'


### PR DESCRIPTION
### Summary

Clears two new high-severity Dependabot alerts against the root client lockfile: `js-yaml` (GHSA-5p4m-2wfm-xmqj / CVE-2026-59870) and `nanoid` (GHSA-2v37-7h3g-55p8). Two override lines plus the regenerated lockfile.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).

### Motivation and Context

| Package | From | To | Advisory | Severity |
| --- | --- | --- | --- | --- |
| `js-yaml` | 4.3.0 | 4.3.1 | GHSA-5p4m-2wfm-xmqj / CVE-2026-59870 — quadratic CPU consumption in `!!omap` resolution | high |
| `nanoid` | 3.3.16 | 3.3.17 | GHSA-2v37-7h3g-55p8 | high |

Both advisories were published on 2026-08-10, after the previous dependency sweep.

The `js-yaml` flaw is worth reading carefully, because it applies to a default configuration: `resolveYamlOmap()` enforces key uniqueness with a linear `indexOf` scan inside the per-element loop, making `!!omap` resolution O(n²). `!!omap` is registered in the **default** schema, so a plain `yaml.load(untrustedInput)` with no options is affected. Reachability is still limited for us: `js-yaml` is a build-time transitive dependency here, and the YAML it parses is our own configuration, not untrusted input.

Fortunately the fix landed on the 4.x line as 4.3.1, so the existing constraint recorded above this pin — consumers require `^4`, and 5.x is an API break — continues to hold and no major bump is needed.

### Description

- `pnpm-workspace.yaml`: `js-yaml` 4.3.0 to 4.3.1.
- `pnpm-workspace.yaml`: added a `nanoid: '3.3.17'` override. Unlike `js-yaml`, `nanoid` was not previously pinned — it arrives through `postcss`, which declares only a range, so the lockfile was free to sit on the vulnerable 3.3.16. An explicit override is what makes the patched version deterministic, and it matches how this file already pins other CVE-patched transitives.
- `pnpm-lock.yaml`: regenerated. Verified that zero occurrences of `js-yaml@4.3.0`, `nanoid@3.3.16` or the corresponding override values remain, since Dependabot parses the lockfile and any leftover string would keep the alert open.

### Steps for Testing

Prerequisites:
- Node and pnpm per the repository setup

1. Run `pnpm install`.
2. Run `pnpm run webapp:prod` and confirm the production bundle builds.
3. Start the client with `pnpm start` and confirm the app loads and navigates normally.

Verification I ran locally:

- `pnpm run webapp:prod` completes successfully in 44 s. This is the relevant gate, since both packages are build-time dependencies — `js-yaml` in the tooling's configuration parsing and `nanoid` under `postcss`.
- `pnpm run check:vite-override` passes.

### Testserver States

> [!NOTE]
> Build-time dependency bumps only; no functional changes and no server involvement.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-10 10:14:51 UTC_

