### PR TITLE
`Development`: Bump the documentation js-yaml and nanoid overrides

### DIFF
--- a/documentation/pnpm-lock.yaml
+++ b/documentation/pnpm-lock.yaml
@@ -13,9 +13,10 @@ overrides:
   follow-redirects: 1.16.0
   http-proxy-middleware: 3.0.7
   joi: 17.13.4
-  js-yaml: 4.3.0
+  js-yaml: 4.3.1
   launch-editor: 2.14.1
   minimatch: 10.2.6
+  nanoid: 3.3.17
   postcss: 8.5.25
   qs: 6.15.3
   serialize-javascript: 7.0.7
@@ -3855,8 +3856,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -4382,8 +4383,8 @@ packages:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5969,7 +5970,7 @@ snapshots:
 
   '@11ty/gray-matter@1.0.0':
     dependencies:
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -7518,7 +7519,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.5
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -8061,7 +8062,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.2(@swc/core@1.15.43)(@swc/html@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.25))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.25)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       fs-extra: 11.3.5
       joi: 17.13.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -8095,7 +8096,7 @@ snapshots:
       github-slugger: 1.5.0
       globby: 11.1.0
       jiti: 1.21.7
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -9802,7 +9803,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -10961,7 +10962,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -11703,7 +11704,7 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -12368,7 +12369,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/documentation/pnpm-workspace.yaml
+++ b/documentation/pnpm-workspace.yaml
@@ -23,9 +23,11 @@ overrides:
   http-proxy-middleware: '3.0.7'
   joi: '17.13.4'
   # Kept on the 4.x line (consumers require ^4; 5.x is an API break).
-  js-yaml: '4.3.0'
+  js-yaml: '4.3.1'
   launch-editor: '2.14.1'
   minimatch: '10.2.6'
+  # Reached via postcss, whose range allows the patched 3.3.17.
+  nanoid: '3.3.17'
   postcss: '8.5.25'
   qs: '6.15.3'
   serialize-javascript: '7.0.7'


### PR DESCRIPTION
### Summary

Clears two new high-severity Dependabot alerts against `documentation/pnpm-lock.yaml`: `js-yaml` (GHSA-5p4m-2wfm-xmqj / CVE-2026-59870) and `nanoid` (GHSA-2v37-7h3g-55p8). Two override lines plus the regenerated lockfile.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

| Package | From | To | Advisory | Severity |
| --- | --- | --- | --- | --- |
| `js-yaml` | 4.3.0 | 4.3.1 | GHSA-5p4m-2wfm-xmqj / CVE-2026-59870 — quadratic CPU consumption in `!!omap` resolution | high |
| `nanoid` | 3.3.16 | 3.3.17 | GHSA-2v37-7h3g-55p8 | high |

Both advisories were published on 2026-08-10. This is the documentation project's half of the same pair; the root project is bumped separately in #13460. They are independent pnpm projects with their own lockfiles, so they stay separate PRs to keep each trivially reviewable.

Neither is reachable here. Both are build-time transitive dependencies of the Docusaurus toolchain: `js-yaml` parses our own configuration and front matter rather than untrusted input, and `nanoid` arrives under `postcss` for generating identifiers during the CSS build. The `js-yaml` fix landed on the 4.x line, so the existing constraint above the pin — consumers require `^4`, 5.x is an API break — still holds.

### Description

- `documentation/pnpm-workspace.yaml`: `js-yaml` 4.3.0 to 4.3.1.
- `documentation/pnpm-workspace.yaml`: added a `nanoid: '3.3.17'` override. `nanoid` was not previously pinned — it comes in through `postcss`, which declares only a range, so the lockfile was free to sit on the vulnerable 3.3.16. The explicit override makes the patched version deterministic and matches how this file already pins other CVE-patched transitives.
- `documentation/pnpm-lock.yaml`: regenerated. Verified that zero occurrences of `js-yaml@4.3.0`, `nanoid@3.3.16` or the corresponding override values remain, since Dependabot parses the lockfile.

### Steps for Testing

Prerequisites:
- Node and pnpm per the repository setup

1. Run `pnpm --dir documentation install`.
2. Run `pnpm --dir documentation run build` and confirm it completes without errors.
3. Run `pnpm --dir documentation run serve` and click through a few pages to confirm the site renders.

Verification I ran locally: `pnpm --dir documentation run build` completes with `[SUCCESS] Generated static files in "build"`. That build is the meaningful gate, since both packages are only used at build time.

### Testserver States

> [!NOTE]
> Documentation build dependencies only. No test server is involved.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage

Not applicable. No production code changed; this touches only the documentation project's dependency pins.