### PR TITLE
`Development`: Bump the js-yaml override to 4.3.1 in programming exercise templates

### DIFF
--- a/src/main/resources/templates/javascript/staticCodeAnalysis/test/package-lock.json
+++ b/src/main/resources/templates/javascript/staticCodeAnalysis/test/package-lock.json
@@ -4975,9 +4975,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {

--- a/src/main/resources/templates/javascript/staticCodeAnalysis/test/package.json
+++ b/src/main/resources/templates/javascript/staticCodeAnalysis/test/package.json
@@ -29,7 +29,7 @@
     },
     "overrides": {
         "brace-expansion": "5.0.8",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "@babel/plugin-transform-modules-systemjs": "7.29.4",
         "uuid": "11.1.1"
     }

--- a/src/main/resources/templates/javascript/test/package-lock.json
+++ b/src/main/resources/templates/javascript/test/package-lock.json
@@ -4001,9 +4001,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {

--- a/src/main/resources/templates/javascript/test/package.json
+++ b/src/main/resources/templates/javascript/test/package.json
@@ -23,7 +23,7 @@
     },
     "overrides": {
         "brace-expansion": "5.0.8",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "@babel/plugin-transform-modules-systemjs": "7.29.4",
         "uuid": "11.1.1"
     }

--- a/src/main/resources/templates/typescript/staticCodeAnalysis/test/package-lock.json
+++ b/src/main/resources/templates/typescript/staticCodeAnalysis/test/package-lock.json
@@ -3947,9 +3947,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {

--- a/src/main/resources/templates/typescript/staticCodeAnalysis/test/package.json
+++ b/src/main/resources/templates/typescript/staticCodeAnalysis/test/package.json
@@ -32,7 +32,7 @@
     "overrides": {
         "@babel/core": "7.29.7",
         "brace-expansion": "5.0.8",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "uuid": "11.1.1"
     }
 }

--- a/src/main/resources/templates/typescript/test/package-lock.json
+++ b/src/main/resources/templates/typescript/test/package-lock.json
@@ -2729,9 +2729,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {

--- a/src/main/resources/templates/typescript/test/package.json
+++ b/src/main/resources/templates/typescript/test/package.json
@@ -25,7 +25,7 @@
     "overrides": {
         "@babel/core": "7.29.7",
         "brace-expansion": "5.0.8",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "uuid": "11.1.1"
     }
 }


### PR DESCRIPTION
### Summary

Clears four new high-severity Dependabot alerts for `js-yaml` (GHSA-5p4m-2wfm-xmqj / CVE-2026-59870) in the JavaScript and TypeScript exercise templates. One override line per template, plus the regenerated lockfiles.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context

GHSA-5p4m-2wfm-xmqj / CVE-2026-59870 (high), affecting `js-yaml` `>= 4.0.0, < 4.3.1`, patched in 4.3.1. `resolveYamlOmap()` enforces key uniqueness with a linear `indexOf` scan inside the per-element loop, making `!!omap` resolution O(n²). Since `!!omap` is registered in the default schema, a plain `yaml.load(untrustedInput)` is affected without any custom configuration.

Dependabot raises it once per template: `javascript/test`, `javascript/staticCodeAnalysis/test`, `typescript/test` and `typescript/staticCodeAnalysis/test`. In all four, `js-yaml` is transitive — reached through `@istanbuljs/load-nyc-config` (Jest coverage) and, in the static-analysis variants, through `@eslint/eslintrc` and `@microsoft/eslint-formatter-sarif`. The YAML parsed is the tooling's own configuration, not student input, so the flaw is not reachable in practice.

One detail worth surfacing, because it looks wrong at first glance: each lockfile carries a single hoisted `js-yaml` at 4.x even though `@istanbuljs/load-nyc-config` requires `^3.13.1`. That is deliberate, not a broken tree — every template's `package.json` already contains an npm `overrides` block forcing `js-yaml`, because the 3.x line never received these fixes (the advisory is explicit that the CVE-2026-59870 fix was not backported, and 3.x is still vulnerable at its latest 3.15.1). So the correct change is to bump the override, not to regenerate the tree — letting npm resolve `^3.13.1` naturally would reintroduce an unpatched 3.x.

### Description

In each of the four templates:

- `package.json`: `overrides.js-yaml` from `4.3.0` to `4.3.1`.
- `package-lock.json`: regenerated with `npm install --package-lock-only`.

The resulting diff is exactly six lines per lockfile — the `js-yaml` version, resolved URL, integrity hash, and the override echo. npm churned nothing else.

### Steps for Testing

Prerequisites:
- 1 Instructor, 1 Student
- A test server with the integrated lifecycle setup (LocalVC and LocalCI)

1. As an instructor, create a JavaScript programming exercise and a TypeScript programming exercise, both with static code analysis enabled.
2. Confirm the template and solution builds succeed and that test results plus static code analysis feedback are reported.
3. As a student, participate in each, push a commit that fails a test and violates a lint rule, and confirm the build completes with both test and code-analysis feedback.

Verification I ran locally, with its limit stated plainly:

- `npm ci` succeeds against each regenerated lockfile, and `js-yaml` resolves to 4.3.1.
- Jest starts and loads its configuration in the `javascript/test` template.
- The suites themselves cannot run in isolation: `package.json` declares `workspaces: ["${studentParentWorkingDirectoryName}"]`, a placeholder substituted with the student's exercise directory at exercise-creation time, so `artemis-exercise/*` imports do not resolve in a bare copy. I confirmed the identical failure on unmodified `develop`, so it is a property of the template rather than a regression — but it does mean **the end-to-end check above is still worth running on a test server**.

### Testserver States

> [!NOTE]
> Needs a test server with the integrated lifecycle setup to confirm the JavaScript and TypeScript exercise builds, since the templates cannot run standalone outside an exercise.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-10 10:28:05 UTC_

