### PR TITLE
`Development`: Poll for port release in the e2e runners and drop the redundant hono overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,8 +190,6 @@ overrides:
   express: 5.2.1
   fast-uri: 3.1.5
   globals: 17.8.0
-  hono: 4.12.34
-  '@hono/node-server': 2.0.12
   http-proxy-middleware: 3.0.7
   immutable: 5.1.9
   ip-address: 10.3.1
@@ -2182,11 +2180,11 @@ packages:
   '@harperfast/extended-iterable@1.0.3':
     resolution: {integrity: sha512-sSAYhQca3rDWtQUHSAPeO7axFIUJOI6hn1gjRC5APVE1a90tuyT8f5WIgRsFhhWA7htNkju2veB9eWL6YHi/Lw==}
 
-  '@hono/node-server@2.0.12':
-    resolution: {integrity: sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==}
-    engines: {node: '>=20'}
+  '@hono/node-server@1.19.17':
+    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
+    engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.34
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -10057,7 +10055,7 @@ snapshots:
   '@harperfast/extended-iterable@1.0.3':
     optional: true
 
-  '@hono/node-server@2.0.12(hono@4.12.34)':
+  '@hono/node-server@1.19.17(hono@4.12.34)':
     dependencies:
       hono: 4.12.34
 
@@ -10404,7 +10402,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.12(hono@4.12.34)
+      '@hono/node-server': 1.19.17(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -147,9 +147,6 @@ overrides:
   # Kept on the 3.x line (ajv/fast-json-stringify require ^3).
   fast-uri: '3.1.5'
   globals: '17.8.0'
-  # Only reached dev-side via @modelcontextprotocol/sdk -> @angular/cli (never run by Artemis).
-  hono: '4.12.34'
-  '@hono/node-server': '2.0.12'
   http-proxy-middleware: '3.0.7'
   immutable: '5.1.9'
   ip-address: '10.3.1'

--- a/run-e2e-tests-local-fast.sh
+++ b/run-e2e-tests-local-fast.sh
@@ -105,6 +105,9 @@ kill_tree() {
 # down stale processes every time they re-run E2E tests. Do NOT replace this with
 # a simple "error and exit" — that was tried and reverted because it broke the
 # hands-free workflow that this script is designed to provide.
+# How long to wait for a killed process to release its listening socket before giving up.
+PORT_RELEASE_TIMEOUT="${PORT_RELEASE_TIMEOUT:-30}"
+
 check_port_available() {
     local port=$1
     local service_name=$2
@@ -120,15 +123,24 @@ check_port_available() {
             echo "  Killing PID $pid..."
             kill_tree "$pid"
         done
-        sleep 2
-        # Verify port is now free after killing
-        listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
+        # Poll for the port to be released instead of sleeping a fixed 2s and checking once. A JVM
+        # shutting down can hold its listening socket noticeably longer than that, and the single
+        # check then aborts the whole run over a port that frees a moment later.
+        local waited=0
+        while [ "$waited" -lt "$PORT_RELEASE_TIMEOUT" ]; do
+            listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
+            if [ -z "$listeners" ]; then
+                break
+            fi
+            sleep 1
+            waited=$((waited + 1))
+        done
         if [ -n "$listeners" ]; then
-            echo -e "${RED}ERROR: Port ${port} is still in use after killing processes. Cannot start ${service_name}.${NC}"
+            echo -e "${RED}ERROR: Port ${port} is still in use ${PORT_RELEASE_TIMEOUT}s after killing processes. Cannot start ${service_name}.${NC}"
             echo "$listeners"
             exit 1
         fi
-        echo -e "${GREEN}Port ${port} is now free.${NC}"
+        echo -e "${GREEN}Port ${port} is now free (released after ${waited}s).${NC}"
     fi
 }
 

--- a/run-e2e-tests-local-fast.sh
+++ b/run-e2e-tests-local-fast.sh
@@ -106,7 +106,13 @@ kill_tree() {
 # a simple "error and exit" — that was tried and reverted because it broke the
 # hands-free workflow that this script is designed to provide.
 # How long to wait for a killed process to release its listening socket before giving up.
+# Validated rather than trusted: a non-numeric value would otherwise blow up the integer comparison below with a
+# bash arithmetic error, in a pre-flight step whose whole job is to get out of the developer's way.
 PORT_RELEASE_TIMEOUT="${PORT_RELEASE_TIMEOUT:-30}"
+if ! [[ "$PORT_RELEASE_TIMEOUT" =~ ^[0-9]+$ ]]; then
+    echo "Ignoring PORT_RELEASE_TIMEOUT='${PORT_RELEASE_TIMEOUT}': expected a non-negative integer number of seconds. Using 30."
+    PORT_RELEASE_TIMEOUT=30
+fi
 
 check_port_available() {
     local port=$1
@@ -126,10 +132,17 @@ check_port_available() {
         # Poll for the port to be released instead of sleeping a fixed 2s and checking once. A JVM
         # shutting down can hold its listening socket noticeably longer than that, and the single
         # check then aborts the whole run over a port that frees a moment later.
+        #
+        # Shaped so the check always happens at least once and always happens *after* the last sleep: a
+        # pre-kill `lsof` result must never be what decides the error, otherwise PORT_RELEASE_TIMEOUT=0
+        # skips the loop entirely and a port released during the final second is still reported as busy.
         local waited=0
-        while [ "$waited" -lt "$PORT_RELEASE_TIMEOUT" ]; do
+        while true; do
             listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
             if [ -z "$listeners" ]; then
+                break
+            fi
+            if [ "$waited" -ge "$PORT_RELEASE_TIMEOUT" ]; then
                 break
             fi
             sleep 1

--- a/run-e2e-tests-local-multinode-fast.sh
+++ b/run-e2e-tests-local-multinode-fast.sh
@@ -96,7 +96,13 @@ kill_tree() {
 }
 
 # How long to wait for a killed process to release its listening socket before giving up.
+# Validated rather than trusted: a non-numeric value would otherwise blow up the integer comparison below with a
+# bash arithmetic error, in a pre-flight step whose whole job is to get out of the developer's way.
 PORT_RELEASE_TIMEOUT="${PORT_RELEASE_TIMEOUT:-30}"
+if ! [[ "$PORT_RELEASE_TIMEOUT" =~ ^[0-9]+$ ]]; then
+    echo "Ignoring PORT_RELEASE_TIMEOUT='${PORT_RELEASE_TIMEOUT}': expected a non-negative integer number of seconds. Using 30."
+    PORT_RELEASE_TIMEOUT=30
+fi
 
 # Free a port if a leftover process holds it. Mirrors run-e2e-tests-local-fast.sh.
 check_port_available() {
@@ -115,10 +121,17 @@ check_port_available() {
         # Poll for the port to be released instead of sleeping a fixed 2s and checking once. A JVM
         # shutting down can hold its listening socket noticeably longer than that, and the single
         # check then aborts the whole run over a port that frees a moment later.
+        #
+        # Shaped so the check always happens at least once and always happens *after* the last sleep: a
+        # pre-kill `lsof` result must never be what decides the error, otherwise PORT_RELEASE_TIMEOUT=0
+        # skips the loop entirely and a port released during the final second is still reported as busy.
         local waited=0
-        while [ "$waited" -lt "$PORT_RELEASE_TIMEOUT" ]; do
+        while true; do
             listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
             if [ -z "$listeners" ]; then
+                break
+            fi
+            if [ "$waited" -ge "$PORT_RELEASE_TIMEOUT" ]; then
                 break
             fi
             sleep 1

--- a/run-e2e-tests-local-multinode-fast.sh
+++ b/run-e2e-tests-local-multinode-fast.sh
@@ -95,7 +95,10 @@ kill_tree() {
     kill "$pid" 2>/dev/null || true
 }
 
-# Free a port if a leftover process holds it. Mirrors run-e2e-tests-local-fast.sh:92-117.
+# How long to wait for a killed process to release its listening socket before giving up.
+PORT_RELEASE_TIMEOUT="${PORT_RELEASE_TIMEOUT:-30}"
+
+# Free a port if a leftover process holds it. Mirrors run-e2e-tests-local-fast.sh.
 check_port_available() {
     local port=$1
     local service_name=$2
@@ -109,14 +112,24 @@ check_port_available() {
             echo "  Killing PID $pid..."
             kill_tree "$pid"
         done
-        sleep 2
-        listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
+        # Poll for the port to be released instead of sleeping a fixed 2s and checking once. A JVM
+        # shutting down can hold its listening socket noticeably longer than that, and the single
+        # check then aborts the whole run over a port that frees a moment later.
+        local waited=0
+        while [ "$waited" -lt "$PORT_RELEASE_TIMEOUT" ]; do
+            listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
+            if [ -z "$listeners" ]; then
+                break
+            fi
+            sleep 1
+            waited=$((waited + 1))
+        done
         if [ -n "$listeners" ]; then
-            echo -e "${RED}ERROR: Port ${port} is still in use after killing processes.${NC}"
+            echo -e "${RED}ERROR: Port ${port} is still in use ${PORT_RELEASE_TIMEOUT}s after killing processes.${NC}"
             echo "$listeners"
             exit 1
         fi
-        echo -e "${GREEN}Port ${port} is now free.${NC}"
+        echo -e "${GREEN}Port ${port} is now free (released after ${waited}s).${NC}"
     fi
 }
 


### PR DESCRIPTION
### Summary

Two small development-tooling fixes. The local E2E runners abort a whole run when a killed process takes more than two seconds to release its port, and the `hono` / `@hono/node-server` pnpm overrides no longer earn their keep — one is redundant and the other forces an out-of-range major.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

**1. The runners' port pre-flight is racy.** `check_port_available` kills whatever holds a required port, then sleeps a fixed `2` seconds and checks **once**. A JVM shutting down gracefully can hold its listening socket longer than that, so the single check reports a false "still in use" and the script exits 1 — over a port that frees a moment later.

This is not theoretical: it aborted two of my runs today, on ports 7921 and 8081. In both cases the reported PID was already gone by the time I looked, and the port was free. The failure mode is confusing too, because the error names the port as occupied while `lsof` shows nothing.

**2. The hono overrides no longer do anything useful.**

- `hono: '4.12.34'` is **redundant**. `@modelcontextprotocol/sdk` declares `hono: ^4.11.4`, so natural resolution already lands on the newest patched 4.x. The pin only creates manual maintenance — it was itself bumped by hand from 4.12.32 in #13460, and because pnpm rewrites peer ranges through overrides, that bump left `@hono/node-server`'s peer key stale at `(hono@4.12.32)` and needed a workaround to re-derive.
- `'@hono/node-server': '2.0.12'` **forces an out-of-range major**. The SDK declares `^1.19.9`; the override pushes it to 2.x, which pnpm permits but which no longer matches what the consumer asked for. It buys nothing on security: natural resolution is 1.19.17, and every `@hono/node-server` 1.x advisory caps below it — GHSA-92pp-h63x-v22m needs `< 1.19.13`, GHSA-wc8c-qw6v-h7f6 `< 1.19.10`, GHSA-hgxw-5xg3-69jx `< 1.10.1`, GHSA-rjq5-w47x-x359 `< 1.4.1`. The two 2.x advisories (GHSA-9mqv-5hh9-4cgg, GHSA-frvp-7c67-39w9) only affect the 2.x line the override put us on in the first place.

Removing both leaves the dependency self-maintaining: still dev-only (reached via `@modelcontextprotocol/sdk` under `@angular/cli`, never run by Artemis), still on non-vulnerable versions, and no longer a pin that goes stale. If a future advisory hits the resolved version, Dependabot flags it and a pin can be added back deliberately.

### Description

- `run-e2e-tests-local-fast.sh` and `run-e2e-tests-local-multinode-fast.sh`: `check_port_available` now polls once a second for the port to be released, up to `PORT_RELEASE_TIMEOUT` (default 30s, overridable via the environment), and reports how long the release took. The error path still exits, but only after genuinely waiting. The logic is duplicated in the two scripts exactly as before — unifying them is a larger change and out of scope here.
- `pnpm-workspace.yaml`: removed the `hono` and `@hono/node-server` overrides.
- `pnpm-lock.yaml`: regenerated. `hono` stays at the patched 4.12.34, `@hono/node-server` moves to 1.19.17, and the peer range recorded for it is now the honest `^4` rather than an override-rewritten exact pin.

### Steps for Testing

Prerequisites:
- A local checkout able to run the E2E scripts

1. Start something that holds a required port, e.g. `python3 -c "import socket,time; s=socket.socket(); s.bind(('127.0.0.1',8080)); s.listen(1); time.sleep(600)"`.
2. Run `./run-e2e-tests-local-fast.sh --filter "Login"`. Confirm it reports the port in use, kills the holder, and proceeds — printing `Port 8080 is now free (released after Ns)`.
3. Run `pnpm install` and confirm the lockfile is unchanged (no drift from the committed state).
4. Run `pnpm run webapp:prod` and confirm the client still builds.

Verification I ran locally:

- Both scripts pass `bash -n`. `shellcheck -S warning` reports only pre-existing findings on lines I did not touch.
- Exercised the new polling logic against a listener deliberately built to take ~5s to release its socket after `SIGTERM` — the case the old code got wrong. It reported `Port 8099 is now free (released after 5s)` and exited 0, where a fixed 2s check would have aborted.
- `pnpm run webapp:prod` succeeds and `pnpm run check:vite-override` passes after the override removal.
- Confirmed the resolved versions: `hono@4.12.34` (all three advisories from #13460 remain fixed) and `@hono/node-server@1.19.17` (above every 1.x advisory ceiling).

### Testserver States

> [!NOTE]
> Local developer tooling and a dev-only transitive dependency. No test server or production code is involved.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-10 19:50:01 UTC_

