### PR TITLE
`Development`: Give the e2e post-reload exam summary check a cold-reload budget

### DIFF
--- a/src/test/playwright/e2e/course/CourseChannelMessages.spec.ts
+++ b/src/test/playwright/e2e/course/CourseChannelMessages.spec.ts
@@ -6,20 +6,11 @@ import { Channel } from 'app/communication/shared/entities/conversation/channel.
 import { Post } from 'app/communication/shared/entities/post.model';
 import { TextExercise } from 'app/text/shared/entities/text-exercise.model';
 import { SEED_COURSES } from '../../support/seedData';
+import { RELOAD_RENDER_TIMEOUT } from '../../support/timeouts';
 
 // Use pre-seeded courses — no course creation needed
 const readOnlyCourse = { id: SEED_COURSES.channel1.id };
 const writeCourse = { id: SEED_COURSES.channel2.id };
-
-// Budget for the client to re-bootstrap after a full page reload. Deliberately larger than the
-// default 10s expect timeout: a reload re-downloads and re-parses the whole bundle (Playwright
-// disables the HTTP cache per context), which is one of the slowest things a test can wait for
-// under parallel CI load.
-// Sized to fit the @fast per-test budget (60s locally, 75s in CI) alongside the work before the
-// reload, so that a genuine regression still fails as a clear assertion error rather than as an
-// opaque whole-test timeout. Only the first assertion after a reload needs this; anything rendered
-// in the same pass is already present by then and uses the default timeout.
-const RELOAD_RENDER_TIMEOUT = 30_000;
 
 test.describe('Channel messages', { tag: '@fast' }, () => {
     test.describe('Create channel', () => {

--- a/src/test/playwright/e2e/exam/ExamParticipation.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamParticipation.spec.ts
@@ -19,7 +19,7 @@ import { ProgrammingExercise } from 'app/programming/shared/entities/programming
 import { GitCloneMethod } from '../../support/pageobjects/exercises/programming/ProgrammingExerciseOverviewPage';
 import { SshEncryptionAlgorithm } from '../../support/pageobjects/exercises/programming/GitClient';
 import { SEED_COURSES } from '../../support/seedData';
-import { BUILD_RESULT_TIMEOUT } from '../../support/timeouts';
+import { BUILD_RESULT_TIMEOUT, RELOAD_RENDER_TIMEOUT } from '../../support/timeouts';
 
 // Common primitives
 const textFixture = 'loremIpsum.txt';
@@ -240,7 +240,10 @@ test.describe('Exam participation', () => {
 
             await page.reload();
 
-            await examParticipation.verifyTextExerciseOnFinalPage(textExercise.id!, textExercise.additionalData!.textFixture!);
+            // First assertion after the reload absorbs the full client re-bootstrap: the summary view lazy-loads its
+            // chunks and Playwright disables the HTTP cache per context, so the default 10s expect timeout is not
+            // enough under parallel CI load. checkExamTitle renders in the same pass and keeps the default.
+            await examParticipation.verifyTextExerciseOnFinalPage(textExercise.id!, textExercise.additionalData!.textFixture!, RELOAD_RENDER_TIMEOUT);
             await examParticipation.checkExamTitle(examTitle);
 
             await login(instructor);

--- a/src/test/playwright/support/pageobjects/exam/ExamParticipationActions.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamParticipationActions.ts
@@ -110,10 +110,19 @@ export class ExamParticipationActions {
         await expect(exercise.locator(`#exercise-group-title-${exerciseID}`).getByText(exerciseTitle)).toBeVisible();
     }
 
-    async verifyTextExerciseOnFinalPage(exerciseID: number, textFixture: string): Promise<void> {
+    /**
+     * Verifies the submitted text of an exercise on the exam summary page.
+     *
+     * @param exerciseID the exercise whose submission is checked
+     * @param textFixture the fixture holding the expected submission text
+     * @param timeout optional override, in ms. Pass `RELOAD_RENDER_TIMEOUT` from `support/timeouts` for the first check after a
+     *                `page.reload()`, where the summary view has to re-bootstrap and lazy-load its chunks; omit it
+     *                otherwise so a genuine regression still fails on the default timeout.
+     */
+    async verifyTextExerciseOnFinalPage(exerciseID: number, textFixture: string, timeout?: number): Promise<void> {
         const exercise = getExercise(this.page, exerciseID);
         const submissionText = await Fixtures.get(textFixture);
-        await expect(exercise.locator('#text-editor')).toHaveValue(submissionText!);
+        await expect(exercise.locator('#text-editor')).toHaveValue(submissionText!, { timeout });
     }
 
     async verifyGradingKeyOnFinalPage(gradeName: string) {

--- a/src/test/playwright/support/timeouts.ts
+++ b/src/test/playwright/support/timeouts.ts
@@ -10,6 +10,7 @@
 const DEFAULT_BUILD_RESULT_TIMEOUT = 120000; // 120 seconds
 const DEFAULT_BUILD_FINISH_TIMEOUT = 300000; // 300 seconds
 const DEFAULT_EXAM_DASHBOARD_TIMEOUT = 120000; // 120 seconds
+const DEFAULT_RELOAD_RENDER_TIMEOUT = 30000; // 30 seconds
 
 /**
  * Timeout for waiting for build results to appear in the UI (e.g., commit history).
@@ -28,6 +29,20 @@ export const BUILD_FINISH_TIMEOUT = parseInt(process.env.BUILD_FINISH_TIMEOUT_MS
  * Environment variable: EXAM_DASHBOARD_TIMEOUT_MS
  */
 export const EXAM_DASHBOARD_TIMEOUT = parseInt(process.env.EXAM_DASHBOARD_TIMEOUT_MS || String(DEFAULT_EXAM_DASHBOARD_TIMEOUT), 10);
+
+/**
+ * Timeout for the first assertion after a full `page.reload()`.
+ * <p>
+ * A reload re-bootstraps the entire client, and Playwright disables the HTTP cache per context, so the bundle and its
+ * lazy chunks are re-fetched from scratch. Under parallel CI load that regularly exceeds the default 10s expect
+ * timeout, which is what made the post-reload assertions in the channel and exam participation tests flaky.
+ * <p>
+ * Apply it only to the first assertion after the reload: anything rendered in the same pass is already present by then,
+ * so later assertions keep the default timeout and the budgets cannot stack into the per-test cap.
+ *
+ * Environment variable: RELOAD_RENDER_TIMEOUT_MS
+ */
+export const RELOAD_RENDER_TIMEOUT = parseInt(process.env.RELOAD_RENDER_TIMEOUT_MS || String(DEFAULT_RELOAD_RENDER_TIMEOUT), 10);
 
 /**
  * Interval between polling attempts (shared across all polling operations).

--- a/src/test/playwright/support/timeouts.ts
+++ b/src/test/playwright/support/timeouts.ts
@@ -19,14 +19,20 @@ const DEFAULT_RELOAD_RENDER_TIMEOUT = 30000; // 30 seconds
  * `parseInt` is too permissive for configuration that decides how long a test waits: it accepts a partial string like
  * `30000ms`, yields `NaN` for anything unparseable, and happily returns negatives. Any of those would silently
  * override a documented budget with a nonsensical one, and the resulting failure would look like a flaky test rather
- * than a misconfigured variable. So an invalid value is reported and ignored rather than used.
+ * than a misconfigured variable. So a value that is present but unusable is reported and ignored rather than used.
+ *
+ * A blank value is deliberately treated as "not configured" and passes without a warning, because that is how these
+ * variables arrive when they are not set: `ci-e2e.yml` supplies them as `${{ vars.SOME_TIMEOUT }}`, which renders an
+ * empty string for an unset repository variable, and the compose files use `${SOME_TIMEOUT:-default}`, which also
+ * treats empty as absent. Warning here would fire on ordinary runs rather than on a mistake.
  *
  * @param variableName name of the environment variable to read
- * @param fallback default timeout in ms, used when the variable is unset or invalid
+ * @param fallback default timeout in ms, used when the variable is unset, blank, or unusable
  */
 function readTimeoutMs(variableName: string, fallback: number): number {
     const raw = process.env[variableName];
     if (raw === undefined || raw.trim() === '') {
+        // Unset, or set to an empty string by an unconfigured CI variable — not a misconfiguration to report.
         return fallback;
     }
     const parsed = Number(raw);

--- a/src/test/playwright/support/timeouts.ts
+++ b/src/test/playwright/support/timeouts.ts
@@ -13,22 +13,48 @@ const DEFAULT_EXAM_DASHBOARD_TIMEOUT = 120000; // 120 seconds
 const DEFAULT_RELOAD_RENDER_TIMEOUT = 30000; // 30 seconds
 
 /**
+ * Reads a timeout from the environment, falling back to the default unless the value is a clean positive integer
+ * number of milliseconds.
+ * <p>
+ * `parseInt` is too permissive for configuration that decides how long a test waits: it accepts a partial string like
+ * `30000ms`, yields `NaN` for anything unparseable, and happily returns negatives. Any of those would silently
+ * override a documented budget with a nonsensical one, and the resulting failure would look like a flaky test rather
+ * than a misconfigured variable. So an invalid value is reported and ignored rather than used.
+ *
+ * @param variableName name of the environment variable to read
+ * @param fallback default timeout in ms, used when the variable is unset or invalid
+ */
+function readTimeoutMs(variableName: string, fallback: number): number {
+    const raw = process.env[variableName];
+    if (raw === undefined || raw.trim() === '') {
+        return fallback;
+    }
+    const parsed = Number(raw);
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+        // eslint-disable-next-line no-console
+        console.warn(`[timeouts] Ignoring ${variableName}="${raw}": expected a positive integer number of milliseconds. Falling back to ${fallback}ms.`);
+        return fallback;
+    }
+    return parsed;
+}
+
+/**
  * Timeout for waiting for build results to appear in the UI (e.g., commit history).
  * Environment variable: BUILD_RESULT_TIMEOUT_MS
  */
-export const BUILD_RESULT_TIMEOUT = parseInt(process.env.BUILD_RESULT_TIMEOUT_MS || String(DEFAULT_BUILD_RESULT_TIMEOUT), 10);
+export const BUILD_RESULT_TIMEOUT = readTimeoutMs('BUILD_RESULT_TIMEOUT_MS', DEFAULT_BUILD_RESULT_TIMEOUT);
 
 /**
  * Timeout for waiting for a build to finish (polling API).
  * Environment variable: BUILD_FINISH_TIMEOUT_MS
  */
-export const BUILD_FINISH_TIMEOUT = parseInt(process.env.BUILD_FINISH_TIMEOUT_MS || String(DEFAULT_BUILD_FINISH_TIMEOUT), 10);
+export const BUILD_FINISH_TIMEOUT = readTimeoutMs('BUILD_FINISH_TIMEOUT_MS', DEFAULT_BUILD_FINISH_TIMEOUT);
 
 /**
  * Timeout for waiting for exam assessment dashboard to load.
  * Environment variable: EXAM_DASHBOARD_TIMEOUT_MS
  */
-export const EXAM_DASHBOARD_TIMEOUT = parseInt(process.env.EXAM_DASHBOARD_TIMEOUT_MS || String(DEFAULT_EXAM_DASHBOARD_TIMEOUT), 10);
+export const EXAM_DASHBOARD_TIMEOUT = readTimeoutMs('EXAM_DASHBOARD_TIMEOUT_MS', DEFAULT_EXAM_DASHBOARD_TIMEOUT);
 
 /**
  * Timeout for the first assertion after a full `page.reload()`.
@@ -42,7 +68,7 @@ export const EXAM_DASHBOARD_TIMEOUT = parseInt(process.env.EXAM_DASHBOARD_TIMEOU
  *
  * Environment variable: RELOAD_RENDER_TIMEOUT_MS
  */
-export const RELOAD_RENDER_TIMEOUT = parseInt(process.env.RELOAD_RENDER_TIMEOUT_MS || String(DEFAULT_RELOAD_RENDER_TIMEOUT), 10);
+export const RELOAD_RENDER_TIMEOUT = readTimeoutMs('RELOAD_RENDER_TIMEOUT_MS', DEFAULT_RELOAD_RENDER_TIMEOUT);
 
 /**
  * Interval between polling attempts (shared across all polling operations).


### PR DESCRIPTION
### Summary

`Exam participation › Early hand-in with continue and reload page › Reloads exam result page and ensures that everything is as expected` is the last frequently-failing E2E test on `develop` — it failed in **2 of the last 5** runs. Same root cause as #13463: a fixed assertion window gating on a full client re-bootstrap after `page.reload()`.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

I sampled the JUnit artifacts of the last five `develop` CI runs (355 E2E tests each) to get a flakiness signal uncontaminated by stale PR branches:

| Test | Failing runs |
| --- | --- |
| `Exam participation › … Reloads exam result page and ensures that everything is as expected` | **2 / 5** |
| `Programming exercise basic submissions › … Renders the result-only badge` | 1 / 5 |

Three of the five runs were completely clean. Both failures of the exam test are byte-identical:

```
Error: expect(locator).toHaveValue(expected) failed
Locator: locator('#exercise-169').locator('#text-editor')
Timeout: 10000ms
Error: element(s) not found
  at support/pageobjects/exam/ExamParticipationActions.ts:116
```

The important detail is what this is **not**. The test already calls `test.slow()` for a 270s budget, and both failures happened at ~61s — so the total per-test timeout is not the constraint. What ran out is the **default 10s expect timeout** on the first assertion after `page.reload()`. The test's own comment already notes that the conduction view "lazy-chunks slowly"; combined with Playwright disabling the HTTP cache per context, a reload re-fetches and re-parses the bundle from scratch, and 10s is not a reliable budget for that under parallel CI load.

That is the same failure shape as the channel editing test fixed in #13463, which is what pointed me here.

### Description

- `support/timeouts.ts`: added `RELOAD_RENDER_TIMEOUT` (30s, overridable via `RELOAD_RENDER_TIMEOUT_MS`), following the existing default-plus-env-override pattern in that module.
- `ExamParticipationActions.verifyTextExerciseOnFinalPage`: takes an optional `timeout`. Omitted, it keeps the default — so a genuine regression on the pre-reload call still fails fast rather than hanging for 30s.
- `ExamParticipation.spec.ts`: passes `RELOAD_RENDER_TIMEOUT` to the **first** assertion after the reload only. `checkExamTitle` renders in the same pass and keeps the default, so the budgets cannot stack into the per-test cap — the mistake I made in the first revision of #13463.
- `CourseChannelMessages.spec.ts`: replaced the local constant introduced by #13463 with an import of the shared one, so the two definitions cannot drift apart.

### Steps for Testing

Prerequisites:
- 1 Instructor, 1 Student
- 1 Exam with a text exercise

1. As a student, participate in an exam, submit a text exercise, hand in early and open the summary.
2. Reload the summary page and confirm the submitted text and the exam title are still shown.
3. As an instructor, confirm the submission is listed as submitted for that student.

Verification I ran locally: both reload-dependent tests pass together against the Angular dev server — `Instructor should be able to edit a channel` (10.5s) and `Reloads exam result page and ensures that everything is as expected` (22.3s), 2 passed. `pnpm run lint:playwright` and Prettier are clean.

I should state the limit honestly: as with #13463, I could not reproduce the CI failure locally — the assertion resolves in well under 10s here, and the failure only appears under CI's parallel load. What this change removes is the dependence on a fixed window, which is the only remaining explanation given the test is nowhere near its total budget when it fails.

### Testserver States

> [!NOTE]
> E2E test and page-object changes only; no production code is touched.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-10 20:20:11 UTC_

