### PR TITLE
`Development`: Only fetch the internal flag when determining the login options

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -184,9 +184,7 @@ jobs:
         run: |
           set -Eeuo pipefail
           # Thresholds are technical debt; lower them as violations are fixed.
-          # 17 -> 18: Exercise.java grew from 1000 to 1005 lines in #13186. This job is skipped on
-          # pushes to develop, so the new violation only surfaces on the next pull request.
-          max_large_classes=18
+          max_large_classes=17
           max_complex_beans=18
 
           python supporting_scripts/analyze_java_files.py \

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -184,7 +184,9 @@ jobs:
         run: |
           set -Eeuo pipefail
           # Thresholds are technical debt; lower them as violations are fixed.
-          max_large_classes=17
+          # 17 -> 18: Exercise.java grew from 1000 to 1005 lines in #13186. This job is skipped on
+          # pushes to develop, so the new violation only surfaces on the next pull request.
+          max_large_classes=18
           max_complex_beans=18
 
           python supporting_scripts/analyze_java_files.py \

--- a/src/main/java/de/tum/cit/aet/artemis/account/repository/UserRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/repository/UserRepository.java
@@ -90,6 +90,40 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
 
     Optional<User> findOneByLogin(String login);
 
+    /**
+     * Determines whether a user with the given login exists and, if so, whether that user is internal.
+     * <p>
+     * Only the {@code internal} flag is projected, so callers that just need to distinguish between "unknown", "internal" and "external" do not load the full user entity
+     * (and stay unaffected by columns or eagerly fetched associations that may be added to {@link User} later on).
+     *
+     * @param login the login to look up
+     * @return an {@link Optional} containing {@code true} if the user exists and is internal, {@code false} if the user exists and is external,
+     *         or an empty {@link Optional} if no user with the given login exists
+     */
+    @Query("""
+            SELECT u.internal
+            FROM User u
+            WHERE u.login = :login
+            """)
+    Optional<Boolean> isInternalUserByLogin(@Param("login") String login);
+
+    /**
+     * Determines whether a user with the given email exists (ignoring case) and, if so, whether that user is internal.
+     * <p>
+     * Only the {@code internal} flag is projected, so callers that just need to distinguish between "unknown", "internal" and "external" do not load the full user entity
+     * (and stay unaffected by columns or eagerly fetched associations that may be added to {@link User} later on).
+     *
+     * @param email the email address to look up, matched case-insensitively
+     * @return an {@link Optional} containing {@code true} if the user exists and is internal, {@code false} if the user exists and is external,
+     *         or an empty {@link Optional} if no user with the given email exists
+     */
+    @Query("""
+            SELECT u.internal
+            FROM User u
+            WHERE LOWER(u.email) = LOWER(:email)
+            """)
+    Optional<Boolean> isInternalUserByEmailIgnoreCase(@Param("email") String email);
+
     Optional<User> findOneByActivationKey(String activationKey);
 
     @EntityGraph(type = LOAD, attributePaths = { "authorities" })

--- a/src/main/java/de/tum/cit/aet/artemis/account/repository/UserRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/repository/UserRepository.java
@@ -97,30 +97,31 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
      * (and stay unaffected by columns or eagerly fetched associations that may be added to {@link User} later on).
      *
      * @param login the login to look up
-     * @return an {@link Optional} containing {@code true} if the user exists and is internal, {@code false} if the user exists and is external,
-     *         or an empty {@link Optional} if no user with the given login exists
+     * @return an {@link Optional} containing {@code true} if a non-deleted user exists and is internal, {@code false} if that user is external,
+     *         or an empty {@link Optional} if no such user exists
      */
     @Query("""
             SELECT u.internal
             FROM User u
             WHERE u.login = :login
+                AND u.deleted = FALSE
             """)
     Optional<Boolean> isInternalUserByLogin(@Param("login") String login);
 
     /**
      * Determines whether a user with the given email exists (ignoring case) and, if so, whether that user is internal.
      * <p>
-     * Only the {@code internal} flag is projected, so callers that just need to distinguish between "unknown", "internal" and "external" do not load the full user entity
-     * (and stay unaffected by columns or eagerly fetched associations that may be added to {@link User} later on).
+     * Projects only the {@code internal} flag, see {@link #isInternalUserByLogin}.
      *
      * @param email the email address to look up, matched case-insensitively
-     * @return an {@link Optional} containing {@code true} if the user exists and is internal, {@code false} if the user exists and is external,
-     *         or an empty {@link Optional} if no user with the given email exists
+     * @return an {@link Optional} containing {@code true} if a non-deleted user exists and is internal, {@code false} if that user is external,
+     *         or an empty {@link Optional} if no such user exists
      */
     @Query("""
             SELECT u.internal
             FROM User u
             WHERE LOWER(u.email) = LOWER(:email)
+                AND u.deleted = FALSE
             """)
     Optional<Boolean> isInternalUserByEmailIgnoreCase(@Param("email") String email);
 

--- a/src/main/java/de/tum/cit/aet/artemis/account/service/LoginOptionsService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/service/LoginOptionsService.java
@@ -59,11 +59,10 @@ public class LoginOptionsService {
         }
         String sanitizedInput = emailOrLogin.trim().toLowerCase(Locale.ROOT);
         boolean isEmail = SecurityUtils.isEmail(sanitizedInput);
-        // only project the internal flag instead of loading the whole user entity: empty means the user is unknown to Artemis
-        Optional<Boolean> internalUser = isEmail ? userRepository.isInternalUserByEmailIgnoreCase(sanitizedInput) : userRepository.isInternalUserByLogin(sanitizedInput);
-        // if user is already in database
-        if (internalUser.isPresent()) {
-            if (internalUser.get()) {
+        // only project the internal flag instead of loading the whole user entity: empty means the user is not in the database
+        Optional<Boolean> internalFlag = isEmail ? userRepository.isInternalUserByEmailIgnoreCase(sanitizedInput) : userRepository.isInternalUserByLogin(sanitizedInput);
+        if (internalFlag.isPresent()) {
+            if (internalFlag.get()) {
                 return new LoginOptionsDTO(LoginMethod.PASSWORD, null);
             }
             else {

--- a/src/main/java/de/tum/cit/aet/artemis/account/service/LoginOptionsService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/service/LoginOptionsService.java
@@ -10,7 +10,6 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
-import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.dto.LoginOptionsDTO;
 import de.tum.cit.aet.artemis.account.dto.LoginOptionsDTO.LoginMethod;
 import de.tum.cit.aet.artemis.account.repository.UserRepository;
@@ -60,10 +59,11 @@ public class LoginOptionsService {
         }
         String sanitizedInput = emailOrLogin.trim().toLowerCase(Locale.ROOT);
         boolean isEmail = SecurityUtils.isEmail(sanitizedInput);
-        Optional<User> user = isEmail ? userRepository.findOneByEmailIgnoreCase(sanitizedInput) : userRepository.findOneByLogin(sanitizedInput);
+        // only project the internal flag instead of loading the whole user entity: empty means the user is unknown to Artemis
+        Optional<Boolean> internalUser = isEmail ? userRepository.isInternalUserByEmailIgnoreCase(sanitizedInput) : userRepository.isInternalUserByLogin(sanitizedInput);
         // if user is already in database
-        if (user.isPresent()) {
-            if (user.get().isInternal()) {
+        if (internalUser.isPresent()) {
+            if (internalUser.get()) {
                 return new LoginOptionsDTO(LoginMethod.PASSWORD, null);
             }
             else {

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicAccountResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicAccountResource.java
@@ -13,7 +13,6 @@ import java.util.regex.Pattern;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Size;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -66,6 +65,12 @@ import de.tum.cit.aet.artemis.notification.service.notifications.MailService;
 public class PublicAccountResource {
 
     private static final Logger log = LoggerFactory.getLogger(PublicAccountResource.class);
+
+    /**
+     * Upper bound for the identifier accepted by {@link #getLoginOptions}. A login is at most {@link Constants#USERNAME_MAX_LENGTH} characters and an email address at most 100,
+     * so this is a generous outer bound that no legitimate identifier reaches. It exists to keep an unauthenticated caller from sending an arbitrarily long string.
+     */
+    private static final int MAX_LOGIN_IDENTIFIER_LENGTH = 255;
 
     @Value("${artemis.user-management.registration.allowed-email-pattern:#{null}}")
     private Optional<Pattern> allowedEmailPattern;
@@ -233,11 +238,16 @@ public class PublicAccountResource {
      *
      * @param usernameOrEmail the login or email address entered by the user
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the {@link LoginOptionsDTO}
+     * @throws BadRequestAlertException {@code 400 (Bad Request)} if the identifier is longer than {@link #MAX_LOGIN_IDENTIFIER_LENGTH} characters
      */
     @GetMapping("login-options")
     @EnforceNothing
     @LimitRequestsPerMinute(type = RateLimitType.AUTHENTICATION)
-    public ResponseEntity<LoginOptionsDTO> getLoginOptions(@RequestParam("usernameOrEmail") @Size(max = 255) String usernameOrEmail) {
+    public ResponseEntity<LoginOptionsDTO> getLoginOptions(@RequestParam("usernameOrEmail") String usernameOrEmail) {
+        // checked here rather than with @Size, because this class is not annotated with @Validated and constraints on method parameters are only enforced when it is
+        if (usernameOrEmail != null && usernameOrEmail.length() > MAX_LOGIN_IDENTIFIER_LENGTH) {
+            throw new BadRequestAlertException("The provided username or email is too long", "Account", "usernameOrEmailTooLong");
+        }
         LoginOptionsDTO loginOptions = loginOptionsService.getLoginOptions(usernameOrEmail);
         return ResponseEntity.ok(loginOptions);
     }

--- a/src/test/java/de/tum/cit/aet/artemis/account/repository/UserRepositoryTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/repository/UserRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -445,5 +446,23 @@ class UserRepositoryTest extends AbstractSpringIntegrationIndependentTest {
         assertThat(userRepository.isAtLeastTeachingAssistantInLectureUnit(regularUser.getLogin(), lectureUnit.getId())).isFalse();
         assertThat(userRepository.isAtLeastEditorInLectureUnit(regularUser.getLogin(), lectureUnit.getId())).isFalse();
         assertThat(userRepository.isAtLeastInstructorInLectureUnit(regularUser.getLogin(), lectureUnit.getId())).isFalse();
+    }
+
+    @Test
+    void testIsInternalUserByLoginAndByEmail() {
+        User internalUser = userUtilService.createAndSaveUser(TEST_PREFIX + "internal");
+        User externalUser = userUtilService.createAndSaveUser(TEST_PREFIX + "external");
+        externalUser.setInternal(false);
+        externalUser = userRepository.save(externalUser);
+
+        assertThat(userRepository.isInternalUserByLogin(internalUser.getLogin())).contains(true);
+        assertThat(userRepository.isInternalUserByLogin(externalUser.getLogin())).contains(false);
+        assertThat(userRepository.isInternalUserByLogin(TEST_PREFIX + "doesnotexist")).isEmpty();
+
+        assertThat(userRepository.isInternalUserByEmailIgnoreCase(internalUser.getEmail())).contains(true);
+        assertThat(userRepository.isInternalUserByEmailIgnoreCase(externalUser.getEmail())).contains(false);
+        assertThat(userRepository.isInternalUserByEmailIgnoreCase(TEST_PREFIX + "doesnotexist@test.de")).isEmpty();
+        // the lookup by email has to stay case-insensitive, just like the entity based findOneByEmailIgnoreCase it replaces
+        assertThat(userRepository.isInternalUserByEmailIgnoreCase(internalUser.getEmail().toUpperCase(Locale.ROOT))).contains(true);
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/account/repository/UserRepositoryTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/repository/UserRepositoryTest.java
@@ -16,6 +16,7 @@ import de.tum.cit.aet.artemis.account.domain.Authority;
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.service.user.PasswordService;
 import de.tum.cit.aet.artemis.account.test_repository.UserTestRepository;
+import de.tum.cit.aet.artemis.account.util.UserFactory;
 import de.tum.cit.aet.artemis.account.util.UserUtilService;
 import de.tum.cit.aet.artemis.core.domain.CourseRole;
 import de.tum.cit.aet.artemis.core.util.CourseUtilService;
@@ -451,17 +452,25 @@ class UserRepositoryTest extends AbstractSpringIntegrationIndependentTest {
     @Test
     void testIsInternalUserByLoginAndByEmail() {
         User internalUser = userUtilService.createAndSaveUser(TEST_PREFIX + "internal");
-        User externalUser = userUtilService.createAndSaveUser(TEST_PREFIX + "external");
+
+        User externalUser = UserFactory.generateActivatedUser(TEST_PREFIX + "external");
         externalUser.setInternal(false);
         externalUser = userRepository.save(externalUser);
+
+        User deletedUser = UserFactory.generateActivatedUser(TEST_PREFIX + "deleted");
+        deletedUser.setDeleted(true);
+        deletedUser = userRepository.save(deletedUser);
 
         assertThat(userRepository.isInternalUserByLogin(internalUser.getLogin())).contains(true);
         assertThat(userRepository.isInternalUserByLogin(externalUser.getLogin())).contains(false);
         assertThat(userRepository.isInternalUserByLogin(TEST_PREFIX + "doesnotexist")).isEmpty();
+        // soft-deleted users must not be reported, following the convention documented on this repository
+        assertThat(userRepository.isInternalUserByLogin(deletedUser.getLogin())).isEmpty();
 
         assertThat(userRepository.isInternalUserByEmailIgnoreCase(internalUser.getEmail())).contains(true);
         assertThat(userRepository.isInternalUserByEmailIgnoreCase(externalUser.getEmail())).contains(false);
         assertThat(userRepository.isInternalUserByEmailIgnoreCase(TEST_PREFIX + "doesnotexist@test.de")).isEmpty();
+        assertThat(userRepository.isInternalUserByEmailIgnoreCase(deletedUser.getEmail())).isEmpty();
         // the lookup by email has to stay case-insensitive, just like the entity based findOneByEmailIgnoreCase it replaces
         assertThat(userRepository.isInternalUserByEmailIgnoreCase(internalUser.getEmail().toUpperCase(Locale.ROOT))).contains(true);
     }

--- a/src/test/java/de/tum/cit/aet/artemis/account/service/LoginOptionsServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/service/LoginOptionsServiceTest.java
@@ -19,7 +19,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.dto.LoginOptionsDTO;
 import de.tum.cit.aet.artemis.account.repository.UserRepository;
 import de.tum.cit.aet.artemis.account.service.ldap.LdapUserDto;
@@ -77,15 +76,13 @@ class LoginOptionsServiceTest {
     @Test
     void testGetLoginOptions_InternalUserInDb_ByLogin_ReturnsPassword() {
         String login = "internal_user";
-        User mockUser = mock(User.class);
-        when(mockUser.isInternal()).thenReturn(true);
-        when(userRepository.findOneByLogin(login)).thenReturn(Optional.of(mockUser));
+        when(userRepository.isInternalUserByLogin(login)).thenReturn(Optional.of(true));
 
         LoginOptionsDTO result = loginOptionsService.getLoginOptions(login);
 
         assertThat(result.loginMethod()).isEqualTo(LoginOptionsDTO.LoginMethod.PASSWORD);
         assertThat(result.idpName()).isNull();
-        verify(userRepository).findOneByLogin(login);
+        verify(userRepository).isInternalUserByLogin(login);
         verifyNoInteractions(ldapUserService);
     }
 
@@ -95,15 +92,13 @@ class LoginOptionsServiceTest {
     @Test
     void testGetLoginOptions_InternalUserInDb_ByEmail_ReturnsPassword() {
         String email = "internal_user@artemis.local";
-        User mockUser = mock(User.class);
-        when(mockUser.isInternal()).thenReturn(true);
-        when(userRepository.findOneByEmailIgnoreCase(email)).thenReturn(Optional.of(mockUser));
+        when(userRepository.isInternalUserByEmailIgnoreCase(email)).thenReturn(Optional.of(true));
 
         LoginOptionsDTO result = loginOptionsService.getLoginOptions(email);
 
         assertThat(result.loginMethod()).isEqualTo(LoginOptionsDTO.LoginMethod.PASSWORD);
         assertThat(result.idpName()).isNull();
-        verify(userRepository).findOneByEmailIgnoreCase(email);
+        verify(userRepository).isInternalUserByEmailIgnoreCase(email);
         verifyNoInteractions(ldapUserService);
     }
 
@@ -113,9 +108,7 @@ class LoginOptionsServiceTest {
     @Test
     void testGetLoginOptions_ExternalUserInDb_OidcEnabled_ReturnsOidc() {
         String login = "external_user";
-        User mockUser = mock(User.class);
-        when(mockUser.isInternal()).thenReturn(false);
-        when(userRepository.findOneByLogin(login)).thenReturn(Optional.of(mockUser));
+        when(userRepository.isInternalUserByLogin(login)).thenReturn(Optional.of(false));
 
         LoginOptionsDTO result = loginOptionsService.getLoginOptions(login);
 
@@ -132,9 +125,7 @@ class LoginOptionsServiceTest {
         ReflectionTestUtils.setField(loginOptionsService, "samlEnabled", true);
 
         String login = "external_user";
-        User mockUser = mock(User.class);
-        when(mockUser.isInternal()).thenReturn(false);
-        when(userRepository.findOneByLogin(login)).thenReturn(Optional.of(mockUser));
+        when(userRepository.isInternalUserByLogin(login)).thenReturn(Optional.of(false));
 
         LoginOptionsDTO result = loginOptionsService.getLoginOptions(login);
 
@@ -151,9 +142,7 @@ class LoginOptionsServiceTest {
         ReflectionTestUtils.setField(loginOptionsService, "samlEnabled", false);
 
         String login = "external_user";
-        User mockUser = mock(User.class);
-        when(mockUser.isInternal()).thenReturn(false);
-        when(userRepository.findOneByLogin(login)).thenReturn(Optional.of(mockUser));
+        when(userRepository.isInternalUserByLogin(login)).thenReturn(Optional.of(false));
 
         LoginOptionsDTO result = loginOptionsService.getLoginOptions(login);
 
@@ -167,7 +156,7 @@ class LoginOptionsServiceTest {
     @Test
     void testGetLoginOptions_UserNotInDb_FoundInLdap_ByLogin_ReturnsOidc() {
         String login = "new_student";
-        when(userRepository.findOneByLogin(login)).thenReturn(Optional.empty());
+        when(userRepository.isInternalUserByLogin(login)).thenReturn(Optional.empty());
 
         LdapUserDto mockLdapUser = mock(LdapUserDto.class);
         when(ldapUserService.findByLogin(login)).thenReturn(Optional.of(mockLdapUser));
@@ -176,7 +165,7 @@ class LoginOptionsServiceTest {
 
         assertThat(result.loginMethod()).isEqualTo(LoginOptionsDTO.LoginMethod.OIDC);
         assertThat(result.idpName()).isEqualTo(OIDC_LABEL);
-        verify(userRepository).findOneByLogin(login);
+        verify(userRepository).isInternalUserByLogin(login);
         verify(ldapUserService).findByLogin(login);
     }
 
@@ -186,7 +175,7 @@ class LoginOptionsServiceTest {
     @Test
     void testGetLoginOptions_UserNotInDb_FoundInLdap_ByEmail_ReturnsOidc() {
         String email = "new_student@tum.de";
-        when(userRepository.findOneByEmailIgnoreCase(email)).thenReturn(Optional.empty());
+        when(userRepository.isInternalUserByEmailIgnoreCase(email)).thenReturn(Optional.empty());
 
         LdapUserDto mockLdapUser = mock(LdapUserDto.class);
         when(ldapUserService.findByAnyEmail(email)).thenReturn(Optional.of(mockLdapUser));
@@ -195,7 +184,7 @@ class LoginOptionsServiceTest {
 
         assertThat(result.loginMethod()).isEqualTo(LoginOptionsDTO.LoginMethod.OIDC);
         assertThat(result.idpName()).isEqualTo(OIDC_LABEL);
-        verify(userRepository).findOneByEmailIgnoreCase(email);
+        verify(userRepository).isInternalUserByEmailIgnoreCase(email);
         verify(ldapUserService).findByAnyEmail(email);
     }
 
@@ -205,7 +194,7 @@ class LoginOptionsServiceTest {
     @Test
     void testGetLoginOptions_UserNotInDb_AndNotInLdap_ReturnsPassword() {
         String login = "unknown_user";
-        when(userRepository.findOneByLogin(login)).thenReturn(Optional.empty());
+        when(userRepository.isInternalUserByLogin(login)).thenReturn(Optional.empty());
         when(ldapUserService.findByLogin(login)).thenReturn(Optional.empty());
 
         LoginOptionsDTO result = loginOptionsService.getLoginOptions(login);
@@ -224,7 +213,7 @@ class LoginOptionsServiceTest {
         ReflectionTestUtils.setField(loginOptionsService, "oidcDisplayName", OIDC_LABEL);
 
         String login = "new_student";
-        when(userRepository.findOneByLogin(login)).thenReturn(Optional.empty());
+        when(userRepository.isInternalUserByLogin(login)).thenReturn(Optional.empty());
 
         LoginOptionsDTO result = loginOptionsService.getLoginOptions(login);
 
@@ -243,7 +232,7 @@ class LoginOptionsServiceTest {
         ReflectionTestUtils.setField(loginOptionsService, "samlEnabled", false);
 
         String login = "new_student";
-        when(userRepository.findOneByLogin(login)).thenReturn(Optional.empty());
+        when(userRepository.isInternalUserByLogin(login)).thenReturn(Optional.empty());
 
         LoginOptionsDTO result = loginOptionsService.getLoginOptions(login);
 
@@ -260,9 +249,7 @@ class LoginOptionsServiceTest {
         ReflectionTestUtils.setField(loginOptionsService, "oidcEnabled", true);
         ReflectionTestUtils.setField(loginOptionsService, "samlEnabled", true);
 
-        User externalUser = new User();
-        externalUser.setInternal(false);
-        when(userRepository.findOneByLogin(anyString())).thenReturn(Optional.of(externalUser));
+        when(userRepository.isInternalUserByLogin(anyString())).thenReturn(Optional.of(false));
 
         LoginOptionsDTO result = loginOptionsService.getLoginOptions("externalUser");
 

--- a/src/test/java/de/tum/cit/aet/artemis/account/web/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/web/AccountResourceIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -20,7 +21,10 @@ import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.cit.aet.artemis.account.domain.Organization;
 import de.tum.cit.aet.artemis.account.domain.User;
+import de.tum.cit.aet.artemis.account.dto.LoginOptionsDTO;
+import de.tum.cit.aet.artemis.account.dto.LoginOptionsDTO.LoginMethod;
 import de.tum.cit.aet.artemis.account.service.AccountService;
+import de.tum.cit.aet.artemis.account.service.LoginOptionsService;
 import de.tum.cit.aet.artemis.account.service.user.PasswordService;
 import de.tum.cit.aet.artemis.account.util.PasskeyCredentialUtilService;
 import de.tum.cit.aet.artemis.account.util.UserFactory;
@@ -44,8 +48,15 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
 
     public static final String AUTHENTICATEDUSER = "authenticateduser";
 
+    private static final String TEST_PREFIX = "loginoptions";
+
+    private static final String EXTERNAL_IDP_NAME = "Test University Login";
+
     @Autowired
     private PublicAccountResource publicAccountResource;
+
+    @Autowired
+    private LoginOptionsService loginOptionsService;
 
     @Autowired
     private AccountService accountService;
@@ -687,5 +698,129 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
             // The endpoint must still return 200 so the language preference can be saved
             request.put("/api/account/basic-information", new UserDTO(user), HttpStatus.OK);
         });
+    }
+
+    /**
+     * Requests the login options for the given identifier. The endpoint is public, so no authentication is set up.
+     *
+     * @param usernameOrEmail the login or email address to ask for
+     * @return the login options returned by the server
+     */
+    private LoginOptionsDTO getLoginOptions(String usernameOrEmail) throws Exception {
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("usernameOrEmail", usernameOrEmail);
+        return request.get("/api/core/public/login-options", HttpStatus.OK, LoginOptionsDTO.class, params);
+    }
+
+    /**
+     * Runs the given test with an external identity provider enabled and a known display name, restoring both afterwards.
+     *
+     * @param enabledFlagName the name of the provider flag on the service, either oidcEnabled or samlEnabled
+     * @param displayNameName the name of the display name attribute belonging to that provider
+     * @param test            the test to execute
+     */
+    private void testWithExternalIdpEnabled(String enabledFlagName, String displayNameName, Executable test) throws Throwable {
+        ConfigUtil.testWithChangedConfig(loginOptionsService, enabledFlagName, true,
+                () -> ConfigUtil.testWithChangedConfig(loginOptionsService, displayNameName, EXTERNAL_IDP_NAME, test));
+    }
+
+    @Test
+    @WithAnonymousUser
+    void getLoginOptionsForInternalUserByLoginReturnsPassword() throws Exception {
+        User internalUser = userUtilService.createAndSaveUser(TEST_PREFIX + "internal");
+
+        LoginOptionsDTO loginOptions = getLoginOptions(internalUser.getLogin());
+
+        assertThat(loginOptions.loginMethod()).isEqualTo(LoginMethod.PASSWORD);
+        assertThat(loginOptions.idpName()).isNull();
+    }
+
+    @Test
+    @WithAnonymousUser
+    void getLoginOptionsForInternalUserByEmailReturnsPassword() throws Exception {
+        User internalUser = userUtilService.createAndSaveUser(TEST_PREFIX + "internalbymail");
+
+        // the client sends whatever the user typed, so the upper case variant has to resolve to the same account
+        LoginOptionsDTO loginOptions = getLoginOptions(internalUser.getEmail().toUpperCase(Locale.ROOT));
+
+        assertThat(loginOptions.loginMethod()).isEqualTo(LoginMethod.PASSWORD);
+        assertThat(loginOptions.idpName()).isNull();
+    }
+
+    @Test
+    @WithAnonymousUser
+    void getLoginOptionsForExternalUserWithOidcEnabledReturnsOidc() throws Throwable {
+        User externalUser = UserFactory.generateActivatedUser(TEST_PREFIX + "externaloidc");
+        externalUser.setInternal(false);
+        userTestRepository.save(externalUser);
+
+        testWithExternalIdpEnabled("oidcEnabled", "oidcDisplayName", () -> {
+            LoginOptionsDTO loginOptions = getLoginOptions(externalUser.getLogin());
+
+            assertThat(loginOptions.loginMethod()).isEqualTo(LoginMethod.OIDC);
+            assertThat(loginOptions.idpName()).isEqualTo(EXTERNAL_IDP_NAME);
+        });
+    }
+
+    @Test
+    @WithAnonymousUser
+    void getLoginOptionsForExternalUserWithSaml2EnabledReturnsSaml2() throws Throwable {
+        User externalUser = UserFactory.generateActivatedUser(TEST_PREFIX + "externalsaml");
+        externalUser.setInternal(false);
+        userTestRepository.save(externalUser);
+
+        testWithExternalIdpEnabled("samlEnabled", "samlDisplayName", () -> {
+            LoginOptionsDTO loginOptions = getLoginOptions(externalUser.getEmail());
+
+            assertThat(loginOptions.loginMethod()).isEqualTo(LoginMethod.SAML2);
+            assertThat(loginOptions.idpName()).isEqualTo(EXTERNAL_IDP_NAME);
+        });
+    }
+
+    @Test
+    @WithAnonymousUser
+    void getLoginOptionsForExternalUserWithoutExternalIdpReturnsPassword() throws Exception {
+        User externalUser = UserFactory.generateActivatedUser(TEST_PREFIX + "externalnoidp");
+        externalUser.setInternal(false);
+        userTestRepository.save(externalUser);
+
+        LoginOptionsDTO loginOptions = getLoginOptions(externalUser.getLogin());
+
+        assertThat(loginOptions.loginMethod()).isEqualTo(LoginMethod.PASSWORD);
+        assertThat(loginOptions.idpName()).isNull();
+    }
+
+    @Test
+    @WithAnonymousUser
+    void getLoginOptionsForUnknownUserReturnsOidcForJustInTimeProvisioning() throws Throwable {
+        testWithExternalIdpEnabled("oidcEnabled", "oidcDisplayName", () -> {
+            LoginOptionsDTO loginOptions = getLoginOptions(TEST_PREFIX + "doesnotexist");
+
+            assertThat(loginOptions.loginMethod()).isEqualTo(LoginMethod.OIDC);
+            assertThat(loginOptions.idpName()).isEqualTo(EXTERNAL_IDP_NAME);
+        });
+    }
+
+    @Test
+    @WithAnonymousUser
+    void getLoginOptionsForSoftDeletedUserTreatsThemAsUnknown() throws Throwable {
+        User deletedUser = UserFactory.generateActivatedUser(TEST_PREFIX + "softdeleted");
+        deletedUser.setDeleted(true);
+        userTestRepository.save(deletedUser);
+
+        // with an external provider enabled, a known internal account would answer PASSWORD, so OIDC proves the account was not found
+        testWithExternalIdpEnabled("oidcEnabled", "oidcDisplayName", () -> {
+            assertThat(getLoginOptions(deletedUser.getLogin()).loginMethod()).isEqualTo(LoginMethod.OIDC);
+            assertThat(getLoginOptions(deletedUser.getEmail()).loginMethod()).isEqualTo(LoginMethod.OIDC);
+        });
+    }
+
+    @Test
+    @WithAnonymousUser
+    void getLoginOptionsForBlankIdentifierReturnsPassword() throws Exception {
+        LoginOptionsDTO loginOptions = getLoginOptions("   ");
+
+        assertThat(loginOptions.loginMethod()).isEqualTo(LoginMethod.PASSWORD);
+        assertThat(loginOptions.idpName()).isNull();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/account/web/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/web/AccountResourceIntegrationTest.java
@@ -823,4 +823,22 @@ class AccountResourceIntegrationTest extends AbstractSpringIntegrationIndependen
         assertThat(loginOptions.loginMethod()).isEqualTo(LoginMethod.PASSWORD);
         assertThat(loginOptions.idpName()).isNull();
     }
+
+    @Test
+    @WithAnonymousUser
+    void getLoginOptionsForOverlyLongIdentifierReturnsBadRequest() throws Exception {
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("usernameOrEmail", "a".repeat(256));
+
+        request.get("/api/core/public/login-options", HttpStatus.BAD_REQUEST, LoginOptionsDTO.class, params);
+    }
+
+    @Test
+    @WithAnonymousUser
+    void getLoginOptionsForIdentifierAtTheLengthLimitIsAccepted() throws Exception {
+        // the limit itself has to stay valid, so only what exceeds it is rejected
+        LoginOptionsDTO loginOptions = getLoginOptions("a".repeat(255));
+
+        assertThat(loginOptions.loginMethod()).isEqualTo(LoginMethod.PASSWORD);
+    }
 }

--- a/src/test/playwright/e2e/Login.spec.ts
+++ b/src/test/playwright/e2e/Login.spec.ts
@@ -46,6 +46,63 @@ test.describe('Login page tests', { tag: '@fast' }, () => {
         await page.waitForURL('/sign-in');
     });
 
+    test('Requests the login options for a known internal user and continues to the password step', async ({ page, loginPage }) => {
+        await page.goto('/sign-in');
+        await loginPage.enterUsername(studentOne.username);
+
+        const responsePromise = page.waitForResponse((response) => response.url().includes(`${BASE_API}/core/public/login-options`));
+        await loginPage.clickContinueButton();
+        const response = await responsePromise;
+
+        expect(response.status()).toBe(200);
+        const options = await response.json();
+        expect(options.loginMethod).toBe('PASSWORD');
+        expect(options.idpName ?? null).toBeNull();
+
+        // internal users authenticate with their Artemis password, so the second stage has to offer the password field
+        await expect(page.locator('#password')).toBeVisible();
+    });
+
+    test('Requests the login options by email address', async ({ page, login, loginPage }) => {
+        // the seeded email address is not hard coded anywhere, so read it from the account of the logged in user
+        await login(studentOne, '/courses');
+        const accountResponse = await page.request.get(`${BASE_API}/core/public/account`);
+        expect(accountResponse.status()).toBe(200);
+        const email = (await accountResponse.json()).email;
+        expect(email).toBeTruthy();
+
+        // return to the anonymous login page and identify via the email address instead of the login
+        await page.context().clearCookies();
+        await page.goto('/sign-in');
+        await loginPage.enterUsername(email);
+
+        const responsePromise = page.waitForResponse((response) => response.url().includes(`${BASE_API}/core/public/login-options`));
+        await loginPage.clickContinueButton();
+        const response = await responsePromise;
+
+        expect(response.status()).toBe(200);
+        const options = await response.json();
+        expect(options.loginMethod).toBe('PASSWORD');
+        expect(options.idpName ?? null).toBeNull();
+        await expect(page.locator('#password')).toBeVisible();
+    });
+
+    test('Answers identically for an unknown account so it cannot be used to enumerate users', async ({ page, loginPage }) => {
+        await page.goto('/sign-in');
+        await loginPage.enterUsername('artemis_test_user_does_not_exist');
+
+        const responsePromise = page.waitForResponse((response) => response.url().includes(`${BASE_API}/core/public/login-options`));
+        await loginPage.clickContinueButton();
+        const response = await responsePromise;
+
+        // this test server has no LDAP and no external identity provider, so an unknown account has to look exactly like a known internal one
+        expect(response.status()).toBe(200);
+        const options = await response.json();
+        expect(options.loginMethod).toBe('PASSWORD');
+        expect(options.idpName ?? null).toBeNull();
+        await expect(page.locator('#password')).toBeVisible();
+    });
+
     test('Verify footer content', async ({ page, loginPage }) => {
         await page.goto('/sign-in');
         await loginPage.shouldShowFooter();


### PR DESCRIPTION
### Summary

The `login-options` endpoint only needs to know whether an account exists and, if it does, whether it is internal or external. Until now it loaded the complete `User` entity from the database to answer that question. This pull request replaces the entity lookup with a database projection that returns just the `is_internal` column, so the query stays minimal no matter how the `User` entity evolves.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

`LoginOptionsService.getLoginOptions` decides which login method the client should offer. It distinguishes exactly three cases:

1. no account with the given login or email exists in Artemis,
2. an account exists and is internal, so Artemis asks for a password,
3. an account exists and is external, so Artemis offers the SSO button.

To make that decision it called `findOneByLogin` or `findOneByEmailIgnoreCase`, which hydrate the entire `User` entity and read all 29 user columns, including the password hash, the VCS access token, and the registration number. Only a single boolean is actually used.

This endpoint is called on every visit to the login page, before the user is authenticated, so it is one of the most frequently hit unauthenticated endpoints. Beyond the wasted columns today, the entity lookup is fragile: every column added to `User` and every association that becomes eagerly fetched in the future silently makes this query more expensive.

### Description

`UserRepository` gains two projection methods that select only the `internal` flag:

```java
@Query("SELECT u.internal FROM User u WHERE u.login = :login")
Optional<Boolean> isInternalUserByLogin(@Param("login") String login);

@Query("SELECT u.internal FROM User u WHERE LOWER(u.email) = LOWER(:email)")
Optional<Boolean> isInternalUserByEmailIgnoreCase(@Param("email") String email);
```

The return type maps onto the three cases directly: an empty `Optional` means no such account exists, `true` means the account is internal, and `false` means it is external. This mirrors the existing projection style in `StudentExamRepository.isSubmitted` and `QuizTrainingLeaderboardRepository.getShowInLeaderboard`, so no additional wrapper record is needed for the single boolean.

`LoginOptionsService.getLoginOptions` now calls these methods instead of the entity finders. The surrounding decision logic, the LDAP fallback, and the response are unchanged, so the endpoint behaves exactly as before.

The lookups keep the semantics of the finders they replace, so emails are still matched case-insensitively. They additionally exclude soft-deleted users, which the repository documentation asks new queries to do and which 28 of its other queries already do. That does not change the outcome for any reachable input, because deleting a user also anonymizes the login and the email, so a deleted row can never be matched by an identifier somebody could actually type.

The email lookup still wraps the column in `LOWER(...)`, exactly like the `UPPER(...)` the derived query generated before, so its use of the index is unchanged. The gain here is data economy, not a faster lookup plan.

#### The length limit on the parameter is now actually enforced

The endpoint declared `@Size(max = 255)` on `usernameOrEmail`, but `PublicAccountResource` is not annotated with `@Validated`, and constraints on method parameters are only enforced when it is. The annotation therefore had no effect and an unauthenticated caller could send a string of any length. It is replaced by an explicit check that answers 400, with a named constant and a comment explaining why it is not an annotation. A login is at most 50 characters and an email address at most 100, so 255 stays a generous outer bound. Both the accepted limit and the rejection are covered by tests.

#### Test coverage for the endpoint

`GET login-options` had no server integration test and no Playwright test at all, even though it is the first step of every login. This pull request adds both.

`AccountResourceIntegrationTest` now covers the endpoint anonymously for an internal user by login, an internal user by upper-case email, an external user with OIDC enabled, an external user with SAML2 enabled, an external user without any external provider, an unknown identifier, a soft-deleted user, a blank identifier, an identifier at the length limit, and an identifier past it. The soft-deleted case runs with OIDC enabled on purpose: with no external provider configured, a found internal account and a missing account both answer `PASSWORD`, so the assertion would prove nothing either way.

`Login.spec.ts` drives the identifier-first flow in the browser for a known user, for the same user identified by email address, and for an account that does not exist. The email address is read from the account endpoint at runtime rather than hard coded, because the seeded address is not declared anywhere in the Playwright setup. The unknown-account test asserts that the answer is indistinguishable from the answer for an existing account, so the endpoint cannot be used to find out which logins exist.

#### Note on the two red checks

Neither is caused by this pull request.

`Test / Server Tests (PostgreSQL)` fails on develop itself with 7 failures in `StudentExamDtoWireContractTest` and `StudentExamIntegrationTest`, all introduced by #13186. Develop and this branch fail exactly the same 7 tests; this branch simply runs 9 more tests, the ones added here, and all of them pass. #13476 repairs those 7.

`Quality / Server Code Quality` fails because develop has 18 classes over 1000 lines against a budget of 17, after #13186 took `Exercise.java` from exactly 1000 to 1005. #13474 removes 30 lines from that entity and brings the count back to 17. This pull request deliberately does not raise the threshold, so that the budget is not left one slot too loose once #13474 lands.

Both checks turn green here once those two pull requests are merged and develop is merged back in.

### Steps for Testing

Prerequisites:
- 1 internal user (for example `artemis_test_user_1`)
- 1 external user, if the test server is connected to an external identity provider

1. Open the Artemis login page while logged out.
2. Enter the login of an internal user and continue. Artemis has to ask for a password, exactly as before.
3. Repeat with the email address of the same user, in mixed upper and lower case. The result has to be identical, which confirms that the email lookup stays case-insensitive.
4. Enter the login of an external user. Artemis has to offer the SSO button with the configured provider name.
5. Enter a login that does not exist in Artemis. On a server with LDAP, a university account has to lead to the SSO button and an unknown account to the password field. On a server without LDAP, the configured SSO option has to appear, or the password field if no external provider is enabled.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/31416262316) did not pass (`failure`). Coverage below may be partial.

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| UserRepository.java | not found (modified) | 1081 |
| LoginOptionsService.java | not found (modified) | 71 |
| PublicAccountResource.java | not found (modified) | 221 |

_Last updated: 2026-08-10 18:19:55 UTC_

