### PR TITLE
`Development`: Verify a submission reached the repository before asserting its score in e2e tests

### DIFF
--- a/src/test/playwright/support/pageobjects/exercises/programming/OnlineEditorPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/OnlineEditorPage.ts
@@ -6,20 +6,36 @@ import { Fixtures } from '../../../../fixtures/fixtures';
 export class OnlineEditorPage {
     private readonly page: Page;
 
+    /**
+     * Participation id observed in the editor's own repository requests, used to read back what was committed.
+     * Captured rather than passed in so every caller of {@link makeSubmissionAndVerifyResults} gets the check.
+     */
+    private participationId?: number;
+
     constructor(page: Page) {
         this.page = page;
+    }
+
+    /** Remembers the participation id embedded in a repository request URL, e.g. `.../participations/42/repository/file`. */
+    private rememberParticipationId(url: string) {
+        const match = /\/participations\/(\d+)\/repository\//.exec(url);
+        if (match) {
+            this.participationId = Number(match[1]);
+        }
     }
 
     findFileBrowser(exerciseID: number) {
         return getExercise(this.page, exerciseID).locator('#cardFiles');
     }
 
-    async typeSubmission(exerciseID: number, submission: ProgrammingExerciseSubmission) {
+    async typeSubmission(exerciseID: number, submission: ProgrammingExerciseSubmission): Promise<WrittenFile[]> {
+        const written: WrittenFile[] = [];
         for (const newFile of submission.files) {
+            let repositoryPath: string;
             if (submission.createFilesInRootFolder) {
-                await this.createFileInRootFolder(exerciseID, newFile.name);
+                repositoryPath = await this.createFileInRootFolder(exerciseID, newFile.name);
             } else {
-                await this.createFileInRootPackage(exerciseID, newFile.name, submission.packageName!);
+                repositoryPath = await this.createFileInRootPackage(exerciseID, newFile.name, submission.packageName!);
             }
             const fileContent = await Fixtures.get(newFile.path);
             // Set the file content through the Monaco API (with a verify-and-retry + sustained-value
@@ -31,8 +47,10 @@ export class OnlineEditorPage {
             // confirms Monaco actually holds the content before we submit.
             const editorContainer = getExercise(this.page, exerciseID).locator('jhi-code-editor-monaco');
             await setMonacoEditorContentByLocator(this.page, editorContainer, fileContent!);
+            written.push({ repositoryPath, content: fileContent! });
         }
         await this.page.waitForTimeout(500);
+        return written;
     }
 
     async deleteFile(exerciseID: number, name: string) {
@@ -84,7 +102,7 @@ export class OnlineEditorPage {
         await expect(this.page.locator('#exercise-header #result-score, jhi-code-editor-container #result-score').first()).toBeVisible({ timeout: 200000 });
     }
 
-    async createFileInRootFolder(exerciseID: number, fileName: string) {
+    async createFileInRootFolder(exerciseID: number, fileName: string): Promise<string> {
         await getExercise(this.page, exerciseID).locator('[id="create_file_root"]').click();
         await this.page.waitForTimeout(500);
         const responsePromise = this.page.waitForResponse(`${BASE_API}/programming/participations/*/repository/file?file=${fileName}`);
@@ -93,11 +111,13 @@ export class OnlineEditorPage {
         await getExercise(this.page, exerciseID).locator('#file-browser-create-node').press('Enter');
         const response = await responsePromise;
         expect(response.status()).toBe(200);
+        this.rememberParticipationId(response.url());
         await expect(this.findFileBrowser(exerciseID).filter({ hasText: fileName })).toBeVisible();
         await this.page.waitForTimeout(500);
+        return fileName;
     }
 
-    async createFileInRootPackage(exerciseID: number, fileName: string, packageName: string) {
+    async createFileInRootPackage(exerciseID: number, fileName: string, packageName: string): Promise<string> {
         const packagePath = packageName.replace(/\./g, '/');
         const filePath = `src/${packagePath}/${fileName}`;
         await getExercise(this.page, exerciseID).locator('#file-browser-folder-create-file').nth(2).click();
@@ -108,8 +128,10 @@ export class OnlineEditorPage {
         await getExercise(this.page, exerciseID).locator('#file-browser-create-node').press('Enter');
         const response = await responsePromise;
         expect(response.status()).toBe(200);
+        this.rememberParticipationId(response.url());
         await expect(this.findFileBrowser(exerciseID).filter({ hasText: fileName })).toBeVisible();
         await this.page.waitForTimeout(500);
+        return filePath;
     }
 
     async getResultPanel() {
@@ -141,10 +163,59 @@ export class OnlineEditorPage {
         for (const deleteFile of submission.deleteFiles) {
             await this.deleteFile(exerciseID, deleteFile);
         }
-        await this.typeSubmission(exerciseID, submission);
+        const written = await this.typeSubmission(exerciseID, submission);
         await this.submit(exerciseID);
+        await this.verifyRepositoryContentAfterSubmit(written);
         await verifyOutput();
     }
+
+    /**
+     * Reads the submitted files back out of the participation's repository and compares them to what was typed.
+     * <p>
+     * This exists to make one specific failure legible. When the editor's content does not reach the repository, the
+     * build runs against an empty or stale file, scores 0%, and the caller's score assertion fails with "expected a
+     * passing score, received 0%" — which reads as a grading or product bug and says nothing about the real cause.
+     * Checking here attributes the failure where it belongs, and the fixture content is known exactly, so a mismatch
+     * is unambiguous. A passing check leaves the score assertion to mean what it says.
+     * <p>
+     * Best-effort by design: it needs the participation id, which is captured from the editor's own file-creation
+     * request, and it skips silently when that was not observed (a submission flow that creates no file) or when the
+     * repository cannot be read. It must diagnose failures, never invent them.
+     */
+    private async verifyRepositoryContentAfterSubmit(written: WrittenFile[]) {
+        if (this.participationId === undefined || written.length === 0) {
+            return;
+        }
+        for (const file of written) {
+            const url = `${BASE_API}/programming/participations/${this.participationId}/repository/file?file=${encodeURIComponent(file.repositoryPath)}`;
+            const response = await this.page.request.get(url).catch(() => undefined);
+            if (!response || !response.ok()) {
+                // Cannot read it back (e.g. permissions or a transient error) — stay out of the way.
+                return;
+            }
+            const committed = normalizeSource(await response.text());
+            const expected = normalizeSource(file.content);
+            expect(
+                committed,
+                `The editor's changes to ${file.repositoryPath} did not reach the repository: it holds ${committed.length === 0 ? 'an empty file' : `${committed.length} characters instead of ${expected.length}`}. ` +
+                    `The build therefore ran against the wrong content and will score 0% — this is lost editor content, not a grading failure.`,
+            ).toBe(expected);
+        }
+    }
+}
+
+/** A file written into the editor during a submission, and the content it was given. */
+interface WrittenFile {
+    repositoryPath: string;
+    content: string;
+}
+
+/**
+ * Normalizes source before comparison: line endings differ between the fixture on disk and what Monaco hands back,
+ * and a trailing newline is not a content loss. Anything beyond that is a real difference.
+ */
+function normalizeSource(source: string): string {
+    return source.replace(/\r\n/g, '\n').trimEnd();
 }
 
 /**


### PR DESCRIPTION
### Summary

`Programming exercise basic submissions › Shows the build result in the course build overview › Renders the result-only badge in the finished build jobs table` failed 1 of the last 5 `develop` runs. I could not establish the root cause with confidence, so this does not pretend to fix it — it makes the next occurrence say what actually went wrong instead of blaming the score.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

The failure reads as a grading bug and is not one:

```
Error: expect(locator).toContainText(expected) failed
Locator: locator('#exercise-246').locator('#result-score')
Expected pattern: /(?:[1-9]\d*(?:\.\d+)?|0\.\d*[1-9]\d*)%/
Received string:  "0%····(4 minutes ago)"
Timeout: 240000ms
```

What the investigation established:

- **It is not a rendering or timing flake.** The badge resolved 400+ times across the full 240s, always `0%` with `text-state-danger`. A result existed; it was a failing one.
- **It is not build-queue saturation.** Comparing that run's build-dependent programming tests against their medians across the healthy runs, nearly all were at or *faster* than median (failing-C 27s vs 25s, practice mode 98s vs 100s, git submissions faster). Only two were anomalous: this test (617s vs 38s) and `Makes a successful C submission` (110s vs 50s) — and both are online-editor submissions expected to pass.
- **A probe refuted my leading hypothesis.** I suspected `submit()`'s wait for `#result-score` to be visible was vacuous, satisfied by a pre-existing badge from an initial build, letting `submit()` return before its own commit. Instrumenting locally showed no result badge exists before the submission (`count=0`), so that wait is meaningful and the `0%` was the submission's *own* build. I discarded the change I had written on that premise rather than ship it.

That leaves lost editor content as the best-supported explanation — `typeSubmission` verifies Monaco holds the content, but then relies on a fixed `waitForTimeout(500)` before submitting, and the editor persists separately via `PUT …/files`. I am not confident enough in that to change the wait, and a wrong fix here is worse than none: it would look like the flake was addressed.

So this PR closes the diagnosis gap instead. If the cause is lost content, the next failure names it. If it is not, this rules the whole class out immediately — which is what the last investigation lacked.

### Description

`OnlineEditorPage`:

- `typeSubmission` now reports the files it wrote and the content it gave them; `createFileInRootFolder` / `createFileInRootPackage` return the repository path they created.
- The participation id is captured from the editor's own file-creation request URL rather than threaded through call sites, so all five `makeSubmissionAndVerifyResults` callers get the check without touching any test.
- After `submit()`, each submitted file is read back via `GET participations/{id}/repository/file` (which is `@EnforceAtLeastStudent`, so the student in the test can read their own repository) and compared to the fixture. Line endings are normalised and a trailing newline ignored, since neither is a content loss.

Deliberately best-effort: it returns quietly when the participation id was not observed or the repository cannot be read. Its job is to explain failures, never to create them.

### Steps for Testing

Prerequisites:
- 1 Instructor, 1 Student
- 1 C programming exercise

1. As a student, start the exercise, submit passing code through the online code editor, and confirm the result score appears as before.
2. As an instructor, open the course build overview and confirm the finished-jobs table shows the score badge.

Verification I ran locally:

- `Renders the result-only badge` (34.1s), `Makes a successful C submission › Makes a submission using code editor` (33.4s) and `Makes a failing C submission › Makes a submission using code editor` (23.2s) — **3 passed**. The failing-submission variant matters: the check compares committed content, not results, so a submission that is *meant* to score 0% is unaffected.
- **Proved it actually catches the defect.** I temporarily made the editor write empty content and re-ran. It failed with:

  > `The editor's changes to helloWorld.c did not reach the repository: it holds an empty file. The build therefore ran against the wrong content and will score 0% — this is lost editor content, not a grading failure.`

  It also failed at **23.3s** rather than after the 240s score timeout, so a real occurrence gets diagnosed sooner as well. The sabotage was reverted and the test re-confirmed green afterwards.
- `pnpm run lint:playwright` and Prettier clean.

### Testserver States

> [!NOTE]
> E2E page-object change only; no production code is touched.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-10 15:38:49 UTC_

