### PR TITLE
`Development`: Remove dead code from the exercise entity

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
@@ -311,20 +311,10 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
         return studentParticipations;
     }
 
-    public Exercise participations(Set<StudentParticipation> participations) {
-        this.studentParticipations = participations;
-        return this;
-    }
-
     public Exercise addParticipation(StudentParticipation participation) {
         this.studentParticipations.add(participation);
         participation.setExercise(this);
         return this;
-    }
-
-    public void removeParticipation(StudentParticipation participation) {
-        this.studentParticipations.remove(participation);
-        participation.setExercise(null);
     }
 
     public void setStudentParticipations(Set<StudentParticipation> studentParticipations) {
@@ -735,11 +725,6 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
         return gradingCriteria;
     }
 
-    public void addGradingCriteria(GradingCriterion gradingCriterion) {
-        this.gradingCriteria.add(gradingCriterion);
-        gradingCriterion.setExercise(this);
-    }
-
     public void setGradingCriteria(Set<GradingCriterion> gradingCriteria) {
         reconnectCriteriaWithExercise(gradingCriteria);
     }
@@ -986,20 +971,5 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
             setGradingCriteria(managedCriteria);
         }
         return managedCriteria;
-    }
-
-    /**
-     * Ensures that the exercise has a mutable set for competency links.
-     * Creates and assigns a new {@link HashSet} if the current set is {@code null}.
-     *
-     * @return the non-null mutable set of competency links
-     */
-    public Set<CompetencyExerciseLink> ensureCompetencyLinksSet() {
-        Set<CompetencyExerciseLink> managedLinks = getCompetencyLinks();
-        if (managedLinks == null) {
-            managedLinks = new HashSet<>();
-            setCompetencyLinks(managedLinks);
-        }
-        return managedLinks;
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingExerciseIntegrationTest.java
@@ -326,7 +326,8 @@ class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationLocalCILo
         var currentCriteriaSize = modelingExercise.getGradingCriteria().size();
         var newCriteria = new GradingCriterion();
         newCriteria.setTitle("new");
-        modelingExercise.addGradingCriteria(newCriteria);
+        newCriteria.setExercise(modelingExercise);
+        modelingExercise.getGradingCriteria().add(newCriteria);
         modelingExercise.setChannelName("testchannel-" + UUID.randomUUID().toString().substring(0, 8));
         ModelingExercise createdModelingExercise = request.postWithResponseBody("/api/modeling/modeling-exercises", modelingExercise, ModelingExercise.class, HttpStatus.CREATED);
         assertThat(createdModelingExercise.getGradingCriteria()).hasSize(currentCriteriaSize + 1);


### PR DESCRIPTION
### Checklist

#### General

- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server

- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).

(No new endpoints, queries, or behavior - dead-code removal only; the remaining server checklist rows do not apply.)

### Motivation and Context

`Exercise.java` crossed 1000 lines with #13186, which makes it the 18th class over the `max_large_classes=17` threshold in the Server Code Quality gate. The gate evaluates the merge ref, so every open PR currently fails it regardless of its own changes. Removing dead code is the fix that does not touch the threshold.

### Description

Removes four provably dead members from `Exercise` (1005 -> 975 lines):

- `participations(Set<StudentParticipation>)` - fluent setter, zero call sites repo-wide, not a Jackson accessor
- `removeParticipation(StudentParticipation)` - zero call sites repo-wide
- `addGradingCriteria(GradingCriterion)` - zero production callers; its one trivial test-fixture use is replaced by the same two lines `ExerciseUtilService.addGradingInstructionsToExercise` already uses
- `ensureCompetencyLinksSet()` - zero call sites; copy-paste sibling of `ensureGradingCriteriaSet()` that never got a caller

Note for maintainers: the gate is now back at exactly 17 of 17. The next class to cross 1000 lines re-trips it for every open PR (`Course.java` is at 1016 already).

### Steps for Testing

No user-facing change; nothing to test through the UI. Correctness is covered by the full architecture sweep (1179 tests green) and `ModelingExerciseIntegrationTest` (75 green, the only test whose fixture was touched).

### Review Progress

#### Code Review

- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/31412577332) did not pass (`failure`). Coverage below may be partial.

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| Exercise.java | not found (modified) | 650 |

_Last updated: 2026-08-10 17:38:43 UTC_

