### PR TITLE
`Development`: Implement OIDC redirects to vs code extension

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/account/config/OIDCConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/config/OIDCConfiguration.java
@@ -107,13 +107,32 @@ public class OIDCConfiguration {
     protected SecurityFilterChain oidcFilterChain(final HttpSecurity http) throws Exception {
         var resolver = new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository(), "/oauth2/authorization");
 
-        // Extract rememberMe field from query and store it into session
+        // Extract rememberMe & redirect field parameters query and store it into session
         resolver.setAuthorizationRequestCustomizer(builder -> {
-            // Get current request
             var attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
             if (attrs != null) {
                 var req = attrs.getRequest();
-                req.getSession(true).setAttribute("OIDC_REMEMBER_ME", "true".equalsIgnoreCase(req.getParameter("rememberMe")));
+                var session = req.getSession(true);
+                session.setAttribute(OIDCConstants.OIDC_REMEMBER_ME_SESSION_KEY, "true".equalsIgnoreCase(req.getParameter("rememberMe")));
+
+                String redirectTarget = req.getParameter("redirect");
+                if (redirectTarget != null && !redirectTarget.isBlank()) {
+                    session.setAttribute(OIDCConstants.OIDC_REDIRECT_TARGET_SESSION_KEY, redirectTarget);
+                }
+                else {
+                    session.removeAttribute(OIDCConstants.OIDC_REDIRECT_TARGET_SESSION_KEY);
+                }
+
+                String codeChallenge = req.getParameter("code_challenge");
+                if (codeChallenge == null || codeChallenge.isBlank()) {
+                    codeChallenge = req.getParameter("codeChallenge");
+                }
+                if (codeChallenge != null && !codeChallenge.isBlank()) {
+                    session.setAttribute(OIDCConstants.OIDC_CODE_CHALLENGE_SESSION_KEY, codeChallenge);
+                }
+                else {
+                    session.removeAttribute(OIDCConstants.OIDC_CODE_CHALLENGE_SESSION_KEY);
+                }
             }
         });
         // @formatter:off

--- a/src/main/java/de/tum/cit/aet/artemis/account/config/OIDCConstants.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/config/OIDCConstants.java
@@ -1,0 +1,17 @@
+package de.tum.cit.aet.artemis.account.config;
+
+public final class OIDCConstants {
+
+    public static final String OIDC_REDIRECT_TARGET_SESSION_KEY = "OIDC_REDIRECT";
+
+    public static final String OIDC_CODE_CHALLENGE_SESSION_KEY = "OIDC_CODE_CHALLENGE";
+
+    public static final String OIDC_REMEMBER_ME_SESSION_KEY = "OIDC_REMEMBER_ME";
+
+    public static final String VS_CODE_REDIRECT_TARGET = "vscode";
+
+    public static final String VS_CODE_DEEP_LINK_BASE = "vscode://aet-tum.iris-thaumantias/auth-callback";
+
+    private OIDCConstants() {
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/account/dto/OIDCCodeExchangeDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/dto/OIDCCodeExchangeDTO.java
@@ -1,0 +1,9 @@
+package de.tum.cit.aet.artemis.account.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record OIDCCodeExchangeDTO(@JsonProperty("code") String code, @JsonProperty("codeVerifier") @JsonAlias("code_verifier") String codeVerifier) {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/account/security/OIDCAuthenticationFailureHandler.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/OIDCAuthenticationFailureHandler.java
@@ -15,7 +15,10 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 
+import de.tum.cit.aet.artemis.account.config.OIDCConstants;
 import de.tum.cit.aet.artemis.account.config.OIDCEnabled;
 
 /**
@@ -29,6 +32,12 @@ public class OIDCAuthenticationFailureHandler implements AuthenticationFailureHa
 
     private static final Logger log = LoggerFactory.getLogger(OIDCAuthenticationFailureHandler.class);
 
+    private final TemplateEngine templateEngine;
+
+    public OIDCAuthenticationFailureHandler(TemplateEngine templateEngine) {
+        this.templateEngine = templateEngine;
+    }
+
     /**
      * Handles OIDC authentication failures by logging the exception and redirecting the client to the sign-in page.
      *
@@ -41,16 +50,32 @@ public class OIDCAuthenticationFailureHandler implements AuthenticationFailureHa
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
         log.error("OIDC authentication failed: {}", exception.getMessage(), exception);
+        String redirectTarget = null;
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            redirectTarget = (String) session.getAttribute(OIDCConstants.OIDC_REDIRECT_TARGET_SESSION_KEY);
+            session.invalidate();
+        }
         // If user is not validated
-        if (exception instanceof OAuth2AuthenticationException oauth2Exception && "user_deactivated".equals(oauth2Exception.getError().getErrorCode())) {
-            HttpSession session = request.getSession(false);
-            if (session != null) {
-                session.invalidate();
-            }
-            response.sendRedirect("/sign-in?loginError=deactivated");
+        boolean isDeactivated = exception instanceof OAuth2AuthenticationException oauth2Exception && "user_deactivated".equals(oauth2Exception.getError().getErrorCode());
+        String errorCode = isDeactivated ? "deactivated" : "oidcFailure";
+
+        if (OIDCConstants.VS_CODE_REDIRECT_TARGET.equalsIgnoreCase(redirectTarget)) {
+            String deepLink = OIDCConstants.VS_CODE_DEEP_LINK_BASE + "?error=" + errorCode;
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.setContentType("text/html;charset=UTF-8");
+
+            Context context = new Context();
+            context.setVariable("deepLink", deepLink);
+            context.setVariable("isError", true);
+            context.setVariable("errorMessage", "Authentication failed: " + errorCode);
+
+            String htmlContent = templateEngine.process("account/vscode-callback", context);
+            response.getWriter().write(htmlContent);
+            response.getWriter().flush();
         }
         else {
-            response.sendRedirect("/sign-in?loginError=oidcFailure");
+            response.sendRedirect("/sign-in?loginError=" + errorCode);
         }
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/account/security/OIDCAuthenticationSuccessHandler.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/OIDCAuthenticationSuccessHandler.java
@@ -19,11 +19,15 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 
+import de.tum.cit.aet.artemis.account.config.OIDCConstants;
 import de.tum.cit.aet.artemis.account.config.OIDCEnabled;
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.repository.UserRepository;
 import de.tum.cit.aet.artemis.account.service.ArtemisSuccessfulLoginService;
+import de.tum.cit.aet.artemis.account.service.OIDCExchangeCodeService;
 import de.tum.cit.aet.artemis.core.security.jwt.AuthenticationMethod;
 import de.tum.cit.aet.artemis.core.security.jwt.JWTCookieService;
 import de.tum.cit.aet.artemis.core.util.HttpRequestUtils;
@@ -35,30 +39,41 @@ public class OIDCAuthenticationSuccessHandler implements AuthenticationSuccessHa
 
     private final JWTCookieService jwtCookieService;
 
+    private final OIDCExchangeCodeService oidcExchangeCodeService;
+
     private final UserRepository userRepository;
 
     private final ArtemisSuccessfulLoginService artemisSuccessfulLoginService;
 
+    private final TemplateEngine templateEngine;
+
     @Value("${artemis.user-management.oidc.mappings.username:preferred_username}")
     private String usernameClaimKey;
 
-    public OIDCAuthenticationSuccessHandler(JWTCookieService jwtCookieService, UserRepository userRepository, ArtemisSuccessfulLoginService artemisSuccessfulLoginService) {
+    public OIDCAuthenticationSuccessHandler(JWTCookieService jwtCookieService, UserRepository userRepository, ArtemisSuccessfulLoginService artemisSuccessfulLoginService,
+            OIDCExchangeCodeService oidcExchangeCodeService, TemplateEngine templateEngine) {
         this.jwtCookieService = jwtCookieService;
+        this.oidcExchangeCodeService = oidcExchangeCodeService;
         this.userRepository = userRepository;
         this.artemisSuccessfulLoginService = artemisSuccessfulLoginService;
+        this.templateEngine = templateEngine;
     }
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         boolean rememberMe = false;
+        String redirectTarget = null;
+        String codeChallenge = null;
         HttpSession session = request.getSession(false);
         if (session != null) {
-            // Extract stored rememberMe field from session
-            Boolean storedRememberMe = (Boolean) session.getAttribute("OIDC_REMEMBER_ME");
+            Boolean storedRememberMe = (Boolean) session.getAttribute(OIDCConstants.OIDC_REMEMBER_ME_SESSION_KEY);
             if (storedRememberMe != null) {
                 rememberMe = storedRememberMe;
             }
+            redirectTarget = (String) session.getAttribute(OIDCConstants.OIDC_REDIRECT_TARGET_SESSION_KEY);
+            codeChallenge = (String) session.getAttribute(OIDCConstants.OIDC_CODE_CHALLENGE_SESSION_KEY);
         }
+
         OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
         String username = oidcUser.getAttribute(usernameClaimKey);
         if (username == null || username.isBlank()) {
@@ -68,24 +83,56 @@ public class OIDCAuthenticationSuccessHandler implements AuthenticationSuccessHa
         User user = userRepository.findOneWithAuthoritiesByLogin(username)
                 .orElseThrow(() -> new IllegalStateException("Authenticated OIDC user " + username + " could not be found in the database."));
 
-        // Artemis-side authorization, get roles from database
         var authorities = user.getAuthorities().stream().map(authority -> new SimpleGrantedAuthority(authority.getName())).toList();
-
-        // Generate Artemis authentication token
         UsernamePasswordAuthenticationToken artemisAuth = new UsernamePasswordAuthenticationToken(user.getLogin(), user.getPassword(), authorities);
-
-        // Generate JWT String
         SecurityContextHolder.getContext().setAuthentication(artemisAuth);
 
         ResponseCookie jwtCookie = jwtCookieService.buildLoginCookie(rememberMe);
         response.addHeader(HttpHeaders.SET_COOKIE, jwtCookie.toString());
         artemisSuccessfulLoginService.sendLoginEmail(user.getLogin(), AuthenticationMethod.OIDC, HttpRequestUtils.getClientEnvironment(request));
-        // Remove state from OIDCConfiguration
+
         if (session != null) {
             session.invalidate();
         }
 
-        // Redirect user to /courses page
-        response.sendRedirect("/");
+        // Handle redirect based on parameter: generate code strictly for recognized VS Code client
+        if (OIDCConstants.VS_CODE_REDIRECT_TARGET.equalsIgnoreCase(redirectTarget)) {
+            // If code challenge is invalid, then reject the native redirect request
+            if (!oidcExchangeCodeService.isValidCodeChallenge(codeChallenge)) {
+                renderCallbackPage(response, OIDCConstants.VS_CODE_DEEP_LINK_BASE + "?error=invalid_request", true, "Invalid authentication request parameters.");
+                return;
+            }
+
+            String jwtToken = jwtCookie.getValue();
+            String exchangeCode = oidcExchangeCodeService.storeJwtAndGenerateCode(jwtToken, codeChallenge);
+            if (exchangeCode == null) {
+                renderCallbackPage(response, OIDCConstants.VS_CODE_DEEP_LINK_BASE + "?error=server_error", true, "Could not generate authorization exchange code.");
+                return;
+            }
+
+            String vscodeDeepLink = OIDCConstants.VS_CODE_DEEP_LINK_BASE + "?code=" + exchangeCode;
+            renderCallbackPage(response, vscodeDeepLink, false, null);
+        }
+        else {
+            response.sendRedirect("/");
+        }
+    }
+
+    /**
+     * Renders a 200 OK HTML landing page that launches the custom URI scheme via JavaScript.
+     * Prevents Service Worker fetch failures caused by HTTP 302 redirects to non-HTTP protocols.
+     */
+    private void renderCallbackPage(HttpServletResponse response, String deepLink, boolean isError, String errorMessage) throws IOException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("text/html;charset=UTF-8");
+
+        Context context = new Context();
+        context.setVariable("deepLink", deepLink);
+        context.setVariable("isError", isError);
+        context.setVariable("errorMessage", errorMessage);
+
+        String htmlContent = templateEngine.process("account/vscode-callback", context);
+        response.getWriter().write(htmlContent);
+        response.getWriter().flush();
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/account/security/OIDCAuthenticationSuccessHandler.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/OIDCAuthenticationSuccessHandler.java
@@ -125,6 +125,8 @@ public class OIDCAuthenticationSuccessHandler implements AuthenticationSuccessHa
     private void renderCallbackPage(HttpServletResponse response, String deepLink, boolean isError, String errorMessage) throws IOException {
         response.setStatus(HttpServletResponse.SC_OK);
         response.setContentType("text/html;charset=UTF-8");
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-store");
+        response.setHeader(HttpHeaders.PRAGMA, "no-cache");
 
         Context context = new Context();
         context.setVariable("deepLink", deepLink);

--- a/src/main/java/de/tum/cit/aet/artemis/account/service/OIDCExchangeCodeService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/service/OIDCExchangeCodeService.java
@@ -1,0 +1,165 @@
+package de.tum.cit.aet.artemis.account.service;
+
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.regex.Pattern;
+
+import jakarta.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+import de.tum.cit.aet.artemis.account.config.OIDCEnabled;
+import de.tum.cit.aet.artemis.account.security.RandomUtil;
+import de.tum.cit.aet.artemis.core.service.distributed.api.DistributedDataProvider;
+import de.tum.cit.aet.artemis.core.service.distributed.api.map.DistributedMap;
+
+/**
+ * Service to store and exchange single-use OIDC codes for JWT tokens bound to PKCE S256 code challenges.
+ */
+@Service
+@Lazy
+@Conditional(OIDCEnabled.class)
+public class OIDCExchangeCodeService {
+
+    // RFC 7636 Section 4.1: code_verifier = 43-128 characters from [A-Za-z0-9-._~]
+    private static final Pattern CODE_VERIFIER_PATTERN = Pattern.compile("^[a-zA-Z0-9\\-._~]{43,128}$");
+
+    // RFC 7636 Section 4.2: S256 code_challenge is 32 bytes SHA-256 in Base64URL without padding = exactly 43 chars
+    private static final Pattern CODE_CHALLENGE_PATTERN = Pattern.compile("^[a-zA-Z0-9\\-_]{43}$");
+
+    // The jwt token is stored in cache for only 5 minutes till collected
+    private static final Duration EXCHANGE_CODE_TIME_TO_LIVE = Duration.ofMinutes(5);
+
+    private static final Logger log = LoggerFactory.getLogger(OIDCExchangeCodeService.class);
+
+    public record ExchangeCodeEntry(String jwtToken, String codeChallenge) implements Serializable {
+    }
+
+    private final DistributedDataProvider distributedDataProvider;
+
+    private DistributedMap<String, ExchangeCodeEntry> codeToEntryMap;
+
+    public OIDCExchangeCodeService(DistributedDataProvider distributedDataProvider) {
+        this.distributedDataProvider = distributedDataProvider;
+    }
+
+    @PostConstruct
+    public void init() {
+        this.codeToEntryMap = distributedDataProvider.getExpiringMap("oidcExchangeCodes", EXCHANGE_CODE_TIME_TO_LIVE);
+    }
+
+    /**
+     * Checks whether the provided code challenge matches the RFC 7636 format requirements.
+     *
+     * @param codeChallenge the code challenge string to validate
+     * @return true if valid, false otherwise
+     */
+    public boolean isValidCodeChallenge(String codeChallenge) {
+        return codeChallenge != null && CODE_CHALLENGE_PATTERN.matcher(codeChallenge).matches();
+    }
+
+    /**
+     * Validates and stores the JWT token bound to the PKCE S256 code challenge in a single entry.
+     *
+     * @param jwtToken      The JWT token to store.
+     * @param codeChallenge The PKCE S256 code challenge sent by the client.
+     * @return A random single-use exchange code, or null if inputs are invalid.
+     */
+    public String storeJwtAndGenerateCode(String jwtToken, String codeChallenge) {
+        if (jwtToken == null || jwtToken.isBlank()) {
+            log.warn("Cannot store OIDC exchange code: JWT token is null or blank");
+            return null;
+        }
+        if (!isValidCodeChallenge(codeChallenge)) {
+            log.warn("Cannot store OIDC exchange code: Code challenge format does not meet RFC 7636 requirements");
+            return null;
+        }
+        try {
+            String code = RandomUtil.generateResetKey();
+            codeToEntryMap.put(code, new ExchangeCodeEntry(jwtToken, codeChallenge), EXCHANGE_CODE_TIME_TO_LIVE);
+            return code;
+        }
+        catch (Exception e) {
+            log.error("Failed to store OIDC exchange code in distributed cache", e);
+            return null;
+        }
+    }
+
+    /**
+     * Atomically validates the PKCE code_verifier against the stored code_challenge and consumes the code entry.
+     *
+     * @param code         The exchange code.
+     * @param codeVerifier The PKCE code verifier string from the client.
+     * @return The JWT token if the code and verifier are valid, or null otherwise.
+     */
+    public String redeemCode(String code, String codeVerifier) {
+        if (code == null || code.isBlank()) {
+            log.warn("Cannot redeem OIDC exchange code: Code is null or blank");
+            return null;
+        }
+        if (codeVerifier == null || !CODE_VERIFIER_PATTERN.matcher(codeVerifier).matches()) {
+            log.warn("Cannot redeem OIDC exchange code: Code verifier format does not meet RFC 7636 requirements");
+            return null;
+        }
+        try {
+            ExchangeCodeEntry entry = codeToEntryMap.get(code);
+            if (entry == null) {
+                log.warn("Cannot redeem OIDC exchange code: Code not found or already expired");
+                return null;
+            }
+            if (entry.codeChallenge() == null || entry.jwtToken() == null) {
+                log.warn("Cannot redeem OIDC exchange code: Corrupted cache entry");
+                return null;
+            }
+            String computedChallenge = computeSHA256Challenge(codeVerifier);
+            // Constant-time comparison to prevent timing attacks
+            if (!MessageDigest.isEqual(entry.codeChallenge().getBytes(StandardCharsets.US_ASCII), computedChallenge.getBytes(StandardCharsets.US_ASCII))) {
+                log.warn("Cannot redeem OIDC exchange code: PKCE code verifier does not match challenge");
+                return null;
+            }
+
+            // Atomically remove the entry (CAS) to ensure single-use
+            if (codeToEntryMap.remove(code, entry)) {
+                return entry.jwtToken();
+            }
+            else {
+                log.warn("Cannot redeem OIDC exchange code: Code was already redeemed");
+                return null;
+            }
+        }
+        catch (Exception e) {
+            log.error("Failed to redeem OIDC exchange code from distributed cache", e);
+            return null;
+        }
+    }
+
+    /**
+     * Computes the S256 code_challenge from the code_verifier according to RFC 7636:
+     * code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier))) without padding.
+     *
+     * @param codeVerifier The PKCE code verifier string.
+     * @return Base64Url-encoded SHA-256 digest string.
+     */
+    public static String computeSHA256Challenge(String codeVerifier) {
+        if (codeVerifier == null) {
+            throw new IllegalArgumentException("codeVerifier cannot be null");
+        }
+        try {
+            byte[] bytes = codeVerifier.getBytes(StandardCharsets.US_ASCII);
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(bytes);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
+        }
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResource.java
@@ -35,9 +35,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import de.tum.cit.aet.artemis.account.dto.OIDCCodeExchangeDTO;
 import de.tum.cit.aet.artemis.account.exception.UserNotActivatedException;
 import de.tum.cit.aet.artemis.account.security.SAML2Service;
 import de.tum.cit.aet.artemis.account.service.ArtemisSuccessfulLoginService;
+import de.tum.cit.aet.artemis.account.service.OIDCExchangeCodeService;
 import de.tum.cit.aet.artemis.core.dto.vm.LoginVM;
 import de.tum.cit.aet.artemis.core.exception.AccessForbiddenException;
 import de.tum.cit.aet.artemis.core.security.RateLimitType;
@@ -62,6 +64,8 @@ public class PublicUserJwtResource {
 
     private final JWTCookieService jwtCookieService;
 
+    private final Optional<OIDCExchangeCodeService> oidcExchangeCodeService;
+
     private final AuthenticationManager authenticationManager;
 
     private final ArtemisSuccessfulLoginService artemisSuccessfulLoginService;
@@ -69,8 +73,9 @@ public class PublicUserJwtResource {
     private final Optional<SAML2Service> saml2Service;
 
     public PublicUserJwtResource(JWTCookieService jwtCookieService, AuthenticationManager authenticationManager, ArtemisSuccessfulLoginService artemisSuccessfulLoginService,
-            Optional<SAML2Service> saml2Service) {
+            Optional<SAML2Service> saml2Service, Optional<OIDCExchangeCodeService> oidcExchangeCodeService) {
         this.jwtCookieService = jwtCookieService;
+        this.oidcExchangeCodeService = oidcExchangeCodeService;
         this.authenticationManager = authenticationManager;
         this.artemisSuccessfulLoginService = artemisSuccessfulLoginService;
         this.saml2Service = saml2Service;
@@ -176,6 +181,26 @@ public class PublicUserJwtResource {
         response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
 
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Exchanges a single-use OIDC code and PKCE code_verifier for a JWT authentication token.
+     *
+     * @param exchangeDTO Request body containing the single-use exchange code and PKCE code_verifier.
+     * @return ResponseEntity with the JWT token as plain text and Cache-Control: no-store, or 404 (Not Found) if verification fails.
+     */
+    @PostMapping("exchange-code")
+    @EnforceNothing
+    @LimitRequestsPerMinute(type = RateLimitType.AUTHENTICATION)
+    public ResponseEntity<String> exchangeCodeToJwtToken(@RequestBody OIDCCodeExchangeDTO exchangeDTO) {
+        if (oidcExchangeCodeService.isEmpty() || exchangeDTO == null || exchangeDTO.code() == null || exchangeDTO.codeVerifier() == null) {
+            return ResponseEntity.notFound().build();
+        }
+        String jwtToken = oidcExchangeCodeService.get().redeemCode(exchangeDTO.code(), exchangeDTO.codeVerifier());
+        if (jwtToken == null || jwtToken.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok().header(HttpHeaders.CACHE_CONTROL, "no-store").header(HttpHeaders.PRAGMA, "no-cache").body(jwtToken);
     }
 
     /**

--- a/src/main/resources/templates/account/vscode-callback.html
+++ b/src/main/resources/templates/account/vscode-callback.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${isError} ? 'Authentication Failed' : 'Redirecting to VS Code...'">Artemis - VS Code Login</title>
+    <style>
+        :root {
+            --tum-blue: #0065BD;
+            --tum-blue-dark: #005293;
+            --bg-color: #f4f6f8;
+            --card-bg: #ffffff;
+            --text-main: #212529;
+            --text-muted: #6c757d;
+            --error-red: #d9534f;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            background-color: var(--bg-color);
+            color: var(--text-main);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            margin: 0;
+            padding: 20px;
+            box-sizing: border-box;
+        }
+
+        .auth-card {
+            background-color: var(--card-bg);
+            border-radius: 8px;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+            max-width: 460px;
+            width: 100%;
+            padding: 36px 30px;
+            text-align: center;
+        }
+
+        .logo {
+            font-size: 28px;
+            font-weight: 700;
+            color: var(--tum-blue);
+            margin-bottom: 20px;
+            letter-spacing: -0.5px;
+        }
+
+        h1 {
+            font-size: 22px;
+            margin: 0 0 12px;
+            font-weight: 600;
+        }
+
+        p {
+            font-size: 15px;
+            color: var(--text-muted);
+            line-height: 1.5;
+            margin: 0 0 24px;
+        }
+
+        .btn {
+            display: inline-block;
+            background-color: var(--tum-blue);
+            color: #ffffff;
+            font-size: 15px;
+            font-weight: 600;
+            padding: 12px 28px;
+            border-radius: 4px;
+            text-decoration: none;
+            transition: background-color 0.15s ease-in-out;
+        }
+
+        .btn:hover {
+            background-color: var(--tum-blue-dark);
+        }
+
+        .error-message {
+            color: var(--error-red);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+    <div class="auth-card">
+        <div class="logo">Artemis</div>
+
+        <div th:if="${!isError}">
+            <h1>Authentication Successful</h1>
+            <p>Redirecting you back to Visual Studio Code...</p>
+            <p>If your editor does not open automatically, click the button below:</p>
+            <a class="btn" th:href="${deepLink}">Open in VS Code</a>
+            <script th:inline="javascript">
+                /*<![CDATA[*/
+                window.location.href = /*[[${deepLink}]]*/ '';
+                /*]]>*/
+            </script>
+        </div>
+
+        <div th:if="${isError}">
+            <h1 class="error-message">Authentication Failed</h1>
+            <p th:text="${errorMessage}">An error occurred during authentication.</p>
+            <a class="btn" th:href="${deepLink}">Return to VS Code</a>
+            <script th:inline="javascript">
+                /*<![CDATA[*/
+                window.location.href = /*[[${deepLink}]]*/ '';
+                /*]]>*/
+            </script>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserOIDCIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserOIDCIntegrationTest.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.account.authentication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -12,30 +13,39 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.test.context.TestSecurityContextHolder;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.thymeleaf.TemplateEngine;
 
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.security.OIDCAuthenticationFailureHandler;
 import de.tum.cit.aet.artemis.account.security.OIDCAuthenticationSuccessHandler;
 import de.tum.cit.aet.artemis.account.security.OIDCService;
 import de.tum.cit.aet.artemis.account.service.ArtemisSuccessfulLoginService;
+import de.tum.cit.aet.artemis.account.service.OIDCExchangeCodeService;
 import de.tum.cit.aet.artemis.account.service.ldap.LdapUserDto;
 import de.tum.cit.aet.artemis.account.service.ldap.LdapUserService;
 import de.tum.cit.aet.artemis.account.service.user.PasswordService;
@@ -67,12 +77,17 @@ class UserOIDCIntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest {
     private JWTCookieService jwtCookieService;
 
     @Autowired
-    private TokenProvider tokenProvider;
-
-    @Autowired
     private ArtemisSuccessfulLoginService artemisSuccessfulLoginService;
 
+    @Autowired
+    private TemplateEngine templateEngine;
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
     private OIDCService oidcService;
+
+    private OIDCExchangeCodeService oidcExchangeCodeService;
 
     private OIDCAuthenticationSuccessHandler successHandler;
 
@@ -83,6 +98,7 @@ class UserOIDCIntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest {
     @BeforeEach
     void initManualMocks() {
         ldapUserServiceMock = mock(LdapUserService.class);
+        oidcExchangeCodeService = mock(OIDCExchangeCodeService.class);
         oidcService = new OIDCService(userTestRepository, userCreationService, Optional.of(ldapUserServiceMock));
 
         ReflectionTestUtils.setField(oidcService, "usernameClaimKey", "preferred_username");
@@ -91,8 +107,8 @@ class UserOIDCIntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest {
         ReflectionTestUtils.setField(oidcService, "lastNameClaimKey", "family_name");
         ReflectionTestUtils.setField(oidcService, "emailClaimKey", "email");
 
-        successHandler = new OIDCAuthenticationSuccessHandler(jwtCookieService, userTestRepository, artemisSuccessfulLoginService);
-        failureHandler = new OIDCAuthenticationFailureHandler();
+        successHandler = new OIDCAuthenticationSuccessHandler(jwtCookieService, userTestRepository, artemisSuccessfulLoginService, oidcExchangeCodeService, templateEngine);
+        failureHandler = new OIDCAuthenticationFailureHandler(templateEngine);
         ReflectionTestUtils.setField(successHandler, "usernameClaimKey", "preferred_username");
     }
 
@@ -195,22 +211,20 @@ class UserOIDCIntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        // Put rememberMe to true
         MockHttpSession session = new MockHttpSession();
         session.setAttribute("OIDC_REMEMBER_ME", true);
         request.setSession(session);
 
         var mockUserRequest = createMockUserRequest(createClaimsMap(STUDENT_REGISTRATION_NUMBER, "FirstName", "LastName"));
         var oidcUser = oidcService.loadUser(mockUserRequest);
-        var auth = new org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken(oidcUser, oidcUser.getAuthorities(), "oidc");
+        var auth = new OAuth2AuthenticationToken(oidcUser, oidcUser.getAuthorities(), "oidc");
 
         successHandler.onAuthenticationSuccess(request, response, auth);
 
         String cookieHeader = response.getHeader(HttpHeaders.SET_COOKIE);
         assertThat(cookieHeader).isNotNull();
-        // Verify that the cookie is the long-lived one. Asserted against the configured validity rather than a literal,
-        // so that changing the remember-me lifetime does not silently turn this into a test of the old number.
         assertThat(cookieHeader).contains("Max-Age=" + tokenProvider.getTokenValidity(true) / 1000);
+        assertThat(session.isInvalid()).isTrue();
     }
 
     @Test
@@ -221,21 +235,89 @@ class UserOIDCIntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
 
-        // Put rememberMe to false
         MockHttpSession session = new MockHttpSession();
         session.setAttribute("OIDC_REMEMBER_ME", false);
         request.setSession(session);
 
         var mockUserRequest = createMockUserRequest(createClaimsMap(STUDENT_REGISTRATION_NUMBER, "FirstName", "LastName"));
         var oidcUser = oidcService.loadUser(mockUserRequest);
-        var auth = new org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken(oidcUser, oidcUser.getAuthorities(), "oidc");
+        var auth = new OAuth2AuthenticationToken(oidcUser, oidcUser.getAuthorities(), "oidc");
 
         successHandler.onAuthenticationSuccess(request, response, auth);
 
         String cookieHeader = response.getHeader(HttpHeaders.SET_COOKIE);
         assertThat(cookieHeader).isNotNull();
-        // Verify that the cookie is the short-lived one, again from the configured validity.
+        assertThat(session.isInvalid()).isTrue();
         assertThat(cookieHeader).contains("Max-Age=" + tokenProvider.getTokenValidity(false) / 1000);
+    }
+
+    @Test
+    void testOidcLogin_withRedirectVsCode_generatesExchangeCodeAndRedirectsToVsCode() throws Exception {
+        assertStudentNotExists();
+        createUser(STUDENT_NAME + "@artemis.local");
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // Valid 43-character S256 code challenge (RFC 7636)
+        String expectedChallenge = "E9Melhoa2OwvFrGMTJguCH5A_lUhKw6YGzaWzkTCdcM";
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("OIDC_REDIRECT", "vscode");
+        session.setAttribute("OIDC_CODE_CHALLENGE", expectedChallenge);
+        request.setSession(session);
+
+        String expectedCode = "mock-exchange-code-123";
+        when(oidcExchangeCodeService.isValidCodeChallenge(expectedChallenge)).thenReturn(true);
+        when(oidcExchangeCodeService.storeJwtAndGenerateCode(anyString(), anyString())).thenReturn(expectedCode);
+
+        // Construct OidcUser directly to keep the handler test focused
+        Map<String, Object> claims = createClaimsMap(STUDENT_REGISTRATION_NUMBER, "FirstName", "LastName");
+        OidcIdToken idToken = new OidcIdToken("mock-raw-id-token-string", Instant.now(), Instant.now().plusSeconds(3600), claims);
+        OidcUser oidcUser = new DefaultOidcUser(Set.of(new SimpleGrantedAuthority("ROLE_USER")), idToken, "preferred_username");
+        var auth = new OAuth2AuthenticationToken(oidcUser, oidcUser.getAuthorities(), "oidc");
+
+        successHandler.onAuthenticationSuccess(request, response, auth);
+
+        // 1. Verify redirect URL
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getContentAsString()).contains("vscode://aet-tum.iris-thaumantias/auth-callback?code=" + expectedCode);
+
+        // 2. Verify exact JWT token and challenge passed to exchange-code service
+        ArgumentCaptor<String> jwtCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> challengeCaptor = ArgumentCaptor.forClass(String.class);
+        verify(oidcExchangeCodeService, times(1)).storeJwtAndGenerateCode(jwtCaptor.capture(), challengeCaptor.capture());
+        String storedJwt = jwtCaptor.getValue();
+        assertThat(storedJwt).isNotNull().isNotBlank();
+        assertThat(response.getHeader(HttpHeaders.SET_COOKIE)).contains(storedJwt);
+        assertThat(challengeCaptor.getValue()).isEqualTo(expectedChallenge);
+
+        // 3. Verify session invalidation
+        assertThat(session.isInvalid()).isTrue();
+    }
+
+    @Test
+    void testOidcLogin_withRedirectVsCode_missingCodeChallenge_redirectsWithInvalidRequestError() throws Exception {
+        assertStudentNotExists();
+        createUser(STUDENT_NAME + "@artemis.local");
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("OIDC_REDIRECT", "vscode");
+        // No OIDC_CODE_CHALLENGE set in session
+        request.setSession(session);
+
+        Map<String, Object> claims = createClaimsMap(STUDENT_REGISTRATION_NUMBER, "FirstName", "LastName");
+        OidcIdToken idToken = new OidcIdToken("mock-raw-id-token-string", Instant.now(), Instant.now().plusSeconds(3600), claims);
+        OidcUser oidcUser = new DefaultOidcUser(Set.of(new SimpleGrantedAuthority("ROLE_USER")), idToken, "preferred_username");
+        var auth = new OAuth2AuthenticationToken(oidcUser, oidcUser.getAuthorities(), "oidc");
+
+        successHandler.onAuthenticationSuccess(request, response, auth);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getContentAsString()).contains("vscode://aet-tum.iris-thaumantias/auth-callback?error=invalid_request");
+        assertThat(session.isInvalid()).isTrue();
     }
 
     @Test
@@ -273,34 +355,78 @@ class UserOIDCIntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest {
     void testOidcFailureHandler_withDeactivatedUserException_redirectsToDeactivatedError() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
-        OAuth2AuthenticationException exception = new OAuth2AuthenticationException(new org.springframework.security.oauth2.core.OAuth2Error("user_deactivated"), "Deactivated");
+        MockHttpSession session = new MockHttpSession();
+        request.setSession(session);
+
+        OAuth2AuthenticationException exception = new OAuth2AuthenticationException(new OAuth2Error("user_deactivated"), "Deactivated");
 
         failureHandler.onAuthenticationFailure(request, response, exception);
 
-        // Verify the correct redirect for deactivated user
         assertThat(response.getRedirectedUrl()).isEqualTo("/sign-in?loginError=deactivated");
+        assertThat(session.isInvalid()).isTrue();
     }
 
     @Test
     void testOidcFailureHandler_withGenericException_redirectsToGenericOidcError() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
-        OAuth2AuthenticationException exception = new OAuth2AuthenticationException(new org.springframework.security.oauth2.core.OAuth2Error("invalid_issuer"), "Wrong Issuer");
+        MockHttpSession session = new MockHttpSession();
+        request.setSession(session);
+
+        OAuth2AuthenticationException exception = new OAuth2AuthenticationException(new OAuth2Error("invalid_issuer"), "Wrong Issuer");
 
         failureHandler.onAuthenticationFailure(request, response, exception);
 
-        // Verify the default error redirect
         assertThat(response.getRedirectedUrl()).isEqualTo("/sign-in?loginError=oidcFailure");
+        assertThat(session.isInvalid()).isTrue();
     }
+
+    @Test
+    void testOidcFailureHandler_withRedirectVsCode_deactivatedUser_redirectsToVsCodeWithError() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("OIDC_REDIRECT", "vscode");
+        request.setSession(session);
+
+        OAuth2AuthenticationException exception = new OAuth2AuthenticationException(new OAuth2Error("user_deactivated"), "Deactivated");
+
+        failureHandler.onAuthenticationFailure(request, response, exception);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getContentAsString()).contains("vscode://aet-tum.iris-thaumantias/auth-callback?error=deactivated");
+        assertThat(session.isInvalid()).isTrue();
+    }
+
+    @Test
+    void testOidcFailureHandler_withRedirectVsCode_genericError_redirectsToVsCodeWithError() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("OIDC_REDIRECT", "vscode");
+        request.setSession(session);
+
+        OAuth2AuthenticationException exception = new OAuth2AuthenticationException(new OAuth2Error("invalid_issuer"), "Wrong Issuer");
+
+        failureHandler.onAuthenticationFailure(request, response, exception);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getContentAsString()).contains("vscode://aet-tum.iris-thaumantias/auth-callback?error=oidcFailure");
+        assertThat(session.isInvalid()).isTrue();
+    }
+
+    private static final Instant FIXED_TIMESTAMP = Instant.parse("2026-08-15T00:00:00Z");
 
     private OidcUserRequest createMockUserRequest(Map<String, Object> claims) {
         ClientRegistration localRegistration = ClientRegistration.withRegistrationId("oidc").clientId("artemis-oidc-client")
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE).redirectUri("{baseUrl}/login/oauth2/code/{registrationId}").tokenUri("http://localhost/token")
                 .authorizationUri("http://localhost/authorize").build();
 
-        OAuth2AccessToken accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "mock-token", Instant.now(), Instant.now().plusSeconds(3600));
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "mock-token", FIXED_TIMESTAMP, FIXED_TIMESTAMP.plusSeconds(3600));
 
-        OidcIdToken idToken = new OidcIdToken("mock-raw-id-token-string", Instant.now(), Instant.now().plusSeconds(3600), claims);
+        OidcIdToken idToken = new OidcIdToken("mock-raw-id-token-string", FIXED_TIMESTAMP, FIXED_TIMESTAMP.plusSeconds(3600), claims);
         return new OidcUserRequest(localRegistration, accessToken, idToken);
     }
 
@@ -342,5 +468,35 @@ class UserOIDCIntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest {
 
     private void assertRegistrationNumber(String registrationNumber) {
         assertThat(userUtilService.getUserByLogin(STUDENT_NAME).getRegistrationNumber()).isEqualTo(registrationNumber);
+    }
+
+    @Test
+    void testOidcLogin_withRedirectVsCode_storeJwtFails_redirectsWithServerError() throws Exception {
+        assertStudentNotExists();
+        createUser(STUDENT_NAME + "@artemis.local");
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        String expectedChallenge = "E9Melhoa2OwvFrGMTJguCH5A_lUhKw6YGzaWzkTCdcM";
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("OIDC_REDIRECT", "vscode");
+        session.setAttribute("OIDC_CODE_CHALLENGE", expectedChallenge);
+        request.setSession(session);
+
+        when(oidcExchangeCodeService.isValidCodeChallenge(expectedChallenge)).thenReturn(true);
+        // Simulate failure in distributed cache store
+        when(oidcExchangeCodeService.storeJwtAndGenerateCode(anyString(), anyString())).thenReturn(null);
+
+        Map<String, Object> claims = createClaimsMap(STUDENT_REGISTRATION_NUMBER, "FirstName", "LastName");
+        OidcIdToken idToken = new OidcIdToken("mock-raw-id-token-string", Instant.now(), Instant.now().plusSeconds(3600), claims);
+        OidcUser oidcUser = new DefaultOidcUser(Set.of(new SimpleGrantedAuthority("ROLE_USER")), idToken, "preferred_username");
+        var auth = new OAuth2AuthenticationToken(oidcUser, oidcUser.getAuthorities(), "oidc");
+
+        successHandler.onAuthenticationSuccess(request, response, auth);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getContentAsString()).contains("vscode://aet-tum.iris-thaumantias/auth-callback?error=server_error");
+        assertThat(session.isInvalid()).isTrue();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/account/service/OIDCExchangeCodeServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/service/OIDCExchangeCodeServiceTest.java
@@ -1,0 +1,138 @@
+package de.tum.cit.aet.artemis.account.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.tum.cit.aet.artemis.account.service.OIDCExchangeCodeService.ExchangeCodeEntry;
+import de.tum.cit.aet.artemis.core.service.distributed.api.DistributedDataProvider;
+import de.tum.cit.aet.artemis.core.service.distributed.api.map.DistributedMap;
+
+class OIDCExchangeCodeServiceTest {
+
+    private static final String VALID_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk_valid_verifier";
+
+    private DistributedDataProvider distributedDataProvider;
+
+    private DistributedMap<String, ExchangeCodeEntry> codeToEntryMap;
+
+    private OIDCExchangeCodeService oidcExchangeCodeService;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        distributedDataProvider = mock(DistributedDataProvider.class);
+        codeToEntryMap = mock(DistributedMap.class);
+        when(distributedDataProvider.<String, ExchangeCodeEntry>getExpiringMap(eq("oidcExchangeCodes"), any(Duration.class))).thenReturn(codeToEntryMap);
+
+        oidcExchangeCodeService = new OIDCExchangeCodeService(distributedDataProvider);
+        oidcExchangeCodeService.init();
+    }
+
+    @Test
+    void testRfc7636TestVector() {
+        String verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        String expectedChallenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+        assertThat(OIDCExchangeCodeService.computeSHA256Challenge(verifier)).isEqualTo(expectedChallenge);
+    }
+
+    @Test
+    void testStoreJwtAndGenerateCode_storesSingleEntryWithTTL() {
+        String jwtToken = "mock_jwt_token_123";
+        String challenge = OIDCExchangeCodeService.computeSHA256Challenge(VALID_VERIFIER);
+
+        String code = oidcExchangeCodeService.storeJwtAndGenerateCode(jwtToken, challenge);
+
+        assertThat(code).isNotNull().isNotBlank();
+        verify(codeToEntryMap).put(eq(code), eq(new ExchangeCodeEntry(jwtToken, challenge)), eq(Duration.ofMinutes(5)));
+    }
+
+    @Test
+    void testStoreJwtAndGenerateCode_invalidInputs_returnsNull() {
+        String validChallenge = OIDCExchangeCodeService.computeSHA256Challenge(VALID_VERIFIER);
+        assertThat(oidcExchangeCodeService.storeJwtAndGenerateCode(null, validChallenge)).isNull();
+        assertThat(oidcExchangeCodeService.storeJwtAndGenerateCode("jwt", null)).isNull();
+        assertThat(oidcExchangeCodeService.storeJwtAndGenerateCode("   ", validChallenge)).isNull();
+        assertThat(oidcExchangeCodeService.storeJwtAndGenerateCode("jwt", "too-short-challenge")).isNull();
+    }
+
+    @Test
+    void testRedeemCode_validCodeAndVerifier_atomicallyRemovesEntryAndReturnsJwt() {
+        String code = "valid_exchange_code";
+        String jwtToken = "mock_jwt_token_123";
+        String challenge = OIDCExchangeCodeService.computeSHA256Challenge(VALID_VERIFIER);
+        ExchangeCodeEntry entry = new ExchangeCodeEntry(jwtToken, challenge);
+
+        when(codeToEntryMap.get(code)).thenReturn(entry);
+        when(codeToEntryMap.remove(code, entry)).thenReturn(true);
+
+        String redeemedToken = oidcExchangeCodeService.redeemCode(code, VALID_VERIFIER);
+
+        assertThat(redeemedToken).isEqualTo(jwtToken);
+        verify(codeToEntryMap).remove(code, entry);
+    }
+
+    @Test
+    void testRedeemCode_invalidVerifier_doesNotRemoveEntryAndReturnsNull() {
+        String code = "valid_exchange_code";
+        String jwtToken = "mock_jwt_token_123";
+        String challenge = OIDCExchangeCodeService.computeSHA256Challenge(VALID_VERIFIER);
+        ExchangeCodeEntry entry = new ExchangeCodeEntry(jwtToken, challenge);
+
+        when(codeToEntryMap.get(code)).thenReturn(entry);
+
+        String invalidVerifier = "wrong_verifier_1234567890123456789012345678901234567890";
+        String redeemedToken = oidcExchangeCodeService.redeemCode(code, invalidVerifier);
+
+        assertThat(redeemedToken).isNull();
+        verify(codeToEntryMap, never()).remove(eq(code), any());
+    }
+
+    @Test
+    void testRedeemCode_tooShortVerifier_returnsNull() {
+        String code = "valid_exchange_code";
+        String redeemedToken = oidcExchangeCodeService.redeemCode(code, "short");
+        assertThat(redeemedToken).isNull();
+    }
+
+    @Test
+    void testRedeemCode_atomicRemoveFailed_returnsNull() {
+        String code = "valid_exchange_code";
+        String jwtToken = "mock_jwt_token_123";
+        String challenge = OIDCExchangeCodeService.computeSHA256Challenge(VALID_VERIFIER);
+        ExchangeCodeEntry entry = new ExchangeCodeEntry(jwtToken, challenge);
+
+        when(codeToEntryMap.get(code)).thenReturn(entry);
+        when(codeToEntryMap.remove(code, entry)).thenReturn(false);
+
+        String redeemedToken = oidcExchangeCodeService.redeemCode(code, VALID_VERIFIER);
+
+        assertThat(redeemedToken).isNull();
+    }
+
+    @Test
+    void testRedeemCode_invalidOrNullInputs_returnsNull() {
+        assertThat(oidcExchangeCodeService.redeemCode(null, VALID_VERIFIER)).isNull();
+        assertThat(oidcExchangeCodeService.redeemCode("   ", VALID_VERIFIER)).isNull();
+        assertThat(oidcExchangeCodeService.redeemCode("code", null)).isNull();
+
+        when(codeToEntryMap.get("invalid_code")).thenReturn(null);
+        assertThat(oidcExchangeCodeService.redeemCode("invalid_code", VALID_VERIFIER)).isNull();
+    }
+
+    @Test
+    void testComputeSHA256Challenge_null_throwsException() {
+        assertThatIllegalArgumentException().isThrownBy(() -> OIDCExchangeCodeService.computeSHA256Challenge(null));
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResourceOIDCIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResourceOIDCIntegrationTest.java
@@ -1,0 +1,109 @@
+package de.tum.cit.aet.artemis.core.web.open;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.tum.cit.aet.artemis.account.dto.OIDCCodeExchangeDTO;
+import de.tum.cit.aet.artemis.account.service.OIDCExchangeCodeService;
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationLocalVCSamlTest;
+
+class PublicUserJwtResourceOIDCIntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest {
+
+    private static final String VALID_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk_valid_verifier";
+
+    @Autowired
+    private OIDCExchangeCodeService oidcExchangeCodeService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void testExchangeCodeToJwtToken_success() throws Exception {
+        String challenge = OIDCExchangeCodeService.computeSHA256Challenge(VALID_VERIFIER);
+        String expectedJwt = "mock.jwt.token.string";
+        String exchangeCode = oidcExchangeCodeService.storeJwtAndGenerateCode(expectedJwt, challenge);
+
+        OIDCCodeExchangeDTO requestDto = new OIDCCodeExchangeDTO(exchangeCode, VALID_VERIFIER);
+
+        mockMvc.perform(post("/api/core/public/exchange-code").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk()).andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store")).andExpect(content().string(expectedJwt));
+    }
+
+    @Test
+    void testExchangeCodeToJwtToken_notFoundForInvalidCode() throws Exception {
+        OIDCCodeExchangeDTO requestDto = new OIDCCodeExchangeDTO("invalid-or-expired-code", VALID_VERIFIER);
+
+        mockMvc.perform(post("/api/core/public/exchange-code").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testExchangeCodeToJwtToken_notFoundForInvalidVerifier() throws Exception {
+        String challenge = OIDCExchangeCodeService.computeSHA256Challenge(VALID_VERIFIER);
+        String expectedJwt = "mock.jwt.token.string";
+        String exchangeCode = oidcExchangeCodeService.storeJwtAndGenerateCode(expectedJwt, challenge);
+
+        String invalidVerifier = "wrong_verifier_1234567890123456789012345678901234567890";
+        OIDCCodeExchangeDTO requestDto = new OIDCCodeExchangeDTO(exchangeCode, invalidVerifier);
+
+        mockMvc.perform(post("/api/core/public/exchange-code").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testExchangeCodeToJwtToken_missingVerifier_returnsNotFound() throws Exception {
+        String challenge = OIDCExchangeCodeService.computeSHA256Challenge(VALID_VERIFIER);
+        String expectedJwt = "mock.jwt.token.string";
+        String exchangeCode = oidcExchangeCodeService.storeJwtAndGenerateCode(expectedJwt, challenge);
+
+        OIDCCodeExchangeDTO requestDto = new OIDCCodeExchangeDTO(exchangeCode, null);
+
+        mockMvc.perform(post("/api/core/public/exchange-code").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testExchangeCodeToJwtToken_successWithSnakeCaseJson() throws Exception {
+        String challenge = OIDCExchangeCodeService.computeSHA256Challenge(VALID_VERIFIER);
+        String expectedJwt = "mock.jwt.token.string";
+        String exchangeCode = oidcExchangeCodeService.storeJwtAndGenerateCode(expectedJwt, challenge);
+
+        String rawSnakeCaseJson = """
+                {
+                    "code": "%s",
+                    "code_verifier": "%s"
+                }
+                """.formatted(exchangeCode, VALID_VERIFIER);
+
+        mockMvc.perform(post("/api/core/public/exchange-code").contentType(MediaType.APPLICATION_JSON).content(rawSnakeCaseJson)).andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store")).andExpect(content().string(expectedJwt));
+    }
+
+    @Test
+    void testExchangeCodeToJwtToken_codeIsSingleUse() throws Exception {
+        String challenge = OIDCExchangeCodeService.computeSHA256Challenge(VALID_VERIFIER);
+        String expectedJwt = "single-use.jwt.token";
+        String exchangeCode = oidcExchangeCodeService.storeJwtAndGenerateCode(expectedJwt, challenge);
+
+        OIDCCodeExchangeDTO requestDto = new OIDCCodeExchangeDTO(exchangeCode, VALID_VERIFIER);
+
+        mockMvc.perform(post("/api/core/public/exchange-code").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk()).andExpect(content().string(expectedJwt));
+
+        mockMvc.perform(post("/api/core/public/exchange-code").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResourceTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -28,7 +28,7 @@ class PublicUserJwtResourceTest extends AbstractSpringIntegrationIndependentTest
 
     private final ObjectMapper objectMapper;
 
-    @MockitoSpyBean
+    @MockitoBean
     private RateLimitService rateLimitService;
 
     @Autowired

--- a/src/test/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResourceTest.java
@@ -1,0 +1,61 @@
+package de.tum.cit.aet.artemis.core.web.open;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.tum.cit.aet.artemis.account.dto.OIDCCodeExchangeDTO;
+import de.tum.cit.aet.artemis.admin.service.RateLimitService;
+import de.tum.cit.aet.artemis.core.exception.RateLimitExceededException;
+import de.tum.cit.aet.artemis.core.security.RateLimitType;
+import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
+
+class PublicUserJwtResourceTest extends AbstractSpringIntegrationIndependentTest {
+
+    private final MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper;
+
+    @MockitoSpyBean
+    private RateLimitService rateLimitService;
+
+    @Autowired
+    public PublicUserJwtResourceTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+        this.mockMvc = mockMvc;
+        this.objectMapper = objectMapper;
+    }
+
+    @Test
+    void testExchangeCodeToJwtToken_whenOidcDisabled_returnsNotFound() throws Exception {
+        OIDCCodeExchangeDTO requestDto = new OIDCCodeExchangeDTO("any-code", "any-verifier-12345678901234567890123456789012345");
+
+        MvcResult result = mockMvc.perform(post("/api/core/public/exchange-code").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)))
+                .andReturn();
+
+        assertThat(result.getResponse().getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    void testExchangeCodeToJwtToken_rateLimitExceeded_returnsTooManyRequests() throws Exception {
+        doThrow(new RateLimitExceededException(60)).when(rateLimitService).enforcePerMinute(any(), eq(RateLimitType.AUTHENTICATION));
+
+        OIDCCodeExchangeDTO requestDto = new OIDCCodeExchangeDTO("any-code", "any-verifier-12345678901234567890123456789012345");
+
+        MvcResult result = mockMvc.perform(post("/api/core/public/exchange-code").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)))
+                .andReturn();
+
+        assertThat(result.getResponse().getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResourceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResourceTest.java
@@ -1,25 +1,18 @@
 package de.tum.cit.aet.artemis.core.web.open;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.tum.cit.aet.artemis.account.dto.OIDCCodeExchangeDTO;
-import de.tum.cit.aet.artemis.admin.service.RateLimitService;
-import de.tum.cit.aet.artemis.core.exception.RateLimitExceededException;
-import de.tum.cit.aet.artemis.core.security.RateLimitType;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationIndependentTest;
 
 class PublicUserJwtResourceTest extends AbstractSpringIntegrationIndependentTest {
@@ -27,9 +20,6 @@ class PublicUserJwtResourceTest extends AbstractSpringIntegrationIndependentTest
     private final MockMvc mockMvc;
 
     private final ObjectMapper objectMapper;
-
-    @MockitoBean
-    private RateLimitService rateLimitService;
 
     @Autowired
     public PublicUserJwtResourceTest(MockMvc mockMvc, ObjectMapper objectMapper) {
@@ -45,17 +35,5 @@ class PublicUserJwtResourceTest extends AbstractSpringIntegrationIndependentTest
                 .andReturn();
 
         assertThat(result.getResponse().getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
-    }
-
-    @Test
-    void testExchangeCodeToJwtToken_rateLimitExceeded_returnsTooManyRequests() throws Exception {
-        doThrow(new RateLimitExceededException(60)).when(rateLimitService).enforcePerMinute(any(), eq(RateLimitType.AUTHENTICATION));
-
-        OIDCCodeExchangeDTO requestDto = new OIDCCodeExchangeDTO("any-code", "any-verifier-12345678901234567890123456789012345");
-
-        MvcResult result = mockMvc.perform(post("/api/core/public/exchange-code").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(requestDto)))
-                .andReturn();
-
-        assertThat(result.getResponse().getStatus()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS.value());
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationLocalVCSamlTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationLocalVCSamlTest.java
@@ -47,7 +47,13 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParti
 @ActiveProfiles({ SPRING_PROFILE_TEST, PROFILE_ARTEMIS, PROFILE_CORE, PROFILE_LOCALVC, PROFILE_LOCALCI, PROFILE_SCHEDULING })
 @TestPropertySource(locations = "classpath:config/application-saml2.yml", factory = YamlPropertySourceFactory.class, properties = { SAML2_ENABLED_PROPERTY_NAME + "=true",
         ATLAS_ENABLED_PROPERTY_NAME + "=false", "artemis.athena.enabled=false", "artemis.apollon.enabled=false", PASSKEY_ENABLED_PROPERTY_NAME + "=true",
-        "artemis.user-management.use-external=false", "spring.jpa.properties.hibernate.cache.hazelcast.instance_name=Artemis_localvc_saml", "artemis.lti.enabled=true" })
+        "artemis.user-management.use-external=false", "spring.jpa.properties.hibernate.cache.hazelcast.instance_name=Artemis_localvc_saml", "artemis.lti.enabled=true",
+        "artemis.user-management.oidc.enabled=true",
+        // OIDC test properties for sharing the Spring Context
+        "spring.security.oauth2.client.registration.oidc.client-id=mock-client-id", "spring.security.oauth2.client.registration.oidc.client-secret=mock-secret",
+        "spring.security.oauth2.client.provider.oidc.issuer-uri=http://mock-issuer", "spring.security.oauth2.client.provider.oidc.authorization-uri=http://mock-auth",
+        "spring.security.oauth2.client.provider.oidc.token-uri=http://mock-token", "spring.security.oauth2.client.provider.oidc.user-info-uri=http://mock-user",
+        "spring.security.oauth2.client.provider.oidc.jwk-set-uri=http://mock-jwk" })
 public abstract class AbstractSpringIntegrationLocalVCSamlTest extends AbstractArtemisIntegrationTest {
 
     private static int sshPort;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 
This PR enhances the OpenID Connect (OIDC) authentication flow to support external clients (specifically the VS Code extension) by introducing a secure, PKCE-bound single-use code exchange mechanism. External clients initiate login with a SHA-256 code challenge and receive a short-lived exchange code via deep-linking, which is then atomically redeemed for an Artemis JWT token via a secure POST endpoint.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [X] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Server
- [X] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [X] I **strictly** followed the principle of **data economy** for all database calls.
- [X] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [X] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, OIDC authentication in Artemis only supports the browser web application, always redirecting users to the root path (/) upon successful login. External desktop clients, such as the VS Code extension, need to support university Identity Providers (IdP) for authentication without exposing sensitive raw JWT tokens in browser histories, process logs, or custom URI scheme handlers.

Following OAuth 2.0 / RFC 7636 best practices for native clients, this PR implements an authorization code exchange with Proof Key for Code Exchange (PKCE) to prevent authorization code injection and credential interception.

### Description
<!-- Describe your changes in detail -->
This PR introduces the following changes and security enhancements:
- PKCE Authorization Initiation (/oauth2/authorization/oidc):
  - Supports `redirect=vscode` and `code_challenge` (S256) query parameters.

  - Validates and temporarily stores the PKCE `code_challenge` in the session alongside the redirect target.

- Secure Callback & Deep-Link Redirection (OIDCAuthenticationSuccessHandler):

  - On successful OIDC authentication, if `redirect=vscode` is specified and a valid `code_challenge` is present, the handler generates a short-lived, single-use exchange code.

  - Stores both the `jwtToken` and `codeChallenge` in a single immutable record (`ExchangeCodeEntry`) inside a distributed Hazelcast cache with a 5-minute TTL.

  - Invalidates the user session, opens a new redirect-page and redirects to the VS Code custom scheme handler: `vscode://aet-tum.iris-thaumantias/auth-callback?code={exchangeCode}`.

  - If the request is missing a required `code_challenge` or the account is deactivated, it safely redirects with appropriate error query parameters (`error=invalid_request`, `error=deactivated`, `error=oidcFailure`).

- Atomic Token Redemption Endpoint (POST /api/core/public/exchange-code):

  - Accepts a JSON payload (`OIDCCodeExchangeDTO`) containing `code` and `code_verifier` (compatible with both code_verifier and codeVerifier).

  - Uses POST (instead of GET query parameters) and returns Cache-Control: no-store to prevent credentials from being persisted in web server access logs, intermediate proxies, or browser caches.

- Security & Concurrency Hardening (OIDCExchangeCodeService):

  - Strict RFC 7636 Format Validation: Verifies that code_verifier matches ^[a-zA-Z0-9\-._~]{43,128}$ and code_challenge matches ^[a-zA-Z0-9\-_]{43}$.

  - Timing-Attack Resistance: Validates the verifier against the challenge using constant-time comparison (MessageDigest.isEqual).

  - Atomic Single-Use Redemption (CAS): Verifies the PKCE verifier before touching the cache so invalid attempts do not invalidate valid codes (DoS prevention). On match, consumes the entry via Hazelcast atomic conditional removal (IMap.remove(code, entry)), preventing race conditions and double-redemption.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->

Prerequisites:
- Any browser (preferably Google Chrome).
This PR is directly bound to the VS code extension implementation, so please, download the [VS Code Extension repository](https://github.com/ls1intum/artemis-extension).
<!-- Use the changes from [this PR:](https://github.com/ls1intum/artemis-extension/pull/420) -->
Since this is not completely [Artemis](https://github.com/ls1intum/Artemis) related PR, if you have any problems with launching VS code extension properly, just let me know either in Slack or here in comments, I'll help you with setup.

1) Open the VS code extension in VS code

2) Make sure you set up your VS code extension with right changes. You should see such login view:
<img width="277" height="252" alt="image" src="https://github.com/user-attachments/assets/1515f14e-bcec-4833-b90c-0eb50638b6d7" />

3) In `Open Artemis Settings` put the Artemis Url of your server where you test the Pr (e.g., `https://artemis-test5.artemis.cit.tum.de`)

4) Enter you TUM id (e.g., `go42tum`)

5) Click on `Sign in with TUM Login`

6) You should be redirected to TUM Login IdP page

7) Open the network tab and complete the authentication

8) After successful login, make sure that a redirect-page is opened and you are asked to open VS code extension.
The redirect page should look like this:
<img width="828" height="573" alt="image" src="https://github.com/user-attachments/assets/2981bd50-9103-4cc2-bf09-acdaf6bd062b" />

9) Verify that in Network tab you should get such Url: `vscode://aet-tum.iris-thaumantias/auth-callback?code={some code}`

10) Open the VS code extension as you were asked

11) Verify that in the end you was logged into your account. 

Thanks for testing :)


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->
- [x] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| OIDCConfiguration.java | 63.64% | 95 |
| OIDCConstants.java | 100.00% | 10 |
| OIDCCodeExchangeDTO.java | 100.00% | 7 |
| OIDCAuthenticationFailureHandler.java | 100.00% | 55 |
| OIDCAuthenticationSuccessHandler.java | 98.25% | 110 |
| OIDCExchangeCodeService.java | 81.82% | 111 |
| PublicUserJwtResource.java | 94.12% | 139 |

_Last updated: 2026-09-02 12:59:26 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added secure, single-use authorization-code exchange for VS Code sign-in using PKCE verification.
- VS Code authentication now displays a dedicated callback page with automatic deep-link redirection.
- Added JWT exchange support for valid codes and verifiers, including snake_case verifier input.

## Bug Fixes
- Improved handling of failed and deactivated-user sign-ins.
- Sessions and stale authentication data are cleared after authentication attempts.
- Invalid, expired, reused, or incorrectly verified exchange codes are rejected.
- Authentication callback responses are protected from caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->