### PR TITLE
`Development`: Fix the failing student exam server tests

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamDtoWireContractTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamDtoWireContractTest.java
@@ -87,7 +87,8 @@ class StudentExamDtoWireContractTest extends AbstractSpringIntegrationIndependen
         student = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
         instructor = userUtilService.getUserByLogin(TEST_PREFIX + "instructor1");
 
-        textExercise = examUtilService.addCourseExamWithReviewDatesExerciseGroupWithOneTextExercise();
+        // the enrolling variant is required: the endpoints under test authorize through the course roles of the user, so without enrollment every request is answered with 403
+        textExercise = examUtilService.addEnrolledCourseExamWithReviewDatesExerciseGroupWithOneTextExercise(TEST_PREFIX);
         exam = textExercise.getExerciseGroup().getExam();
         course = exam.getCourse();
 

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamIntegrationTest.java
@@ -380,11 +380,11 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testGetStudentExamsForExam_asInstructor() throws Exception {
-        // measured baseline is 7 queries (auth + access checks + findByExamIdWithSessions); guards against an
-        // accidental N+1 regression (e.g. touching a lazy association per element) creeping into the DTO factory
+        // measured baseline is 8 queries (auth + access checks including the user_course_role membership check + findByExamIdWithSessions);
+        // guards against an accidental N+1 regression (e.g. touching a lazy association per element) creeping into the DTO factory
         List<StudentExamDTO> studentExams = assertThatDb(
                 () -> request.getList("/api/exam/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams", HttpStatus.OK, StudentExamDTO.class))
-                .hasBeenCalledAtMostTimes(7);
+                .hasBeenCalledAtMostTimes(8);
         assertThat(studentExams).hasSize(2);
         // the nested exam/user are intentionally omitted for this endpoint (see StudentExamDTO#of)
         assertThat(studentExams).allSatisfy(dto -> {
@@ -752,11 +752,11 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVC
         examUtilService.setupTestRunForExamWithExerciseGroupsForInstructor(exam, instructor, exam.getExerciseGroups());
         examUtilService.setupTestRunForExamWithExerciseGroupsForInstructor(exam, instructor2, exam.getExerciseGroups());
 
-        // measured baseline is 7 queries (auth + access checks + findAllTestRunsByExamId); guards against an
-        // accidental N+1 regression (e.g. touching a lazy association per element) creeping into the DTO factory
+        // measured baseline is 8 queries (auth + access checks including the user_course_role membership check + findAllTestRunsByExamId);
+        // guards against an accidental N+1 regression (e.g. touching a lazy association per element) creeping into the DTO factory
         List<StudentExamDTO> response = assertThatDb(
                 () -> request.getList("/api/exam/courses/" + exam.getCourse().getId() + "/exams/" + exam.getId() + "/test-runs", HttpStatus.OK, StudentExamDTO.class))
-                .hasBeenCalledAtMostTimes(7);
+                .hasBeenCalledAtMostTimes(8);
         assertThat(response).hasSize(2);
         // the template reads user.name/user.id (see StudentExamDTO#withUser); the nested exam is intentionally omitted
         assertThat(response).allSatisfy(dto -> {


### PR DESCRIPTION
### Summary

Seven server tests have been failing on develop since #13186 was merged, which makes `Test / Server Tests (PostgreSQL)` red for every pull request opened against develop. This pull request repairs all seven. They are test-only problems: no production behaviour changes.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context

`Test / Server Tests (PostgreSQL)` currently fails on develop itself with 7 failures, so the required gate is red on every open pull request regardless of what that pull request changes. All seven tests were introduced or touched by #13186, and they fail at that merge commit as well, which means they never passed on develop even once.

Verified by checking out the merge commit of #13186 and running the three affected classes: 7 tests, 0 successes, 7 failures. The two commits that landed on develop afterwards are unrelated, so nothing else can be responsible.

### Description

Two separate causes.

**Five failures in `StudentExamDtoWireContractTest`, all `Response status expected:<200> but was:<403>`.**

The setup created its course with `addCourseExamWithReviewDatesExerciseGroupWithOneTextExercise()`, the variant that does not enroll anybody. The endpoints under test authorize through the course roles of the requesting user, so neither the student nor the instructor was ever a member of the course and every request was rejected. The fix switches to `addEnrolledCourseExamWithReviewDatesExerciseGroupWithOneTextExercise(TEST_PREFIX)`, the enrolling variant of the same helper, which is what comparable exam tests use.

**Two failures in `StudentExamIntegrationTest`, both `Expected at most <7> queries, but <8> were performed`.**

`testGetStudentExamsForExam_asInstructor` and `testFindAllTestRunsForExam` guard against an N+1 in the DTO factory with a query budget. The budget was written as 7, but both endpoints issue 8 on develop. Captured the statements with `org.hibernate.SQL` at debug level: the additional one is

```sql
select exists(select ucr1_0.course_id, ucr1_0.course_role, ucr1_0.user_id
              from user_course_role ucr1_0
              where ucr1_0.user_id = ? and ucr1_0.course_id = ? and ucr1_0.course_role in (?))
```

which is the membership check introduced when course group strings were replaced by user course roles. It is a constant part of the authorization path, not an N+1: both endpoints are off by exactly one although they return different result sets, and the student exams themselves still arrive in a single query with their sessions joined. The budgets are therefore raised to the value that is actually measured, and the comments now name the extra statement so the next reader does not have to capture SQL again.

### Steps for Testing

This is a test-only change, so the verification is running the tests.

1. Check out develop and run `./gradlew test --tests StudentExamDtoWireContractTest --tests StudentExamIntegrationTest -x webapp`. Seven tests fail.
2. Check out this branch and run the same command. All 132 tests in the two classes pass.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-10 18:34:38 UTC_


### Note on the large class check

`Quality / Server Code Quality` will fail on this pull request for a reason it does not cause: develop currently has 18 classes over 1000 lines against a budget of 17, because #13186 also took `Exercise.java` from exactly 1000 to 1005 lines. #13474 removes 30 lines from that entity and brings the count back to 17, which is the proper fix. This pull request deliberately does not raise the threshold.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated exam test fixtures to use properly enrolled participants.
  * Adjusted expected database query counts for student exam and test-run list requests.
  * Expanded test documentation to reflect authorization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->