### PR TITLE
`General`: Align items in collapsed sidebar

### DIFF
--- a/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.html
+++ b/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.html
@@ -12,7 +12,7 @@
         </div>
 
         <!-- NavItems grouped -->
-        <div>
+        <div class="justify-items-center">
             <hr class="mt-0" />
             <ul class="grow list-none p-0">
                 @for (group of sidebarGroups(); track group.translation; let groupIndex = $index) {
@@ -50,12 +50,12 @@
         </div>
     </div>
 
-    <div class="mb-2 shrink-0 bg-[var(--module-bg)]">
+    <div class="my-2 shrink-0 bg-[var(--module-bg)]">
         @if (!isNavbarCollapsed() && canExpand()) {
             <button
                 type="button"
-                class="double-arrow flex w-full cursor-pointer items-center justify-end border-none bg-transparent px-2 pe-[10px] font-[inherit] text-inherit"
-                [class.menu-closed]="isNavbarCollapsed()"
+                class="flex w-full justify-end border-none bg-transparent px-2"
+                [class.menu-collapsed]="isNavbarCollapsed()"
                 [tumUiTooltip]="'global.menu.admin.collapseMenu' | artemisTranslate"
                 tumUiTooltipPlacement="right"
                 (click)="toggleCollapseState.emit()"
@@ -72,15 +72,15 @@
         @if (isNavbarCollapsed() && canExpand()) {
             <button
                 type="button"
-                class="double-arrow mb-2 flex w-full cursor-pointer items-center justify-center border-none bg-transparent pe-[10px] font-[inherit] text-inherit"
-                [class.menu-closed]="isNavbarCollapsed()"
+                class="w-full border-none bg-transparent text-center"
+                [class.menu-collapsed]="isNavbarCollapsed()"
                 [tumUiTooltip]="'global.menu.admin.expandMenu' | artemisTranslate"
                 tumUiTooltipPlacement="right"
                 (click)="toggleCollapseState.emit()"
                 [attr.aria-expanded]="!isNavbarCollapsed()"
                 data-testid="admin-sidebar-expand"
             >
-                <span class="double-arrow-icon inline-flex min-w-10 items-center gap-1">
+                <span class="double-arrow-icon gap-1">
                     <fa-icon class="-me-[10px] fa-xs" [icon]="faChevronRight" />
                     <fa-icon class="fa-xs" [icon]="faChevronRight" />
                 </span>

--- a/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.html
+++ b/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.html
@@ -1,8 +1,8 @@
-<div class="sidebar-container flex h-full min-h-full flex-col justify-between bg-[var(--module-bg)]" [class.collapsed]="isNavbarCollapsed()" data-testid="admin-sidebar">
+<div class="sidebar-container flex h-full min-h-full flex-col justify-between bg-(--module-bg)" [class.collapsed]="isNavbarCollapsed() || !canExpand()" data-testid="admin-sidebar">
     <div class="flex-1 overflow-x-hidden overflow-y-auto">
         <!-- Admin Header -->
         <div id="admin-header" class="flex items-center p-3 no-underline">
-            <div class="admin-icon flex h-9 min-w-9 items-center justify-center rounded-full bg-[var(--course-image-bg)] text-color">
+            <div class="admin-icon flex h-9 min-w-9 items-center justify-center rounded-full bg-(--course-image-bg) text-color">
                 <fa-icon [icon]="faUserShield" />
             </div>
             @if (!isNavbarCollapsed()) {
@@ -12,7 +12,7 @@
         </div>
 
         <!-- NavItems grouped -->
-        <div class="justify-items-center">
+        <div>
             <hr class="mt-0" />
             <ul class="grow list-none p-0">
                 @for (group of sidebarGroups(); track group.translation; let groupIndex = $index) {
@@ -23,7 +23,7 @@
                         </li>
                     } @else if (groupIndex > 0) {
                         <li>
-                            <hr class="mx-2 my-2 border-[var(--p-content-border-color)] opacity-50" />
+                            <hr class="mx-2 my-2 border-surface opacity-50" />
                         </li>
                     }
 
@@ -33,7 +33,7 @@
                             <a
                                 class="nav-link-sidebar flex items-center px-2 py-2 whitespace-nowrap no-underline"
                                 [attr.id]="item.testId"
-                                [class.collapsed]="isNavbarCollapsed()"
+                                [class.collapsed]="isNavbarCollapsed() || !canExpand()"
                                 [routerLink]="item.routerLink"
                                 routerLinkActive="active"
                                 [title]="item.title"
@@ -50,7 +50,7 @@
         </div>
     </div>
 
-    <div class="my-2 shrink-0 bg-[var(--module-bg)]">
+    <div class="my-2 shrink-0 bg-(--module-bg)">
         @if (!isNavbarCollapsed() && canExpand()) {
             <button
                 type="button"

--- a/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.scss
+++ b/src/main/webapp/app/admin/admin-sidebar/admin-sidebar.component.scss
@@ -62,17 +62,12 @@
     text-decoration-thickness: 1px;
 }
 
-/* Chevron rotation/translation reacts to the runtime `menu-closed` class, so it stays in SCSS. */
-.double-arrow.menu-closed {
-    transform: translate(16px);
-}
-
 .double-arrow-icon {
     transition: transform 0.3s ease;
     transform: rotate(180deg);
 }
 
-.menu-closed .double-arrow-icon {
+.menu-collapsed .double-arrow-icon {
     transform: rotate(0deg);
 }
 

--- a/src/main/webapp/app/course/shared/course-sidebar/course-sidebar.component.html
+++ b/src/main/webapp/app/course/shared/course-sidebar/course-sidebar.component.html
@@ -1,15 +1,15 @@
-<div class="mt-2 sidebar-container d-flex h-100 justify-content-between flex-column" [class]="{ collapsed: isNavbarCollapsed() }">
+<div class="mt-2 sidebar-container px-1 d-flex h-100 justify-content-between flex-column" [class]="{ collapsed: isNavbarCollapsed() || !canExpand() }">
     <div>
         <!-- NavItems -->
         <div>
-            <ul ngbDropdown #itemsDrop="ngbDropdown" container="body" placement="right" class="navbar-nav justify-content-end flex-grow-1 text-decoration-none">
+            <ul ngbDropdown #itemsDrop="ngbDropdown" container="body" placement="right" class="navbar-nav justify-content-end grow text-decoration-none">
                 @for (sidebarItem of sidebarItemsTop(); track sidebarItem.routerLink) {
                     <li class="nav-item" [hidden]="sidebarItem.hidden">
                         <ng-template *ngTemplateOutlet="navItem; context: { $implicit: sidebarItem, iconTextTemplate: navIconAndText }" />
                     </li>
                 }
                 <li ngbDropdownToggle class="nav-item">
-                    <div [hidden]="!anyItemHidden()" class="three-dots nav-link px-2">
+                    <div [hidden]="!anyItemHidden()" class="three-dots nav-link nav-link-sidebar px-2" [class]="{ collapsed: isNavbarCollapsed() }">
                         <fa-icon [fixedWidth]="true" [icon]="faEllipsis" />
                         <span
                             class="more ms-2"
@@ -28,7 +28,7 @@
                         @for (courseActionItem of courseActionItems(); track courseActionItem) {
                             <li class="nav-item">
                                 <a
-                                    class="nav-link nav-link-sidebar px-2 py-2"
+                                    class="nav-link nav-link-sidebar py-2"
                                     [ngClass]="{ collapsed: isNavbarCollapsed() }"
                                     (click)="courseActionItemClick.emit(courseActionItem)"
                                     [title]="courseActionItem.title"
@@ -50,7 +50,7 @@
                     @for (courseActionItem of courseActionItems(); track courseActionItem; let i = $index) {
                         <a
                             [id]="'action-item-' + i"
-                            class="nav-link nav-link-sidebar px-2"
+                            class="nav-link nav-link-sidebar"
                             [ngClass]="{ collapsed: isNavbarCollapsed() }"
                             (click)="courseActionItemClick.emit(courseActionItem)"
                             [title]="courseActionItem.title"
@@ -65,13 +65,13 @@
         <div class="navbar-nav mb-2">
             @for (bottomItem of sidebarItemsBottom(); track bottomItem.routerLink; let isLast = $last) {
                 <li class="nav-item" [hidden]="bottomItem.hidden">
-                    <div class="d-flex align-items-center justify-content-between">
+                    <div [class.d-flex]="!isNavbarCollapsed() && canExpand()">
                         <a
                             class="nav-link nav-link-sidebar px-2 py-2"
                             [id]="bottomItem.testId ?? ''"
                             [ngClass]="{
                                 newMessage: !communicationRouteLoaded() && hasUnreadMessages() && bottomItem.title === 'Communication',
-                                collapsed: isNavbarCollapsed(),
+                                collapsed: isNavbarCollapsed() || !canExpand(),
                             }"
                             [routerLink]="bottomItem.routerLink"
                             routerLinkActive="active"
@@ -92,7 +92,7 @@
                         @if (isLast && !isNavbarCollapsed() && canExpand()) {
                             <div
                                 class="double-arrow px-2"
-                                [ngClass]="{ 'menu-closed': isNavbarCollapsed() }"
+                                [ngClass]="{ 'menu-collapsed': isNavbarCollapsed() }"
                                 [ngbTooltip]="'Collapse Menu (Ctrl + M)'"
                                 tooltipClass="double-arrow-tooltip"
                                 [container]="'body'"
@@ -110,8 +110,8 @@
 
             @if ((isNavbarCollapsed() || !sidebarItemsBottom().length) && canExpand()) {
                 <div
-                    class="double-arrow mb-2"
-                    [ngClass]="{ 'menu-closed': isNavbarCollapsed() }"
+                    class="double-arrow mb-3"
+                    [ngClass]="{ 'menu-collapsed': isNavbarCollapsed() }"
                     [tooltipClass]="isNavbarCollapsed() ? 'double-arrow-tooltip-collapsed' : 'double-arrow-tooltip-no-bottom-items'"
                     [ngbTooltip]="(isNavbarCollapsed() ? 'Expand' : 'Collapse') + ' Menu (Ctrl + M)'"
                     (click)="toggleCollapseState.emit()"

--- a/src/main/webapp/app/course/shared/course-sidebar/course-sidebar.component.html
+++ b/src/main/webapp/app/course/shared/course-sidebar/course-sidebar.component.html
@@ -91,7 +91,7 @@
                         </a>
                         @if (isLast && !isNavbarCollapsed() && canExpand()) {
                             <div
-                                class="double-arrow px-2"
+                                class="double-arrow pe-1"
                                 [ngClass]="{ 'menu-collapsed': isNavbarCollapsed() }"
                                 [ngbTooltip]="'Collapse Menu (Ctrl + M)'"
                                 tooltipClass="double-arrow-tooltip"

--- a/src/main/webapp/app/course/shared/course-sidebar/course-sidebar.component.scss
+++ b/src/main/webapp/app/course/shared/course-sidebar/course-sidebar.component.scss
@@ -66,7 +66,7 @@ $transition-color-length: 0.2s;
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    min-width: 40px;
+    min-width: 22px;
     transition: transform 0.3s ease;
     transform: rotate(180deg);
 }

--- a/src/main/webapp/app/course/shared/course-sidebar/course-sidebar.component.scss
+++ b/src/main/webapp/app/course/shared/course-sidebar/course-sidebar.component.scss
@@ -44,9 +44,10 @@ $transition-color-length: 0.2s;
  * Open, the toggle is pushed towards the right edge; collapsed it centres in the rail like every icon above it, so
  * the nudge and the padding that align it in the open state have to go.
  */
-.double-arrow.menu-closed {
+.double-arrow.menu-collapsed {
     transform: none;
     padding-right: 0;
+    margin-top: 0.5rem;
 }
 
 .double-arrow {
@@ -55,10 +56,9 @@ $transition-color-length: 0.2s;
     align-items: center;
     justify-content: flex-end;
     cursor: pointer;
-    padding-right: 10px;
 }
 
-.menu-closed.double-arrow {
+.menu-collapsed.double-arrow {
     justify-content: center;
 }
 
@@ -71,7 +71,7 @@ $transition-color-length: 0.2s;
     transform: rotate(180deg);
 }
 
-.menu-closed .double-arrow-icon {
+.menu-collapsed .double-arrow-icon {
     transform: rotate(0deg);
 
     /* The 40px minimum is what reserves room for the label beside it when open; collapsed it just offsets the pair. */
@@ -93,6 +93,11 @@ $transition-color-length: 0.2s;
         width: var(--sidebar-nav-width-collapsed) !important;
     }
 
+    .nav-link-sidebar.collapsed {
+        display: flex;
+        justify-content: center;
+    }
+
     .auto-collapse {
         display: none;
     }
@@ -109,38 +114,12 @@ $transition-color-length: 0.2s;
     color: var(--bs-body-color);
 }
 
-/*
- * Collapsed an item is nothing but its icon, so centre it in the rail. The gap to the label sits on the label rather
- * than on the icon for exactly this reason: with the label gone there is no margin left to push the icon off-centre.
- */
-.nav-link-sidebar.collapsed {
+.collapsed .nav-link-sidebar {
     display: flex;
     justify-content: center;
 
-    > .d-flex {
-        justify-content: center;
-    }
-}
-
-.sidebar-container.collapsed {
-    /*
-     * The bottom items share their row with the collapse toggle while the sidebar is open, so the link is only as wide
-     * as its content — collapsed, that left the settings icon short of the centre the icons above it sit on. The
-     * dropdown toggle is a plain `.nav-link`, so it needs centring of its own.
-     */
-    .nav-link-sidebar,
-    .three-dots {
-        width: 100%;
-    }
-
-    .three-dots {
-        display: flex;
-        justify-content: center;
-    }
-
-    /* Set the expand toggle apart from the last item rather than having it read as another entry. */
-    .double-arrow {
-        margin-top: 0.75rem;
+    .dropdown-content & {
+        justify-content: flex-start;
     }
 }
 
@@ -170,18 +149,12 @@ a:not(.btn):not(.tab-link):hover {
     }
 }
 
-.dropdown-li {
-    display: block;
-    text-decoration: none;
-}
-
 .dropdown-content {
     overflow-y: auto;
-    position: absolute;
     background-color: var(--dropdown-bg);
     border: 1px solid var(--border-color);
     z-index: 3000;
-    border-radius: 4px;
+    border-radius: 0.25rem;
 
     &.fixedContentSize {
         max-height: 171px; // To avoid cut offs in the dropdown menu content (4 items)
@@ -189,8 +162,7 @@ a:not(.btn):not(.tab-link):hover {
 }
 
 .dropdown-menu {
-    min-width: 204px;
-    max-width: 294px;
+    max-width: var(--sidebar-nav-width);
 }
 
 .dropdown-courses.active {
@@ -211,8 +183,7 @@ a:not(.btn):not(.tab-link):hover {
 ::ng-deep .double-arrow-tooltip {
     // without this styling the tooltip is positioned with some distance to the left of the collapse icon when the sidebar is expanded.
     // the margin bottom ensures the tooltip does not overlap with the collapse icon
-    left: 2rem !important;
-    margin-bottom: 0.25rem !important;
+    margin-left: 0.8rem !important;
 }
 
 ::ng-deep .double-arrow-tooltip-no-bottom-items {
@@ -222,5 +193,5 @@ a:not(.btn):not(.tab-link):hover {
 
 ::ng-deep .double-arrow-tooltip-collapsed {
     // without this styling the tooltip is positioned with too much distance to the right of the collapse icon when the sidebar is collapsed.
-    left: -2.25rem !important;
+    margin-left: -0.5rem !important;
 }

--- a/src/main/webapp/app/course/shared/course-sidebar/course-sidebar.component.scss
+++ b/src/main/webapp/app/course/shared/course-sidebar/course-sidebar.component.scss
@@ -114,13 +114,13 @@ $transition-color-length: 0.2s;
     color: var(--bs-body-color);
 }
 
+.dropdown-content .nav-link-sidebar {
+    justify-content: flex-start;
+}
+
 .collapsed .nav-link-sidebar {
     display: flex;
     justify-content: center;
-
-    .dropdown-content & {
-        justify-content: flex-start;
-    }
 }
 
 .nav-link-sidebar:hover,

--- a/src/main/webapp/app/exam/overview/exam-navigation-sidebar/exam-navigation-sidebar.component.html
+++ b/src/main/webapp/app/exam/overview/exam-navigation-sidebar/exam-navigation-sidebar.component.html
@@ -66,7 +66,7 @@
     <div
         id="test-collapse"
         class="auto-collapse double-arrow mb-2"
-        [ngClass]="{ 'menu-closed': isCollapsed() }"
+        [ngClass]="{ 'menu-collapsed': isCollapsed() }"
         [ngbTooltip]="(isCollapsed() ? 'Expand' : 'Collapse') + ' Menu (Ctrl + M)'"
         (click)="toggleCollapseState()"
     >

--- a/src/main/webapp/app/exam/overview/exam-navigation-sidebar/exam-navigation-sidebar.component.scss
+++ b/src/main/webapp/app/exam/overview/exam-navigation-sidebar/exam-navigation-sidebar.component.scss
@@ -85,7 +85,7 @@ $exam-sidebar-margin: 62px;
     }
 }
 
-.double-arrow.menu-closed {
+.double-arrow.menu-collapsed {
     transform: translate(24px);
 }
 
@@ -99,7 +99,7 @@ $exam-sidebar-margin: 62px;
     display: flex;
 }
 
-.menu-closed .double-arrow-icon {
+.menu-collapsed .double-arrow-icon {
     transform: rotate(0deg);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The sidebar items were no longer centered when the sidebar automatically collapsed due to the screen size. This fix restores the correct alignment in the collapsed state.

### Description
<!-- Describe your changes in detail -->
This PR fixes several sidebar layout and interaction issues:
- Centers sidebar items again when the sidebar is automatically collapsed due to reduced screen width.
- Left-aligns items inside the More menu instead of centering them.
- Reduces the width of the More menu.
- Removes unused code.
- Fixes a flickering tooltip on the sidebar collapse icon.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor
- 1 admin

1. Open the sidebar in the Student View
2. Collapse and expand the sidebar manually.
3. Hover over the sidebar collapse icon and verify that the tooltip no longer flickers.
4. Reduce the screen width until the sidebar collapses automatically.
5. Verify that sidebar items remain centered in both collapsed states.
Repeat Step 1-5 for the Management View and the Admin View, too. 

6. In the Student View and Management View, reduce the screen height until the More item appears.
7. Open the More menu and verify that its items are left-aligned.
Repeat Steps 5 & 6 for the Management View, too. 



Note: The Admin View does not have a More menu.
### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before: 
<img width="288" height="306" alt="Screenshot 2026-08-10 at 18 24 06" src="https://github.com/user-attachments/assets/c3f75399-663e-48cb-ae70-ccc6d1de0254" />
<img width="118" height="903" alt="Screenshot 2026-08-10 at 21 08 03" src="https://github.com/user-attachments/assets/b1a717d3-bfbd-405c-8511-9f69f9dc553e" />
https://github.com/user-attachments/assets/03d073ba-cc92-46be-9e79-57223927c501


After: 
<img width="80" height="832" alt="Screenshot 2026-08-10 at 21 14 32" src="https://github.com/user-attachments/assets/9e3c4880-93e8-4d7b-86fc-e49a5124511e" />
<img width="168" height="136" alt="image" src="https://github.com/user-attachments/assets/0268b502-2eec-4f1e-99f9-de0ff047d825" />
https://github.com/user-attachments/assets/6991297a-33c6-4b77-a29d-36dcb5e11ee2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## UI Improvements

- Refined admin, course, and exam navigation sidebar layouts.
- Improved collapse and expand controls with consistent visual states.
- Enhanced alignment and centering of links and controls in collapsed sidebars.
- Adjusted dropdown sizing, spacing, icon positioning, and tooltip placement.
- Updated sidebar separators, spacing, and responsive behavior for a cleaner navigation experience.
- Improved handling of sidebar content when expansion is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->