### PR TITLE
`Communication`: Keep the open conversation when loading the conversations fails

### DIFF
--- a/src/main/webapp/app/communication/course-conversations-components/layout/conversation-header/conversation-header.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/layout/conversation-header/conversation-header.component.ts
@@ -146,6 +146,8 @@ export class ConversationHeaderComponent implements OnInit, OnDestroy {
             .subscribe(() => {
                 this.metisConversationService.forceRefresh().subscribe({
                     complete: () => {},
+                    // the service already reported the failure to the user, nothing is derived from the refresh here
+                    error: () => {},
                 });
             });
     }
@@ -179,6 +181,8 @@ export class ConversationHeaderComponent implements OnInit, OnDestroy {
             .subscribe(() => {
                 this.metisConversationService.forceRefresh().subscribe({
                     complete: () => {},
+                    // the service already reported the failure to the user, nothing is derived from the refresh here
+                    error: () => {},
                 });
                 this.onUpdateSidebar.emit();
             });

--- a/src/main/webapp/app/communication/course-conversations-components/layout/conversation-header/conversation-header.component.ts
+++ b/src/main/webapp/app/communication/course-conversations-components/layout/conversation-header/conversation-header.component.ts
@@ -168,7 +168,11 @@ export class ConversationHeaderComponent implements OnInit, OnDestroy {
                 selectedTab,
                 onUserNameClicked: (userId: number) => {
                     ref?.destroy();
-                    this.metisConversationService.createOneToOneChatWithId(userId).subscribe();
+                    this.metisConversationService.createOneToOneChatWithId(userId).subscribe({
+                        // the chat is created before the conversations are reloaded, and a failed reload is already
+                        // reported by the service, so it must not surface as an unhandled error here
+                        error: () => {},
+                    });
                 },
             },
         });

--- a/src/main/webapp/app/communication/directive/posting.directive.ts
+++ b/src/main/webapp/app/communication/directive/posting.directive.ts
@@ -204,7 +204,11 @@ export abstract class PostingDirective<T extends Posting> implements OnInit, OnD
         const course = this.metisService.getCourse();
         if (isMessagingEnabled(course)) {
             if (this.isCommunicationPage()) {
-                this.metisConversationService.createOneToOneChat(referencedUserLogin).subscribe();
+                this.metisConversationService.createOneToOneChat(referencedUserLogin).subscribe({
+                    // the chat itself is created before the conversations are reloaded, and a failed reload is already
+                    // reported by the service, so it must not surface as an unhandled error here
+                    error: () => {},
+                });
             } else {
                 this.oneToOneChatService.create(course.id!, referencedUserLogin).subscribe((res) => {
                     void this.router.navigate(['courses', course.id, 'communication'], {
@@ -230,7 +234,10 @@ export abstract class PostingDirective<T extends Posting> implements OnInit, OnD
         const course = this.metisService.getCourse();
         if (isMessagingEnabled(course)) {
             if (this.isCommunicationPage()) {
-                this.metisConversationService.createOneToOneChatWithId(referencedUserId).subscribe();
+                this.metisConversationService.createOneToOneChatWithId(referencedUserId).subscribe({
+                    // see above, a failed reload of the conversations must not surface as an unhandled error
+                    error: () => {},
+                });
             } else {
                 this.oneToOneChatService.createWithId(course.id!, referencedUserId).subscribe((res) => {
                     void this.router.navigate(['courses', course.id, 'communication'], {

--- a/src/main/webapp/app/communication/service/metis-conversation.service.spec.ts
+++ b/src/main/webapp/app/communication/service/metis-conversation.service.spec.ts
@@ -12,7 +12,7 @@ import { ConversationService } from 'app/communication/conversations/service/con
 import { ChannelService } from 'app/communication/conversations/service/channel.service';
 import { AccountService } from 'app/core/auth/account.service';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
-import { Subject, forkJoin, of } from 'rxjs';
+import { Subject, forkJoin, of, take, throwError } from 'rxjs';
 import { ConversationDTO } from '../shared/entities/conversation/conversation.model';
 import { generateExampleChannelDTO, generateExampleGroupChatDTO, generateOneToOneChatDTO } from 'test/helpers/sample/conversationExampleModels';
 import { GroupChatDTO } from 'app/communication/shared/entities/conversation/group-chat.model';
@@ -176,6 +176,49 @@ describe('MetisConversationService', () => {
                             done({});
                         },
                     });
+                },
+            });
+        });
+    });
+
+    it('should keep the cached conversations and the active conversation when a force refresh fails', () => {
+        return new Promise((done) => {
+            metisConversationService.setUpConversationService(course).subscribe({
+                complete: () => {
+                    metisConversationService.setActiveConversation(groupChat);
+                    vi.spyOn(conversationService, 'getConversationsOfUser').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
+
+                    metisConversationService.forceRefresh().subscribe({
+                        complete: () => {
+                            // A failed refresh must not be mistaken for "the user has no conversations": dropping the cache
+                            // would clear the active conversation and strip its id from the URL, so a reload could not restore it
+                            forkJoin({
+                                conversations: metisConversationService.conversationsOfUser$.pipe(take(1)),
+                                activeConversation: metisConversationService.activeConversation$.pipe(take(1)),
+                            }).subscribe(({ conversations, activeConversation }) => {
+                                expect(conversations).toHaveLength(3);
+                                expect(activeConversation?.id).toBe(groupChat.id);
+                                done({});
+                            });
+                        },
+                    });
+                },
+            });
+        });
+    });
+
+    it('should not report the service as set up when the conversations cannot be loaded', () => {
+        return new Promise((done) => {
+            vi.spyOn(conversationService, 'getConversationsOfUser').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
+            const isServiceSetUpValues: boolean[] = [];
+            metisConversationService.isServiceSetup$.subscribe((isSetUp) => isServiceSetUpValues.push(isSetUp));
+
+            metisConversationService.setUpConversationService(course).subscribe({
+                complete: () => {
+                    // announcing the service as ready with an empty cache would make every conversation opened from the
+                    // URL look like one the user is not a member of
+                    expect(isServiceSetUpValues).toEqual([false]);
+                    done({});
                 },
             });
         });

--- a/src/main/webapp/app/communication/service/metis-conversation.service.spec.ts
+++ b/src/main/webapp/app/communication/service/metis-conversation.service.spec.ts
@@ -225,14 +225,15 @@ describe('MetisConversationService', () => {
                     vi.spyOn(conversationService, 'getConversationsOfUser').mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
 
                     metisConversationService.forceRefresh().subscribe({
-                        complete: () => {
+                        // the failure is passed on, so that subscribers cannot mistake it for an up to date list
+                        error: () => {
                             // A failed refresh must not be mistaken for "the user has no conversations": dropping the cache
                             // would clear the active conversation and strip its id from the URL, so a reload could not restore it
                             forkJoin({
                                 conversations: metisConversationService.conversationsOfUser$.pipe(take(1)),
                                 activeConversation: metisConversationService.activeConversation$.pipe(take(1)),
                             }).subscribe(({ conversations, activeConversation }) => {
-                                expect(conversations).toHaveLength(3);
+                                expect(conversations).toEqual([groupChat, oneToOneChat, channel]);
                                 expect(activeConversation?.id).toBe(groupChat.id);
                                 done({});
                             });
@@ -250,7 +251,8 @@ describe('MetisConversationService', () => {
             metisConversationService.isServiceSetup$.subscribe((isSetUp) => isServiceSetUpValues.push(isSetUp));
 
             metisConversationService.setUpConversationService(course).subscribe({
-                complete: () => {
+                // the failure is passed on, so the caller does not record the service as instantiated
+                error: () => {
                     // announcing the service as ready with an empty cache would make every conversation opened from the
                     // URL look like one the user is not a member of
                     expect(isServiceSetUpValues).toEqual([false]);

--- a/src/main/webapp/app/communication/service/metis-conversation.service.spec.ts
+++ b/src/main/webapp/app/communication/service/metis-conversation.service.spec.ts
@@ -181,6 +181,42 @@ describe('MetisConversationService', () => {
         });
     });
 
+    it('should keep the open conversation when a conversation that is not cached is requested', () => {
+        return new Promise((done) => {
+            metisConversationService.setUpConversationService(course).subscribe({
+                complete: () => {
+                    metisConversationService.setActiveConversation(groupChat);
+
+                    metisConversationService.setActiveConversation(9999);
+
+                    // closing the open conversation would empty the view and strip its id from the URL, so a reload
+                    // could not restore it either
+                    metisConversationService.activeConversation$.pipe(take(1)).subscribe((activeConversation) => {
+                        expect(activeConversation?.id).toBe(groupChat.id);
+                        done({});
+                    });
+                },
+            });
+        });
+    });
+
+    it('should still clear the active conversation when it is cleared on purpose', () => {
+        return new Promise((done) => {
+            metisConversationService.setUpConversationService(course).subscribe({
+                complete: () => {
+                    metisConversationService.setActiveConversation(groupChat);
+
+                    metisConversationService.setActiveConversation(undefined);
+
+                    metisConversationService.activeConversation$.pipe(take(1)).subscribe((activeConversation) => {
+                        expect(activeConversation).toBeUndefined();
+                        done({});
+                    });
+                },
+            });
+        });
+    });
+
     it('should keep the cached conversations and the active conversation when a force refresh fails', () => {
         return new Promise((done) => {
             metisConversationService.setUpConversationService(course).subscribe({

--- a/src/main/webapp/app/communication/service/metis-conversation.service.ts
+++ b/src/main/webapp/app/communication/service/metis-conversation.service.ts
@@ -134,6 +134,10 @@ export class MetisConversationService implements OnDestroy {
                 type: AlertType.WARNING,
                 message: 'artemisApp.metis.channel.notAMember',
             });
+            // Keep whatever is currently open instead of closing it. Replacing it with nothing empties the view, and the
+            // active conversation subscriber reacts to that by removing the conversationId from the URL, so a reload can
+            // no longer restore the conversation either. Clearing on purpose stays possible by passing undefined.
+            return;
         }
         if (this.activeConversation?.id !== conversationId) {
             this.updateConversationAsRead();

--- a/src/main/webapp/app/communication/service/metis-conversation.service.ts
+++ b/src/main/webapp/app/communication/service/metis-conversation.service.ts
@@ -214,7 +214,11 @@ export class MetisConversationService implements OnDestroy {
             catchError((res: HttpErrorResponse) => {
                 onError(this.alertService, res);
                 this.setIsLoading(false);
-                return of([]);
+                // Do not continue into the mapping below with an empty list. Treating a failed request as "the user has no
+                // conversations" would drop the cached conversations, reset the active conversation and, through the
+                // active conversation subscriber, strip the conversationId from the URL. A reload could then not restore
+                // the conversation any more, because the identifier it needs is gone. Keep the last known state instead.
+                return EMPTY;
             }),
             map((conversations: ConversationDTO[]) => {
                 this.conversationsOfUser = conversations;
@@ -297,7 +301,10 @@ export class MetisConversationService implements OnDestroy {
                 onError(this.alertService, res);
                 this.setIsLoading(false);
                 this._isServiceSetup$.next(false);
-                return of([]);
+                // Stop here instead of running the setup below with an empty list, which would announce the service as
+                // ready while no conversation is known. Every conversation opened from the URL would then be reported
+                // as one the user is not a member of, and the view would stay empty.
+                return EMPTY;
             }),
             map((conversations: ConversationDTO[]) => {
                 this.conversationsOfUser = conversations;

--- a/src/main/webapp/app/communication/service/metis-conversation.service.ts
+++ b/src/main/webapp/app/communication/service/metis-conversation.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnDestroy, inject } from '@angular/core';
-import { EMPTY, Observable, ReplaySubject, Subject, Subscription, catchError, finalize, map, of, switchMap, tap } from 'rxjs';
+import { EMPTY, Observable, ReplaySubject, Subject, Subscription, catchError, finalize, map, of, switchMap, tap, throwError } from 'rxjs';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { ConversationService } from 'app/communication/conversations/service/conversation.service';
 import { WebsocketService } from 'app/foundation/service/websocket.service';
@@ -222,7 +222,9 @@ export class MetisConversationService implements OnDestroy {
                 // conversations" would drop the cached conversations, reset the active conversation and, through the
                 // active conversation subscriber, strip the conversationId from the URL. A reload could then not restore
                 // the conversation any more, because the identifier it needs is gone. Keep the last known state instead.
-                return EMPTY;
+                // The error is passed on rather than swallowed, so that subscribers acting in their completion handler
+                // do not mistake a failed refresh for an up to date list.
+                return throwError(() => res);
             }),
             map((conversations: ConversationDTO[]) => {
                 this.conversationsOfUser = conversations;
@@ -307,8 +309,9 @@ export class MetisConversationService implements OnDestroy {
                 this._isServiceSetup$.next(false);
                 // Stop here instead of running the setup below with an empty list, which would announce the service as
                 // ready while no conversation is known. Every conversation opened from the URL would then be reported
-                // as one the user is not a member of, and the view would stay empty.
-                return EMPTY;
+                // as one the user is not a member of, and the view would stay empty. The error is passed on so that the
+                // caller does not record the service as instantiated and can set it up again later.
+                return throwError(() => res);
             }),
             map((conversations: ConversationDTO[]) => {
                 this.conversationsOfUser = conversations;

--- a/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
+++ b/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
@@ -346,6 +346,10 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
                 }
                 this.isServiceSetUp.set(true);
                 this.isLoading.set(false);
+            } else {
+                // The conversations could not be loaded and the service reported the failure. Stop the loading indicator
+                // instead of spinning forever, the error itself has already been raised by the service.
+                this.isLoading.set(false);
             }
 
             this.createChannelFn = (channel: ChannelDTO) => this.metisConversationService.createChannel(channel);

--- a/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
+++ b/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
@@ -678,6 +678,10 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
                     complete: () => {
                         this.prepareSidebarData();
                     },
+                    error: () => {
+                        // The group chat itself was created, only reloading the conversations failed. Leave the sidebar as
+                        // it is rather than rebuilding it from a list that never arrived; the service reported the error.
+                    },
                 });
             });
     }
@@ -697,6 +701,9 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
                     this.metisConversationService.createOneToOneChat(chatPartner.login).subscribe({
                         complete: () => {
                             this.prepareSidebarData();
+                        },
+                        error: () => {
+                            // see above, the chat exists and only the reload of the conversations failed
                         },
                     });
                 }

--- a/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
+++ b/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.ts
@@ -347,8 +347,10 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
                 this.isServiceSetUp.set(true);
                 this.isLoading.set(false);
             } else {
-                // The conversations could not be loaded and the service reported the failure. Stop the loading indicator
-                // instead of spinning forever, the error itself has already been raised by the service.
+                // The service reported that it is not set up, either because loading the conversations failed or because it
+                // was disabled. Follow that state instead of keeping the view in its previous one, and stop the loading
+                // indicator rather than spinning forever. The error itself has already been raised by the service.
+                this.isServiceSetUp.set(false);
                 this.isLoading.set(false);
             }
 
@@ -597,6 +599,10 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
                 this.accordionConversationGroups().recents.entityData = this.sidebarConversations()?.filter((item) => item.isCurrent) || [];
                 this.updateSidebarData();
             },
+            error: () => {
+                // Keep the sidebar as it is. Rebuilding it from a refresh that failed would show a list that does not
+                // match the server, and the error has already been reported by the service.
+            },
         });
     }
 
@@ -724,6 +730,8 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
                         this.prepareSidebarData();
                         this.closeSidebarOnMobile();
                     },
+                    // the service already reported the failure, the sidebar keeps its current contents
+                    error: () => {},
                 });
             },
         });
@@ -753,6 +761,10 @@ export class CourseConversationsComponent implements OnInit, OnDestroy {
                                 this.metisConversationService.setActiveConversation(newActiveConversation);
                                 this.closeSidebarOnMobile();
                             }
+                        },
+                        error: () => {
+                            // Do not open the conversation after a failed refresh. It is not part of the cached list yet,
+                            // so activating it would only warn that the user is not a member of it.
                         },
                     });
                 } else {

--- a/src/main/webapp/app/course/shared/course-base-container/course-base-container.component.ts
+++ b/src/main/webapp/app/course/shared/course-base-container/course-base-container.component.ts
@@ -280,6 +280,10 @@ export abstract class BaseCourseContainerComponent implements OnInit, OnDestroy,
                         // service is fully set up, now we can subscribe to the respective observables
                         this.subscribeToHasUnreadMessages();
                     },
+                    error: () => {
+                        // Leave the service marked as not instantiated so that a later attempt sets it up again. The error
+                        // itself has already been shown to the user by the service.
+                    },
                 });
         } else if (!this.checkedForUnreadMessages() && isMessagingEnabled(currentCourse)) {
             this.metisConversationService.checkForUnreadMessages(currentCourse);


### PR DESCRIPTION
### Summary

A failed request for the conversations of a user was treated as the answer "this user has no conversations". That emptied the loaded conversation list, cleared the open conversation and removed its identifier from the URL, so the view stayed empty and even a reload could not bring it back. This pull request makes both places that load the conversations leave the existing state alone when the request fails.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

Two communication end-to-end tests fail from time to time, most recently on #13469:

- `Channel messages > Edit channel > Instructor should be able to edit a channel`
- `Message interactions > Bookmark/save toggle > Bookmarked message should persist after page reload`

Both fail in the same way, and neither failure is a slow render. The channel test reports `element(s) not found` for the conversation header after waiting 30 seconds, and the bookmark test exhausts a retry loop of three full reloads. The conversation simply never comes back after a reload, which is why the workarounds already present in both tests, a tripled test budget and a reload retry loop, do not help.

The cause is in the client, and it also affects real users: whenever the request for the conversations of the user fails, the open conversation disappears and the page cannot recover from a reload, accompanied by a misleading message that the user is not a member of the conversation.

### Description

`MetisConversationService.forceRefresh` mapped a failed request to an empty list and then continued into the success path:

```ts
catchError((res: HttpErrorResponse) => {
    onError(this.alertService, res);
    this.setIsLoading(false);
    return of([]);           // failure continues below
}),
map((conversations: ConversationDTO[]) => {
    this.conversationsOfUser = conversations;                  // cache replaced by []
    if (this.activeConversation && !found) {
        this.activeConversation = undefined;                   // open conversation cleared
    }
    this._activeConversation$.next(this.activeConversation);
})
```

The component subscribes to the active conversation and calls `updateQueryParameters` on every emission. That method builds `conversationId` from the active conversation, so an undefined conversation removes the parameter from the URL. One failed refresh therefore destroys the loaded state and removes the identifier needed to rebuild it, which is exactly why a following reload finds nothing.

`setUpConversationService` had the same fall through. Its error branch reports the service as not set up, but the shared success branch below immediately reports it as set up while the list is empty. Every conversation opened from the URL is then rejected as one the user is not a member of.

Both error branches now return `EMPTY` instead of `of([])`, so the loaded conversations and the open conversation survive a failed request. The conversation view also stops its loading indicator when the setup fails, instead of spinning forever.

`setActiveConversation` had the same destructive shape one level lower, and it is the mechanism the two cases above merely triggered:

```ts
if (!cachedConversation && conversationIdentifier) {
    this.alertService.addAlert({ ..., message: 'artemisApp.metis.channel.notAMember' });
}
this.activeConversation = cachedConversation;      // closes whatever was open
this._activeConversation$.next(this.activeConversation);
```

Asking for a conversation that is not in the cache closed the conversation the user was reading, told them they are not a member of it, and emptied the view. Since the emission also removes `conversationId` from the URL, the reload could not recover. The method now keeps the open conversation and only warns. Clearing on purpose still works, because those call sites pass `undefined` instead of an identifier that cannot be resolved.

The workarounds in the two end-to-end tests are intentionally left in place for now. Removing them in the same pull request would leave no signal if this diagnosis turns out to be incomplete; they can go once the tests have been quiet for a while.

### Steps for Testing

Prerequisites:
- 1 student
- 1 course with communication enabled and at least one channel

1. Open a channel in the communication view of a course.
2. Open the browser devtools and block requests to `**/api/communication/courses/*/conversations`.
3. Trigger a refresh of the conversations, for example by editing the channel or by opening and closing the conversation detail dialog.
4. The conversation has to stay open, the conversation list has to stay populated, and the URL has to keep its `conversationId`. Before this change the view went empty, the list disappeared, the URL lost the parameter and a reload could not restore the conversation.
5. Unblock the requests and reload. Everything continues to work as before.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| conversation-header.component.ts | 92.30% | 160 | 25 | 15.6 |
| posting.directive.ts | 86.81% | 185 | 42 | 22.7 |
| metis-conversation.service.ts | 88.50% | 462 | 86 | 18.6 |
| course-conversations.component.ts | 84.15% | 777 | 113 | 14.5 |
| course-base-container.component.ts | 97.18% | 267 | ? | ? |

_Last updated: 2026-08-10 22:57:25 UTC_

