### PR TITLE
`Development`: Read the login options from the API in the e2e tests

### DIFF
--- a/src/test/playwright/e2e/Login.spec.ts
+++ b/src/test/playwright/e2e/Login.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test';
+import { Page, expect } from '@playwright/test';
 import { test } from '../support/fixtures';
 import { studentOne } from '../support/users';
 import { BASE_API } from '../support/constants';
@@ -46,18 +46,23 @@ test.describe('Login page tests', { tag: '@fast' }, () => {
         await page.waitForURL('/sign-in');
     });
 
+    /**
+     * Reads the login options straight from the API. The browser network buffer is deliberately not used: entries in it
+     * can be evicted before the body is read, which fails with "No data found for resource with given identifier" on a
+     * loaded runner even though the request itself succeeded.
+     */
+    async function fetchLoginOptions(page: Page, usernameOrEmail: string) {
+        const response = await page.request.get(`${BASE_API}/core/public/login-options`, { params: { usernameOrEmail } });
+        expect(response.status()).toBe(200);
+        return response.json();
+    }
+
     test('Requests the login options for a known internal user and continues to the password step', async ({ page, loginPage }) => {
+        expect(await fetchLoginOptions(page, studentOne.username)).toEqual({ loginMethod: 'PASSWORD', idpName: null });
+
         await page.goto('/sign-in');
         await loginPage.enterUsername(studentOne.username);
-
-        const responsePromise = page.waitForResponse((response) => response.url().includes(`${BASE_API}/core/public/login-options`));
         await loginPage.clickContinueButton();
-        const response = await responsePromise;
-
-        expect(response.status()).toBe(200);
-        const options = await response.json();
-        expect(options.loginMethod).toBe('PASSWORD');
-        expect(options.idpName ?? null).toBeNull();
 
         // internal users authenticate with their Artemis password, so the second stage has to offer the password field
         await expect(page.locator('#password')).toBeVisible();
@@ -73,33 +78,25 @@ test.describe('Login page tests', { tag: '@fast' }, () => {
 
         // return to the anonymous login page and identify via the email address instead of the login
         await page.context().clearCookies();
+        expect(await fetchLoginOptions(page, email)).toEqual({ loginMethod: 'PASSWORD', idpName: null });
+
         await page.goto('/sign-in');
         await loginPage.enterUsername(email);
-
-        const responsePromise = page.waitForResponse((response) => response.url().includes(`${BASE_API}/core/public/login-options`));
         await loginPage.clickContinueButton();
-        const response = await responsePromise;
-
-        expect(response.status()).toBe(200);
-        const options = await response.json();
-        expect(options.loginMethod).toBe('PASSWORD');
-        expect(options.idpName ?? null).toBeNull();
         await expect(page.locator('#password')).toBeVisible();
     });
 
     test('Answers identically for an unknown account so it cannot be used to enumerate users', async ({ page, loginPage }) => {
+        // this test server has no LDAP and no external identity provider, so an unknown account has to be answered
+        // exactly like a known one. Comparing the two answers states that directly instead of restating the expected shape.
+        const knownAccount = await fetchLoginOptions(page, studentOne.username);
+        const unknownAccount = await fetchLoginOptions(page, 'artemis_test_user_does_not_exist');
+        expect(unknownAccount).toEqual(knownAccount);
+
+        // the second stage must not give it away either
         await page.goto('/sign-in');
         await loginPage.enterUsername('artemis_test_user_does_not_exist');
-
-        const responsePromise = page.waitForResponse((response) => response.url().includes(`${BASE_API}/core/public/login-options`));
         await loginPage.clickContinueButton();
-        const response = await responsePromise;
-
-        // this test server has no LDAP and no external identity provider, so an unknown account has to look exactly like a known internal one
-        expect(response.status()).toBe(200);
-        const options = await response.json();
-        expect(options.loginMethod).toBe('PASSWORD');
-        expect(options.idpName ?? null).toBeNull();
         await expect(page.locator('#password')).toBeVisible();
     });
 


### PR DESCRIPTION
### Summary

The three login option tests added in #13469 read the response body out of the browser network buffer. Entries in that buffer can be evicted before the body is read, so the test fails even though the request itself succeeded. This pull request reads the login options through the API context instead, which does not depend on that buffer.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

`Login page tests > Answers identically for an unknown account so it cannot be used to enumerate users` failed in CI, on the first attempt and again on the retry:

```
Error: response.json: Protocol error (Network.getResponseBody): No data found for resource with given identifier
Response body is not available for a response that was navigated away from.
```

The request succeeded, only its body was no longer retrievable. All three tests added in #13469 use the same pattern, so all three can fail this way, and the failure is intermittent: the same tests passed 24 of 24 in the pull request that introduced them.

### Description

Each test captured the response with `page.waitForResponse` and then called `response.json()`. That reads through the Chrome DevTools protocol, whose response buffer is limited and evicted under load. `serviceWorkers: 'block'` already removed the other known cause of this error, but a plain buffer eviction is still possible on a busy runner.

The login options are now fetched with `page.request.get`, which performs its own request and hands back a body that cannot be evicted. The browser part of each test keeps asserting what the user actually sees, namely that the second stage offers the password field.

The enumeration test additionally became a better test of the property it protects. Instead of repeating the expected shape for the unknown account, it now fetches the answer for a known account and for an unknown one and compares them:

```ts
const knownAccount = await fetchLoginOptions(page, studentOne.username);
const unknownAccount = await fetchLoginOptions(page, 'artemis_test_user_does_not_exist');
expect(unknownAccount).toEqual(knownAccount);
```

If the endpoint ever starts answering differently for the two, the test fails regardless of what the difference is.

### Steps for Testing

This is a test-only change, so the verification is running the tests.

1. Run `./run-e2e-tests-local-fast.sh --filter "Login"`.
2. All 11 tests of `Login.spec.ts` pass.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-10 22:30:33 UTC_

