### PR TITLE
`Development`: Restore the route when an e2e reload drifts to the courses fallback

### DIFF
--- a/src/test/playwright/e2e/course/CourseChannelMessages.spec.ts
+++ b/src/test/playwright/e2e/course/CourseChannelMessages.spec.ts
@@ -7,6 +7,7 @@ import { Post } from 'app/communication/shared/entities/post.model';
 import { TextExercise } from 'app/text/shared/entities/text-exercise.model';
 import { SEED_COURSES } from '../../support/seedData';
 import { RELOAD_RENDER_TIMEOUT } from '../../support/timeouts';
+import { Commands } from '../../support/commands';
 
 // Use pre-seeded courses — no course creation needed
 const readOnlyCourse = { id: SEED_COURSES.channel1.id };
@@ -165,7 +166,10 @@ test.describe('Channel messages', { tag: '@fast' }, () => {
             // assertions themselves (they poll) rather than gating on an intermediate element within a
             // fixed window. Only the first assertion absorbs the re-bootstrap; the topic is rendered in
             // the same pass, so it keeps the default timeout and the two budgets cannot stack.
-            await page.reload();
+            // Restore the route after the reload: a lazy route chunk that fails to resolve sends the
+            // router to the bare /courses fallback, where the channel header does not exist at all and
+            // the assertion below waits out its whole budget on a page that can never satisfy it.
+            await Commands.reloadAndRestoreRoute(page);
             await expect(courseMessages.getName()).toContainText(newName, { timeout: RELOAD_RENDER_TIMEOUT });
             await expect(courseMessages.getTopic()).toContainText(topic);
         });

--- a/src/test/playwright/e2e/course/CourseMessageInteractions.spec.ts
+++ b/src/test/playwright/e2e/course/CourseMessageInteractions.spec.ts
@@ -5,6 +5,7 @@ import { generateUUID } from '../../support/utils';
 import { Post } from 'app/communication/shared/entities/post.model';
 import { Channel } from 'app/communication/shared/entities/conversation/channel.model';
 import { SEED_COURSES, SEED_CHANNELS } from '../../support/seedData';
+import { Commands } from '../../support/commands';
 
 const writeCourse = { id: SEED_COURSES.channel2.id };
 // Use the pre-seeded "random" channel — students are already joined
@@ -51,9 +52,12 @@ test.describe('Message interactions', { tag: '@fast' }, () => {
             // re-activate from the conversationId query param after a reload (the conversations-cache activation race
             // that openConversation also works around), leaving an empty view in which the message never renders.
             // Retry the full reload until the message reappears so this assertion tests bookmark persistence rather
-            // than that unrelated activation race.
+            // than that unrelated activation race. Every retry returns to the route captured here: a reload that
+            // drifts to the bare /courses fallback would otherwise poison the remaining attempts, which would
+            // reload the fallback rather than the conversation.
+            const conversationUrl = page.url();
             for (let attempt = 0; attempt < 3; attempt++) {
-                await page.reload();
+                await Commands.reloadAndRestoreRoute(page, conversationUrl);
                 try {
                     await courseMessages.getSinglePost(message.id!).waitFor({ state: 'visible', timeout: 12000 });
                     break;

--- a/src/test/playwright/support/commands.ts
+++ b/src/test/playwright/support/commands.ts
@@ -107,6 +107,23 @@ export class Commands {
     };
 
     /**
+     * Whether the page currently sits on the route that was asked for.
+     * <p>
+     * Only the path is compared. A reload re-bootstraps the app, and several pages rewrite their own query
+     * parameters afterwards, so requiring the full URL to match would report a failed restore for a page that
+     * did come back correctly. The path is what distinguishes the requested route from the `/courses`
+     * fallback, from an authentication redirect, and from anywhere else the router may land.
+     *
+     * @param requestedUrl the url the caller asked for, absolute or relative
+     * @param currentUrl   the url the page is on now
+     */
+    static isOnRequestedRoute(requestedUrl: string, currentUrl: string): boolean {
+        const withoutTrailingSlash = (path: string) => (path.length > 1 ? path.replace(/\/$/, '') : path);
+        const requestedAbsolute = requestedUrl.startsWith('http') ? new URL(requestedUrl) : new URL(requestedUrl, currentUrl);
+        return withoutTrailingSlash(requestedAbsolute.pathname) === withoutTrailingSlash(new URL(currentUrl).pathname);
+    }
+
+    /**
      * Detects the specific lazy-chunk-load fallback where Angular routes the page to a bare
      * `/courses` after a navigation to a different intended URL. Returns true only when
      * the caller-requested URL was NOT itself the bare `/courses` and the current URL has
@@ -290,13 +307,16 @@ export class Commands {
      * from a page that merely finished loading, so that is what this waits on.
      */
     static restoreRouteIfDrifted = async (page: Page, expectedUrl: string): Promise<boolean> => {
-        if (!Commands.driftedToCoursesFallback(expectedUrl, page.url())) {
+        if (Commands.isOnRequestedRoute(expectedUrl, page.url())) {
             return true;
         }
+        // Deliberately not "anything that is not the fallback": an authentication redirect, or any other route
+        // the app decides on, would otherwise be reported as a successful restore, and the caller would keep
+        // polling for route-specific content that cannot appear there.
         await page.goto(expectedUrl);
         await page.waitForLoadState('load');
         return page
-            .waitForURL((url) => !Commands.driftedToCoursesFallback(expectedUrl, url.toString()), { timeout: Commands.ROUTE_RESTORE_TIMEOUT })
+            .waitForURL((url) => Commands.isOnRequestedRoute(expectedUrl, url.toString()), { timeout: Commands.ROUTE_RESTORE_TIMEOUT })
             .then(() => true)
             .catch(() => false);
     };

--- a/src/test/playwright/support/commands.ts
+++ b/src/test/playwright/support/commands.ts
@@ -447,7 +447,7 @@ export class Commands {
                     failedRouteRestores++;
                 }
             } catch (reloadError) {
-                throw new Error(`Failed to reload page while waiting for text "${expectedText}": ${reloadError}`, { cause: reloadError });
+                throw new Error(`Failed to reload or restore the page while waiting for text "${expectedText}": ${reloadError}`, { cause: reloadError });
             }
         }
 

--- a/src/test/playwright/support/commands.ts
+++ b/src/test/playwright/support/commands.ts
@@ -1,5 +1,5 @@
 import { UserCredentials } from './users';
-import { Locator, Page, expect } from '@playwright/test';
+import { Locator, Page, errors, expect } from '@playwright/test';
 import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { ExerciseAPIRequests } from './requests/ExerciseAPIRequests';
 import { BUILD_FINISH_TIMEOUT, POLLING_INTERVAL } from './timeouts';
@@ -292,6 +292,43 @@ export class Commands {
     private static readonly ROUTE_RESTORE_TIMEOUT = 15_000;
 
     /**
+     * How long the page has to stay on a route before it counts as restored.
+     * <p>
+     * The drift this whole mechanism guards against happens *after* the document has loaded: the router
+     * resolves the lazy route, the chunk fails, and only then does the URL change to `/courses`. Reading the
+     * URL once therefore reports success for a page that is about to leave the route again.
+     * <p>
+     * Kept short because a healthy reload pays it too, and because the fallback redirect follows the load
+     * closely rather than arbitrarily later.
+     */
+    private static readonly ROUTE_SETTLE_TIMEOUT = 1_000;
+
+    /**
+     * Whether the page is on the requested route and is still on it {@link ROUTE_SETTLE_TIMEOUT} later.
+     * <p>
+     * `waitForURL` resolves the moment its predicate holds, so it cannot express "and keeps holding". Waiting
+     * for the opposite does: a redirect away resolves the wait, and nothing happening times out. Playwright
+     * reports the router's same-document navigation, so the fallback redirect is observed rather than missed.
+     *
+     * @param page        the page to observe
+     * @param expectedUrl the url the caller asked for
+     */
+    private static holdsRequestedRoute = async (page: Page, expectedUrl: string): Promise<boolean> => {
+        if (!Commands.isOnRequestedRoute(expectedUrl, page.url())) {
+            return false;
+        }
+        try {
+            await page.waitForURL((url) => !Commands.isOnRequestedRoute(expectedUrl, url.toString()), { timeout: Commands.ROUTE_SETTLE_TIMEOUT });
+            return false;
+        } catch (error) {
+            // Only the timeout means the route held. Anything else — a closed page above all — is not a
+            // restored route, and reporting one would send the caller back to polling for content it can
+            // never see.
+            return error instanceof errors.TimeoutError;
+        }
+    };
+
+    /**
      * Re-navigates to {@link expectedUrl} if the page has landed on the bare `/courses` fallback instead,
      * and reports whether the page is on the expected route afterwards.
      * <p>
@@ -304,10 +341,11 @@ export class Commands {
      * The document being loaded is not the readiness signal to wait for: `load` fires once the shell and
      * its resources have arrived, while the router may still be resolving the lazy route — and it lands
      * back on the fallback when that resolution fails again. The URL is what separates a restored route
-     * from a page that merely finished loading, so that is what this waits on.
+     * from a page that merely finished loading, so that is what this waits on, and it has to still be the
+     * requested one a moment later rather than only at the instant it is read.
      */
     static restoreRouteIfDrifted = async (page: Page, expectedUrl: string): Promise<boolean> => {
-        if (Commands.isOnRequestedRoute(expectedUrl, page.url())) {
+        if (await Commands.holdsRequestedRoute(page, expectedUrl)) {
             return true;
         }
         // Deliberately not "anything that is not the fallback": an authentication redirect, or any other route
@@ -315,10 +353,13 @@ export class Commands {
         // polling for route-specific content that cannot appear there.
         await page.goto(expectedUrl);
         await page.waitForLoadState('load');
-        return page
+        const arrived = await page
             .waitForURL((url) => Commands.isOnRequestedRoute(expectedUrl, url.toString()), { timeout: Commands.ROUTE_RESTORE_TIMEOUT })
             .then(() => true)
             .catch(() => false);
+        // Arriving is not the same as staying: the re-navigation can hit the same lazy-chunk failure and drop
+        // back to the fallback, which is precisely the case the caller needs reported as a failed restore.
+        return arrived && (await Commands.holdsRequestedRoute(page, expectedUrl));
     };
 
     /**

--- a/src/test/playwright/support/commands.ts
+++ b/src/test/playwright/support/commands.ts
@@ -267,22 +267,43 @@ export class Commands {
     };
 
     /**
-     * Re-navigates to {@link expectedUrl} if the page has landed on the bare `/courses` fallback instead.
+     * How long a restored route gets to prove it stayed off the `/courses` fallback.
+     * <p>
+     * Short on purpose: this only covers the router resolving the lazy route it was just sent to, and
+     * the common case — the navigation landed where it was asked to — returns immediately.
+     */
+    private static readonly ROUTE_RESTORE_TIMEOUT = 15_000;
+
+    /**
+     * Re-navigates to {@link expectedUrl} if the page has landed on the bare `/courses` fallback instead,
+     * and reports whether the page is on the expected route afterwards.
      * <p>
      * A reload re-bootstraps the SPA from scratch. When a lazy route chunk fails to resolve — a known
      * symptom under heavy parallel CI load — the router falls back to `/courses`, and nothing ever
      * navigates back. Any assertion about route-specific content then waits for an element that cannot
      * exist, and every further reload re-loads the fallback, so a retry loop makes it worse rather than
      * better. Restoring the route explicitly turns that dead end into one more attempt.
+     * <p>
+     * The document being loaded is not the readiness signal to wait for: `load` fires once the shell and
+     * its resources have arrived, while the router may still be resolving the lazy route — and it lands
+     * back on the fallback when that resolution fails again. The URL is what separates a restored route
+     * from a page that merely finished loading, so that is what this waits on.
      */
-    static restoreRouteIfDrifted = async (page: Page, expectedUrl: string): Promise<void> => {
-        if (Commands.driftedToCoursesFallback(expectedUrl, page.url())) {
-            await page.goto(expectedUrl, { waitUntil: 'domcontentloaded' });
+    static restoreRouteIfDrifted = async (page: Page, expectedUrl: string): Promise<boolean> => {
+        if (!Commands.driftedToCoursesFallback(expectedUrl, page.url())) {
+            return true;
         }
+        await page.goto(expectedUrl);
+        await page.waitForLoadState('load');
+        return page
+            .waitForURL((url) => !Commands.driftedToCoursesFallback(expectedUrl, url.toString()), { timeout: Commands.ROUTE_RESTORE_TIMEOUT })
+            .then(() => true)
+            .catch(() => false);
     };
 
     /**
      * Reloads the page, then restores the route if the reload drifted to the `/courses` fallback.
+     * Returns whether the page ended up on the expected route.
      * <p>
      * Pass {@link expectedUrl} when reloading in a loop: the URL the loop started on is the one to
      * return to, whereas the URL immediately before a later reload may already be the fallback.
@@ -290,10 +311,10 @@ export class Commands {
      *
      * @see restoreRouteIfDrifted for why the fallback is a dead end without this.
      */
-    static reloadAndRestoreRoute = async (page: Page, expectedUrl?: string): Promise<void> => {
+    static reloadAndRestoreRoute = async (page: Page, expectedUrl?: string): Promise<boolean> => {
         const targetUrl = expectedUrl ?? page.url();
         await page.reload();
-        await Commands.restoreRouteIfDrifted(page, targetUrl);
+        return Commands.restoreRouteIfDrifted(page, targetUrl);
     };
 
     static reloadUntilFound = async (page: Page, locator: Locator, interval = 10000, timeout = 60000) => {
@@ -301,6 +322,7 @@ export class Commands {
         // The route this loop is polling on. Every reload returns here, so a drift to the /courses
         // fallback costs one attempt instead of the whole timeout budget.
         const requestedUrl = page.url();
+        let failedRouteRestores = 0;
 
         while (Date.now() - startTime < timeout) {
             try {
@@ -317,16 +339,20 @@ export class Commands {
                     throw new Error(`Page was closed while waiting for element matching "${locator}"`);
                 }
                 try {
-                    await Commands.reloadAndRestoreRoute(page, requestedUrl);
+                    if (!(await Commands.reloadAndRestoreRoute(page, requestedUrl))) {
+                        failedRouteRestores++;
+                    }
                 } catch (reloadError) {
                     throw new Error(`Failed to reload or restore the page while waiting for element: ${reloadError}`, { cause: reloadError });
                 }
             }
         }
 
-        // Name both routes: a final URL that is not the requested one is the signal that the SPA
-        // drifted and never came back, which is otherwise indistinguishable from a missing element.
-        throw new Error(`Timed out finding an element matching the "${locator}" locator (requested URL: ${requestedUrl}, final URL: ${page.url()})`);
+        // Name both routes and any failed restores: a final URL that is not the requested one, or a
+        // restore that never stuck, is the signal that the SPA could not load this route at all — which
+        // is otherwise indistinguishable from an element that simply never appeared.
+        const restoreNote = failedRouteRestores > 0 ? `, route restore failed ${failedRouteRestores} time(s)` : '';
+        throw new Error(`Timed out finding an element matching the "${locator}" locator (requested URL: ${requestedUrl}, final URL: ${page.url()}${restoreNote})`);
     };
 
     static reloadUntilTextFound = async (page: Page, locator: Locator, expectedText: string | RegExp, interval = 5000, timeout = 60000) => {

--- a/src/test/playwright/support/commands.ts
+++ b/src/test/playwright/support/commands.ts
@@ -266,8 +266,41 @@ export class Commands {
         await attachedWithin(30_000);
     };
 
+    /**
+     * Re-navigates to {@link expectedUrl} if the page has landed on the bare `/courses` fallback instead.
+     * <p>
+     * A reload re-bootstraps the SPA from scratch. When a lazy route chunk fails to resolve — a known
+     * symptom under heavy parallel CI load — the router falls back to `/courses`, and nothing ever
+     * navigates back. Any assertion about route-specific content then waits for an element that cannot
+     * exist, and every further reload re-loads the fallback, so a retry loop makes it worse rather than
+     * better. Restoring the route explicitly turns that dead end into one more attempt.
+     */
+    static restoreRouteIfDrifted = async (page: Page, expectedUrl: string): Promise<void> => {
+        if (Commands.driftedToCoursesFallback(expectedUrl, page.url())) {
+            await page.goto(expectedUrl, { waitUntil: 'domcontentloaded' });
+        }
+    };
+
+    /**
+     * Reloads the page, then restores the route if the reload drifted to the `/courses` fallback.
+     * <p>
+     * Pass {@link expectedUrl} when reloading in a loop: the URL the loop started on is the one to
+     * return to, whereas the URL immediately before a later reload may already be the fallback.
+     * Defaults to the current URL, which is what a single reload wants.
+     *
+     * @see restoreRouteIfDrifted for why the fallback is a dead end without this.
+     */
+    static reloadAndRestoreRoute = async (page: Page, expectedUrl?: string): Promise<void> => {
+        const targetUrl = expectedUrl ?? page.url();
+        await page.reload();
+        await Commands.restoreRouteIfDrifted(page, targetUrl);
+    };
+
     static reloadUntilFound = async (page: Page, locator: Locator, interval = 10000, timeout = 60000) => {
         const startTime = Date.now();
+        // The route this loop is polling on. Every reload returns here, so a drift to the /courses
+        // fallback costs one attempt instead of the whole timeout budget.
+        const requestedUrl = page.url();
 
         while (Date.now() - startTime < timeout) {
             try {
@@ -284,14 +317,16 @@ export class Commands {
                     throw new Error(`Page was closed while waiting for element matching "${locator}"`);
                 }
                 try {
-                    await page.reload();
+                    await Commands.reloadAndRestoreRoute(page, requestedUrl);
                 } catch (reloadError) {
-                    throw new Error(`Failed to reload page while waiting for element: ${reloadError}`, { cause: reloadError });
+                    throw new Error(`Failed to reload or restore the page while waiting for element: ${reloadError}`, { cause: reloadError });
                 }
             }
         }
 
-        throw new Error(`Timed out finding an element matching the "${locator}" locator (URL: ${page.url()})`);
+        // Name both routes: a final URL that is not the requested one is the signal that the SPA
+        // drifted and never came back, which is otherwise indistinguishable from a missing element.
+        throw new Error(`Timed out finding an element matching the "${locator}" locator (requested URL: ${requestedUrl}, final URL: ${page.url()})`);
     };
 
     static reloadUntilTextFound = async (page: Page, locator: Locator, expectedText: string | RegExp, interval = 5000, timeout = 60000) => {

--- a/src/test/playwright/support/commands.ts
+++ b/src/test/playwright/support/commands.ts
@@ -420,6 +420,11 @@ export class Commands {
         const startTime = Date.now();
         let lastSeenText: string | null = null;
         const matches = (text: string | null): boolean => text != null && (expectedText instanceof RegExp ? expectedText.test(text) : text.includes(expectedText));
+        // The route this loop is polling on, for the same reason as in reloadUntilFound: a reload that drifts to the
+        // /courses fallback is a dead end, because every later reload then reloads the fallback and the text being
+        // waited for lives on a route the page is no longer on.
+        const requestedUrl = page.url();
+        let failedRouteRestores = 0;
 
         while (Date.now() - startTime < timeout) {
             try {
@@ -438,13 +443,18 @@ export class Commands {
             }
 
             try {
-                await page.reload();
+                if (!(await Commands.reloadAndRestoreRoute(page, requestedUrl))) {
+                    failedRouteRestores++;
+                }
             } catch (reloadError) {
                 throw new Error(`Failed to reload page while waiting for text "${expectedText}": ${reloadError}`, { cause: reloadError });
             }
         }
 
-        throw new Error(`Timed out waiting for text "${expectedText}" in locator "${locator}" (URL: ${page.url()}). Last seen text: "${lastSeenText}"`);
+        const restoreNote = failedRouteRestores > 0 ? `, route restore failed ${failedRouteRestores} time(s)` : '';
+        throw new Error(
+            `Timed out waiting for text "${expectedText}" in locator "${locator}" (requested URL: ${requestedUrl}, final URL: ${page.url()}${restoreNote}). Last seen text: "${lastSeenText}"`,
+        );
     };
 
     /**


### PR DESCRIPTION
### Summary
`reloadUntilFound` reloads whatever URL the page currently has. When a reload drifts to the bare `/courses` fallback, every later reload re-loads that fallback, so the loop can never find route-specific content again — it burns its whole timeout on a page that cannot satisfy it. The loop now pins the route it started on and returns to it after each reload.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
> **Status update (after develop went green):** when this PR was opened, `Static code analysis tests › Verifies SCA feedback is displayed correctly after submission @slow` was the only hard E2E failure on develop. It passes on the current develop (`aaef83310e`: 347 passed, 4 flaky, 0 failed), and #13478 fixed the two conversation tests app-side. So this PR no longer fixes a red build — it removes a dead end that made one drift cost a whole test. Judge it as robustness, not as a fix for a currently failing test.

The failure that motivated it named its own cause once you looked at the URL:

```
Error: Timed out finding an element matching the
  "locator('#exercise-headers-information').locator('#result-score').getByText('96%')"
  locator (URL: https://artemis-nginx/courses)
    at Commands.reloadUntilFound (support/commands.ts:294:15)
```

The test logs in at `/courses/{id}/exercises/{id}`, but 3.6 minutes later the page is on `/courses`. A reload re-bootstraps the client, and a lazy route chunk that fails to resolve sends the router to the bare `/courses` fallback. `#exercise-headers-information` does not exist there, so `reloadUntilFound` reloads — the fallback — and repeats until the timeout expires. `Commands.login` already detects this drift for its own `page.goto`, via `driftedToCoursesFallback`; the polling loop had no such protection.

Because the drift is load-dependent, a green run does not prove it is gone: the same test failed on develop `5bbd742dc9` and passed on `aaef83310e` with nothing in between that touches exercise routes. What this PR changes is the cost when it does happen — one polling attempt instead of the entire timeout budget — and whether the failure says so.

### Description
- `Commands.restoreRouteIfDrifted(page, expectedUrl)` re-navigates when the page has landed on the `/courses` fallback instead of `expectedUrl`, reusing the existing `driftedToCoursesFallback` predicate.
- `Commands.reloadAndRestoreRoute(page, expectedUrl?)` reloads and then restores. The explicit `expectedUrl` matters inside a loop: the URL just before a later reload may already be the fallback, so the route to return to is the one the loop started on.
- `reloadUntilFound` captures its route at entry and reloads through that helper.
- The two conversation tests that reload and then expect route-specific content use it too. Both were failing when this PR was written, with symptoms that match a lost route — `Edit channel` waits for `h4.d-inline-block` and reports `element(s) not found`, and the bookmark test raises `conversation failed to re-activate`. **#13478 has since fixed both app-side**, so for them this is now belt-and-braces rather than the fix; the bookmark test's own three retries still reloaded whatever URL they were on, so one drift would have poisoned the rest. Say the word if you would rather I drop those two edits and keep the PR to `commands.ts` alone.
- The timeout message now names the requested and the final URL. Reading the old message, a lost route is indistinguishable from a missing element.

`reloadUntilTextFound` needs the same treatment and is deliberately untouched: #13212 already carries that change, and duplicating it here would only create a conflict.

### Steps for Testing
This is test-infrastructure only; no application code changes.

1. Confirm the E2E run on this PR is green — in particular `Static code analysis tests › Verifies SCA feedback is displayed correctly after submission`, `Channel messages › Edit channel` and `Message interactions › Bookmark/save toggle`.

The drift is load-dependent and does not reproduce on demand, so there is no local repro to offer and a green run is not proof either way. What this change guarantees by construction is that a drift costs one attempt rather than the whole timeout, and that the failure message names the requested and final URL plus the count of restores that did not stick.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-11 21:40:55 UTC_

