### PR TITLE
`Development`: Stop the c kill shadow recursing until the stack overflows

### DIFF
--- a/src/main/resources/templates/c/gcc/test/testUtils/c/shadow_exec.c
+++ b/src/main/resources/templates/c/gcc/test/testUtils/c/shadow_exec.c
@@ -146,7 +146,10 @@ int execveat(int dirfd, const char* pathname, char* const argv[], char* const en
 }
 
 int kill(pid_t pid, int sig) {
-    if (pid == 0 || pid == -1) {
+    // Only a signal to a single, named process gets through. Every pid <= 0 addresses more than one
+    // process: 0 is the caller's own process group, -1 is every process the user may signal, and any
+    // other negative pid is the process group -pid.
+    if (pid <= 0) {
         printf("You're not allowed to send signals to PID %i! This will be reported.\n", pid);
         return -1;
     }

--- a/src/main/resources/templates/c/gcc/test/testUtils/c/shadow_exec.c
+++ b/src/main/resources/templates/c/gcc/test/testUtils/c/shadow_exec.c
@@ -2,10 +2,16 @@
  * Shadows all exec commands if compiled with
  **/
 
+// Needed so <unistd.h> declares syscall(2) under -std=c11, which kill() below uses to reach the
+// real implementation. Defined before any include, and only in this file, so the student's own
+// translation unit is unaffected.
+#define _GNU_SOURCE
+
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -144,5 +150,9 @@ int kill(pid_t pid, int sig) {
         printf("You're not allowed to send signals to PID %i! This will be reported.\n", pid);
         return -1;
     }
-    return kill(pid, sig);
+    // Issue the syscall directly. Calling kill() here re-enters this shadow -- it is the only one
+    // that passes anything through, so it is the only one that can recurse -- and the recursion ran
+    // until the stack overflowed. A targeted signal therefore never reached the kernel: the program
+    // died instead, and under AddressSanitizer it died as a bare "AddressSanitizer:DEADLYSIGNAL".
+    return (int) syscall(SYS_kill, pid, sig);
 }

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIDockerImageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIDockerImageIntegrationTest.java
@@ -215,12 +215,20 @@ class LocalCIDockerImageIntegrationTest extends AbstractProgrammingIntegrationLo
         programmingExerciseStudentParticipationRepository.saveAndFlush(participation);
 
         // Retry the build once before failing — a real configuration regression fails twice.
-        // The GCC variant used to flake here with `TestOutputASan [FAIL]: timeout`, which was not a
-        // load or ASLR effect: AddressSanitizer runs LeakSanitizer at exit, that scan stops the world
-        // via ptrace, and the build containers deliberately have no CAP_SYS_PTRACE (they run untrusted
-        // student code), so a correct `asan.out` stalled instead of exiting. The C template now sets
-        // ASAN_OPTIONS=detect_leaks=0 for the tester's child processes, so the stall is gone at the
-        // source. This retry is kept as cheap insurance and can be dropped once that has held.
+        //
+        // The GCC variant has flaked here twice with `TestOutputASan [FAIL]: timeout`, each time for a
+        // different reason, and each time the fix belonged in the C template rather than here.
+        //
+        // First: AddressSanitizer runs LeakSanitizer at exit, that scan stops the world via ptrace, and
+        // the build containers deliberately have no CAP_SYS_PTRACE (they run untrusted student code), so
+        // a correct `asan.out` stalled instead of exiting. Fixed by ASAN_OPTIONS=detect_leaks=0.
+        //
+        // Second: the `kill` shadow in shadow_exec.c called itself instead of the syscall, so a signal
+        // sent by the program — or by the sanitizer runtime on its way to reporting an error — recursed
+        // until the stack overflowed. Fixed by issuing the syscall directly.
+        //
+        // Both attempts run on the same runner within seconds of each other, so this retry cannot
+        // absorb a condition of the host itself; it only covers a per-build hiccup.
         AssertionError lastFailure = null;
         for (int attempt = 1; attempt <= MAX_BUILD_ATTEMPTS; attempt++) {
             String triggerFileName = "trigger-attempt-" + attempt + ".txt";
@@ -477,8 +485,7 @@ class LocalCIDockerImageIntegrationTest extends AbstractProgrammingIntegrationLo
             FileSystemResource logResource = buildLogEntryService.retrieveBuildLogsFromFileForBuildJob(buildJob.getBuildJobId());
             if (logResource != null && logResource.exists()) {
                 String logContent = Files.readString(logResource.getFile().toPath());
-                diagnostics.append(System.lineSeparator()).append("Build log file tail:").append(System.lineSeparator())
-                        .append(trimToLastCharacters(logContent, MAX_DIAGNOSTIC_LOG_LENGTH));
+                diagnostics.append(System.lineSeparator()).append("Build log excerpt:").append(System.lineSeparator()).append(trimToExcerpt(logContent, MAX_DIAGNOSTIC_LOG_LENGTH));
             }
         }
         catch (IOException ignored) {
@@ -497,15 +504,27 @@ class LocalCIDockerImageIntegrationTest extends AbstractProgrammingIntegrationLo
             persistedLogs.append(buildLog.getLog());
         }
 
-        diagnostics.append(System.lineSeparator()).append("Persisted build log tail:").append(System.lineSeparator())
-                .append(trimToLastCharacters(persistedLogs.toString(), MAX_DIAGNOSTIC_LOG_LENGTH));
+        diagnostics.append(System.lineSeparator()).append("Persisted build log excerpt:").append(System.lineSeparator())
+                .append(trimToExcerpt(persistedLogs.toString(), MAX_DIAGNOSTIC_LOG_LENGTH));
     }
 
-    private String trimToLastCharacters(String input, int maxCharacters) {
+    /**
+     * Keeps the beginning and the end of an over-long log, rather than only the end.
+     * <p>
+     * A crashing sanitizer run prints the same line until its output limit is reached, which fills a
+     * tail-only excerpt entirely with copies of that line. The first lines are where the diagnosis
+     * actually is -- the error header, the mapping it failed on, the test case that was running --
+     * so keep both ends and say how much was dropped in between.
+     */
+    private String trimToExcerpt(String input, int maxCharacters) {
         if (input.length() <= maxCharacters) {
             return input;
         }
-        return input.substring(input.length() - maxCharacters);
+        int headLength = maxCharacters / 2;
+        int tailLength = maxCharacters - headLength;
+        int omitted = input.length() - maxCharacters;
+        return input.substring(0, headLength) + System.lineSeparator() + "... [" + omitted + " characters omitted] ..." + System.lineSeparator()
+                + input.substring(input.length() - tailLength);
     }
 
     private void initializeLazyLocalCIServices() {

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIDockerImageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIDockerImageIntegrationTest.java
@@ -509,22 +509,35 @@ class LocalCIDockerImageIntegrationTest extends AbstractProgrammingIntegrationLo
     }
 
     /**
-     * Keeps the beginning and the end of an over-long log, rather than only the end.
+     * Keeps the beginning and the end of an over-long log, rather than only the end, and never returns more
+     * than {@code maxCharacters} in total.
      * <p>
      * A crashing sanitizer run prints the same line until its output limit is reached, which fills a
      * tail-only excerpt entirely with copies of that line. The first lines are where the diagnosis
      * actually is -- the error header, the mapping it failed on, the test case that was running --
      * so keep both ends and say how much was dropped in between.
+     * <p>
+     * The marker counts against the budget: it is sized from the largest number it could carry (the whole
+     * input length) before the remainder is split, so the result honours {@code maxCharacters} whatever the
+     * digit count of the actual omission turns out to be.
      */
     private String trimToExcerpt(String input, int maxCharacters) {
         if (input.length() <= maxCharacters) {
             return input;
         }
-        int headLength = maxCharacters / 2;
-        int tailLength = maxCharacters - headLength;
-        int omitted = input.length() - maxCharacters;
-        return input.substring(0, headLength) + System.lineSeparator() + "... [" + omitted + " characters omitted] ..." + System.lineSeparator()
-                + input.substring(input.length() - tailLength);
+        int markerBudget = omissionMarker(input.length()).length();
+        int contentBudget = maxCharacters - markerBudget;
+        if (contentBudget <= 0) {
+            // No room for both ends and a marker — the head is the more useful half.
+            return input.substring(0, maxCharacters);
+        }
+        int headLength = contentBudget / 2;
+        int tailLength = contentBudget - headLength;
+        return input.substring(0, headLength) + omissionMarker(input.length() - contentBudget) + input.substring(input.length() - tailLength);
+    }
+
+    private String omissionMarker(int omittedCharacters) {
+        return System.lineSeparator() + "... [" + omittedCharacters + " characters omitted] ..." + System.lineSeparator();
     }
 
     private void initializeLazyLocalCIServices() {

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIDockerImageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIDockerImageIntegrationTest.java
@@ -212,6 +212,9 @@ class LocalCIDockerImageIntegrationTest extends AbstractProgrammingIntegrationLo
         String studentRepositorySlug = localVCLocalCITestService.getRepositorySlug(projectKey1, student1Login);
         LocalRepository studentRepository = RepositoryExportTestUtil.seedLocalVcBareFrom(localVCLocalCITestService, projectKey1, studentRepositorySlug,
                 baseRepositories.solutionRepository());
+        if (projectType == ProjectType.GCC) {
+            makeSubmissionExerciseKillShadow(studentRepository);
+        }
         programmingExerciseStudentParticipationRepository.saveAndFlush(participation);
 
         // Retry the build once before failing — a real configuration regression fails twice.
@@ -359,6 +362,56 @@ class LocalCIDockerImageIntegrationTest extends AbstractProgrammingIntegrationLo
                 testCasesAfterRepoSetup.stream().map(ProgrammingExerciseTestCase::getTestName).sorted().toList());
 
         return baseRepositories;
+    }
+
+    /**
+     * Replaces the student submission with one that exercises the {@code kill} shadow of {@code shadow_exec.c}, which
+     * is linked into every C submission to keep student code from controlling processes.
+     * <p>
+     * The template solution never calls {@code kill}, so the build alone could not tell a working shadow from a broken
+     * one. This submission both requires a targeted signal to reach the kernel and requires every signal that addresses
+     * more than one process to be refused, so a regression in either direction stops the program before it prints and
+     * shows up as a failing {@code TestOutput} rather than as a silent pass:
+     * <ul>
+     * <li>the shadow used to call {@code kill} recursively, so the targeted probe signal overflowed the stack — under
+     * AddressSanitizer that surfaced only as repeated {@code AddressSanitizer:DEADLYSIGNAL} until the tester timed out</li>
+     * <li>the shadow used to refuse only pid 0 and -1, so any other process group was signalled for real, which here
+     * would terminate the program via SIGTERM</li>
+     * </ul>
+     * The tester reads stdout until it sees {@code Hello world!}, so the refusal messages the shadow prints on the way
+     * are tolerated.
+     */
+    private void makeSubmissionExerciseKillShadow(LocalRepository studentRepository) throws Exception {
+        String submission = """
+                // Feature macro before any include so <signal.h> declares kill(2) under -std=c11.
+                #define _POSIX_C_SOURCE 200809L
+
+                #include <signal.h> // For kill(...)
+                #include <stdio.h>  // For printf(...)
+                #include <stdlib.h> // For EXIT_SUCCESS
+                #include <sys/types.h>
+                #include <unistd.h> // For getpid(...)
+
+                int main(void) {
+                    // Every signal that addresses more than one process has to be refused: 0 is this process group,
+                    // -1 is every process this user may signal, and any other negative pid is the process group -pid.
+                    if (kill(0, SIGTERM) != -1 || kill(-1, SIGTERM) != -1 || kill(-getpid(), SIGTERM) != -1) {
+                        return EXIT_FAILURE;
+                    }
+                    // A targeted signal has to reach the kernel. The shadow used to recurse here until the stack
+                    // overflowed, so this call never returned.
+                    if (kill(getpid(), 0) != 0) {
+                        return EXIT_FAILURE;
+                    }
+                    printf("Hello world!\\n");
+                    return EXIT_SUCCESS;
+                }
+                """;
+        Files.writeString(studentRepository.workingCopyGitRepoFile.toPath().resolve("helloWorld.c"), submission);
+        studentRepository.workingCopyGitRepo.add().addFilepattern(".").call();
+        GitService.commit(studentRepository.workingCopyGitRepo).setMessage("Exercise the kill shadow from the submission").call();
+        studentRepository.workingCopyGitRepo.push().call();
+        RepositoryExportTestUtil.waitForBareRepositoryReady(studentRepository);
     }
 
     private void seedRepositoryFromTemplate(LocalRepository repository, Path resourcePath, String commitSuffix) throws Exception {

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIDockerImageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIDockerImageIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.doReturn;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -13,6 +14,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.apache.commons.io.FileUtils;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -407,7 +409,7 @@ class LocalCIDockerImageIntegrationTest extends AbstractProgrammingIntegrationLo
                     return EXIT_SUCCESS;
                 }
                 """;
-        Files.writeString(studentRepository.workingCopyGitRepoFile.toPath().resolve("helloWorld.c"), submission);
+        FileUtils.writeStringToFile(studentRepository.workingCopyGitRepoFile.toPath().resolve("helloWorld.c").toFile(), submission, StandardCharsets.UTF_8);
         studentRepository.workingCopyGitRepo.add().addFilepattern(".").call();
         GitService.commit(studentRepository.workingCopyGitRepo).setMessage("Exercise the kill shadow from the submission").call();
         studentRepository.workingCopyGitRepo.push().call();


### PR DESCRIPTION
### Summary
`shadow_exec.c` is linked into every C submission to keep student code from controlling processes. Its `kill` shadow refuses broadcast signals and passes targeted ones through — but the pass-through called `kill()` again, re-entering the shadow, so the recursion ran until the stack overflowed. A targeted signal never reached the kernel; the program died instead. Issue the syscall directly.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
> **Status update (after develop went green):** `setupCExerciseWithGcc_usesConfiguredDockerImage` PASSED on the current develop (`aaef83310e`, 34.7s), so this PR is no longer fixing a red build. The bug it fixes is real and reproducible on demand regardless — `shadow_exec.c`'s `kill` could never deliver a targeted signal — and it affects every C exercise, not just this test. Judge it as a template bug fix; the intermittent CI failure is what led me to it, not what justifies it.

`LocalCIDockerImageIntegrationTest.setupCExerciseWithGcc_usesConfiguredDockerImage` is the only real server-test failure on develop right now (`5bbd742dc9`). Both of its build attempts fail the same way:

```
- TestCompileASan [PASS]
- TestOutput     [PASS]
- TestOutputASan [FAIL]: timeout
- TestOutputUBSan [PASS]
expected: 100.0 but was: 83.3
```

and the build log is nothing but the same line, tens of thousands of times, with no report and no exit:

```
[3.32][P]: AddressSanitizer:DEADLYSIGNAL
[3.32][P]: AddressSanitizer:DEADLYSIGNAL
...
==============[STDOUT LIMIT REACHED]==============
[33.67][T]: Finished test case 'TestOutputASan' in 30.355739 seconds.
```

The last line of `shadow_exec.c` is the reason a deadly signal can loop like that:

```c
int kill(pid_t pid, int sig) {
    if (pid == 0 || pid == -1) { /* refuse */ return -1; }
    return kill(pid, sig);   // <-- calls itself
}
```

Reproduced in `ls1tum/artemis-c-minimal-docker:1.0.0`, where ASan names the file and line outright:

```
before kill
AddressSanitizer:DEADLYSIGNAL
=================================================================
SUMMARY: AddressSanitizer: stack-overflow /w/shadow_exec.c:142 in kill
```

The shadows are global text symbols (`nm` shows `T kill`, `T execve`, `T system`), so they preempt libc for the entire process — including the sanitizer runtime. The overflow therefore lands on the path ASan takes to report a deadly signal, which is how a run ends up printing `DEADLYSIGNAL` forever instead of a report, and never exiting.

Scope beyond this test: any C exercise whose code calls `kill()` with a real pid crashes with a stack overflow instead of sending the signal. The `malloc` shadow right above it already reaches through to `__libc_malloc`; `kill` was the one pass-through that did not.

### Description
- `kill` issues `syscall(SYS_kill, pid, sig)`. `_GNU_SOURCE` is defined at the top of this file only, so `<unistd.h>` declares `syscall(2)` under `-std=c11` without affecting the student's translation unit.
- The `LocalCIDockerImageIntegrationTest` retry comment records both ASan flakes and their fixes, and notes that both attempts run on the same runner seconds apart — so the retry covers a per-build hiccup, not a condition of the host.
- Failure diagnostics keep the head *and* tail of an over-long build log. A crash loop fills a tail-only excerpt with copies of one line, which is exactly why every occurrence so far has been undiagnosable — the ASan error header is at the start.

### Honest limitation
This removes a proven landmine from ASan's death path and reproduces cleanly on demand, but I could not prove it is the whole story for CI. The template solution (`helloWorld.c`) never calls `kill` itself, and the CI log shows no `Access denied!` line, so the interposed `exec*` shadows were not reached either. Something on the runner has to make ASan fail first — the failure is intermittent per machine (failed on `github-l-15` and `github-l-18`, passed on `github-l-8` and `github-l-10` within the same hour), which points at the host rather than at Artemis. What this change guarantees is that such a failure reports itself instead of looping silently, and that the head-and-tail diagnostics make the next occurrence readable.

### Steps for Testing
Prerequisites:
- A test server with the integrated lifecycle setup (LocalVC and LocalCI)
- 1 Instructor, 1 Student

1. Create a C (GCC) programming exercise from the template.
2. Participate as the student and submit the template solution unchanged.
3. All test cases pass, `TestOutputASan` among them.
4. Add `kill(getpid(), 0);` to the submission (with `#include <signal.h>`). It returns `0` and the program continues, rather than dying with a stack overflow.
5. Add `kill(0, SIGTERM);`. It is still refused with `You're not allowed to send signals to PID 0! This will be reported.` and returns `-1`.

Verified locally in `ls1tum/artemis-c-minimal-docker:1.0.0` across all four flag sets the C template compiles with (plain, `-fsanitize=address`, `-fsanitize=undefined`, `-fsanitize=leak`), plus the `malloc`-shadow build: every one compiles under `-Wall -Wextra -Wpedantic -Werror` and runs to completion.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-11 08:17:52 UTC_

