### PR TITLE
`Development`: Fix a flaky re-evaluate test that picked its exercise by row order

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
@@ -2187,8 +2187,7 @@ public class ProgrammingExerciseIntegrationTestService {
     }
 
     void testReEvaluateAndUpdateProgrammingExercise_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseUtilService.addEnrolledCourseWithOneProgrammingExercise(userPrefix);
-        ProgrammingExercise programmingExercise = programmingExerciseTestRepository.findAllWithEagerTemplateAndSolutionParticipations().getFirst();
+        ProgrammingExercise programmingExercise = createCourseWithProgrammingExerciseForReEvaluation();
         request.put("/api/programming/programming-exercises/" + programmingExercise.getId() + "/re-evaluate", UpdateProgrammingExerciseDTO.of(programmingExercise),
                 HttpStatus.FORBIDDEN);
     }
@@ -2198,13 +2197,30 @@ public class ProgrammingExerciseIntegrationTestService {
     }
 
     void testReEvaluateAndUpdateProgrammingExercise_isNotSameGivenExerciseIdInRequestBody_conflict() throws Exception {
-        programmingExerciseUtilService.addEnrolledCourseWithOneProgrammingExercise(userPrefix);
-        programmingExerciseUtilService.addEnrolledCourseWithOneProgrammingExercise(userPrefix);
-        ProgrammingExercise programmingExercise = programmingExerciseTestRepository.findAllWithEagerTemplateAndSolutionParticipations().getFirst();
-        ProgrammingExercise programmingExerciseToBeConflicted = programmingExerciseTestRepository.findAllWithEagerTemplateAndSolutionParticipations().get(1);
+        ProgrammingExercise programmingExercise = createCourseWithProgrammingExerciseForReEvaluation();
+        ProgrammingExercise programmingExerciseToBeConflicted = createCourseWithProgrammingExerciseForReEvaluation();
 
         request.put("/api/programming/programming-exercises/" + programmingExercise.getId() + "/re-evaluate", UpdateProgrammingExerciseDTO.of(programmingExerciseToBeConflicted),
                 HttpStatus.CONFLICT);
+    }
+
+    /**
+     * Creates a course with one programming exercise and returns that exercise, loaded with the associations
+     * {@link UpdateProgrammingExerciseDTO#of} needs.
+     * <p>
+     * The exercise is looked up through the course it was just created in, rather than by taking an element out of
+     * {@code findAll()}. The setup of this class already puts two programming exercises in the database - one in a
+     * course and one in an exam - and {@code findAll()} has no {@code ORDER BY}, so its row order is whatever the
+     * database returns. When the exam exercise came first, the request ran against an exercise whose course is only
+     * reachable through its exercise group, {@code getCourseViaExerciseGroupOrCourseMember()} returned null, and the
+     * endpoint answered 500 instead of the expected status.
+     *
+     * @return the programming exercise of the newly created course
+     */
+    private ProgrammingExercise createCourseWithProgrammingExerciseForReEvaluation() {
+        Course course = programmingExerciseUtilService.addEnrolledCourseWithOneProgrammingExercise(userPrefix);
+        ProgrammingExercise exercise = ExerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
+        return programmingExerciseTestRepository.findWithEagerTemplateAndSolutionParticipationsById(exercise.getId()).orElseThrow();
     }
 
     void testGetTemplateRepositoryFilesWithContentOmitBinaries() throws Exception {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
@@ -2209,11 +2209,12 @@ public class ProgrammingExerciseIntegrationTestService {
      * {@link UpdateProgrammingExerciseDTO#of} needs.
      * <p>
      * The exercise is looked up through the course it was just created in, rather than by taking an element out of
-     * {@code findAll()}. The setup of this class already puts two programming exercises in the database - one in a
-     * course and one in an exam - and {@code findAll()} has no {@code ORDER BY}, so its row order is whatever the
-     * database returns. When the exam exercise came first, the request ran against an exercise whose course is only
-     * reachable through its exercise group, {@code getCourseViaExerciseGroupOrCourseMember()} returned null, and the
-     * endpoint answered 500 instead of the expected status.
+     * {@link ProgrammingExerciseTestRepository#findAllWithEagerTemplateAndSolutionParticipations()}. The setup of this
+     * class already puts two programming exercises in the database - one in a course and one in an exam - and that
+     * query has no {@code ORDER BY}, so its row order is whatever the database returns. When the exam exercise came
+     * first, the request ran against an exercise whose course is only reachable through its exercise group,
+     * {@code getCourseViaExerciseGroupOrCourseMember()} returned null, and the endpoint answered 500 instead of the
+     * expected status.
      *
      * @return the programming exercise of the newly created course
      */


### PR DESCRIPTION
### Summary

`ProgrammingExerciseLocalVCIntegrationTest.testReEvaluateAndUpdateProgrammingExercise_instructorNotInCourse_forbidden` intermittently fails with `Response status expected:<403> but was:<500>`. The test picked its exercise out of an unordered `findAll()`, so it sometimes ran against the wrong one.

### Motivation and Context

Seen on the server test job of #13388, where it is unrelated to the change under test. It is not reproducible on demand, which is what made it worth tracking down rather than re-running.

### Description

Both re-evaluate tests created a course with a programming exercise and then took an element out of `findAllWithEagerTemplateAndSolutionParticipations()`:

```java
programmingExerciseUtilService.addEnrolledCourseWithOneProgrammingExercise(userPrefix);
ProgrammingExercise programmingExercise = programmingExerciseTestRepository.findAllWithEagerTemplateAndSolutionParticipations().getFirst();
```

That query has no `ORDER BY`, so which exercise comes back is whatever the database chooses to return. `ProgrammingExerciseIntegrationTestService.setup` already puts two programming exercises in the database before any test runs: one in a course, and one in an exam. So `getFirst()` had three candidates and picked between them by row order.

When the exam exercise came out first, the request ran against an exercise whose course is reachable only through its exercise group. `CourseService.retrieveCourseOverExerciseGroupOrCourseId` then dereferenced a null:

```
java.lang.NullPointerException: Cannot invoke "Course.getId()" because the return value of
"Exercise.getCourseViaExerciseGroupOrCourseMember()" is null
	at CourseService.retrieveCourseOverExerciseGroupOrCourseId(CourseService.java:309)
	at ProgrammingExerciseUpdateResource.reEvaluateAndUpdateProgrammingExercise(ProgrammingExerciseUpdateResource.java:522)
```

That line sits two lines above the authorization check the test asserts on, so the endpoint answered 500 before it ever decided whether the user was allowed in.

The exercise is now looked up through the course it was just created in, which is the pattern the rest of this class already uses. The conflict test creates its second exercise explicitly instead of relying on index 1 of the same unordered list.

The production NPE is left as it is. It is only reachable for an exercise that belongs to neither a course nor an exam, which is not a state the schema permits and which no caller other than this mis-selecting test produced.

### Steps for Testing

This is a test-only change; the check is that the suite stays green.

1. Run `./gradlew test --tests ProgrammingExerciseLocalVCIntegrationTest -x webapp`.
2. Run `./gradlew test --tests ProgrammingExerciseIntegrationJenkinsLocalVCTest --tests ProgrammingExerciseLocalVCExportsIntegrationTest --tests ProgrammingExerciseParticipationIntegrationTest -x webapp`, which are the other classes sharing `ProgrammingExerciseIntegrationTestService`.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-11 22:53:41 UTC_

