### PR TITLE
`Development`: Pre-pull the e2e exercise images before the tests run

### DIFF
--- a/.ci/E2E-tests/prepull-exercise-images.sh
+++ b/.ci/E2E-tests/prepull-exercise-images.sh
@@ -34,12 +34,62 @@ IMAGES=(
 
 CONFIG_FILE="src/main/resources/config/application.yml"
 MAX_ATTEMPTS=3
+# A cold pull of the ~1 GB Maven image takes a couple of minutes on a healthy runner. The cap only
+# has to be generous enough not to cut a working pull short, because its job is to stop a *stalled*
+# one: an unbounded `docker pull` here would hang until the job timeout, which is the same
+# undiagnosable failure this script exists to remove, just moved earlier.
+PULL_TIMEOUT_SECONDS=600
+
+# Prints every image configured for the build agent, one per line.
+#
+# Reads only the build agent's own block (`artemis.continuous-integration.build.images`) rather than
+# grepping the whole file, so an image name appearing in a comment or an unrelated setting cannot
+# satisfy the drift check below. The file holds a second, unrelated `images:` block for Kubernetes
+# app definitions, hence the requirement that the block be nested directly under `build:`. Language
+# keys carry no value of their own and are skipped; values are accepted quoted or bare, and trailing
+# comments are stripped.
+configured_images() {
+    awk '
+        /^[[:space:]]*build:[[:space:]]*$/ {
+            build_indent = match($0, /[^[:space:]]/)
+            next
+        }
+        !in_block && build_indent && /^[[:space:]]*images:[[:space:]]*$/ && match($0, /[^[:space:]]/) > build_indent {
+            in_block = 1
+            block_indent = match($0, /[^[:space:]]/)
+            next
+        }
+        in_block {
+            if ($0 ~ /^[[:space:]]*$/) { next }
+            if (match($0, /[^[:space:]]/) <= block_indent) { in_block = 0; build_indent = 0; next }
+            line = $0
+            sub(/[[:space:]]+#.*$/, "", line)
+            if (line !~ /:[[:space:]]*[^[:space:]]/) { next }
+            sub(/^[^:]*:[[:space:]]*/, "", line)
+            gsub(/^["'"'"']|["'"'"']$/, "", line)
+            if (line != "") { print line }
+        }
+    ' "$CONFIG_FILE"
+}
 
 # Guard against drift: the list above is a copy of the tags configured for the build agent, so a tag
 # bumped in application.yml without updating this script would silently reintroduce the on-demand
 # pull this step exists to prevent. Fail here, where the reason is obvious, instead of there.
+mapfile -t CONFIGURED < <(configured_images)
+if [ ${#CONFIGURED[@]} -eq 0 ]; then
+    echo "::error title=Could not read E2E exercise images::Found no images under the 'images:' block of ${CONFIG_FILE}. The configuration layout changed; update configured_images() in $0."
+    exit 1
+fi
+
 for image in "${IMAGES[@]}"; do
-    if ! grep -qF "\"${image}\"" "$CONFIG_FILE"; then
+    found=false
+    for configured in "${CONFIGURED[@]}"; do
+        if [ "$image" = "$configured" ]; then
+            found=true
+            break
+        fi
+    done
+    if [ "$found" != true ]; then
         echo "::error title=E2E image list is stale::${image} is no longer configured in ${CONFIG_FILE}. Update IMAGES in $0 to match the tags the build agent uses, otherwise the exercise image is pulled on demand during the test run and Java build assertions fail."
         exit 1
     fi
@@ -51,10 +101,29 @@ for image in "${IMAGES[@]}"; do
         continue
     fi
 
+    # A bound turns a stalled pull into a non-zero exit so the retry below can act on it. coreutils
+    # ships `timeout` on the CI runners; macOS names it `gtimeout` when coreutils is installed via
+    # Homebrew, which keeps the bound working for anyone running this locally. Without either the pull
+    # stays unbounded, which is worth saying out loud rather than failing over.
+    pull=(docker pull --quiet "$image")
+    timeout_bin=""
+    if command -v timeout > /dev/null 2>&1; then
+        timeout_bin="timeout"
+    elif command -v gtimeout > /dev/null 2>&1; then
+        timeout_bin="gtimeout"
+    fi
+    if [ -n "$timeout_bin" ]; then
+        # --kill-after escalates to SIGKILL for a pull wedged badly enough to ignore the SIGTERM, so
+        # the step cannot be held open by the very stall it is meant to cut short.
+        pull=("$timeout_bin" --kill-after=30s "${PULL_TIMEOUT_SECONDS}s" "${pull[@]}")
+    else
+        echo "Note: neither 'timeout' nor 'gtimeout' is available, so a stalled pull of ${image} cannot be bounded."
+    fi
+
     pulled=false
     for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
         echo "Pulling ${image} (attempt ${attempt}/${MAX_ATTEMPTS})..."
-        if docker pull --quiet "$image"; then
+        if "${pull[@]}"; then
             pulled=true
             break
         fi

--- a/.ci/E2E-tests/prepull-exercise-images.sh
+++ b/.ci/E2E-tests/prepull-exercise-images.sh
@@ -36,20 +36,12 @@ IMAGES=(
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 CONFIG_FILE="${REPO_ROOT}/src/main/resources/config/application.yml"
 
-MAX_ATTEMPTS=3
+MAX_ATTEMPTS=2
 # Cold pulls of all four images together took 30 seconds on the CI runner, the Maven image 11 of them,
-# so these caps carry a large multiple of the real cost. They exist to stop a *stalled* pull: an
-# unbounded `docker pull` here would hang until the job timeout, which is the same undiagnosable
-# failure this script exists to remove, only moved earlier.
-PULL_TIMEOUT_SECONDS=300
-# `timeout` only terminates the `docker pull` client; the daemon keeps the pull going and the next
-# attempt attaches to it. Against a genuinely stalled daemon or registry every attempt would therefore
-# burn its full cap, so the retries need a shared ceiling as well — otherwise the step could outlive
-# the job timeout and be killed before it can report why.
-PULL_DEADLINE_SECONDS=600
-# Grace between SIGTERM and SIGKILL for a pull that will not stop on its own. Subtracted from each
-# attempt's cap rather than added to it, so the deadline stays a true ceiling.
-KILL_GRACE_SECONDS=30
+# so this cap carries a large multiple of the real cost while keeping the worst case bounded: two
+# attempts per image, so a totally unreachable registry costs about 8 minutes before the step reports
+# why rather than hanging until the job timeout.
+PULL_TIMEOUT_SECONDS=120
 
 # Prints every image configured for the build agent, one per line.
 #
@@ -146,51 +138,23 @@ for image in "${IMAGES[@]}"; do
     fi
 
     pulled=false
-    deadline=$((SECONDS + PULL_DEADLINE_SECONDS))
     for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-        remaining=$((deadline - SECONDS))
-        if [ "$remaining" -le 0 ]; then
-            echo "Giving up on ${image}: its ${PULL_DEADLINE_SECONDS}s budget is spent after $((attempt - 1)) attempt(s)."
-            break
-        fi
-
-        # Cap the attempt by whatever is left of the image's budget, not just by PULL_TIMEOUT_SECONDS.
-        # Checking the deadline only between attempts would let a single hanging pull overrun it by a
-        # further PULL_TIMEOUT_SECONDS, so the shared ceiling has to bound the pull itself.
-        attempt_cap=$((remaining < PULL_TIMEOUT_SECONDS ? remaining : PULL_TIMEOUT_SECONDS))
-
-        # The SIGKILL grace period has to come out of the attempt's own share of the budget, not be
-        # added to it: `timeout --kill-after=D T` sends SIGTERM at T and only escalates at T+D, so
-        # charging D on top would let a pull that ignores SIGTERM run past the deadline the comment
-        # above claims to hold. Below the grace period there is no room to be graceful, so kill outright.
-        pull=(docker pull --quiet "$image")
-        if [ "$attempt_cap" -gt "$KILL_GRACE_SECONDS" ]; then
-            pull=("$timeout_bin" --kill-after="${KILL_GRACE_SECONDS}s" "$((attempt_cap - KILL_GRACE_SECONDS))s" "${pull[@]}")
-        else
-            pull=("$timeout_bin" --signal=KILL "${attempt_cap}s" "${pull[@]}")
-        fi
-
-        echo "Pulling ${image} (attempt ${attempt}/${MAX_ATTEMPTS}, up to ${attempt_cap}s)..."
-        if "${pull[@]}"; then
+        echo "Pulling ${image} (attempt ${attempt}/${MAX_ATTEMPTS}, up to ${PULL_TIMEOUT_SECONDS}s)..."
+        # SIGKILL after a short grace, so a pull wedged badly enough to ignore SIGTERM cannot hold the
+        # step open either.
+        if "$timeout_bin" --kill-after=30s "${PULL_TIMEOUT_SECONDS}s" docker pull --quiet "$image"; then
             pulled=true
             break
         fi
-
-        # A pull that dies part-way leaves the partial layers behind; the next attempt resumes from
-        # them, so a plain retry after a short backoff is worth more than it looks. The backoff is
-        # bounded by the budget too, otherwise sleeping could push the loop past the deadline.
-        remaining=$((deadline - SECONDS))
-        if [ "$attempt" -lt "$MAX_ATTEMPTS" ] && [ "$remaining" -gt 0 ]; then
-            backoff=$((attempt * 10))
-            if [ "$backoff" -gt "$remaining" ]; then
-                backoff=$remaining
-            fi
-            sleep "$backoff"
+        # A pull that dies part-way leaves the partial layers behind, so the next attempt resumes from
+        # them rather than starting over.
+        if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+            sleep 10
         fi
     done
 
     if [ "$pulled" != true ]; then
-        echo "::error title=Could not provision E2E exercise image::Failed to pull ${image} within ${PULL_DEADLINE_SECONDS}s (up to ${MAX_ATTEMPTS} attempts). Programming-exercise builds cannot run without it, so every test asserting on a build result would fail with an unexplained 0% score. Check the runner's disk space and registry connectivity."
+        echo "::error title=Could not provision E2E exercise image::Failed to pull ${image} after ${MAX_ATTEMPTS} attempts of up to ${PULL_TIMEOUT_SECONDS}s. Programming-exercise builds cannot run without it, so every test asserting on a build result would fail with an unexplained 0% score. Check the runner's disk space and registry connectivity."
         exit 1
     fi
     echo "Pulled: ${image}"

--- a/.ci/E2E-tests/prepull-exercise-images.sh
+++ b/.ci/E2E-tests/prepull-exercise-images.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Pre-pulls the LocalCI exercise images that the E2E suite's programming exercises build in.
+#
+# Why this exists
+# ---------------
+# The E2E stack mounts the host's Docker socket (docker/playwright-E2E-tests-postgres-localci.yml),
+# so the Artemis build agent runs exercise builds against the runner's own Docker daemon. Without
+# this step the first Java build of a run discovers that the ~1 GB Maven image is missing and pulls
+# it *while the suite is already running*, competing with the test workload for CPU, disk and
+# network. Observed consequence on a PR run: every pull of ls1tum/artemis-maven-template died
+# mid-extraction ("DockerClientException: Could not pull image: Extracting") for the first 25
+# minutes, 261 build jobs failed, and every test that asserts on a Java build result failed with a
+# "0%, Build failed" score — which reads as a grading regression and says nothing about the cause.
+# Tests scheduled after the image finally landed passed, so the symptom tracked the schedule rather
+# than the code, and the same handful of early tests failed on every pull request.
+#
+# Pulling here instead moves that one-off cost in front of the suite, where it competes with nothing
+# and can be retried, and turns an unobtainable image into one loud setup failure rather than a few
+# mystifying assertion failures. Images already present on the host are left alone, so on a warm
+# self-hosted runner this is a no-op.
+
+set -euo pipefail
+
+# Images to provision, with the language whose exercises need them. Only the languages the E2E suite
+# actually creates exercises for are listed — pulling every language in application.yml would cost
+# several gigabytes for images no test builds in.
+IMAGES=(
+    "ls1tum/artemis-maven-template:java17-25" # java + kotlin default (also the default exercise language)
+    "ls1tum/artemis-c-minimal-docker:1.0.0"   # c default
+    "ls1tum/artemis-fact-minimal-docker:1.1.0" # c, fact project type
+    "ls1tum/artemis-python-docker:v1.1.0"     # python default
+)
+
+CONFIG_FILE="src/main/resources/config/application.yml"
+MAX_ATTEMPTS=3
+
+# Guard against drift: the list above is a copy of the tags configured for the build agent, so a tag
+# bumped in application.yml without updating this script would silently reintroduce the on-demand
+# pull this step exists to prevent. Fail here, where the reason is obvious, instead of there.
+for image in "${IMAGES[@]}"; do
+    if ! grep -qF "\"${image}\"" "$CONFIG_FILE"; then
+        echo "::error title=E2E image list is stale::${image} is no longer configured in ${CONFIG_FILE}. Update IMAGES in $0 to match the tags the build agent uses, otherwise the exercise image is pulled on demand during the test run and Java build assertions fail."
+        exit 1
+    fi
+done
+
+for image in "${IMAGES[@]}"; do
+    if docker image inspect "$image" > /dev/null 2>&1; then
+        echo "Already present: ${image}"
+        continue
+    fi
+
+    pulled=false
+    for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+        echo "Pulling ${image} (attempt ${attempt}/${MAX_ATTEMPTS})..."
+        if docker pull --quiet "$image"; then
+            pulled=true
+            break
+        fi
+        # A pull that dies part-way leaves the partial layers behind; the next attempt resumes from
+        # them, so a plain retry after a short backoff is worth more than it looks.
+        if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+            sleep $((attempt * 10))
+        fi
+    done
+
+    if [ "$pulled" != true ]; then
+        echo "::error title=Could not provision E2E exercise image::Failed to pull ${image} after ${MAX_ATTEMPTS} attempts. Programming-exercise builds cannot run without it, so every test asserting on a build result would fail with an unexplained 0% score. Check the runner's disk space and registry connectivity."
+        exit 1
+    fi
+    echo "Pulled: ${image}"
+done
+
+echo "All E2E exercise images are available."

--- a/.ci/E2E-tests/prepull-exercise-images.sh
+++ b/.ci/E2E-tests/prepull-exercise-images.sh
@@ -32,13 +32,21 @@ IMAGES=(
     "ls1tum/artemis-python-docker:v1.1.0"     # python default
 )
 
-CONFIG_FILE="src/main/resources/config/application.yml"
+# Resolved from the script's own location so it does not matter which directory the caller is in.
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+CONFIG_FILE="${REPO_ROOT}/src/main/resources/config/application.yml"
+
 MAX_ATTEMPTS=3
-# A cold pull of the ~1 GB Maven image takes a couple of minutes on a healthy runner. The cap only
-# has to be generous enough not to cut a working pull short, because its job is to stop a *stalled*
-# one: an unbounded `docker pull` here would hang until the job timeout, which is the same
-# undiagnosable failure this script exists to remove, just moved earlier.
-PULL_TIMEOUT_SECONDS=600
+# Cold pulls of all four images together took 30 seconds on the CI runner, the Maven image 11 of them,
+# so these caps carry a large multiple of the real cost. They exist to stop a *stalled* pull: an
+# unbounded `docker pull` here would hang until the job timeout, which is the same undiagnosable
+# failure this script exists to remove, only moved earlier.
+PULL_TIMEOUT_SECONDS=300
+# `timeout` only terminates the `docker pull` client; the daemon keeps the pull going and the next
+# attempt attaches to it. Against a genuinely stalled daemon or registry every attempt would therefore
+# burn its full cap, so the retries need a shared ceiling as well — otherwise the step could outlive
+# the job timeout and be killed before it can report why.
+PULL_DEADLINE_SECONDS=600
 
 # Prints every image configured for the build agent, one per line.
 #
@@ -75,7 +83,17 @@ configured_images() {
 # Guard against drift: the list above is a copy of the tags configured for the build agent, so a tag
 # bumped in application.yml without updating this script would silently reintroduce the on-demand
 # pull this step exists to prevent. Fail here, where the reason is obvious, instead of there.
-mapfile -t CONFIGURED < <(configured_images)
+if [ ! -r "$CONFIG_FILE" ]; then
+    echo "::error title=Could not read E2E exercise images::${CONFIG_FILE} is missing or unreadable, so the configured image tags cannot be checked."
+    exit 1
+fi
+
+# A `while read` loop rather than `mapfile`, which macOS's default Bash 3.2 does not provide.
+CONFIGURED=()
+while IFS= read -r configured_image; do
+    CONFIGURED+=("$configured_image")
+done < <(configured_images)
+
 if [ ${#CONFIGURED[@]} -eq 0 ]; then
     echo "::error title=Could not read E2E exercise images::Found no images under the 'images:' block of ${CONFIG_FILE}. The configuration layout changed; update configured_images() in $0."
     exit 1
@@ -121,7 +139,12 @@ for image in "${IMAGES[@]}"; do
     fi
 
     pulled=false
+    deadline=$((SECONDS + PULL_DEADLINE_SECONDS))
     for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "Giving up on ${image} after ${PULL_DEADLINE_SECONDS}s spent across ${attempt} attempts."
+            break
+        fi
         echo "Pulling ${image} (attempt ${attempt}/${MAX_ATTEMPTS})..."
         if "${pull[@]}"; then
             pulled=true

--- a/.ci/E2E-tests/prepull-exercise-images.sh
+++ b/.ci/E2E-tests/prepull-exercise-images.sh
@@ -58,19 +58,28 @@ KILL_GRACE_SECONDS=30
 # satisfy the drift check below. The file holds a second, unrelated `images:` block for Kubernetes app
 # definitions at a shallower indent, which is why the block has to be nested inside `build:` to count:
 # `build_indent` is tracked while inside that block and cleared on leaving it, so an `images:` key in
-# some later section cannot be picked up. Language keys carry no value of their own and are skipped;
-# values are accepted quoted or bare, and trailing comments are stripped.
+# some later section cannot be picked up. It has to be the *direct* child: `build_child_indent` is taken
+# from the first key below `build:`, and only an `images:` at exactly that indent counts, so an `images:`
+# mapping nested deeper under `build:` - inside `default-docker-flags:`, say - is not mistaken for the
+# list of build agent images. Language keys carry no value of their own and are skipped; values are
+# accepted quoted or bare, and trailing comments are stripped.
 configured_images() {
     awk '
         /^[[:space:]]*build:[[:space:]]*$/ {
             build_indent = match($0, /[^[:space:]]/)
+            build_child_indent = 0
             next
         }
         # Left the build block without having found its images child — stop looking until the next one.
         !in_block && build_indent && !/^[[:space:]]*$/ && match($0, /[^[:space:]]/) <= build_indent {
             build_indent = 0
+            build_child_indent = 0
         }
-        !in_block && build_indent && /^[[:space:]]*images:[[:space:]]*$/ && match($0, /[^[:space:]]/) > build_indent {
+        # The first key below `build:` fixes the indent its direct children sit at.
+        !in_block && build_indent && !build_child_indent && !/^[[:space:]]*$/ && match($0, /[^[:space:]]/) > build_indent {
+            build_child_indent = match($0, /[^[:space:]]/)
+        }
+        !in_block && build_indent && /^[[:space:]]*images:[[:space:]]*$/ && match($0, /[^[:space:]]/) == build_child_indent {
             in_block = 1
             block_indent = match($0, /[^[:space:]]/)
             next

--- a/.ci/E2E-tests/prepull-exercise-images.sh
+++ b/.ci/E2E-tests/prepull-exercise-images.sh
@@ -52,15 +52,20 @@ PULL_DEADLINE_SECONDS=600
 #
 # Reads only the build agent's own block (`artemis.continuous-integration.build.images`) rather than
 # grepping the whole file, so an image name appearing in a comment or an unrelated setting cannot
-# satisfy the drift check below. The file holds a second, unrelated `images:` block for Kubernetes
-# app definitions, hence the requirement that the block be nested directly under `build:`. Language
-# keys carry no value of their own and are skipped; values are accepted quoted or bare, and trailing
-# comments are stripped.
+# satisfy the drift check below. The file holds a second, unrelated `images:` block for Kubernetes app
+# definitions at a shallower indent, which is why the block has to be nested inside `build:` to count:
+# `build_indent` is tracked while inside that block and cleared on leaving it, so an `images:` key in
+# some later section cannot be picked up. Language keys carry no value of their own and are skipped;
+# values are accepted quoted or bare, and trailing comments are stripped.
 configured_images() {
     awk '
         /^[[:space:]]*build:[[:space:]]*$/ {
             build_indent = match($0, /[^[:space:]]/)
             next
+        }
+        # Left the build block without having found its images child — stop looking until the next one.
+        !in_block && build_indent && !/^[[:space:]]*$/ && match($0, /[^[:space:]]/) <= build_indent {
+            build_indent = 0
         }
         !in_block && build_indent && /^[[:space:]]*images:[[:space:]]*$/ && match($0, /[^[:space:]]/) > build_indent {
             in_block = 1
@@ -113,52 +118,66 @@ for image in "${IMAGES[@]}"; do
     fi
 done
 
+# A bound turns a stalled pull into a non-zero exit so the retries can act on it. coreutils ships
+# `timeout` on the CI runners; macOS names it `gtimeout` when coreutils is installed via Homebrew,
+# which keeps the bound working for anyone running this locally. Without either, pulls stay unbounded,
+# which is worth saying out loud rather than failing over.
+timeout_bin=""
+if command -v timeout > /dev/null 2>&1; then
+    timeout_bin="timeout"
+elif command -v gtimeout > /dev/null 2>&1; then
+    timeout_bin="gtimeout"
+else
+    echo "Note: neither 'timeout' nor 'gtimeout' is available, so a stalled pull cannot be bounded."
+fi
+
 for image in "${IMAGES[@]}"; do
     if docker image inspect "$image" > /dev/null 2>&1; then
         echo "Already present: ${image}"
         continue
     fi
 
-    # A bound turns a stalled pull into a non-zero exit so the retry below can act on it. coreutils
-    # ships `timeout` on the CI runners; macOS names it `gtimeout` when coreutils is installed via
-    # Homebrew, which keeps the bound working for anyone running this locally. Without either the pull
-    # stays unbounded, which is worth saying out loud rather than failing over.
-    pull=(docker pull --quiet "$image")
-    timeout_bin=""
-    if command -v timeout > /dev/null 2>&1; then
-        timeout_bin="timeout"
-    elif command -v gtimeout > /dev/null 2>&1; then
-        timeout_bin="gtimeout"
-    fi
-    if [ -n "$timeout_bin" ]; then
-        # --kill-after escalates to SIGKILL for a pull wedged badly enough to ignore the SIGTERM, so
-        # the step cannot be held open by the very stall it is meant to cut short.
-        pull=("$timeout_bin" --kill-after=30s "${PULL_TIMEOUT_SECONDS}s" "${pull[@]}")
-    else
-        echo "Note: neither 'timeout' nor 'gtimeout' is available, so a stalled pull of ${image} cannot be bounded."
-    fi
-
     pulled=false
     deadline=$((SECONDS + PULL_DEADLINE_SECONDS))
     for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-        if [ "$SECONDS" -ge "$deadline" ]; then
-            echo "Giving up on ${image} after ${PULL_DEADLINE_SECONDS}s spent across ${attempt} attempts."
+        remaining=$((deadline - SECONDS))
+        if [ "$remaining" -le 0 ]; then
+            echo "Giving up on ${image}: its ${PULL_DEADLINE_SECONDS}s budget is spent after $((attempt - 1)) attempt(s)."
             break
         fi
-        echo "Pulling ${image} (attempt ${attempt}/${MAX_ATTEMPTS})..."
+
+        # Cap the attempt by whatever is left of the image's budget, not just by PULL_TIMEOUT_SECONDS.
+        # Checking the deadline only between attempts would let a single hanging pull overrun it by a
+        # further PULL_TIMEOUT_SECONDS, so the shared ceiling has to bound the pull itself.
+        attempt_cap=$((remaining < PULL_TIMEOUT_SECONDS ? remaining : PULL_TIMEOUT_SECONDS))
+        pull=(docker pull --quiet "$image")
+        if [ -n "$timeout_bin" ]; then
+            # --kill-after escalates to SIGKILL for a pull wedged badly enough to ignore the SIGTERM,
+            # so the step cannot be held open by the very stall it is meant to cut short.
+            pull=("$timeout_bin" --kill-after=30s "${attempt_cap}s" "${pull[@]}")
+        fi
+
+        echo "Pulling ${image} (attempt ${attempt}/${MAX_ATTEMPTS}, up to ${attempt_cap}s)..."
         if "${pull[@]}"; then
             pulled=true
             break
         fi
+
         # A pull that dies part-way leaves the partial layers behind; the next attempt resumes from
-        # them, so a plain retry after a short backoff is worth more than it looks.
-        if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-            sleep $((attempt * 10))
+        # them, so a plain retry after a short backoff is worth more than it looks. The backoff is
+        # bounded by the budget too, otherwise sleeping could push the loop past the deadline.
+        remaining=$((deadline - SECONDS))
+        if [ "$attempt" -lt "$MAX_ATTEMPTS" ] && [ "$remaining" -gt 0 ]; then
+            backoff=$((attempt * 10))
+            if [ "$backoff" -gt "$remaining" ]; then
+                backoff=$remaining
+            fi
+            sleep "$backoff"
         fi
     done
 
     if [ "$pulled" != true ]; then
-        echo "::error title=Could not provision E2E exercise image::Failed to pull ${image} after ${MAX_ATTEMPTS} attempts. Programming-exercise builds cannot run without it, so every test asserting on a build result would fail with an unexplained 0% score. Check the runner's disk space and registry connectivity."
+        echo "::error title=Could not provision E2E exercise image::Failed to pull ${image} within ${PULL_DEADLINE_SECONDS}s (up to ${MAX_ATTEMPTS} attempts). Programming-exercise builds cannot run without it, so every test asserting on a build result would fail with an unexplained 0% score. Check the runner's disk space and registry connectivity."
         exit 1
     fi
     echo "Pulled: ${image}"

--- a/.ci/E2E-tests/prepull-exercise-images.sh
+++ b/.ci/E2E-tests/prepull-exercise-images.sh
@@ -47,6 +47,9 @@ PULL_TIMEOUT_SECONDS=300
 # burn its full cap, so the retries need a shared ceiling as well — otherwise the step could outlive
 # the job timeout and be killed before it can report why.
 PULL_DEADLINE_SECONDS=600
+# Grace between SIGTERM and SIGKILL for a pull that will not stop on its own. Subtracted from each
+# attempt's cap rather than added to it, so the deadline stays a true ceiling.
+KILL_GRACE_SECONDS=30
 
 # Prints every image configured for the build agent, one per line.
 #
@@ -120,21 +123,26 @@ done
 
 # A bound turns a stalled pull into a non-zero exit so the retries can act on it. coreutils ships
 # `timeout` on the CI runners; macOS names it `gtimeout` when coreutils is installed via Homebrew,
-# which keeps the bound working for anyone running this locally. Without either, pulls stay unbounded,
-# which is worth saying out loud rather than failing over.
+# which keeps the bound working for anyone running this locally.
 timeout_bin=""
 if command -v timeout > /dev/null 2>&1; then
     timeout_bin="timeout"
 elif command -v gtimeout > /dev/null 2>&1; then
     timeout_bin="gtimeout"
-else
-    echo "Note: neither 'timeout' nor 'gtimeout' is available, so a stalled pull cannot be bounded."
 fi
 
 for image in "${IMAGES[@]}"; do
     if docker image inspect "$image" > /dev/null 2>&1; then
         echo "Already present: ${image}"
         continue
+    fi
+
+    # Refuse to start a pull that cannot be bounded: an unbounded `docker pull` that stalls would hold
+    # the setup step open until the job timeout, which is the failure this script exists to remove. Only
+    # reached when an image is actually missing, so a machine with every image cached still succeeds.
+    if [ -z "$timeout_bin" ]; then
+        echo "::error title=Cannot bound the E2E image pull::${image} is missing and neither 'timeout' nor 'gtimeout' is available, so a stalled pull could hang this step indefinitely. Install coreutils (on macOS: brew install coreutils) or pull the image manually."
+        exit 1
     fi
 
     pulled=false
@@ -150,11 +158,16 @@ for image in "${IMAGES[@]}"; do
         # Checking the deadline only between attempts would let a single hanging pull overrun it by a
         # further PULL_TIMEOUT_SECONDS, so the shared ceiling has to bound the pull itself.
         attempt_cap=$((remaining < PULL_TIMEOUT_SECONDS ? remaining : PULL_TIMEOUT_SECONDS))
+
+        # The SIGKILL grace period has to come out of the attempt's own share of the budget, not be
+        # added to it: `timeout --kill-after=D T` sends SIGTERM at T and only escalates at T+D, so
+        # charging D on top would let a pull that ignores SIGTERM run past the deadline the comment
+        # above claims to hold. Below the grace period there is no room to be graceful, so kill outright.
         pull=(docker pull --quiet "$image")
-        if [ -n "$timeout_bin" ]; then
-            # --kill-after escalates to SIGKILL for a pull wedged badly enough to ignore the SIGTERM,
-            # so the step cannot be held open by the very stall it is meant to cut short.
-            pull=("$timeout_bin" --kill-after=30s "${attempt_cap}s" "${pull[@]}")
+        if [ "$attempt_cap" -gt "$KILL_GRACE_SECONDS" ]; then
+            pull=("$timeout_bin" --kill-after="${KILL_GRACE_SECONDS}s" "$((attempt_cap - KILL_GRACE_SECONDS))s" "${pull[@]}")
+        else
+            pull=("$timeout_bin" --signal=KILL "${attempt_cap}s" "${pull[@]}")
         fi
 
         echo "Pulling ${image} (attempt ${attempt}/${MAX_ATTEMPTS}, up to ${attempt_cap}s)..."

--- a/.github/actions/e2e-setup/action.yml
+++ b/.github/actions/e2e-setup/action.yml
@@ -62,6 +62,13 @@ runs:
       shell: bash
       run: .ci/E2E-tests/cleanup.sh
 
+    # Must run after the cleanup (which stops containers but leaves images) and before the tests, so
+    # no build job ever races a multi-gigabyte on-demand pull. See the script header for the failure
+    # this prevents.
+    - name: Pre-pull exercise images
+      shell: bash
+      run: .ci/E2E-tests/prepull-exercise-images.sh
+
     - name: Clean old test results
       shell: bash
       run: |


### PR DESCRIPTION
### Summary

The E2E stack mounts the runner's Docker socket, so exercise builds run against the host daemon — but nothing provisions the exercise images. The first Java build of a run therefore discovers that the ~1 GB Maven image is missing and pulls it *while the suite is already running*, competing with the test workload. This adds a pre-pull step to the shared E2E setup action so no build job ever races an on-demand pull.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

A handful of E2E tests have been failing on **every** pull request, and the flakiness classifier scores them as real regressions, so they block the required gate. They are not regressions.

On run [31575061135](https://github.com/ls1intum/Artemis/actions/runs/31575061135) the app container log shows:

\`\`\`
BuildJobManagementService : Error while executing build job 3151786522675528:
  LocalCIException: Could not pull Docker image ls1tum/artemis-maven-template:java17-25
Caused by: ... BuildAgentDockerService.doPullDockerImage
Caused by: com.github.dockerjava.api.exception.DockerClientException:
  Could not pull image: Extracting
\`\`\`

docker-java's \`PullImageResultCallback\` throws with the last status it saw, so \"Extracting\" means the pull stream ended part-way through unpacking layers. In that run:

- the image was absent at stack start and **261 build jobs** failed on it, from 07:55:43 to 08:20:04;
- once it landed, later Java builds passed in ~10s (\`ProgrammingExerciseParticipation › Team members make git submissions\`, 08:24);
- the tests that fail run at 08:15–08:20, i.e. inside the dead window.

Because test order is stable, the same early-scheduled tests fail every time: both \`ProgrammingExercisePracticeMode\` submission tests and \`Static code analysis tests › Verifies SCA feedback is displayed correctly after submission\`. They fail on unrelated PRs too (#13493, #13492) and pass locally, where the images are already on the machine — I ran the practice-mode spec against a local stack and all 3 tests pass in 1.5 minutes with real Maven builds reaching 100%.

The symptom is misleading on its own: the assertion reports \`Status 0%, Build failed\`, which reads as a grading regression and says nothing about the missing image.

Ruled out along the way: Artemis's own pull timeout and stall detector never fire (zero \`did not finish within\` / \`reported no progress\` messages, so \`image-pull-timeout-seconds\` is not involved); the \`java17-25\` tag does exist on Docker Hub; and \`.ci/E2E-tests/cleanup.sh\` stops containers but does not remove images.

### Description

- **New \`.ci/E2E-tests/prepull-exercise-images.sh\`** — pulls the four images the suite's programming exercises actually build in (Java/Kotlin Maven template, C minimal, C fact, Python). Images already present are skipped, so on a warm self-hosted runner this is a no-op. Failed pulls are retried with backoff; a partial pull leaves its layers behind, so a retry resumes rather than restarts.
- **Drift guard** — each tag must still appear in \`application.yml\`. Bumping a tag there without updating the script fails with an explicit message instead of silently reintroducing the on-demand pull this step exists to prevent.
- **Wired into \`.github/actions/e2e-setup\`** after the cleanup step (which stops containers but leaves images) and before the tests, so all three E2E jobs get it.

This moves a cost that was already being paid in front of the suite, where it competes with nothing and can be retried, and turns an unobtainable image into one loud setup failure rather than a handful of unexplained assertion failures.

**What this does not do:** it does not explain why the host's pulls die mid-extraction — disk pressure, concurrent E2E jobs on shared self-hosted runners and registry flakiness are all candidates, and telling them apart needs host-level access. If the host cannot pull at all, the job now fails fast at setup with the real reason instead of producing 261 opaque build failures. Happy to downgrade that to a warning if you would rather a degraded run still executed.

### Steps for Testing

This only affects CI, so the check is the E2E run on this PR itself:

1. Open the \`E2E / Phase 1\` job and confirm the new **Pre-pull exercise images** step runs after the cleanup step and reports each image as either pulled or already present.
2. Confirm the app container log contains no \`Could not pull Docker image\` errors.
3. Confirm the three previously-failing tests now pass:
   - \`Programming exercise practice mode › Keeps the practice mode selectable when switching back to graded\`
   - \`Programming exercise practice mode › Shows the submission state when submitting in the practice mode code editor\`
   - \`Static code analysis tests › Verifies SCA feedback is displayed correctly after submission\`

Locally verified all four script paths: images already present (no-op), pull needed (pulled successfully), tag no longer in \`application.yml\` (fails with the stale-list error), and unpullable image (retries, then fails with the provisioning error). \`shellcheck\` and \`bash -n\` are clean.

### Testserver States

Not applicable — this changes CI setup only and cannot be exercised on a test server.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated setup for Docker images required by end-to-end programming exercises.
  * Validates configured images and identifies mismatches before provisioning.
  * Skips images already available locally and retries missing image downloads with timeouts, backoff, and a shared deadline.
  * Provides clear error messages when configuration validation, required tooling, or image provisioning fails.
  * Improves reliability and visibility when preparing exercise environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->