### PR TITLE
`Development`: Remove the stale per-entity Hibernate cache comments

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/account/domain/User.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/domain/User.java
@@ -199,7 +199,6 @@ public class User extends AbstractAuditingEntity implements Participant {
     @JsonIgnoreProperties(value = "user", allowSetters = true)
     private Set<Organization> organizations = new HashSet<>();
 
-    // No @Cache: mutated on every tutorial-group enrolment change; NONSTRICT caused stale cross-node reads, same class of bug as #12574.
     @OneToMany(mappedBy = "student", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     @JsonIgnoreProperties(value = "student", allowSetters = true)
     public Set<TutorialGroupRegistration> tutorialGroupRegistrations = new HashSet<>();
@@ -216,7 +215,6 @@ public class User extends AbstractAuditingEntity implements Participant {
     @JsonIgnore
     private Set<LearningPath> learningPaths = new HashSet<>();
 
-    // No @Cache: mutated on every exam registration; NONSTRICT caused stale cross-node reads, same class of bug as #12574.
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIgnore
     private Set<ExamUser> examUsers = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradingCriterion.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradingCriterion.java
@@ -25,7 +25,6 @@ import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class GradingCriterion extends DomainObject {
 
-    // No @Cache here on purpose: mutated while instructors edit grading criteria, same bug class as #12574 / #12584.
     @OneToMany(mappedBy = "gradingCriterion", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JsonIgnoreProperties(value = "gradingCriterion", allowSetters = true)
     private Set<GradingInstruction> structuredGradingInstructions = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradingInstruction.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradingInstruction.java
@@ -47,8 +47,6 @@ public class GradingInstruction extends DomainObject {
     @ManyToOne(fetch = FetchType.LAZY)
     private GradingCriterion gradingCriterion;
 
-    // No @Cache here on purpose: grows every time a tutor applies this grading instruction during manual assessment,
-    // same bug class as #12574 / #12584 on a clustered L2 cache.
     @OneToMany(mappedBy = "gradingInstruction", fetch = FetchType.LAZY)
     @JsonIgnoreProperties(value = "gradingInstruction", allowSetters = true)
     private Set<Feedback> feedbacks = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradingScale.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradingScale.java
@@ -80,7 +80,6 @@ public class GradingScale extends DomainObject {
      * Current implementation works with one Bonus instance as GradingScale.bonusFrom per Bonus.bonusTo instance (OneToOne) but
      * the relation is defined as OneToMany in order to allow applying multiple bonuses.
      */
-    // No @Cache on the two child collections below: mutated during grading-scale edits, same bug class as #12574 / #12584.
     @OneToMany(mappedBy = "gradingScale", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JsonIgnoreProperties(value = "gradingScale", allowSetters = true)
     private Set<GradeStep> gradeSteps = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Result.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Result.java
@@ -92,7 +92,6 @@ public class Result extends DomainObject implements Comparable<Result> {
     @JsonIgnoreProperties({ "results" })
     private Submission submission;
 
-    // No @Cache: actively mutated during manual assessment; NONSTRICT caused stale feedback lists across nodes, same class of bug as #12574.
     // Stored as a Set: feedback ordering is not semantically meaningful — every consumer that cares about
     // presentation order sorts explicitly (by credits, by FeedbackType, by reference, ...). Using a Set
     // avoids the @OrderColumn null-index race (Hibernate "Illegal null value for list index" under

--- a/src/main/java/de/tum/cit/aet/artemis/course/domain/Course.java
+++ b/src/main/java/de/tum/cit/aet/artemis/course/domain/Course.java
@@ -182,8 +182,6 @@ public class Course extends DomainObject {
     @Column(name = "time_zone")
     private String timeZone;
 
-    // No @Cache: instructors create / archive / edit exercises while every student's course-overview read hits this; NONSTRICT caused the dashboard to "forget"
-    // exercises on other nodes for a short window, same class of bug as #12574.
     @OneToMany(mappedBy = "course", fetch = FetchType.LAZY)
     @JsonIgnoreProperties("course")
     private Set<Exercise> exercises = new HashSet<>();
@@ -215,7 +213,6 @@ public class Course extends DomainObject {
     @OrderBy("title")
     private Set<TutorialGroup> tutorialGroups = new HashSet<>();
 
-    // No @Cache: exams are created / edited / archived by instructors while students see the course overview, same class of bug as #12574.
     @OneToMany(mappedBy = "course", fetch = FetchType.LAZY)
     @JsonIgnoreProperties("course")
     private Set<Exam> exams = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/artemis/exam/domain/Exam.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/domain/Exam.java
@@ -151,8 +151,6 @@ public class Exam extends DomainObject {
     @JsonIgnoreProperties(value = "exam", allowSetters = true)
     private List<ExerciseGroup> exerciseGroups = new ArrayList<>();
 
-    // No @Cache on studentExams / examUsers / examRoomExamAssignments: all grow / are mutated during exam registration and prep while conduction monitoring reads
-    // them concurrently; NONSTRICT caused stale cross-node reads, same class of bug as #12574.
     @OneToMany(mappedBy = "exam", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIgnoreProperties("exam")
     private Set<StudentExam> studentExams = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/artemis/exam/domain/StudentExam.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/domain/StudentExam.java
@@ -63,8 +63,6 @@ public class StudentExam extends AbstractAuditingEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    // No @Cache on exercises / examSessions / studentParticipations: all three are mutated during exam prep and conduct (session reconnects, participations grow
-    // as the student works); NONSTRICT would give monitoring reads on another node a stale view, same class of bug as #12574.
     @ManyToMany
     @JoinTable(name = "student_exam_exercise", joinColumns = @JoinColumn(name = "student_exam_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "exercise_id", referencedColumnName = "id"))
     @OrderColumn(name = "exercise_order")

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
@@ -148,13 +148,10 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
     @JsonIgnoreProperties("exercises")
     private ExerciseVariantGroup exerciseVariantGroup;
 
-    // No @Cache: instructors edit grading criteria while assessors read them during assessment; NONSTRICT produced
-    // stale cross-node reads, same class of bug as #12574 / #12584.
     @OneToMany(mappedBy = "exercise", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIgnoreProperties(value = "exercise", allowSetters = true)
     private Set<GradingCriterion> gradingCriteria = new HashSet<>();
 
-    // No @Cache: grows every time a student starts / submits the exercise; NONSTRICT caused stale reads for instructors and scoring paths, same class of bug as #12574.
     @OneToMany(mappedBy = "exercise", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIgnoreProperties("exercise")
     private Set<StudentParticipation> studentParticipations = new HashSet<>();
@@ -167,12 +164,10 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
     @JsonIgnoreProperties("exercise")
     private Set<ExampleSubmission> exampleSubmissions = new HashSet<>();
 
-    // No @Cache: instructors edit attachments while students are viewing the exercise page; NONSTRICT caused stale cross-node reads, same class of bug as #12574.
     @OneToMany(mappedBy = "exercise", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIgnoreProperties("exercise")
     private Set<Attachment> attachments = new HashSet<>();
 
-    // No @Cache: plagiarism cases are appended by detection runs while instructors read the list, same class of bug as #12574.
     @OneToMany(mappedBy = "exercise", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIncludeProperties({ "id" })
     private Set<PlagiarismCase> plagiarismCases = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
@@ -83,7 +83,6 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     @ManyToOne
     private Participation participation;
 
-    // No @Cache: appended on every save; NONSTRICT produced stale version lists for concurrent readers, same class of bug as #12574.
     @JsonIgnore
     @OneToMany(mappedBy = "submission", cascade = CascadeType.REMOVE)
     private Set<SubmissionVersion> versions = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
@@ -89,8 +89,6 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
 
     /**
      * A submission can have multiple results, therefore, results are persisted and removed with a submission.
-     * CacheStrategy.NONSTRICT_READ_WRITE leads to problems with the deletion of a submission, because first the results
-     * are deleted in a transactional method.
      */
     @OneToMany(mappedBy = "submission", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderColumn(name = "results_order")

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Team.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Team.java
@@ -45,10 +45,6 @@ public class Team extends AbstractAuditingEntity implements Participant {
     @JsonIgnore
     private Exercise exercise;
 
-    /**
-     * The cache concurrency strategy needs to be READ_WRITE (and not NONSTRICT_READ_WRITE) since the non-strict mode will cause an SQLIntegrityConstraintViolationException to
-     * occur when trying to persist the entity for the first time after changes have been made to the related entities of the ManyToMany relationship (users in this case).
-     */
     @ManyToMany(fetch = FetchType.LAZY)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JoinTable(name = "team_student", joinColumns = @JoinColumn(name = "team_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "student_id", referencedColumnName = "id"))

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/participation/Participation.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/participation/Participation.java
@@ -94,7 +94,6 @@ public abstract class Participation extends DomainObject implements Participatio
      * have to use the save function and not the saveAndFlush function because otherwise an exception is thrown. We can think about adding orphanRemoval=true here, after adding the
      * participationId to all submissions.
      */
-    // No @Cache: grows on every submit; NONSTRICT produced stale submission lists for concurrent readers, same class of bug as #12574.
     @OneToMany(mappedBy = "participation", fetch = FetchType.LAZY)
     @JsonIgnoreProperties({ "participation" })
     private Set<Submission> submissions = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/domain/Lecture.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/domain/Lecture.java
@@ -79,8 +79,6 @@ public class Lecture extends DomainObject {
      * long as they use the provided methods to add/remove/reorder lecture units.
      *
      */
-    // No @Cache here on purpose: mutated whenever lecture units are added / reordered / removed.
-    // Clustered NONSTRICT_READ_WRITE on an actively mutated collection is the #12574 bug class.
     @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("lectureUnitOrder ASC") // DB → Java: always ordered by that column
     @JsonIgnoreProperties("lecture")

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/domain/LectureUnit.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/domain/LectureUnit.java
@@ -80,7 +80,6 @@ public abstract class LectureUnit extends DomainObject implements LearningObject
     @JoinColumn(name = "lecture_id", nullable = false)
     private Lecture lecture;
 
-    // No @Cache here on purpose: mutated whenever competencies are linked / unlinked. See #12574 / #12584.
     @OneToMany(mappedBy = "lectureUnit", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JsonIgnoreProperties("lectureUnit")
     protected Set<CompetencyLectureUnitLink> competencyLinks = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingSubmission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingSubmission.java
@@ -42,7 +42,6 @@ public class ProgrammingSubmission extends Submission {
     private boolean buildFailed;
 
     // Only present if buildFailed == true.
-    // No @Cache: written asynchronously by the CI callback; NONSTRICT caused partial log reads from other nodes, same class of bug as #12574.
     @OneToMany(mappedBy = "programmingSubmission", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderColumn(name = "build_log_entries_order")
     @JsonIgnoreProperties(value = "programmingSubmission", allowSetters = true)

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/build/BuildPlan.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/build/BuildPlan.java
@@ -29,7 +29,6 @@ public class BuildPlan extends DomainObject {
     @Column(name = "build_plan", table = "build_plan", length = 10_000)
     private String buildPlan;
 
-    // No @Cache here on purpose: mutated when build plans are linked / unlinked from programming exercises. See #12574 / #12584.
     @OneToMany
     @JoinColumn(name = "build_plan_id")
     private Set<ProgrammingExercise> programmingExercises = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizBatch.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizBatch.java
@@ -20,7 +20,6 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A QuizBatch.
  */
-// No @Cache here on purpose: written every time a student joins a BATCHED quiz. See #12574 / #12584.
 @Entity
 @Table(name = "quiz_batch")
 @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizExercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizExercise.java
@@ -71,8 +71,6 @@ public class QuizExercise extends Exercise implements QuizConfiguration {
     @JoinColumn(unique = true)
     private QuizPointStatistic quizPointStatistic;
 
-    // No @Cache here on purpose: this collection is mutated on every quiz edit/import and re-read on every student participation.
-    // NONSTRICT_READ_WRITE on a clustered L2 cache produced partial / stale reads that were the #12574 / #12584 bug class.
     // Bidirectional mapping: QuizQuestion.exercise owns the exercise_id FK, so a parent saveAndFlush issues targeted
     // UPDATEs on the order column instead of the DELETE+INSERT cascade that produced #12584.
     // See documentation/docs/developer/guidelines/database.mdx → "Ordered Collection with Duplicates (List)" for the
@@ -81,8 +79,6 @@ public class QuizExercise extends Exercise implements QuizConfiguration {
     @OrderColumn(name = "quiz_questions_order")
     private List<QuizQuestion> quizQuestions = new ArrayList<>();
 
-    // No @Cache here on purpose: quizBatches is mutated on every student join in BATCHED mode, so the cache is actively hot
-    // and NONSTRICT's async-invalidation window is too loose for the multi-node setup. See #12574 / #12584.
     @OneToMany(mappedBy = "quizExercise", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Set<QuizBatch> quizBatches = new HashSet<>();
 

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizPointStatistic.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizPointStatistic.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class QuizPointStatistic extends QuizStatistic {
 
-    // No @Cache: counters are incremented on every evaluation while instructors watch live statistics, same class of bug as #12574.
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true, mappedBy = "quizPointStatistic")
     private Set<PointCounter> pointCounters = new HashSet<>();
 

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizQuestion.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizQuestion.java
@@ -32,8 +32,6 @@ import de.tum.cit.aet.artemis.quiz.domain.scoring.ScoringStrategy;
 /**
  * A QuizQuestion.
  */
-// No @Cache here on purpose: parent entity of the question hierarchy loaded during quiz-submission merge cascade.
-// Clustered NONSTRICT_READ_WRITE produced the stale-collection behaviour tracked in #12574 / #12584.
 @Entity
 @Table(name = "quiz_question")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizStatistic.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizStatistic.java
@@ -18,7 +18,6 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A QuizStatistic.
  */
-// No @Cache here on purpose: incremented on every quiz evaluation while instructors watch live statistics. See #12574 / #12584.
 @Entity
 @Table(name = "quiz_statistic")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizStatisticCounter.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizStatisticCounter.java
@@ -18,7 +18,6 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A QuizStatisticCounter.
  */
-// No @Cache here on purpose: incremented on every quiz evaluation. See #12574 / #12584.
 @Entity
 @Table(name = "quiz_statistic_counter")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizSubmission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizSubmission.java
@@ -29,7 +29,6 @@ public class QuizSubmission extends Submission {
     @Column(name = "score_in_points")
     private Double scoreInPoints;
 
-    // No @Cache: actively mutated on every autosave / submit / evaluation; NONSTRICT reads caused #12574.
     @OneToMany(mappedBy = "submission", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private Set<@Valid SubmittedAnswer> submittedAnswers = new HashSet<>();
 

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/SubmittedAnswer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/SubmittedAnswer.java
@@ -25,7 +25,6 @@ import de.tum.cit.aet.artemis.core.domain.DomainObject;
 /**
  * A SubmittedAnswer.
  */
-// No @Cache here on purpose: parent of MC/DnD/SA submitted answers, inserted on every live save/submit. See #12574 / #12584.
 @Entity
 @Table(name = "submitted_answer")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)

--- a/src/main/java/de/tum/cit/aet/artemis/tutorialgroup/domain/TutorialGroup.java
+++ b/src/main/java/de/tum/cit/aet/artemis/tutorialgroup/domain/TutorialGroup.java
@@ -143,7 +143,6 @@ public class TutorialGroup extends DomainObject {
     @JsonIgnoreProperties(value = "tutorialGroup", allowSetters = true)
     private TutorialGroupSchedule tutorialGroupSchedule;
 
-    // No @Cache here on purpose: mutated when sessions are generated / adjusted for the schedule. See #12574 / #12584.
     @OneToMany(mappedBy = "tutorialGroup", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIgnoreProperties(value = "tutorialGroup, tutorialGroupSchedule", allowSetters = true)
     private Set<TutorialGroupSession> tutorialGroupSessions = new HashSet<>();

--- a/src/main/java/de/tum/cit/aet/artemis/tutorialgroup/domain/TutorialGroupSchedule.java
+++ b/src/main/java/de/tum/cit/aet/artemis/tutorialgroup/domain/TutorialGroupSchedule.java
@@ -108,7 +108,6 @@ public class TutorialGroupSchedule extends DomainObject {
      * The sessions that were generated from this schedule, i.e. the sessions that follow this recurrence pattern.
      * Do NOT use orphanRemoval = true, as it will delete the sessions when they are disconnected from the schedule.
      */
-    // No @Cache here on purpose: mutated whenever sessions are regenerated from schedule changes. See #12574 / #12584.
     @OneToMany(mappedBy = "tutorialGroupSchedule", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     @JsonIgnoreProperties(value = "tutorialGroupSchedule", allowSetters = true)
     private List<TutorialGroupSession> tutorialGroupSessions = new ArrayList<>();

--- a/src/test/java/de/tum/cit/aet/artemis/quiz/QuizSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/quiz/QuizSubmissionIntegrationTest.java
@@ -939,8 +939,9 @@ class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
      * <p>
      * Previously, refresh-path queries relied on Hibernate's EAGER fetch for {@code MultipleChoiceSubmittedAnswer.selectedOptions},
      * which was not reliably initialized when the polymorphic {@code submittedAnswers} collection was loaded alongside a join-table
-     * {@code ManyToMany} with a second-level cache — leading to different options appearing deselected across refreshes and (once
-     * re-evaluation read the same partial state) the stored score flipping between 0 and its true value.
+     * {@code ManyToMany} that was then cached in the Hibernate second-level cache, leading to different options appearing deselected
+     * across refreshes and (once re-evaluation read the same partial state) the stored score flipping between 0 and its true value.
+     * That cache has since been disabled cluster-wide, but the explicit fetch this test guards is what makes the result deterministic.
      */
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")


### PR DESCRIPTION
### Summary

Removes 45 stale comment lines across 27 files that discuss Hibernate second-level cache strategies. Comments only, no behaviour change.

### Checklist

#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).

### Motivation and Context

When the Hibernate second-level cache was removed in #12578 and #12579, every entity that lost an annotation kept a note in its place, of the form:

```java
// No @Cache: grows every time a student starts / submits the exercise; NONSTRICT caused stale reads for
// instructors and scoring paths, same class of bug as #12574.
@OneToMany(mappedBy = "exercise", ...)
private Set<StudentParticipation> studentParticipations = new HashSet<>();
```

Those notes made sense while the decision was still per field. It no longer is. L2 is disabled cluster-wide, and `ArchitectureTest.testNoHibernateSecondLevelCacheAnnotation` fails the build if any `@Cache` reappears, on any entity, whatever that field's write pattern happens to be. So a reader gets 25 files each arguing a case that was settled globally, and each restating the same two issue numbers.

They also invite a wrong inference. Explaining that *this* collection is too hot to cache implies that a colder one would be fine, which is exactly the conclusion the ArchUnit rule exists to prevent.

Separately, three older comments predating that cleanup still discussed which strategy to pick, which is now a choice that does not exist.

### Description

**Removed the `// No @Cache …` blocks** from the 25 entities that carried them, 40 lines in total.

**Removed three older cache-strategy comments** that survived the earlier cleanup because they live in Javadoc rather than in line comments:

- `Team.students` carried a Javadoc arguing the strategy must be `READ_WRITE` and not `NONSTRICT_READ_WRITE`. There is no strategy to choose any more, so the block is gone.
- `Submission.results` explained that `CacheStrategy.NONSTRICT_READ_WRITE` breaks deletion. Only that sentence is gone; the note that results are persisted and removed with the submission stays, because it describes the cascade, not the cache.
- The #12574 regression test in `QuizSubmissionIntegrationTest` describes the original bug, which involved the second-level cache. That history is worth keeping, but as written it implies the cache is still present and the test therefore obsolete. It now says the cache has since been disabled and that the explicit fetch the test guards is what makes the result deterministic.

**Deliberately kept**, because these are where the policy is stated, enforced, or genuinely still true:

- `ArchitectureTest.testNoHibernateSecondLevelCacheAnnotation`, the enforcement
- `HazelcastConfiguration`, which documents the sanctioned alternative (Spring `@Cacheable` on the Hazelcast cache manager with explicit eviction) and already says not to annotate entities
- `ArtemisMetricsEndpoint`, where the note explains why the endpoint reports no JCache regions
- `application.yml` / `application-buildagent.yml`, which actually disable L2 and query cache
- `ProgrammingExerciseUpdateResource`, which refers to the L1 persistence context, a different and still-active mechanism
- `User.getCourseRolesByCourseId`, an in-memory index on the entity instance, unrelated to Hibernate caching
- `documentation/docs/developer/guidelines/caching.mdx` and the `@Cache` references in the database, performance and server-development guidelines, which all state the prohibition rather than stale advice

Two comment blocks mixed cache rationale with unrelated notes, and only the cache lines were taken: the bidirectional-mapping and `@OrderColumn` explanation in `QuizExercise`, and the Set versus `@OrderColumn` explanation in `Result`.

### Steps for Testing

Nothing to test manually. The diff is 3 changed lines and 48 deletions, all in comments.

Verification performed:

- `./gradlew spotlessJavaCheck checkstyleMain compileTestJava -x webapp` passes, which compiles both main and test sources
- no `@Cache` annotation or `CacheConcurrencyStrategy` import exists anywhere in `src/main/java`, before or after
- after the change, a repository-wide search for `NONSTRICT`, `CacheStrategy`, `CacheConcurrencyStrategy` and `cache concurrency` across `src/main/java`, `src/test/java` and `src/main/webapp` returns nothing

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed obsolete explanatory comments from internal data models.
  * Updated regression-test documentation to clarify data-loading behavior in distributed environments.
  * Preserved all existing persistence mappings, declarations, and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->