### PR TITLE
`Programming exercises`: Stop warning instructors about their own commits

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseEditorSyncService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseEditorSyncService.java
@@ -77,9 +77,13 @@ public class ExerciseEditorSyncService {
      *                                  repository, tests repository)
      * @param auxiliaryRepositoryId (optional) the id of the auxiliary repository
      *                                  associated with this commit
+     * @param clientSessionId       (optional) the session of the client whose commit this is, so that client can filter the
+     *                                  alert out again. Passed in rather than read here, because the caller runs
+     *                                  asynchronously and {@link #getClientSessionId()} only works on a request thread.
      */
-    public void broadcastNewCommitAlert(@NonNull Long exerciseId, @NonNull ExerciseEditorSyncTarget target, @Nullable Long auxiliaryRepositoryId) {
-        ExerciseNewCommitAlertDTO payload = new ExerciseNewCommitAlertDTO(ExerciseEditorSyncEventType.NEW_COMMIT_ALERT, target, auxiliaryRepositoryId, getClientSessionId(),
+    public void broadcastNewCommitAlert(@NonNull Long exerciseId, @NonNull ExerciseEditorSyncTarget target, @Nullable Long auxiliaryRepositoryId,
+            @Nullable String clientSessionId) {
+        ExerciseNewCommitAlertDTO payload = new ExerciseNewCommitAlertDTO(ExerciseEditorSyncEventType.NEW_COMMIT_ALERT, target, auxiliaryRepositoryId, clientSessionId,
                 Instant.now().toEpochMilli());
         websocketMessagingService.sendMessage(getSynchronizationTopic(exerciseId), payload).exceptionally(exception -> {
             log.warn("Cannot send new commit alert for exercise {}", exerciseId, exception);

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionService.java
@@ -143,17 +143,22 @@ public class ExerciseVersionService {
      * @param author         The user who created the version
      */
     public void createExerciseVersion(Exercise targetExercise, User author) {
-        exerciseVersionExecutor.execute(() -> createExerciseVersionInternal(targetExercise, author));
+        // Read on the calling thread for the same reason the author is: the client session id lives in the request, and the
+        // executor thread has no request context. Without it the new commit alert carries no origin, so the editor that
+        // caused the commit cannot recognise the alert as its own and warns the user about their own submit.
+        String clientSessionId = ExerciseEditorSyncService.getClientSessionId();
+        exerciseVersionExecutor.execute(() -> createExerciseVersionInternal(targetExercise, author, clientSessionId));
     }
 
     /**
      * Creates an exercise version: fetches the exercise eagerly for its type, initializes an {@link ExerciseSnapshotDTO}
      * and persists a new {@link ExerciseVersion}. Runs on the {@code exerciseVersionExecutor} thread.
      *
-     * @param targetExercise The exercise to create a version of
-     * @param author         The user who created the version
+     * @param targetExercise  The exercise to create a version of
+     * @param author          The user who created the version
+     * @param clientSessionId the session of the client that triggered this version, or null when no request did
      */
-    private void createExerciseVersionInternal(Exercise targetExercise, User author) {
+    private void createExerciseVersionInternal(Exercise targetExercise, User author, @Nullable String clientSessionId) {
         if (author == null) {
             log.error("No active user during exercise version creation check");
             return;
@@ -188,7 +193,7 @@ public class ExerciseVersionService {
             exerciseVersion.setExerciseSnapshot(exerciseSnapshot);
             ExerciseVersion savedExerciseVersion = exerciseVersionRepository.save(exerciseVersion);
             this.determineSynchronizationForActiveEditors(exercise.getId(), exerciseSnapshot, previousVersion.map(ExerciseVersion::getExerciseSnapshot).orElse(null), author,
-                    savedExerciseVersion.getId());
+                    savedExerciseVersion.getId(), clientSessionId);
             log.info("Exercise version {} has been created for exercise {}", savedExerciseVersion.getId(), exercise.getId());
             previousVersion.ifPresent(prev -> {
                 try {
@@ -257,9 +262,11 @@ public class ExerciseVersionService {
      * @param previousSnapshot     the previous snapshot (optional)
      * @param author               the author of the new version
      * @param newExerciseVersionId the id of the new exercise version
+     * @param clientSessionId      the session of the client that triggered this version, so its own editor can filter the
+     *                                 alert out again, or null when no request triggered it
      */
     private void determineSynchronizationForActiveEditors(Long exerciseId, ExerciseSnapshotDTO newSnapshot, ExerciseSnapshotDTO previousSnapshot, User author,
-            Long newExerciseVersionId) {
+            Long newExerciseVersionId, @Nullable String clientSessionId) {
         if (previousSnapshot == null || newSnapshot == null) {
             return;
         }
@@ -304,7 +311,7 @@ public class ExerciseVersionService {
             // to refresh
             // For problem statement changes, changes are broadcasted via client-to-client
             // messages.
-            exerciseEditorSyncService.broadcastNewCommitAlert(exerciseId, target, auxiliaryRepositoryId);
+            exerciseEditorSyncService.broadcastNewCommitAlert(exerciseId, target, auxiliaryRepositoryId, clientSessionId);
         }
         if (!changedFields.isEmpty()) {
             exerciseEditorSyncService.broadcastNewExerciseVersionAlert(exerciseId, newExerciseVersionId, author, changedFields);

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionService.java
@@ -143,7 +143,7 @@ public class ExerciseVersionService {
      * @param author         The user who created the version
      */
     public void createExerciseVersion(Exercise targetExercise, User author) {
-        createExerciseVersion(targetExercise, author, null, null);
+        createExerciseVersion(targetExercise, author, null, null, null);
     }
 
     /**
@@ -153,27 +153,28 @@ public class ExerciseVersionService {
      * the commit, so that client can filter its own alert out instead of being warned about its own submit. Callers that do
      * not create a commit pass nothing and no alert is ever attributed to them.
      *
-     * @param targetExercise           The exercise to create a version of
-     * @param author                   The user who created the version
-     * @param triggeringRepositoryType The repository this request committed to, or null when it committed to none
-     * @param triggeringCommitHash     The commit this request created, or null when the request created no commit
+     * @param targetExercise                  The exercise to create a version of
+     * @param author                          The user who created the version
+     * @param triggeringRepositoryType        The repository this request committed to, or null when it committed to none
+     * @param triggeringAuxiliaryRepositoryId The id of that repository when it is an auxiliary one, null otherwise
+     * @param triggeringCommitHash            The commit this request created, or null when the request created no commit
      */
-    public void createExerciseVersion(Exercise targetExercise, User author, @Nullable RepositoryType triggeringRepositoryType, @Nullable String triggeringCommitHash) {
+    public void createExerciseVersion(Exercise targetExercise, User author, @Nullable RepositoryType triggeringRepositoryType, @Nullable Long triggeringAuxiliaryRepositoryId,
+            @Nullable String triggeringCommitHash) {
         // Read on the calling thread for the same reason the author is: the client session id lives in the request, and the
         // executor thread has no request context.
         String clientSessionId = ExerciseEditorSyncService.getClientSessionId();
         ExerciseEditorSyncTarget triggeringTarget = attributableTarget(triggeringRepositoryType);
-        exerciseVersionExecutor.execute(() -> createExerciseVersionInternal(targetExercise, author, clientSessionId, triggeringTarget, triggeringCommitHash));
+        exerciseVersionExecutor
+                .execute(() -> createExerciseVersionInternal(targetExercise, author, clientSessionId, triggeringTarget, triggeringAuxiliaryRepositoryId, triggeringCommitHash));
     }
 
     /**
      * Maps a committed repository to the synchronization target an alert about it would carry, for the repositories an alert
      * can be attributed to.
      * <p>
-     * Auxiliary repositories are deliberately excluded. An alert about one names a specific auxiliary repository by id, and
-     * that id is not resolved where a push is handled, so an auxiliary commit cannot be matched exactly. Returning null leaves
-     * those alerts unattributed, which warns everyone including the committer: the behaviour that existed before, rather than
-     * an attribution that might be wrong.
+     * An auxiliary repository maps to the auxiliary target; which of the exercise's auxiliary repositories it is has to be
+     * settled separately, by the id, because one target covers all of them.
      */
     @Nullable
     private static ExerciseEditorSyncTarget attributableTarget(@Nullable RepositoryType repositoryType) {
@@ -184,7 +185,9 @@ public class ExerciseVersionService {
             case TEMPLATE -> ExerciseEditorSyncTarget.TEMPLATE_REPOSITORY;
             case SOLUTION -> ExerciseEditorSyncTarget.SOLUTION_REPOSITORY;
             case TESTS -> ExerciseEditorSyncTarget.TESTS_REPOSITORY;
-            case AUXILIARY, USER -> null;
+            case AUXILIARY -> ExerciseEditorSyncTarget.AUXILIARY_REPOSITORY;
+            // a student repository has no editor to warn and never produces a version
+            case USER -> null;
         };
     }
 
@@ -192,14 +195,15 @@ public class ExerciseVersionService {
      * Creates an exercise version: fetches the exercise eagerly for its type, initializes an {@link ExerciseSnapshotDTO}
      * and persists a new {@link ExerciseVersion}. Runs on the {@code exerciseVersionExecutor} thread.
      *
-     * @param targetExercise       The exercise to create a version of
-     * @param author               The user who created the version
-     * @param clientSessionId      the session of the client that triggered this version, or null when no request did
-     * @param triggeringTarget     the repository that client committed to, or null when it committed to none
-     * @param triggeringCommitHash the commit that client created, or null when it created none
+     * @param targetExercise                  The exercise to create a version of
+     * @param author                          The user who created the version
+     * @param clientSessionId                 the session of the client that triggered this version, or null when no request did
+     * @param triggeringTarget                the repository that client committed to, or null when it committed to none
+     * @param triggeringAuxiliaryRepositoryId the id of that repository when it is an auxiliary one, null otherwise
+     * @param triggeringCommitHash            the commit that client created, or null when it created none
      */
     private void createExerciseVersionInternal(Exercise targetExercise, User author, @Nullable String clientSessionId, @Nullable ExerciseEditorSyncTarget triggeringTarget,
-            @Nullable String triggeringCommitHash) {
+            @Nullable Long triggeringAuxiliaryRepositoryId, @Nullable String triggeringCommitHash) {
         if (author == null) {
             log.error("No active user during exercise version creation check");
             return;
@@ -234,7 +238,7 @@ public class ExerciseVersionService {
             exerciseVersion.setExerciseSnapshot(exerciseSnapshot);
             ExerciseVersion savedExerciseVersion = exerciseVersionRepository.save(exerciseVersion);
             this.determineSynchronizationForActiveEditors(exercise.getId(), exerciseSnapshot, previousVersion.map(ExerciseVersion::getExerciseSnapshot).orElse(null), author,
-                    savedExerciseVersion.getId(), clientSessionId, triggeringTarget, triggeringCommitHash);
+                    savedExerciseVersion.getId(), clientSessionId, triggeringTarget, triggeringAuxiliaryRepositoryId, triggeringCommitHash);
             log.info("Exercise version {} has been created for exercise {}", savedExerciseVersion.getId(), exercise.getId());
             previousVersion.ifPresent(prev -> {
                 try {
@@ -311,7 +315,8 @@ public class ExerciseVersionService {
      *                                 commit before attributing it
      */
     private void determineSynchronizationForActiveEditors(Long exerciseId, ExerciseSnapshotDTO newSnapshot, ExerciseSnapshotDTO previousSnapshot, User author,
-            Long newExerciseVersionId, @Nullable String clientSessionId, @Nullable ExerciseEditorSyncTarget triggeringTarget, @Nullable String triggeringCommitHash) {
+            Long newExerciseVersionId, @Nullable String clientSessionId, @Nullable ExerciseEditorSyncTarget triggeringTarget, @Nullable Long triggeringAuxiliaryRepositoryId,
+            @Nullable String triggeringCommitHash) {
         if (previousSnapshot == null || newSnapshot == null) {
             return;
         }
@@ -363,7 +368,7 @@ public class ExerciseVersionService {
             // For problem statement changes, changes are broadcasted via client-to-client
             // messages.
             exerciseEditorSyncService.broadcastNewCommitAlert(exerciseId, target, auxiliaryRepositoryId,
-                    sessionOwningCommit(clientSessionId, triggeringTarget, triggeringCommitHash, target, changedCommitId));
+                    sessionOwningCommit(clientSessionId, triggeringTarget, triggeringAuxiliaryRepositoryId, triggeringCommitHash, target, auxiliaryRepositoryId, changedCommitId));
         }
         if (!changedFields.isEmpty()) {
             exerciseEditorSyncService.broadcastNewExerciseVersionAlert(exerciseId, newExerciseVersionId, author, changedFields);
@@ -487,20 +492,33 @@ public class ExerciseVersionService {
      * commit made in two of them by the same author in the same second is byte-identical and therefore has the same id.
      * Matching on the id alone would let an alert about one repository be attributed to a client that committed to another.
      *
-     * @param clientSessionId      the session that queued this version, or null if no request did
-     * @param triggeringTarget     the repository that session committed to, or null if it committed to none
-     * @param triggeringCommitHash the commit that session created, or null if it created none
-     * @param alertedTarget        the repository this alert is about
-     * @param changedCommitId      the commit the alerted repository now stands at
+     * For an auxiliary repository the id has to match as well, because one target covers every auxiliary repository of the
+     * exercise. An auxiliary commit whose id could not be resolved stays unattributed rather than matching all of them.
+     *
+     * @param clientSessionId                 the session that queued this version, or null if no request did
+     * @param triggeringTarget                the repository that session committed to, or null if it committed to none
+     * @param triggeringAuxiliaryRepositoryId the id of that repository when it is an auxiliary one, null otherwise
+     * @param triggeringCommitHash            the commit that session created, or null if it created none
+     * @param alertedTarget                   the repository this alert is about
+     * @param alertedAuxiliaryRepositoryId    the auxiliary repository this alert is about, null for the other targets
+     * @param changedCommitId                 the commit the alerted repository now stands at
      * @return the session to attribute the alert to, or null to attribute it to nobody
      */
     @Nullable
-    static String sessionOwningCommit(@Nullable String clientSessionId, @Nullable ExerciseEditorSyncTarget triggeringTarget, @Nullable String triggeringCommitHash,
-            @Nullable ExerciseEditorSyncTarget alertedTarget, @Nullable String changedCommitId) {
+    static String sessionOwningCommit(@Nullable String clientSessionId, @Nullable ExerciseEditorSyncTarget triggeringTarget, @Nullable Long triggeringAuxiliaryRepositoryId,
+            @Nullable String triggeringCommitHash, @Nullable ExerciseEditorSyncTarget alertedTarget, @Nullable Long alertedAuxiliaryRepositoryId,
+            @Nullable String changedCommitId) {
         if (clientSessionId == null || triggeringTarget == null || triggeringCommitHash == null || alertedTarget == null || changedCommitId == null) {
             return null;
         }
-        return triggeringTarget == alertedTarget && triggeringCommitHash.equals(changedCommitId) ? clientSessionId : null;
+        if (triggeringTarget != alertedTarget || !triggeringCommitHash.equals(changedCommitId)) {
+            return null;
+        }
+        if (alertedTarget == ExerciseEditorSyncTarget.AUXILIARY_REPOSITORY
+                && (triggeringAuxiliaryRepositoryId == null || !triggeringAuxiliaryRepositoryId.equals(alertedAuxiliaryRepositoryId))) {
+            return null;
+        }
+        return clientSessionId;
     }
 
     @Nullable

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionService.java
@@ -143,22 +143,37 @@ public class ExerciseVersionService {
      * @param author         The user who created the version
      */
     public void createExerciseVersion(Exercise targetExercise, User author) {
+        createExerciseVersion(targetExercise, author, null);
+    }
+
+    /**
+     * Requests the (asynchronous) creation of an exercise version for a repository commit, identifying that commit.
+     * <p>
+     * The hash is what lets the resulting new commit alert be attributed to the client that made the commit, so that client
+     * can filter its own alert out instead of being warned about its own submit. Callers that do not create a commit pass
+     * nothing and no alert is ever attributed to them.
+     *
+     * @param targetExercise       The exercise to create a version of
+     * @param author               The user who created the version
+     * @param triggeringCommitHash The commit this request created, or null when the request created no commit
+     */
+    public void createExerciseVersion(Exercise targetExercise, User author, @Nullable String triggeringCommitHash) {
         // Read on the calling thread for the same reason the author is: the client session id lives in the request, and the
-        // executor thread has no request context. Without it the new commit alert carries no origin, so the editor that
-        // caused the commit cannot recognise the alert as its own and warns the user about their own submit.
+        // executor thread has no request context.
         String clientSessionId = ExerciseEditorSyncService.getClientSessionId();
-        exerciseVersionExecutor.execute(() -> createExerciseVersionInternal(targetExercise, author, clientSessionId));
+        exerciseVersionExecutor.execute(() -> createExerciseVersionInternal(targetExercise, author, clientSessionId, triggeringCommitHash));
     }
 
     /**
      * Creates an exercise version: fetches the exercise eagerly for its type, initializes an {@link ExerciseSnapshotDTO}
      * and persists a new {@link ExerciseVersion}. Runs on the {@code exerciseVersionExecutor} thread.
      *
-     * @param targetExercise  The exercise to create a version of
-     * @param author          The user who created the version
-     * @param clientSessionId the session of the client that triggered this version, or null when no request did
+     * @param targetExercise       The exercise to create a version of
+     * @param author               The user who created the version
+     * @param clientSessionId      the session of the client that triggered this version, or null when no request did
+     * @param triggeringCommitHash the commit that client created, or null when it created none
      */
-    private void createExerciseVersionInternal(Exercise targetExercise, User author, @Nullable String clientSessionId) {
+    private void createExerciseVersionInternal(Exercise targetExercise, User author, @Nullable String clientSessionId, @Nullable String triggeringCommitHash) {
         if (author == null) {
             log.error("No active user during exercise version creation check");
             return;
@@ -193,7 +208,7 @@ public class ExerciseVersionService {
             exerciseVersion.setExerciseSnapshot(exerciseSnapshot);
             ExerciseVersion savedExerciseVersion = exerciseVersionRepository.save(exerciseVersion);
             this.determineSynchronizationForActiveEditors(exercise.getId(), exerciseSnapshot, previousVersion.map(ExerciseVersion::getExerciseSnapshot).orElse(null), author,
-                    savedExerciseVersion.getId(), clientSessionId);
+                    savedExerciseVersion.getId(), clientSessionId, triggeringCommitHash);
             log.info("Exercise version {} has been created for exercise {}", savedExerciseVersion.getId(), exercise.getId());
             previousVersion.ifPresent(prev -> {
                 try {
@@ -264,9 +279,11 @@ public class ExerciseVersionService {
      * @param newExerciseVersionId the id of the new exercise version
      * @param clientSessionId      the session of the client that triggered this version, so its own editor can filter the
      *                                 alert out again, or null when no request triggered it
+     * @param triggeringCommitHash the commit that client created, used to check that the alert really is about its own
+     *                                 commit before attributing it
      */
     private void determineSynchronizationForActiveEditors(Long exerciseId, ExerciseSnapshotDTO newSnapshot, ExerciseSnapshotDTO previousSnapshot, User author,
-            Long newExerciseVersionId, @Nullable String clientSessionId) {
+            Long newExerciseVersionId, @Nullable String clientSessionId, @Nullable String triggeringCommitHash) {
         if (previousSnapshot == null || newSnapshot == null) {
             return;
         }
@@ -275,18 +292,23 @@ public class ExerciseVersionService {
         ProgrammingExerciseSnapshotDTO previousProgrammingData = previousSnapshot.programmingData();
         ExerciseEditorSyncTarget target = null;
         Long auxiliaryRepositoryId = null;
+        // The commit the detected repository now stands at, needed to decide whose commit this alert is about
+        String changedCommitId = null;
 
         // Repository commits cannot change simultaneously because each commit triggers a separate
         // version creation. The if-else chain intentionally detects only the first changed repository.
         if (newProgrammingData != null && previousProgrammingData != null) {
             if (participationCommitChanged(previousProgrammingData.templateParticipation(), newProgrammingData.templateParticipation())) {
                 target = ExerciseEditorSyncTarget.TEMPLATE_REPOSITORY;
+                changedCommitId = participationCommitId(newProgrammingData.templateParticipation());
             }
             else if (participationCommitChanged(previousProgrammingData.solutionParticipation(), newProgrammingData.solutionParticipation())) {
                 target = ExerciseEditorSyncTarget.SOLUTION_REPOSITORY;
+                changedCommitId = participationCommitId(newProgrammingData.solutionParticipation());
             }
             else if (!Objects.equals(previousProgrammingData.testsCommitId(), newProgrammingData.testsCommitId())) {
                 target = ExerciseEditorSyncTarget.TESTS_REPOSITORY;
+                changedCommitId = newProgrammingData.testsCommitId();
             }
             else {
                 Map<Long, String> previousAuxiliaries = Optional.ofNullable(previousProgrammingData.auxiliaryRepositories()).orElseGet(List::of).stream()
@@ -298,6 +320,7 @@ public class ExerciseVersionService {
                     if (!Objects.equals(previousCommitId, auxiliary.commitId())) {
                         target = ExerciseEditorSyncTarget.AUXILIARY_REPOSITORY;
                         auxiliaryRepositoryId = auxiliary.id();
+                        changedCommitId = auxiliary.commitId();
                         break;
                     }
                 }
@@ -311,7 +334,8 @@ public class ExerciseVersionService {
             // to refresh
             // For problem statement changes, changes are broadcasted via client-to-client
             // messages.
-            exerciseEditorSyncService.broadcastNewCommitAlert(exerciseId, target, auxiliaryRepositoryId, clientSessionId);
+            exerciseEditorSyncService.broadcastNewCommitAlert(exerciseId, target, auxiliaryRepositoryId,
+                    sessionOwningCommit(clientSessionId, triggeringCommitHash, changedCommitId));
         }
         if (!changedFields.isEmpty()) {
             exerciseEditorSyncService.broadcastNewExerciseVersionAlert(exerciseId, newExerciseVersionId, author, changedFields);
@@ -421,6 +445,33 @@ public class ExerciseVersionService {
      * @param newParticipation      the new participation snapshot
      * @return true if the commit id changed
      */
+    /**
+     * The session an alert may be attributed to, which is only the session whose own commit the alert describes.
+     * <p>
+     * Version jobs run asynchronously on several workers and read the repository refs when they execute, not when they were
+     * queued. So a job queued by one client can snapshot a commit another client pushed in the meantime. Attributing that
+     * alert to the queueing client would make its editor filter out a warning about somebody else's commit, and a missing
+     * warning is worse than the duplicate warning this attribution exists to remove. Whenever the identity cannot be
+     * established the alert goes out unattributed, which warns everyone, including the committer.
+     *
+     * @param clientSessionId      the session that queued this version, or null if no request did
+     * @param triggeringCommitHash the commit that session created, or null if it created none
+     * @param changedCommitId      the commit the alerted repository now stands at
+     * @return the session to attribute the alert to, or null to attribute it to nobody
+     */
+    @Nullable
+    static String sessionOwningCommit(@Nullable String clientSessionId, @Nullable String triggeringCommitHash, @Nullable String changedCommitId) {
+        if (clientSessionId == null || triggeringCommitHash == null || changedCommitId == null) {
+            return null;
+        }
+        return triggeringCommitHash.equals(changedCommitId) ? clientSessionId : null;
+    }
+
+    @Nullable
+    private static String participationCommitId(ProgrammingExerciseSnapshotDTO.@Nullable ParticipationSnapshotDTO participation) {
+        return participation == null ? null : participation.commitId();
+    }
+
     private boolean participationCommitChanged(ProgrammingExerciseSnapshotDTO.ParticipationSnapshotDTO previousParticipation,
             ProgrammingExerciseSnapshotDTO.ParticipationSnapshotDTO newParticipation) {
         if (previousParticipation == null && newParticipation == null) {

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionService.java
@@ -143,25 +143,49 @@ public class ExerciseVersionService {
      * @param author         The user who created the version
      */
     public void createExerciseVersion(Exercise targetExercise, User author) {
-        createExerciseVersion(targetExercise, author, null);
+        createExerciseVersion(targetExercise, author, null, null);
     }
 
     /**
      * Requests the (asynchronous) creation of an exercise version for a repository commit, identifying that commit.
      * <p>
-     * The hash is what lets the resulting new commit alert be attributed to the client that made the commit, so that client
-     * can filter its own alert out instead of being warned about its own submit. Callers that do not create a commit pass
-     * nothing and no alert is ever attributed to them.
+     * The repository and the commit together are what let the resulting new commit alert be attributed to the client that made
+     * the commit, so that client can filter its own alert out instead of being warned about its own submit. Callers that do
+     * not create a commit pass nothing and no alert is ever attributed to them.
      *
-     * @param targetExercise       The exercise to create a version of
-     * @param author               The user who created the version
-     * @param triggeringCommitHash The commit this request created, or null when the request created no commit
+     * @param targetExercise           The exercise to create a version of
+     * @param author                   The user who created the version
+     * @param triggeringRepositoryType The repository this request committed to, or null when it committed to none
+     * @param triggeringCommitHash     The commit this request created, or null when the request created no commit
      */
-    public void createExerciseVersion(Exercise targetExercise, User author, @Nullable String triggeringCommitHash) {
+    public void createExerciseVersion(Exercise targetExercise, User author, @Nullable RepositoryType triggeringRepositoryType, @Nullable String triggeringCommitHash) {
         // Read on the calling thread for the same reason the author is: the client session id lives in the request, and the
         // executor thread has no request context.
         String clientSessionId = ExerciseEditorSyncService.getClientSessionId();
-        exerciseVersionExecutor.execute(() -> createExerciseVersionInternal(targetExercise, author, clientSessionId, triggeringCommitHash));
+        ExerciseEditorSyncTarget triggeringTarget = attributableTarget(triggeringRepositoryType);
+        exerciseVersionExecutor.execute(() -> createExerciseVersionInternal(targetExercise, author, clientSessionId, triggeringTarget, triggeringCommitHash));
+    }
+
+    /**
+     * Maps a committed repository to the synchronization target an alert about it would carry, for the repositories an alert
+     * can be attributed to.
+     * <p>
+     * Auxiliary repositories are deliberately excluded. An alert about one names a specific auxiliary repository by id, and
+     * that id is not resolved where a push is handled, so an auxiliary commit cannot be matched exactly. Returning null leaves
+     * those alerts unattributed, which warns everyone including the committer: the behaviour that existed before, rather than
+     * an attribution that might be wrong.
+     */
+    @Nullable
+    private static ExerciseEditorSyncTarget attributableTarget(@Nullable RepositoryType repositoryType) {
+        if (repositoryType == null) {
+            return null;
+        }
+        return switch (repositoryType) {
+            case TEMPLATE -> ExerciseEditorSyncTarget.TEMPLATE_REPOSITORY;
+            case SOLUTION -> ExerciseEditorSyncTarget.SOLUTION_REPOSITORY;
+            case TESTS -> ExerciseEditorSyncTarget.TESTS_REPOSITORY;
+            case AUXILIARY, USER -> null;
+        };
     }
 
     /**
@@ -171,9 +195,11 @@ public class ExerciseVersionService {
      * @param targetExercise       The exercise to create a version of
      * @param author               The user who created the version
      * @param clientSessionId      the session of the client that triggered this version, or null when no request did
+     * @param triggeringTarget     the repository that client committed to, or null when it committed to none
      * @param triggeringCommitHash the commit that client created, or null when it created none
      */
-    private void createExerciseVersionInternal(Exercise targetExercise, User author, @Nullable String clientSessionId, @Nullable String triggeringCommitHash) {
+    private void createExerciseVersionInternal(Exercise targetExercise, User author, @Nullable String clientSessionId, @Nullable ExerciseEditorSyncTarget triggeringTarget,
+            @Nullable String triggeringCommitHash) {
         if (author == null) {
             log.error("No active user during exercise version creation check");
             return;
@@ -208,7 +234,7 @@ public class ExerciseVersionService {
             exerciseVersion.setExerciseSnapshot(exerciseSnapshot);
             ExerciseVersion savedExerciseVersion = exerciseVersionRepository.save(exerciseVersion);
             this.determineSynchronizationForActiveEditors(exercise.getId(), exerciseSnapshot, previousVersion.map(ExerciseVersion::getExerciseSnapshot).orElse(null), author,
-                    savedExerciseVersion.getId(), clientSessionId, triggeringCommitHash);
+                    savedExerciseVersion.getId(), clientSessionId, triggeringTarget, triggeringCommitHash);
             log.info("Exercise version {} has been created for exercise {}", savedExerciseVersion.getId(), exercise.getId());
             previousVersion.ifPresent(prev -> {
                 try {
@@ -279,11 +305,13 @@ public class ExerciseVersionService {
      * @param newExerciseVersionId the id of the new exercise version
      * @param clientSessionId      the session of the client that triggered this version, so its own editor can filter the
      *                                 alert out again, or null when no request triggered it
+     * @param triggeringTarget     the repository that client committed to, checked against the repository this alert is
+     *                                 about before attributing it
      * @param triggeringCommitHash the commit that client created, used to check that the alert really is about its own
      *                                 commit before attributing it
      */
     private void determineSynchronizationForActiveEditors(Long exerciseId, ExerciseSnapshotDTO newSnapshot, ExerciseSnapshotDTO previousSnapshot, User author,
-            Long newExerciseVersionId, @Nullable String clientSessionId, @Nullable String triggeringCommitHash) {
+            Long newExerciseVersionId, @Nullable String clientSessionId, @Nullable ExerciseEditorSyncTarget triggeringTarget, @Nullable String triggeringCommitHash) {
         if (previousSnapshot == null || newSnapshot == null) {
             return;
         }
@@ -335,7 +363,7 @@ public class ExerciseVersionService {
             // For problem statement changes, changes are broadcasted via client-to-client
             // messages.
             exerciseEditorSyncService.broadcastNewCommitAlert(exerciseId, target, auxiliaryRepositoryId,
-                    sessionOwningCommit(clientSessionId, triggeringCommitHash, changedCommitId));
+                    sessionOwningCommit(clientSessionId, triggeringTarget, triggeringCommitHash, target, changedCommitId));
         }
         if (!changedFields.isEmpty()) {
             exerciseEditorSyncService.broadcastNewExerciseVersionAlert(exerciseId, newExerciseVersionId, author, changedFields);
@@ -454,17 +482,25 @@ public class ExerciseVersionService {
      * warning is worse than the duplicate warning this attribution exists to remove. Whenever the identity cannot be
      * established the alert goes out unattributed, which warns everyone, including the committer.
      *
+     * The repository has to match as well as the commit. A commit id identifies an object, not a place: repositories of one
+     * exercise are seeded from each other, so the same commit legitimately exists in more than one of them, and an empty
+     * commit made in two of them by the same author in the same second is byte-identical and therefore has the same id.
+     * Matching on the id alone would let an alert about one repository be attributed to a client that committed to another.
+     *
      * @param clientSessionId      the session that queued this version, or null if no request did
+     * @param triggeringTarget     the repository that session committed to, or null if it committed to none
      * @param triggeringCommitHash the commit that session created, or null if it created none
+     * @param alertedTarget        the repository this alert is about
      * @param changedCommitId      the commit the alerted repository now stands at
      * @return the session to attribute the alert to, or null to attribute it to nobody
      */
     @Nullable
-    static String sessionOwningCommit(@Nullable String clientSessionId, @Nullable String triggeringCommitHash, @Nullable String changedCommitId) {
-        if (clientSessionId == null || triggeringCommitHash == null || changedCommitId == null) {
+    static String sessionOwningCommit(@Nullable String clientSessionId, @Nullable ExerciseEditorSyncTarget triggeringTarget, @Nullable String triggeringCommitHash,
+            @Nullable ExerciseEditorSyncTarget alertedTarget, @Nullable String changedCommitId) {
+        if (clientSessionId == null || triggeringTarget == null || triggeringCommitHash == null || alertedTarget == null || changedCommitId == null) {
             return null;
         }
-        return triggeringCommitHash.equals(changedCommitId) ? clientSessionId : null;
+        return triggeringTarget == alertedTarget && triggeringCommitHash.equals(changedCommitId) ? clientSessionId : null;
     }
 
     @Nullable

--- a/src/main/java/de/tum/cit/aet/artemis/localvc/service/GitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localvc/service/GitService.java
@@ -441,16 +441,21 @@ public class GitService extends AbstractGitService {
      * @param message     Commit Message
      * @param emptyCommit whether the git service should also produce an empty commit
      * @param user        The user who should initiate the commit. If the user is null, the artemis user will be used
+     * @return the id of the commit that was created
      * @throws GitAPIException if the commit failed.
      */
-    public void commitAndPush(Repository repo, String message, boolean emptyCommit, @Nullable User user) throws GitAPIException {
+    public String commitAndPush(Repository repo, String message, boolean emptyCommit, @Nullable User user) throws GitAPIException {
         String name = user != null ? user.getName() : artemisGitName;
         String email = user != null ? user.getEmail() : artemisGitEmail;
         try (Git git = new Git(repo)) {
-            GitService.commit(git).setMessage(message).setAllowEmpty(emptyCommit).setCommitter(name, email).call();
+            RevCommit commit = GitService.commit(git).setMessage(message).setAllowEmpty(emptyCommit).setCommitter(name, email).call();
             log.debug("commitAndPush -> Push {}", repo.getLocalPath());
             setRemoteUrl(repo);
             pushCommand(git).call();
+            // Returned rather than discarded so callers can identify the commit they just created. Reading the repository head
+            // afterwards is not equivalent: the online editor shares one working copy per repository, so a concurrent commit
+            // to the same repository can move the head between the commit and the read.
+            return commit.getName();
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/localvc/service/LocalVCServletService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localvc/service/LocalVCServletService.java
@@ -977,7 +977,12 @@ public class LocalVCServletService {
 
         try {
             if (exerciseVersionService.isRepositoryTypeVersionable(repositoryType)) {
-                exerciseVersionService.createExerciseVersion(exercise, user);
+                // Identify the commit this push created, so the new commit alert can be attributed to the client that made it
+                // and to no other. Resolved here because the caller may not know the hash yet: a commit from the online editor
+                // arrives with a null hash and only the repository itself knows what was just written. Kept in a separate
+                // variable, because the build-triggering code below relies on commitHash staying null in that case.
+                String triggeringCommitHash = commitHash != null ? commitHash : getLatestCommitHash(repository);
+                exerciseVersionService.createExerciseVersion(exercise, user, triggeringCommitHash);
             }
 
             if (repositoryType.equals(RepositoryType.TESTS)) {

--- a/src/main/java/de/tum/cit/aet/artemis/localvc/service/LocalVCServletService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localvc/service/LocalVCServletService.java
@@ -1001,7 +1001,7 @@ public class LocalVCServletService {
                 // The identified commit, not the repository head. Attribution has to name the commit this request created, and
                 // re-reading the head here would be a race: the online editor shares one working copy per repository, so a
                 // concurrent commit can move it and the alert would then be attributed to the wrong client.
-                exerciseVersionService.createExerciseVersion(exercise, user, triggeringCommitHash);
+                exerciseVersionService.createExerciseVersion(exercise, user, repositoryType, triggeringCommitHash);
             }
 
             if (repositoryType.equals(RepositoryType.TESTS)) {

--- a/src/main/java/de/tum/cit/aet/artemis/localvc/service/LocalVCServletService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localvc/service/LocalVCServletService.java
@@ -949,6 +949,27 @@ public class LocalVCServletService {
      */
     public void processNewPush(String commitHash, Repository repository, User user, Optional<ProgrammingExercise> cachedExercise,
             Optional<ProgrammingExerciseParticipation> cachedParticipation, Optional<VcsAccessLog> vcsAccessLog) {
+        // A git push knows the id it pushed, so it is also the commit that triggered this call
+        processNewPush(commitHash, repository, user, cachedExercise, cachedParticipation, vcsAccessLog, commitHash);
+    }
+
+    /**
+     * Process a new push, identifying the commit that triggered it.
+     * <p>
+     * The online editor commits through {@code RepositoryService} and reaches this method with no pushed hash, because the
+     * hash the build is triggered for is resolved later. The id of the commit the request actually created still has to be
+     * known here, so the resulting new commit alert can be attributed to the client that made that commit and to no other.
+     *
+     * @param commitHash           the hash of the last commit, may be null for a commit from the online editor
+     * @param repository           the remote repository which was pushed to
+     * @param user                 the user who pushed the commit
+     * @param cachedExercise       the exercise which is potentially already loaded
+     * @param cachedParticipation  the participation which is potentially already loaded
+     * @param vcsAccessLog         the vcsAccessLog which is potentially already loaded
+     * @param triggeringCommitHash the id of the commit this request created, or null when the caller does not know it
+     */
+    public void processNewPush(String commitHash, Repository repository, User user, Optional<ProgrammingExercise> cachedExercise,
+            Optional<ProgrammingExerciseParticipation> cachedParticipation, Optional<VcsAccessLog> vcsAccessLog, @Nullable String triggeringCommitHash) {
         long timeNanoStart = System.nanoTime();
 
         Path repositoryFolderPath = repository.getDirectory().toPath();
@@ -977,11 +998,9 @@ public class LocalVCServletService {
 
         try {
             if (exerciseVersionService.isRepositoryTypeVersionable(repositoryType)) {
-                // Identify the commit this push created, so the new commit alert can be attributed to the client that made it
-                // and to no other. Resolved here because the caller may not know the hash yet: a commit from the online editor
-                // arrives with a null hash and only the repository itself knows what was just written. Kept in a separate
-                // variable, because the build-triggering code below relies on commitHash staying null in that case.
-                String triggeringCommitHash = commitHash != null ? commitHash : getLatestCommitHash(repository);
+                // The identified commit, not the repository head. Attribution has to name the commit this request created, and
+                // re-reading the head here would be a race: the online editor shares one working copy per repository, so a
+                // concurrent commit can move it and the alert would then be attributed to the wrong client.
                 exerciseVersionService.createExerciseVersion(exercise, user, triggeringCommitHash);
             }
 

--- a/src/main/java/de/tum/cit/aet/artemis/localvc/service/LocalVCServletService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localvc/service/LocalVCServletService.java
@@ -1001,7 +1001,11 @@ public class LocalVCServletService {
                 // The identified commit, not the repository head. Attribution has to name the commit this request created, and
                 // re-reading the head here would be a race: the online editor shares one working copy per repository, so a
                 // concurrent commit can move it and the alert would then be attributed to the wrong client.
-                exerciseVersionService.createExerciseVersion(exercise, user, repositoryType, triggeringCommitHash);
+                // An alert about an auxiliary repository names one specific repository by id, so attributing it needs that id too
+                Long triggeringAuxiliaryRepositoryId = repositoryType == RepositoryType.AUXILIARY
+                        ? auxiliaryRepositoryService.findAuxiliaryRepositoryIdOfExercise(repositoryTypeOrUserName, exercise).orElse(null)
+                        : null;
+                exerciseVersionService.createExerciseVersion(exercise, user, repositoryType, triggeringAuxiliaryRepositoryId, triggeringCommitHash);
             }
 
             if (repositoryType.equals(RepositoryType.TESTS)) {

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/AuxiliaryRepositoryService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/AuxiliaryRepositoryService.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Matcher;
 
 import org.springframework.context.annotation.Lazy;
@@ -220,12 +221,23 @@ public class AuxiliaryRepositoryService {
      * @return true if the repository is an auxiliary repository of the exercise, false otherwise.
      */
     public boolean isAuxiliaryRepositoryOfExercise(String repositoryName, ProgrammingExercise exercise) {
+        return findAuxiliaryRepositoryIdOfExercise(repositoryName, exercise).isPresent();
+    }
+
+    /**
+     * Finds the id of the auxiliary repository of the given exercise that carries the given name.
+     *
+     * @param repositoryName the name of the auxiliary repository, as it appears in its repository uri
+     * @param exercise       the exercise the repository belongs to
+     * @return the id of that auxiliary repository, or empty if the exercise has none by that name
+     */
+    public Optional<Long> findAuxiliaryRepositoryIdOfExercise(String repositoryName, ProgrammingExercise exercise) {
         List<AuxiliaryRepository> auxiliaryRepositories = auxiliaryRepositoryRepository.findByExerciseId(exercise.getId());
         for (AuxiliaryRepository repo : auxiliaryRepositories) {
             if (repo.getName().equals(repositoryName)) {
-                return true;
+                return Optional.ofNullable(repo.getId());
             }
         }
-        return false;
+        return Optional.empty();
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/RepositoryService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/RepositoryService.java
@@ -751,11 +751,12 @@ public class RepositoryService {
      *
      * @param repository for which to execute the commit.
      * @param user       the user who has committed the changes in the online editor
+     * @return the id of the commit that was created
      * @throws GitAPIException if the staging/committing process fails.
      */
-    public void commitChanges(Repository repository, User user) throws GitAPIException {
+    public String commitChanges(Repository repository, User user) throws GitAPIException {
         gitService.stageAllChanges(repository);
-        gitService.commitAndPush(repository, "Changes by Online Editor", true, user);
+        return gitService.commitAndPush(repository, "Changes by Online Editor", true, user);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/RepositoryResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/RepositoryResource.java
@@ -274,13 +274,18 @@ public abstract class RepositoryResource {
 
         return executeAndCheckForExceptions(() -> {
             Repository repository = getRepository(domainId, RepositoryActionType.WRITE, true, true);
-            repositoryService.commitChanges(repository, user);
+            // Kept, so the commit alert that versioning broadcasts can be attributed to this client and to no other. The
+            // repository head is not a substitute: this working copy is shared per repository, so a concurrent commit from
+            // another editor can move it.
+            String createdCommitHash = repositoryService.commitChanges(repository, user);
             var vcsAccessLog = repositoryService.savePreliminaryCodeEditorAccessLog(repository, user, domainId);
 
             // Trigger a build, and process the result.
             // For Jenkins, webhooks were added when creating the repository,
             // that notify the CI system when the commit happens and thus trigger the build.
-            localVCServletService.orElseThrow().processNewPush(null, repository, user, Optional.empty(), Optional.empty(), vcsAccessLog);
+            // The build hash stays null on purpose, so the latest commit is used for the build; only the attribution of the
+            // commit alert uses the exact commit created above.
+            localVCServletService.orElseThrow().processNewPush(null, repository, user, Optional.empty(), Optional.empty(), vcsAccessLog, createdCommitHash);
             return new ResponseEntity<>(HttpStatus.OK);
         });
     }

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/ExerciseEditorSyncServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/ExerciseEditorSyncServiceTest.java
@@ -66,7 +66,7 @@ class ExerciseEditorSyncServiceTest extends AbstractProgrammingIntegrationLocalC
      */
     @Test
     void broadcastNewCommitAlert() {
-        synchronizationService.broadcastNewCommitAlert(90L, ExerciseEditorSyncTarget.TESTS_REPOSITORY, null);
+        synchronizationService.broadcastNewCommitAlert(90L, ExerciseEditorSyncTarget.TESTS_REPOSITORY, null, null);
 
         var captor = ArgumentCaptor.forClass(ExerciseNewCommitAlertDTO.class);
         verify(websocketMessagingService).sendMessage(eq("/topic/exercises/90/synchronization"), captor.capture());
@@ -82,7 +82,7 @@ class ExerciseEditorSyncServiceTest extends AbstractProgrammingIntegrationLocalC
      */
     @Test
     void broadcastNewCommitAlertForAuxiliaryRepository() {
-        synchronizationService.broadcastNewCommitAlert(100L, ExerciseEditorSyncTarget.AUXILIARY_REPOSITORY, 25L);
+        synchronizationService.broadcastNewCommitAlert(100L, ExerciseEditorSyncTarget.AUXILIARY_REPOSITORY, 25L, null);
 
         var captor = ArgumentCaptor.forClass(ExerciseNewCommitAlertDTO.class);
         verify(websocketMessagingService).sendMessage(eq("/topic/exercises/100/synchronization"), captor.capture());
@@ -94,15 +94,18 @@ class ExerciseEditorSyncServiceTest extends AbstractProgrammingIntegrationLocalC
     }
 
     /**
-     * Verifies that the client session header is forwarded into the alert payload.
+     * The session of the committing client has to reach the payload even though there is no request context here.
+     * <p>
+     * This is the actual bug behind #13459. Exercise versioning runs on the {@code exerciseVersionTaskExecutor}, and this
+     * method used to read the session from {@code RequestContextHolder} itself, which on that thread holds nothing. The
+     * payload therefore carried no origin, the committing editor could not recognise the alert as its own, and every
+     * instructor was warned about the commit they had just made. It stayed invisible in the test suite because the executor
+     * is a {@code SyncTaskExecutor} under the test profile, so tests still ran with the caller's request context.
      */
     @Test
-    void broadcastNewCommitAlertUsesClientSessionHeader() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addHeader(ExerciseEditorSyncService.CLIENT_SESSION_HEADER, "client-commits");
-        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
-
-        synchronizationService.broadcastNewCommitAlert(101L, ExerciseEditorSyncTarget.SOLUTION_REPOSITORY, null);
+    void broadcastNewCommitAlertCarriesTheCommittingSessionWithoutARequestContext() {
+        // deliberately no request attributes, which is the situation on the versioning executor thread
+        synchronizationService.broadcastNewCommitAlert(101L, ExerciseEditorSyncTarget.SOLUTION_REPOSITORY, null, "client-commits");
 
         var captor = ArgumentCaptor.forClass(ExerciseNewCommitAlertDTO.class);
         verify(websocketMessagingService).sendMessage(eq("/topic/exercises/101/synchronization"), captor.capture());
@@ -110,6 +113,26 @@ class ExerciseEditorSyncServiceTest extends AbstractProgrammingIntegrationLocalC
 
         assertThat(sentMessage.sessionId()).isEqualTo("client-commits");
         assertThat(sentMessage.eventType()).isEqualTo(ExerciseEditorSyncEventType.NEW_COMMIT_ALERT);
+    }
+
+    /**
+     * The helper that callers on a request thread use to capture the session before handing work to an executor.
+     */
+    @Test
+    void getClientSessionIdReadsTheHeaderOnARequestThread() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(ExerciseEditorSyncService.CLIENT_SESSION_HEADER, "client-commits");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        assertThat(ExerciseEditorSyncService.getClientSessionId()).isEqualTo("client-commits");
+    }
+
+    /**
+     * Off a request thread there is nothing to read, which is why the session has to be captured by the caller.
+     */
+    @Test
+    void getClientSessionIdIsNullWithoutARequestThread() {
+        assertThat(ExerciseEditorSyncService.getClientSessionId()).isNull();
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionCommitAttributionTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionCommitAttributionTest.java
@@ -1,0 +1,51 @@
+package de.tum.cit.aet.artemis.exercise.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests which client a new commit alert may be attributed to.
+ * <p>
+ * Attribution is what stops an instructor from being warned about the commit they just made themselves. It has to be exact:
+ * version jobs run asynchronously on several workers and read the repository refs when they execute, so a job queued by one
+ * client can snapshot a commit that another client pushed in the meantime. Attributing that alert to the queueing client
+ * would make its editor discard a warning about somebody else's commit, which is a worse outcome than the duplicate warning
+ * attribution removes.
+ */
+class ExerciseVersionCommitAttributionTest {
+
+    private static final String OWN_SESSION = "session-of-the-committer";
+
+    private static final String OWN_COMMIT = "1111111111111111111111111111111111111111";
+
+    private static final String OTHER_COMMIT = "2222222222222222222222222222222222222222";
+
+    @Test
+    void shouldAttributeAnAlertAboutTheClientsOwnCommit() {
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, OWN_COMMIT, OWN_COMMIT)).isEqualTo(OWN_SESSION);
+    }
+
+    @Test
+    void shouldNotAttributeAnAlertAboutSomebodyElsesCommit() {
+        // the job was queued by our submit but ended up snapshotting a commit pushed by someone else in the meantime
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, OWN_COMMIT, OTHER_COMMIT)).isNull();
+    }
+
+    @Test
+    void shouldNotAttributeWhenTheTriggeringCommitIsUnknown() {
+        // a version created by a metadata change, which cannot own a repository commit
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, null, OWN_COMMIT)).isNull();
+    }
+
+    @Test
+    void shouldNotAttributeWhenTheSnapshotHasNoCommitForTheTarget() {
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, OWN_COMMIT, null)).isNull();
+    }
+
+    @Test
+    void shouldNotAttributeWithoutAClientSession() {
+        // a plain git push from a clone, which has no editor session to filter by
+        assertThat(ExerciseVersionService.sessionOwningCommit(null, OWN_COMMIT, OWN_COMMIT)).isNull();
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionCommitAttributionTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionCommitAttributionTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
+import de.tum.cit.aet.artemis.exercise.dto.synchronization.ExerciseEditorSyncTarget;
+
 /**
  * Tests which client a new commit alert may be attributed to.
  * <p>
@@ -21,31 +23,48 @@ class ExerciseVersionCommitAttributionTest {
 
     private static final String OTHER_COMMIT = "2222222222222222222222222222222222222222";
 
+    private static final ExerciseEditorSyncTarget TESTS = ExerciseEditorSyncTarget.TESTS_REPOSITORY;
+
+    private static final ExerciseEditorSyncTarget TEMPLATE = ExerciseEditorSyncTarget.TEMPLATE_REPOSITORY;
+
     @Test
     void shouldAttributeAnAlertAboutTheClientsOwnCommit() {
-        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, OWN_COMMIT, OWN_COMMIT)).isEqualTo(OWN_SESSION);
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, OWN_COMMIT, TESTS, OWN_COMMIT)).isEqualTo(OWN_SESSION);
     }
 
     @Test
     void shouldNotAttributeAnAlertAboutSomebodyElsesCommit() {
         // the job was queued by our submit but ended up snapshotting a commit pushed by someone else in the meantime
-        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, OWN_COMMIT, OTHER_COMMIT)).isNull();
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, OWN_COMMIT, TESTS, OTHER_COMMIT)).isNull();
+    }
+
+    @Test
+    void shouldNotAttributeAnAlertAboutADifferentRepositoryAtTheSameCommit() {
+        // a commit id identifies an object, not a place: repositories of one exercise are seeded from each other, so the same
+        // id can stand in more than one of them, and matching on the id alone would attribute the wrong repository's alert
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, OWN_COMMIT, TEMPLATE, OWN_COMMIT)).isNull();
+    }
+
+    @Test
+    void shouldNotAttributeWhenTheTriggeringRepositoryIsUnknown() {
+        // an auxiliary repository commit, which cannot be matched to one specific auxiliary repository here
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, null, OWN_COMMIT, TESTS, OWN_COMMIT)).isNull();
     }
 
     @Test
     void shouldNotAttributeWhenTheTriggeringCommitIsUnknown() {
         // a version created by a metadata change, which cannot own a repository commit
-        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, null, OWN_COMMIT)).isNull();
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, null, TESTS, OWN_COMMIT)).isNull();
     }
 
     @Test
     void shouldNotAttributeWhenTheSnapshotHasNoCommitForTheTarget() {
-        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, OWN_COMMIT, null)).isNull();
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, OWN_COMMIT, TESTS, null)).isNull();
     }
 
     @Test
     void shouldNotAttributeWithoutAClientSession() {
         // a plain git push from a clone, which has no editor session to filter by
-        assertThat(ExerciseVersionService.sessionOwningCommit(null, OWN_COMMIT, OWN_COMMIT)).isNull();
+        assertThat(ExerciseVersionService.sessionOwningCommit(null, TESTS, OWN_COMMIT, TESTS, OWN_COMMIT)).isNull();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionCommitAttributionTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/ExerciseVersionCommitAttributionTest.java
@@ -29,42 +29,60 @@ class ExerciseVersionCommitAttributionTest {
 
     @Test
     void shouldAttributeAnAlertAboutTheClientsOwnCommit() {
-        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, OWN_COMMIT, TESTS, OWN_COMMIT)).isEqualTo(OWN_SESSION);
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, null, OWN_COMMIT, TESTS, null, OWN_COMMIT)).isEqualTo(OWN_SESSION);
     }
 
     @Test
     void shouldNotAttributeAnAlertAboutSomebodyElsesCommit() {
         // the job was queued by our submit but ended up snapshotting a commit pushed by someone else in the meantime
-        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, OWN_COMMIT, TESTS, OTHER_COMMIT)).isNull();
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, null, OWN_COMMIT, TESTS, null, OTHER_COMMIT)).isNull();
     }
 
     @Test
     void shouldNotAttributeAnAlertAboutADifferentRepositoryAtTheSameCommit() {
         // a commit id identifies an object, not a place: repositories of one exercise are seeded from each other, so the same
         // id can stand in more than one of them, and matching on the id alone would attribute the wrong repository's alert
-        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, OWN_COMMIT, TEMPLATE, OWN_COMMIT)).isNull();
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, null, OWN_COMMIT, TEMPLATE, null, OWN_COMMIT)).isNull();
     }
 
     @Test
     void shouldNotAttributeWhenTheTriggeringRepositoryIsUnknown() {
         // an auxiliary repository commit, which cannot be matched to one specific auxiliary repository here
-        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, null, OWN_COMMIT, TESTS, OWN_COMMIT)).isNull();
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, null, null, OWN_COMMIT, TESTS, null, OWN_COMMIT)).isNull();
     }
 
     @Test
     void shouldNotAttributeWhenTheTriggeringCommitIsUnknown() {
         // a version created by a metadata change, which cannot own a repository commit
-        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, null, TESTS, OWN_COMMIT)).isNull();
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, null, null, TESTS, null, OWN_COMMIT)).isNull();
     }
 
     @Test
     void shouldNotAttributeWhenTheSnapshotHasNoCommitForTheTarget() {
-        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, OWN_COMMIT, TESTS, null)).isNull();
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, TESTS, null, OWN_COMMIT, TESTS, null, null)).isNull();
     }
 
     @Test
     void shouldNotAttributeWithoutAClientSession() {
         // a plain git push from a clone, which has no editor session to filter by
-        assertThat(ExerciseVersionService.sessionOwningCommit(null, TESTS, OWN_COMMIT, TESTS, OWN_COMMIT)).isNull();
+        assertThat(ExerciseVersionService.sessionOwningCommit(null, TESTS, null, OWN_COMMIT, TESTS, null, OWN_COMMIT)).isNull();
+    }
+
+    private static final ExerciseEditorSyncTarget AUXILIARY = ExerciseEditorSyncTarget.AUXILIARY_REPOSITORY;
+
+    @Test
+    void shouldAttributeAnAlertAboutTheClientsOwnAuxiliaryRepositoryCommit() {
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, AUXILIARY, 7L, OWN_COMMIT, AUXILIARY, 7L, OWN_COMMIT)).isEqualTo(OWN_SESSION);
+    }
+
+    @Test
+    void shouldNotAttributeAnAlertAboutADifferentAuxiliaryRepository() {
+        // one target covers every auxiliary repository of the exercise, so the id has to settle which one this alert is about
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, AUXILIARY, 7L, OWN_COMMIT, AUXILIARY, 8L, OWN_COMMIT)).isNull();
+    }
+
+    @Test
+    void shouldNotAttributeAnAuxiliaryAlertWhenTheCommittedRepositoryCouldNotBeIdentified() {
+        assertThat(ExerciseVersionService.sessionOwningCommit(OWN_SESSION, AUXILIARY, null, OWN_COMMIT, AUXILIARY, 7L, OWN_COMMIT)).isNull();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionCodeGenerationExecutionServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionCodeGenerationExecutionServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -71,6 +72,8 @@ import de.tum.cit.aet.artemis.programming.test_repository.ProgrammingSubmissionT
 import de.tum.cit.aet.artemis.programming.test_repository.TemplateProgrammingExerciseParticipationTestRepository;
 
 class HyperionCodeGenerationExecutionServiceTest {
+
+    private static final String COMMIT_HASH = "abc123abc123abc123abc123abc123abc123abc1";
 
     @Mock
     private GitService gitService;
@@ -198,7 +201,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         when(gitService.getLastCommitHash(any(LocalVCRepositoryUri.class))).thenReturn(originalCommitId, newCommitId, newCommitId);
         when(gitService.getFileByName(repository, "src/Test.java")).thenReturn(Optional.empty());
         doNothing().when(repositoryService).createFile(eq(repository), eq("src/Test.java"), any());
-        doNothing().when(repositoryService).commitChanges(repository, user);
+        doReturn(COMMIT_HASH).when(repositoryService).commitChanges(repository, user);
         doNothing().when(gitService).resetToOriginHead(repository);
         when(repositoryStructureService.getRepositoryStructure(repository)).thenReturn("structure");
         when(repositoryStructureService.getBuildEnvironmentContext(repository)).thenReturn("pom.xml");
@@ -267,7 +270,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         when(gitService.getLastCommitHash(any(LocalVCRepositoryUri.class))).thenReturn(originalCommitId, newCommitId, newCommitId);
         when(gitService.getFileByName(repository, "src/Test.java")).thenReturn(Optional.empty());
         doNothing().when(repositoryService).createFile(eq(repository), eq("src/Test.java"), any());
-        doNothing().when(repositoryService).commitChanges(repository, user);
+        doReturn(COMMIT_HASH).when(repositoryService).commitChanges(repository, user);
         doNothing().when(gitService).resetToOriginHead(repository);
         when(repositoryStructureService.getRepositoryStructure(repository)).thenReturn("structure");
         when(repositoryStructureService.getBuildEnvironmentContext(repository)).thenReturn("pom.xml");
@@ -307,7 +310,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         when(gitService.getLastCommitHash(any(LocalVCRepositoryUri.class))).thenReturn(originalCommitId, newCommitId, newCommitId);
         when(gitService.getFileByName(repository, "src/Test.java")).thenReturn(Optional.empty());
         doNothing().when(repositoryService).createFile(eq(repository), eq("src/Test.java"), any());
-        doNothing().when(repositoryService).commitChanges(repository, user);
+        doReturn(COMMIT_HASH).when(repositoryService).commitChanges(repository, user);
         doNothing().when(gitService).resetToOriginHead(repository);
         when(repositoryStructureService.getRepositoryStructure(repository)).thenReturn("structure");
         when(repositoryStructureService.getBuildEnvironmentContext(repository)).thenReturn("pom.xml");
@@ -360,7 +363,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         when(gitService.getLastCommitHash(any(LocalVCRepositoryUri.class))).thenReturn(originalCommitId, newCommitId, newCommitId);
         when(gitService.getFileByName(repository, "src/Test.java")).thenReturn(Optional.empty());
         doNothing().when(repositoryService).createFile(eq(repository), eq("src/Test.java"), any());
-        doNothing().when(repositoryService).commitChanges(repository, user);
+        doReturn(COMMIT_HASH).when(repositoryService).commitChanges(repository, user);
         doNothing().when(gitService).resetToOriginHead(repository);
         when(repositoryStructureService.getRepositoryStructure(repository)).thenReturn("structure");
         when(repositoryStructureService.getBuildEnvironmentContext(repository)).thenReturn("pom.xml");
@@ -394,7 +397,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         when(gitService.getLastCommitHash(any(LocalVCRepositoryUri.class))).thenReturn(originalCommitId, newCommitId);
         when(gitService.getFileByName(repository, "src/Test.java")).thenReturn(Optional.empty());
         doNothing().when(repositoryService).createFile(eq(repository), eq("src/Test.java"), any());
-        doNothing().when(repositoryService).commitChanges(repository, user);
+        doReturn(COMMIT_HASH).when(repositoryService).commitChanges(repository, user);
         doNothing().when(gitService).resetToOriginHead(repository);
         when(repositoryStructureService.getRepositoryStructure(repository)).thenReturn("structure");
         when(repositoryStructureService.getBuildEnvironmentContext(repository)).thenReturn("pom.xml");
@@ -439,7 +442,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         when(gitService.getLastCommitHash(any(LocalVCRepositoryUri.class))).thenReturn(originalCommitId, newCommitId, newCommitId);
         when(gitService.getFileByName(repository, "src/Test.java")).thenReturn(Optional.empty());
         doNothing().when(repositoryService).createFile(eq(repository), eq("src/Test.java"), any());
-        doNothing().when(repositoryService).commitChanges(repository, user);
+        doReturn(COMMIT_HASH).when(repositoryService).commitChanges(repository, user);
         doNothing().when(gitService).resetToOriginHead(repository);
         when(repositoryStructureService.getRepositoryStructure(repository)).thenReturn("structure");
         when(repositoryStructureService.getBuildEnvironmentContext(repository)).thenReturn("pom.xml");
@@ -477,7 +480,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         when(gitService.getFileByName(repository, "src/main/java/OldSort.java")).thenReturn(Optional.of(obsoleteFile));
         when(obsoleteFile.isFile()).thenReturn(true);
         doNothing().when(repositoryService).deleteFile(repository, "src/main/java/OldSort.java");
-        doNothing().when(repositoryService).commitChanges(repository, user);
+        doReturn(COMMIT_HASH).when(repositoryService).commitChanges(repository, user);
         doNothing().when(gitService).resetToOriginHead(repository);
         when(repositoryStructureService.getRepositoryStructure(repository)).thenReturn("structure");
         when(repositoryStructureService.getBuildEnvironmentContext(repository)).thenReturn("pom.xml");
@@ -754,7 +757,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         LocalVCRepositoryUri repositoryUri = mock(LocalVCRepositoryUri.class);
         SolutionProgrammingExerciseParticipation mockParticipation = mock(SolutionProgrammingExerciseParticipation.class);
 
-        doNothing().when(repositoryService).commitChanges(mockRepository, user);
+        doReturn(COMMIT_HASH).when(repositoryService).commitChanges(mockRepository, user);
         when(gitService.getLastCommitHash(repositoryUri)).thenReturn("new-commit-hash");
         when(programmingExerciseParticipationService.retrieveSolutionParticipation(exercise)).thenReturn(mockParticipation);
         doNothing().when(continuousIntegrationTriggerService).triggerBuild(mockParticipation, "new-commit-hash", RepositoryType.SOLUTION);
@@ -772,7 +775,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         LocalVCRepositoryUri repositoryUri = mock(LocalVCRepositoryUri.class);
         SolutionProgrammingExerciseParticipation mockParticipation = mock(SolutionProgrammingExerciseParticipation.class);
 
-        doNothing().when(repositoryService).commitChanges(mockRepository, user);
+        doReturn(COMMIT_HASH).when(repositoryService).commitChanges(mockRepository, user);
         when(gitService.getLastCommitHash(repositoryUri)).thenReturn("new-commit-hash");
         when(programmingExerciseParticipationService.retrieveSolutionParticipation(exercise)).thenReturn(mockParticipation);
         doThrow(new ContinuousIntegrationException("CI error")).when(continuousIntegrationTriggerService).triggerBuild(mockParticipation, "new-commit-hash",
@@ -790,7 +793,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         LocalVCRepositoryUri repositoryUri = mock(LocalVCRepositoryUri.class);
         SolutionProgrammingExerciseParticipation mockParticipation = mock(SolutionProgrammingExerciseParticipation.class);
 
-        doNothing().when(repositoryService).commitChanges(mockRepository, user);
+        doReturn(COMMIT_HASH).when(repositoryService).commitChanges(mockRepository, user);
         when(gitService.getLastCommitHash(repositoryUri)).thenReturn("commit-tests");
         when(programmingExerciseParticipationService.retrieveSolutionParticipation(exercise)).thenReturn(mockParticipation);
 
@@ -969,7 +972,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         when(gitService.getLastCommitHash(any(LocalVCRepositoryUri.class))).thenReturn(originalCommitId, newCommitId, newCommitId);
         when(gitService.getFileByName(repository, "src/Test.java")).thenReturn(Optional.empty());
         doNothing().when(repositoryService).createFile(eq(repository), eq("src/Test.java"), any());
-        doNothing().when(repositoryService).commitChanges(repository, user);
+        doReturn(COMMIT_HASH).when(repositoryService).commitChanges(repository, user);
         doNothing().when(gitService).resetToOriginHead(repository);
         when(repositoryStructureService.getRepositoryStructure(repository)).thenReturn("structure");
         when(repositoryStructureService.getBuildEnvironmentContext(repository)).thenReturn("pom.xml");

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseGitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseGitIntegrationTest.java
@@ -152,7 +152,14 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractProgrammingIntegrati
             Files.createDirectories(localFile.getParent());
             FileUtils.writeStringToFile(localFile.toFile(), "hello world", java.nio.charset.StandardCharsets.UTF_8);
             gitService.stageAllChanges(checkedOut);
-            gitService.commitAndPush(checkedOut, "Add hello.txt", true, null);
+            String createdCommitHash = gitService.commitAndPush(checkedOut, "Add hello.txt", true, null);
+
+            // The returned id has to be the commit just created, because that identity is what attributes a new commit alert
+            // to the client that made the commit. Re-reading the head instead would be a race: the online editor shares one
+            // working copy per repository, so a concurrent commit can move the head before it is read.
+            assertThat(createdCommitHash).as("commitAndPush should return the id of the commit it created").isNotNull().hasSize(40);
+            assertThat(createdCommitHash).as("the created commit must be the new head, not the commit it replaced").isNotEqualTo(lastHash);
+            assertThat(gitService.getLastCommitHash(repoUri)).as("the created commit must be what the remote now stands at").isEqualTo(createdCommitHash);
 
             // Pull and reset operations should not throw
             gitService.pullIgnoreConflicts(checkedOut);


### PR DESCRIPTION
### Summary

Fixes #13459. Submitting to the template, solution or tests repository from the exercise editor warned the instructor that a new commit had been pushed to the repository, on every submit.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

The warning is meant for commits made elsewhere, for instance from an offline IDE or by a colleague, so that you know to refresh before you keep editing. Being told about the commit you just made yourself is noise, and it trains people to ignore the message when it does matter.

### Description

The machinery to suppress this already existed and was not reaching the point where it works.

The client drops synchronization events that carry its own session id, centrally, in `ExerciseEditorSyncService.connect()`. The commit alert payload has a `sessionId` field for exactly that purpose. It was always empty, so the filter could never match and the alert reached every editor including the one that caused it.

The reason it was empty: exercise versioning is asynchronous. `ExerciseVersionService.createExerciseVersion` hands the work to the `exerciseVersionTaskExecutor`, and `broadcastNewCommitAlert` read the session id from `RequestContextHolder` at the point of broadcast, which is on an `exercise-versioning-*` thread with no request context. `getClientSessionId()` returned null and `@JsonInclude(NON_EMPTY)` dropped the field.

The session id is now read on the request thread, one line next to where the author is already captured for exactly the same reason, and passed through to the broadcast. Other editors of the same exercise are unaffected and still get the warning.

Two notes for reviewers:

* **Why no test caught this.** Under the `test` profile `exerciseVersionTaskExecutor` is a `SyncTaskExecutor`, so the task runs on the calling thread and the caller's request context is still in place. The existing test set up a request context and passed. The broadcast is now tested without one, which is the production situation.
* **The same latent gap exists for two neighbours.** `broadcastNewExerciseVersionAlert` and `broadcastReviewThreadUpdate` are reached from the same asynchronous path and also end up with a null session id. No client currently filters on it, so nothing is visibly broken, and I left them alone to keep this fix small. Worth a follow-up.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Log in as instructor and open **Edit in Editor** for the exercise.
2. Submit to the template repository, with or without changes.
3. Confirm that no "New commit detected" warning appears.
4. Repeat for the solution and tests repositories, and for an auxiliary repository if the exercise has one.
5. Open the same exercise editor in a second browser session, as a second instructor or a private window. Submit in the first session and confirm the second session still shows the warning, since that commit really is external to it.
6. Push a commit to one of those repositories from a local git clone and confirm the open editor shows the warning.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization alerts during exercise version creation.
  * Prevented editors from receiving and reacting to their own commit alerts.
  * Preserved editing-session association for alerts, including asynchronous operations.
  * Improved commit attribution when repository changes trigger exercise version creation.
  * Ensured alerts identify the originating commit when it can be confirmed and remain unattributed when it cannot.
  * Improved consistency across template, solution, test, and auxiliary repository changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Update after review

The first version attributed the alert to the session of the request that **queued** the version job. @Claudia-Anthropica pointed out that this is not the same thing as the session that owns the commit the job eventually snapshots, and that is correct.

Version jobs run on an executor with several workers and read the repository refs when they execute, not when they were queued. If two instructors submit to the same repository close together, the job queued by A can snapshot B's commit and broadcast it carrying A's session. A's editor would then discard a warning about B's commit. That is worse than the duplicate warning this PR set out to remove, since an extra warning is noise but a missing one loses data.

The commit is now carried with the session and the alert is attributed only when the repository in the snapshot stands at exactly that commit:

* `LocalVCServletService` resolves the hash of the commit the push created, on the request thread. It has to resolve it rather than pass it through, because a commit from the online editor arrives with a null hash and only the repository knows what was just written. It is held in a separate variable so the build-triggering code below keeps the null it relies on.
* `determineSynchronizationForActiveEditors` records which commit the detected repository now stands at, next to the target it already computed.
* `ExerciseVersionService.sessionOwningCommit` attributes the alert only on an exact hash match, and returns null in every other case. Unattributed means everyone is warned, including the committer, which is the safe direction.

`ExerciseVersionCommitAttributionTest` covers the match, the overlapping-submit mismatch, and the three cases where identity cannot be established.
