### PR TITLE
`Development`: Fix two failing programming exercise participation e2e tests

### DIFF
--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseParticipation.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseParticipation.spec.ts
@@ -330,7 +330,12 @@ test.describe('Programming exercise advanced participation', { tag: '@slow' }, (
             await expect(programmingExerciseOverview.getCodeButton()).not.toBeVisible();
             await expect(programmingExerciseOverview.getExerciseDetails().getByText('Not yet started')).toBeVisible();
             await courseOverview.startExercise(exercise.id!);
-            await expect(programmingExerciseOverview.getExerciseDetails().getByText('No graded result')).toBeVisible();
+            // Starting gives this student their own fresh participation, so the header shows the graded-result
+            // placeholder `artemisApp.result.noGradedResult` ("Not graded") instead of the other team's score. The text
+            // asserted before ("No graded result") belongs to `courseOverview.exerciseDetails.noGradedResult`, a
+            // translation key the client stopped rendering in 2019 — long before this test was added — so the
+            // assertion could never match and failed deterministically.
+            await expect(programmingExerciseOverview.getExerciseDetails().getByText('Not graded')).toBeVisible();
         });
 
         test.describe('Check team participation', () => {

--- a/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseOverviewPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseOverviewPage.ts
@@ -87,8 +87,6 @@ export class ProgrammingExerciseOverviewPage {
 
         const codeButtonLocator = codeButton ?? this.getCodeButton();
         await Commands.reloadUntilFound(this.page, codeButtonLocator, 10000, 40000);
-        await codeButtonLocator.click();
-        await this.page.locator('.popover-body').waitFor({ state: 'visible' });
 
         // The popover loads SSH-key / token status asynchronously after it opens (see
         // code-button.component: getCachedSshKeys / getVcsAccessToken run in ngOnInit). As those
@@ -96,13 +94,26 @@ export class ProgrammingExerciseOverviewPage {
         // ngb repositions it — so the `.https-or-ssh-button` toggle and the dropdown options
         // re-render and briefly detach. Under heavy multi-node load this churn window is long
         // enough that a single click races a detach ("element is not stable" / "element was
-        // detached from the DOM"). Retry the toggle + option selection as a unit, re-finding the
-        // elements each attempt and only re-toggling when the dropdown is not already open.
+        // detached from the DOM"). Retry opening the popover plus the toggle and option selection as
+        // a unit, re-finding the elements each attempt and only re-toggling when the dropdown is not
+        // already open.
+        const popover = this.page.locator('.popover-body');
         const toggle = this.page.locator('.https-or-ssh-button');
         const cloneMethodOption = this.page.locator(gitCloneMethodSelector[cloneMethod]);
         const maxAttempts = 5;
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
             try {
+                // Opening the popover belongs inside the retry: the page keeps rendering after
+                // `reloadUntilFound` returns, and because the popover is attached to `body` with
+                // `autoClose: 'outside'`, any re-render of the code button dismisses it again. The toggle
+                // exists only while the popover is open, so waiting for the toggle alone cannot recover
+                // from that — every attempt would wait out its timeout on an element that can no longer
+                // appear. Reopen instead, and skip the click when the popover is already showing (clicking
+                // the trigger again would close it).
+                if (!(await popover.isVisible())) {
+                    await codeButtonLocator.click();
+                    await popover.waitFor({ state: 'visible', timeout: 15_000 });
+                }
                 await toggle.waitFor({ state: 'visible', timeout: 15_000 });
                 if (!(await cloneMethodOption.isVisible())) {
                     await toggle.click({ timeout: 10_000 });


### PR DESCRIPTION
### Summary
Two tests in `ProgrammingExerciseParticipation.spec.ts` fail on `develop`. One asserts a text the client has not rendered since 2019, the other cannot recover when the clone popover is dismissed. Both fixes are test-only; no production code is touched.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
`Students of other teams have their own submission` fails on every run, on `develop` and on every open PR. The JUnit artifacts report `element(s) not found` for both the first attempt and the retry, so it is not a timing race — the asserted text does not exist.

`Makes a git submission using SSH with RSA key` passes in CI, but only just: it used 173 s of its 180 s budget. It fails reproducibly on a local multi-node stack, and because its `describe.serial` block aborts on failure, the ED25519 case is skipped with it.

### Description
**1. An assertion that could never match** (`ProgrammingExerciseParticipation.spec.ts`)

After starting the exercise the test asserted `getByText('No graded result')`. That string only ever appeared in `courseOverview.exerciseDetails.noGradedResult` ("You have no graded result."), a translation key whose last reference in app code was removed in 2019 (`111ca93fc7`) — five years before the assertion was written in #8559. The key still sits in `student-dashboard.json`, which is why the mismatch was easy to miss.

The header actually renders `artemisApp.result.noGradedResult` = **"Not graded"** (`result.component.html`, reached because a fresh programming participation before the due date satisfies `shouldShowResult()` while `showUngradedResults` is `false` for a graded participation). The failure snapshot confirms it: `Points 0 / 10 … Status Not graded`. The test now asserts that text.

**2. `openCloneMenu` could not recover from a dismissed popover** (`ProgrammingExerciseOverviewPage.ts`)

`openCloneMenu` calls `Commands.reloadUntilFound`, so the popover is opened while the page is still rendering. The popover is attached to `body` with `autoClose: 'outside'`, so any re-render of the code button dismisses it. The retry loop then waited only for `.https-or-ssh-button`, which exists *only* while the popover is open — so once dismissed, all five attempts waited out their 15 s timeout on an element that could no longer appear (the observed ~90 s failure, with no popover in the failure snapshot).

Opening the popover is now part of the retried unit, guarded so an already-open popover is not clicked shut.

### Steps for Testing
This PR only changes Playwright tests, so testing means running them.

Prerequisites:
- A local multi-node stack (`./run-e2e-tests-local-multinode-fast.sh`)

1. On `develop`, run `./run-e2e-tests-local-multinode-fast.sh --filter "ProgrammingExerciseParticipation"` and observe 2 failures (`:210` SSH RSA, `:312` team submission) plus 1 skip (ED25519).
2. On this branch, run the same command and observe both tests pass, and the ED25519 case now runs.
3. Alternatively, check the `slow-tests` results of this PR's E2E phase: `Students of other teams have their own submission` must pass.

### Testserver States
Not applicable — this PR changes only Playwright E2E tests and no production code.

### Review Progress
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated exercise participation checks to reflect the visible “Not graded” status for newly started programming exercises.
  * Improved the clone menu interaction to reliably open and select the clone option despite asynchronous UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->