### PR TITLE
`Development`: Install the repository dependencies for e2e runs

### DIFF
--- a/.ci/E2E-tests/execute-locally.sh
+++ b/.ci/E2E-tests/execute-locally.sh
@@ -98,12 +98,16 @@ if [ -n "$TEST_FILTER" ]; then
 # AUTO-GENERATED - DO NOT COMMIT
 services:
     artemis-playwright:
+        # Both installs are required: specs load src/main/webapp models, which resolve their own dependencies from the
+        # repository root upwards, so a Playwright-only install leaves them unresolvable and collection finds no tests.
         command: >
             sh -c '
-            cd /app/artemis/src/test/playwright &&
+            cd /app/artemis &&
             chmod 777 /root &&
-            rm -f test-reports/results*.xml &&
             corepack enable &&
+            pnpm install --frozen-lockfile &&
+            cd /app/artemis/src/test/playwright &&
+            rm -f test-reports/results*.xml &&
             pnpm install --frozen-lockfile &&
             pnpm run playwright:setup &&
             PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-reports/results.xml pnpm exec playwright test e2e --grep "${TEST_FILTER}" --reporter=list,junit,monocart-reporter

--- a/docker/playwright.yml
+++ b/docker/playwright.yml
@@ -28,12 +28,18 @@ services:
             PLAYWRIGHT_REPORT_PHASE: '${PLAYWRIGHT_REPORT_PHASE:-}'
             PLAYWRIGHT_REPORT_TRIGGERED_BY: '${PLAYWRIGHT_REPORT_TRIGGERED_BY:-}'
             GITHUB_RUN_ID: '${GITHUB_RUN_ID:-}'
+        # Both installs are required. The suite reuses the application's models through the `app/*` alias, so loading a
+        # spec pulls in files under src/main/webapp, and those resolve their own dependencies (lodash-es, ...) from the
+        # repository root upwards. Installing only the Playwright workspace leaves them unresolvable, which makes
+        # Playwright fail during collection and report zero tests rather than a failing test.
         command: >
           sh -c '
-          cd /app/artemis/src/test/playwright &&
+          cd /app/artemis &&
           chmod 777 /root &&
-          chmod +x ./run-tests.sh &&
           corepack enable &&
+          pnpm install --frozen-lockfile &&
+          cd /app/artemis/src/test/playwright &&
+          chmod +x ./run-tests.sh &&
           pnpm install --frozen-lockfile &&
           pnpm run playwright:setup &&
           rm -f ./test-reports/results.xml ./test-reports/results-*.xml &&

--- a/run-e2e-tests-local-multinode.sh
+++ b/run-e2e-tests-local-multinode.sh
@@ -297,12 +297,16 @@ if [ -n "$TEST_FILTER" ]; then
 # AUTO-GENERATED — DO NOT COMMIT
 services:
     artemis-playwright:
+        # Both installs are required: specs load src/main/webapp models, which resolve their own dependencies from the
+        # repository root upwards, so a Playwright-only install leaves them unresolvable and collection finds no tests.
         command: >
             sh -c '
-            cd /app/artemis/src/test/playwright &&
+            cd /app/artemis &&
             chmod 777 /root &&
-            rm -f test-reports/results*.xml &&
             corepack enable &&
+            pnpm install --frozen-lockfile &&
+            cd /app/artemis/src/test/playwright &&
+            rm -f test-reports/results*.xml &&
             pnpm install --frozen-lockfile &&
             pnpm run playwright:setup &&
             PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-reports/results.xml pnpm exec playwright test e2e --grep "${TEST_FILTER}" --reporter=list,junit,monocart-reporter


### PR DESCRIPTION
### Summary

Every E2E run on `develop` currently collects **0 tests**. Loading any spec fails with `Cannot find module 'lodash-es'`, so Playwright exits before running anything and `E2E / Report E2E Overall Status` is red on every PR. This restores collection — verified at **375 tests in 78 files**, from `0 tests in 0 files`.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

The Playwright suite reuses the application's own models through the `app/*` alias — 79 spec/support files import 32 distinct webapp modules — so loading a spec pulls in files under `src/main/webapp`. Node resolves a bare specifier from the **importing file's** directory upwards. For a webapp file that walk is `webapp` → `main` → `src` → repository root, and `src/test/playwright/node_modules` is a *sibling* of that walk, never an ancestor. The containerised run installed only that workspace, so no directory on the walk carried the dependency.

The confusing part, and why the obvious fix does not work: `lodash-es` **is** declared in `src/test/playwright/package.json` and **is** installed — the CI log prints `+ lodash-es 4.18.1` moments before `Cannot find module 'lodash-es'`. It installs into a directory the lookup never consults.

Nothing hit this for as long as the webapp files reachable from a spec imported external packages **only for their types**, which TypeScript elides — `course.model.ts` imports `dayjs` purely as `dayjs.Dayjs`, so no `require` is ever emitted. #13351 added `import { hydrate } from 'app/foundation/util/deep-clone.util'` to that same model, used as a value at line 165, making it the first webapp file in a spec's import graph to need a package at runtime. `hydrate` genuinely needs `deepClone` — it clones each source to detach the model from the DTO — so the dependency is real rather than incidental.

### Description

The three containerised E2E entry points (`docker/playwright.yml`, `.ci/E2E-tests/execute-locally.sh`, `run-e2e-tests-local-multinode.sh`) now run `pnpm install --frozen-lockfile` at the repository root as well as in the Playwright workspace. The webapp files then resolve their dependencies exactly as they do in every other environment — the client build, the unit tests, a developer's checkout — with no resolution tricks.

Cost measured rather than assumed: **48s** for the root install in the container on a cold store, and **12s** on the CI runners (the `Install Dependencies` step of `Quality / Client Compilation` and `Client Code Style` in the same workflow), against E2E runs of many minutes.

Considered and rejected:
- **Extending `NODE_PATH` / `Module._initPaths()` from `playwright.config.ts`.** Works, and was the first version of this PR, but it is a resolution workaround built on a private Node API to paper over an incomplete install.
- **Decoupling the E2E suite from the application models.** 79 files, 32 modules; sharing the models is a deliberate choice that keeps E2E aligned with the real shapes.
- **Making `hydrate` dependency-free.** It needs `deepClone` for its documented semantics.

### Steps for Testing

This reproduces without the Artemis stack, since it fails during spec collection:

```bash
docker run --rm -v "$(pwd)":/app/artemis \
  -v /app/artemis/node_modules \
  -v /app/artemis/src/test/playwright/node_modules \
  -w /app/artemis mcr.microsoft.com/playwright:v1.62.1 \
  sh -c 'corepack enable && cd src/test/playwright && pnpm install --frozen-lockfile && npx playwright test --list'
```

The two anonymous volumes reproduce CI's state: no repository-root `node_modules`, and a freshly installed Playwright workspace.

1. That command reproduces the failure: `Error: Cannot find module 'lodash-es'`, `Total: 0 tests in 0 files`.
2. Adding the root install this PR introduces (`cd /app/artemis && pnpm install --frozen-lockfile` before the workspace install) yields `Total: 375 tests in 78 files`.
3. A normal E2E run (`./run-e2e-tests-local-fast.sh`) behaves as before.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-13 14:38:37 UTC_

