### PR TITLE
`Iris`: Fix lecture visibility synchronization after ingestion

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisConnectorService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisConnectorService.java
@@ -298,7 +298,7 @@ public class PyrisConnectorService {
             restTemplate.postForEntity(pyrisUrl + endpoint, dto, Void.class);
         }
         catch (HttpStatusCodeException e) {
-            log.error("Failed to send lecture unit metadata {} to Pyris: {}", dto.lectureUnitId(), e.getMessage());
+            logLectureUnitSyncFailure("metadata", dto.lectureUnitId(), e);
             throw toIrisException(e);
         }
         catch (RestClientException | IllegalArgumentException e) {
@@ -318,12 +318,21 @@ public class PyrisConnectorService {
             restTemplate.postForEntity(pyrisUrl + endpoint, dto, Void.class);
         }
         catch (HttpStatusCodeException e) {
-            log.error("Failed to send lecture unit visibility {} to Pyris: {}", dto.lectureUnitId(), e.getMessage());
+            logLectureUnitSyncFailure("visibility", dto.lectureUnitId(), e);
             throw toIrisException(e);
         }
         catch (RestClientException | IllegalArgumentException e) {
             log.error("Failed to send lecture unit visibility {} to Pyris: {}", dto.lectureUnitId(), e.getMessage());
             throw new PyrisConnectorException("Could not send lecture visibility to Pyris");
+        }
+    }
+
+    private void logLectureUnitSyncFailure(String updateKind, long lectureUnitId, HttpStatusCodeException exception) {
+        if (exception.getStatusCode().value() == 404) {
+            log.warn("Pyris has no lecture unit {} for {} sync (HTTP 404); retrying with backoff", lectureUnitId, updateKind);
+        }
+        else {
+            log.error("Failed to send lecture unit {} {} sync to Pyris: {}", lectureUnitId, updateKind, exception.getMessage());
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/repository/AttachmentVideoUnitRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/repository/AttachmentVideoUnitRepository.java
@@ -20,6 +20,7 @@ import de.tum.cit.aet.artemis.core.repository.base.ArtemisJpaRepository;
 import de.tum.cit.aet.artemis.lecture.config.LectureEnabled;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentType;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
+import de.tum.cit.aet.artemis.lecture.domain.ProcessingPhase;
 
 /**
  * Spring Data JPA repository for the Attachment Unit entity.
@@ -131,16 +132,22 @@ public interface AttachmentVideoUnitRepository extends ArtemisJpaRepository<Atta
      * This supports a bounded rollout backfill for units created before retryable synchronization
      * was introduced.
      *
-     * @param now      the current time for determining active courses
-     * @param pageable pagination to limit results
+     * @param now             the current time for determining active courses
+     * @param processingPhase the required processing phase
+     * @param pageable        pagination to limit results
      * @return attachment video units without an Iris synchronization state
      */
     @Query("""
             SELECT avu FROM AttachmentVideoUnit avu
             JOIN avu.lecture l
             JOIN l.course c
+            LEFT JOIN avu.attachment attachment
             LEFT JOIN IrisLectureUnitSyncState syncState ON syncState.lectureUnitId = avu.id AND syncState.visibilityHash IS NOT NULL
             WHERE syncState.id IS NULL
+                AND EXISTS (
+                    SELECT processingState.id FROM LectureUnitProcessingState processingState
+                    WHERE processingState.lectureUnit.id = avu.id AND processingState.phase = :processingPhase
+                )
                 AND (c.startDate <= :now OR c.startDate IS NULL)
                 AND (c.endDate >= :now OR c.endDate IS NULL)
                 AND c.testCourse = FALSE
@@ -148,9 +155,10 @@ public interface AttachmentVideoUnitRepository extends ArtemisJpaRepository<Atta
                 AND (
                     (avu.videoSource IS NOT NULL AND avu.videoSource <> '')
                     OR
-                    (avu.attachment IS NOT NULL AND LOWER(avu.attachment.link) LIKE '%.pdf')
+                    (attachment IS NOT NULL AND LOWER(attachment.link) LIKE '%.pdf')
                 )
             ORDER BY avu.id
             """)
-    List<AttachmentVideoUnit> findUnitsMissingIrisSyncStateFromActiveCourses(@Param("now") ZonedDateTime now, Pageable pageable);
+    List<AttachmentVideoUnit> findUnitsMissingIrisSyncStateFromActiveCourses(@Param("now") ZonedDateTime now, @Param("processingPhase") ProcessingPhase processingPhase,
+            Pageable pageable);
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/repository/IrisLectureUnitSyncStateRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/repository/IrisLectureUnitSyncStateRepository.java
@@ -76,10 +76,11 @@ public interface IrisLectureUnitSyncStateRepository extends ArtemisJpaRepository
      * @param metadataHash   the new metadata hash, or null if metadata did not change
      * @param visibilityHash the new visibility hash, or null if visibility did not change
      * @param nextRetryAt    the earliest retry time
+     * @param resetSynced    whether to revoke previous synchronization results
      * @return the persisted dirty state
      */
     @Transactional
-    default IrisLectureUnitSyncState markDirty(long lectureUnitId, String metadataHash, String visibilityHash, ZonedDateTime nextRetryAt) {
+    default IrisLectureUnitSyncState markDirty(long lectureUnitId, String metadataHash, String visibilityHash, ZonedDateTime nextRetryAt, boolean resetSynced) {
         if (findAttachmentVideoUnitForUpdateById(lectureUnitId).isEmpty()) {
             throw new EntityNotFoundException("AttachmentVideoUnit", lectureUnitId);
         }
@@ -95,7 +96,11 @@ public interface IrisLectureUnitSyncStateRepository extends ArtemisJpaRepository
         if (visibilityHash != null) {
             state.setVisibilityHash(visibilityHash);
         }
-        boolean hasActiveLease = IrisLectureUnitSyncState.STATUS_IN_PROGRESS.equals(state.getStatus()) && state.getNextRetryAt() != null
+        if (resetSynced) {
+            state.setLastSyncedMetadataHash(null);
+            state.setLastSyncedVisibilityHash(null);
+        }
+        boolean hasActiveLease = !resetSynced && IrisLectureUnitSyncState.STATUS_IN_PROGRESS.equals(state.getStatus()) && state.getNextRetryAt() != null
                 && state.getNextRetryAt().isAfter(nextRetryAt);
         if (!hasActiveLease && java.util.Objects.equals(state.getMetadataHash(), state.getLastSyncedMetadataHash())
                 && java.util.Objects.equals(state.getVisibilityHash(), state.getLastSyncedVisibilityHash())) {
@@ -112,4 +117,5 @@ public interface IrisLectureUnitSyncStateRepository extends ArtemisJpaRepository
         }
         return save(state);
     }
+
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureUnitProcessingStateRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/repository/LectureUnitProcessingStateRepository.java
@@ -4,14 +4,18 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.persistence.LockModeType;
+
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import de.tum.cit.aet.artemis.core.repository.base.ArtemisJpaRepository;
 import de.tum.cit.aet.artemis.lecture.config.LectureEnabled;
+import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.LectureUnitProcessingState;
 import de.tum.cit.aet.artemis.lecture.domain.ProcessingPhase;
 
@@ -24,6 +28,12 @@ import de.tum.cit.aet.artemis.lecture.domain.ProcessingPhase;
 @Repository
 public interface LectureUnitProcessingStateRepository extends ArtemisJpaRepository<LectureUnitProcessingState, Long> {
 
+    boolean existsByLectureUnit_IdAndPhase(long lectureUnitId, ProcessingPhase phase);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT unit FROM AttachmentVideoUnit unit WHERE unit.id = :lectureUnitId")
+    Optional<AttachmentVideoUnit> findAttachmentVideoUnitForUpdateById(@Param("lectureUnitId") long lectureUnitId);
+
     /**
      * Find the processing state for a specific lecture unit.
      *
@@ -31,6 +41,10 @@ public interface LectureUnitProcessingStateRepository extends ArtemisJpaReposito
      * @return the processing state if it exists
      */
     Optional<LectureUnitProcessingState> findByLectureUnit_Id(Long lectureUnitId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT ps FROM LectureUnitProcessingState ps WHERE ps.lectureUnit.id = :lectureUnitId")
+    Optional<LectureUnitProcessingState> findByLectureUnitIdForUpdate(@Param("lectureUnitId") Long lectureUnitId);
 
     /**
      * Find processing states that are stuck (no callback received recently).

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentVideoUnitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/AttachmentVideoUnitService.java
@@ -7,6 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -102,7 +103,6 @@ public class AttachmentVideoUnitService {
 
         // Trigger automated content processing (transcription and ingestion)
         contentProcessingService.ifPresent(api -> api.triggerProcessing(savedAttachmentVideoUnit));
-        irisLectureUnitSyncService.markVisibilityDirtyAfterCommit(buildSnapshot(savedAttachmentVideoUnit));
 
         return savedAttachmentVideoUnit;
     }
@@ -124,11 +124,19 @@ public class AttachmentVideoUnitService {
     public AttachmentVideoUnit updateAttachmentVideoUnit(AttachmentVideoUnit existingAttachmentVideoUnit, AttachmentVideoUnitDTO updateUnitDTO, Attachment updateAttachment,
             MultipartFile updateFile, boolean keepFilename, List<HiddenPageInfoDTO> hiddenPages, List<SlideOrderDTO> pageOrder, Set<Long> originalCompetencyIds) {
         LectureContentUpdateSnapshot beforeSnapshot = buildSnapshot(existingAttachmentVideoUnit);
+        boolean hasUploadedFile = updateFile != null && !updateFile.isEmpty();
+        boolean contentWillChange = !Objects.equals(existingAttachmentVideoUnit.getVideoSource(), updateUnitDTO.videoSource())
+                || hasUploadedFile && (existingAttachmentVideoUnit.getAttachment() == null || !getOrBackfillStoredFileSha256Hash(existingAttachmentVideoUnit.getAttachment())
+                        .filter(attachmentFileHashService.sha256(updateFile).value()::equals).isPresent());
+        boolean processingReserved = contentWillChange && existingAttachmentVideoUnit.getLecture() != null && !existingAttachmentVideoUnit.getLecture().isTutorialLecture()
+                && contentProcessingService.isPresent();
+        if (processingReserved) {
+            contentProcessingService.orElseThrow().prepareForReprocessing(existingAttachmentVideoUnit);
+        }
         existingAttachmentVideoUnit.setDescription(updateUnitDTO.description());
         existingAttachmentVideoUnit.setName(updateUnitDTO.name());
         existingAttachmentVideoUnit.setReleaseDate(updateUnitDTO.releaseDate());
         existingAttachmentVideoUnit.setVideoSource(updateUnitDTO.videoSource());
-        boolean hasUploadedFile = updateFile != null && !updateFile.isEmpty();
         // Note: competency links are updated by the resource layer using lectureUnitService.updateCompetencyLinks
 
         Attachment existingAttachment = existingAttachmentVideoUnit.getAttachment();
@@ -196,20 +204,26 @@ public class AttachmentVideoUnitService {
 
         LectureContentUpdateSnapshot afterSnapshot = buildSnapshot(savedAttachmentVideoUnit, projectedSlideHiddenUntilBySlideNumber);
         var updateKinds = lectureContentUpdateClassifierService.classifyAll(beforeSnapshot, afterSnapshot, fileUpdateResult);
-        triggerContentProcessingForUpdateKinds(savedAttachmentVideoUnit, afterSnapshot, updateKinds);
+        triggerContentProcessingForUpdateKinds(savedAttachmentVideoUnit, afterSnapshot, updateKinds, processingReserved);
         prepareAttachmentVideoUnitForClient(savedAttachmentVideoUnit);
 
         return savedAttachmentVideoUnit;
     }
 
     private void triggerContentProcessingForUpdateKinds(AttachmentVideoUnit savedAttachmentVideoUnit, LectureContentUpdateSnapshot afterSnapshot,
-            Set<LectureContentUpdateKind> updateKinds) {
+            Set<LectureContentUpdateKind> updateKinds, boolean processingReserved) {
         if (updateKinds.isEmpty()) {
             return;
         }
 
         if (updateKinds.contains(LectureContentUpdateKind.CONTENT)) {
-            contentProcessingService.ifPresent(service -> service.triggerProcessing(savedAttachmentVideoUnit));
+            if (processingReserved) {
+                contentProcessingService.orElseThrow().triggerProcessing(savedAttachmentVideoUnit);
+                return;
+            }
+            if (savedAttachmentVideoUnit.getLecture() != null && savedAttachmentVideoUnit.getLecture().isTutorialLecture()) {
+                return;
+            }
         }
 
         if (updateKinds.contains(LectureContentUpdateKind.METADATA)) {

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/IrisLectureUnitSyncDispatchService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/IrisLectureUnitSyncDispatchService.java
@@ -9,12 +9,15 @@ import java.util.Optional;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.cit.aet.artemis.iris.api.IrisLectureUnitSyncApi;
 import de.tum.cit.aet.artemis.lecture.config.LectureWithIrisEnabled;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.LectureContentUpdateKind;
+import de.tum.cit.aet.artemis.lecture.domain.ProcessingPhase;
 import de.tum.cit.aet.artemis.lecture.domain.Slide;
+import de.tum.cit.aet.artemis.lecture.repository.LectureUnitProcessingStateRepository;
 import de.tum.cit.aet.artemis.lecture.repository.SlideRepository;
 
 @Conditional(LectureWithIrisEnabled.class)
@@ -26,9 +29,13 @@ public class IrisLectureUnitSyncDispatchService {
 
     private final Optional<IrisLectureUnitSyncApi> irisLectureUnitSyncApi;
 
-    public IrisLectureUnitSyncDispatchService(SlideRepository slideRepository, Optional<IrisLectureUnitSyncApi> irisLectureUnitSyncApi) {
+    private final LectureUnitProcessingStateRepository processingStateRepository;
+
+    public IrisLectureUnitSyncDispatchService(SlideRepository slideRepository, Optional<IrisLectureUnitSyncApi> irisLectureUnitSyncApi,
+            LectureUnitProcessingStateRepository processingStateRepository) {
         this.slideRepository = slideRepository;
         this.irisLectureUnitSyncApi = irisLectureUnitSyncApi;
+        this.processingStateRepository = processingStateRepository;
     }
 
     /**
@@ -38,13 +45,22 @@ public class IrisLectureUnitSyncDispatchService {
      * @param updateKind          the classified update kind
      * @return the visibility hash of the dispatched payload, or null for non-visibility updates
      */
+    @Transactional
     public String triggerSyncForUpdateKind(AttachmentVideoUnit attachmentVideoUnit, LectureContentUpdateKind updateKind) {
         return triggerSyncForUpdateKind(attachmentVideoUnit, updateKind, null);
     }
 
+    @Transactional
     String triggerSyncForUpdateKind(AttachmentVideoUnit attachmentVideoUnit, LectureContentUpdateKind updateKind,
             Map<Integer, ZonedDateTime> projectedSlideHiddenUntilBySlideNumber) {
         Objects.requireNonNull(updateKind, "updateKind");
+        if (processingStateRepository.findAttachmentVideoUnitForUpdateById(attachmentVideoUnit.getId()).isEmpty()) {
+            return null;
+        }
+        if ((updateKind == LectureContentUpdateKind.METADATA || updateKind == LectureContentUpdateKind.VISIBILITY)
+                && !processingStateRepository.existsByLectureUnit_IdAndPhase(attachmentVideoUnit.getId(), ProcessingPhase.DONE)) {
+            return null;
+        }
         return switch (updateKind) {
             case NONE -> {
                 yield null;

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/IrisLectureUnitSyncEventListener.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/IrisLectureUnitSyncEventListener.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.lecture.service;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -20,6 +21,7 @@ import de.tum.cit.aet.artemis.lecture.config.LectureWithIrisEnabled;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.IrisLectureUnitSyncState;
 import de.tum.cit.aet.artemis.lecture.domain.LectureContentUpdateKind;
+import de.tum.cit.aet.artemis.lecture.domain.ProcessingPhase;
 import de.tum.cit.aet.artemis.lecture.repository.AttachmentVideoUnitRepository;
 import de.tum.cit.aet.artemis.lecture.repository.IrisLectureUnitSyncStateRepository;
 import de.tum.cit.aet.artemis.lecture.repository.SlideRepository;
@@ -66,6 +68,19 @@ public class IrisLectureUnitSyncEventListener {
         synchronize(event.lectureUnitId(), LectureContentUpdateKind.VISIBILITY, event.slideHiddenUntilBySlideNumber());
     }
 
+    /** @param event the ingestion completion event */
+    @EventListener
+    @Async
+    public void handleResyncAfterIngestion(IrisLectureUnitSyncService.IrisLectureUnitResyncAfterIngestionEvent event) {
+        try {
+            ZonedDateTime claimTime = ZonedDateTime.now();
+            syncStateRepository.claimRetry(event.lectureUnitId(), claimTime, claimTime.plusMinutes(RETRY_LEASE_MINUTES)).ifPresent(this::synchronizeDirtyState);
+        }
+        catch (Exception e) {
+            log.warn("Could not claim Iris lecture unit sync state {} after ingestion", event.lectureUnitId(), e);
+        }
+    }
+
     /**
      * Retries Iris/Pyris metadata and visibility updates that failed during event handling.
      */
@@ -84,7 +99,7 @@ public class IrisLectureUnitSyncEventListener {
      */
     @Scheduled(fixedRate = 300000)
     public void backfillMissingSyncStates() {
-        attachmentVideoUnitRepository.findUnitsMissingIrisSyncStateFromActiveCourses(ZonedDateTime.now(), PageRequest.of(0, 50)).forEach(unit -> {
+        attachmentVideoUnitRepository.findUnitsMissingIrisSyncStateFromActiveCourses(ZonedDateTime.now(), ProcessingPhase.DONE, PageRequest.of(0, 50)).forEach(unit -> {
             try {
                 var snapshot = new LectureContentUpdateSnapshot(unit.getId(), null, null, null, null, null, null, null, unit.resolveReleaseDate(),
                         SlideVisibilitySnapshotHelper.toSortedHiddenUntilBySlideNumber(slideRepository.findAllByAttachmentVideoUnitId(unit.getId())));
@@ -100,9 +115,9 @@ public class IrisLectureUnitSyncEventListener {
         if (!Objects.equals(state.getMetadataHash(), state.getLastSyncedMetadataHash())) {
             synchronize(state, LectureContentUpdateKind.METADATA);
         }
-        if (!Objects.equals(state.getVisibilityHash(), state.getLastSyncedVisibilityHash())) {
-            synchronize(state, LectureContentUpdateKind.VISIBILITY);
-        }
+        syncStateRepository.findByLectureUnitId(state.getLectureUnitId())
+                .filter(currentState -> !Objects.equals(currentState.getVisibilityHash(), currentState.getLastSyncedVisibilityHash()))
+                .ifPresent(currentState -> synchronize(currentState, LectureContentUpdateKind.VISIBILITY));
     }
 
     private void synchronize(Long lectureUnitId, LectureContentUpdateKind updateKind) {
@@ -125,6 +140,7 @@ public class IrisLectureUnitSyncEventListener {
     }
 
     private void synchronize(IrisLectureUnitSyncState state, LectureContentUpdateKind updateKind, Map<Integer, ZonedDateTime> projectedSlideHiddenUntilBySlideNumber) {
+        ZonedDateTime claimDeadline = state.getNextRetryAt();
         try {
             AttachmentVideoUnit unit = attachmentVideoUnitRepository.findWithLectureAndCourseAndAttachmentById(state.getLectureUnitId()).orElse(null);
             if (unit == null) {
@@ -137,18 +153,27 @@ public class IrisLectureUnitSyncEventListener {
                     .map(projectedVisibility -> syncDispatchService.triggerSyncForUpdateKind(unit, updateKind, projectedVisibility))
                     .orElseGet(() -> syncDispatchService.triggerSyncForUpdateKind(unit, updateKind));
             String dispatchedHash = getDispatchedHash(state, updateKind, dispatchResult);
-            syncStateRepository.updateWithLectureUnitLock(state.getLectureUnitId(),
-                    currentState -> Optional.ofNullable(dispatchedHash).ifPresentOrElse(hash -> markSynced(currentState, updateKind, hash), () -> markSkipped(currentState)));
+            syncStateRepository.updateWithLectureUnitLock(state.getLectureUnitId(), currentState -> {
+                if (hasSameClaimDeadline(currentState.getNextRetryAt(), claimDeadline)) {
+                    Optional.ofNullable(dispatchedHash).ifPresentOrElse(hash -> markSynced(currentState, updateKind, hash), () -> markSkipped(currentState));
+                }
+            });
         }
         catch (Exception e) {
             try {
                 syncStateRepository.updateWithLectureUnitLock(state.getLectureUnitId(),
-                        currentState -> Optional.of(currentState).filter(candidate -> isDirtyForUpdateKind(candidate, updateKind)).ifPresent(candidate -> markRetry(candidate, e)));
+                        currentState -> Optional.of(currentState).filter(candidate -> hasSameClaimDeadline(candidate.getNextRetryAt(), claimDeadline))
+                                .filter(candidate -> isDirtyForUpdateKind(candidate, updateKind)).ifPresent(candidate -> markRetry(candidate, e)));
             }
             catch (Exception persistenceException) {
                 log.warn("Could not persist retry state for Iris lecture unit sync {}", state.getLectureUnitId(), persistenceException);
             }
         }
+    }
+
+    private static boolean hasSameClaimDeadline(ZonedDateTime currentDeadline, ZonedDateTime claimedDeadline) {
+        return currentDeadline != null && claimedDeadline != null
+                && currentDeadline.toInstant().truncatedTo(ChronoUnit.MICROS).equals(claimedDeadline.toInstant().truncatedTo(ChronoUnit.MICROS));
     }
 
     private static String getDispatchedHash(IrisLectureUnitSyncState state, LectureContentUpdateKind updateKind, String dispatchResult) {

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/IrisLectureUnitSyncService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/IrisLectureUnitSyncService.java
@@ -11,11 +11,19 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
+import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.lecture.config.LectureEnabled;
+import de.tum.cit.aet.artemis.lecture.domain.Attachment;
+import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
+import de.tum.cit.aet.artemis.lecture.domain.Lecture;
+import de.tum.cit.aet.artemis.lecture.repository.AttachmentVideoUnitRepository;
 import de.tum.cit.aet.artemis.lecture.repository.IrisLectureUnitSyncStateRepository;
+import de.tum.cit.aet.artemis.lecture.repository.SlideRepository;
 
 @Conditional(LectureEnabled.class)
 @Lazy
@@ -28,9 +36,16 @@ public class IrisLectureUnitSyncService {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    public IrisLectureUnitSyncService(IrisLectureUnitSyncStateRepository repository, ApplicationEventPublisher eventPublisher) {
+    private final AttachmentVideoUnitRepository attachmentVideoUnitRepository;
+
+    private final SlideRepository slideRepository;
+
+    public IrisLectureUnitSyncService(IrisLectureUnitSyncStateRepository repository, ApplicationEventPublisher eventPublisher,
+            AttachmentVideoUnitRepository attachmentVideoUnitRepository, SlideRepository slideRepository) {
         this.repository = repository;
         this.eventPublisher = eventPublisher;
+        this.attachmentVideoUnitRepository = attachmentVideoUnitRepository;
+        this.slideRepository = slideRepository;
     }
 
     /**
@@ -39,7 +54,7 @@ public class IrisLectureUnitSyncService {
      * @param snapshot the current lecture unit snapshot
      */
     public void markMetadataDirtyAfterCommit(LectureContentUpdateSnapshot snapshot) {
-        repository.markDirty(snapshot.lectureUnitId(), metadataHash(snapshot), null, ZonedDateTime.now());
+        repository.markDirty(snapshot.lectureUnitId(), metadataHash(snapshot), null, ZonedDateTime.now(), false);
         publishAfterCommit(new IrisLectureUnitMetadataDirtyEvent(snapshot.lectureUnitId()));
     }
 
@@ -49,8 +64,24 @@ public class IrisLectureUnitSyncService {
      * @param snapshot the current lecture unit snapshot
      */
     public void markVisibilityDirtyAfterCommit(LectureContentUpdateSnapshot snapshot) {
-        repository.markDirty(snapshot.lectureUnitId(), null, visibilityHash(snapshot), ZonedDateTime.now());
+        repository.markDirty(snapshot.lectureUnitId(), null, visibilityHash(snapshot), ZonedDateTime.now(), false);
         publishAfterCommit(new IrisLectureUnitVisibilityDirtyEvent(snapshot.lectureUnitId(), snapshot.slideHiddenUntilBySlideNumber()));
+    }
+
+    /** @param lectureUnitId the attachment video unit id */
+    @Transactional
+    public void markCurrentStateDirtyAfterIngestion(long lectureUnitId) {
+        attachmentVideoUnitRepository.findByIdForUpdate(lectureUnitId).orElseThrow(() -> new EntityNotFoundException("AttachmentVideoUnit", lectureUnitId));
+        AttachmentVideoUnit unit = attachmentVideoUnitRepository.findWithLectureAndCourseAndAttachmentById(lectureUnitId)
+                .orElseThrow(() -> new EntityNotFoundException("AttachmentVideoUnit", lectureUnitId));
+        Lecture lecture = unit.getLecture();
+        Course course = lecture.getCourse();
+        Attachment attachment = unit.getAttachment();
+        var snapshot = new LectureContentUpdateSnapshot(unit.getId(), unit.getName(), lecture.getTitle(), course.getTitle(), course.getDescription(),
+                attachment != null ? attachment.getVersion() : null, attachment != null ? attachment.getLink() : null, unit.getVideoSource(), unit.resolveReleaseDate(),
+                SlideVisibilitySnapshotHelper.toSortedHiddenUntilBySlideNumber(slideRepository.findAllByAttachmentVideoUnitId(lectureUnitId)));
+        repository.markDirty(lectureUnitId, metadataHash(snapshot), visibilityHash(snapshot), ZonedDateTime.now(), true);
+        publishAfterCommit(new IrisLectureUnitResyncAfterIngestionEvent(lectureUnitId));
     }
 
     private void publishAfterCommit(Object event) {
@@ -125,5 +156,8 @@ public class IrisLectureUnitSyncService {
     }
 
     public record IrisLectureUnitVisibilityDirtyEvent(Long lectureUnitId, Map<Integer, ZonedDateTime> slideHiddenUntilBySlideNumber) {
+    }
+
+    public record IrisLectureUnitResyncAfterIngestionEvent(Long lectureUnitId) {
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingScheduler.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingScheduler.java
@@ -164,6 +164,11 @@ public class LectureContentProcessingScheduler {
 
         log.info("Recovering stuck processing state for unit {}, phase: {}", freshState.getLectureUnit().getId(), phase);
 
+        if (freshState.getIngestionJobToken() == null) {
+            processingService.triggerProcessing((AttachmentVideoUnit) freshState.getLectureUnit());
+            return;
+        }
+
         // Treat stuck jobs as failures: the content itself may cause Iris to hang or crash
         // silently (e.g. malformed PDF, OOM during transcription). Incrementing retryCount
         // ensures poison-pill jobs eventually fail permanently instead of looping forever.

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingService.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.cit.aet.artemis.core.security.SecurityUtils;
 import de.tum.cit.aet.artemis.core.service.feature.Feature;
@@ -80,6 +81,20 @@ public class LectureContentProcessingService {
     }
 
     // -------------------- Public API --------------------
+
+    /** @param unit the unit to reserve for asynchronous reprocessing */
+    @Transactional
+    public void prepareForReprocessing(AttachmentVideoUnit unit) {
+        processingStateRepository.findAttachmentVideoUnitForUpdateById(unit.getId()).orElseThrow();
+        LectureUnitProcessingState state = processingStateRepository.findByLectureUnitIdForUpdate(unit.getId()).orElseGet(() -> new LectureUnitProcessingState(unit));
+        state.setPhase(ProcessingPhase.TRANSCRIBING);
+        state.setStartedAt(ZonedDateTime.now());
+        state.setIngestionJobToken(null);
+        state.setRetryEligibleAt(null);
+        state.setErrorKey(null);
+        state.setLastUpdated(ZonedDateTime.now());
+        processingStateRepository.saveAndFlush(state);
+    }
 
     /**
      * Main entry point: Trigger processing for an AttachmentVideoUnit.
@@ -155,6 +170,10 @@ public class LectureContentProcessingService {
         LectureUnitProcessingState state = existingState.orElseGet(() -> new LectureUnitProcessingState(unit));
 
         // Detect content changes
+        if (state.getPhase() == ProcessingPhase.TRANSCRIBING && state.getIngestionJobToken() == null && state.getStartedAt() != null) {
+            state.setPhase(ProcessingPhase.IDLE);
+            state.setStartedAt(null);
+        }
         boolean contentChanged = handleContentChanges(unit, state, hasVideo, hasPdf);
         boolean shouldReprocess = contentChanged || forceReprocessing;
         if (shouldReprocess) {

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/ProcessingStateCallbackService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/ProcessingStateCallbackService.java
@@ -34,6 +34,7 @@ import de.tum.cit.aet.artemis.lecture.domain.ProcessingPhase;
 import de.tum.cit.aet.artemis.lecture.domain.TranscriptionStatus;
 import de.tum.cit.aet.artemis.lecture.dto.LectureUnitCombinedStatusDTO;
 import de.tum.cit.aet.artemis.lecture.repository.AttachmentRepository;
+import de.tum.cit.aet.artemis.lecture.repository.AttachmentVideoUnitRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureTranscriptionRepository;
 import de.tum.cit.aet.artemis.lecture.repository.LectureUnitProcessingStateRepository;
 
@@ -81,17 +82,24 @@ public class ProcessingStateCallbackService {
 
     private final AttachmentRepository attachmentRepository;
 
+    private final AttachmentVideoUnitRepository attachmentVideoUnitRepository;
+
     private final Optional<IrisLectureApi> irisLectureApi;
 
     private final WebsocketMessagingService websocketMessagingService;
 
+    private final IrisLectureUnitSyncService irisLectureUnitSyncService;
+
     public ProcessingStateCallbackService(LectureUnitProcessingStateRepository processingStateRepository, LectureTranscriptionRepository transcriptionRepository,
-            AttachmentRepository attachmentRepository, Optional<IrisLectureApi> irisLectureApi, WebsocketMessagingService websocketMessagingService) {
+            AttachmentRepository attachmentRepository, AttachmentVideoUnitRepository attachmentVideoUnitRepository, Optional<IrisLectureApi> irisLectureApi,
+            WebsocketMessagingService websocketMessagingService, IrisLectureUnitSyncService irisLectureUnitSyncService) {
         this.processingStateRepository = processingStateRepository;
         this.transcriptionRepository = transcriptionRepository;
         this.attachmentRepository = attachmentRepository;
+        this.attachmentVideoUnitRepository = attachmentVideoUnitRepository;
         this.irisLectureApi = irisLectureApi;
         this.websocketMessagingService = websocketMessagingService;
+        this.irisLectureUnitSyncService = irisLectureUnitSyncService;
     }
 
     // -------------------- Capacity-Aware Dispatch --------------------
@@ -230,8 +238,10 @@ public class ProcessingStateCallbackService {
      * @param displayPageNumbers list of displayed page numbers indexed by slide number (0-based: index 0 = slide 1);
      *                               {@code null} if not applicable or unavailable
      */
+    @Transactional
     public void handleIngestionComplete(Long lectureUnitId, String jobToken, boolean success, @Nullable String errorCode, @Nullable List<Integer> displayPageNumbers) {
-        Optional<LectureUnitProcessingState> stateOpt = processingStateRepository.findByLectureUnit_Id(lectureUnitId);
+        attachmentVideoUnitRepository.findByIdForUpdate(lectureUnitId);
+        Optional<LectureUnitProcessingState> stateOpt = processingStateRepository.findByLectureUnitIdForUpdate(lectureUnitId);
 
         if (stateOpt.isEmpty()) {
             log.warn("Received completion callback for unit {} but no processing state exists", lectureUnitId);
@@ -257,6 +267,7 @@ public class ProcessingStateCallbackService {
             state.setIngestionJobToken(null);
             processingStateRepository.save(state);
             saveDisplayPageNumbers(state, displayPageNumbers);
+            irisLectureUnitSyncService.markCurrentStateDirtyAfterIngestion(lectureUnitId);
 
             // Notify UI via WebSocket
             TranscriptionStatus txStatus = transcriptionRepository.findByLectureUnit_Id(lectureUnitId).map(LectureTranscription::getTranscriptionStatus).orElse(null);
@@ -289,12 +300,13 @@ public class ProcessingStateCallbackService {
      * @param jobToken      the job token for validation
      * @param resultJson    the JSON string containing transcription data
      */
+    @Transactional
     public void handleCheckpointData(long lectureUnitId, String jobToken, String resultJson) {
         if (resultJson == null || resultJson.isBlank()) {
             return;
         }
 
-        Optional<LectureUnitProcessingState> stateOpt = processingStateRepository.findByLectureUnit_Id(lectureUnitId);
+        Optional<LectureUnitProcessingState> stateOpt = processingStateRepository.findByLectureUnitIdForUpdate(lectureUnitId);
         if (stateOpt.isEmpty()) {
             log.warn("Received checkpoint for unit {} but no processing state exists", lectureUnitId);
             return;
@@ -336,8 +348,9 @@ public class ProcessingStateCallbackService {
      * @param lectureUnitId the ID of the lecture unit
      * @param jobToken      the job token for validation
      */
+    @Transactional
     public void handleHeartbeat(long lectureUnitId, String jobToken) {
-        Optional<LectureUnitProcessingState> stateOpt = processingStateRepository.findByLectureUnit_Id(lectureUnitId);
+        Optional<LectureUnitProcessingState> stateOpt = processingStateRepository.findByLectureUnitIdForUpdate(lectureUnitId);
         if (stateOpt.isEmpty()) {
             return;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/ProcessingStateRecoveryService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/ProcessingStateRecoveryService.java
@@ -71,6 +71,9 @@ public class ProcessingStateRecoveryService {
         int resetCount = 0;
         RuntimeException firstFailure = null;
         for (LectureUnitProcessingState state : activeStates) {
+            if (state.getIngestionJobToken() == null) {
+                continue;
+            }
             try {
                 if (resetToIdleForRecovery(state)) {
                     resetCount++;

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/architecture/LectureRepositoryArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/architecture/LectureRepositoryArchitectureTest.java
@@ -17,6 +17,13 @@ class LectureRepositoryArchitectureTest extends AbstractModuleRepositoryArchitec
                 "de.tum.cit.aet.artemis.lecture.service.LectureImportService.importLecture(de.tum.cit.aet.artemis.lecture.domain.Lecture, de.tum.cit.aet.artemis.course.domain.Course, boolean)",
                 // dispatchPendingJobs needs @Transactional because it uses FOR UPDATE SKIP LOCKED and its callers have no transaction context.
                 "de.tum.cit.aet.artemis.lecture.service.ProcessingStateCallbackService.dispatchPendingJobs()",
+                "de.tum.cit.aet.artemis.lecture.service.ProcessingStateCallbackService.handleIngestionComplete(java.lang.Long, java.lang.String, boolean, java.lang.String, java.util.List)",
+                "de.tum.cit.aet.artemis.lecture.service.ProcessingStateCallbackService.handleCheckpointData(long, java.lang.String, java.lang.String)",
+                "de.tum.cit.aet.artemis.lecture.service.ProcessingStateCallbackService.handleHeartbeat(long, java.lang.String)",
+                "de.tum.cit.aet.artemis.lecture.service.LectureContentProcessingService.prepareForReprocessing(de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit)",
+                "de.tum.cit.aet.artemis.lecture.service.IrisLectureUnitSyncService.markCurrentStateDirtyAfterIngestion(long)",
+                "de.tum.cit.aet.artemis.lecture.service.IrisLectureUnitSyncDispatchService.triggerSyncForUpdateKind(de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit, de.tum.cit.aet.artemis.lecture.domain.LectureContentUpdateKind)",
+                "de.tum.cit.aet.artemis.lecture.service.IrisLectureUnitSyncDispatchService.triggerSyncForUpdateKind(de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit, de.tum.cit.aet.artemis.lecture.domain.LectureContentUpdateKind, java.util.Map)",
                 // Slide splitting holds a pessimistic unit lock while coordinating database rows with file-system rollback and after-commit actions.
                 "de.tum.cit.aet.artemis.lecture.service.SlideSplitterService.splitAttachmentVideoUnitIntoSingleSlides(de.tum.cit.aet.artemis.lecture.service.AttachmentVideoUnitSlideSplitJob)",
                 "de.tum.cit.aet.artemis.lecture.service.SlideSplitterService.updateSlideVisibility(de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit, java.util.List)",

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/service/AttachmentVideoUnitServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/service/AttachmentVideoUnitServiceTest.java
@@ -3,9 +3,12 @@ package de.tum.cit.aet.artemis.lecture.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.nio.file.Path;
@@ -86,7 +89,7 @@ class AttachmentVideoUnitServiceTest {
                 lectureUnitService, Optional.of(contentProcessingService), attachmentFileHashService, new LectureContentUpdateClassifierService(), slideRepository,
                 irisLectureUnitSyncService);
         when(attachmentVideoUnitRepository.save(any(AttachmentVideoUnit.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        when(slideRepository.findAllByAttachmentVideoUnitId(LECTURE_UNIT_ID)).thenReturn(List.of());
+        lenient().when(slideRepository.findAllByAttachmentVideoUnitId(LECTURE_UNIT_ID)).thenReturn(List.of());
     }
 
     @Test
@@ -102,15 +105,12 @@ class AttachmentVideoUnitServiceTest {
     }
 
     @Test
-    void saveAttachmentVideoUnitMarksInitialVisibilityDirtyForRetryableSync() {
+    void saveAttachmentVideoUnitDefersVisibilitySyncUntilIngestionCompletes() {
         var unit = attachmentVideoUnit("New unit", null);
 
         service.saveAttachmentVideoUnit(unit, null, null, false);
 
-        var snapshotCaptor = ArgumentCaptor.forClass(LectureContentUpdateSnapshot.class);
-        verify(irisLectureUnitSyncService).markVisibilityDirtyAfterCommit(snapshotCaptor.capture());
-        assertThat(snapshotCaptor.getValue().lectureUnitId()).isEqualTo(LECTURE_UNIT_ID);
-        assertThat(snapshotCaptor.getValue().releaseDate().toInstant()).isEqualTo(unit.getReleaseDate().toInstant());
+        verify(irisLectureUnitSyncService, never()).markVisibilityDirtyAfterCommit(any());
         verify(contentProcessingService).triggerProcessing(unit);
     }
 
@@ -129,6 +129,7 @@ class AttachmentVideoUnitServiceTest {
         service.updateAttachmentVideoUnit(unit, dto, attachment, uploadedFile, false, null, null, Set.of());
 
         verify(slideSplitterService).splitAttachmentVideoUnitIntoSingleSlides(any(AttachmentVideoUnitSlideSplitJob.class));
+        verify(contentProcessingService, never()).prepareForReprocessing(any());
         verify(contentProcessingService, never()).triggerProcessing(any());
         verify(irisLectureUnitSyncService, never()).markMetadataDirtyAfterCommit(any());
         verify(irisLectureUnitSyncService, never()).markVisibilityDirtyAfterCommit(any());
@@ -203,15 +204,26 @@ class AttachmentVideoUnitServiceTest {
     }
 
     @Test
-    void updateAttachmentVideoUnitTriggersAsyncContentProcessingForVideoSourceChange() {
+    void updateAttachmentVideoUnitDefersCombinedLightweightUpdatesUntilContentProcessingCompletes() {
         var unit = attachmentVideoUnit("Unit", null);
-        var dto = attachmentVideoUnitDTO(unit, unit.getName(), unit.getReleaseDate(), "https://video.example/updated");
+        var dto = attachmentVideoUnitDTO(unit, "Updated unit", unit.getReleaseDate().plusDays(1), "https://video.example/updated");
 
         service.updateAttachmentVideoUnit(unit, dto, null, null, false, null, null, Set.of());
 
-        verify(contentProcessingService).triggerProcessing(unit);
+        var processingOrder = inOrder(contentProcessingService);
+        processingOrder.verify(contentProcessingService).prepareForReprocessing(unit);
+        processingOrder.verify(contentProcessingService).triggerProcessing(unit);
         verify(irisLectureUnitSyncService, never()).markMetadataDirtyAfterCommit(any());
         verify(irisLectureUnitSyncService, never()).markVisibilityDirtyAfterCommit(any());
+    }
+
+    @Test
+    void updateAttachmentVideoUnitDoesNotReserveTutorialContent() {
+        var unit = attachmentVideoUnit("Unit", null);
+        unit.getLecture().setIsTutorialLecture(true);
+        var dto = attachmentVideoUnitDTO(unit, "Updated", unit.getReleaseDate(), "https://video.example/updated");
+        service.updateAttachmentVideoUnit(unit, dto, null, null, false, null, null, Set.of());
+        verifyNoInteractions(contentProcessingService, irisLectureUnitSyncService);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/service/IrisLectureUnitSyncDispatchServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/service/IrisLectureUnitSyncDispatchServiceTest.java
@@ -23,7 +23,9 @@ import org.mockito.ArgumentCaptor;
 import de.tum.cit.aet.artemis.iris.api.IrisLectureUnitSyncApi;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.LectureContentUpdateKind;
+import de.tum.cit.aet.artemis.lecture.domain.ProcessingPhase;
 import de.tum.cit.aet.artemis.lecture.domain.Slide;
+import de.tum.cit.aet.artemis.lecture.repository.LectureUnitProcessingStateRepository;
 import de.tum.cit.aet.artemis.lecture.test_repository.SlideTestRepository;
 
 class IrisLectureUnitSyncDispatchServiceTest {
@@ -34,16 +36,21 @@ class IrisLectureUnitSyncDispatchServiceTest {
 
     private IrisLectureUnitSyncApi irisLectureUnitSyncApi;
 
+    private LectureUnitProcessingStateRepository processingStateRepository;
+
     private IrisLectureUnitSyncDispatchService service;
 
     @BeforeEach
     void setUp() {
         slideRepository = mock(SlideTestRepository.class);
         irisLectureUnitSyncApi = mock(IrisLectureUnitSyncApi.class);
+        processingStateRepository = mock(LectureUnitProcessingStateRepository.class);
         when(irisLectureUnitSyncApi.updateLectureUnitMetadataInPyris(any())).thenReturn("metadata-token");
         when(irisLectureUnitSyncApi.updateLectureUnitVisibilityInPyris(any(), any())).thenReturn("visibility-token");
+        when(processingStateRepository.findAttachmentVideoUnitForUpdateById(LECTURE_UNIT_ID)).thenAnswer(invocation -> Optional.of(attachmentVideoUnit()));
+        when(processingStateRepository.existsByLectureUnit_IdAndPhase(LECTURE_UNIT_ID, ProcessingPhase.DONE)).thenReturn(true);
 
-        service = new IrisLectureUnitSyncDispatchService(slideRepository, Optional.of(irisLectureUnitSyncApi));
+        service = new IrisLectureUnitSyncDispatchService(slideRepository, Optional.of(irisLectureUnitSyncApi), processingStateRepository);
     }
 
     @Test
@@ -90,12 +97,20 @@ class IrisLectureUnitSyncDispatchServiceTest {
 
     @Test
     void triggerSyncForUpdateKindDoesNothingWhenIrisApiIsUnavailable() {
-        service = new IrisLectureUnitSyncDispatchService(slideRepository, Optional.empty());
+        service = new IrisLectureUnitSyncDispatchService(slideRepository, Optional.empty(), processingStateRepository);
 
         service.triggerSyncForUpdateKind(attachmentVideoUnit(), LectureContentUpdateKind.METADATA);
         service.triggerSyncForUpdateKind(attachmentVideoUnit(), LectureContentUpdateKind.VISIBILITY);
 
         verify(slideRepository, never()).findAllByAttachmentVideoUnitId(any());
+    }
+
+    @Test
+    void triggerSyncForUpdateKindSkipsUnitsUntilIngestionCompletes() {
+        when(processingStateRepository.existsByLectureUnit_IdAndPhase(LECTURE_UNIT_ID, ProcessingPhase.DONE)).thenReturn(false);
+        assertThat(service.triggerSyncForUpdateKind(attachmentVideoUnit(), LectureContentUpdateKind.METADATA)).isNull();
+        assertThat(service.triggerSyncForUpdateKind(attachmentVideoUnit(), LectureContentUpdateKind.VISIBILITY)).isNull();
+        verifyNoInteractions(irisLectureUnitSyncApi);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/service/IrisLectureUnitSyncEventListenerTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/service/IrisLectureUnitSyncEventListenerTest.java
@@ -13,7 +13,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,6 +30,7 @@ import org.springframework.data.domain.Pageable;
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.IrisLectureUnitSyncState;
 import de.tum.cit.aet.artemis.lecture.domain.LectureContentUpdateKind;
+import de.tum.cit.aet.artemis.lecture.domain.ProcessingPhase;
 import de.tum.cit.aet.artemis.lecture.domain.Slide;
 import de.tum.cit.aet.artemis.lecture.repository.IrisLectureUnitSyncStateRepository;
 import de.tum.cit.aet.artemis.lecture.test_repository.AttachmentVideoUnitTestRepository;
@@ -59,7 +62,12 @@ class IrisLectureUnitSyncEventListenerTest {
     void setUp() {
         listener = new IrisLectureUnitSyncEventListener(attachmentVideoUnitRepository, syncStateRepository, syncDispatchService, slideRepository, syncService);
         lenient().when(syncDispatchService.triggerSyncForUpdateKind(any(), eq(LectureContentUpdateKind.METADATA))).thenReturn("metadata-token");
-        lenient().when(syncStateRepository.claimRetry(eq(LECTURE_UNIT_ID), any(), any())).thenAnswer(_ -> syncStateRepository.findByLectureUnitId(LECTURE_UNIT_ID));
+        lenient().when(syncStateRepository.claimRetry(eq(LECTURE_UNIT_ID), any(), any()))
+                .thenAnswer(invocation -> syncStateRepository.findByLectureUnitId(LECTURE_UNIT_ID).map(state -> {
+                    state.setStatus(IrisLectureUnitSyncState.STATUS_IN_PROGRESS);
+                    state.setNextRetryAt(invocation.getArgument(2));
+                    return state;
+                }));
     }
 
     @Test
@@ -70,7 +78,7 @@ class IrisLectureUnitSyncEventListenerTest {
         var slide = new Slide();
         slide.setSlideNumber(2);
         slide.setHidden(ZonedDateTime.parse("2026-07-04T10:15:30Z"));
-        when(attachmentVideoUnitRepository.findUnitsMissingIrisSyncStateFromActiveCourses(any(), any(Pageable.class))).thenReturn(List.of(unit));
+        when(attachmentVideoUnitRepository.findUnitsMissingIrisSyncStateFromActiveCourses(any(), eq(ProcessingPhase.DONE), any(Pageable.class))).thenReturn(List.of(unit));
         when(slideRepository.findAllByAttachmentVideoUnitId(LECTURE_UNIT_ID)).thenReturn(List.of(slide));
 
         listener.backfillMissingSyncStates();
@@ -131,7 +139,6 @@ class IrisLectureUnitSyncEventListenerTest {
         assertThat(state.getLastSyncedMetadataHash()).isEqualTo("metadata-hash");
         assertThat(state.getLastSyncedVisibilityHash()).isNull();
         assertThat(state.getStatus()).isEqualTo(IrisLectureUnitSyncState.STATUS_DIRTY);
-        assertThat(state.getNextRetryAt().toInstant()).isEqualTo(nextRetryAt.toInstant());
     }
 
     @Test
@@ -142,7 +149,6 @@ class IrisLectureUnitSyncEventListenerTest {
         var state = syncState();
         state.setVisibilityHash("projected-visibility-hash");
         when(syncStateRepository.findTop50ByStatusInAndNextRetryAtLessThanEqualOrderByNextRetryAtAsc(any(), any())).thenReturn(List.of(state));
-        when(syncStateRepository.claimRetry(eq(LECTURE_UNIT_ID), any(), any())).thenReturn(Optional.of(state));
         when(attachmentVideoUnitRepository.findWithLectureAndCourseAndAttachmentById(LECTURE_UNIT_ID)).thenReturn(Optional.of(unit));
         when(syncStateRepository.findByLectureUnitId(LECTURE_UNIT_ID)).thenReturn(Optional.of(state));
         when(syncDispatchService.triggerSyncForUpdateKind(unit, LectureContentUpdateKind.VISIBILITY)).thenReturn("persisted-slide-hash");
@@ -191,7 +197,10 @@ class IrisLectureUnitSyncEventListenerTest {
         var currentState = syncState();
         currentState.setMetadataHash("new-dirty-hash");
         when(attachmentVideoUnitRepository.findWithLectureAndCourseAndAttachmentById(LECTURE_UNIT_ID)).thenReturn(Optional.of(unit));
-        when(syncStateRepository.findByLectureUnitId(LECTURE_UNIT_ID)).thenReturn(Optional.of(dispatchedState), Optional.of(currentState));
+        when(syncStateRepository.findByLectureUnitId(LECTURE_UNIT_ID)).thenReturn(Optional.of(dispatchedState)).thenAnswer(_ -> {
+            currentState.setNextRetryAt(dispatchedState.getNextRetryAt());
+            return Optional.of(currentState);
+        });
 
         listener.handleMetadataDirty(new IrisLectureUnitSyncService.IrisLectureUnitMetadataDirtyEvent(LECTURE_UNIT_ID));
 
@@ -223,6 +232,40 @@ class IrisLectureUnitSyncEventListenerTest {
         listener.handleMetadataDirty(new IrisLectureUnitSyncService.IrisLectureUnitMetadataDirtyEvent(LECTURE_UNIT_ID));
 
         assertThat(retryState.getNextRetryAt().toInstant()).isBetween(before.plusMinutes(60).toInstant(), ZonedDateTime.now().plusMinutes(60).toInstant());
+    }
+
+    @Test
+    void syncResultDoesNotOverrideClaimRevokedByIngestionCompletion() {
+        enableStateTransitions();
+        var unit = new AttachmentVideoUnit();
+        unit.setId(LECTURE_UNIT_ID);
+        var claimedState = syncState();
+        claimedState.setMetadataHash("metadata-hash");
+        var stateAfterIngestion = syncState();
+        stateAfterIngestion.setMetadataHash("metadata-hash");
+        stateAfterIngestion.setNextRetryAt(ZonedDateTime.now());
+        when(attachmentVideoUnitRepository.findWithLectureAndCourseAndAttachmentById(LECTURE_UNIT_ID)).thenReturn(Optional.of(unit));
+        when(syncStateRepository.findByLectureUnitId(LECTURE_UNIT_ID)).thenReturn(Optional.of(claimedState), Optional.of(stateAfterIngestion));
+        listener.handleMetadataDirty(new IrisLectureUnitSyncService.IrisLectureUnitMetadataDirtyEvent(LECTURE_UNIT_ID));
+        assertThat(stateAfterIngestion.getLastSyncedMetadataHash()).isNull();
+    }
+
+    @Test
+    void syncResultAcceptsClaimDeadlineAfterDatabaseNormalization() {
+        enableStateTransitions();
+        var unit = new AttachmentVideoUnit();
+        unit.setId(LECTURE_UNIT_ID);
+        var claimedState = syncState();
+        claimedState.setMetadataHash("metadata-hash");
+        var reloadedState = syncState();
+        reloadedState.setMetadataHash("metadata-hash");
+        when(attachmentVideoUnitRepository.findWithLectureAndCourseAndAttachmentById(LECTURE_UNIT_ID)).thenReturn(Optional.of(unit));
+        when(syncStateRepository.findByLectureUnitId(LECTURE_UNIT_ID)).thenReturn(Optional.of(claimedState)).thenAnswer(_ -> {
+            reloadedState.setNextRetryAt(claimedState.getNextRetryAt().withZoneSameInstant(ZoneOffset.ofHours(2)).truncatedTo(ChronoUnit.MICROS));
+            return Optional.of(reloadedState);
+        });
+        listener.handleMetadataDirty(new IrisLectureUnitSyncService.IrisLectureUnitMetadataDirtyEvent(LECTURE_UNIT_ID));
+        assertThat(reloadedState.getLastSyncedMetadataHash()).isEqualTo("metadata-hash");
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/service/IrisLectureUnitSyncServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/service/IrisLectureUnitSyncServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,7 +28,10 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import de.tum.cit.aet.artemis.lecture.domain.AttachmentVideoUnit;
 import de.tum.cit.aet.artemis.lecture.domain.IrisLectureUnitSyncState;
+import de.tum.cit.aet.artemis.lecture.domain.Lecture;
 import de.tum.cit.aet.artemis.lecture.repository.IrisLectureUnitSyncStateRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.AttachmentVideoUnitTestRepository;
+import de.tum.cit.aet.artemis.lecture.test_repository.SlideTestRepository;
 
 @ExtendWith(MockitoExtension.class)
 class IrisLectureUnitSyncServiceTest {
@@ -45,13 +48,19 @@ class IrisLectureUnitSyncServiceTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
+    @Mock
+    private AttachmentVideoUnitTestRepository attachmentVideoUnitRepository;
+
+    @Mock
+    private SlideTestRepository slideRepository;
+
     private IrisLectureUnitSyncService service;
 
     @BeforeEach
     void setUp() {
-        service = new IrisLectureUnitSyncService(repository, eventPublisher);
-        doCallRealMethod().when(repository).markDirty(anyLong(), nullable(String.class), nullable(String.class), any(ZonedDateTime.class));
-        when(repository.findAttachmentVideoUnitForUpdateById(LECTURE_UNIT_ID)).thenReturn(Optional.of(new AttachmentVideoUnit()));
+        service = new IrisLectureUnitSyncService(repository, eventPublisher, attachmentVideoUnitRepository, slideRepository);
+        lenient().doCallRealMethod().when(repository).markDirty(anyLong(), nullable(String.class), nullable(String.class), any(ZonedDateTime.class), any(Boolean.class));
+        lenient().when(repository.findAttachmentVideoUnitForUpdateById(LECTURE_UNIT_ID)).thenReturn(Optional.of(new AttachmentVideoUnit()));
     }
 
     @Test
@@ -223,6 +232,30 @@ class IrisLectureUnitSyncServiceTest {
         assertThat(persistedState.get().getVisibilityHash()).hasSize(64);
         assertThat(persistedState.get().getMetadataHash()).hasSize(64);
         verify(repository, times(2)).findAttachmentVideoUnitForUpdateById(LECTURE_UNIT_ID);
+    }
+
+    @Test
+    void ingestionCompletionReplacesBothSnapshotsAndPublishesCombinedEvent() {
+        var unit = new AttachmentVideoUnit();
+        unit.setId(LECTURE_UNIT_ID);
+        var lecture = new Lecture();
+        lecture.setCourse(new de.tum.cit.aet.artemis.course.domain.Course());
+        unit.setLecture(lecture);
+        var state = new IrisLectureUnitSyncState();
+        state.setLastSyncedMetadataHash("old-metadata");
+        state.setLastSyncedVisibilityHash("old-visibility");
+        state.setStatus(IrisLectureUnitSyncState.STATUS_IN_PROGRESS);
+        state.setNextRetryAt(ZonedDateTime.now().plusHours(1));
+        when(attachmentVideoUnitRepository.findByIdForUpdate(LECTURE_UNIT_ID)).thenReturn(Optional.of(unit));
+        when(attachmentVideoUnitRepository.findWithLectureAndCourseAndAttachmentById(LECTURE_UNIT_ID)).thenReturn(Optional.of(unit));
+        when(repository.findByLectureUnitId(LECTURE_UNIT_ID)).thenReturn(Optional.of(state));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        service.markCurrentStateDirtyAfterIngestion(LECTURE_UNIT_ID);
+        assertThat(List.of(state.getMetadataHash(), state.getVisibilityHash())).allMatch(hash -> hash.length() == 64);
+        assertThat(state.getLastSyncedMetadataHash()).isNull();
+        assertThat(state.getLastSyncedVisibilityHash()).isNull();
+        assertThat(state.getStatus()).isEqualTo(IrisLectureUnitSyncState.STATUS_DIRTY);
+        verify(eventPublisher).publishEvent(new IrisLectureUnitSyncService.IrisLectureUnitResyncAfterIngestionEvent(LECTURE_UNIT_ID));
     }
 
     private static LectureContentUpdateSnapshot snapshot() {

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingSchedulerTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingSchedulerTest.java
@@ -80,6 +80,7 @@ class LectureContentProcessingSchedulerTest {
             testState.setPhase(ProcessingPhase.TRANSCRIBING);
             testState.setRetryCount(1);
             testState.setStartedAt(ZonedDateTime.now().minusMinutes(130));
+            testState.setIngestionJobToken("job-token");
             testState.setRetryEligibleAt(null);
 
             when(processingStateRepository.findStuckStates(eq(List.of(ProcessingPhase.TRANSCRIBING)), any(ZonedDateTime.class))).thenReturn(List.of(testState));
@@ -89,8 +90,17 @@ class LectureContentProcessingSchedulerTest {
             // When
             scheduler.processScheduledRetries();
 
-            // Then: Should delegate to callbackService.handleProcessingFailure
             verify(callbackService).handleProcessingFailure(testState);
+        }
+
+        @Test
+        void shouldRestartFullProcessingForLostReservation() {
+            testState.setPhase(ProcessingPhase.TRANSCRIBING);
+            when(processingStateRepository.findStuckStates(eq(List.of(ProcessingPhase.TRANSCRIBING)), any())).thenReturn(List.of(testState));
+            when(processingStateRepository.findById(testState.getId())).thenReturn(Optional.of(testState));
+            scheduler.processScheduledRetries();
+            verify(processingService).triggerProcessing(testUnit);
+            verify(callbackService, never()).handleProcessingFailure(any());
         }
 
         @Test

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/service/LectureContentProcessingServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -74,6 +75,8 @@ class LectureContentProcessingServiceTest {
 
     private WebsocketMessagingService websocketMessagingService;
 
+    private IrisLectureUnitSyncService syncService;
+
     private AttachmentVideoUnit testUnit;
 
     private Lecture testLecture;
@@ -87,13 +90,14 @@ class LectureContentProcessingServiceTest {
         attachmentVideoUnitRepository = mock(AttachmentVideoUnitTestRepository.class);
         attachmentRepository = mock(AttachmentRepository.class);
         irisLectureApi = mock(IrisLectureApi.class);
+        syncService = mock(IrisLectureUnitSyncService.class);
         FeatureToggleService featureToggleService = mock(FeatureToggleService.class);
 
         when(featureToggleService.isFeatureEnabled(Feature.LectureContentProcessing)).thenReturn(true);
 
         websocketMessagingService = mock(WebsocketMessagingService.class);
-        callbackService = new ProcessingStateCallbackService(processingStateRepository, transcriptionRepository, attachmentRepository, Optional.of(irisLectureApi),
-                websocketMessagingService);
+        callbackService = new ProcessingStateCallbackService(processingStateRepository, transcriptionRepository, attachmentRepository, attachmentVideoUnitRepository,
+                Optional.of(irisLectureApi), websocketMessagingService, syncService);
         recoveryService = new ProcessingStateRecoveryService(processingStateRepository, transcriptionRepository, websocketMessagingService);
 
         service = new LectureContentProcessingService(processingStateRepository, Optional.of(irisLectureApi), featureToggleService, callbackService, attachmentRepository);
@@ -109,6 +113,9 @@ class LectureContentProcessingServiceTest {
 
         testState = new LectureUnitProcessingState(testUnit);
         testState.setPhase(ProcessingPhase.IDLE);
+        lenient().when(processingStateRepository.findByLectureUnitIdForUpdate(anyLong()))
+                .thenAnswer(invocation -> processingStateRepository.findByLectureUnit_Id(invocation.getArgument(0)));
+        lenient().when(processingStateRepository.findAttachmentVideoUnitForUpdateById(anyLong())).thenReturn(Optional.of(testUnit));
     }
 
     // ==================== FLOW 1: Enqueue New Unit ====================
@@ -161,7 +168,7 @@ class LectureContentProcessingServiceTest {
             FeatureToggleService fts = mock(FeatureToggleService.class);
             when(fts.isFeatureEnabled(Feature.LectureContentProcessing)).thenReturn(true);
             ProcessingStateCallbackService noIrisCallback = new ProcessingStateCallbackService(processingStateRepository, transcriptionRepository, attachmentRepository,
-                    Optional.empty(), mock(WebsocketMessagingService.class));
+                    attachmentVideoUnitRepository, Optional.empty(), mock(WebsocketMessagingService.class), syncService);
             service = new LectureContentProcessingService(processingStateRepository, Optional.empty(), fts, noIrisCallback, attachmentRepository);
 
             service.triggerProcessing(testUnit);
@@ -397,6 +404,7 @@ class LectureContentProcessingServiceTest {
 
             assertThat(testState.getPhase()).isEqualTo(ProcessingPhase.DONE);
             assertThat(testState.getIngestionJobToken()).isNull();
+            verify(syncService).markCurrentStateDirtyAfterIngestion(testUnit.getId());
         }
 
         @Test
@@ -1018,6 +1026,7 @@ class LectureContentProcessingServiceTest {
             LectureUnitProcessingState failingState = new LectureUnitProcessingState(testUnit);
             failingState.setId(301L);
             failingState.setPhase(ProcessingPhase.TRANSCRIBING);
+            failingState.setIngestionJobToken("token-1");
 
             AttachmentVideoUnit secondUnit = new AttachmentVideoUnit();
             secondUnit.setId(201L);
@@ -1025,6 +1034,7 @@ class LectureContentProcessingServiceTest {
             LectureUnitProcessingState recoverableState = new LectureUnitProcessingState(secondUnit);
             recoverableState.setId(302L);
             recoverableState.setPhase(ProcessingPhase.INGESTING);
+            recoverableState.setIngestionJobToken("token-2");
 
             when(processingStateRepository.findByPhaseIn(any())).thenReturn(List.of(failingState, recoverableState));
             when(processingStateRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));


### PR DESCRIPTION
### Summary

Delay lightweight Iris lecture-unit metadata and visibility synchronization until Pyris has successfully ingested the unit. After ingestion, synchronize the latest metadata and visibility together and retain retryable updates when Pyris is temporarily unavailable.

### Checklist

#### General

- [x] This is a small server-side issue that I tested locally.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server

- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many unnecessary or complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added focused unit and PostgreSQL integration tests with extensive assertions.
- [x] I documented the new Java code using JavaDoc style.

### Motivation and Context

Artemis can enqueue a lightweight visibility or metadata update before Pyris has ingested the lecture unit. Pyris then returns HTTP 404. Temporary failures also caused the synchronization attempt to be abandoned too early, while noisy error output obscured the actual state.

### Description

- Defer lightweight lecture-unit synchronization while an existing processing state is not `DONE`.
- Remove the creation-time visibility update and recompute the current metadata and slide visibility after successful ingestion.
- Atomically re-arm both desired snapshots after ingestion and synchronize them through one claim.
- Prevent stale in-flight synchronization results from overwriting the post-ingestion state.
- Restrict the legacy visibility backfill to successfully processed units and preserve video-only units in the query.
- Keep genuine Pyris 404 responses retryable through the existing exponential backoff while logging one concise warning line.

### Steps for Testing

1. Create an attachment video unit and verify that Artemis does not call the lightweight visibility endpoint before ingestion completes.
2. Complete Pyris ingestion and verify that Artemis synchronizes the current metadata and visibility.
3. Return HTTP 404 or 429 from a lightweight Pyris endpoint and verify that the dirty state remains retryable with exponential backoff.
4. Change metadata or slide visibility while ingestion is running and verify that the latest state is synchronized after completion.

Automated locally:

- 97 focused service, architecture, and PostgreSQL integration tests
- `spotlessCheck`
- `checkstyleMain`
- Server module coverage test run for `iris` and `lecture`

### Testserver States

Not deployed to a test server. The change is limited to the server-side Iris lecture synchronization workflow and was verified locally.

### Review Progress

#### Performance Review

- [ ] I (as a reviewer) confirm that the server changes are implemented with very good performance even for very large courses with more than 2000 students.

#### Code Review

- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests

- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| PyrisConnectorService.java | 56.02% | 313 |
| AttachmentVideoUnitRepository.java | 80.00% | 120 |
| IrisLectureUnitSyncStateRepository.java | 88.89% | 82 |
| LectureUnitProcessingStateRepository.java | 25.00% | 80 |
| AttachmentVideoUnitService.java | 91.81% | 288 |
| IrisLectureUnitSyncDispatchService.java | 96.97% | 77 |
| IrisLectureUnitSyncEventListener.java | 88.07% | 196 |
| IrisLectureUnitSyncService.java | 96.97% | 126 |
| LectureContentProcessingScheduler.java | 84.93% | 124 |
| LectureContentProcessingService.java | 92.05% | 279 |
| ProcessingStateCallbackService.java | 86.55% | 348 |
| ProcessingStateRecoveryService.java | 94.00% | 92 |

_Last updated: 2026-08-13 18:36:10 UTC_

