### PR TITLE
`Development`: Drop the unused reference index on the feedback table

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20260816213553_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260816213553_changelog.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+    Drops idx_reference on feedback.reference, the largest piece of dead schema on the biggest table.
+
+    On a production copy (36.1M feedback rows) the index occupies 716 MB (45,824 pages per
+    mysql.innodb_index_stats) - 19% of the table's 3.7 GB of secondary indexes - and 82% of its
+    entries are NULL keys, because only 3.9M rows have a reference at all.
+
+    No query has ever used it at runtime: an exhaustive search of every @Query/native query in
+    src/main/java finds no WHERE/JOIN predicate on feedback.reference. The column is only read in
+    Java after the entity is loaded (text/modeling assessment element matching, Athena DTO
+    conversion). The single SQL statement that ever filtered on it was the one-shot test_case_id
+    backfill migration in changelog 20230810100000 (feedback.reference IS NULL as an SCA exclusion),
+    long since consolidated away. The column has no foreign key, so no constraint requires the index.
+
+    Besides the space, every one of the ~36M inserts and deletes on this table currently maintains
+    the index for nothing.
+
+    The initial schema (00000000000000_initial_schema.xml) still creates the index for fresh
+    installations and cannot be edited without invalidating recorded checksums, so - as with
+    changelog 20260728223939 - fresh installations create it and drop it again here, which costs
+    milliseconds on an empty table. DROP INDEX is an INPLACE metadata-only operation on MySQL 8.0+
+    and PostgreSQL, so this migration is instant regardless of table size; the freed pages return to
+    the tablespace immediately (file shrink, as always, only on the next table rebuild).
+    -->
+
+    <changeSet id="20260816213553-01-drop-feedback-idx-reference" author="krusche">
+        <preConditions onFail="MARK_RAN">
+            <indexExists tableName="feedback" indexName="idx_reference"/>
+        </preConditions>
+        <dropIndex tableName="feedback" indexName="idx_reference"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -41,6 +41,7 @@
     <include file="classpath:config/liquibase/changelog/20260803160000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260811120000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260811231613_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20260816213553_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command "date '+%Y%m%d%H%M%S'" to get the current date and time in the correct format -->


### PR DESCRIPTION
### Summary
Drops `idx_reference` on `feedback.reference`, a dead index on the largest table in the database.

### Checklist
#### General
- [x] This is a small issue that I tested locally (see “Local verification” below); confirmation on a test server is still pending.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.

### Motivation and Context
A space analysis of the `feedback` table showed that `idx_reference` occupies roughly a fifth of the table's secondary-index volume — while **82% of its entries are NULL keys** (only a small fraction of rows have a `reference` at all).

The index has no consumer:
- An exhaustive search over every `@Query`/native query in `src/main/java` finds **no WHERE/JOIN predicate on `feedback.reference`**. The column is only read in Java after the entity is loaded (text/modeling assessment element matching, Athena DTO conversion).
- The only SQL that ever filtered on it was the one-shot `test_case_id` backfill migration (changelog `20230810100000`), long since consolidated away.
- The column has no foreign key, so no constraint requires an index.

Besides the wasted space, every insert/delete on the table (every CI build result) maintains the index for nothing.

### Description
- New changelog `20260816213553_changelog.xml` with a single changeset: `dropIndex` on `feedback.idx_reference`, guarded by an `indexExists` precondition (`onFail="MARK_RAN"`), following the pattern of `20260728223939`.
- The initial schema still creates the index for fresh installations (it cannot be edited without invalidating recorded checksums), so fresh installations create it and immediately drop it — milliseconds on an empty table.
- `DROP INDEX` is a metadata-only INPLACE operation on MySQL 8+ and PostgreSQL, so the migration is instant regardless of table size. Freed pages return to the tablespace immediately; the `.ibd` file itself shrinks on the next table rebuild, as usual.

### Local verification
- `DROP INDEX idx_reference ON feedback` was executed against a structural copy (`CREATE TABLE ... LIKE`) of the production `feedback` table on MySQL: the index is removed, the three FK indexes and the primary key remain untouched.
- The changeset is pattern-identical to the merged `20260728223939` changelog (`preConditions onFail="MARK_RAN"` + drop). Server CI boots Liquibase with the full changelog against PostgreSQL (Testcontainers) on every integration test, which exercises this changeset on the second dialect.

### Steps for Testing
Prerequisites: any local setup (MySQL or PostgreSQL).

1. Start the server on an existing database → the migration runs instantly; verify with `SHOW INDEX FROM feedback` (MySQL) or `\di feedback*` (PostgreSQL) that `idx_reference` is gone.
2. Start the server on a fresh database → Liquibase creates the schema and drops the index without errors.
3. Exercise text/modeling assessment and programming exercises with SCA (the features that populate `feedback.reference`) — behavior is unchanged, since the column itself remains.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2


### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-16 20:19:13 UTC_