### PR TITLE
fix(buildagent): eliminate race in removeOfflineNodes between listener and removeProcessingJobsForNode

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
@@ -724,8 +724,7 @@ public class SharedQueueProcessingService {
             if (isClusterMember && !isInMemberSet) {
                 log.info("removeOfflineNodes: REMOVING agent '{}' with address '{}' (was cluster member but is now offline)", agentKey, storedMemberAddress);
                 removeBuildAgentInformationForNode(agentKey, storedMemberAddress);
-                removeProcessingJobsForNode(storedMemberAddress);
-            }
+}
         }
     }
 


### PR DESCRIPTION
Fixes #13408

## Root cause

`SharedQueueProcessingService.removeOfflineNodes` calls two methods in sequence:

```java
removeBuildAgentInformationForNode(agentKey, storedMemberAddress);
removeProcessingJobsForNode(storedMemberAddress);
```

1. `removeBuildAgentInformationForNode` fires a Hazelcast `MapEntryRemovedEvent`, which triggers `BuildAgentListener.entryRemoved` → `handleOrphanedJobsForRemovedAgent`. This listener **re-queues** the orphaned jobs.

2. `removeProcessingJobsForNode` removes the same jobs from the processing-jobs map **without re-queuing** them.

Since the listener is asynchronous (Hazelcast distributed event) and the second call is synchronous, which one wins is a race. If `removeProcessingJobsForNode` wins, the jobs are silently dropped — the student's build never completes and never fails.

## Fix

Remove the `removeProcessingJobsForNode(storedMemberAddress)` call from `removeOfflineNodes`. The `handleOrphanedJobsForRemovedAgent` listener already handles cleanup of orphaned jobs with proper re-queuing (up to `MAX_ORPHANED_JOB_RETRIES`). Removing the duplicate cleanup path eliminates the race entirely.

This is safe because `removeProcessingJobsForNode` is only called from `removeOfflineNodes` (L727) and has no other callers.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Processing jobs assigned to offline build agents are no longer removed prematurely.
  * Offline agents are still removed from the active build-agent list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->