### PR TITLE
`Development`: Only report a started quiz practice attempt when one started

### DIFF
--- a/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.ts
@@ -244,7 +244,6 @@ export class ProgrammingExerciseUpdateComponent implements AfterViewInit, OnDest
     // This is used to revert the select if the user cancels to override the new selected project type.
     private selectedProjectTypeValue?: ProjectType;
 
-    // Left undefined until categories load; code distinguishes undefined ("not yet loaded") from an empty array.
     // Initialised here rather than left undefined, because getProgrammingExerciseCreationConfig() must hand the child
     // components a stable array identity. See the comment on that getter.
     exerciseCategories: ExerciseCategory[] = [];

--- a/src/test/playwright/e2e/exercise/ExerciseSplitPanelResize.spec.ts
+++ b/src/test/playwright/e2e/exercise/ExerciseSplitPanelResize.spec.ts
@@ -30,25 +30,32 @@ test.describe('Resizable exercise split panel (p-splitter)', { tag: '@fast' }, (
         await page.mouse.up();
     }
 
-    /** Polls the panel width until two consecutive reads agree, so the splitter has finished its initial layout. */
+    /**
+     * Polls the panel width until two consecutive reads agree, so the splitter has finished its initial layout.
+     * <p>
+     * Only a width that repeated is returned. A panel that is still being laid out reports a different width on every
+     * poll, and returning the last of those as "settled" hands an in-flight layout to the resize assertion, which then
+     * compares against a number that was never the panel's resting width.
+     */
     async function waitForSettledWidth(panel: Locator): Promise<number> {
-        let previous = -1;
+        let previous: number | undefined;
         for (let i = 0; i < 20; i++) {
             // No box means the panel is between renders, which is the opposite of settled: keep polling instead of
             // dereferencing null, which turned a panel that was still laying itself out into a TypeError.
             const box = await panel.boundingBox();
-            if (box) {
-                if (Math.abs(box.width - previous) < 1 && box.width > 0) {
+            if (box && box.width > 0) {
+                if (previous !== undefined && Math.abs(box.width - previous) < 1) {
                     return box.width;
                 }
                 previous = box.width;
             }
             await panel.page().waitForTimeout(100);
         }
-        if (previous <= 0) {
-            throw new Error('The panel never reported a measurable width, so there is no settled layout to compare a resize against.');
-        }
-        return previous;
+        throw new Error(
+            previous === undefined
+                ? 'The panel never reported a measurable width, so there is no settled layout to compare a resize against.'
+                : `The panel width never settled, last read ${previous}px, so there is no resting layout to compare a resize against.`,
+        );
     }
 
     test('repartitions the panels by dragging the splitter gutter', async ({ login, page, courseOverview }) => {

--- a/src/test/playwright/e2e/exercise/ExerciseSplitPanelResize.spec.ts
+++ b/src/test/playwright/e2e/exercise/ExerciseSplitPanelResize.spec.ts
@@ -48,6 +48,10 @@ test.describe('Resizable exercise split panel (p-splitter)', { tag: '@fast' }, (
                     return box.width;
                 }
                 previous = box.width;
+            } else {
+                // The reads have to be consecutive: keeping the width from before a render gap would let it agree with
+                // one from after the gap and pass a layout that was never stable across two polls as settled.
+                previous = undefined;
             }
             await panel.page().waitForTimeout(100);
         }

--- a/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
@@ -1,5 +1,5 @@
 import { BASE_API } from '../../constants';
-import { Locator, Page, Response, expect } from '@playwright/test';
+import { ElementHandle, Locator, Page, Response, expect } from '@playwright/test';
 
 /**
  * A class which encapsulates UI selectors and actions for the Course Overview page (/courses/*).
@@ -69,21 +69,21 @@ export class CourseOverviewPage {
         this.page.on('response', recordQuizLoad);
         try {
             for (let attempt = 0; attempt < 3; attempt++) {
+                // The question of a previous attempt, if one is on screen. It has to be gone before a visible question
+                // counts as this attempt's: the response is reported when its headers arrive, before Angular has
+                // applied the body, so the submitted attempt's question would otherwise pass as the new one and the
+                // caller's next answer click would land on the controls of the attempt that is already over.
+                const previousQuestion = await question.elementHandle({ timeout: 1_000 }).catch(() => null);
                 await this.recordNextClickTime(`#quiz-start-practice-${exerciseId}`);
                 // The click is part of what is retried: the same re-render that swallows a click also detaches the
                 // button, and letting that error escape would end the helper instead of trying again.
                 await button.click({ timeout: 10_000 }).catch(() => undefined);
                 const clickedAt = await this.readRecordedClickTime();
                 const loadedByThisClick = await this.waitUntil(() => loadStartTimes.some((startTime) => startTime >= clickedAt), 15_000);
-                if (
-                    loadedByThisClick &&
-                    (await question.waitFor({ state: 'visible', timeout: 15_000 }).then(
-                        () => true,
-                        () => false,
-                    ))
-                ) {
+                if (loadedByThisClick && (await this.hasFreshQuestion(previousQuestion, question))) {
                     return;
                 }
+                await previousQuestion?.dispose().catch(() => undefined);
                 await button.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined);
             }
         } finally {
@@ -91,6 +91,27 @@ export class CourseOverviewPage {
             await this.stopRecordingClickTime();
         }
         throw new Error(`Could not start a practice attempt for quiz ${exerciseId}: no attempt loaded a question after clicking start practice.`);
+    }
+
+    /**
+     * Whether a question belonging to the new attempt is on screen: the previous attempt's question, if there was one,
+     * has to be gone first, and a question has to be visible afterwards.
+     */
+    private async hasFreshQuestion(previousQuestion: ElementHandle<SVGElement | HTMLElement> | null, question: Locator): Promise<boolean> {
+        if (previousQuestion) {
+            const replaced = await previousQuestion.waitForElementState('hidden', { timeout: 15_000 }).then(
+                () => true,
+                () => false,
+            );
+            await previousQuestion.dispose().catch(() => undefined);
+            if (!replaced) {
+                return false;
+            }
+        }
+        return await question.waitFor({ state: 'visible', timeout: 15_000 }).then(
+            () => true,
+            () => false,
+        );
     }
 
     /** Polls a condition until it holds or the timeout passes, reporting which happened rather than throwing. */

--- a/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
@@ -1,5 +1,5 @@
 import { BASE_API } from '../../constants';
-import { Locator, Page, expect } from '@playwright/test';
+import { Locator, Page, Response, expect } from '@playwright/test';
 
 /**
  * A class which encapsulates UI selectors and actions for the Course Overview page (/courses/*).
@@ -40,25 +40,57 @@ export class CourseOverviewPage {
      * header. Works for both the first attempt and subsequent attempts (the button reappears after each submit).
      * @param exerciseId The id of the quiz exercise to practice.
      */
+    /** Polls a condition until it holds or the timeout passes, reporting which happened rather than throwing. */
+    private async waitUntil(condition: () => boolean, timeout: number): Promise<boolean> {
+        const deadline = Date.now() + timeout;
+        while (Date.now() < deadline) {
+            if (condition()) {
+                return true;
+            }
+            await this.page.waitForTimeout(200);
+        }
+        return condition();
+    }
+
     async startQuizPractice(exerciseId: number) {
         const button = this.page.locator(`#quiz-start-practice-${exerciseId}`);
         await button.waitFor({ state: 'visible', timeout: 30_000 });
 
         // Starting a practice attempt loads the quiz for the student, both for the first attempt and for a restart in
-        // the same session. Waiting for that request is what proves the click started an attempt: the exercise page
-        // re-renders its header while the details settle, and a click lost to that re-render leaves the caller waiting
-        // for a question that was never requested. Retry until an attempt is actually under way.
-        for (let attempt = 0; attempt < 3; attempt++) {
-            const quizLoaded = this.page
-                .waitForResponse((response) => response.url().includes(`/quiz-exercises/${exerciseId}/for-student`) && response.ok(), { timeout: 15_000 })
-                .catch(() => undefined);
-            await button.click({ timeout: 10_000 });
-            if (await quizLoaded) {
-                return;
+        // the same session, and then renders its first question. Both are required as proof that the click started an
+        // attempt: the exercise page loads the same quiz on its own, so a load request alone is also satisfied by a
+        // click that the header's re-render swallowed, and the caller is then left waiting for a question that no
+        // attempt is behind. Counting the requests seen since the click is what separates the two.
+        let quizLoads = 0;
+        const countQuizLoad = (response: Response) => {
+            if (response.url().includes(`/quiz-exercises/${exerciseId}/for-student`) && response.ok()) {
+                quizLoads++;
             }
-            await button.waitFor({ state: 'visible', timeout: 10_000 });
+        };
+        this.page.on('response', countQuizLoad);
+        try {
+            const question = this.page.locator('#question0');
+            for (let attempt = 0; attempt < 3; attempt++) {
+                const loadsBeforeClick = quizLoads;
+                // The click is part of what is retried: the same re-render that swallows a click also detaches the
+                // button, and letting that error escape would end the helper instead of trying again.
+                await button.click({ timeout: 10_000 }).catch(() => undefined);
+                const loaded = await this.waitUntil(() => quizLoads > loadsBeforeClick, 15_000);
+                if (
+                    loaded &&
+                    (await question.waitFor({ state: 'visible', timeout: 15_000 }).then(
+                        () => true,
+                        () => false,
+                    ))
+                ) {
+                    return;
+                }
+                await button.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined);
+            }
+        } finally {
+            this.page.off('response', countQuizLoad);
         }
-        throw new Error(`Could not start a practice attempt for quiz ${exerciseId}: the quiz was never loaded for the student after clicking start practice.`);
+        throw new Error(`Could not start a practice attempt for quiz ${exerciseId}: no attempt loaded a question after clicking start practice.`);
     }
 
     /**

--- a/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
@@ -88,6 +88,7 @@ export class CourseOverviewPage {
             }
         } finally {
             this.page.off('response', recordQuizLoad);
+            await this.stopRecordingClickTime();
         }
         throw new Error(`Could not start a practice attempt for quiz ${exerciseId}: no attempt loaded a question after clicking start practice.`);
     }
@@ -112,10 +113,34 @@ export class CourseOverviewPage {
      */
     private async recordNextClickTime(selector: string) {
         await this.page.evaluate((clickSelector) => {
-            const store = window as unknown as { __artemisClickedAt?: number };
+            const store = window as unknown as { __artemisClickedAt?: number; __artemisClickListener?: (event: Event) => void };
             store.__artemisClickedAt = undefined;
-            document.querySelector(clickSelector)?.addEventListener('click', () => (store.__artemisClickedAt = Date.now()), { once: true, capture: true });
+            if (store.__artemisClickListener) {
+                document.removeEventListener('click', store.__artemisClickListener, true);
+            }
+            // Listening on the document rather than on the element resolved right now: the header re-render that this
+            // helper exists to survive also replaces the button, and a listener left on the detached node would miss
+            // the click that landed on its replacement, so a successful attempt would look like a swallowed one.
+            store.__artemisClickListener = (event: Event) => {
+                if ((event.target as Element | null)?.closest(clickSelector)) {
+                    store.__artemisClickedAt = Date.now();
+                }
+            };
+            document.addEventListener('click', store.__artemisClickListener, true);
         }, selector);
+    }
+
+    /** Removes the click listener again, so it cannot outlive the helper and record a later, unrelated click. */
+    private async stopRecordingClickTime() {
+        await this.page
+            .evaluate(() => {
+                const store = window as unknown as { __artemisClickListener?: (event: Event) => void };
+                if (store.__artemisClickListener) {
+                    document.removeEventListener('click', store.__artemisClickListener, true);
+                    store.__artemisClickListener = undefined;
+                }
+            })
+            .catch(() => undefined);
     }
 
     /** The recorded click time, or infinity when no click reached the element, so nothing counts as caused by it. */

--- a/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
@@ -1,5 +1,5 @@
 import { BASE_API } from '../../constants';
-import { Locator, Page, Response, expect } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
 
 /**
  * A class which encapsulates UI selectors and actions for the Course Overview page (/courses/*).
@@ -40,55 +40,39 @@ export class CourseOverviewPage {
      * header. Works for both the first attempt and subsequent attempts (the button reappears after each submit).
      * @param exerciseId The id of the quiz exercise to practice.
      */
-    /** Polls a condition until it holds or the timeout passes, reporting which happened rather than throwing. */
-    private async waitUntil(condition: () => boolean, timeout: number): Promise<boolean> {
-        const deadline = Date.now() + timeout;
-        while (Date.now() < deadline) {
-            if (condition()) {
-                return true;
-            }
-            await this.page.waitForTimeout(200);
-        }
-        return condition();
-    }
-
     async startQuizPractice(exerciseId: number) {
         const button = this.page.locator(`#quiz-start-practice-${exerciseId}`);
         await button.waitFor({ state: 'visible', timeout: 30_000 });
 
         // Starting a practice attempt loads the quiz for the student, both for the first attempt and for a restart in
         // the same session, and then renders its first question. Both are required as proof that the click started an
-        // attempt: the exercise page loads the same quiz on its own, so a load request alone is also satisfied by a
-        // click that the header's re-render swallowed, and the caller is then left waiting for a question that no
-        // attempt is behind. Counting the requests seen since the click is what separates the two.
-        let quizLoads = 0;
-        const countQuizLoad = (response: Response) => {
-            if (response.url().includes(`/quiz-exercises/${exerciseId}/for-student`) && response.ok()) {
-                quizLoads++;
+        // attempt: the exercise page loads the same quiz on its own, so a load alone is also satisfied by a click that
+        // the header's re-render swallowed, and the caller is then left waiting for a question that no attempt is
+        // behind. The load has to have been *started* after the click, not merely have arrived after it - the page's
+        // own load can still be in flight at that moment - which is what the request's start time distinguishes.
+        const question = this.page.locator('#question0');
+        for (let attempt = 0; attempt < 3; attempt++) {
+            const clickedAt = Date.now();
+            const quizLoaded = this.page
+                .waitForResponse(
+                    (response) => response.url().includes(`/quiz-exercises/${exerciseId}/for-student`) && response.ok() && response.request().timing().startTime >= clickedAt,
+                    { timeout: 15_000 },
+                )
+                .then(() => true)
+                .catch(() => false);
+            // The click is part of what is retried: the same re-render that swallows a click also detaches the
+            // button, and letting that error escape would end the helper instead of trying again.
+            await button.click({ timeout: 10_000 }).catch(() => undefined);
+            if (
+                (await quizLoaded) &&
+                (await question.waitFor({ state: 'visible', timeout: 15_000 }).then(
+                    () => true,
+                    () => false,
+                ))
+            ) {
+                return;
             }
-        };
-        this.page.on('response', countQuizLoad);
-        try {
-            const question = this.page.locator('#question0');
-            for (let attempt = 0; attempt < 3; attempt++) {
-                const loadsBeforeClick = quizLoads;
-                // The click is part of what is retried: the same re-render that swallows a click also detaches the
-                // button, and letting that error escape would end the helper instead of trying again.
-                await button.click({ timeout: 10_000 }).catch(() => undefined);
-                const loaded = await this.waitUntil(() => quizLoads > loadsBeforeClick, 15_000);
-                if (
-                    loaded &&
-                    (await question.waitFor({ state: 'visible', timeout: 15_000 }).then(
-                        () => true,
-                        () => false,
-                    ))
-                ) {
-                    return;
-                }
-                await button.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined);
-            }
-        } finally {
-            this.page.off('response', countQuizLoad);
+            await button.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined);
         }
         throw new Error(`Could not start a practice attempt for quiz ${exerciseId}: no attempt loaded a question after clicking start practice.`);
     }

--- a/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
@@ -1,5 +1,5 @@
 import { BASE_API } from '../../constants';
-import { Locator, Page, expect } from '@playwright/test';
+import { Locator, Page, Response, expect } from '@playwright/test';
 
 /**
  * A class which encapsulates UI selectors and actions for the Course Overview page (/courses/*).
@@ -45,36 +45,82 @@ export class CourseOverviewPage {
         await button.waitFor({ state: 'visible', timeout: 30_000 });
 
         // Starting a practice attempt loads the quiz for the student, both for the first attempt and for a restart in
-        // the same session, and then renders its first question. Both are required as proof that the click started an
-        // attempt: the exercise page loads the same quiz on its own, so a load alone is also satisfied by a click that
-        // the header's re-render swallowed, and the caller is then left waiting for a question that no attempt is
-        // behind. The load has to have been *started* after the click, not merely have arrived after it - the page's
-        // own load can still be in flight at that moment - which is what the request's start time distinguishes.
+        // the same session, and then renders its first question. A load alone does not prove the attempt started: the
+        // exercise page loads the same quiz on its own, so a click the header's re-render swallowed would pass too,
+        // and the caller is then left waiting for a question that no attempt is behind. What separates them is a load
+        // whose request *started* after the click, and the boundary has to come from the click event itself - a
+        // timestamp taken before it also covers the click's own actionability wait, which is long enough for the
+        // page's automatic load to begin inside it.
         const question = this.page.locator('#question0');
-        for (let attempt = 0; attempt < 3; attempt++) {
-            const clickedAt = Date.now();
-            const quizLoaded = this.page
-                .waitForResponse(
-                    (response) => response.url().includes(`/quiz-exercises/${exerciseId}/for-student`) && response.ok() && response.request().timing().startTime >= clickedAt,
-                    { timeout: 15_000 },
-                )
-                .then(() => true)
-                .catch(() => false);
-            // The click is part of what is retried: the same re-render that swallows a click also detaches the
-            // button, and letting that error escape would end the helper instead of trying again.
-            await button.click({ timeout: 10_000 }).catch(() => undefined);
-            if (
-                (await quizLoaded) &&
-                (await question.waitFor({ state: 'visible', timeout: 15_000 }).then(
-                    () => true,
-                    () => false,
-                ))
-            ) {
+        // Every quiz load is recorded with the time its request started, and the decision is taken once the click time
+        // is known. Deciding inside the response predicate instead would race the click time being read back and
+        // discard the very load the click caused.
+        const loadStartTimes: number[] = [];
+        const recordQuizLoad = (response: Response) => {
+            if (!response.url().includes(`/quiz-exercises/${exerciseId}/for-student`) || !response.ok()) {
                 return;
             }
-            await button.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined);
+            try {
+                loadStartTimes.push(response.request().timing().startTime);
+            } catch {
+                // No timing for this response, so it cannot be attributed to the click; ignore it.
+            }
+        };
+        this.page.on('response', recordQuizLoad);
+        try {
+            for (let attempt = 0; attempt < 3; attempt++) {
+                await this.recordNextClickTime(`#quiz-start-practice-${exerciseId}`);
+                // The click is part of what is retried: the same re-render that swallows a click also detaches the
+                // button, and letting that error escape would end the helper instead of trying again.
+                await button.click({ timeout: 10_000 }).catch(() => undefined);
+                const clickedAt = await this.readRecordedClickTime();
+                const loadedByThisClick = await this.waitUntil(() => loadStartTimes.some((startTime) => startTime >= clickedAt), 15_000);
+                if (
+                    loadedByThisClick &&
+                    (await question.waitFor({ state: 'visible', timeout: 15_000 }).then(
+                        () => true,
+                        () => false,
+                    ))
+                ) {
+                    return;
+                }
+                await button.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined);
+            }
+        } finally {
+            this.page.off('response', recordQuizLoad);
         }
         throw new Error(`Could not start a practice attempt for quiz ${exerciseId}: no attempt loaded a question after clicking start practice.`);
+    }
+
+    /** Polls a condition until it holds or the timeout passes, reporting which happened rather than throwing. */
+    private async waitUntil(condition: () => boolean, timeout: number): Promise<boolean> {
+        const deadline = Date.now() + timeout;
+        while (Date.now() < deadline) {
+            if (condition()) {
+                return true;
+            }
+            await this.page.waitForTimeout(200);
+        }
+        return condition();
+    }
+
+    /**
+     * Arms a one-shot listener that stores the page's own clock reading of the next click on `selector`.
+     * <p>
+     * The page clock is what request timings are measured against, and the click event is the only point that is
+     * neither before the click's actionability wait nor after the request it triggers.
+     */
+    private async recordNextClickTime(selector: string) {
+        await this.page.evaluate((clickSelector) => {
+            const store = window as unknown as { __artemisClickedAt?: number };
+            store.__artemisClickedAt = undefined;
+            document.querySelector(clickSelector)?.addEventListener('click', () => (store.__artemisClickedAt = Date.now()), { once: true, capture: true });
+        }, selector);
+    }
+
+    /** The recorded click time, or infinity when no click reached the element, so nothing counts as caused by it. */
+    private async readRecordedClickTime(): Promise<number> {
+        return await this.page.evaluate(() => (window as unknown as { __artemisClickedAt?: number }).__artemisClickedAt ?? Number.POSITIVE_INFINITY);
     }
 
     /**

--- a/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
@@ -254,8 +254,16 @@ export class ExerciseTeamsPage {
         // Ensure the input is mounted before we start typing — under parallel CI load the dialog
         // body can render late and pressSequentially against an absent element silently no-ops.
         await inputLocator.waitFor({ state: 'visible', timeout: 30_000 });
+        // A deadline for the search as a whole, not only for its individual actions: four attempts of bounded steps
+        // still add up to minutes, and the caller adds several students in sequence inside one test budget. Attempts
+        // stop once the deadline passes, so the helper reports its own error while the test can still act on it.
+        const startedAt = Date.now();
+        const deadline = startedAt + 90_000;
         for (let attempt = 0; attempt < 4; attempt++) {
             if (attempt > 0) {
+                if (Date.now() > deadline) {
+                    break;
+                }
                 await this.page.waitForTimeout(500);
             }
 
@@ -275,9 +283,12 @@ export class ExerciseTeamsPage {
                 await option.click({ timeout: 10_000 });
                 return;
             } catch {
-                if (attempt === 3) throw new Error(`Student search autocomplete did not appear after 4 attempts for '${username}'`);
+                if (attempt === 3 || Date.now() > deadline) {
+                    throw new Error(`Student search autocomplete did not appear for '${username}' within ${Math.round((Date.now() - startedAt) / 1000)}s`);
+                }
             }
         }
+        throw new Error(`Student search autocomplete did not appear for '${username}' before the search deadline`);
     }
 
     /**

--- a/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
@@ -259,36 +259,37 @@ export class ExerciseTeamsPage {
         // stop once the deadline passes, so the helper reports its own error while the test can still act on it.
         const startedAt = Date.now();
         const deadline = startedAt + 90_000;
-        for (let attempt = 0; attempt < 4; attempt++) {
+        // Every step is capped by what is left of the deadline, not only by its own maximum. Bounding the steps alone
+        // still let an attempt start just before the deadline and run for another minute past it, and the caller adds
+        // several students in sequence inside one test budget.
+        const remaining = (maximum: number) => Math.max(1, Math.min(maximum, deadline - Date.now()));
+        for (let attempt = 0; attempt < 4 && Date.now() < deadline; attempt++) {
             if (attempt > 0) {
-                if (Date.now() > deadline) {
-                    break;
-                }
-                await this.page.waitForTimeout(500);
+                await this.page.waitForTimeout(Math.min(500, remaining(500)));
             }
 
             try {
-                // Typing into the field belongs inside the retry, and every step is bounded. Without a timeout these
-                // actions inherit the test's whole budget, so an input that never becomes actionable - the dialog
-                // re-renders under load and detaches it - hung the entire test instead of failing this attempt, and
-                // the run reported a 10 minute timeout rather than the clear message below.
-                await inputLocator.click({ timeout: 10_000 });
-                await inputLocator.fill('', { timeout: 10_000 });
-                await this.page.waitForTimeout(300);
-                await inputLocator.pressSequentially(username, { delay: 100, timeout: 20_000 });
+                // Typing into the field belongs inside the retry. Without a timeout these actions inherit the test's
+                // whole budget, so an input that never becomes actionable - the dialog re-renders under load and
+                // detaches it - hung the entire test instead of failing this attempt, and the run reported a 10 minute
+                // timeout rather than the clear message below.
+                await inputLocator.click({ timeout: remaining(10_000) });
+                await inputLocator.fill('', { timeout: remaining(10_000) });
+                await this.page.waitForTimeout(Math.min(300, remaining(300)));
+                await inputLocator.pressSequentially(username, { delay: 100, timeout: remaining(20_000) });
 
-                await listbox.waitFor({ state: 'visible', timeout: 15000 });
+                await listbox.waitFor({ state: 'visible', timeout: remaining(15_000) });
                 const option = listbox.getByText(new RegExp(escapeRegExp(username), 'i')).first();
-                await option.waitFor({ state: 'visible', timeout: 5000 });
-                await option.click({ timeout: 10_000 });
+                await option.waitFor({ state: 'visible', timeout: remaining(5_000) });
+                await option.click({ timeout: remaining(10_000) });
                 return;
             } catch {
-                if (attempt === 3 || Date.now() > deadline) {
-                    throw new Error(`Student search autocomplete did not appear for '${username}' within ${Math.round((Date.now() - startedAt) / 1000)}s`);
+                if (attempt === 3 || Date.now() >= deadline) {
+                    break;
                 }
             }
         }
-        throw new Error(`Student search autocomplete did not appear for '${username}' before the search deadline`);
+        throw new Error(`Student search autocomplete did not appear for '${username}' within ${Math.round((Date.now() - startedAt) / 1000)}s`);
     }
 
     /**

--- a/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
@@ -264,6 +264,11 @@ export class ExerciseTeamsPage {
         for (let attempt = 0; attempt < 4 && Date.now() < deadline; attempt++) {
             if (attempt > 0) {
                 await this.page.waitForTimeout(Math.min(500, remaining(500)));
+                // The delay can be what exhausts the budget, and `remaining` clamps to 1 ms rather than to zero, so
+                // without this the next attempt would still start its actions past the deadline.
+                if (Date.now() >= deadline) {
+                    break;
+                }
             }
 
             try {

--- a/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
@@ -251,18 +251,16 @@ export class ExerciseTeamsPage {
      */
     private async searchStudent(inputLocator: ReturnType<Page['locator']>, username: string) {
         const listbox = this.page.getByRole('listbox');
-        // Ensure the input is mounted before we start typing — under parallel CI load the dialog
-        // body can render late and pressSequentially against an absent element silently no-ops.
-        await inputLocator.waitFor({ state: 'visible', timeout: 30_000 });
-        // A deadline for the search as a whole, not only for its individual actions: four attempts of bounded steps
-        // still add up to minutes, and the caller adds several students in sequence inside one test budget. Attempts
-        // stop once the deadline passes, so the helper reports its own error while the test can still act on it.
+        // A deadline for the search as a whole, not only for its individual actions, and it starts here rather than
+        // after the first wait: four attempts of bounded steps still add up to minutes, an attempt starting just
+        // before the deadline would run past it, and a 30 s wait left outside made the advertised 90 s budget 120 s.
+        // The caller adds several students in sequence inside one test budget, which is what all of that has to fit.
         const startedAt = Date.now();
         const deadline = startedAt + 90_000;
-        // Every step is capped by what is left of the deadline, not only by its own maximum. Bounding the steps alone
-        // still let an attempt start just before the deadline and run for another minute past it, and the caller adds
-        // several students in sequence inside one test budget.
         const remaining = (maximum: number) => Math.max(1, Math.min(maximum, deadline - Date.now()));
+        // Ensure the input is mounted before we start typing — under parallel CI load the dialog
+        // body can render late and pressSequentially against an absent element silently no-ops.
+        await inputLocator.waitFor({ state: 'visible', timeout: remaining(30_000) });
         for (let attempt = 0; attempt < 4 && Date.now() < deadline; attempt++) {
             if (attempt > 0) {
                 await this.page.waitForTimeout(Math.min(500, remaining(500)));

--- a/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseOverviewPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseOverviewPage.ts
@@ -183,6 +183,10 @@ export class ProgrammingExerciseOverviewPage {
             await this.page.locator('.popover-body').waitFor({ state: 'visible' });
             await expect(button).toBeEnabled({ timeout: 15000 });
         }
+        // The copy button is enabled before the URL next to it has switched, so copying right away can put the previous
+        // plain HTTPS URL on the clipboard and the caller clones without the token it asked for. Wait for the displayed
+        // URL to be the tokenized one first; it is the same source the button copies from.
+        await this.getCloneUrl(GitCloneMethod.httpsWithToken);
         await button.click();
         return await this.page.evaluate(async () => {
             return await navigator.clipboard.readText();


### PR DESCRIPTION
### Summary

Follow-up to #13502: the review findings that arrived after it was merged. All of it is in Playwright helpers, except one stale comment. One of the findings turned out to sit on top of a real weakness, which is fixed here too.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

Five findings from the final review of #13502 were valid:

1. **Starting a quiz practice attempt could report success without starting one.** The helper waited for the quiz-load request as proof, but the exercise page loads the same quiz by itself, so a click the header's re-render had swallowed satisfied that wait too. The caller was then left waiting for a question that no attempt was behind. Reproduced locally: `keeps all practice attempts in the result history` failed exactly this way, and passes with the fix.
2. **A click that threw ended the practice helper** instead of being retried, which is what the retry exists for.
3. **The splitter helper returned the last transient width** when the layout never settled, so the resize assertion compared against a number that was never the panel's resting width.
4. **The team search bounded its actions but not the search itself**, so four attempts could still approach the test budget while the caller adds several students one after another.
5. **Copying the tokenized clone URL waited only for the copy button**, which is enabled while the URL beside it is still the plain HTTPS one.

The sixth finding, duplicated declarations in `course-exercise-details.component.spec.ts`, does not hold: each declaration appears once on develop and the spec compiles (client tests are green). The seventh, requiring the exact `{"status":"UP"}` body in the runner's readiness gates, needs no change: the probe answers 503 when the node is not ready and `curl -sf` already fails on that, so a 200 means ready.

### Description

**`CourseOverviewPage.startQuizPractice`** counts the quiz loads that follow the click and waits for the first question, so only an attempt that actually started counts as success, and the click is inside the retry.

**`ExerciseSplitPanelResize`** returns a width only after two reads agree, and says which of the two failure modes happened otherwise.

**`ExerciseTeamsPage.searchStudent`** has a 90 second deadline for the whole search.

**`ProgrammingExerciseOverviewPage.copyCloneUrl`** waits for the tokenized URL to be the one on screen before copying it.

**`programming-exercise-update.component.ts`**: removed the comment describing the undefined fallback that the field's initialiser replaced.

### Steps for Testing

These are test helpers, so testing them means running the tests they serve:

```bash
./run-e2e-tests-local-multinode-fast.sh --filter "practice mode|splitter gutter|Create an exercise team|participation using secure git"
```

Locally: the two quiz practice tests pass 4 out of 4 (one of them failed before this change), the splitter and team creation tests pass, and the whole file of practice mode tests is unaffected.

### Review Progress

#### Code Review
- [x] I (as a reviewer) confirm that the code is fully functional and that no obvious bugs are introduced.
- [x] I (as a reviewer) confirm that the code is well structured, readable and maintainable.

#### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/32194069529) did not pass (`failure`). Coverage below may be partial.

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| programming-exercise-update.component.ts | 87.91% | 1355 | 208 | 15.4 |

_Last updated: 2026-08-18 23:14:04 UTC_

