### PR TITLE
`Development`: Use case-insensitive email lookup when trusting external LTI systems

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/account/repository/UserRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/repository/UserRepository.java
@@ -161,6 +161,9 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
     Optional<User> findOneWithAuthoritiesByEmail(String email);
 
     @EntityGraph(type = LOAD, attributePaths = { "authorities" })
+    Optional<User> findOneWithAuthoritiesByEmailIgnoreCase(String email);
+
+    @EntityGraph(type = LOAD, attributePaths = { "authorities" })
     Optional<User> findOneWithAuthoritiesByLoginAndInternal(String login, boolean internal);
 
     @EntityGraph(type = LOAD, attributePaths = { "authorities" })

--- a/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiService.java
@@ -110,7 +110,7 @@ public class LtiService {
 
             if (trustExternalLTISystems) {
                 log.info("Trusting external LTI system. Authenticating user with email: {}", email);
-                User user = userRepository.findOneWithAuthoritiesByEmail(email).orElseThrow();
+                User user = userRepository.findOneWithAuthoritiesByEmailIgnoreCase(email).orElseThrow();
                 SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(user.getLogin(), user.getPassword(), user.getGrantedAuthorities()));
                 return;
             }

--- a/src/test/java/de/tum/cit/aet/artemis/lti/LtiServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/LtiServiceTest.java
@@ -232,8 +232,6 @@ class LtiServiceTest {
     }
 
     @Test
-
-    @Test
     void authenticateLtiUser_caseInsensitiveEmailLookup() throws Exception {
         SecurityContextHolder.getContext().setAuthentication(null);
 

--- a/src/test/java/de/tum/cit/aet/artemis/lti/LtiServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/LtiServiceTest.java
@@ -232,6 +232,29 @@ class LtiServiceTest {
     }
 
     @Test
+
+    @Test
+    void authenticateLtiUser_caseInsensitiveEmailLookup() throws Exception {
+        SecurityContextHolder.getContext().setAuthentication(null);
+
+        // Set trustExternalLTISystems to true via reflection
+        var field = LtiService.class.getDeclaredField("trustExternalLTISystems");
+        field.setAccessible(true);
+        field.set(ltiService, true);
+
+        String emailInDb = "John.Doe@test.com";
+        String emailFromLti = "john.doe@test.com";
+        user.setEmail(emailInDb);
+
+        when(userRepository.findOneByEmailIgnoreCase(emailFromLti)).thenReturn(Optional.of(user));
+        when(userRepository.findOneWithAuthoritiesByEmailIgnoreCase(emailFromLti)).thenReturn(Optional.of(user));
+
+        ltiService.authenticateLtiUser(emailFromLti, "username", "firstname", "lastname", false);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth.getPrincipal()).isEqualTo(user.getLogin());
+    }
+
     void isNotLtiCreatedUser() {
         user.setLtiCreated(false);
 

--- a/src/test/java/de/tum/cit/aet/artemis/lti/LtiServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/LtiServiceTest.java
@@ -255,6 +255,7 @@ class LtiServiceTest {
         assertThat(auth.getPrincipal()).isEqualTo(user.getLogin());
     }
 
+    @Test
     void isNotLtiCreatedUser() {
         user.setLtiCreated(false);
 


### PR DESCRIPTION
### Description

Fixes #13522

When `trustExternalLTISystems` is enabled, `authenticateLtiUser` in `LtiService` uses `findOneByEmailIgnoreCase` for the guard check (case-insensitive) but `findOneWithAuthoritiesByEmail` (case-sensitive) for the actual user lookup. If the email in the database differs in case from the LTI-provided email, the lookup fails with `NoSuchElementException`.

### Changes

1. **UserRepository.java**: Added `findOneWithAuthoritiesByEmailIgnoreCase` method with `@EntityGraph` for eager authority loading
2. **LtiService.java**: Changed `authenticateLtiUser` to use `findOneWithAuthoritiesByEmailIgnoreCase` instead of `findOneWithAuthoritiesByEmail`
3. **LtiServiceTest.java**: Added test `authenticateLtiUser_caseInsensitiveEmailLookup` verifying case-insensitive email authentication

### Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LTI authentication now matches user email addresses without regard to capitalization.
  * Trusted external LTI sign-ins correctly authenticate existing users even when email casing differs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->