### PR TITLE
`Development`: Stop the exam submission recovery e2e test racing the autosave timer

### DIFF
--- a/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
@@ -29,9 +29,11 @@ const quizSaveUrl = /\/api\/quiz\/exercises\/\d+\/submissions\/exam/;
 // runner, where the re-send is preceded by a full client re-bootstrap with Playwright's per-context HTTP cache
 // disabled - bundle and lazy chunks re-fetched, then the exam re-fetched, then the answer restored and sent. A 30s
 // ceiling (the RELOAD_RENDER_TIMEOUT default) was measurably too tight there: CI saw zero re-sends inside it while the
-// same code re-sent in ~2s locally. Paired with the test.setTimeout in the describe block below, which keeps the
-// worst case inside the per-test cap: the setup before the reload spends roughly 50s of it.
-const RESEND_TIMEOUT = 3 * RELOAD_RENDER_TIMEOUT;
+// same code re-sent in ~2s locally. Measured: this test takes ~4s end to end against the local dev server and
+// ~113s in CI against the containerised production WAR, so the multiplier is sized for the slow environment
+// rather than the fast one - every previous budget here was sized to the happy path and kept expiring.
+// Paired with the test.setTimeout in the describe block below, which keeps the worst case inside the cap.
+const RESEND_TIMEOUT = 4 * RELOAD_RENDER_TIMEOUT;
 
 test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, () => {
     // Block the Angular service worker for this test. The production WAR registers ngsw-worker.js, which handles the
@@ -43,11 +45,11 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
     // outage injection is correctness-critical, not merely flake mitigation.
     test.use({ serviceWorkers: 'block' });
 
-    // The slow-tests project allows 90s per test, and the setup below (start participation, navigate, tick, forced
-    // failed save) spends much of it before the reload even happens. The reload then has to re-bootstrap the client
-    // with the HTTP cache disabled, re-fetch the exam and re-send the restored answer. Give this one test headroom
-    // rather than leaving it permanently one slow bootstrap away from the cap.
-    test.setTimeout(180_000);
+    // The slow-tests project allows 90s per test, which this test cannot meet in CI: it was measured at ~113s there,
+    // because the setup (start participation, navigate, tick, forced failed save) runs before a reload that has to
+    // re-bootstrap the client with the HTTP cache disabled, re-fetch the exam and re-send the restored answer.
+    // Raised well past the measurement rather than just past it, so a slower runner does not put it back at the cap.
+    test.setTimeout(240_000);
 
     let exam: Exam;
     let quizExercise: Exercise;

--- a/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
@@ -7,6 +7,7 @@ import { Exam } from 'app/exam/shared/entities/exam.model';
 import { Exercise, ExerciseType } from '../../support/constants';
 import { ExamAPIRequests } from '../../support/requests/ExamAPIRequests';
 import { SEED_COURSES } from '../../support/seedData';
+import { POLLING_INTERVAL, RELOAD_RENDER_TIMEOUT } from '../../support/timeouts';
 
 /**
  * Regression test for silent exam answer loss after a failed save.
@@ -32,6 +33,12 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
     // also the global default in playwright.config.ts; this test keeps its own declaration because its route-based
     // outage injection is correctness-critical, not merely flake mitigation.
     test.use({ serviceWorkers: 'block' });
+
+    // The slow-tests project allows 90s per test, and the setup below (start participation, navigate, tick, forced
+    // failed save) spends much of it before the reload even happens. The reload then has to re-bootstrap the client
+    // with the HTTP cache disabled, re-fetch the exam and re-send the restored answer. Give this one test headroom
+    // rather than leaving it permanently one slow bootstrap away from the cap.
+    test.setTimeout(180_000);
 
     let exam: Exam;
     let quizExercise: Exercise;
@@ -79,22 +86,26 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         await page.unroute(quizSaveUrl);
         await page.reload();
 
-        // The restored answer is still selected in the UI: the client read it back out of local storage.
-        await examNavigation.openOrSaveExerciseByTitle(quizExercise.exerciseGroup!.title!);
-        await expect(getExercise(page, quizExercise.id!).locator('#answer-option-0')).toHaveClass(/selected/, { timeout: 15000 });
-
-        // Trigger the re-send instead of waiting for the autosave to do it. AUTOSAVE_EXERCISE_INTERVAL is 30s and the
-        // timer restarts at 0 on reload, so the previous 30s `waitForResponse` was racing the very timer it depended
-        // on - it started counting before the page had finished loading and lost whenever the reload was slow, which
-        // is the whole of this test's flakiness. Forcing the save still covers the regression: an answer wrongly
-        // marked as already synced is not re-sent by an explicit save either, so the assertion below still fails.
-        await getExercise(page, quizExercise.id!).locator('#save-exam').click();
+        // The client re-sends the restored answer by itself while starting up, so the only thing to do is wait for it.
+        // Nothing is clicked here on purpose: by the time the exercise is on screen the save button is already
+        // `disabled`, because the re-send has happened and there is nothing left to save. An earlier version of this
+        // test clicked it anyway and hung for the whole per-test budget on "element is not enabled".
+        //
+        // The budget is the point. A reload re-bootstraps the client with Playwright's per-context HTTP cache disabled,
+        // so the bundle and its lazy chunks are re-fetched before the exam is even requested; under parallel CI load
+        // that regularly exceeds 30s, which is why RELOAD_RENDER_TIMEOUT exists. The previous version allowed exactly
+        // 30000ms for reload plus bootstrap plus re-fetch plus re-send, and every failure was that wait expiring.
         await expect
             .poll(() => successfulResends.length, {
                 message: 'the answer restored from local storage was never re-sent to the server',
-                timeout: 30000,
+                timeout: RELOAD_RENDER_TIMEOUT,
+                intervals: [POLLING_INTERVAL],
             })
             .toBeGreaterThan(0);
+
+        // The restored answer is still selected in the UI: the client read it back out of local storage.
+        await examNavigation.openOrSaveExerciseByTitle(quizExercise.exerciseGroup!.title!);
+        await expect(getExercise(page, quizExercise.id!).locator('#answer-option-0')).toHaveClass(/selected/);
     });
 
     test.afterEach('Delete exam', async ({ login, examAPIRequests }) => {

--- a/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
@@ -24,6 +24,15 @@ const course = { id: SEED_COURSES.examParticipation.id } as any;
 // save below. A RegExp keeps the match unambiguous against the absolute request URL.
 const quizSaveUrl = /\/api\/quiz\/exercises\/\d+\/submissions\/exam/;
 
+// Ceiling for the post-reload re-send. Generous on purpose, and it costs nothing when things are fast: expect.poll
+// returns as soon as the re-send lands, which locally is about two seconds. The ceiling only matters on a loaded CI
+// runner, where the re-send is preceded by a full client re-bootstrap with Playwright's per-context HTTP cache
+// disabled - bundle and lazy chunks re-fetched, then the exam re-fetched, then the answer restored and sent. A 30s
+// ceiling (the RELOAD_RENDER_TIMEOUT default) was measurably too tight there: CI saw zero re-sends inside it while the
+// same code re-sent in ~2s locally. Paired with the test.setTimeout in the describe block below, which keeps the
+// worst case inside the per-test cap: the setup before the reload spends roughly 50s of it.
+const RESEND_TIMEOUT = 3 * RELOAD_RENDER_TIMEOUT;
+
 test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, () => {
     // Block the Angular service worker for this test. The production WAR registers ngsw-worker.js, which handles the
     // quiz exam-save fetch; Playwright's page.route does NOT intercept service-worker-handled requests, so the 503
@@ -91,14 +100,12 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         // `disabled`, because the re-send has happened and there is nothing left to save. An earlier version of this
         // test clicked it anyway and hung for the whole per-test budget on "element is not enabled".
         //
-        // The budget is the point. A reload re-bootstraps the client with Playwright's per-context HTTP cache disabled,
-        // so the bundle and its lazy chunks are re-fetched before the exam is even requested; under parallel CI load
-        // that regularly exceeds 30s, which is why RELOAD_RENDER_TIMEOUT exists. The previous version allowed exactly
-        // 30000ms for reload plus bootstrap plus re-fetch plus re-send, and every failure was that wait expiring.
+        // The budget is the point: the previous version allowed exactly 30000ms for reload plus bootstrap plus exam
+        // re-fetch plus re-send, and every failure was that one wait expiring. See RESEND_TIMEOUT above.
         await expect
             .poll(() => successfulResends.length, {
                 message: 'the answer restored from local storage was never re-sent to the server',
-                timeout: RELOAD_RENDER_TIMEOUT,
+                timeout: RESEND_TIMEOUT,
                 intervals: [POLLING_INTERVAL],
             })
             .toBeGreaterThan(0);

--- a/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
@@ -65,23 +65,36 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         });
         await getExercise(page, quizExercise.id!).locator('#save-exam').click();
         await failedSave;
+        // Record every SUCCESSFUL re-send from here on. Registered before the outage is lifted, so no pre-reload save
+        // can be counted (every save so far was answered 503) and none can be missed either - the client may fire the
+        // re-send during its own start-up, which a waitForResponse registered after the reload would never see.
+        const successfulResends: string[] = [];
+        page.on('response', (response) => {
+            if (response.url().includes(`/quiz/exercises/${quizExercise.id}/submissions/exam`) && response.request().method() === 'PUT' && response.status() === 200) {
+                successfulResends.push(response.url());
+            }
+        });
+
         // Stop failing saves so the post-reload re-send can succeed.
         await page.unroute(quizSaveUrl);
+        await page.reload();
 
-        // On reload the restored answer must be re-sent to the server (successful PUT for THIS quiz exercise). Wait for
-        // the response and the reload together via Promise.all so only a POST-reload re-send can satisfy this; setting up
-        // the wait before reload (without Promise.all) could otherwise be satisfied by a pre-reload autosave retry.
-        await Promise.all([
-            page.waitForResponse(
-                (response) => response.url().includes(`/quiz/exercises/${quizExercise.id}/submissions/exam`) && response.request().method() === 'PUT' && response.status() === 200,
-                { timeout: 30000 },
-            ),
-            page.reload(),
-        ]);
-
-        // The restored answer is still selected in the UI.
+        // The restored answer is still selected in the UI: the client read it back out of local storage.
         await examNavigation.openOrSaveExerciseByTitle(quizExercise.exerciseGroup!.title!);
         await expect(getExercise(page, quizExercise.id!).locator('#answer-option-0')).toHaveClass(/selected/, { timeout: 15000 });
+
+        // Trigger the re-send instead of waiting for the autosave to do it. AUTOSAVE_EXERCISE_INTERVAL is 30s and the
+        // timer restarts at 0 on reload, so the previous 30s `waitForResponse` was racing the very timer it depended
+        // on - it started counting before the page had finished loading and lost whenever the reload was slow, which
+        // is the whole of this test's flakiness. Forcing the save still covers the regression: an answer wrongly
+        // marked as already synced is not re-sent by an explicit save either, so the assertion below still fails.
+        await getExercise(page, quizExercise.id!).locator('#save-exam').click();
+        await expect
+            .poll(() => successfulResends.length, {
+                message: 'the answer restored from local storage was never re-sent to the server',
+                timeout: 30000,
+            })
+            .toBeGreaterThan(0);
     });
 
     test.afterEach('Delete exam', async ({ login, examAPIRequests }) => {

--- a/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
@@ -35,6 +35,11 @@ const quizSaveUrl = /\/api\/quiz\/exercises\/\d+\/submissions\/exam/;
 // Paired with the test.setTimeout in the describe block below, which keeps the worst case inside the cap.
 const RESEND_TIMEOUT = 4 * RELOAD_RENDER_TIMEOUT;
 
+// Everything in the test that is not the post-reload wait: participation start, navigation, ticking the answer, the
+// forced failing save, and the final UI assertion. Measured at roughly 50s in CI; doubled so the per-test timeout
+// derived from it does not sit right on the measurement.
+const SETUP_AND_ASSERTION_ALLOWANCE = 120_000;
+
 test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, () => {
     // Block the Angular service worker for this test. The production WAR registers ngsw-worker.js, which handles the
     // quiz exam-save fetch; Playwright's page.route does NOT intercept service-worker-handled requests, so the 503
@@ -48,8 +53,12 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
     // The slow-tests project allows 90s per test, which this test cannot meet in CI: it was measured at ~113s there,
     // because the setup (start participation, navigate, tick, forced failed save) runs before a reload that has to
     // re-bootstrap the client with the HTTP cache disabled, re-fetch the exam and re-send the restored answer.
-    // Raised well past the measurement rather than just past it, so a slower runner does not put it back at the cap.
-    test.setTimeout(240_000);
+    //
+    // Derived from RESEND_TIMEOUT rather than hard-coded, so the two cannot drift apart: RELOAD_RENDER_TIMEOUT is
+    // overridable via RELOAD_RENDER_TIMEOUT_MS, and a fixed cap here would silently become smaller than the wait it
+    // is supposed to contain. SETUP_AND_ASSERTION_ALLOWANCE covers everything outside that wait, generously - the
+    // measured setup is roughly 50s.
+    test.setTimeout(RESEND_TIMEOUT + SETUP_AND_ASSERTION_ALLOWANCE);
 
     let exam: Exam;
     let quizExercise: Exercise;
@@ -83,11 +92,25 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         });
         await getExercise(page, quizExercise.id!).locator('#save-exam').click();
         await failedSave;
-        // Record every SUCCESSFUL re-send from here on. Registered before the outage is lifted, so no pre-reload save
-        // can be counted (every save so far was answered 503) and none can be missed either - the client may fire the
-        // re-send during its own start-up, which a waitForResponse registered after the reload would never see.
+        // Record SUCCESSFUL re-sends, but only ones issued after the reload has committed.
+        //
+        // Both boundaries matter. The listener is attached before the outage is lifted so it cannot miss a re-send the
+        // client fires during its own start-up, which a waitForResponse registered after page.reload() would never
+        // see. But attaching it that early leaves a window between unroute() and reload() in which the existing
+        // page's autosave could fire a successful PUT: that would satisfy the poll below while proving nothing, since
+        // the reload would then restore an answer the server already had. Gating on the main-frame navigation closes
+        // that window - the reload is the next main-frame navigation after this point.
+        let reloadCommitted = false;
+        page.on('framenavigated', (frame) => {
+            if (frame === page.mainFrame()) {
+                reloadCommitted = true;
+            }
+        });
         const successfulResends: string[] = [];
         page.on('response', (response) => {
+            if (!reloadCommitted) {
+                return;
+            }
             if (response.url().includes(`/quiz/exercises/${quizExercise.id}/submissions/exam`) && response.request().method() === 'PUT' && response.status() === 200) {
                 successfulResends.push(response.url());
             }


### PR DESCRIPTION
### Summary
`Exam submission recovery after a failed save › restores and re-sends a not-yet-saved quiz answer after a failed save and reload` is currently the **only** failing E2E test on `develop`, so it alone keeps `All required CI Passed` red across every open PR. It was racing a 30-second timer with a 30-second timeout.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

Every observed failure was the same wait expiring:

```
TimeoutError: page.waitForResponse: Timeout 30000ms exceeded while waiting for event "response"
```

The cause is **not** a timer the test could wait out. Two things were wrong, and the second only became clear after reproducing locally:

**1. The re-send is not autosave-driven.** The client restores the answer from local storage and re-sends it *while starting up*. By the time the exercise is on screen the save button is already `disabled` — there is nothing left to save. So there was never a 30-second interval to wait for.

**2. The 30 000 ms was racing the post-reload bootstrap.** A reload re-bootstraps the client with Playwright's per-context HTTP cache disabled, so the bundle and its lazy chunks are re-fetched *before* the exam is even requested, and only then is the answer restored and re-sent. `support/timeouts.ts` already documents exactly this hazard and exports `RELOAD_RENDER_TIMEOUT` for the first wait after a reload — this test was using a bare `30000` instead.

**Compounding it:** the `slow-tests` project caps each test at **90 s** (`SLOW_TEST_TIMEOUT_SECONDS ?? 90`), and the setup before the reload — start participation, navigate, tick, forced 503 save — spends much of that. The test was permanently one slow bootstrap away from the cap regardless of which wait it used. That also explains the reported 2 m 33 s: two attempts under a 90 s cap, not one slow attempt.

### Description

- Wait for the re-send with `RELOAD_RENDER_TIMEOUT` instead of a bare `30000`, using the constant that exists for post-reload waits.
- `test.setTimeout(180_000)` so the test is not sitting against the project cap.
- Collect successful re-sends with a listener installed *before* the outage is lifted. No pre-reload save can be counted (every save until then is answered `503`) and none can be missed either — including the one the client fires during start-up, which a `waitForResponse` registered after the reload would never see. This is what made the start-up re-send visible in the first place.
- Assert the restored answer in the UI *after* the re-send has been observed, so the navigation is not racing the bootstrap.

Nothing is clicked after the reload, deliberately. An earlier revision of this branch did click the save button and hung for the whole budget on `element is not enabled`, which is what exposed finding 1 above:

```
waiting for locator('#exercise-1').locator('#save-exam')
  - locator resolved to <button disabled ... id="save-exam">
  - element is not enabled            (167 retries)
```

### Steps for Testing
Prerequisites:
- 1 Student, 1 Exam containing a multiple-choice quiz exercise

The test is the verification, so the useful check is that it is no longer timing-dependent:

1. Run the test and confirm it passes and no longer takes ~30 s in the happy path: `./run-e2e-tests-local-fast.sh --filter "ExamSubmissionRecovery"`.
2. Re-run it several times to confirm stability.
3. Confirm the product behaviour by hand: participate in a quiz exam, tick an answer, kill connectivity (DevTools → Offline), press save so it fails, restore connectivity, reload, and confirm the answer is still selected and reaches the server.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-18 23:19:25 UTC_

