### PR TITLE
`Development`: Migrate to ng-mocks 14.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
         "jsdom": "catalog:",
         "lighthouse": "13.4.1",
         "lint-staged": "17.3.0",
-        "ng-mocks": "14.15.3",
+        "ng-mocks": "14.17.1",
         "ng-packagr": "catalog:",
         "postcss": "catalog:",
         "postcss-html": "2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -508,8 +508,8 @@ importers:
         specifier: 17.3.0
         version: 17.3.0
       ng-mocks:
-        specifier: 14.15.3
-        version: 14.15.3(07c60d662419b4715cf4332873f6ea3e)
+        specifier: 14.17.1
+        version: 14.17.1(07c60d662419b4715cf4332873f6ea3e)
       ng-packagr:
         specifier: 'catalog:'
         version: 22.1.1(@angular/compiler-cli@22.1.2(@angular/compiler@22.1.2)(supports-color@10.2.2)(typescript@6.0.3))(tailwindcss@4.3.3)(tslib@2.8.1)(typescript@6.0.3)
@@ -6673,8 +6673,8 @@ packages:
     resolution: {integrity: sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==}
     engines: {node: '>= 10'}
 
-  ng-mocks@14.15.3:
-    resolution: {integrity: sha512-J0UafeI2K5kc5oDhIinGu+VqT990b0sP2dlKV3JxXYTlaQxQ7Mm0LLrxGz10hsGGJVtn9JEKkhjnpb6oijLT3w==}
+  ng-mocks@14.17.1:
+    resolution: {integrity: sha512-YxHOVaXoCTBlR89vXs/niq8v7ncyIgAP5MUuFG6F80LHvC7wRw+chto2hiboKboJJ6V9uynIhZzLsSIVyti9gA==}
     peerDependencies:
       '@angular/common': ^22.0.0
       '@angular/core': ^22.0.0
@@ -14358,7 +14358,7 @@ snapshots:
 
   neotraverse@1.0.1: {}
 
-  ng-mocks@14.15.3(07c60d662419b4715cf4332873f6ea3e):
+  ng-mocks@14.17.1(07c60d662419b4715cf4332873f6ea3e):
     dependencies:
       '@angular/common': 22.1.2(@angular/core@22.1.2(@angular/compiler@22.1.2)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
       '@angular/core': 22.1.2(@angular/compiler@22.1.2)(rxjs@7.8.2)(zone.js@0.16.2)

--- a/src/main/webapp/app/atlas/manage/edit/edit-competency.component.spec.ts
+++ b/src/main/webapp/app/atlas/manage/edit/edit-competency.component.spec.ts
@@ -103,7 +103,7 @@ describe('EditCompetencyComponent', () => {
             description: competencyOfResponse.description,
             optional: competencyOfResponse.optional,
         });
-        expect(competencyFormComponent.formData).toEqual(editCompetencyComponent.formData());
+        expect(competencyFormComponent.formData()).toEqual(editCompetencyComponent.formData());
     });
 
     it('should send PUT request upon form submission and navigate', () => {

--- a/src/main/webapp/app/atlas/manage/edit/edit-prerequisite.component.spec.ts
+++ b/src/main/webapp/app/atlas/manage/edit/edit-prerequisite.component.spec.ts
@@ -104,7 +104,7 @@ describe('EditPrerequisiteComponent', () => {
             description: competencyOfResponse.description,
             optional: competencyOfResponse.optional,
         });
-        expect(competencyFormComponent.formData).toEqual(editPrerequisiteComponent.formData());
+        expect(competencyFormComponent.formData()).toEqual(editPrerequisiteComponent.formData());
     });
 
     it('should send PUT request upon form submission and navigate', () => {

--- a/src/main/webapp/app/communication/posting-markdown-editor/posting-markdown-editor.component.spec.ts
+++ b/src/main/webapp/app/communication/posting-markdown-editor/posting-markdown-editor.component.spec.ts
@@ -232,7 +232,7 @@ describe('PostingsMarkdownEditor', () => {
     it('should initialize markdown correctly with post content', () => {
         fixture.componentRef.setInput('maxContentLength', 200);
         fixture.changeDetectorRef.detectChanges();
-        expect(mockMarkdownEditorComponent.markdown).toEqual(component.content());
+        expect(mockMarkdownEditorComponent.markdown()).toEqual(component.content());
     });
 
     it('should update value if markdown change is emitted', () => {

--- a/src/main/webapp/app/course/manage/control-center/control-center.component.spec.ts
+++ b/src/main/webapp/app/course/manage/control-center/control-center.component.spec.ts
@@ -58,7 +58,7 @@ describe('ControlCenterComponent', () => {
     it('should display the iris enabled component with correct inputs', () => {
         const irisEnabledComponent = fixture.debugElement.query(By.directive(IrisEnabledComponent));
         expect(irisEnabledComponent).toBeTruthy();
-        expect(irisEnabledComponent.componentInstance.course).toEqual(course);
+        expect(irisEnabledComponent.componentInstance.course()).toEqual(course);
     });
 
     it('should display the iris logo', () => {

--- a/src/main/webapp/app/course/overview/course-settings/notification-settings/notification-settings.component.spec.ts
+++ b/src/main/webapp/app/course/overview/course-settings/notification-settings/notification-settings.component.spec.ts
@@ -197,8 +197,8 @@ describe('NotificationSettingsComponent', () => {
         const presetPicker = fixture.debugElement.query(By.directive(CourseNotificationPresetPickerComponent));
         expect(presetPicker).not.toBeNull();
 
-        expect(presetPicker.componentInstance.availableCourseSettingPresets).toEqual(mockPresets);
-        expect(presetPicker.componentInstance.selectedCourseSettingPreset).toEqual(mockPresets[0]);
+        expect(presetPicker.componentInstance.availableCourseSettingPresets()).toEqual(mockPresets);
+        expect(presetPicker.componentInstance.selectedCourseSettingPreset()).toEqual(mockPresets[0]);
     });
 
     it('should render specification cards when not loading', () => {
@@ -211,7 +211,7 @@ describe('NotificationSettingsComponent', () => {
         const specificationCards = fixture.debugElement.queryAll(By.directive(CourseNotificationSettingSpecificationCardComponent));
         expect(specificationCards).toHaveLength(1);
 
-        expect(specificationCards[0].componentInstance.settingSpecification).toEqual(component['notificationSpecifications']()[0]);
+        expect(specificationCards[0].componentInstance.settingSpecification()).toEqual(component['notificationSpecifications']()[0]);
     });
 
     it('should correctly update specifications from notification map', () => {

--- a/src/main/webapp/app/course/overview/exercise-details/student-actions/exercise-details-student-actions.component.spec.ts
+++ b/src/main/webapp/app/course/overview/exercise-details/student-actions/exercise-details-student-actions.component.spec.ts
@@ -343,8 +343,8 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
 
         const feedbackButton = debugElement.query(By.css('jhi-request-feedback-button'));
         expect(feedbackButton).not.toBeNull();
-        expect(feedbackButton.componentInstance.isSubmitted).toBe(true);
-        expect(feedbackButton.componentInstance.participationId).toBe(gradedParticipation.id);
+        expect(feedbackButton.componentInstance.isSubmitted()).toBe(true);
+        expect(feedbackButton.componentInstance.participationId()).toBe(gradedParticipation.id);
     });
 
     it('should show correct buttons in exam mode', async () => {

--- a/src/main/webapp/app/exam/manage/exams/update/exam-timeline.component.spec.ts
+++ b/src/main/webapp/app/exam/manage/exams/update/exam-timeline.component.spec.ts
@@ -41,9 +41,9 @@ describe('ExamTimelineComponent', () => {
 
     it('should use sequentially strict timeline validation', () => {
         fixture.detectChanges();
-        const timeline = fixture.debugElement.query(By.directive(TimelineComponent)).componentInstance as unknown as { validationMode: TimelineValidationMode };
+        const timeline = fixture.debugElement.query(By.directive(TimelineComponent)).componentInstance as unknown as { validationMode: () => TimelineValidationMode };
 
-        expect(timeline.validationMode).toBe(TimelineValidationMode.SEQUENTIALLY_STRICT);
+        expect(timeline.validationMode()).toBe(TimelineValidationMode.SEQUENTIALLY_STRICT);
     });
 
     it('should use the working-window labels for a test exam', () => {

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header/exercise-header.component.spec.ts
@@ -141,7 +141,7 @@ describe('ExerciseHeaderComponent', () => {
 
             const feedbackButton = fixture.debugElement.query(By.css('jhi-request-feedback-button'));
             expect(feedbackButton).not.toBeNull();
-            expect(feedbackButton.componentInstance.isSubmitted).toBe(true);
+            expect(feedbackButton.componentInstance.isSubmitted()).toBe(true);
         });
 
         it.each([false, true])('should disable the feedback button for an unsubmitted submission with hasResult=%s', (hasResult) => {
@@ -149,7 +149,7 @@ describe('ExerciseHeaderComponent', () => {
 
             const feedbackButton = fixture.debugElement.query(By.css('jhi-request-feedback-button'));
             expect(feedbackButton).not.toBeNull();
-            expect(feedbackButton.componentInstance.isSubmitted).toBe(false);
+            expect(feedbackButton.componentInstance.isSubmitted()).toBe(false);
         });
 
         it('should pass the active participation to the feedback button', () => {
@@ -171,15 +171,15 @@ describe('ExerciseHeaderComponent', () => {
             fixture.detectChanges();
 
             let feedbackButton = fixture.debugElement.query(By.css('jhi-request-feedback-button'));
-            expect(feedbackButton.componentInstance.participationId).toBe(gradedParticipation.id);
-            expect(feedbackButton.componentInstance.isSubmitted).toBe(true);
+            expect(feedbackButton.componentInstance.participationId()).toBe(gradedParticipation.id);
+            expect(feedbackButton.componentInstance.isSubmitted()).toBe(true);
 
             fixture.componentRef.setInput('participationMode', 'practice');
             fixture.detectChanges();
 
             feedbackButton = fixture.debugElement.query(By.css('jhi-request-feedback-button'));
-            expect(feedbackButton.componentInstance.participationId).toBe(practiceParticipation.id);
-            expect(feedbackButton.componentInstance.isSubmitted).toBe(false);
+            expect(feedbackButton.componentInstance.participationId()).toBe(practiceParticipation.id);
+            expect(feedbackButton.componentInstance.isSubmitted()).toBe(false);
         });
 
         it('should hide the feedback button when the exercise has not been started', () => {

--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-registrations-container/tutorial-registrations-container.component.spec.ts
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-registrations-container/tutorial-registrations-container.component.spec.ts
@@ -155,11 +155,11 @@ describe('TutorialRegistrationsContainerComponent', () => {
             loggedInUserIsAtLeastTutorOfGroup: boolean;
             loggedInUserIsAtLeastInstructorInCourse: boolean;
         };
-        expect(child.courseId).toBe(2);
-        expect(child.tutorialGroupId).toBe(17);
-        expect(child.registeredStudents).toEqual(registeredStudents);
-        expect(child.loggedInUserIsAtLeastTutorOfGroup).toBe(true);
-        expect(child.loggedInUserIsAtLeastInstructorInCourse).toBe(false);
+        expect(child.courseId()).toBe(2);
+        expect(child.tutorialGroupId()).toBe(17);
+        expect(child.registeredStudents()).toEqual(registeredStudents);
+        expect(child.loggedInUserIsAtLeastTutorOfGroup()).toBe(true);
+        expect(child.loggedInUserIsAtLeastInstructorInCourse()).toBe(false);
     });
 
     it('should mark the user as at least tutor of the group when they have editor rights in the course and as instructor when they have instructor rights', () => {

--- a/src/test/javascript/spec/integration/code-editor/code-editor-student.integration.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-student.integration.spec.ts
@@ -209,8 +209,8 @@ describe('CodeEditorStudentIntegration', () => {
         // Repository should be locked because due date has passed and it's not practice mode
         expect(container.repositoryIsLocked()).toBe(true);
         expect(getElement(containerDebugElement, '.locked-container').innerHTML).toContain('fa-icon');
-        expect(container.codeEditorContainer()!.fileBrowser()!.disableActions).toBe(true);
-        expect(container.codeEditorContainer()!.actions()!.disableActions).toBe(true);
+        expect(container.codeEditorContainer()!.fileBrowser()!.disableActions()).toBe(true);
+        expect(container.codeEditorContainer()!.actions()!.disableActions()).toBe(true);
     });
 
     it('should abort initialization and show error state if participation cannot be retrieved', () => {


### PR DESCRIPTION
### Summary
Unblocks the `ng-mocks` dependency train. #13511 had to hold it at 14.15.3 because 14.17.1 failed 13 assertions across 9 spec files; this adapts those specs and takes the bump.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage).

### Motivation and Context
`ng-mocks` 14.17 models **signal inputs on mock components faithfully**. Reading one off a mock now yields the `InputSignal` rather than the raw value, so it has to be *called* — exactly as on the real component. The uncalled form yields ng-mocks' internal `inputValueFn`, which produced the giveaway failure:

```
AssertionError: expected [Function inputValueFn] to deeply equal 'metisPostExerciseUser1'
  ❯ posting-markdown-editor.component.spec.ts:235
      expect(mockMarkdownEditorComponent.markdown).toEqual(component.content());
```

This is a fidelity improvement rather than a regression, and the migration makes the specs agree with the component under test. `MarkdownEditorMonacoComponent` declares `readonly markdown = input<string>()`, so `markdown()` is how production code reads it too — the specs were relying on a mock behaving *unlike* the real thing.

### Description
`ng-mocks` 14.15.3 → **14.17.1**, plus `mock.someInput` → `mock.someInput()` in the affected assertions. No production code changed.

The 9 spec files:

| File | Inputs called |
|---|---|
| `posting-markdown-editor.component.spec.ts` | `markdown` |
| `code-editor-student.integration.spec.ts` | `disableActions` (file browser and actions) |
| `edit-competency.component.spec.ts` | `formData` |
| `edit-prerequisite.component.spec.ts` | `formData` |
| `control-center.component.spec.ts` | `course` |
| `exercise-header.component.spec.ts` | `isSubmitted`, `participationId` |
| `tutorial-registrations-container.component.spec.ts` | `courseId`, `tutorialGroupId`, `registeredStudents`, `loggedInUserIsAtLeastTutorOfGroup`, `loggedInUserIsAtLeastInstructorInCourse` |
| `notification-settings.component.spec.ts` | `availableCourseSettingPresets`, `selectedCourseSettingPreset`, `settingSpecification` |
| `exercise-details-student-actions.component.spec.ts` | `isSubmitted`, `participationId` |

Worth noting for the reviewer: the failures **cascade**. Each assertion block had several consecutive reads of mocked inputs, and Vitest only reports the first failing one per test, so fixing a line reveals the next. The count went 13 → 5 → 1 → 0 across three passes; the full-suite run below is what confirms the end of the chain rather than the absence of the next report.

### Steps for Testing
This is a test-infrastructure change, so the suite is the verification.

Prerequisites:
- A local checkout

1. `pnpm install --frozen-lockfile`
2. `pnpm exec vitest run` — expect 1281 files / 16787 tests, 0 failures.
3. `pnpm run compile:tests` — expect a clean typecheck.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-18 23:09:43 UTC_

