### PR TITLE
`Development`: Add a lockstep guardrail for tightly-coupled dependency families

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -56,6 +56,12 @@ jobs:
       - name: Java Documentation
         run: ./gradlew checkstyleMain -x webapp
         if: ${{ !cancelled() }}
+      # Tightly-coupled dependency families (HttpComponents, Bouncy Castle, JGit, SSHD) must not resolve to mixed or
+      # downgraded versions: that is a runtime LinkageError rather than a build failure, so nothing else catches it.
+      # Run explicitly because this task hangs off `check`, which no CI job invokes.
+      - name: Dependency Families
+        run: ./gradlew verifyDependencyFamilies -x webapp
+        if: ${{ !cancelled() }}
       - name: Java Architecture Tests
         run: ./gradlew test -DincludeTags='ArchitectureTest' -x webapp
         if: ${{ !cancelled() }}

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ ext.tumUiRuntimeSources = fileTree("packages/tum-ui/src") {
 apply from: "gradle/liquibase.gradle"
 apply from: "gradle/spotless.gradle"
 apply from: "gradle/sbom.gradle"
+apply from: "gradle/dependency-families.gradle"
 
 if (project.hasProperty("prod")) {
     apply from: "gradle/profile_prod.gradle"

--- a/gradle/dependency-families.gradle
+++ b/gradle/dependency-families.gradle
@@ -29,23 +29,98 @@ def watchedFamilies = [
     'org.apache.sshd',
 ]
 
-/** Compares Maven-style versions numerically segment by segment, tolerating suffixes like `.Final` or `-r`. */
+/**
+ * Splits a version into its leading numeric segments and the qualifier that follows, e.g.
+ * `4.2.17.Final` -> [[4, 2, 17], 'Final'] and `7.7.1.202607240634-r` -> [[7, 7, 1, 202607240634], 'r'].
+ *
+ * Segments are parsed as BigInteger rather than int: JGit versions carry a 12-digit timestamp segment, which
+ * overflows int and would otherwise be misread as part of the qualifier.
+ */
+static List parseVersion(String version) {
+    def parts = version.split(/[.\-_]/)
+    def numeric = []
+    int i = 0
+    while (i < parts.length && parts[i] ==~ /\d+/) {
+        numeric << new BigInteger(parts[i])
+        i++
+    }
+    def qualifier = i < parts.length ? parts[i..<parts.length].join('.') : ''
+    return [numeric, qualifier]
+}
+
+/**
+ * Maven-compatible version ordering.
+ *
+ * Numeric segments compare numerically with a missing segment treated as 0, so `1.85` == `1.85.0` < `1.85.2`. When
+ * the numeric parts are equal, a version WITHOUT a qualifier outranks one with a qualifier, because a qualifier marks
+ * a pre-release: `2.19.0` > `2.19.0-M1`. Comparing missing segments as empty strings (the previous implementation)
+ * inverted exactly that case, which would have let Rule B reject a valid upgrade to a final release and miss a real
+ * downgrade to a milestone or snapshot.
+ *
+ * Two qualifiers compare case-insensitively and lexically. That is not Maven's full known-qualifier ranking
+ * (alpha < beta < milestone < rc < release), which is deliberate: no watched family uses two different qualifiers on
+ * the same numeric version, and a lexical tie-break keeps this readable. Revisit if one starts to.
+ */
 static int compareVersions(String a, String b) {
-    def pa = a.split(/[.\-]/)
-    def pb = b.split(/[.\-]/)
-    for (int i = 0; i < Math.max(pa.length, pb.length); i++) {
-        def x = i < pa.length ? pa[i] : ''
-        def y = i < pb.length ? pb[i] : ''
-        if (x.isInteger() && y.isInteger()) {
-            int c = (x as int) <=> (y as int)
-            if (c != 0) {
-                return c
-            }
-        } else if (x != y) {
-            return x <=> y
+    def (List numericA, String qualifierA) = parseVersion(a)
+    def (List numericB, String qualifierB) = parseVersion(b)
+    int segments = Math.max(numericA.size(), numericB.size())
+    for (int i = 0; i < segments; i++) {
+        BigInteger x = i < numericA.size() ? numericA[i] : BigInteger.ZERO
+        BigInteger y = i < numericB.size() ? numericB[i] : BigInteger.ZERO
+        int c = x <=> y
+        if (c != 0) {
+            return c
         }
     }
-    return 0
+    if (qualifierA == qualifierB) {
+        return 0
+    }
+    // A final release outranks any pre-release of the same numeric version.
+    if (qualifierA.isEmpty()) {
+        return 1
+    }
+    if (qualifierB.isEmpty()) {
+        return -1
+    }
+    return qualifierA.compareToIgnoreCase(qualifierB)
+}
+
+/**
+ * Self-check for {@link #compareVersions}. The comparator is the only place this task can be silently wrong - a bad
+ * ordering either fails a clean build or waves through the very mismatch the task exists to catch - and there is no
+ * Groovy test harness in this repository, so it verifies itself before being trusted.
+ */
+static void verifyVersionComparator() {
+    def expectations = [
+        // [lower, higher]
+        ['1.85', '1.85.2'],
+        ['5.3.6', '5.4.3'],
+        ['5.6.1', '5.6.3'],
+        ['2.19.0-M1', '2.19.0'],
+        ['2.19.0-SNAPSHOT', '2.19.0'],
+        ['4.2.16.Final', '4.2.17.Final'],
+        ['0.31.8.RELEASE', '0.31.9.RELEASE'],
+        ['7.7.0.202606012155-r', '7.7.1.202607240634-r'],
+        // The timestamp segment exceeds int range; it must still compare numerically.
+        ['7.7.1.202606012155-r', '7.7.1.202607240634-r'],
+    ]
+    expectations.each { pair ->
+        if (compareVersions(pair[0], pair[1]) >= 0) {
+            throw new GradleException("Version comparator is broken: expected ${pair[0]} < ${pair[1]}.")
+        }
+        if (compareVersions(pair[1], pair[0]) <= 0) {
+            throw new GradleException("Version comparator is broken: expected ${pair[1]} > ${pair[0]}.")
+        }
+    }
+    ['1.85', '2.19.0-M1', '7.7.1.202607240634-r'].each { version ->
+        if (compareVersions(version, version) != 0) {
+            throw new GradleException("Version comparator is broken: ${version} should equal itself.")
+        }
+    }
+    if (compareVersions('1.85', '1.85.0') != 0) {
+        throw new GradleException('Version comparator is broken: 1.85 should equal 1.85.0.')
+    }
 }
 
 tasks.register('verifyDependencyFamilies') {
@@ -56,6 +131,7 @@ tasks.register('verifyDependencyFamilies') {
     def families = watchedFamilies
 
     doLast {
+        verifyVersionComparator()
         def problems = []
         def selectedByGroup = [:].withDefault { [:] }
         def requestedFor = [:].withDefault { [] as Set }

--- a/gradle/dependency-families.gradle
+++ b/gradle/dependency-families.gradle
@@ -99,7 +99,9 @@ static int compareVersions(String a, String b) {
  * to an unqualified version. A service pack patches the release it names and therefore outranks it.
  */
 static int qualifierLevel(String qualifier) {
-    def normalised = qualifier.toLowerCase()
+    // Locale.ROOT, not the default locale: in a Turkish locale `toLowerCase()` maps I to a dotless i, so "FINAL"
+    // would not match 'final' and a release-aliased version would be misread as a pre-release.
+    def normalised = qualifier.toLowerCase(Locale.ROOT)
     if (normalised.isEmpty() || normalised in ['final', 'ga', 'release']) {
         return 0
     }

--- a/gradle/dependency-families.gradle
+++ b/gradle/dependency-families.gradle
@@ -57,9 +57,15 @@ static List parseVersion(String version) {
  * inverted exactly that case, which would have let Rule B reject a valid upgrade to a final release and miss a real
  * downgrade to a milestone or snapshot.
  *
- * Two qualifiers compare case-insensitively and lexically. That is not Maven's full known-qualifier ranking
- * (alpha < beta < milestone < rc < release), which is deliberate: no watched family uses two different qualifiers on
- * the same numeric version, and a lexical tie-break keeps this readable. Revisit if one starts to.
+ * Qualifiers follow Maven's aliasing and level ordering: `final`, `ga` and `release` mean the same thing as no
+ * qualifier at all, so `4.2.17.Final` == `4.2.17`; a service pack outranks the release it patches, so
+ * `1.0-sp1` > `1.0`; and anything else is a pre-release that ranks below the release. Within a level, two qualifiers
+ * compare case-insensitively and lexically.
+ *
+ * That lexical tie-break is not Maven's full `alpha < beta < milestone < rc` ranking. It is a documented limit rather
+ * than an oversight: no watched family carries two different pre-release qualifiers on the same numeric version, so
+ * the tie-break is unreachable today. The aliasing above is implemented because it is not a ranking nicety - reading
+ * `4.2.17.Final` as older than `4.2.17` would make Rule B reject a correct tree.
  */
 static int compareVersions(String a, String b) {
     def (List numericA, String qualifierA) = parseVersion(a)
@@ -73,17 +79,34 @@ static int compareVersions(String a, String b) {
             return c
         }
     }
-    if (qualifierA == qualifierB) {
+    int levelA = qualifierLevel(qualifierA)
+    int levelB = qualifierLevel(qualifierB)
+    if (levelA != levelB) {
+        return levelA <=> levelB
+    }
+    // At the release level every spelling means the same release, so `4.2.17` == `4.2.17.Final` == `4.2.17.ga`.
+    // Only within the pre-release and service-pack levels does the text distinguish anything.
+    if (levelA == 0) {
         return 0
     }
-    // A final release outranks any pre-release of the same numeric version.
-    if (qualifierA.isEmpty()) {
+    return qualifierA.compareToIgnoreCase(qualifierB)
+}
+
+/**
+ * Maven's qualifier levels: pre-release (-1) < release (0) < service pack (1).
+ *
+ * `final`, `ga` and `release` are Maven aliases for "no qualifier", so they sit at the release level and compare equal
+ * to an unqualified version. A service pack patches the release it names and therefore outranks it.
+ */
+static int qualifierLevel(String qualifier) {
+    def normalised = qualifier.toLowerCase()
+    if (normalised.isEmpty() || normalised in ['final', 'ga', 'release']) {
+        return 0
+    }
+    if (normalised ==~ /sp\d*/) {
         return 1
     }
-    if (qualifierB.isEmpty()) {
-        return -1
-    }
-    return qualifierA.compareToIgnoreCase(qualifierB)
+    return -1
 }
 
 /**
@@ -113,13 +136,22 @@ static void verifyVersionComparator() {
             throw new GradleException("Version comparator is broken: expected ${pair[1]} > ${pair[0]}.")
         }
     }
+    // Aliases and levels: these must compare EQUAL, which a plain pre-release/release split gets wrong.
+    [['4.2.17', '4.2.17.Final'], ['4.2.17', '4.2.17.ga'], ['4.2.17', '4.2.17.RELEASE'], ['1.85', '1.85.0']].each { pair ->
+        if (compareVersions(pair[0], pair[1]) != 0) {
+            throw new GradleException("Version comparator is broken: expected ${pair[0]} == ${pair[1]}.")
+        }
+    }
+    // A service pack outranks the release it patches, and a release outranks a pre-release even when aliased.
+    [['1.0', '1.0-sp1'], ['1.0-rc1', '1.0-sp1'], ['1.0-rc1', '1.0.Final']].each { pair ->
+        if (compareVersions(pair[0], pair[1]) >= 0) {
+            throw new GradleException("Version comparator is broken: expected ${pair[0]} < ${pair[1]}.")
+        }
+    }
     ['1.85', '2.19.0-M1', '7.7.1.202607240634-r'].each { version ->
         if (compareVersions(version, version) != 0) {
             throw new GradleException("Version comparator is broken: ${version} should equal itself.")
         }
-    }
-    if (compareVersions('1.85', '1.85.0') != 0) {
-        throw new GradleException('Version comparator is broken: 1.85 should equal 1.85.0.')
     }
 }
 

--- a/gradle/dependency-families.gradle
+++ b/gradle/dependency-families.gradle
@@ -1,0 +1,124 @@
+// Guards dependency families that must move in lockstep.
+//
+// WHY: bumping one member of a tightly-coupled family and leaving its siblings behind produces a runtime
+// LinkageError, not a build failure, so it reaches production. Two real incidents:
+//
+//   * PR #12638 raised httpclient5 5.5.1 -> 5.6.1. httpcore5 stayed on the 5.3 line, but httpclient5 5.6.x
+//     references org.apache.hc.core5.io.IOFunction, which only exists from httpcore5 5.4. Every Eureka registry
+//     fetch then threw NoClassDefFoundError; DiscoveryClient swallows Throwable, so getInstances() simply returned
+//     0 and every node formed its own single-member Hazelcast cluster. Reverted in PR #12652 with the cause
+//     misattributed to IPv6 Basic auth, which cost a second investigation to disprove.
+//   * A later sweep raised bcprov-jdk18on to 1.85.2 while bcpkix/bcpg/bcutil stayed on 1.85. Bouncy Castle requires
+//     its modules to share a version; that one was caught in review rather than by a build.
+//
+// WHAT IS CHECKED, against the RESOLVED graph (so transitive members count too):
+//   A. Every module of a watched family resolves to a single version.
+//   B. No module of a watched family resolves BELOW a version that some other module asked for. This is the #12638
+//      shape: a managed/pinned version silently holding a family member under what its sibling needs. It reads the
+//      requested versions out of the graph, so it stays correct without a hand-maintained compatibility table.
+//
+// Wired into `check`, and therefore into CI, but it resolves runtimeClasspath so it is not free — it is deliberately
+// not wired into `compileJava`.
+
+/** Families whose members must share one version. Keyed by Maven group. */
+def watchedFamilies = [
+    'org.apache.httpcomponents.client5',
+    'org.apache.httpcomponents.core5',
+    'org.bouncycastle',
+    'org.eclipse.jgit',
+    'org.apache.sshd',
+]
+
+/** Compares Maven-style versions numerically segment by segment, tolerating suffixes like `.Final` or `-r`. */
+static int compareVersions(String a, String b) {
+    def pa = a.split(/[.\-]/)
+    def pb = b.split(/[.\-]/)
+    for (int i = 0; i < Math.max(pa.length, pb.length); i++) {
+        def x = i < pa.length ? pa[i] : ''
+        def y = i < pb.length ? pb[i] : ''
+        if (x.isInteger() && y.isInteger()) {
+            int c = (x as int) <=> (y as int)
+            if (c != 0) {
+                return c
+            }
+        } else if (x != y) {
+            return x <=> y
+        }
+    }
+    return 0
+}
+
+tasks.register('verifyDependencyFamilies') {
+    group = 'verification'
+    description = 'Fails if a tightly-coupled dependency family (HttpComponents, Bouncy Castle, JGit, SSHD) resolves to mixed or downgraded versions.'
+
+    def resolutionResult = configurations.named('runtimeClasspath').map { it.incoming.resolutionResult.root }
+    def families = watchedFamilies
+
+    doLast {
+        def problems = []
+        def selectedByGroup = [:].withDefault { [:] }
+        def requestedFor = [:].withDefault { [] as Set }
+
+        def visited = [] as Set
+        def walk
+        walk = { component ->
+            if (!visited.add(component.id.displayName)) {
+                return
+            }
+            component.dependencies.each { dependency ->
+                if (!(dependency instanceof org.gradle.api.artifacts.result.ResolvedDependencyResult)) {
+                    return
+                }
+                def requested = dependency.requested
+                def selected = dependency.selected
+                if (requested instanceof org.gradle.api.artifacts.component.ModuleComponentSelector) {
+                    def group = requested.group
+                    if (families.contains(group) && requested.version) {
+                        requestedFor["${group}:${requested.module}"] << requested.version
+                    }
+                }
+                def selectedId = selected.moduleVersion
+                if (selectedId != null && families.contains(selectedId.group)) {
+                    selectedByGroup[selectedId.group][selectedId.name] = selectedId.version
+                }
+                walk(selected)
+            }
+        }
+        walk(resolutionResult.get())
+
+        // Rule A: one version per family.
+        selectedByGroup.each { group, modules ->
+            def versions = modules.values().toSet()
+            if (versions.size() > 1) {
+                def detail = modules.sort().collect { name, version -> "    ${group}:${name}:${version}" }.join('\n')
+                problems << "Family '${group}' resolves to mixed versions ${versions.sort()}. Its modules are built and released together and must share one version:\n${detail}"
+            }
+        }
+
+        // Rule B: nothing in a watched family resolved below a version another module asked for.
+        requestedFor.each { coordinate, requestedVersions ->
+            def (group, name) = coordinate.split(':', 2)
+            def selected = selectedByGroup[group][name]
+            if (selected == null) {
+                return
+            }
+            requestedVersions.findAll { !it.startsWith('[') && !it.startsWith('(') && !it.endsWith('+') }.each { requested ->
+                if (compareVersions(selected, requested) < 0) {
+                    problems << "'${group}:${name}' resolved to ${selected}, below the ${requested} that another module on the classpath asks for. " +
+                            'A pinned or BOM-managed version is holding it under what its sibling needs, which is a LinkageError at runtime rather than a build failure ' +
+                            "(see the httpclient5/httpcore5 note in gradle/dependency-families.gradle). Raise the pin for '${group}:${name}' to at least ${requested}."
+                }
+            }
+        }
+
+        if (problems) {
+            throw new GradleException("Dependency family verification failed:\n\n" + problems.collect { "  - ${it}" }.join('\n\n') + '\n')
+        }
+        logger.lifecycle("Dependency families verified: ${families.size()} families, all consistent.")
+    }
+}
+
+tasks.named('check') {
+    dependsOn 'verifyDependencyFamilies'
+}


### PR DESCRIPTION
### Summary
Adds `verifyDependencyFamilies`, a build check that fails when a tightly-coupled dependency family resolves to mixed or downgraded versions. This class of mistake produces a runtime `LinkageError` rather than a build failure, so nothing currently catches it — and it has bitten twice in the last few weeks.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

**Incident 1 — Hazelcast cluster formation (#12638 → reverted in #12652).** `httpclient5` was raised 5.5.1 → 5.6.1 while `httpcore5` stayed on the 5.3 line. `httpclient5` 5.6.x references `org.apache.hc.core5.io.IOFunction`, a class that **only exists from httpcore5 5.4**:

```
httpcore5 5.3.6: org/apache/hc/core5/io/IOFunction.class  -> absent
httpcore5 5.4.3: org/apache/hc/core5/io/IOFunction.class  -> present
```

Every Eureka registry fetch therefore threw `NoClassDefFoundError`. `DiscoveryClient.fetchRegistry()` catches `Throwable`, so it failed silently: `getInstances()` returned 0 and every node formed its own single-member Hazelcast cluster. The build was green throughout.

#12652 reverted it and attributed the cause to Basic auth over IPv6. That attribution is wrong — the failure reproduces identically over IPv4 — and disproving it cost a second investigation when the same bump came up again.

**Incident 2 — Bouncy Castle.** A later sweep raised `bcprov-jdk18on` to 1.85.2 while `bcpkix`, `bcpg` and `bcutil` stayed on 1.85. Bouncy Castle requires its modules to share a version. Caught in review rather than by a build, i.e. by luck.

Both are the same shape, and both were invisible to `compileJava`, `test`, `checkstyleMain` and `spotlessCheck`.

### Description

`gradle/dependency-families.gradle` registers `verifyDependencyFamilies`, which inspects the **resolved** `runtimeClasspath` — so transitive family members count too, not just what `build.gradle` declares — and applies two rules:

**Rule A — one version per family.** All modules of a watched group must resolve to the same version. Catches incident 2.

**Rule B — no family member resolved below a version a sibling asks for.** Catches incident 1: a pinned or BOM-managed version holding a family member under what another module on the classpath needs.

Rule B deliberately reads the requested versions **out of the dependency graph** rather than from a hand-maintained compatibility table, so it stays correct as versions move and cannot go stale. Range and `+` requests are skipped.

Watched families: `org.apache.httpcomponents.client5`, `org.apache.httpcomponents.core5`, `org.bouncycastle`, `org.eclipse.jgit`, `org.apache.sshd`. All five are multi-artifact families released in lockstep.

**Where it runs.** The task hangs off the `check` lifecycle task, which is the right semantics for `./gradlew check` locally. But no CI job invokes `check` — CI runs `test`, `checkstyleMain`, `spotlessCheck`, `jacocoTestCoverageVerification` and `bootWar` — so the `Server Code Style` workflow runs it **explicitly**, alongside the checks it belongs with. A guardrail that only fires locally would be no guardrail at all.

It resolves `runtimeClasspath`, so it is not free and is deliberately *not* wired into `compileJava`.

### Steps for Testing
Prerequisites:
- A local checkout with a warm Gradle cache

1. Confirm it passes as-is:
   ```
   ./gradlew verifyDependencyFamilies -x webapp
   → Dependency families verified: 5 families, all consistent.
   ```
2. Confirm it actually catches the real bug. Reintroduce the #12638 state by editing `build.gradle` to pin `httpcore5` back to `5.3.6`, then re-run. Expected — both rules fire:
   ```
   - Family 'org.apache.httpcomponents.core5' resolves to mixed versions [5.3.6, 5.4.3].
     Its modules are built and released together and must share one version:
       org.apache.httpcomponents.core5:httpcore5:5.3.6
       org.apache.httpcomponents.core5:httpcore5-h2:5.4.3

   - 'org.apache.httpcomponents.core5:httpcore5' resolved to 5.3.6, below the 5.4.3 that
     another module on the classpath asks for. ... Raise the pin for
     'org.apache.httpcomponents.core5:httpcore5' to at least 5.4.3.
   ```
3. Revert the edit and confirm it passes again.

Step 2 is the one that matters: a guard that never fires is worthless, so it was validated against the actual historical failure rather than only against a green tree.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [ ] Reproduce the failure per step 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-18 23:38:51 UTC_

