### PR TITLE
`Development`: Patch apache http components on the build script classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,10 @@ buildscript {
             // httpcore5 5.4.2 / httpcore5-h2 5.4, which the GitHub dependency graph reports and Dependabot flags
             // (GHSA-hjcp-jmpx-g3qm, GHSA-hf6x-8p5f-cgmf, GHSA-v3jc-474w-2wm6) even though the shipped WAR only ever
             // contains the patched versions pinned in the dependencies block below. Build-time only, not shipped.
-            // Same reasoning as the jackson-bom enforcedPlatform further down; keep these in sync with the
-            // project-level pins so the whole family stays on one version.
+            // Same reasoning as the jackson-bom enforcedPlatform further down. Note the two trains are versioned
+            // independently and must not be collapsed onto one number: client5 tracks 5.6.x and core5 tracks 5.4.x,
+            // because httpclient5-parent:5.6.3 itself declares <httpcore.version>5.4.3</httpcore.version>. Keep each
+            // force equal to that module's project-level pin in the dependencies block below.
             force "org.apache.httpcomponents.client5:httpclient5:5.6.3"
             force "org.apache.httpcomponents.client5:httpclient5-cache:5.6.3"
             force "org.apache.httpcomponents.core5:httpcore5:5.4.3"

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,17 @@ buildscript {
     configurations.classpath {
         resolutionStrategy {
             force "com.github.jknack:handlebars:4.5.4"
+            // Force the patched Apache HttpComponents onto the build-script / plugin classpath too. The
+            // org.owasp.dependencycheck and org.springframework.boot plugins drag in httpclient5 5.6.1 /
+            // httpcore5 5.4.2 / httpcore5-h2 5.4, which the GitHub dependency graph reports and Dependabot flags
+            // (GHSA-hjcp-jmpx-g3qm, GHSA-hf6x-8p5f-cgmf, GHSA-v3jc-474w-2wm6) even though the shipped WAR only ever
+            // contains the patched versions pinned in the dependencies block below. Build-time only, not shipped.
+            // Same reasoning as the jackson-bom enforcedPlatform further down; keep these in sync with the
+            // project-level pins so the whole family stays on one version.
+            force "org.apache.httpcomponents.client5:httpclient5:5.6.3"
+            force "org.apache.httpcomponents.client5:httpclient5-cache:5.6.3"
+            force "org.apache.httpcomponents.core5:httpcore5:5.4.3"
+            force "org.apache.httpcomponents.core5:httpcore5-h2:5.4.3"
         }
     }
     // The custom OpenAPI generator (generatorName "angular22", https://github.com/ls1intum/openapi-generator-angular22)


### PR DESCRIPTION
### Summary
Closes the three Dependabot alerts that survived #13511. They are real reports against a real classpath — just not the one anybody was looking at: the **build-script / plugin classpath**, which GitHub's automatic Gradle dependency submission resolves along with everything else.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

#13511 raised `httpclient5` to 5.6.3 and `httpcore5`/`httpcore5-h2` to 5.4.3, and its `log4j-api` and `nanoid` alerts duly closed. These three did not:

| # | Severity | Package | Fix |
|---|---|---|---|
| 705 | medium | `httpclient5` | 5.6.3 — GHSA-hjcp-jmpx-g3qm |
| 703 | high | `httpcore5-h2` | 5.4.3 — GHSA-v3jc-474w-2wm6 |
| 700 | high | `httpcore5` | 5.4.3 — GHSA-hf6x-8p5f-cgmf |

That asymmetry is the clue: the shipped versions were already patched, so something *else* was reporting old ones. `./gradlew buildEnvironment` on `develop` shows what:

```
org.owasp.dependencycheck 12.2.2  -> httpclient5 5.6.1, httpclient5-cache 5.6,
                                     httpcore5 5.4.2, httpcore5-h2 5.4
org.springframework.boot  4.1.0   -> httpclient5 5.6.1
```

Both are Gradle plugins, so this is build-time only and never reaches the WAR. But the dependency graph submission resolves the plugin classpath too, so Dependabot sees and flags it.

This is not a new phenomenon in this repo — the same `buildscript` block already carries an `enforcedPlatform("com.fasterxml.jackson:jackson-bom")` for precisely this reason, with the comment *"which the GitHub dependency graph reports and Dependabot flags even though the shipped WAR only ever contains the patched version"*. Same problem, same treatment.

### Description
Four `force` entries on `configurations.classpath`, next to the existing handlebars force, pinning `httpclient5`, `httpclient5-cache`, `httpcore5` and `httpcore5-h2` to the versions the project already uses. The comment records which plugins pull the old ones and why the forces exist, so the next person does not have to re-derive it.

Deliberately `force` on the buildscript classpath rather than a version bump anywhere: the project-level pins are already correct, and the plugins cannot be upgraded independently of their own releases.

### Steps for Testing
Prerequisites:
- A local checkout with a warm Gradle cache

1. Confirm the plugin classpath is clean — every entry resolves to a patched version:
   ```
   ./gradlew buildEnvironment | grep -oE "httpcomponents\.(client5|core5):[a-z0-9-]+:[0-9.]+( -> [0-9.]+)?" | sort -u
   ```
   Expect `httpclient5 -> 5.6.3`, `httpclient5-cache -> 5.6.3`, `httpcore5 -> 5.4.3`, `httpcore5-h2 5.4.3`.
2. Confirm **no** configuration anywhere still resolves a vulnerable version:
   ```
   ./gradlew dependencies | grep -oE "httpcomponents\.(client5|core5):[a-z0-9-]+:[0-9.]+( -> [0-9.]+)?" | sort -u
   ```
3. Confirm the build is unaffected: `./gradlew compileJava compileTestJava spotlessCheck checkstyleMain -x webapp`.

Step 2 is the one that matters. Fixing only the classpath that happened to be flagged would have left the same trap for the next scan, so it was checked project-wide.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Verify per step 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-18 23:55:28 UTC_


### Follow-up worth considering
`verifyDependencyFamilies` in #13529 would not have caught this: it inspects `runtimeClasspath` only. Extending it to the build-script classpath is tempting, but plugin classpaths legitimately carry a wide spread of versions, so a naive extension would be noisy. A narrower check — "no configuration resolves a family member below the version the project pins for it" — would cover this case without the noise. Left out of this PR to keep the security fix small.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Apache HttpComponents dependencies to patched versions, improving security and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->