### PR TITLE
fix: fall back to login for LTI users with null first/last name

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiService.java
@@ -133,7 +133,12 @@ public class LtiService {
     protected Authentication createNewUserFromLaunchRequest(String email, String login, String firstName, String lastName) {
         final var user = userRepository.findOneByLogin(login).orElseGet(() -> {
             var password = RandomUtil.generatePassword();
-            final User newUser = userCreationService.createUser(login, password, firstName, lastName, email, null, null, Constants.DEFAULT_LANGUAGE, true);
+            // Some LTI platforms (e.g. Open edX) omit the given_name and family_name claims in the id token.
+            // Fall back to the login so the user always has a non-null display name; a null name would
+            // otherwise crash JGit's PersonIdent ("Name of PersonIdent must not be null") on the next commit.
+            String effectiveFirstName = StringUtils.hasLength(firstName) ? firstName : login;
+            String effectiveLastName = StringUtils.hasLength(lastName) ? lastName : "";
+            final User newUser = userCreationService.createUser(login, password, effectiveFirstName, effectiveLastName, email, null, null, Constants.DEFAULT_LANGUAGE, true);
             newUser.setLtiCreated(true);
             newUser.setActivationKey(null);
             userRepository.save(newUser);

--- a/src/test/java/de/tum/cit/aet/artemis/lti/LtiServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/LtiServiceTest.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.lti;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -236,5 +237,58 @@ class LtiServiceTest {
         user.setLtiCreated(false);
 
         assertThat(ltiService.isLtiCreatedUser(user)).isFalse();
+    }
+
+    @Test
+    void authenticateLtiUser_newUser_withNullNames_createsUserWithLoginFallback() {
+        SecurityContextHolder.getContext().setAuthentication(null);
+        onlineCourseConfiguration.setRequireExistingUser(false);
+        when(userRepository.findOneByLogin("edx_janedoe")).thenReturn(Optional.empty());
+        when(userRepository.findOneByEmailIgnoreCase("jane@example.com")).thenReturn(Optional.empty());
+        when(artemisAuthenticationProvider.getUsernameForEmail("jane@example.com")).thenReturn(Optional.empty());
+
+        ltiService.authenticateLtiUser("jane@example.com", "edx_janedoe", null, null, onlineCourseConfiguration.isRequireExistingUser());
+
+        // The user must be created with the login as a fallback display name so JGit's PersonIdent
+        // does not throw "Name of PersonIdent must not be null" on the next commit.
+        ArgumentCaptor<String> firstNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> lastNameCaptor = ArgumentCaptor.forClass(String.class);
+        verify(userCreationService).createUser(eq("edx_janedoe"), any(), firstNameCaptor.capture(), lastNameCaptor.capture(), eq("jane@example.com"), any(), any(), any(), anyBoolean());
+        assertThat(firstNameCaptor.getValue()).isEqualTo("edx_janedoe");
+        assertThat(lastNameCaptor.getValue()).isEmpty();
+    }
+
+    @Test
+    void authenticateLtiUser_newUser_withBlankNames_createsUserWithLoginFallback() {
+        SecurityContextHolder.getContext().setAuthentication(null);
+        onlineCourseConfiguration.setRequireExistingUser(false);
+        when(userRepository.findOneByLogin("edx_janedoe")).thenReturn(Optional.empty());
+        when(userRepository.findOneByEmailIgnoreCase("jane@example.com")).thenReturn(Optional.empty());
+        when(artemisAuthenticationProvider.getUsernameForEmail("jane@example.com")).thenReturn(Optional.empty());
+
+        ltiService.authenticateLtiUser("jane@example.com", "edx_janedoe", "   ", "  ", onlineCourseConfiguration.isRequireExistingUser());
+
+        ArgumentCaptor<String> firstNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> lastNameCaptor = ArgumentCaptor.forClass(String.class);
+        verify(userCreationService).createUser(eq("edx_janedoe"), any(), firstNameCaptor.capture(), lastNameCaptor.capture(), eq("jane@example.com"), any(), any(), any(), anyBoolean());
+        assertThat(firstNameCaptor.getValue()).isEqualTo("edx_janedoe");
+        assertThat(lastNameCaptor.getValue()).isEmpty();
+    }
+
+    @Test
+    void authenticateLtiUser_newUser_withNames_keepsProvidedNames() {
+        SecurityContextHolder.getContext().setAuthentication(null);
+        onlineCourseConfiguration.setRequireExistingUser(false);
+        when(userRepository.findOneByLogin("edx_janedoe")).thenReturn(Optional.empty());
+        when(userRepository.findOneByEmailIgnoreCase("jane@example.com")).thenReturn(Optional.empty());
+        when(artemisAuthenticationProvider.getUsernameForEmail("jane@example.com")).thenReturn(Optional.empty());
+
+        ltiService.authenticateLtiUser("jane@example.com", "edx_janedoe", "Jane", "Doe", onlineCourseConfiguration.isRequireExistingUser());
+
+        ArgumentCaptor<String> firstNameCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> lastNameCaptor = ArgumentCaptor.forClass(String.class);
+        verify(userCreationService).createUser(eq("edx_janedoe"), any(), firstNameCaptor.capture(), lastNameCaptor.capture(), eq("jane@example.com"), any(), any(), any(), anyBoolean());
+        assertThat(firstNameCaptor.getValue()).isEqualTo("Jane");
+        assertThat(lastNameCaptor.getValue()).isEqualTo("Doe");
     }
 }


### PR DESCRIPTION
### Description
<!-- Thank you for contributing to Artemis! Please describe the change and the issue it fixes. -->

Some LTI platforms (e.g. Open edX) do not send the `given_name` and `family_name` claims in the id token. When this happens, the user is created with a null `firstName`/`lastName`. Later, when the user submits a programming exercise in the online editor, `GitService.commitAndPush` calls `user.getName()` and passes it to JGit's `PersonIdent`, which throws:

```
java.lang.IllegalArgumentException: Name of PersonIdent must not be null.
```

### Changes
- In `LtiService.createNewUserFromLaunchRequest`, fall back to the login when the LTI platform omits `given_name`/`family_name`
- Added three unit tests to verify:
  - null names → login fallback
  - blank/whitespace names → login fallback
  - non-null names are preserved unchanged

Fixes #13537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LTI account creation when name information is missing.
  * New accounts now use the login as a fallback first name and leave the last name blank when necessary.
  * Provided first and last names continue to be preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->