### PR TITLE
`Integrated code lifecycle`: Stop aborting healthy Docker image pulls after the poll interval

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerService.java
@@ -347,12 +347,14 @@ public class BuildAgentDockerService {
          * time elapsed first. Unlike {@link #awaitCompletion(long, java.util.concurrent.TimeUnit)} it never closes the
          * pull stream, so it is safe to call repeatedly while the pull is still running.
          *
+         * Public so that the shared docker mock in {@code DockerClientTestService} (a different package) can stub it.
+         *
          * @param timeout the maximum time to wait
          * @param unit    the unit of {@code timeout}
          * @return {@code true} if the pull finished within the given time
          * @throws InterruptedException if interrupted while waiting
          */
-        boolean awaitFinished(long timeout, TimeUnit unit) throws InterruptedException {
+        public boolean awaitFinished(long timeout, TimeUnit unit) throws InterruptedException {
             return pullFinished.await(timeout, unit);
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerService.java
@@ -532,9 +532,21 @@ public class BuildAgentDockerService {
             // timeout shorter than the poll interval is honoured just as precisely as a longer one.
             long nowNanos = System.nanoTime();
             long sliceNanos = Math.max(0, Math.min(pollIntervalNanos, Math.min(lastProgressAtNanos + stallNanos - nowNanos, deadlineNanos - nowNanos)));
-            if (callback.awaitFinished(sliceNanos, TimeUnit.NANOSECONDS)) {
-                callback.throwIfPullFailed();
-                return;
+            try {
+                if (callback.awaitFinished(sliceNanos, TimeUnit.NANOSECONDS)) {
+                    callback.throwIfPullFailed();
+                    return;
+                }
+            }
+            catch (InterruptedException e) {
+                try {
+                    callback.close();
+                }
+                catch (IOException closeException) {
+                    log.warn("Could not close the callback of the interrupted pull of docker image {}", imageName, closeException);
+                }
+                Thread.currentThread().interrupt();
+                throw e;
             }
             long progressCount = callback.progressCount();
             if (progressCount != lastProgressCount) {

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerService.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
@@ -90,8 +91,11 @@ public class BuildAgentDockerService {
 
     private static final Logger log = LoggerFactory.getLogger(BuildAgentDockerService.class);
 
-    /** How often a running pull is re-examined while waiting, short enough to notice a stall promptly. */
-    private static final int PULL_PROGRESS_POLL_INTERVAL_SECONDS = 5;
+    /**
+     * How often a running pull is re-examined while waiting, short enough to notice a stall promptly and long enough to
+     * keep the polling overhead negligible over a multi-minute pull. Not final so tests can shorten it.
+     */
+    private long pullProgressPollIntervalMillis = TimeUnit.SECONDS.toMillis(5);
 
     private final BuildAgentConfiguration buildAgentConfiguration;
 
@@ -292,6 +296,19 @@ public class BuildAgentDockerService {
         private final AtomicLong progressCount = new AtomicLong();
 
         /**
+         * Signals that the pull has finished, whether it completed or failed. Counted down from {@link #close()}, which
+         * docker-java invokes on both {@code onComplete} and {@code onError}.
+         * <p>
+         * The build thread waits on this rather than on {@link #awaitCompletion(long, java.util.concurrent.TimeUnit)}.
+         * That method is meant to be called once, after the pull has finished: on every call it runs {@code throwFirstError()}
+         * and closes the pull stream in its {@code finally} block. Calling it in a polling loop therefore both aborts a
+         * healthy pull after the first timed-out slice and, because a pull still in progress has no success response yet,
+         * throws {@code "Could not pull image"} the moment a slice elapses. This latch lets the wait be sliced for stall
+         * detection without triggering either.
+         */
+        private final CountDownLatch pullFinished = new CountDownLatch(1);
+
+        /**
          * How many updates the daemon has reported so far.
          *
          * @return the number of progress updates received for this pull
@@ -313,6 +330,41 @@ public class BuildAgentDockerService {
             String msg = "~~~~~~~~~~~~~~~~~~~~ Pull image complete ~~~~~~~~~~~~~~~~~~~~";
             log.debug(msg);
             super.onComplete();
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            }
+            finally {
+                pullFinished.countDown();
+            }
+        }
+
+        /**
+         * Waits up to the given time for the pull to finish, returning {@code true} once it has and {@code false} if the
+         * time elapsed first. Unlike {@link #awaitCompletion(long, java.util.concurrent.TimeUnit)} it never closes the
+         * pull stream, so it is safe to call repeatedly while the pull is still running.
+         *
+         * @param timeout the maximum time to wait
+         * @param unit    the unit of {@code timeout}
+         * @return {@code true} if the pull finished within the given time
+         * @throws InterruptedException if interrupted while waiting
+         */
+        boolean awaitFinished(long timeout, TimeUnit unit) throws InterruptedException {
+            return pullFinished.await(timeout, unit);
+        }
+
+        /**
+         * Re-throws a pull failure once the pull has finished, mirroring what
+         * {@link #awaitCompletion(long, java.util.concurrent.TimeUnit)} did through {@code throwFirstError()}: a pull that
+         * reported an error, or whose final response does not indicate success, fails the build rather than being treated
+         * as a successful pull. Must only be called after {@link #awaitFinished(long, java.util.concurrent.TimeUnit)}
+         * reported completion, so the final response is available.
+         */
+        void throwIfPullFailed() {
+            throwFirstError();
         }
     }
 
@@ -452,8 +504,12 @@ public class BuildAgentDockerService {
      * Waits for a Docker image pull to finish, aborting it once {@code artemis.continuous-integration.image-pull-timeout-seconds} has elapsed.
      * <p>
      * Without a timeout a pull that stops making progress, for example because a configured registry mirror silently drops packets, blocks the build thread forever.
-     * The timed {@code awaitCompletion} keeps the error handling of the untimed one: it still calls {@code throwFirstError()}, so a pull that fails rather than stalls
-     * propagates its exception exactly as before, and it closes the callback itself, so the stalled pull is aborted rather than left running in the background.
+     * <p>
+     * The wait must not be sliced with docker-java's {@code awaitCompletion(timeout, unit)}: that method is built to be called once, after the pull has finished, and on
+     * every call it runs {@code throwFirstError()} and closes the pull stream in its {@code finally} block. Used in a loop it aborts a healthy pull after the first
+     * timed-out slice and throws {@code "Could not pull image"} as soon as a slice elapses, because a pull still in progress has no success response yet. The wait is
+     * therefore sliced on the callback's own completion signal instead, and {@link MyPullImageResultCallback#throwIfPullFailed()} surfaces a genuine pull failure once the
+     * pull has actually finished, exactly as {@code awaitCompletion} used to.
      *
      * @param callback     the callback of the running pull command
      * @param imageName    the name of the Docker image being pulled
@@ -463,7 +519,7 @@ public class BuildAgentDockerService {
      * @throws LocalCIException     if the pull does not finish within the configured timeout
      */
     private void awaitPullCompletion(MyPullImageResultCallback callback, String imageName, BuildJobQueueItem buildJob, BuildLogsMap buildLogsMap) throws InterruptedException {
-        final long pollIntervalNanos = TimeUnit.SECONDS.toNanos(PULL_PROGRESS_POLL_INTERVAL_SECONDS);
+        final long pollIntervalNanos = TimeUnit.MILLISECONDS.toNanos(pullProgressPollIntervalMillis);
         final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(imagePullTimeoutSeconds);
         final long stallNanos = TimeUnit.SECONDS.toNanos(imagePullStallTimeoutSeconds);
         long lastProgressAtNanos = System.nanoTime();
@@ -474,7 +530,8 @@ public class BuildAgentDockerService {
             // timeout shorter than the poll interval is honoured just as precisely as a longer one.
             long nowNanos = System.nanoTime();
             long sliceNanos = Math.max(0, Math.min(pollIntervalNanos, Math.min(lastProgressAtNanos + stallNanos - nowNanos, deadlineNanos - nowNanos)));
-            if (callback.awaitCompletion(sliceNanos, TimeUnit.NANOSECONDS)) {
+            if (callback.awaitFinished(sliceNanos, TimeUnit.NANOSECONDS)) {
+                callback.throwIfPullFailed();
                 return;
             }
             long progressCount = callback.progressCount();

--- a/src/test/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
@@ -23,6 +24,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +46,7 @@ import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.exception.NotModifiedException;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Info;
+import com.github.dockerjava.api.model.PullResponseItem;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
 
@@ -92,7 +95,7 @@ class BuildAgentDockerServiceTest extends AbstractProgrammingIntegrationLocalCIL
         doReturn(defaultPullImageCmd).when(defaultPullImageCmd).withPlatform(anyString());
         BuildAgentDockerService.MyPullImageResultCallback defaultCallback = mock(BuildAgentDockerService.MyPullImageResultCallback.class);
         doReturn(defaultCallback).when(defaultPullImageCmd).exec(any(BuildAgentDockerService.MyPullImageResultCallback.class));
-        lenient().when(defaultCallback.awaitCompletion(anyLong(), any(TimeUnit.class))).thenReturn(true);
+        lenient().when(defaultCallback.awaitFinished(anyLong(), any(TimeUnit.class))).thenReturn(true);
     }
 
     @Test
@@ -166,9 +169,9 @@ class BuildAgentDockerServiceTest extends AbstractProgrammingIntegrationLocalCIL
     @Test
     void testPullDockerImageFailsFastWhenPullMakesNoProgress() throws InterruptedException, IOException {
         var build = mockPendingImagePull();
-        // A pull that is not getting through at all: the await never completes and the daemon reports nothing, so the
+        // A pull that is not getting through at all: it never finishes and the daemon reports nothing, so the
         // progress counter never moves.
-        when(pullImageCallback.awaitCompletion(anyLong(), any(TimeUnit.class))).thenReturn(false);
+        when(pullImageCallback.awaitFinished(anyLong(), any(TimeUnit.class))).thenReturn(false);
         when(pullImageCallback.progressCount()).thenReturn(0L);
         int originalStallTimeout = (int) ReflectionTestUtils.getField(buildAgentDockerService, "imagePullStallTimeoutSeconds");
         ReflectionTestUtils.setField(buildAgentDockerService, "imagePullStallTimeoutSeconds", 1);
@@ -194,7 +197,7 @@ class BuildAgentDockerServiceTest extends AbstractProgrammingIntegrationLocalCIL
     void testPullDockerImageFailsWhenAProgressingPullExceedsTheTotalTimeout() throws InterruptedException {
         var build = mockPendingImagePull();
         // A pull that keeps reporting progress but never arrives, so only the overall budget can stop it.
-        when(pullImageCallback.awaitCompletion(anyLong(), any(TimeUnit.class))).thenReturn(false);
+        when(pullImageCallback.awaitFinished(anyLong(), any(TimeUnit.class))).thenReturn(false);
         AtomicLong reportedProgress = new AtomicLong();
         when(pullImageCallback.progressCount()).thenAnswer(invocation -> reportedProgress.incrementAndGet());
         int originalTimeout = (int) ReflectionTestUtils.getField(buildAgentDockerService, "imagePullTimeoutSeconds");
@@ -214,6 +217,100 @@ class BuildAgentDockerServiceTest extends AbstractProgrammingIntegrationLocalCIL
     }
 
     @Test
+    void testProgressingPullThatOutlastsThePollIntervalIsNotAborted() throws Exception {
+        // Regression test: a healthy pull that keeps reporting progress and takes longer than a single poll interval must
+        // run to completion. Before the fix, awaitPullCompletion sliced the wait with docker-java's
+        // ResultCallbackTemplate.awaitCompletion(timeout, unit), which closes (aborts) the pull stream in its finally
+        // block on every call. The first timed-out slice therefore killed any pull longer than the poll interval, and the
+        // build failed with "Could not pull Docker image ...". This test drives a real callback, so it exercises that
+        // real docker-java behaviour rather than a mock.
+
+        // Shorten the slice so the pull only has to outlast a few tens of milliseconds instead of the 5s default.
+        long originalPollInterval = (long) ReflectionTestUtils.getField(buildAgentDockerService, "pullProgressPollIntervalMillis");
+        ReflectionTestUtils.setField(buildAgentDockerService, "pullProgressPollIntervalMillis", 20L);
+
+        AtomicBoolean pullCompleted = new AtomicBoolean(false);
+        AtomicBoolean streamClosed = new AtomicBoolean(false);
+        AtomicInteger inspectCount = new AtomicInteger();
+
+        InspectImageCmd inspectImageCmd = mock(InspectImageCmd.class);
+        doReturn(inspectImageCmd).when(dockerClient).inspectImageCmd(anyString());
+        InspectImageResponse pulledImage = new InspectImageResponse().withArch("amd64");
+        // The first two inspects miss, which is what drives the code into the pull. The inspect after the pull only finds
+        // the image if the pull was actually allowed to finish - a prematurely aborted pull leaves nothing behind, exactly
+        // as on a real daemon.
+        doAnswer(invocation -> {
+            if (inspectCount.incrementAndGet() <= 2) {
+                throw new NotFoundException("");
+            }
+            if (pullCompleted.get()) {
+                return pulledImage;
+            }
+            throw new NotFoundException("");
+        }).when(inspectImageCmd).exec();
+
+        var realCallback = new BuildAgentDockerService.MyPullImageResultCallback();
+        PullImageCmd pullImageCmd = mock(PullImageCmd.class);
+        doReturn(pullImageCmd).when(dockerClient).pullImageCmd(anyString());
+        doReturn(pullImageCmd).when(pullImageCmd).withPlatform(anyString());
+
+        Thread pullFeeder = new Thread(() -> {
+            try {
+                // Report progress for longer than one poll interval, then finish successfully.
+                for (int i = 0; i < 8 && !streamClosed.get(); i++) {
+                    realCallback.onNext(progressItem("Downloading layer " + i));
+                    Thread.sleep(15);
+                }
+                if (!streamClosed.get()) {
+                    realCallback.onNext(progressItem("Status: Downloaded newer image for test-image-name"));
+                    pullCompleted.set(true);
+                    realCallback.onComplete();
+                }
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }, "test-pull-feeder");
+
+        doAnswer(invocation -> {
+            // Mirror the real daemon: the pull starts on exec and reports back through the callback. onStart wires the
+            // stream docker-java closes on abort, so the feeder can tell when the pull was cut short.
+            realCallback.onStart(() -> streamClosed.set(true));
+            pullFeeder.start();
+            return realCallback;
+        }).when(pullImageCmd).exec(any(BuildAgentDockerService.MyPullImageResultCallback.class));
+
+        BuildConfig buildConfig = new BuildConfig("echo 'test'", "test-image-name", "test", "test", "test", "test", null, null, false, false, null, 0, null, null, null, null);
+        BuildAgentDTO buildAgent = new BuildAgentDTO("buildagent1", "address1", "buildagent1");
+        var build = new BuildJobQueueItem("progressing-pull-job", "job1", buildAgent, 1, 1, 1, 1, 1, BuildStatus.SUCCESSFUL, null, null, buildConfig, null);
+
+        try {
+            buildAgentDockerService.pullDockerImage(build, buildLogsMap);
+
+            assertThat(pullCompleted).as("the pull was allowed to run to completion instead of being aborted mid-pull").isTrue();
+            assertThat(buildAgentDockerService.isImagePullInProgress(build.id())).isFalse();
+        }
+        finally {
+            pullFeeder.interrupt();
+            pullFeeder.join(1000);
+            ReflectionTestUtils.setField(buildAgentDockerService, "pullProgressPollIntervalMillis", originalPollInterval);
+            buildLogsMap.removeBuildLogs(build.id());
+        }
+    }
+
+    /**
+     * Builds a pull response item carrying the given status, the way the Docker daemon reports pull progress.
+     *
+     * @param status the status line, e.g. a layer download step or the final success message
+     * @return a pull response item with that status
+     */
+    private static PullResponseItem progressItem(String status) {
+        PullResponseItem item = new PullResponseItem();
+        ReflectionTestUtils.setField(item, "status", status);
+        return item;
+    }
+
+    @Test
     void testNonPositivePullStallTimeoutIsRejectedAtStartup() {
         int originalStallTimeout = (int) ReflectionTestUtils.getField(buildAgentDockerService, "imagePullStallTimeoutSeconds");
         try {
@@ -230,7 +327,7 @@ class BuildAgentDockerServiceTest extends AbstractProgrammingIntegrationLocalCIL
     void testImagePullIsVisibleWhileItIsRunning() throws InterruptedException {
         var build = mockPendingImagePull();
         AtomicBoolean pullInProgressDuringPull = new AtomicBoolean(false);
-        when(pullImageCallback.awaitCompletion(anyLong(), any(TimeUnit.class))).thenAnswer(invocation -> {
+        when(pullImageCallback.awaitFinished(anyLong(), any(TimeUnit.class))).thenAnswer(invocation -> {
             pullInProgressDuringPull.set(buildAgentDockerService.isImagePullInProgress(build.id()));
             return true;
         });

--- a/src/test/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerServiceTest.java
@@ -217,6 +217,25 @@ class BuildAgentDockerServiceTest extends AbstractProgrammingIntegrationLocalCIL
     }
 
     @Test
+    void testPullDockerImageClosesCallbackAndRestoresInterruptStatusWhenInterrupted() throws InterruptedException, IOException {
+        var build = mockPendingImagePull();
+        doThrow(new InterruptedException()).when(pullImageCallback).awaitFinished(anyLong(), any(TimeUnit.class));
+
+        try {
+            assertThatThrownBy(() -> buildAgentDockerService.pullDockerImage(build, buildLogsMap)).isInstanceOf(LocalCIException.class).rootCause()
+                    .isInstanceOf(InterruptedException.class);
+
+            verify(pullImageCallback).close();
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            assertThat(buildAgentDockerService.isImagePullInProgress(build.id())).isFalse();
+        }
+        finally {
+            Thread.interrupted();
+            buildLogsMap.removeBuildLogs(build.id());
+        }
+    }
+
+    @Test
     void testProgressingPullThatOutlastsThePollIntervalIsNotAborted() throws Exception {
         // Regression test: a healthy pull that keeps reporting progress and takes longer than a single poll interval must
         // run to completion. Before the fix, awaitPullCompletion sliced the wait with docker-java's

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/DockerClientTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/DockerClientTestService.java
@@ -91,9 +91,9 @@ public class DockerClientTestService {
         when(pullImageCmd.withPlatform(anyString())).thenReturn(pullImageCmd);
         BuildAgentDockerService.MyPullImageResultCallback callback1 = mock(BuildAgentDockerService.MyPullImageResultCallback.class);
         when(pullImageCmd.exec(any(BuildAgentDockerService.MyPullImageResultCallback.class))).thenReturn(callback1);
-        // The production code waits with an explicit timeout, so the timed variant has to report that the pull finished. Without this stub Mockito returns false, which
-        // the production code correctly interprets as a pull timeout.
-        when(callback1.awaitCompletion(anyLong(), any(TimeUnit.class))).thenReturn(true);
+        // The production code waits in slices on the callback's own completion signal, so this has to report that the pull finished. Without the stub Mockito returns
+        // false, which the production code correctly interprets as a pull that never completes and aborts once the stall timeout elapses.
+        when(callback1.awaitFinished(anyLong(), any(TimeUnit.class))).thenReturn(true);
 
         String dummyContainerId = "1234567890";
 


### PR DESCRIPTION
### Summary

Since the 9.9 release (2026-08-13), roughly 5% of build jobs fail with `Could not pull Docker image <image>`, exactly one poll interval (5 s) after the pull starts and only on cold pulls. The build agent sliced the wait for a running image pull with docker-java's timed `awaitCompletion(timeout, unit)`, which is meant to be called once after completion: on every call it runs `throwFirstError()` and closes the pull stream in its `finally` block. The first timed-out slice therefore threw `Could not pull image` and aborted any pull longer than the poll interval. This PR waits on the callback's own completion latch instead, so a healthy, still-progressing pull is no longer killed.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context

Introduced by #13311 ("Stop cancelling build jobs during docker image pulls") and shipped in release 9.9 (published 2026-08-13), which matches when the failures began. Around 5% of build jobs — the cold-pull fraction — fail with:

```
Could not pull Docker image <image>
LocalCIException: Error while pulling docker image <image>
  ... DockerClientException: Could not pull image: <last pull progress line>
  at BuildAgentDockerService.awaitPullCompletion(...)
```

The failure lands exactly one poll interval (5 s) after the pull begins, and only when the image is not already cached on the agent — hence a steady ~5% rather than all jobs.

**Root cause:** `awaitPullCompletion` slices the wait for the pull with docker-java's timed `ResultCallbackTemplate.awaitCompletion(timeout, unit)`. That method is designed to be called once, after the pull has finished. On every call it (1) runs `throwFirstError()` — overridden by `PullImageResultCallback` to throw `DockerClientException("Could not pull image: …")` whenever the latest response is not a success, which a still-running pull never is — and (2) closes the pull stream in its `finally` block. So the first 5 s slice on a cold pull both throws and aborts the download. Any pull slower than the poll interval is killed.

The original tests missed this because they all mock `MyPullImageResultCallback.awaitCompletion(...)`, so the real docker-java behaviour was never exercised.

### Description

- `MyPullImageResultCallback` gains a `CountDownLatch pullFinished`, counted down from an overridden `close()` (docker-java calls `close()` on both `onComplete` and `onError`).
- New `awaitFinished(timeout, unit)` waits on that latch and **never** closes the pull stream, so it is safe to call repeatedly for stall detection.
- New `throwIfPullFailed()` runs `throwFirstError()` **once, after the pull has actually finished**, preserving the previous error handling: a pull that errors, or whose final response is not a success, still fails the build.
- `awaitPullCompletion` now waits via `awaitFinished` and calls `throwIfPullFailed()` only on completion. The stall / total-timeout abort logic is unchanged; it still explicitly `close()`s the stream only when it genuinely decides to abort.
- The poll interval became a settable field (`pullProgressPollIntervalMillis`) so the regression test can shorten it. No configuration or API changes; `image-pull-timeout-seconds` / `image-pull-stall-timeout-seconds` behaviour is preserved.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Programming Exercise
- A build agent (integrated LocalVC/LocalCI) whose local Docker cache does **not** contain the exercise image

1. Ensure the exercise's Docker image is not present on the build agent (fresh agent, or `docker rmi <image>`), and pick an image whose cold pull takes longer than 5 seconds.
2. Trigger a build (student submission or "Trigger all").
3. Before the fix: the build fails after ~5 s with "Could not pull Docker image". After the fix: the image pulls to completion and the build runs normally.
4. Re-trigger a build once the image is cached to confirm the fast path (inspect hit, no pull) is unaffected.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| BuildAgentDockerService.java | 71.79% | 466 |

_Last updated: 2026-08-21 16:19:25 UTC_


### Screenshots

Not applicable — server-only change, no UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image pull monitoring to prevent active pulls from being interrupted during progress.
  * Added configurable polling intervals while preserving stall and overall timeout handling.
  * Improved reporting of pull completion and failures.
  * Improved cleanup and interruption handling for interrupted image pulls.

* **Tests**
  * Added regression coverage for image pulls that continue progressing beyond a polling interval.
  * Updated pull-related tests to reflect the improved completion handling and interruption behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->