### PR TITLE
`Development`: Update Spring Boot, Framework, Security and Cloud to the latest releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -501,8 +501,8 @@ dependencies {
     // spring-cloud-dependencies BOM does not publish versions for these specific modules.
     // 2025.1.2 introduces Spring Boot 4.1.0 compatibility; the 2025.1.1 verifier rejected 4.1.0 and shut the app down.
     implementation "org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:5.0.2"
-    implementation "org.springframework.cloud:spring-cloud-starter-config:5.0.4"
-    implementation "org.springframework.cloud:spring-cloud-commons:5.0.2"
+    implementation "org.springframework.cloud:spring-cloud-starter-config:5.0.5"
+    implementation "org.springframework.cloud:spring-cloud-commons:5.0.3"
 
     // required by the Websocket Broker Connection in WebsocketConfiguration (due to multi node setup support).
     // Version managed by the Spring Boot BOM.
@@ -565,7 +565,10 @@ dependencies {
 
     // required by sshd-git; pinned to a patched release addressing GHSA-4jwv-qpf8-5w8v, GHSA-6w4m-2xhg-2658, GHSA-fwcp-hj66-p6g3
     implementation "org.bouncycastle:bcpkix-jdk18on:1.85"
-    implementation "org.bouncycastle:bcprov-jdk18on:1.85"
+    // 1.85.2 is a provider-only patch (AES CBC-256 via the id_aes256_CBC OID silently derived a 192-bit key,
+    // bc-java #2390) with no bcpkix/bcpg/bcutil counterpart; spring-cloud-starter 5.0.3 asks for it too. See the
+    // org.bouncycastle entry in gradle/dependency-families.gradle for why the family guard accepts the odd one out.
+    implementation "org.bouncycastle:bcprov-jdk18on:1.85.2"
     // pulled transitively by sshd-git; pin to patched version
     implementation "org.bouncycastle:bcpg-jdk18on:1.85"
 

--- a/build.gradle
+++ b/build.gradle
@@ -497,9 +497,11 @@ dependencies {
     implementation "org.springframework.data:spring-data-ldap"
     implementation "org.springframework.ldap:spring-ldap-core"
 
-    // Spring Cloud 2025.1.2 (Oakwood) — individual module versions are pinned because the
-    // spring-cloud-dependencies BOM does not publish versions for these specific modules.
-    // 2025.1.2 introduces Spring Boot 4.1.0 compatibility; the 2025.1.1 verifier rejected 4.1.0 and shut the app down.
+    // Spring Cloud (Oakwood 2025.1.x; the exact train is spring_cloud_version in gradle.properties) —
+    // these individual module versions are pinned because the spring-cloud-dependencies BOM does not
+    // publish versions for them. The train's compatibility verifier accepts Spring Boot 4.0.x and 4.1.x;
+    // do not drop below 2025.1.2, because 2025.1.1 rejected Boot 4.1.0 and shut the app down at startup.
+    // eureka-client trails the other two: spring-cloud-netflix was not re-released in 2025.1.3.
     implementation "org.springframework.cloud:spring-cloud-starter-netflix-eureka-client:5.0.2"
     implementation "org.springframework.cloud:spring-cloud-starter-config:5.0.5"
     implementation "org.springframework.cloud:spring-cloud-commons:5.0.3"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,8 @@ node_version=24.18.0
 pnpm_version=11.22.0
 
 # Dependency versions
-spring_boot_version=4.1.0
-spring_cloud_version=2025.1.2
+spring_boot_version=4.1.1
+spring_cloud_version=2025.1.3
 opensaml_version=5.2.3
 jwt_version=0.13.0
 jaxb_runtime_version=4.0.9

--- a/gradle/dependency-families.gradle
+++ b/gradle/dependency-families.gradle
@@ -30,6 +30,21 @@ def watchedFamilies = [
 ]
 
 /**
+ * Families that ship an out-of-band patch for a single module, where the vendor's compatibility contract is the
+ * leading version segments rather than the whole version string. Keyed by Maven group, valued by the number of
+ * leading numeric segments that Rule A requires to agree. A family absent here must match on the full version.
+ *
+ * org.bouncycastle: BC releases its modules together as `1.<release>` and occasionally patches one of them on top
+ * of that release. bcprov-jdk18on 1.85.2 is such a patch - it fixes AES CBC-256 obtained via the id_aes256_CBC OID
+ * silently deriving a 192-bit key (bc-java #2390) - and has no bcpkix/bcpg/bcutil counterpart, so 1.85.2 sitting
+ * beside 1.85 siblings is the shape BC ships rather than the mismatch this task guards against. Two agreeing
+ * segments still reject the incident recorded above, where bcprov moved to 1.85 and its siblings stayed on 1.84.
+ */
+def familyVersionPrecision = [
+    'org.bouncycastle': 2,
+]
+
+/**
  * Splits a version into its leading numeric segments and the qualifier that follows, e.g.
  * `4.2.17.Final` -> [[4, 2, 17], 'Final'] and `7.7.1.202607240634-r` -> [[7, 7, 1, 202607240634], 'r'].
  *
@@ -112,6 +127,22 @@ static int qualifierLevel(String qualifier) {
 }
 
 /**
+ * The first {@code segments} numeric segments of a version, e.g. `versionLine('1.85.2', 2)` -> `1.85`. Used by Rule A
+ * to compare members of a family that patches single modules out of band (see {@code familyVersionPrecision}).
+ * A version with fewer segments is returned as-is, so `1.85` and `1.85.2` share the line `1.85`.
+ *
+ * Truncation drops any qualifier along with the trailing segments, so this must only be used for families whose
+ * members are all final releases - which is what {@code familyVersionPrecision} opts in one group at a time.
+ */
+static String versionLine(String version, int segments) {
+    List numeric = parseVersion(version)[0] as List
+    if (numeric.size() <= segments) {
+        return version
+    }
+    return numeric[0..<segments].join('.')
+}
+
+/**
  * Self-check for {@link #compareVersions}. The comparator is the only place this task can be silently wrong - a bad
  * ordering either fails a clean build or waves through the very mismatch the task exists to catch - and there is no
  * Groovy test harness in this repository, so it verifies itself before being trusted.
@@ -143,6 +174,16 @@ static void verifyVersionComparator() {
         if (compareVersions(pair[0], pair[1]) != 0) {
             throw new GradleException("Version comparator is broken: expected ${pair[0]} == ${pair[1]}.")
         }
+    }
+    // versionLine underpins Rule A for families that patch single modules out of band, so it is checked here too:
+    // a provider-only patch must share its siblings' line, and a genuine release difference must not.
+    [['1.85.2', 2, '1.85'], ['1.85', 2, '1.85'], ['1.84', 2, '1.84'], ['7.7.1.202607240634-r', 2, '7.7']].each { c ->
+        if (versionLine(c[0], c[1]) != c[2]) {
+            throw new GradleException("versionLine is broken: expected versionLine(${c[0]}, ${c[1]}) == ${c[2]}, got ${versionLine(c[0], c[1])}.")
+        }
+    }
+    if (versionLine('1.85.2', 2) == versionLine('1.84', 2)) {
+        throw new GradleException('versionLine is broken: 1.85.2 and 1.84 must not share a line.')
     }
     // A service pack outranks the release it patches, and a release outranks a pre-release even when aliased.
     [['1.0', '1.0-sp1'], ['1.0-rc1', '1.0-sp1'], ['1.0-rc1', '1.0.Final']].each { pair ->
@@ -197,9 +238,10 @@ tasks.register('verifyDependencyFamilies') {
         }
         walk(resolutionResult.get())
 
-        // Rule A: one version per family.
+        // Rule A: one version per family, compared at the family's declared precision.
         selectedByGroup.each { group, modules ->
-            def versions = modules.values().toSet()
+            def precision = familyVersionPrecision[group]
+            def versions = modules.values().collect { precision ? versionLine(it, precision) : it }.toSet()
             if (versions.size() > 1) {
                 def detail = modules.sort().collect { name, version -> "    ${group}:${name}:${version}" }.join('\n')
                 problems << "Family '${group}' resolves to mixed versions ${versions.sort()}. Its modules are built and released together and must share one version:\n${detail}"


### PR DESCRIPTION
### Summary
Moves the Spring stack to its current releases. Spring Boot 4.1.0 → 4.1.1 carries Spring Framework 7.0.8 → 7.0.9 and Spring Security 7.1.0 → 7.1.1 through the Boot BOM, and Spring Cloud 2025.1.2 → 2025.1.3 brings the Cloud modules that the BOM does not version for us. All four are patch releases within the majors Artemis already runs, so there is no API surface to migrate.

One change is not a version number. Spring Cloud 5.0.3 asks for `bcprov-jdk18on` 1.85.2, a provider-only Bouncy Castle patch that `verifyDependencyFamilies` rejected because its siblings have no 1.85.2 counterpart. The task now compares Bouncy Castle at two segments instead of the full version string, which is BC's own compatibility contract, and the pin takes the patch.

### Checklist
#### General
- [x] This is a small change that I verified locally (build, style, architecture tests, and the crypto-adjacent integration tests listed below). It still needs a reviewer to confirm it on a test server.
- [x] I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).

### Motivation and Context
Keeping the Spring stack current is how security fixes reach Artemis. This round matters more than usual: `bcprov-jdk18on` 1.85.2 fixes AES CBC-256 obtained via the `id_aes256_CBC` OID silently deriving a **192-bit key** instead of 256 ([bc-java#2390](https://github.com/bcgit/bc-java/issues/2390)), and Bouncy Castle is on the classpath for the SSH server, SAML2, and passkeys.

### Description
**Versions**

| Dependency | Before | After | How |
|---|---|---|---|
| Spring Boot | 4.1.0 | 4.1.1 | `spring_boot_version` |
| Spring Framework | 7.0.8 | 7.0.9 | via the Boot BOM |
| Spring Security | 7.1.0 | 7.1.1 | via the Boot BOM |
| Spring Cloud | 2025.1.2 | 2025.1.3 | `spring_cloud_version` |
| `spring-cloud-starter-config` | 5.0.4 | 5.0.5 | explicit (not in the BOM) |
| `spring-cloud-commons` | 5.0.2 | 5.0.3 | explicit (not in the BOM) |
| `bcprov-jdk18on` | 1.85 | 1.85.2 | explicit |

`spring-cloud-starter-netflix-eureka-client` stays on 5.0.2 — spring-cloud-netflix was not re-released in 2025.1.3. Boot 4.1.1 also pulls Hibernate 7.4.1 → 7.4.5, Tomcat 11.0.22 → 11.0.24, Jackson 3.1.4 → 3.1.5, Spring Data 2026.0.0 → 2026.0.1 and Micrometer 1.17.0 → 1.17.1 through the BOM. Spring Cloud 2025.1.3's compatibility verifier accepts `4.0.x` and `4.1.x`, so Boot 4.1.1 is in range.

**Why the dependency-family guard had to change**

`verifyDependencyFamilies` enforces that every module of a watched family resolves to one version, because a split family is a runtime `LinkageError` rather than a build failure. Bouncy Castle publishes `bcprov` 1.85.2 with **no** matching `bcpkix`/`bcpg`/`bcutil` release, so "one version" read literally makes the patch unadoptable.

The task now takes a per-family precision — `org.bouncycastle: 2` — so Rule A compares `1.85` against `1.85`, while a genuine release split still fails. Verified both ways locally:

```
# with the patch adopted
Dependency families verified: 5 families, all consistent.

# with bcpkix knocked back to 1.84, the shape the guard exists to catch
Family 'org.bouncycastle' resolves to mixed versions [1.84, 1.85] ...
  org.bouncycastle:bcpg-jdk18on:1.85
  org.bouncycastle:bcpkix-jdk18on:1.84
  org.bouncycastle:bcprov-jdk18on:1.85.2
  org.bouncycastle:bcutil-jdk18on:1.85
```

Rule B is untouched and still compares exact versions. The new `versionLine` helper is covered by the file's existing self-check, which runs before every verification.

### Steps for Testing
This is a dependency bump with no functional change; CI is the test. Locally verified on this branch:

```
./gradlew compileJava compileTestJava -x webapp        # BUILD SUCCESSFUL
./gradlew verifyDependencyFamilies -x webapp           # 5 families, all consistent
./gradlew spotlessCheck                                # BUILD SUCCESSFUL
./gradlew checkstyleMain -x webapp                     # BUILD SUCCESSFUL
./gradlew test -DincludeTags='ArchitectureTest' -x webapp   # BUILD SUCCESSFUL
```

Plus the crypto-adjacent integration tests, since Bouncy Castle and Spring Security SAML2 both moved: `LocalVCSshIntegrationTest`, `BuildAgentSshAuthenticationIntegrationTest`, `UserSaml2IntegrationTest`, `PasskeySaml2IntegrationTest`, `PasskeyIntegrationTest`, `Lti13LaunchIntegrationTest`, `Lti13InitiationIntegrationTest`, `OAuth2JWKSIntegrationTest`, `SshFingerprintsProviderIntegrationTest`.

Reviewers may want to confirm on a test server that the app registers with Eureka and forms a single Hazelcast cluster, since `spring-cloud-commons` moved.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependency Updates**
  * Updated Spring Boot and Spring Cloud components to newer patch releases.
  * Updated the Bouncy Castle security provider to version 1.85.2.

* **Build Improvements**
  * Improved handling of compatible patch-level dependency versions.
  * Added validation to ensure dependency version matching remains consistent across supported libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->