### PR TITLE
`Communication`: Fix the member search of course-wide channels

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/account/repository/UserRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/repository/UserRepository.java
@@ -420,7 +420,7 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
     }
 
     @Query("""
-            SELECT DISTINCT user.id
+            SELECT user.id
             FROM User user
                 JOIN ConversationParticipant cp ON cp.user.id = user.id AND cp.conversation.id = :conversationId
                 JOIN UserCourseRole ucr ON ucr.user.id = user.id AND ucr.course.id = :courseId AND ucr.role IN :roles
@@ -430,7 +430,8 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
                     OR user.login LIKE :#{#loginOrName}%
                     OR CONCAT(user.firstName, ' ', user.lastName) LIKE %:#{#loginOrName}%
                 )
-            ORDER BY user.id ASC
+            GROUP BY user.id, user.firstName, user.lastName
+            ORDER BY user.firstName, user.lastName, user.id
             """)
     List<Long> findUserIdsByLoginOrNameInConversationWithCourseRoles(@Param("loginOrName") String loginOrName, @Param("conversationId") long conversationId,
             @Param("courseId") long courseId, @Param("roles") Set<CourseRole> roles, Pageable pageable);
@@ -462,10 +463,7 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
      * @return a paginated list of {@link User} entities matching the search criteria. If no entities are found, returns an empty page.
      */
     default Page<User> searchAllWithCourseRolesByLoginOrNameInConversation(Pageable pageable, String loginOrName, long conversationId, long courseId, Set<CourseRole> roles) {
-        // Use an unsorted pageable for the ID lookup: SELECT DISTINCT user.id cannot ORDER BY firstName/lastName (not in SELECT)
-        // The final result ordering is applied by findUsersByIdsWithCourseRolesOrdered.
-        Pageable unsortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        List<Long> ids = findUserIdsByLoginOrNameInConversationWithCourseRoles(loginOrName, conversationId, courseId, roles, unsortedPageable);
+        List<Long> ids = findUserIdsByLoginOrNameInConversationWithCourseRoles(loginOrName, conversationId, courseId, roles, withoutSort(pageable));
         if (ids.isEmpty()) {
             return Page.empty(pageable);
         }
@@ -725,6 +723,24 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
     }
 
     /**
+     * Strips the caller's sort from a pageable that is about to be handed to one of the id-only lookup queries below.
+     * <p>
+     * Those queries select {@code user.id} and group by the name columns, so they carry their own deterministic
+     * {@code ORDER BY user.firstName, user.lastName, user.id}. A sort appended from the request would either duplicate
+     * that ordering or, for any column outside the grouping, make the statement invalid. The page content is ordered by
+     * {@link #findUsersByIdsWithCourseRolesOrdered(List)} anyway, so no caller-visible ordering is lost.
+     *
+     * @param pageable the pagination information supplied by the caller
+     * @return the same pagination window without any sort
+     */
+    private static Pageable withoutSort(Pageable pageable) {
+        if (pageable.isUnpaged()) {
+            return Pageable.unpaged();
+        }
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+    }
+
+    /**
      * Find all users by their logins with their organizations eagerly loaded.
      *
      * @param logins the logins to look up
@@ -734,7 +750,7 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
     List<User> findAllByLoginsWithOrganizations(@Param("logins") Collection<String> logins);
 
     @Query("""
-            SELECT DISTINCT user.id
+            SELECT user.id
             FROM User user
             JOIN UserCourseRole ucr ON ucr.user.id = user.id AND ucr.course.id = :courseId
             WHERE user.deleted = FALSE
@@ -742,6 +758,8 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
                     user.login LIKE :#{#loginOrName}%
                     OR CONCAT(user.firstName, ' ', user.lastName) LIKE %:#{#loginOrName}%
                 )
+            GROUP BY user.id, user.firstName, user.lastName
+            ORDER BY user.firstName, user.lastName, user.id
             """)
     List<Long> findUserIdsByLoginOrNameInCourse(@Param("loginOrName") String loginOrName, @Param("courseId") long courseId, Pageable pageable);
 
@@ -767,7 +785,7 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
      * @return a paginated list of {@link User} entities matching the search criteria. If no entities are found, returns an empty page.
      */
     default Page<User> searchAllWithCourseRolesByLoginOrNameInCourseAndReturnPage(Pageable pageable, String loginOrName, long courseId) {
-        List<Long> userIds = findUserIdsByLoginOrNameInCourse(loginOrName, courseId, pageable);
+        List<Long> userIds = findUserIdsByLoginOrNameInCourse(loginOrName, courseId, withoutSort(pageable));
         if (userIds.isEmpty()) {
             return new PageImpl<>(List.of(), pageable, 0);
         }
@@ -777,7 +795,7 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
     }
 
     @Query("""
-            SELECT DISTINCT user.id
+            SELECT user.id
             FROM User user
             JOIN UserCourseRole ucr ON ucr.user.id = user.id
                 AND ucr.course.id = :courseId
@@ -787,6 +805,8 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
                     user.login LIKE %:loginOrName%
                     OR CONCAT(user.firstName, ' ', user.lastName) LIKE %:loginOrName%
                 )
+            GROUP BY user.id, user.firstName, user.lastName
+            ORDER BY user.firstName, user.lastName, user.id
             """)
     List<Long> findUserIdsByLoginOrNameInCourseWithRoles(@Param("loginOrName") String loginOrName, @Param("courseId") long courseId, @Param("roles") Set<CourseRole> roles,
             Pageable pageable);
@@ -815,7 +835,7 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
      * @return a paginated list of matching {@link User} entities, or an empty page if none found
      */
     default Page<User> searchAllWithCourseRolesByLoginOrNameInCourse(Pageable pageable, String loginOrName, long courseId, Set<CourseRole> roles) {
-        List<Long> ids = findUserIdsByLoginOrNameInCourseWithRoles(loginOrName, courseId, roles, pageable);
+        List<Long> ids = findUserIdsByLoginOrNameInCourseWithRoles(loginOrName, courseId, roles, withoutSort(pageable));
         if (ids.isEmpty()) {
             return Page.empty(pageable);
         }
@@ -834,7 +854,7 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
      * @return a paginated list of matching users as {@link UserDTO}, or an empty page if none found
      */
     default Page<UserDTO> searchUsersByLoginOrNameInCourseWithRolesAndConvertToDTO(Pageable pageable, String loginOrName, long courseId, Set<CourseRole> roles) {
-        List<Long> ids = findUserIdsByLoginOrNameInCourseWithRoles(loginOrName, courseId, roles, pageable);
+        List<Long> ids = findUserIdsByLoginOrNameInCourseWithRoles(loginOrName, courseId, roles, withoutSort(pageable));
         if (ids.isEmpty()) {
             return Page.empty(pageable);
         }
@@ -846,7 +866,7 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
     // --- courseRoles-based search variants ---
 
     @Query("""
-            SELECT DISTINCT user.id
+            SELECT user.id
             FROM User user
             JOIN UserCourseRole ucr ON ucr.user.id = user.id
                 AND ucr.course.id = :courseId
@@ -857,6 +877,8 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
                     user.login LIKE %:loginOrName%
                     OR CONCAT(user.firstName, ' ', user.lastName) LIKE %:loginOrName%
                 )
+            GROUP BY user.id, user.firstName, user.lastName
+            ORDER BY user.firstName, user.lastName, user.id
             """)
     List<Long> findUserIdsByLoginOrNameInCourseWithRolesNotUserId(@Param("loginOrName") String loginOrName, @Param("courseId") long courseId, @Param("roles") Set<CourseRole> roles,
             @Param("idOfUser") long idOfUser, Pageable pageable);
@@ -882,7 +904,7 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
             FROM User user
                 LEFT JOIN FETCH user.courseRoles
             WHERE user.id IN :ids
-            ORDER BY user.firstName, user.lastName
+            ORDER BY user.firstName, user.lastName, user.id
             """)
     List<User> findUsersByIdsWithCourseRolesOrdered(@Param("ids") List<Long> ids);
 
@@ -898,7 +920,7 @@ public interface UserRepository extends ArtemisJpaRepository<User, Long>, JpaSpe
      * @return a paginated list of {@link User} entities matching the search criteria. If no entities are found, returns an empty page.
      */
     default Page<User> searchAllWithCourseRolesByLoginOrNameInCourseNotUserId(Pageable pageable, String loginOrName, long courseId, Set<CourseRole> roles, long idOfUser) {
-        List<Long> ids = findUserIdsByLoginOrNameInCourseWithRolesNotUserId(loginOrName, courseId, roles, idOfUser, pageable);
+        List<Long> ids = findUserIdsByLoginOrNameInCourseWithRolesNotUserId(loginOrName, courseId, roles, idOfUser, withoutSort(pageable));
         if (ids.isEmpty()) {
             return Page.empty(pageable);
         }

--- a/src/test/java/de/tum/cit/aet/artemis/communication/ConversationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/ConversationIntegrationTest.java
@@ -5,6 +5,8 @@ import static org.awaitility.Awaitility.await;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -31,6 +33,7 @@ import de.tum.cit.aet.artemis.communication.dto.GroupChatDTO;
 import de.tum.cit.aet.artemis.communication.dto.OneToOneChatDTO;
 import de.tum.cit.aet.artemis.communication.dto.ResponsibleUserDTO;
 import de.tum.cit.aet.artemis.communication.util.ConversationUtilService;
+import de.tum.cit.aet.artemis.core.domain.CourseRole;
 import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.course.domain.CourseInformationSharingConfiguration;
 import de.tum.cit.aet.artemis.exam.domain.Exam;
@@ -536,6 +539,58 @@ class ConversationIntegrationTest extends AbstractConversationTest {
 
         // cleanup
         conversationRepository.deleteById(channel.getId());
+    }
+
+    /**
+     * Course-wide channels resolve their members over user_course_role instead of the conversation participants, which
+     * used to run an id-only lookup that PostgreSQL rejected as soon as the client asked for a name sort
+     * ("for SELECT DISTINCT, ORDER BY expressions must appear in select list"). The client always sends
+     * {@code sort=firstName,asc&sort=lastName,asc}, so every member dialog of a course-wide channel answered 500.
+     */
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void searchMembersOfCourseWideChannel_withNameSort_shouldPaginateInStableNameOrder() throws Exception {
+        var channel = createCourseWideChannel(TEST_PREFIX + "coursewide-members");
+        // A second course role for the same user makes the underlying join fan out, which is what the de-duplication in
+        // the member lookup has to absorb. Without it the pagination assertions below would pass even on a broken query.
+        userUtilService.enrollUserInCourse(userUtilService.getUserByLogin(testPrefix + "tutor1"), exampleCourse, CourseRole.EDITOR);
+
+        var allMembers = searchCourseWideChannelMembers(channel.getId(), 0, 20, null);
+        assertThat(allMembers).hasSizeGreaterThan(2);
+        assertThat(allMembers).extracting(ConversationUserDTO::getId).doesNotHaveDuplicates();
+        assertThat(allMembers).isSortedAccordingTo(
+                Comparator.comparing(ConversationUserDTO::getFirstName).thenComparing(ConversationUserDTO::getLastName).thenComparing(ConversationUserDTO::getId));
+
+        // Paging with a window smaller than the result set must partition that same list: no repeats, no gaps and no
+        // reshuffling between pages.
+        var pagedMembers = new ArrayList<ConversationUserDTO>();
+        for (int page = 0; page * 2 < allMembers.size(); page++) {
+            pagedMembers.addAll(searchCourseWideChannelMembers(channel.getId(), page, 2, null));
+        }
+        assertThat(pagedMembers).extracting(ConversationUserDTO::getId).containsExactlyElementsOf(allMembers.stream().map(ConversationUserDTO::getId).toList());
+
+        // The role-filtered variant runs a separate id-only query and regressed in exactly the same way.
+        var tutors = searchCourseWideChannelMembers(channel.getId(), 0, 20, "TUTOR");
+        assertThat(tutors).extracting(ConversationUserDTO::getId).doesNotHaveDuplicates();
+        assertThat(tutors).extracting(ConversationUserDTO::getLogin).contains(testPrefix + "tutor1");
+
+        // cleanup
+        conversationRepository.deleteById(channel.getId());
+    }
+
+    private List<ConversationUserDTO> searchCourseWideChannelMembers(Long channelId, int page, int size, String filter) throws Exception {
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("loginOrName", "");
+        // The exact sort the client sends; it is the trigger for the regression this test guards.
+        params.add("sort", "firstName,asc");
+        params.add("sort", "lastName,asc");
+        params.add("page", String.valueOf(page));
+        params.add("size", String.valueOf(size));
+        if (filter != null) {
+            params.add("filter", filter);
+        }
+        return request.getList("/api/communication/courses/" + exampleCourseId + "/conversations/" + channelId + "/members/search", HttpStatus.OK, ConversationUserDTO.class,
+                params);
     }
 
     @Test


### PR DESCRIPTION
### Summary
The members dialog of every course-wide channel answers HTTP 500 and renders an empty list with an "Internal server error" toast, although the channel header still reports the correct member count. This PR fixes the underlying query defect and adds a regression test that reproduces the failure.

### Motivation and Context
`GET /api/communication/courses/{courseId}/conversations/{conversationId}/members/search` fails for course-wide channels. The client always requests `sort=firstName,asc&sort=lastName,asc`, and Spring Data appends that `ORDER BY` to the id-only lookups behind the endpoint. PostgreSQL rejects the result:

```
org.postgresql.util.PSQLException: ERROR: for SELECT DISTINCT,
  ORDER BY expressions must appear in select list
  Position: 255
[select distinct u1_0.id from jhi_user u1_0
 join user_course_role ucr1_0 on ucr1_0.user_id=u1_0.id and ucr1_0.course_id=?
 where u1_0.is_deleted=false and (...)
 order by u1_0.first_name,u1_0.last_name fetch first ? rows only]
```

Only course-wide channels are affected. Every other channel resolves its members through a query that selects the whole entity (`SELECT DISTINCT user`), so the name columns are in the select list and the same `ORDER BY` is legal.

Measured on a production course with 15 channels: all 5 course-wide channels return 500, all 10 others return 200. Within a course-wide channel, `sort=id,asc` returns 200 while `sort=firstName,asc` and `sort=login,asc` return 500, which isolates the sort key as the trigger. The `CHANNEL_MODERATOR` filter returns 200 because it runs a conversation-scoped query instead.

The construct is tolerated by MySQL and rejected by PostgreSQL, so this became reachable with the move to PostgreSQL.

### Description
Two candidate fixes were rejected first:

- **Dropping `DISTINCT`** is not safe. The primary key of `user_course_role` is `(user_id, course_id, course_role)`, so a user holding two roles in a course makes the join fan out and produce duplicate rows.
- **Stripping the sort from the `Pageable`** removes the error but leaves the `LIMIT`/`OFFSET` query with no total order at all, so pages may overlap or skip members. A neighbouring method already used this approach; it is replaced here.

Instead, the four id-only queries now group by the projected user together with its name columns and carry their own deterministic ordering:

```
SELECT user.id
...
GROUP BY user.id, user.firstName, user.lastName
ORDER BY user.firstName, user.lastName, user.id
```

`GROUP BY` de-duplicates exactly as `DISTINCT` did (`id` is the primary key, so grouping by the triple is equivalent to grouping by `id`), and PostgreSQL permits `ORDER BY` on grouped columns that are not projected.

A private `withoutSort(Pageable)` helper keeps the caller's sort from reaching these queries, where it would duplicate or invalidate the `ORDER BY`. It handles `Pageable.unpaged()`, which one caller passes. This discards no caller-visible behaviour: each wrapper already re-fetches its page content through `findUsersByIdsWithCourseRolesOrdered`, so the requested sort never influenced the returned ordering, only which rows were selected. That re-fetch gains `user.id` as a tiebreaker so the two stages agree on a total order.

Known related defect, deliberately not addressed here to keep this PR focused: `StudentParticipationRepository.findIdsByExerciseIdAndStudentName` has the same `SELECT DISTINCT p.id` shape and is reachable from `SubmissionService.getSubmissionsOnPageWithSize` when the example-submission import table is sorted by student name. Its count query also uses `COUNT(p)` over a join, which inflates `totalPages`.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Course with communication enabled and at least one course-wide channel (for example `announcement`)
- More course members than the page size

1. Log in to Artemis as the instructor.
2. Navigate to Course Management > Communication.
3. Open a course-wide channel and click the members button in the top right.
4. The dialog lists the members. Before this change it showed an empty list and an "Internal server error" toast.
5. Switch the role filter between All Members, Instructors, Tutors and Students. Each returns results rather than an error.
6. Scroll the list past the first page and confirm the alphabetical order continues across the page boundary, with no repeated or missing members.
7. Open a channel that is not course-wide and confirm its members dialog is unchanged.

### Server
- [x] I implemented the changes with a very good performance and prevented too many (unnecessary) and too complex database calls.
- [x] I strictly followed the principle of data economy for all database calls.
- [x] I strictly followed the server coding and design guidelines and the REST API guidelines.
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved member search results with consistent name-based sorting and user ID tie-breaking.
  * Preserved stable ordering when paginating results.
  * Prevented duplicate course roles from producing duplicate members.
  * Improved filtering of members by course role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->