### PR TITLE
fix: prevent Hyperion WebSocket deadlock by using fire-and-forget send

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/hyperion/service/websocket/HyperionWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/hyperion/service/websocket/HyperionWebsocketService.java
@@ -1,7 +1,5 @@
 package de.tum.cit.aet.artemis.hyperion.service.websocket;
 
-import java.util.concurrent.ExecutionException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Conditional;
@@ -35,12 +33,14 @@ public class HyperionWebsocketService {
      */
     public void send(String userLogin, String topicSuffix, Object payload) {
         String topic = TOPIC_PREFIX + topicSuffix;
-        try {
-            websocketMessagingService.sendMessageToUser(userLogin, topic, payload).get();
-            log.debug("Sent Hyperion message to {} on topic {}: {}", userLogin, topic, payload);
-        }
-        catch (InterruptedException | ExecutionException e) {
-            log.error("Error sending Hyperion message to {} on topic {}: {}", userLogin, topic, payload, e);
-        }
+        websocketMessagingService.sendMessageToUser(userLogin, topic, payload)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Error sending Hyperion message to {} on topic {}: {}", userLogin, topic, payload, ex);
+                    }
+                    else {
+                        log.debug("Sent Hyperion message to {} on topic {}: {}", userLogin, topic, payload);
+                    }
+                });
     }
 }


### PR DESCRIPTION
### Description

Fixes #13556

`HyperionWebsocketService.send()` calls `.get()` on the websocket send future,
blocking the current thread indefinitely. When the shared `taskExecutor` pool
is saturated by Hyperion code generation jobs (both threads parked), the
websocket send task — which runs on the same pool — can never execute,
creating a permanent deadlock.

### Fix

Replace `.get()` with `.whenComplete()` (fire-and-forget). The websocket
progress update is informational — if it fails, the job continues without
issue, and the next progress event will be sent normally. This is the
simplest and most correct fix per the options described in the issue.

### Changes

- `HyperionWebsocketService.java`: remove `.get()` blocking call, use
  `.whenComplete()` callback for async logging
- Removed unused `java.util.concurrent.ExecutionException` import

### Testing

- No behavioral change for the normal (non-deadlock) case — the send still
  executes and logs success/failure
- Under pool saturation, the send no longer blocks the worker thread,
  preventing the deadlock entirely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * WebSocket message delivery now completes asynchronously, helping avoid blocking operations and improving responsiveness.

* **Reliability**
  * Success and failure outcomes are reported after message processing completes, providing more accurate delivery status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->