### PR TITLE
`Migration`: Convert user SSH key date columns to DATETIME to fix the Year-2038 limit

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20260825000000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260825000000_changelog.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        Convert the date columns of user_public_ssh_key (creation_date, last_used_date, expiry_date) from
+        TIMESTAMP to DATETIME(3) on MySQL. MySQL TIMESTAMP cannot represent values after 2038-01-19 03:14:07 UTC,
+        so an SSH key whose expiry date reaches that point fails to store and the insert errors out. DATETIME has
+        no such ceiling and matches the type already used by every other date column in the schema.
+
+        MySQL only: on PostgreSQL these columns are "timestamp without time zone", which has no 2038 ceiling and
+        needs no change. The ALTER runs under a UTC session so the UTC values held in the TIMESTAMP columns keep
+        their wall-clock reading once copied into the time-zone-less DATETIME columns; the previous session time
+        zone is restored afterwards. A MySQL MODIFY drops NOT NULL unless it is restated, so creation_date keeps
+        it explicitly.
+    -->
+    <changeSet id="20260825000000-1" author="harbeck">
+        <preConditions onFail="MARK_RAN">
+            <dbms type="mysql"/>
+        </preConditions>
+        <sql>
+            SET @old_time_zone = @@SESSION.time_zone;
+            SET time_zone = '+00:00';
+            ALTER TABLE user_public_ssh_key
+                MODIFY creation_date DATETIME(3) NOT NULL,
+                MODIFY last_used_date DATETIME(3) NULL,
+                MODIFY expiry_date DATETIME(3) NULL;
+            SET time_zone = @old_time_zone;
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -44,6 +44,7 @@
     <include file="classpath:config/liquibase/changelog/20260811231613_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260816213553_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260820091251_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20260825000000_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command "date '+%Y%m%d%H%M%S'" to get the current date and time in the correct format -->

--- a/src/test/java/de/tum/cit/aet/artemis/core/config/migration/SshKeyDateColumnMigrationMySqlTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/config/migration/SshKeyDateColumnMigrationMySqlTest.java
@@ -1,0 +1,180 @@
+package de.tum.cit.aet.artemis.core.config.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.mysql.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+
+/**
+ * Verifies the MySQL-only migration {@code 20260825000000_changelog.xml}, which converts the date columns of
+ * {@code user_public_ssh_key} from TIMESTAMP to DATETIME(3) to remove the Year-2038 ceiling of MySQL TIMESTAMP.
+ * <p>
+ * The migration is not observable in the regular test suite because that runs against PostgreSQL, whose
+ * {@code timestamp} type has no such ceiling. This test therefore drives Liquibase against a real MySQL
+ * container. It seeds the pre-migration schema under a non-UTC session so a missing {@code SET time_zone = '+00:00'}
+ * in the changeset would shift the existing values and fail the wall-clock assertion.
+ */
+@EnabledIf("isDockerAvailable")
+class SshKeyDateColumnMigrationMySqlTest {
+
+    private static final String CHANGELOG = "config/liquibase/changelog/20260825000000_changelog.xml";
+
+    private static final String NON_UTC_SESSION_ZONE = "+02:00";
+
+    private static MySQLContainer mysql;
+
+    static boolean isDockerAvailable() {
+        try {
+            return DockerClientFactory.instance().isDockerAvailable();
+        }
+        catch (Exception e) {
+            return false;
+        }
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        String mysqlVersion = System.getProperty("mysql.version", "9.7.2");
+        mysql = new MySQLContainer(DockerImageName.parse("mysql:" + mysqlVersion));
+        mysql.start();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (mysql != null) {
+            mysql.stop();
+        }
+    }
+
+    @Test
+    void shouldConvertSshKeyDateColumnsToDatetimePreservingData() throws Exception {
+        // The stored UTC epochs of the seeded dates; UNIX_TIMESTAMP is time-zone independent for TIMESTAMP columns.
+        long seededCreationEpoch;
+        long seededLastUsedEpoch;
+        long seededExpiryEpoch;
+
+        // Seed the pre-migration schema and data under a non-UTC session, mirroring an existing MySQL instance.
+        try (Connection connection = newConnection(); Statement statement = connection.createStatement()) {
+            statement.execute("SET time_zone = '" + NON_UTC_SESSION_ZONE + "'");
+            statement.execute("""
+                    CREATE TABLE user_public_ssh_key (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        user_id BIGINT NOT NULL,
+                        label VARCHAR(50) NOT NULL,
+                        public_key VARCHAR(1000) NOT NULL,
+                        key_hash VARCHAR(100) NOT NULL,
+                        creation_date TIMESTAMP NOT NULL,
+                        last_used_date TIMESTAMP NULL,
+                        expiry_date TIMESTAMP NULL
+                    )
+                    """);
+            statement.execute("CREATE INDEX idx_user_public_ssh_key_expiry_date ON user_public_ssh_key (expiry_date)");
+            statement.execute("""
+                    INSERT INTO user_public_ssh_key (user_id, label, public_key, key_hash, creation_date, last_used_date, expiry_date)
+                    VALUES (1, 'full', 'ssh-ed25519 AAAA', 'hash-full', '2030-06-15 12:00:00', '2031-01-02 08:30:00', '2032-03-04 03:00:00')
+                    """);
+            statement.execute("""
+                    INSERT INTO user_public_ssh_key (user_id, label, public_key, key_hash, creation_date, last_used_date, expiry_date)
+                    VALUES (2, 'nulls', 'ssh-ed25519 BBBB', 'hash-nulls', '2030-06-15 12:00:00', NULL, NULL)
+                    """);
+            try (ResultSet resultSet = statement
+                    .executeQuery("SELECT UNIX_TIMESTAMP(creation_date), UNIX_TIMESTAMP(last_used_date), UNIX_TIMESTAMP(expiry_date) FROM user_public_ssh_key WHERE id = 1")) {
+                resultSet.next();
+                seededCreationEpoch = resultSet.getLong(1);
+                seededLastUsedEpoch = resultSet.getLong(2);
+                seededExpiryEpoch = resultSet.getLong(3);
+            }
+        }
+
+        // Run the migration on a non-UTC session and keep the connection open for the assertions.
+        try (Connection connection = newConnection(); Statement statement = connection.createStatement()) {
+            statement.execute("SET time_zone = '" + NON_UTC_SESSION_ZONE + "'");
+
+            Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(connection));
+            Liquibase liquibase = new Liquibase(CHANGELOG, new ClassLoaderResourceAccessor(), database);
+            liquibase.update(new Contexts(), new LabelExpression());
+            // Liquibase may leave the connection without auto-commit; restore it for the plain JDBC assertions below.
+            connection.setAutoCommit(true);
+
+            // The changeset must restore the previous session time zone after the conversion.
+            try (ResultSet resultSet = statement.executeQuery("SELECT @@session.time_zone")) {
+                resultSet.next();
+                assertThat(resultSet.getString(1)).as("session time zone restored after migration").isEqualTo(NON_UTC_SESSION_ZONE);
+            }
+
+            // All three columns are now DATETIME with millisecond precision, and nullability is preserved.
+            assertColumn(statement, "creation_date", "datetime", 3, "NO");
+            assertColumn(statement, "last_used_date", "datetime", 3, "YES");
+            assertColumn(statement, "expiry_date", "datetime", 3, "YES");
+
+            // The expiry_date index survives the column rewrite.
+            try (ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM information_schema.statistics "
+                    + "WHERE table_schema = DATABASE() AND table_name = 'user_public_ssh_key' AND index_name = 'idx_user_public_ssh_key_expiry_date'")) {
+                resultSet.next();
+                assertThat(resultSet.getInt(1)).as("expiry_date index preserved").isPositive();
+            }
+
+            // The pre-existing values keep their UTC wall-clock: read as UTC, their epochs must match the seeded epochs.
+            statement.execute("SET time_zone = '+00:00'");
+            try (ResultSet resultSet = statement
+                    .executeQuery("SELECT UNIX_TIMESTAMP(creation_date), UNIX_TIMESTAMP(last_used_date), UNIX_TIMESTAMP(expiry_date) FROM user_public_ssh_key WHERE id = 1")) {
+                resultSet.next();
+                assertThat(resultSet.getLong(1)).as("creation_date keeps its UTC wall-clock").isEqualTo(seededCreationEpoch);
+                assertThat(resultSet.getLong(2)).as("last_used_date keeps its UTC wall-clock").isEqualTo(seededLastUsedEpoch);
+                assertThat(resultSet.getLong(3)).as("expiry_date keeps its UTC wall-clock").isEqualTo(seededExpiryEpoch);
+            }
+
+            // NULL values are preserved.
+            try (ResultSet resultSet = statement.executeQuery("SELECT last_used_date, expiry_date FROM user_public_ssh_key WHERE id = 2")) {
+                resultSet.next();
+                resultSet.getObject(1);
+                assertThat(resultSet.wasNull()).as("last_used_date stays NULL").isTrue();
+                resultSet.getObject(2);
+                assertThat(resultSet.wasNull()).as("expiry_date stays NULL").isTrue();
+            }
+
+            // A post-2038 expiry date, previously rejected by MySQL TIMESTAMP, can now be stored.
+            assertThatCode(() -> statement.execute("""
+                    INSERT INTO user_public_ssh_key (user_id, label, public_key, key_hash, creation_date, expiry_date)
+                    VALUES (3, 'future', 'ssh-ed25519 CCCC', 'hash-future', '2030-06-15 12:00:00.000', '2040-01-01 03:00:00.000')
+                    """)).as("post-2038 expiry date is accepted").doesNotThrowAnyException();
+            try (ResultSet resultSet = statement.executeQuery("SELECT YEAR(expiry_date) FROM user_public_ssh_key WHERE id = 3")) {
+                resultSet.next();
+                assertThat(resultSet.getInt(1)).as("post-2038 expiry date is stored").isEqualTo(2040);
+            }
+        }
+    }
+
+    private Connection newConnection() throws Exception {
+        return DriverManager.getConnection(mysql.getJdbcUrl(), mysql.getUsername(), mysql.getPassword());
+    }
+
+    private void assertColumn(Statement statement, String columnName, String expectedDataType, int expectedPrecision, String expectedNullable) throws Exception {
+        try (ResultSet resultSet = statement.executeQuery("SELECT data_type, datetime_precision, is_nullable FROM information_schema.columns "
+                + "WHERE table_schema = DATABASE() AND table_name = 'user_public_ssh_key' AND column_name = '" + columnName + "'")) {
+            resultSet.next();
+            assertThat(resultSet.getString("data_type")).as("data type of %s", columnName).isEqualTo(expectedDataType);
+            assertThat(resultSet.getInt("datetime_precision")).as("precision of %s", columnName).isEqualTo(expectedPrecision);
+            assertThat(resultSet.getString("is_nullable")).as("nullability of %s", columnName).isEqualTo(expectedNullable);
+        }
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/core/config/migration/SshKeyDateColumnMigrationMySqlTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/config/migration/SshKeyDateColumnMigrationMySqlTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 
@@ -74,7 +75,7 @@ class SshKeyDateColumnMigrationMySqlTest {
 
         // Seed the pre-migration schema and data under a non-UTC session, mirroring an existing MySQL instance.
         try (Connection connection = newConnection(); Statement statement = connection.createStatement()) {
-            statement.execute("SET time_zone = '" + NON_UTC_SESSION_ZONE + "'");
+            statement.execute("SET time_zone = '+02:00'");
             statement.execute("""
                     CREATE TABLE user_public_ssh_key (
                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -107,7 +108,7 @@ class SshKeyDateColumnMigrationMySqlTest {
 
         // Run the migration on a non-UTC session and keep the connection open for the assertions.
         try (Connection connection = newConnection(); Statement statement = connection.createStatement()) {
-            statement.execute("SET time_zone = '" + NON_UTC_SESSION_ZONE + "'");
+            statement.execute("SET time_zone = '+02:00'");
 
             Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(connection));
             Liquibase liquibase = new Liquibase(CHANGELOG, new ClassLoaderResourceAccessor(), database);
@@ -122,15 +123,18 @@ class SshKeyDateColumnMigrationMySqlTest {
             }
 
             // All three columns are now DATETIME with millisecond precision, and nullability is preserved.
-            assertColumn(statement, "creation_date", "datetime", 3, "NO");
-            assertColumn(statement, "last_used_date", "datetime", 3, "YES");
-            assertColumn(statement, "expiry_date", "datetime", 3, "YES");
+            assertColumn(connection, "creation_date", "datetime", 3, "NO");
+            assertColumn(connection, "last_used_date", "datetime", 3, "YES");
+            assertColumn(connection, "expiry_date", "datetime", 3, "YES");
 
-            // The expiry_date index survives the column rewrite.
-            try (ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM information_schema.statistics "
-                    + "WHERE table_schema = DATABASE() AND table_name = 'user_public_ssh_key' AND index_name = 'idx_user_public_ssh_key_expiry_date'")) {
-                resultSet.next();
-                assertThat(resultSet.getInt(1)).as("expiry_date index preserved").isPositive();
+            // The index survives the column rewrite and still targets expiry_date as its first column.
+            try (ResultSet resultSet = statement.executeQuery("""
+                    SELECT column_name, seq_in_index FROM information_schema.statistics
+                    WHERE table_schema = DATABASE() AND table_name = 'user_public_ssh_key' AND index_name = 'idx_user_public_ssh_key_expiry_date'
+                    """)) {
+                assertThat(resultSet.next()).as("expiry_date index preserved").isTrue();
+                assertThat(resultSet.getString("column_name")).as("index targets expiry_date").isEqualTo("expiry_date");
+                assertThat(resultSet.getInt("seq_in_index")).as("expiry_date is the first index column").isEqualTo(1);
             }
 
             // The pre-existing values keep their UTC wall-clock: read as UTC, their epochs must match the seeded epochs.
@@ -168,13 +172,18 @@ class SshKeyDateColumnMigrationMySqlTest {
         return DriverManager.getConnection(mysql.getJdbcUrl(), mysql.getUsername(), mysql.getPassword());
     }
 
-    private void assertColumn(Statement statement, String columnName, String expectedDataType, int expectedPrecision, String expectedNullable) throws Exception {
-        try (ResultSet resultSet = statement.executeQuery("SELECT data_type, datetime_precision, is_nullable FROM information_schema.columns "
-                + "WHERE table_schema = DATABASE() AND table_name = 'user_public_ssh_key' AND column_name = '" + columnName + "'")) {
-            resultSet.next();
-            assertThat(resultSet.getString("data_type")).as("data type of %s", columnName).isEqualTo(expectedDataType);
-            assertThat(resultSet.getInt("datetime_precision")).as("precision of %s", columnName).isEqualTo(expectedPrecision);
-            assertThat(resultSet.getString("is_nullable")).as("nullability of %s", columnName).isEqualTo(expectedNullable);
+    private void assertColumn(Connection connection, String columnName, String expectedDataType, int expectedPrecision, String expectedNullable) throws Exception {
+        try (PreparedStatement statement = connection.prepareStatement("""
+                SELECT data_type, datetime_precision, is_nullable FROM information_schema.columns
+                WHERE table_schema = DATABASE() AND table_name = 'user_public_ssh_key' AND column_name = ?
+                """)) {
+            statement.setString(1, columnName);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                resultSet.next();
+                assertThat(resultSet.getString("data_type")).as("data type of %s", columnName).isEqualTo(expectedDataType);
+                assertThat(resultSet.getInt("datetime_precision")).as("precision of %s", columnName).isEqualTo(expectedPrecision);
+                assertThat(resultSet.getString("is_nullable")).as("nullability of %s", columnName).isEqualTo(expectedNullable);
+            }
         }
     }
 }


### PR DESCRIPTION
### Summary
Fixes the Year-2038 problem for SSH key expiry dates (security finding F-004). The date columns of `user_public_ssh_key` are MySQL `TIMESTAMP`, which cannot store a value after `2038-01-19 03:14:07 UTC`, so saving an SSH key whose expiry date reaches that point fails with an internal server error. This PR migrates those columns to `DATETIME(3)` on MySQL.

This is the schema half of the fix. The application-level validation of the expiry date is the companion PR #13565.

### Checklist
#### General
<!-- Tested locally: a Testcontainers MySQL migration test and a full local MySQL boot that applies the changeset. Test-server verification is still pending. Re-add and check one of the two items below once a colleague has confirmed it on a test server.
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
-->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added an integration test (Spring, Testcontainers MySQL) related to the change (`SshKeyDateColumnMigrationMySqlTest`).
<!-- No new or changed REST endpoints: this PR only adds a Liquibase changelog and a test.
- [ ] I added pre-authorization annotations according to the guidelines and checked the course groups for all new REST Calls (security).
-->
- [x] I documented the Java code using JavaDoc style.

<!-- No client changes: this PR is a MySQL-only schema migration plus a migration test.
#### Client
- [ ] Performance / data economy / client guidelines / UI-UX / theming / Vitest / authorities / JSDoc / screenshots / translations — not applicable, no client code is touched.
-->

<!-- SSH keys are used for LocalVC repository access, but this PR changes only the database column type; it does not change any programming-exercise behaviour. Verified locally on the integrated LocalVC/LocalCI setup via the migration test and a full local MySQL boot.
#### Changes affecting Programming Exercises
- [ ] I tested all changes on a test server configured with the integrated lifecycle setup (LocalVC and LocalCI).
- [ ] I tested all changes on a test server configured with LocalVC and Jenkins.
-->

### Motivation and Context
`user_public_ssh_key.creation_date`, `last_used_date` and `expiry_date` use the Liquibase `timestamp` type, which maps to MySQL `TIMESTAMP` (a 32-bit Unix timestamp capped at `2038-01-19 03:14:07 UTC`). SSH keys are long-lived and users naturally pick expiry dates years or decades ahead, so the cap is already reachable today: creating a key with an expiry date on or after that point makes the `INSERT` fail (`DataIntegrityViolationException`, HTTP 500, "Failed to save SSH Key, internal server error"). PostgreSQL is not affected, as its `timestamp` type has no such cap. `DATETIME` (range up to year 9999) is already the type used by every other date column in the schema.

### Description
- New Liquibase changeset `20260825000000_changelog.xml` (MySQL only, guarded by `<preConditions><dbms type="mysql"/></preConditions>`) converts `creation_date`, `last_used_date` and `expiry_date` on `user_public_ssh_key` from `TIMESTAMP` to `DATETIME(3)`.
- The `ALTER TABLE` runs under a UTC session (`SET time_zone = '+00:00'`), so the UTC values held in the `TIMESTAMP` columns keep their wall-clock reading once copied into the time-zone-less `DATETIME` columns; the previous session time zone is saved beforehand and restored afterwards.
- `creation_date` keeps its `NOT NULL` constraint explicitly, which a MySQL `MODIFY` would otherwise drop.
- No entity or DTO change is required: the Java fields are already `ZonedDateTime`, and the application persists all timestamps as UTC (`hibernate.jdbc.time_zone: UTC`).

### Steps for Testing
This is a MySQL-only schema migration; the behaviour is not observable on PostgreSQL.

Prerequisites:
- A MySQL-backed Artemis instance
- 1 user with an existing SSH key (to check existing-data preservation)

1. Before deploying this branch, note the current values of the `user_public_ssh_key` date columns (`SELECT creation_date, last_used_date, expiry_date FROM user_public_ssh_key;`) and their types (`SHOW COLUMNS FROM user_public_ssh_key;` → `timestamp`).
2. Start Artemis on this branch so Liquibase applies the changeset.
3. Confirm the three columns are now `datetime(3)` and the existing values are unchanged (same wall-clock).
4. As a user, add an SSH key with an expiry date after 2038 (e.g. 2040). → It saves instead of returning "Failed to save SSH Key, internal server error".

The automated `SshKeyDateColumnMigrationMySqlTest` (Testcontainers MySQL) applies the real changeset under a non-UTC session and asserts the column type and precision, nullability, index preservation, session-time-zone restore, wall-clock preservation of existing rows, `NULL` preservation, and a post-2038 round-trip.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Schema-only change: no runtime database call is added, so no dedicated performance review is required.
#### Performance Review
- [ ] I (as a reviewer) confirm that the client changes are implemented with a very good performance even for very large courses with more than 2000 students.
- [ ] I (as a reviewer) confirm that the server changes are implemented with a very good performance even for very large courses with more than 2000 students.
-->
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] On MySQL, the three columns become `datetime(3)` and existing values are preserved after the migration.
- [ ] An SSH key with a post-2038 expiry date can be saved.
<!-- Exam mode is not affected: this only changes the storage type of user SSH key columns.
#### Exam Mode Test
- [ ] Test 1
-->
<!-- No performance test is required for a column type change.
#### Performance Tests
- [ ] Test 1
-->

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-14 12:28:12 UTC_


### Screenshots
<!-- No UI changes in this PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation for the MySQL migration of SSH key expiration dates.
  * Verified millisecond precision, null handling, existing values, column constraints, and preservation of the expiration-date index.
  * Confirmed consistent behavior across session time zones without altering application-visible timestamps.
  * Added coverage confirming support for expiration dates beyond 2038 while preserving existing data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->