### PR TITLE
`LocalVC`: Validate the SSH key expiry date on the client and server

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/localvc/service/sshuserkeys/UserSshPublicKeyService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localvc/service/sshuserkeys/UserSshPublicKeyService.java
@@ -5,6 +5,9 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.PublicKey;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -28,6 +31,12 @@ import de.tum.cit.aet.artemis.programming.repository.UserSshPublicKeyRepository;
 @Lazy
 @Service
 public class UserSshPublicKeyService {
+
+    /**
+     * The latest instant a MySQL DATETIME(3) column can represent. A normalised expiry date beyond this value
+     * could not be persisted, so it is rejected up front instead of failing at the database layer.
+     */
+    private static final Instant MAX_EXPIRY_DATE = Instant.parse("9999-12-31T23:59:59.999Z");
 
     private final UserSshPublicKeyRepository userSshPublicKeyRepository;
 
@@ -59,11 +68,35 @@ public class UserSshPublicKeyService {
         newUserSshPublicKey.setCreationDate(ZonedDateTime.now());
 
         if (sshPublicKey.expiryDate() != null) {
-            var expiryDate = sshPublicKey.expiryDate().withHour(3).withMinute(0).withSecond(0).withNano(0).plusDays(1);
-            newUserSshPublicKey.setExpiryDate(expiryDate);
+            newUserSshPublicKey.setExpiryDate(validateAndNormaliseExpiryDate(sshPublicKey.expiryDate()));
         }
 
         userSshPublicKeyRepository.save(newUserSshPublicKey);
+    }
+
+    /**
+     * Normalises the requested expiry date to 03:00 on the following day and validates that it can be stored.
+     * The resulting date must lie in the future and must not exceed the maximum value the database can hold.
+     *
+     * @param requestedExpiryDate the expiry date requested by the user
+     * @return the normalised expiry date to persist
+     * @throws BadRequestAlertException if the expiry date is in the past or too far in the future
+     */
+    private ZonedDateTime validateAndNormaliseExpiryDate(ZonedDateTime requestedExpiryDate) {
+        ZonedDateTime expiryDate;
+        try {
+            expiryDate = requestedExpiryDate.withHour(3).withMinute(0).withSecond(0).withNano(0).plusDays(1);
+        }
+        catch (DateTimeException | ArithmeticException e) {
+            throw new BadRequestAlertException("The expiry date is too far in the future", "SSH key", "sshKeyExpiryDateTooFarInFuture", true);
+        }
+        if (!expiryDate.isAfter(ZonedDateTime.now(ZoneOffset.UTC))) {
+            throw new BadRequestAlertException("The expiry date must be in the future", "SSH key", "sshKeyExpiryDateInPast", true);
+        }
+        if (expiryDate.toInstant().isAfter(MAX_EXPIRY_DATE)) {
+            throw new BadRequestAlertException("The expiry date is too far in the future", "SSH key", "sshKeyExpiryDateTooFarInFuture", true);
+        }
+        return expiryDate;
     }
 
     /**

--- a/src/main/webapp/app/account/user/settings/ssh-settings/details/ssh-user-settings-key-details.component.html
+++ b/src/main/webapp/app/account/user/settings/ssh-settings/details/ssh-user-settings-key-details.component.html
@@ -75,6 +75,7 @@
                                 [pickerType]="DateTimePickerType.CALENDAR"
                                 [shouldDisplayTimeZoneWarning]="false"
                                 [min]="currentDate()"
+                                [max]="maxExpiryDate"
                                 [requiredField]="true"
                                 (valueChange)="validateExpiryDate()"
                                 name="expiryDate"

--- a/src/main/webapp/app/account/user/settings/ssh-settings/details/ssh-user-settings-key-details.component.spec.ts
+++ b/src/main/webapp/app/account/user/settings/ssh-settings/details/ssh-user-settings-key-details.component.spec.ts
@@ -113,6 +113,43 @@ describe('SshUserSettingsComponent', () => {
         expect(router.navigate).not.toHaveBeenCalled();
     });
 
+    it('should mark an expiry date in the past as invalid', () => {
+        comp.ngOnInit();
+        comp.displayedExpiryDate = dayjs().subtract(2, 'day');
+        comp.validateExpiryDate();
+        expect(comp.isExpiryDateValid()).toBe(false);
+    });
+
+    it('should mark a future expiry date as valid', () => {
+        comp.ngOnInit();
+        comp.displayedExpiryDate = dayjs().add(1, 'year');
+        comp.validateExpiryDate();
+        expect(comp.isExpiryDateValid()).toBe(true);
+    });
+
+    it('should mark an expiry date too far in the future as invalid', () => {
+        comp.ngOnInit();
+        comp.displayedExpiryDate = dayjs('9999-12-31');
+        comp.validateExpiryDate();
+        expect(comp.isExpiryDateValid()).toBe(false);
+    });
+
+    it('should show a specific error when the server rejects the expiry date', () => {
+        const httpError = new HttpErrorResponse({
+            error: { errorKey: 'sshKeyExpiryDateInPast' },
+            status: 400,
+        });
+        sshServiceMock.addNewSshPublicKey.mockReturnValue(throwError(() => httpError));
+        comp.ngOnInit();
+        comp.displayedSshKey = mockKey;
+        comp.displayedExpiryDate = dayjs().add(1, 'year');
+        comp.displayedKeyLabel = 'label';
+        comp.validateExpiryDate();
+        comp.saveSshKey();
+        expect(alertServiceMock.error).toHaveBeenCalledWith('artemisApp.userSettings.sshSettingsPage.sshKeyExpiryDateInPast');
+        expect(router.navigate).not.toHaveBeenCalled();
+    });
+
     it('should initialize key details view with key loaded', async () => {
         sshServiceMock.getSshPublicKey.mockReturnValue(of(mockedUserSshKeys));
         activatedRoute.setParameters({ keyId: 1 });

--- a/src/main/webapp/app/account/user/settings/ssh-settings/details/ssh-user-settings-key-details.component.ts
+++ b/src/main/webapp/app/account/user/settings/ssh-settings/details/ssh-user-settings-key-details.component.ts
@@ -32,6 +32,8 @@ export class SshUserSettingsKeyDetailsComponent implements OnInit, OnDestroy {
     readonly invalidKeyFormat = 'invalidKeyFormat';
     readonly keyAlreadyExists = 'keyAlreadyExists';
     readonly keyLabelTooLong = 'keyLabelTooLong';
+    readonly sshKeyExpiryDateInPast = 'sshKeyExpiryDateInPast';
+    readonly sshKeyExpiryDateTooFarInFuture = 'sshKeyExpiryDateTooFarInFuture';
 
     protected readonly faEdit = faEdit;
     protected readonly faSave = faSave;
@@ -57,6 +59,8 @@ export class SshUserSettingsKeyDetailsComponent implements OnInit, OnDestroy {
     readonly displayCreationDate = signal<dayjs.Dayjs | undefined>(undefined);
     readonly displayedLastUsedDate = signal<dayjs.Dayjs | undefined>(undefined);
     readonly currentDate = signal<dayjs.Dayjs>(undefined!);
+    // The latest selectable expiry date; a later date would exceed the maximum the database can store once the server normalises it.
+    readonly maxExpiryDate = dayjs('9999-12-30');
 
     private dialogErrorSource = new Subject<string>();
     dialogError$ = this.dialogErrorSource.asObservable();
@@ -112,7 +116,7 @@ export class SshUserSettingsKeyDetailsComponent implements OnInit, OnDestroy {
             },
             error: (error) => {
                 const errorKey = error.error.errorKey;
-                if ([this.invalidKeyFormat, this.keyAlreadyExists, this.keyLabelTooLong].indexOf(errorKey) > -1) {
+                if ([this.invalidKeyFormat, this.keyAlreadyExists, this.keyLabelTooLong, this.sshKeyExpiryDateInPast, this.sshKeyExpiryDateTooFarInFuture].indexOf(errorKey) > -1) {
                     this.alertService.error(`artemisApp.userSettings.sshSettingsPage.${errorKey}`);
                 } else {
                     this.alertService.error('artemisApp.userSettings.sshSettingsPage.saveFailure');
@@ -126,7 +130,10 @@ export class SshUserSettingsKeyDetailsComponent implements OnInit, OnDestroy {
     }
 
     validateExpiryDate() {
-        this.isExpiryDateValid.set(!!this.displayedExpiryDate?.isValid());
+        const isValidDate = !!this.displayedExpiryDate?.isValid();
+        const isNotInPast = !!this.displayedExpiryDate && !this.displayedExpiryDate.isBefore(dayjs(), 'day');
+        const isNotTooFar = !!this.displayedExpiryDate && !this.displayedExpiryDate.isAfter(this.maxExpiryDate, 'day');
+        this.isExpiryDateValid.set(isValidDate && isNotInPast && isNotTooFar);
     }
 
     private setMessageBasedOnOS(os: string): void {

--- a/src/main/webapp/i18n/de/userSettings.json
+++ b/src/main/webapp/i18n/de/userSettings.json
@@ -60,6 +60,8 @@
                 "invalidKeyFormat": "SSH-Schlüssel konnte nicht gespeichert werden. Stelle sicher, dass es ein gültiger und unterstützter Schlüssel im richtigen Format ist.",
                 "keyAlreadyExists": "SSH-Schlüssel konnte nicht gespeichert werden. Du verwendest diesen Schlüssel schon.",
                 "keyLabelTooLong": "SSH-Schlüssel konnte nicht gespeichert werden. Das Label darf maximal 50 Zeichen besitzen.",
+                "sshKeyExpiryDateInPast": "SSH-Schlüssel konnte nicht gespeichert werden. Das Ablaufdatum muss in der Zukunft liegen.",
+                "sshKeyExpiryDateTooFarInFuture": "SSH-Schlüssel konnte nicht gespeichert werden. Das Ablaufdatum liegt zu weit in der Zukunft.",
                 "loadKeyFailure": "Laden der SSH-Schlüssel ist fehlgeschlagen.",
                 "saveFailure": "SSH-Schlüssel konnte nicht gespeichert werden.",
                 "saveSuccess": "SSH-Schlüssel erfolgreich gespeichert.",

--- a/src/main/webapp/i18n/en/userSettings.json
+++ b/src/main/webapp/i18n/en/userSettings.json
@@ -60,6 +60,8 @@
                 "invalidKeyFormat": "Failed to save SSH key. Make sure the key is in a valid and supported format.",
                 "keyAlreadyExists": "Failed to save SSH key. You already use the provided key.",
                 "keyLabelTooLong": "Failed to save SSH key. The key label is limited to 50 characters.",
+                "sshKeyExpiryDateInPast": "Failed to save SSH key. The expiry date must be in the future.",
+                "sshKeyExpiryDateTooFarInFuture": "Failed to save SSH key. The expiry date is too far in the future.",
                 "loadKeyFailure": "Failed to load SSH keys.",
                 "saveFailure": "Failed to save SSH key.",
                 "saveSuccess": "Successfully save SSH key.",

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/RequestUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/RequestUtilService.java
@@ -651,6 +651,17 @@ public class RequestUtilService {
         assertThat(response.getHeader(errorHeader)).isEqualTo(fullErrorKey);
     }
 
+    public void postAndExpectError(String path, Object body, HttpStatus expectedStatus, String expectedErrorKey) throws Exception {
+        final var jsonBody = mapper.writeValueAsString(body);
+        final var response = performMvcRequest(MockMvcRequestBuilders.post(new URI(path)).contentType(MediaType.APPLICATION_JSON).content(jsonBody))
+                .andExpect(status().is(expectedStatus.value())).andReturn().getResponse();
+        restoreSecurityContext();
+
+        final var fullErrorKey = "error." + expectedErrorKey;
+        final var errorHeader = "X-" + APPLICATION_NAME + "-error";
+        assertThat(response.getHeader(errorHeader)).isEqualTo(fullErrorKey);
+    }
+
     public <T> T get(String path, HttpStatus expectedStatus, Class<T> responseType) throws Exception {
         return get(path, expectedStatus, responseType, new LinkedMultiValueMap<>());
     }

--- a/src/test/java/de/tum/cit/aet/artemis/localvc/service/LocalVCSshSettingsIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localvc/service/LocalVCSshSettingsIntegrationTest.java
@@ -66,6 +66,24 @@ class LocalVCSshSettingsIntegrationTest extends AbstractSpringIntegrationLocalCI
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void failToAddSshPublicKeyWithPastExpiryDate() throws Exception {
+        sshSettingsTestService.failToAddSshPublicKeyWithPastExpiryDate();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void failToAddSshPublicKeyWithExpiryDateTooFarInFuture() throws Exception {
+        sshSettingsTestService.failToAddSshPublicKeyWithExpiryDateTooFarInFuture();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void addSshPublicKeyWithFutureExpiryDate() throws Exception {
+        sshSettingsTestService.addSshPublicKeyWithFutureExpiryDate();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void deleteSshPublicKeyByUser() throws Exception {
         sshSettingsTestService.addAndDeleteSshPublicKey();
     }

--- a/src/test/java/de/tum/cit/aet/artemis/localvc/util/SshSettingsTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localvc/util/SshSettingsTestService.java
@@ -4,6 +4,8 @@ import static de.tum.cit.aet.artemis.core.config.ArtemisConstants.SPRING_PROFILE
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -131,6 +133,46 @@ public class SshSettingsTestService {
 
         request.delete(requestPrefix + "public-keys/3443", HttpStatus.FORBIDDEN);
         request.get(requestPrefix + "public-keys/43443", HttpStatus.FORBIDDEN, UserSshPublicKeyDTO.class);
+    }
+
+    // Test
+    public void failToAddSshPublicKeyWithPastExpiryDate() throws Exception {
+        User user = userTestRepository.getUser();
+
+        var keyWithPastExpiry = createNewValidSSHKey(user, sshKey1);
+        keyWithPastExpiry.setExpiryDate(ZonedDateTime.now().minusDays(2));
+
+        request.postAndExpectError(requestPrefix + "public-keys", keyWithPastExpiry, HttpStatus.BAD_REQUEST, "sshKeyExpiryDateInPast");
+        assertThat(userSshPublicKeyRepository.findAllByUserId(user.getId())).isEmpty();
+    }
+
+    // Test
+    public void failToAddSshPublicKeyWithExpiryDateTooFarInFuture() throws Exception {
+        User user = userTestRepository.getUser();
+
+        var keyWithTooFarExpiry = createNewValidSSHKey(user, sshKey1);
+        // Normalising this date (03:00 on the following day) exceeds the maximum value the database can store.
+        keyWithTooFarExpiry.setExpiryDate(ZonedDateTime.of(9999, 12, 31, 0, 0, 0, 0, ZoneOffset.UTC));
+
+        request.postAndExpectError(requestPrefix + "public-keys", keyWithTooFarExpiry, HttpStatus.BAD_REQUEST, "sshKeyExpiryDateTooFarInFuture");
+        assertThat(userSshPublicKeyRepository.findAllByUserId(user.getId())).isEmpty();
+    }
+
+    // Test
+    public void addSshPublicKeyWithFutureExpiryDate() throws Exception {
+        User user = userTestRepository.getUser();
+
+        var requestedExpiryDate = ZonedDateTime.now(ZoneOffset.UTC).plusYears(24);
+        var keyWithFutureExpiry = createNewValidSSHKey(user, sshKey1);
+        keyWithFutureExpiry.setExpiryDate(requestedExpiryDate);
+
+        request.postWithResponseBody(requestPrefix + "public-keys", keyWithFutureExpiry, String.class, HttpStatus.OK);
+
+        // The stored date is normalised to 03:00 on the day following the requested date.
+        var expectedExpiryDate = requestedExpiryDate.withHour(3).withMinute(0).withSecond(0).withNano(0).plusDays(1);
+        var storedUserKey = userSshPublicKeyRepository.findAllByUserId(user.getId()).getFirst();
+        assertThat(storedUserKey.getExpiryDate()).isNotNull();
+        assertThat(storedUserKey.getExpiryDate().toInstant()).isEqualTo(expectedExpiryDate.toInstant());
     }
 
     // Test


### PR DESCRIPTION
### Summary
Validates the SSH key expiry date on both the client and the server (security finding F-004). An expiry date in the past, or so far in the future that it could not be stored, is now rejected with a clear message instead of being silently accepted or failing at the database layer.

This is the application-level half of the fix. The MySQL schema migration (`TIMESTAMP` → `DATETIME(3)`) is the companion PR #13564.

### Checklist
#### General
<!-- Tested locally: JUnit integration tests, Vitest, a manual localhost check, and a live server-side API check that bypasses the client. Test-server verification is still pending. Re-add and check one of the two items below once a colleague has confirmed it on a test server.
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
-->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the feature (past, too-far and accepted-future cases, asserting the exact error keys).
<!-- No new REST endpoints: the existing POST /api/programming/ssh-settings/public-keys keeps its @EnforceAtLeastStudent authorization.
- [ ] I added pre-authorization annotations according to the guidelines and checked the course groups for all new REST Calls (security).
-->
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
<!-- No new UI components, layout, interactions or colors: the change adds a `[max]` bound to the existing date picker and two validation messages to the existing SSH key form.
- [ ] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [ ] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
-->
- [x] I added multiple integration tests (Vitest) related to the feature (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
<!-- No routes or navigation elements were added.
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
-->
- [x] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

<!-- SSH keys are used for LocalVC repository access; this PR changes user SSH key settings, not programming-exercise behaviour. Verified locally on the integrated LocalVC/LocalCI setup via the integration tests, a manual localhost check, and a live server-side API check.
#### Changes affecting Programming Exercises
- [ ] I tested all changes on a test server configured with the integrated lifecycle setup (LocalVC and LocalCI).
- [ ] I tested all changes on a test server configured with LocalVC and Jenkins.
-->

### Motivation and Context
The SSH key creation endpoint accepted any expiry date. A date in the past is meaningless for a key that is only just being created, and a date beyond the maximum the database can store failed with an internal server error. The client merely greyed out past dates in the picker, which is convenience only, not an authoritative check, so a direct API call bypassed it entirely. This PR adds an authoritative server-side check and mirrors it on the client for immediate feedback.

### Description
- **Server** (`UserSshPublicKeyService`): the requested expiry date is normalised to 03:00 on the following day (unchanged behaviour), then rejected if
  - it is not in the future → HTTP 400, error key `sshKeyExpiryDateInPast`, or
  - it would exceed the maximum storable timestamp `9999-12-31T23:59:59.999Z` → HTTP 400, error key `sshKeyExpiryDateTooFarInFuture`.

  The normalisation is guarded against extreme values (`DateTimeException`/`ArithmeticException`), which map to the too-far case. The current time is read in UTC.
- **Client** (`ssh-user-settings-key-details`): `validateExpiryDate()` mirrors both bounds at day granularity, the date picker gets a `[max]` (`9999-12-30`, the last input that stays within the ceiling after next-day-03:00 normalisation), and the Save button stays disabled while the date is invalid. Both error keys are handled and translated into English and German.
- **Two layers**: the client block is convenience; the server check is authoritative and returns HTTP 400 even when the client is bypassed.

### Steps for Testing
Prerequisites:
- 1 Student
- Artemis running with the `localvc` profile (integrated lifecycle setup)

**Background — two layers.** The bound is enforced on both the client and the server:
- **Client:** the SSH key form disables Save and the date picker blocks out-of-range dates before any request is sent.
- **Server:** the endpoint rejects the request with HTTP 400 even when the client is bypassed.

In the normal form you will therefore only ever see the client block. To observe the server-side 400 you have to bypass the client (browser DevTools console).

1. **Client block, past date.** Log in, go to Profile → User Settings → SSH Keys → add a new key, paste a valid public key, choose "expire automatically", and try to pick a date in the past. → The picker blocks it and Save stays disabled.
2. **Positive case, post-2038 date.** Pick an expiry date after 2038 (e.g. 2040). → Save is enabled and the key is stored (requires the companion schema migration #13564 on MySQL; on PostgreSQL it stores regardless).
3. **Client block, far-future date.** Try to pick a date near year 9999. → The picker `[max]` blocks it and Save stays disabled.
4. **Server 400, bypassing the client.** In the DevTools console of the logged-in session, POST directly to the endpoint:
   - past date, e.g. `expiryDate: "2020-01-01T00:00:00Z"` → HTTP 400, error key `sshKeyExpiryDateInPast`,
   - far-future date, e.g. `expiryDate: "9999-12-31T00:00:00Z"` → HTTP 400, error key `sshKeyExpiryDateTooFarInFuture`.

   ```js
   await fetch('/api/programming/ssh-settings/public-keys', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + JSON.parse(localStorage.getItem('jhi-authenticationToken')) },
     body: JSON.stringify({ publicKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEbgjoSpKnry5yuMiWh/uwhMG2Jq5Sh8Uw9vz+39or2i', label: 'test', expiryDate: '2020-01-01T00:00:00Z' })
   }).then(r => r.status);
   ```

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] A past expiry date is rejected on the client (Save disabled) and on the server (HTTP 400 `sshKeyExpiryDateInPast`).
- [ ] A post-2038 expiry date is accepted and stored.
- [ ] A far-future date near year 9999 is rejected on the client and on the server (HTTP 400 `sshKeyExpiryDateTooFarInFuture`).
<!-- Exam mode is not affected: this only changes validation of user SSH key settings.
#### Exam Mode Test
- [ ] Test 1
-->

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| ssh-user-settings-key-details.component.ts | 98.63% | 140 | 25 | 17.9 |

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| UserSshPublicKeyService.java | 89.13% | 105 |

_Last updated: 2026-08-27 09:55:49 UTC_


### Screenshots
<!-- TODO: add a screenshot of the SSH key form with a past date selected, showing the disabled Save button (and one with a valid future date, showing Save enabled). -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH key expiry dates are now validated to ensure they are in the future and within the supported date range.
  * The expiry date picker limits selection to the latest supported date.
  * Clear error messages are shown when an expiry date is invalid or too far in the future.

* **Bug Fixes**
  * Valid expiry dates are normalized consistently when saved.

* **Tests**
  * Added coverage for valid, past, and excessively distant SSH key expiry dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->