### PR TITLE
`Development`: Minimize data transfer when processing a build result

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Result.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Result.java
@@ -113,6 +113,17 @@ public class Result extends DomainObject implements Comparable<Result> {
     @Column(name = "assessment_type")
     private AssessmentType assessmentType;
 
+    /**
+     * Which correction round this result belongs to: 0 for the first correction, 1 for the second, and so on. Null for
+     * automatic and Athena results, which are not correction rounds.
+     * <p>
+     * This used to be the position of the result inside its submission's result list, which is why that list carried an
+     * order column. Keeping the round here means a result can be written without loading and re-saving the whole
+     * submission just so Hibernate can renumber the list.
+     */
+    @Column(name = "correction_round")
+    private Integer correctionRound;
+
     @Column(name = "has_complaint")
     private Boolean hasComplaint;
 
@@ -453,6 +464,15 @@ public class Result extends DomainObject implements Comparable<Result> {
 
     public AssessmentType getAssessmentType() {
         return assessmentType;
+    }
+
+    @Nullable
+    public Integer getCorrectionRound() {
+        return correctionRound;
+    }
+
+    public void setCorrectionRound(@Nullable Integer correctionRound) {
+        this.correctionRound = correctionRound;
     }
 
     public Result assessmentType(AssessmentType assessmentType) {

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/dto/ResultDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/dto/ResultDTO.java
@@ -22,8 +22,8 @@ import de.tum.cit.aet.artemis.exercise.dto.SubmissionDTO;
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ResultDTO(Long id, ZonedDateTime completionDate, Boolean successful, Double score, Boolean rated, SubmissionDTO submission, ParticipationDTO participation,
-        List<FeedbackDTO> feedbacks, AssessmentType assessmentType, Boolean hasComplaint, Boolean exampleResult, UserNameDTO assessor, AssessmentNoteDTO assessmentNote)
-        implements Serializable {
+        List<FeedbackDTO> feedbacks, AssessmentType assessmentType, Integer correctionRound, Boolean hasComplaint, Boolean exampleResult, UserNameDTO assessor,
+        AssessmentNoteDTO assessmentNote) implements Serializable {
 
     /**
      * Converts a Result into a ResultDTO.
@@ -53,6 +53,6 @@ public record ResultDTO(Long id, ZonedDateTime completionDate, Boolean successfu
         }
         AssessmentNoteDTO assessmentNoteDTO = AssessmentNoteDTO.of(result.getAssessmentNote());
         return new ResultDTO(result.getId(), result.getCompletionDate(), result.isSuccessful(), result.getScore(), result.isRated(), submissionDTO, participationDTO, feedbackDTOs,
-                result.getAssessmentType(), result.hasComplaint(), result.isExampleResult(), assessorDTO, assessmentNoteDTO);
+                result.getAssessmentType(), result.getCorrectionRound(), result.hasComplaint(), result.isExampleResult(), assessorDTO, assessmentNoteDTO);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ResultRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ResultRepository.java
@@ -34,6 +34,7 @@ import de.tum.cit.aet.artemis.core.dto.DueDateStat;
 import de.tum.cit.aet.artemis.core.repository.base.ArtemisJpaRepository;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
 import de.tum.cit.aet.artemis.exercise.domain.Submission;
+import de.tum.cit.aet.artemis.exercise.dto.CorrectionRoundResultDTO;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
 
 /**
@@ -499,6 +500,30 @@ public interface ResultRepository extends ArtemisJpaRepository<Result, Long> {
      * @return true if a result exists for the given submission ID, false otherwise.
      */
     boolean existsBySubmissionId(long submissionId);
+
+    /**
+     * Returns the manual results of the given submissions together with the correction round each belongs to.
+     * <p>
+     * The scores overview renders assessment actions per correction round, so it needs one entry per round rather than
+     * only the newest result. Automatic and Athena results are left out because they are not correction rounds, which
+     * matches {@link de.tum.cit.aet.artemis.exercise.domain.Submission#getManualResults()} and keeps a result whose
+     * assessment type is not set yet.
+     *
+     * @param submissionIds the submissions whose manual results should be read
+     * @return the manual results of those submissions, in no particular order
+     */
+    @Query("""
+            SELECT new de.tum.cit.aet.artemis.exercise.dto.CorrectionRoundResultDTO(
+                result.submission.id, result.id, result.correctionRound, result.assessmentType, result.completionDate, result.hasComplaint)
+            FROM Result result
+            WHERE result.submission.id IN :submissionIds
+                AND (result.assessmentType IS NULL
+                    OR result.assessmentType NOT IN (
+                        de.tum.cit.aet.artemis.assessment.domain.AssessmentType.AUTOMATIC,
+                        de.tum.cit.aet.artemis.assessment.domain.AssessmentType.AUTOMATIC_ATHENA
+                    ))
+            """)
+    List<CorrectionRoundResultDTO> findCorrectionRoundResultsBySubmissionIds(@Param("submissionIds") Set<Long> submissionIds);
 
     /**
      * Returns true if there is at least one result for the given exercise.

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamService.java
@@ -285,11 +285,11 @@ public class ExamService {
                 if (latestResult != null) {
                     latestResult.setSubmission(lastSubmission);
                     latestResult.filterSensitiveInformation();
-                    lastSubmission.setResults(List.of(latestResult));
+                    lastSubmission.setResults(Set.of(latestResult));
                 }
             }
             else {
-                lastSubmission.setResults(List.of());
+                lastSubmission.setResults(Set.of());
             }
         }
     }
@@ -434,7 +434,7 @@ public class ExamService {
                 ex.getSolutionParticipation().getSubmissions().forEach(sub -> {
                     Result result = latestSolutionResults.get(sub.getId());
                     if (result != null) {
-                        sub.setResults(List.of(result));
+                        sub.setResults(Set.of(result));
                     }
                 });
             }
@@ -442,7 +442,7 @@ public class ExamService {
                 ex.getTemplateParticipation().getSubmissions().forEach(sub -> {
                     Result result = latestTemplateResults.get(sub.getId());
                     if (result != null) {
-                        sub.setResults(List.of(result));
+                        sub.setResults(Set.of(result));
                     }
                 });
             }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Exercise.java
@@ -523,7 +523,7 @@ public abstract class Exercise extends BaseExercise implements LearningObject {
         boolean isAssessmentOver = getAssessmentDueDate() == null || getAssessmentDueDate().isBefore(ZonedDateTime.now());
 
         participation.getSubmissions().forEach(submission -> {
-            List<Result> results = submission.getResults();
+            Set<Result> results = submission.getResults();
             if (results != null && !results.isEmpty()) {
                 if (!isAssessmentOver) {
                     // For assessment that's not over yet

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -26,7 +25,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import org.hibernate.annotations.ConcreteProxy;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -86,6 +84,12 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     private Set<SubmissionVersion> versions = new HashSet<>();
 
     /**
+     * Orders results by their id, putting a result that was not saved yet at the end: it has just been created, so it
+     * is the newest one. Without the null handling every lookup here would throw for an in-memory result.
+     */
+    private static final Comparator<Result> BY_ID = Comparator.comparing(Result::getId, Comparator.nullsLast(Comparator.naturalOrder()));
+
+    /**
      * A submission can have multiple results, therefore, results are persisted and removed with a submission.
      * <p>
      * Deliberately unordered. This used to be an ordered list whose position carried the correction round, which meant
@@ -129,7 +133,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     @Nullable
     @JsonIgnore
     public Result getLatestResult() {
-        Result latestResult = Optional.ofNullable(results).orElse(Set.of()).stream().filter(Objects::nonNull).max(Comparator.comparing(Result::getId)).orElse(null);
+        Result latestResult = Optional.ofNullable(results).orElse(Set.of()).stream().filter(Objects::nonNull).max(BY_ID).orElse(null);
 
         if (latestResult != null) {
             latestResult.setSubmission(this);
@@ -173,16 +177,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
         }
         // The lowest id among the matches, so that the answer does not depend on the iteration order of an unordered
         // set. There should only ever be one result per round, and picking the earliest is what the ordered list did.
-        return filterNonAutomaticResults().stream().filter(result -> Objects.equals(result.getCorrectionRound(), correctionRound)).min(Comparator.comparing(Result::getId))
-                .orElse(null);
-    }
-
-    /**
-     * @return an unmodifiable list or all non-automatic results
-     */
-    @NonNull
-    private List<Result> filterNonAutomaticResults() {
-        return results.stream().filter(result -> result == null || !(result.isAutomatic() || result.isAthenaBased())).toList();
+        return getManualResults().stream().filter(result -> Objects.equals(result.getCorrectionRound(), correctionRound)).min(BY_ID).orElse(null);
     }
 
     /**
@@ -270,7 +265,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
         if (results == null || results.isEmpty()) {
             return null;
         }
-        return results.stream().filter(Objects::nonNull).min(Comparator.comparing(Result::getId)).orElse(null);
+        return results.stream().filter(Objects::nonNull).min(BY_ID).orElse(null);
     }
 
     /**
@@ -286,7 +281,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
         if (results == null) {
             return null;
         }
-        return getManualResults().stream().min(Comparator.comparing(Result::getId)).orElse(null);
+        return getManualResults().stream().min(BY_ID).orElse(null);
     }
 
     /**
@@ -305,15 +300,9 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
         if (results == null) {
             return null;
         }
-        return getManualResults().stream().max(Comparator.comparing(Result::getId)).orElse(null);
+        return getManualResults().stream().max(BY_ID).orElse(null);
     }
 
-    /**
-     * Add a result to the list.
-     * NOTE: You must make sure to correctly persist the result in the database!
-     *
-     * @param result the {@link Result} which should be added
-     */
     /**
      * Adds a result to this submission and, if it is a correction-round result that does not have a round yet, assigns
      * the next one.

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -22,6 +23,7 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 
 import org.hibernate.annotations.ConcreteProxy;
@@ -92,14 +94,17 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     /**
      * A submission can have multiple results, therefore, results are persisted and removed with a submission.
      * <p>
-     * Deliberately unordered. This used to be an ordered list whose position carried the correction round, which meant
-     * every write in this area had to load and re-save the whole submission so that Hibernate could renumber the order
-     * column. The correction round now lives on {@link Result#getCorrectionRound()}, and the newest result is the one
-     * with the highest id, so nothing needs the position any more.
+     * A set, not a list: this used to be an ordered list whose position carried the correction round, which meant every
+     * write in this area had to load and re-save the whole submission so that Hibernate could renumber the order
+     * column. The correction round now lives on {@link Result#getCorrectionRound()}, so nothing needs the position.
+     * <p>
+     * Ordered by id all the same. Nothing on the server depends on it, but the collection is serialized to the client,
+     * and a hash set would hand it the results in an order that can change between two requests for the same data.
      */
     @OneToMany(mappedBy = "submission", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("id")
     @JsonIgnoreProperties({ "submission", "participation" })
-    private Set<Result> results = new HashSet<>();
+    private Set<Result> results = new LinkedHashSet<>();
 
     @Column(name = "submission_date")
     private ZonedDateTime submissionDate;
@@ -153,7 +158,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     @JsonIgnore
     public Result getLatestCompletedResult() {
         Result latestResult = Optional.ofNullable(results).orElse(Set.of()).stream().filter(result -> result != null && result.getCompletionDate() != null)
-                .max(Comparator.comparing(Result::getCompletionDate)).orElse(null);
+                .max(Comparator.comparing(Result::getCompletionDate).thenComparing(BY_ID)).orElse(null);
 
         if (latestResult != null) {
             latestResult.setSubmission(this);
@@ -199,7 +204,8 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      */
     @JsonIgnore
     public void removeAutomaticResults() {
-        this.results = this.results.stream().filter(result -> result == null || !(result.isAutomatic() || result.isAthenaBased())).collect(Collectors.toCollection(HashSet::new));
+        this.results = this.results.stream().filter(result -> result == null || !(result.isAutomatic() || result.isAthenaBased()))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
@@ -214,7 +220,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      */
     @JsonIgnore
     public void removeNullResults() {
-        this.results = this.results.stream().filter(Objects::nonNull).collect(Collectors.toCollection(HashSet::new));
+        this.results = this.results.stream().filter(Objects::nonNull).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     @JsonProperty(value = "results", access = JsonProperty.Access.READ_ONLY)
@@ -224,12 +230,12 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
 
     @JsonIgnore
     public Set<Result> getAutomaticResults() {
-        return results.stream().filter(result -> result != null && (result.isAutomatic() || result.isAthenaBased())).collect(Collectors.toCollection(HashSet::new));
+        return results.stream().filter(result -> result != null && (result.isAutomatic() || result.isAthenaBased())).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     @JsonIgnore
     public Set<Result> getManualResults() {
-        return results.stream().filter(result -> result != null && !result.isAutomatic() && !result.isAthenaBased()).collect(Collectors.toCollection(HashSet::new));
+        return results.stream().filter(result -> result != null && !result.isAutomatic() && !result.isAthenaBased()).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
@@ -239,7 +245,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      */
     @JsonIgnore
     public Set<Result> getNonAthenaResults() {
-        return results.stream().filter(result -> result != null && !result.isAthenaBased()).collect(Collectors.toCollection(HashSet::new));
+        return results.stream().filter(result -> result != null && !result.isAthenaBased()).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
@@ -338,7 +344,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      */
     @JsonProperty(value = "results", access = JsonProperty.Access.WRITE_ONLY)
     public void setResults(Set<Result> results) {
-        this.results = results != null ? results : new HashSet<>();
+        this.results = results != null ? results : new LinkedHashSet<>();
     }
 
     public Participation getParticipation() {

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
@@ -87,8 +87,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
 
     /**
      * A submission can have multiple results, therefore, results are persisted and removed with a submission.
-     */
-    /**
+     * <p>
      * Deliberately unordered. This used to be an ordered list whose position carried the correction round, which meant
      * every write in this area had to load and re-save the whole submission so that Hibernate could renumber the order
      * column. The correction round now lives on {@link Result#getCorrectionRound()}, and the newest result is the one
@@ -172,7 +171,10 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
         if (correctionRound < 0) {
             return null;
         }
-        return filterNonAutomaticResults().stream().filter(result -> Objects.equals(result.getCorrectionRound(), correctionRound)).findFirst().orElse(null);
+        // The lowest id among the matches, so that the answer does not depend on the iteration order of an unordered
+        // set. There should only ever be one result per round, and picking the earliest is what the ordered list did.
+        return filterNonAutomaticResults().stream().filter(result -> Objects.equals(result.getCorrectionRound(), correctionRound)).min(Comparator.comparing(Result::getId))
+                .orElse(null);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
@@ -2,7 +2,6 @@ package de.tum.cit.aet.artemis.exercise.domain;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -24,7 +23,6 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
 
 import org.hibernate.annotations.ConcreteProxy;
@@ -90,10 +88,15 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     /**
      * A submission can have multiple results, therefore, results are persisted and removed with a submission.
      */
+    /**
+     * Deliberately unordered. This used to be an ordered list whose position carried the correction round, which meant
+     * every write in this area had to load and re-save the whole submission so that Hibernate could renumber the order
+     * column. The correction round now lives on {@link Result#getCorrectionRound()}, and the newest result is the one
+     * with the highest id, so nothing needs the position any more.
+     */
     @OneToMany(mappedBy = "submission", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderColumn(name = "results_order")
     @JsonIgnoreProperties({ "submission", "participation" })
-    private List<Result> results = new ArrayList<>();
+    private Set<Result> results = new HashSet<>();
 
     @Column(name = "submission_date")
     private ZonedDateTime submissionDate;
@@ -127,7 +130,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     @Nullable
     @JsonIgnore
     public Result getLatestResult() {
-        Result latestResult = Optional.ofNullable(results).orElse(List.of()).stream().filter(Objects::nonNull).max(Comparator.comparing(Result::getId)).orElse(null);
+        Result latestResult = Optional.ofNullable(results).orElse(Set.of()).stream().filter(Objects::nonNull).max(Comparator.comparing(Result::getId)).orElse(null);
 
         if (latestResult != null) {
             latestResult.setSubmission(this);
@@ -146,7 +149,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     @Nullable
     @JsonIgnore
     public Result getLatestCompletedResult() {
-        Result latestResult = Optional.ofNullable(results).orElse(List.of()).stream().filter(result -> result != null && result.getCompletionDate() != null)
+        Result latestResult = Optional.ofNullable(results).orElse(Set.of()).stream().filter(result -> result != null && result.getCompletionDate() != null)
                 .max(Comparator.comparing(Result::getCompletionDate)).orElse(null);
 
         if (latestResult != null) {
@@ -166,11 +169,10 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     @Nullable
     @JsonIgnore
     public Result getResultForCorrectionRound(int correctionRound) {
-        List<Result> filteredResults = filterNonAutomaticResults();
-        if (correctionRound >= 0 && filteredResults.size() > correctionRound) {
-            return filteredResults.get(correctionRound);
+        if (correctionRound < 0) {
+            return null;
         }
-        return null;
+        return filterNonAutomaticResults().stream().filter(result -> Objects.equals(result.getCorrectionRound(), correctionRound)).findFirst().orElse(null);
     }
 
     /**
@@ -191,11 +193,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      */
     @JsonIgnore
     public boolean hasResultForCorrectionRound(int correctionRound) {
-        List<Result> withoutAutomaticResults = filterNonAutomaticResults();
-        if (withoutAutomaticResults.size() > correctionRound) {
-            return withoutAutomaticResults.get(correctionRound) != null;
-        }
-        return false;
+        return getResultForCorrectionRound(correctionRound) != null;
     }
 
     /**
@@ -204,7 +202,7 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      */
     @JsonIgnore
     public void removeAutomaticResults() {
-        this.results = this.results.stream().filter(result -> result == null || !(result.isAutomatic() || result.isAthenaBased())).collect(Collectors.toCollection(ArrayList::new));
+        this.results = this.results.stream().filter(result -> result == null || !(result.isAutomatic() || result.isAthenaBased())).collect(Collectors.toCollection(HashSet::new));
     }
 
     /**
@@ -219,22 +217,22 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      */
     @JsonIgnore
     public void removeNullResults() {
-        this.results = this.results.stream().filter(Objects::nonNull).collect(Collectors.toCollection(ArrayList::new));
+        this.results = this.results.stream().filter(Objects::nonNull).collect(Collectors.toCollection(HashSet::new));
     }
 
     @JsonProperty(value = "results", access = JsonProperty.Access.READ_ONLY)
-    public List<Result> getResults() {
+    public Set<Result> getResults() {
         return results;
     }
 
     @JsonIgnore
-    public List<Result> getAutomaticResults() {
-        return results.stream().filter(result -> result != null && (result.isAutomatic() || result.isAthenaBased())).collect(Collectors.toCollection(ArrayList::new));
+    public Set<Result> getAutomaticResults() {
+        return results.stream().filter(result -> result != null && (result.isAutomatic() || result.isAthenaBased())).collect(Collectors.toCollection(HashSet::new));
     }
 
     @JsonIgnore
-    public List<Result> getManualResults() {
-        return results.stream().filter(result -> result != null && !result.isAutomatic() && !result.isAthenaBased()).collect(Collectors.toCollection(ArrayList::new));
+    public Set<Result> getManualResults() {
+        return results.stream().filter(result -> result != null && !result.isAutomatic() && !result.isAthenaBased()).collect(Collectors.toCollection(HashSet::new));
     }
 
     /**
@@ -243,8 +241,8 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      * @return non athena automatic results excluding null results
      */
     @JsonIgnore
-    public List<Result> getNonAthenaResults() {
-        return results.stream().filter(result -> result != null && !result.isAthenaBased()).collect(Collectors.toCollection(ArrayList::new));
+    public Set<Result> getNonAthenaResults() {
+        return results.stream().filter(result -> result != null && !result.isAthenaBased()).collect(Collectors.toCollection(HashSet::new));
     }
 
     /**
@@ -267,10 +265,10 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     @Nullable
     @JsonIgnore
     public Result getFirstResult() {
-        if (results != null && !results.isEmpty()) {
-            return results.getFirst();
+        if (results == null || results.isEmpty()) {
+            return null;
         }
-        return null;
+        return results.stream().filter(Objects::nonNull).min(Comparator.comparing(Result::getId)).orElse(null);
     }
 
     /**
@@ -281,10 +279,12 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     @Nullable
     @JsonIgnore
     public Result getFirstManualResult() {
-        // Guard on the manual results, not on all results: a submission can carry only automatic or Athena results, and
-        // getFirst() on the then empty manual list would throw instead of returning null as declared.
-        List<Result> manualResults = results == null ? List.of() : getManualResults();
-        return manualResults.isEmpty() ? null : manualResults.getFirst();
+        // The earliest manual result, which is the one of the first correction round. Guard on the manual results, not
+        // on all results: a submission can carry only automatic or Athena results and then there is none.
+        if (results == null) {
+            return null;
+        }
+        return getManualResults().stream().min(Comparator.comparing(Result::getId)).orElse(null);
     }
 
     /**
@@ -299,8 +299,11 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     @Nullable
     @JsonIgnore
     public Result getLatestManualResult() {
-        List<Result> manualResults = results == null ? List.of() : getManualResults();
-        return manualResults.isEmpty() ? null : manualResults.getLast();
+        // The most recent manual result, which is the one of the highest correction round.
+        if (results == null) {
+            return null;
+        }
+        return getManualResults().stream().max(Comparator.comparing(Result::getId)).orElse(null);
     }
 
     /**
@@ -309,8 +312,31 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      *
      * @param result the {@link Result} which should be added
      */
+    /**
+     * Adds a result to this submission and, if it is a correction-round result that does not have a round yet, assigns
+     * the next one.
+     * <p>
+     * This is where the round used to come from implicitly: the results were an ordered list and the position carried
+     * the round, so adding a result to the list decided which round it belonged to. The round now lives on the result,
+     * and this is the same moment, so the behaviour is unchanged for every caller that does not set it itself.
+     * {@code SubmissionService.lockSubmission} does set it, from the round the tutor asked for, and that takes
+     * precedence. Automatic and Athena results are not correction rounds and keep no round.
+     *
+     * @param result the result to add
+     */
     public void addResult(Result result) {
+        if (result != null && result.getCorrectionRound() == null && !result.isAutomatic() && !result.isAthenaBased()) {
+            result.setCorrectionRound(countCorrectionRoundResults(result));
+        }
         this.results.add(result);
+    }
+
+    /**
+     * @param resultToAdd the result that is about to be added, which must not count itself
+     * @return how many correction-round results this submission already holds
+     */
+    private int countCorrectionRoundResults(Result resultToAdd) {
+        return (int) results.stream().filter(other -> other != null && other != resultToAdd && !other.isAutomatic() && !other.isAthenaBased()).count();
     }
 
     /**
@@ -320,8 +346,8 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      * @param results The list of {@link Result} which should replace the existing results of the submission
      */
     @JsonProperty(value = "results", access = JsonProperty.Access.WRITE_ONLY)
-    public void setResults(List<Result> results) {
-        this.results = results;
+    public void setResults(Set<Result> results) {
+        this.results = results != null ? results : new HashSet<>();
     }
 
     public Participation getParticipation() {
@@ -398,9 +424,12 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      */
     public void removeNotNeededResults(int correctionRound, Long resultId) {
         if (correctionRound == 0 && resultId == null && getResults().size() >= 2) {
-            var resultList = new ArrayList<Result>();
-            resultList.add(getFirstManualResult());
-            setResults(resultList);
+            var remainingResults = new HashSet<Result>();
+            var firstManualResult = getFirstManualResult();
+            if (firstManualResult != null) {
+                remainingResults.add(firstManualResult);
+            }
+            setResults(remainingResults);
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/CorrectionRoundResultDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/CorrectionRoundResultDTO.java
@@ -1,0 +1,28 @@
+package de.tum.cit.aet.artemis.exercise.dto;
+
+import java.time.ZonedDateTime;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
+
+/**
+ * One manual result of a submission together with the correction round it belongs to.
+ * <p>
+ * The scores overview renders one set of assessment actions per correction round, and it needs to know, per round,
+ * whether that round has a result, whether it is finished and whether it has a complaint. Everything else about the
+ * result is already covered by the flat fields of {@link ParticipationScoreDTO}, which describe the newest result.
+ *
+ * @param submissionId    the submission the result belongs to
+ * @param resultId        the result
+ * @param correctionRound the round the result belongs to, null for a result that is not a correction round
+ * @param assessmentType  how the result was produced
+ * @param completionDate  when the assessment was finished, null while it is still a draft
+ * @param hasComplaint    whether the student complained about this result
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record CorrectionRoundResultDTO(long submissionId, long resultId, @Nullable Integer correctionRound, @Nullable AssessmentType assessmentType,
+        @Nullable ZonedDateTime completionDate, @Nullable Boolean hasComplaint) {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationScoreDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/ParticipationScoreDTO.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.exercise.dto;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -13,5 +14,5 @@ import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 public record ParticipationScoreDTO(long participationId, ZonedDateTime initializationDate, int submissionCount, String participantName, String participantIdentifier,
         Long studentId, Long teamId, Long resultId, Double score, Boolean successful, ZonedDateTime completionDate, AssessmentType assessmentType, String assessmentNote,
         Long durationInSeconds, Long submissionId, Boolean buildFailed, String buildPlanId, String repositoryUri, boolean testRun, Integer testCaseCount,
-        Integer passedTestCaseCount, Integer codeIssueCount) {
+        Integer passedTestCaseCount, Integer codeIssueCount, List<CorrectionRoundResultDTO> correctionRoundResults) {
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationDeletionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationDeletionService.java
@@ -215,7 +215,7 @@ public class ParticipationDeletionService {
         // Delete all submissions for this participation
         submissions.forEach(submission -> {
             // We have to set the results to an empty list because otherwise clearing the build log entries does not work correctly
-            submission.setResults(List.of());
+            submission.setResults(Set.of());
             if (submission instanceof ProgrammingSubmission programmingSubmission) {
                 buildLogEntryService.deleteBuildLogEntriesForProgrammingSubmission(programmingSubmission);
             }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationFilterService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationFilterService.java
@@ -2,8 +2,8 @@ package de.tum.cit.aet.artemis.exercise.service;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
-import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -95,7 +95,7 @@ public class ParticipationFilterService {
                     latestResult.filterSensitiveInformation();
                 }
             }
-            submission.setResults(new ArrayList<>(results));
+            submission.setResults(new HashSet<>(results));
         }
         else {
             // A quiz that has not ended yet intentionally exposes neither its submission's answers nor its result (see
@@ -130,7 +130,7 @@ public class ParticipationFilterService {
                     sanitizedSubmission.setId(submission.getId());
                     sanitizedSubmission.setSubmitted(true);
                     sanitizedSubmission.setSubmissionDate(submission.getSubmissionDate());
-                    sanitizedSubmission.setResults(new ArrayList<>());
+                    sanitizedSubmission.setResults(new HashSet<>());
                     return sanitizedSubmission;
                 });
     }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationFilterService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationFilterService.java
@@ -3,7 +3,7 @@ package de.tum.cit.aet.artemis.exercise.service;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -95,7 +95,7 @@ public class ParticipationFilterService {
                     latestResult.filterSensitiveInformation();
                 }
             }
-            submission.setResults(new HashSet<>(results));
+            submission.setResults(new LinkedHashSet<>(results));
         }
         else {
             // A quiz that has not ended yet intentionally exposes neither its submission's answers nor its result (see
@@ -130,7 +130,7 @@ public class ParticipationFilterService {
                     sanitizedSubmission.setId(submission.getId());
                     sanitizedSubmission.setSubmitted(true);
                     sanitizedSubmission.setSubmissionDate(submission.getSubmissionDate());
-                    sanitizedSubmission.setResults(new HashSet<>());
+                    sanitizedSubmission.setResults(new LinkedHashSet<>());
                     return sanitizedSubmission;
                 });
     }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationService.java
@@ -41,6 +41,7 @@ import de.tum.cit.aet.artemis.exercise.domain.Team;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participant;
 import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
 import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation;
+import de.tum.cit.aet.artemis.exercise.dto.CorrectionRoundResultDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationDueDateUpdateDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationManagementDTO;
 import de.tum.cit.aet.artemis.exercise.dto.ParticipationNameExportDTO;
@@ -1086,9 +1087,14 @@ public class ParticipationService {
         // Load latest results with assessment notes
         Set<Long> submissionIds = participations.stream().flatMap(p -> p.getSubmissions().stream()).map(Submission::getId).filter(Objects::nonNull).collect(Collectors.toSet());
         Map<Long, Result> resultBySubmissionId = Map.of();
+        // The scores view renders assessment actions per correction round, so it needs one entry per round on top of the
+        // newest result the score columns are built from.
+        Map<Long, List<CorrectionRoundResultDTO>> correctionRoundResultsBySubmissionId = Map.of();
         if (!submissionIds.isEmpty()) {
             Set<Result> results = resultRepository.findLatestResultsWithAssessmentNoteBySubmissionIds(submissionIds);
             resultBySubmissionId = results.stream().collect(Collectors.toMap(result -> result.getSubmission().getId(), Function.identity()));
+            correctionRoundResultsBySubmissionId = resultRepository.findCorrectionRoundResultsBySubmissionIds(submissionIds).stream()
+                    .collect(Collectors.groupingBy(CorrectionRoundResultDTO::submissionId));
         }
 
         // Load submission counts for these IDs
@@ -1097,12 +1103,15 @@ public class ParticipationService {
         // Step 3: Map to DTOs, preserving the ID query order
         Map<Long, StudentParticipation> participationById = participations.stream().collect(Collectors.toMap(p -> p.getId(), Function.identity()));
         final Map<Long, Result> finalResultMap = resultBySubmissionId;
-        List<ParticipationScoreDTO> dtos = ids.stream().map(participationById::get).filter(Objects::nonNull).map(p -> mapToDTO(p, submissionCountMap, finalResultMap)).toList();
+        final Map<Long, List<CorrectionRoundResultDTO>> finalCorrectionRoundResults = correctionRoundResultsBySubmissionId;
+        List<ParticipationScoreDTO> dtos = ids.stream().map(participationById::get).filter(Objects::nonNull)
+                .map(p -> mapToDTO(p, submissionCountMap, finalResultMap, finalCorrectionRoundResults)).toList();
 
         return new PageImpl<>(dtos, pageable, idPage.getTotalElements());
     }
 
-    private ParticipationScoreDTO mapToDTO(StudentParticipation participation, Map<Long, Integer> submissionCountMap, Map<Long, Result> resultBySubmissionId) {
+    private ParticipationScoreDTO mapToDTO(StudentParticipation participation, Map<Long, Integer> submissionCountMap, Map<Long, Result> resultBySubmissionId,
+            Map<Long, List<CorrectionRoundResultDTO>> correctionRoundResultsBySubmissionId) {
         // Participant info
         String participantName;
         String participantIdentifier;
@@ -1165,9 +1174,11 @@ public class ParticipationService {
         Integer passedTestCaseCount = latestResult != null ? latestResult.getPassedTestCaseCount() : null;
         Integer codeIssueCount = latestResult != null ? latestResult.getCodeIssueCount() : null;
 
+        List<CorrectionRoundResultDTO> correctionRoundResults = submissionId != null ? correctionRoundResultsBySubmissionId.getOrDefault(submissionId, List.of()) : List.of();
+
         return new ParticipationScoreDTO(participation.getId(), participation.getInitializationDate(), submissionCount, participantName, participantIdentifier, studentId, teamId,
                 resultId, score, successful, completionDate, assessmentType, assessmentNote, durationInSeconds, submissionId, buildFailed, buildPlanId, repositoryUri, testRun,
-                testCaseCount, passedTestCaseCount, codeIssueCount);
+                testCaseCount, passedTestCaseCount, codeIssueCount, correctionRoundResults);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionFilterService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionFilterService.java
@@ -4,7 +4,6 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.time.ZonedDateTime;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -100,9 +99,9 @@ public class SubmissionFilterService {
          * Sometimes we cannot show the last submission because the assessment due date has not yet passed,
          * but we should still show the student the latest automatically determined score.
          */
-        List<Result> automaticResults = programmingSubmission.getAutomaticResults();
-        if (!automaticResults.isEmpty()) {
-            programmingSubmission.setResults(List.of(automaticResults.getLast()));
+        var latestAutomaticResult = programmingSubmission.getAutomaticResults().stream().max(Comparator.comparing(Result::getId));
+        if (latestAutomaticResult.isPresent()) {
+            programmingSubmission.setResults(Set.of(latestAutomaticResult.get()));
             return true;
         }
         return false;

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
@@ -8,6 +8,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -183,8 +184,7 @@ public class SubmissionService {
         if (examMode) {
             var participations = this.studentParticipationRepository.findAllByParticipationExerciseIdAndResultAssessorAndCorrectionRoundIgnoreTestRuns(exerciseId, tutor);
             submissions = participations.stream().map(StudentParticipation::findLatestSubmission).filter(Optional::isPresent).map(Optional::get).map(submission -> (T) submission)
-                    .filter(submission -> submission.getResults().size() - 1 >= correctionRound && submission.getResults().get(correctionRound) != null)
-                    .collect(Collectors.toCollection(ArrayList::new));
+                    .filter(submission -> submission.hasResultForCorrectionRound(correctionRound)).collect(Collectors.toCollection(ArrayList::new));
         }
         else {
             submissions = this.submissionRepository.findAllByParticipationExerciseIdAndResultAssessorIgnoreTestRuns(exerciseId, tutor);
@@ -362,7 +362,7 @@ public class SubmissionService {
                 // make sure that sensitive information is not sent to the client for students
                 if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user)) {
                     exercise.filterSensitiveInformation();
-                    submission.setResults(new ArrayList<>());
+                    submission.setResults(new HashSet<>());
                 }
                 // remove information about the student or team from the submission for tutors to ensure a double-blind assessment
                 if (!authCheckService.isAtLeastInstructorForExercise(exercise, user)) {
@@ -629,6 +629,10 @@ public class SubmissionService {
             result.setAssessor(userRepository.getUser());
         }
 
+        // The round this result belongs to is stored on the result itself. This is the one place where a manual result
+        // for a correction round is created or claimed, so it is also where a result that predates the column gets its
+        // round the first time a tutor opens it.
+        result.setCorrectionRound(correctionRound);
         result.setAssessmentType(AssessmentType.MANUAL);
         // Workaround to prevent the assessor turning into a proxy object after saving
         var assessor = result.getAssessor();

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/SubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/SubmissionResource.java
@@ -4,6 +4,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,12 +114,12 @@ public class SubmissionResource {
         }
 
         checkAccessPermissionAtInstructor(submission.get());
-        List<Result> results = submission.get().getResults();
+        Set<Result> results = submission.get().getResults();
         for (Result result : results) {
             resultService.deleteResult(result, true);
         }
         // We have to set the results to an empty list because otherwise clearing the build log entries does not work correctly
-        submission.get().setResults(List.of());
+        submission.get().setResults(Set.of());
         if (submission.get() instanceof ProgrammingSubmission programmingSubmission) {
             buildLogEntryService.deleteBuildLogEntriesForProgrammingSubmission(programmingSubmission);
         }

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/dto/FileUploadResultDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/dto/FileUploadResultDTO.java
@@ -19,23 +19,25 @@ import de.tum.cit.aet.artemis.fileupload.domain.FileUploadSubmission;
 /**
  * DTO representing a result / assessment of a file upload submission.
  *
- * @param id             the ID of the result
- * @param completionDate the date and time when the assessment was completed
- * @param successful     whether the result is considered successful
- * @param score          the score achieved (in percent or points depending on context)
- * @param rated          whether the result is rated (counts for the final score)
- * @param assessmentType the type of assessment (e.g. MANUAL, AUTOMATIC)
- * @param hasComplaint   whether a complaint has been filed for this result
- * @param exampleResult  whether this result belongs to an example submission
- * @param assessmentNote the assessment note associated with the result
- * @param assessor       the tutor/instructor who assessed the submission
- * @param feedbacks      the feedbacks generated for this result
- * @param submission     the submission context if requested
+ * @param id              the ID of the result
+ * @param completionDate  the date and time when the assessment was completed
+ * @param successful      whether the result is considered successful
+ * @param score           the score achieved (in percent or points depending on context)
+ * @param rated           whether the result is rated (counts for the final score)
+ * @param assessmentType  the type of assessment (e.g. MANUAL, AUTOMATIC)
+ * @param hasComplaint    whether a complaint has been filed for this result
+ * @param exampleResult   whether this result belongs to an example submission
+ * @param correctionRound which correction round the result belongs to
+ * @param assessmentNote  the assessment note associated with the result
+ * @param assessor        the tutor/instructor who assessed the submission
+ * @param feedbacks       the feedbacks generated for this result
+ * @param submission      the submission context if requested
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record FileUploadResultDTO(Long id, @Nullable ZonedDateTime completionDate, @Nullable Boolean successful, @Nullable Double score, boolean rated,
-        @Nullable AssessmentType assessmentType, @Nullable Boolean hasComplaint, @Nullable Boolean exampleResult, @Nullable FileUploadAssessmentNoteDTO assessmentNote,
-        @Nullable FileUploadUserDTO assessor, @Nullable List<FileUploadFeedbackDTO> feedbacks, @Nullable FileUploadSubmissionDTO submission) {
+        @Nullable AssessmentType assessmentType, @Nullable Integer correctionRound, @Nullable Boolean hasComplaint, @Nullable Boolean exampleResult,
+        @Nullable FileUploadAssessmentNoteDTO assessmentNote, @Nullable FileUploadUserDTO assessor, @Nullable List<FileUploadFeedbackDTO> feedbacks,
+        @Nullable FileUploadSubmissionDTO submission) {
 
     /**
      * Factory method to map a {@link Result} entity to a nested {@link FileUploadResultDTO} (without including submission loop).
@@ -86,6 +88,6 @@ public record FileUploadResultDTO(Long id, @Nullable ZonedDateTime completionDat
         }
 
         return new FileUploadResultDTO(result.getId(), result.getCompletionDate(), result.isSuccessful(), result.getScore(), result.isRated(), result.getAssessmentType(),
-                result.hasComplaint(), result.isExampleResult(), assessmentNoteDTO, assessorDTO, feedbackDTOs, submissionDTO);
+                result.getCorrectionRound(), result.hasComplaint(), result.isExampleResult(), assessmentNoteDTO, assessorDTO, feedbackDTOs, submissionDTO);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/dto/FileUploadSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/dto/FileUploadSubmissionDTO.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.fileupload.dto;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.Hibernate;
 import org.jspecify.annotations.Nullable;
@@ -29,7 +30,7 @@ import de.tum.cit.aet.artemis.fileupload.domain.FileUploadSubmission;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record FileUploadSubmissionDTO(Long id, @Nullable Boolean submitted, @Nullable SubmissionType type, @Nullable Boolean exampleSubmission,
         @Nullable ZonedDateTime submissionDate, @Nullable Long durationInMinutes, String submissionExerciseType, @Nullable String filePath,
-        @Nullable FileUploadParticipationDTO participation, @Nullable List<@Nullable FileUploadResultDTO> results) {
+        @Nullable FileUploadParticipationDTO participation, @Nullable List<FileUploadResultDTO> results) {
 
     /**
      * Factory method to map a {@link FileUploadSubmission} to a DTO after a successful submission.
@@ -118,7 +119,7 @@ public record FileUploadSubmissionDTO(Long id, @Nullable Boolean submitted, @Nul
 
         List<FileUploadResultDTO> resultDTOs = null;
         if (includeResults && submission.getResults() != null && Hibernate.isInitialized(submission.getResults())) {
-            resultDTOs = submission.getResults().stream().map(result -> result == null ? null : FileUploadResultDTO.ofNested(result)).toList();
+            resultDTOs = submission.getResults().stream().filter(Objects::nonNull).map(FileUploadResultDTO::ofNested).toList();
         }
 
         return new FileUploadSubmissionDTO(submission.getId(), submission.isSubmitted(), submission.getType(), submission.isExampleSubmission(), submission.getSubmissionDate(),

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/service/FileUploadSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/service/FileUploadSubmissionService.java
@@ -6,7 +6,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Optional;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -159,7 +159,7 @@ public class FileUploadSubmissionService extends SubmissionService {
         }
 
         // remove result from submission (in the unlikely case it is passed here), so that students cannot inject a result
-        fileUploadSubmission.setResults(new ArrayList<>());
+        fileUploadSubmission.setResults(new HashSet<>());
 
         // Note: we save before the new file path is set to potentially remove the old file on the file system
         fileUploadSubmission = fileUploadSubmissionRepository.save(fileUploadSubmission);

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/web/FileUploadSubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/web/FileUploadSubmissionResource.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.fileupload.web;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
@@ -371,7 +372,7 @@ public class FileUploadSubmissionResource extends AbstractSubmissionResource {
             boolean assessmentDueDateNotOver = !ExerciseDateService.isAfterAssessmentDueDate(fileUploadExercise);
 
             if (assessmentUnfinished || assessmentDueDateNotOver) {
-                fileUploadSubmission.setResults(List.of());
+                fileUploadSubmission.setResults(Set.of());
             }
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionCodeGenerationExecutionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionCodeGenerationExecutionService.java
@@ -340,7 +340,7 @@ public class HyperionCodeGenerationExecutionService {
         // build-log graph; otherwise a compile failure (the most common retry trigger) is hidden behind a useless fallback message.
         try {
             List<BuildLogEntry> buildLogEntries = programmingSubmissionRepository.findWithEagerBuildLogEntriesById(programmingSubmission.getId())
-                    .map(ProgrammingSubmission::getBuildLogEntries).orElse(List.of());
+                    .map(ProgrammingSubmission::getBuildLogEntries).map(List::copyOf).orElse(List.of());
             if (!buildLogEntries.isEmpty()) {
                 return buildLogEntries.stream().map(BuildLogEntry::getLog).collect(Collectors.joining("\n"));
             }

--- a/src/main/java/de/tum/cit/aet/artemis/modeling/dto/ModelingSubmissionResponseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/dto/ModelingSubmissionResponseDTO.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.modeling.dto;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.Hibernate;
 
@@ -62,10 +63,9 @@ public record ModelingSubmissionResponseDTO(Long id, String submissionExerciseTy
 
         List<ResultDTO> results = null;
         if (submission.getResults() != null && Hibernate.isInitialized(submission.getResults())) {
-            // Preserve the list structure verbatim, INCLUDING null padding: when a submission is fetched for a specific
-            // assessor the results collection is padded with nulls to keep the @OrderColumn index stable, and the client
-            // reads results[correctionRound]. Dropping the null slots would shift the indices. ResultDTO.of(null) is null.
-            results = submission.getResults().stream().map(ResultDTO::of).toList();
+            // No null slots: the results used to be an ordered list padded with nulls so that the client could read
+            // results[correctionRound], and the round now lives on the result itself, so the client matches on it.
+            results = submission.getResults().stream().filter(Objects::nonNull).map(ResultDTO::of).toList();
         }
 
         ModelingParticipationDTO participation = null;

--- a/src/main/java/de/tum/cit/aet/artemis/modeling/service/ModelingSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/service/ModelingSubmissionService.java
@@ -1,7 +1,7 @@
 package de.tum.cit.aet.artemis.modeling.service;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Optional;
 
 import org.jspecify.annotations.Nullable;
@@ -146,7 +146,7 @@ public class ModelingSubmissionService extends SubmissionService {
         }
 
         // remove result from submission (in the unlikely case it is passed here), so that students cannot inject a result
-        modelingSubmission.setResults(new ArrayList<>());
+        modelingSubmission.setResults(new HashSet<>());
         if (modelingSubmission.getId() != null) {
             // Autosave of an existing submission: only the client-editable fields changed, and the row is already there.
             // Saving the detached entity would merge it, which reads the submission and its whole eager association graph

--- a/src/main/java/de/tum/cit/aet/artemis/modeling/web/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/web/ModelingSubmissionResource.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.modeling.web;
 
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -403,14 +404,14 @@ public class ModelingSubmissionResource extends AbstractSubmissionResource {
         Result latestResult = modelingSubmission.getLatestResult();
         if (latestResult != null && latestResult.getAssessmentType() != AssessmentType.AUTOMATIC_ATHENA
                 && (latestResult.getCompletionDate() == null || latestResult.getAssessor() == null)) {
-            modelingSubmission.setResults(List.of());
+            modelingSubmission.setResults(Set.of());
         }
 
         if (!ExerciseDateService.isAfterAssessmentDueDate(exercise)) {
             // We want to have the preliminary feedback before the assessment due date too
             List<Result> athenaResults = modelingSubmission.getResults().stream().filter(result -> result != null && result.getAssessmentType() == AssessmentType.AUTOMATIC_ATHENA)
                     .toList();
-            modelingSubmission.setResults(athenaResults);
+            modelingSubmission.setResults(new LinkedHashSet<>(athenaResults));
         }
 
         if (modelingSubmission.getLatestResult() != null && !authCheckService.isAtLeastTeachingAssistantForExercise(exercise)) {
@@ -468,7 +469,8 @@ public class ModelingSubmissionResource extends AbstractSubmissionResource {
 
             // Set filtered results back into the submission if any results remain after filtering
             if (!filteredResults.isEmpty()) {
-                submission.setResults(filteredResults);
+                // A LinkedHashSet because the results were just sorted for the client and that order has to survive.
+                submission.setResults(new LinkedHashSet<>(filteredResults));
                 return true; // Include submission as it has relevant results
             }
             return false;

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/TextPlagiarismDetectionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/TextPlagiarismDetectionService.java
@@ -4,7 +4,7 @@ import static de.tum.cit.aet.artemis.plagiarism.service.PlagiarismService.hasMin
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -119,7 +119,7 @@ public class TextPlagiarismDetectionService {
             textSubmissions.forEach(submission -> {
                 var progressMessage = "Getting submission: " + processedSubmissionCount + "/" + textSubmissions.size();
                 plagiarismWebsocketService.notifyInstructorAboutPlagiarismState(topic, PlagiarismCheckState.RUNNING, List.of(progressMessage));
-                submission.setResults(new ArrayList<>());
+                submission.setResults(new HashSet<>());
 
                 StudentParticipation participation = (StudentParticipation) submission.getParticipation();
                 participation.setExercise(null);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingExercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingExercise.java
@@ -607,7 +607,7 @@ public class ProgrammingExercise extends Exercise {
     @Override
     public void filterResultsForStudents(Participation participation) {
         participation.getSubmissions().forEach(submission -> {
-            List<Result> results = submission.getResults();
+            Set<Result> results = submission.getResults();
             if (results != null && !results.isEmpty()) {
                 results.removeIf(result -> !(result.isAssessmentComplete() && (result.isAutomatic() || ExerciseDateService.isAfterAssessmentDueDate(this))));
             }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingSubmission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingSubmission.java
@@ -10,7 +10,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderColumn;
+import jakarta.persistence.OrderBy;
 
 import org.jspecify.annotations.NonNull;
 
@@ -41,9 +41,16 @@ public class ProgrammingSubmission extends Submission {
     @Column(name = "build_failed")
     private boolean buildFailed;
 
-    // Only present if buildFailed == true.
+    /**
+     * Only present if buildFailed == true.
+     * <p>
+     * Ordered by the time the build produced them rather than by a position column. A position column has to be
+     * maintained by Hibernate, which means every write has to go through this collection and therefore through a save of
+     * the whole submission, and saving a submission selects it together with its participation, exercise and course
+     * because those are eager. The entries carry their own timestamp, so the order does not need to be stored.
+     */
     @OneToMany(mappedBy = "programmingSubmission", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderColumn(name = "build_log_entries_order")
+    @OrderBy("time")
     @JsonIgnoreProperties(value = "programmingSubmission", allowSetters = true)
     private List<BuildLogEntry> buildLogEntries = new ArrayList<>();
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingSubmission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingSubmission.java
@@ -50,7 +50,7 @@ public class ProgrammingSubmission extends Submission {
      * because those are eager. The entries carry their own timestamp, so the order does not need to be stored.
      */
     @OneToMany(mappedBy = "programmingSubmission", cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderBy("time")
+    @OrderBy("time, id")
     @JsonIgnoreProperties(value = "programmingSubmission", allowSetters = true)
     private Set<BuildLogEntry> buildLogEntries = new LinkedHashSet<>();
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingSubmission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingSubmission.java
@@ -1,9 +1,9 @@
 package de.tum.cit.aet.artemis.programming.domain;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -52,7 +52,7 @@ public class ProgrammingSubmission extends Submission {
     @OneToMany(mappedBy = "programmingSubmission", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("time")
     @JsonIgnoreProperties(value = "programmingSubmission", allowSetters = true)
-    private List<BuildLogEntry> buildLogEntries = new ArrayList<>();
+    private Set<BuildLogEntry> buildLogEntries = new LinkedHashSet<>();
 
     /**
      * There can be two reasons for the case that there is no programmingSubmission:
@@ -99,11 +99,11 @@ public class ProgrammingSubmission extends Submission {
         this.buildFailed = buildFailed;
     }
 
-    public List<BuildLogEntry> getBuildLogEntries() {
+    public Set<BuildLogEntry> getBuildLogEntries() {
         return buildLogEntries;
     }
 
-    public void setBuildLogEntries(List<BuildLogEntry> buildLogEntries) {
+    public void setBuildLogEntries(Set<BuildLogEntry> buildLogEntries) {
         this.buildLogEntries = buildLogEntries;
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/dto/BuildResultSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/dto/BuildResultSubmissionDTO.java
@@ -1,7 +1,6 @@
 package de.tum.cit.aet.artemis.programming.dto;
 
 import java.time.ZonedDateTime;
-import java.util.Objects;
 
 import org.jspecify.annotations.Nullable;
 
@@ -66,13 +65,5 @@ public record BuildResultSubmissionDTO(long submissionId, boolean buildFailed, @
             submission.addResult(latestResult);
         }
         return submission;
-    }
-
-    /**
-     * @param other another projection of the same kind
-     * @return true if both describe the same submission
-     */
-    public boolean isSameSubmissionAs(@Nullable BuildResultSubmissionDTO other) {
-        return other != null && Objects.equals(submissionId, other.submissionId());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/dto/BuildResultSubmissionDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/dto/BuildResultSubmissionDTO.java
@@ -1,0 +1,78 @@
+package de.tum.cit.aet.artemis.programming.dto;
+
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
+import de.tum.cit.aet.artemis.assessment.domain.Result;
+import de.tum.cit.aet.artemis.exercise.domain.SubmissionType;
+import de.tum.cit.aet.artemis.exercise.domain.participation.Participation;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
+
+/**
+ * The submission a build result belongs to, and its newest result, as the grading code reads them.
+ * <p>
+ * Loading the submission as an entity is expensive out of all proportion to what is read off it: a submission eagerly
+ * resolves its participation, the participation its exercise, and the exercise its course, so the row carries the
+ * exercise's problem statement and the course's code of conduct even though grading looks at a flag and an id.
+ *
+ * @param submissionId                the submission the result belongs to
+ * @param buildFailed                 whether the build of this submission had already been recorded as failed
+ * @param commitHash                  the commit the submission points at
+ * @param submissionType              how the submission came to be
+ * @param submissionDate              when the submission was made
+ * @param submitted                   whether the submission was submitted
+ * @param exampleSubmission           whether the submission is an example submission
+ * @param latestResultId              the newest result of the submission, null when it has none
+ * @param latestResultType            the assessment type of that newest result
+ * @param latestResultCompletionDate  when that newest result was completed
+ * @param latestResultCorrectionRound which correction round that newest result belongs to
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record BuildResultSubmissionDTO(long submissionId, boolean buildFailed, @Nullable String commitHash, @Nullable SubmissionType submissionType,
+        @Nullable ZonedDateTime submissionDate, @Nullable Boolean submitted, @Nullable Boolean exampleSubmission, @Nullable Long latestResultId,
+        @Nullable AssessmentType latestResultType, @Nullable ZonedDateTime latestResultCompletionDate, @Nullable Integer latestResultCorrectionRound) {
+
+    /**
+     * Builds the detached submission the grading code works on, carrying its newest result and the participation the
+     * caller already loaded.
+     * <p>
+     * Only the fields that path reads are set. The result of the new build is added to this submission and saved through
+     * its own repository, which owns the foreign key, so this object is never passed to a repository itself.
+     *
+     * @param participation the participation of the submission, already loaded by the caller
+     * @return a detached submission holding what grading reads
+     */
+    public ProgrammingSubmission toDetachedSubmission(Participation participation) {
+        var submission = new ProgrammingSubmission();
+        submission.setId(submissionId);
+        submission.setBuildFailed(buildFailed);
+        submission.setCommitHash(commitHash);
+        submission.setType(submissionType);
+        submission.setSubmissionDate(submissionDate);
+        submission.setSubmitted(submitted);
+        submission.setExampleSubmission(exampleSubmission);
+        submission.setParticipation(participation);
+        if (latestResultId != null) {
+            var latestResult = new Result();
+            latestResult.setId(latestResultId);
+            latestResult.setAssessmentType(latestResultType);
+            latestResult.setCompletionDate(latestResultCompletionDate);
+            latestResult.setCorrectionRound(latestResultCorrectionRound);
+            submission.addResult(latestResult);
+        }
+        return submission;
+    }
+
+    /**
+     * @param other another projection of the same kind
+     * @return true if both describe the same submission
+     */
+    public boolean isSameSubmissionAs(@Nullable BuildResultSubmissionDTO other) {
+        return other != null && Objects.equals(submissionId, other.submissionId());
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/programming/dto/ResultDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/dto/ResultDTO.java
@@ -26,8 +26,8 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseTestCase;
 // this would also simplify the logic in result.component.ts and and result.service.ts and make the experience more consistent among different clients (webapp, ios, android)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record ResultDTO(Long id, ZonedDateTime completionDate, Boolean successful, Double score, Boolean rated, SubmissionDTO submission, ParticipationDTO participation,
-        List<FeedbackDTO> feedbacks, AssessmentType assessmentType, Boolean hasComplaint, Boolean exampleResult, Integer testCaseCount, Integer passedTestCaseCount,
-        Integer codeIssueCount) implements Serializable {
+        List<FeedbackDTO> feedbacks, AssessmentType assessmentType, Integer correctionRound, Boolean hasComplaint, Boolean exampleResult, Integer testCaseCount,
+        Integer passedTestCaseCount, Integer codeIssueCount) implements Serializable {
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public record FeedbackDTO(Long id, String text, String detailText, boolean hasLongFeedbackText, String reference, Double credits, Boolean positive, FeedbackType type,
@@ -68,7 +68,7 @@ public record ResultDTO(Long id, ZonedDateTime completionDate, Boolean successfu
         }
         var feedbackDTOs = filteredFeedback.stream().map(FeedbackDTO::of).toList();
         return new ResultDTO(result.getId(), result.getCompletionDate(), result.isSuccessful(), result.getScore(), result.isRated(), submissionDTO,
-                ParticipationDTO.of(result.getSubmission().getParticipation()), feedbackDTOs, result.getAssessmentType(), result.hasComplaint(), result.isExampleResult(),
-                result.getTestCaseCount(), result.getPassedTestCaseCount(), result.getCodeIssueCount());
+                ParticipationDTO.of(result.getSubmission().getParticipation()), feedbackDTOs, result.getAssessmentType(), result.getCorrectionRound(), result.hasComplaint(),
+                result.isExampleResult(), result.getTestCaseCount(), result.getPassedTestCaseCount(), result.getCodeIssueCount());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/dto/SubmissionPolicyValuesDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/dto/SubmissionPolicyValuesDTO.java
@@ -1,0 +1,68 @@
+package de.tum.cit.aet.artemis.programming.dto;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.programming.domain.submissionpolicy.LockRepositoryPolicy;
+import de.tum.cit.aet.artemis.programming.domain.submissionpolicy.SubmissionPenaltyPolicy;
+import de.tum.cit.aet.artemis.programming.domain.submissionpolicy.SubmissionPolicy;
+
+/**
+ * The values of a {@link SubmissionPolicy}, without the exercise it belongs to.
+ * <p>
+ * A submission policy holds an inverse one-to-one back to its programming exercise, and that association is eager, so
+ * loading a policy as an entity loads the whole exercise with it and the course the exercise eagerly brings along. On
+ * the path that processes a build result, that means the exercise's problem statement and the course's code of conduct
+ * travel over the wire again for the sake of two numbers and a flag.
+ *
+ * @param id               the policy
+ * @param type             which kind of policy it is, so the caller can rebuild the right one
+ * @param submissionLimit  how many submissions the policy allows
+ * @param active           whether the policy is enforced
+ * @param exceedingPenalty the points deducted per submission over the limit, only set for a penalty policy
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record SubmissionPolicyValuesDTO(long id, @Nullable String type, @Nullable Integer submissionLimit, @Nullable Boolean active, @Nullable Double exceedingPenalty) {
+
+    private static final Logger log = LoggerFactory.getLogger(SubmissionPolicyValuesDTO.class);
+
+    /** Kept in sync with the concrete subclasses of {@link SubmissionPolicy} by SubmissionPolicyValuesDTOTest. */
+    public static final String LOCK_REPOSITORY = "LOCK_REPOSITORY";
+
+    public static final String SUBMISSION_PENALTY = "SUBMISSION_PENALTY";
+
+    /**
+     * Rebuilds the policy these values came from, so that the grading code can keep asking the exercise for its policy
+     * and matching on its type.
+     * <p>
+     * The result carries only the fields grading reads and is never passed to a repository. It is detached on purpose:
+     * the exercise it would point back at is exactly what this projection exists to avoid loading.
+     *
+     * @return the policy, or null if its type is not one this version knows about
+     */
+    @Nullable
+    public SubmissionPolicy toDetachedPolicy() {
+        SubmissionPolicy policy = switch (type) {
+            case LOCK_REPOSITORY -> new LockRepositoryPolicy();
+            case SUBMISSION_PENALTY -> {
+                var penaltyPolicy = new SubmissionPenaltyPolicy();
+                penaltyPolicy.setExceedingPenalty(exceedingPenalty);
+                yield penaltyPolicy;
+            }
+            case null, default -> null;
+        };
+        if (policy == null) {
+            // Not a hard failure: an unknown policy is treated as no policy, which is what happened before a policy of
+            // that kind existed. The test named above is what stops a new subclass from arriving here unnoticed.
+            log.error("Unknown submission policy type '{}' for policy {}; grading continues without applying it", type, id);
+            return null;
+        }
+        policy.setId(id);
+        policy.setSubmissionLimit(submissionLimit);
+        policy.setActive(active);
+        return policy;
+    }
+}

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
@@ -40,6 +40,7 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise_;
 import de.tum.cit.aet.artemis.programming.domain.SolutionProgrammingExerciseParticipation;
 import de.tum.cit.aet.artemis.programming.domain.TemplateProgrammingExerciseParticipation;
 import de.tum.cit.aet.artemis.programming.dto.ProgrammingExerciseNamesDTO;
+import de.tum.cit.aet.artemis.programming.dto.SubmissionPolicyValuesDTO;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseRepository.ProgrammingExerciseFetchOptions;
 
 /**
@@ -80,6 +81,34 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
      * @param testCasesChanged the value to set the flag to
      * @return 1 if the flag was changed, 0 if it already held that value or no such exercise exists
      */
+    /**
+     * Returns the values of the exercise's submission policy, without the exercise the policy points back at.
+     * <p>
+     * Deliberately a projection. The policy's back reference to its exercise is an eager inverse one-to-one, so loading
+     * the policy as an entity, or loading the exercise again to read it off there, fetches the whole exercise and the
+     * course it eagerly brings along. Grading reads a limit, a flag and possibly a penalty. See
+     * {@link SubmissionPolicyValuesDTO}.
+     *
+     * @param exerciseId the exercise whose submission policy should be read
+     * @return the values of the policy, or empty if the exercise has none
+     */
+    @Query("""
+            SELECT new de.tum.cit.aet.artemis.programming.dto.SubmissionPolicyValuesDTO(
+                policy.id,
+                CASE
+                    WHEN TYPE(policy) = LockRepositoryPolicy THEN 'LOCK_REPOSITORY'
+                    WHEN TYPE(policy) = SubmissionPenaltyPolicy THEN 'SUBMISSION_PENALTY'
+                    ELSE 'UNKNOWN'
+                END,
+                policy.submissionLimit,
+                policy.active,
+                TREAT (policy AS SubmissionPenaltyPolicy).exceedingPenalty)
+            FROM ProgrammingExercise exercise
+                JOIN exercise.submissionPolicy policy
+            WHERE exercise.id = :exerciseId
+            """)
+    Optional<SubmissionPolicyValuesDTO> findSubmissionPolicyValuesByExerciseId(@Param("exerciseId") long exerciseId);
+
     @Transactional // ok because of modifying query
     @Modifying
     @Query("""

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingExerciseRepository.java
@@ -68,20 +68,6 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
     Optional<ProgrammingExercise> findWithBuildConfigAndAuxiliaryRepositoriesById(long exerciseId);
 
     /**
-     * Sets the flag that marks the exercise as having changed test cases, but only when it does not already hold that
-     * value.
-     * <p>
-     * Deliberately a modifying query. The flag is a single boolean, and reading the exercise in order to change it
-     * meant fetching the whole exercise together with the course it eagerly brings along, then merging all of it back,
-     * which is two wide statements for one column. Guarding on the current value inside the statement also means the
-     * previous value does not have to be read: the affected row count answers whether anything changed. A null in the
-     * column counts as false, which is how {@link ProgrammingExercise#getTestCasesChanged()} reads it.
-     *
-     * @param exerciseId       the exercise whose flag should be set
-     * @param testCasesChanged the value to set the flag to
-     * @return 1 if the flag was changed, 0 if it already held that value or no such exercise exists
-     */
-    /**
      * Returns the values of the exercise's submission policy, without the exercise the policy points back at.
      * <p>
      * Deliberately a projection. The policy's back reference to its exercise is an eager inverse one-to-one, so loading
@@ -109,6 +95,20 @@ public interface ProgrammingExerciseRepository extends DynamicSpecificationRepos
             """)
     Optional<SubmissionPolicyValuesDTO> findSubmissionPolicyValuesByExerciseId(@Param("exerciseId") long exerciseId);
 
+    /**
+     * Sets the flag that marks the exercise as having changed test cases, but only when it does not already hold that
+     * value.
+     * <p>
+     * Deliberately a modifying query. The flag is a single boolean, and reading the exercise in order to change it
+     * meant fetching the whole exercise together with the course it eagerly brings along, then merging all of it back,
+     * which is two wide statements for one column. Guarding on the current value inside the statement also means the
+     * previous value does not have to be read: the affected row count answers whether anything changed. A null in the
+     * column counts as false, which is how {@link ProgrammingExercise#getTestCasesChanged()} reads it.
+     *
+     * @param exerciseId       the exercise whose flag should be set
+     * @param testCasesChanged the value to set the flag to
+     * @return 1 if the flag was changed, 0 if it already held that value or no such exercise exists
+     */
     @Transactional // ok because of modifying query
     @Modifying
     @Query("""

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingSubmissionRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingSubmissionRepository.java
@@ -15,12 +15,15 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.cit.aet.artemis.core.repository.base.ArtemisJpaRepository;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
+import de.tum.cit.aet.artemis.programming.dto.BuildResultSubmissionDTO;
 import de.tum.cit.aet.artemis.programming.dto.ParticipationCommitHashDTO;
 import de.tum.cit.aet.artemis.programming.dto.ProgrammingSubmissionCommitHashDTO;
 import de.tum.cit.aet.artemis.programming.dto.ProgrammingSubmissionIdAndSubmissionDateDTO;
@@ -75,6 +78,50 @@ public interface ProgrammingSubmissionRepository extends ArtemisJpaRepository<Pr
 
     @EntityGraph(type = LOAD, attributePaths = { "results" })
     Optional<ProgrammingSubmission> findProgrammingSubmissionWithResultsById(long programmingSubmissionId);
+
+    /**
+     * Records whether the build of a submission failed.
+     * <p>
+     * Deliberately a modifying query. This is one boolean on a row that already exists, and it used to be written by
+     * saving the whole submission, which for a detached submission means a select of the submission together with its
+     * participation, exercise and course, because those are eager associations. That select carried the exercise's
+     * problem statement and the course's code of conduct for every build.
+     *
+     * @param submissionId the submission whose build outcome should be recorded
+     * @param buildFailed  whether the build failed
+     */
+    /**
+     * Returns what the grading code reads off the submission a build result belongs to, together with its newest result.
+     * <p>
+     * Deliberately a projection rather than the submission itself: a submission eagerly resolves its participation, that
+     * its exercise, and that its course, so loading one ships the exercise's problem statement and the course's code of
+     * conduct for every build. See {@link BuildResultSubmissionDTO}.
+     *
+     * @param submissionId the submission the build result belongs to
+     * @return what grading reads off that submission, or empty if it no longer exists
+     */
+    @Query("""
+            SELECT new de.tum.cit.aet.artemis.programming.dto.BuildResultSubmissionDTO(
+                submission.id, submission.buildFailed, submission.commitHash, submission.type, submission.submissionDate,
+                submission.submitted, submission.exampleSubmission,
+                latestResult.id, latestResult.assessmentType, latestResult.completionDate, latestResult.correctionRound)
+            FROM ProgrammingSubmission submission
+                LEFT JOIN submission.results latestResult
+                    ON latestResult.id = (SELECT MAX(otherResult.id)
+                                          FROM submission.results otherResult)
+            WHERE submission.id = :submissionId
+            """)
+    Optional<BuildResultSubmissionDTO> findBuildResultSubmissionById(@Param("submissionId") long submissionId);
+
+    @Transactional // ok because of modifying query
+    @Modifying
+    @Query("""
+            UPDATE ProgrammingSubmission submission
+            SET submission.buildFailed = :buildFailed
+            WHERE submission.id = :submissionId
+                AND submission.buildFailed <> :buildFailed
+            """)
+    void updateBuildFailed(@Param("submissionId") long submissionId, @Param("buildFailed") boolean buildFailed);
 
     /**
      * Returns what is needed to decide which submission of the participation a build result belongs to.

--- a/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingSubmissionRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/repository/ProgrammingSubmissionRepository.java
@@ -80,17 +80,6 @@ public interface ProgrammingSubmissionRepository extends ArtemisJpaRepository<Pr
     Optional<ProgrammingSubmission> findProgrammingSubmissionWithResultsById(long programmingSubmissionId);
 
     /**
-     * Records whether the build of a submission failed.
-     * <p>
-     * Deliberately a modifying query. This is one boolean on a row that already exists, and it used to be written by
-     * saving the whole submission, which for a detached submission means a select of the submission together with its
-     * participation, exercise and course, because those are eager associations. That select carried the exercise's
-     * problem statement and the course's code of conduct for every build.
-     *
-     * @param submissionId the submission whose build outcome should be recorded
-     * @param buildFailed  whether the build failed
-     */
-    /**
      * Returns what the grading code reads off the submission a build result belongs to, together with its newest result.
      * <p>
      * Deliberately a projection rather than the submission itself: a submission eagerly resolves its participation, that
@@ -113,6 +102,17 @@ public interface ProgrammingSubmissionRepository extends ArtemisJpaRepository<Pr
             """)
     Optional<BuildResultSubmissionDTO> findBuildResultSubmissionById(@Param("submissionId") long submissionId);
 
+    /**
+     * Records whether the build of a submission failed.
+     * <p>
+     * Deliberately a modifying query. This is one boolean on a row that already exists, and it used to be written by
+     * saving the whole submission, which for a detached submission means a select of the submission together with its
+     * participation, exercise and course, because those are eager associations. That select carried the exercise's
+     * problem statement and the course's code of conduct for every build.
+     *
+     * @param submissionId the submission whose build outcome should be recorded
+     * @param buildFailed  whether the build failed
+     */
     @Transactional // ok because of modifying query
     @Modifying
     @Query("""

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/BuildLogEntryService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/BuildLogEntryService.java
@@ -78,16 +78,17 @@ public class BuildLogEntryService {
      * @return the saved build logs
      */
     public List<BuildLogEntry> saveBuildLogs(List<BuildLogEntry> buildLogs, ProgrammingSubmission programmingSubmission) {
+        // Replaces the logs of a previous build of the same submission. This used to happen implicitly: the entries were
+        // saved without their submission, and saving the submission afterwards both attached them and removed the old
+        // ones through the collection's orphan removal. That save is what made every result fetch the whole submission
+        // together with its participation, exercise and course, so both steps are done directly here instead.
+        buildLogEntryRepository.deleteByProgrammingSubmissionId(programmingSubmission.getId());
         return buildLogs.stream().map(buildLogEntry -> {
             // Truncate the log so that it fits into the database
             buildLogEntry.truncateLogToMaxLength();
-            // Cut association to parent object
-            buildLogEntry.setProgrammingSubmission(null);
-            // persist the BuildLogEntry object without an association to the parent object.
-            var updatedBuildLogEntry = buildLogEntryRepository.save(buildLogEntry);
-            // restore the association to the parent object
-            updatedBuildLogEntry.setProgrammingSubmission(programmingSubmission);
-            return updatedBuildLogEntry;
+            // The entry owns the foreign key, so setting the submission before saving writes it with the insert.
+            buildLogEntry.setProgrammingSubmission(programmingSubmission);
+            return buildLogEntryRepository.save(buildLogEntry);
         }).collect(Collectors.toCollection(ArrayList::new));
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/BuildLogEntryService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/BuildLogEntryService.java
@@ -99,7 +99,8 @@ public class BuildLogEntryService {
      * @return the build log entries
      */
     public List<BuildLogEntry> getLatestBuildLogs(ProgrammingSubmission programmingSubmission) {
-        return programmingSubmissionRepository.findWithEagerBuildLogEntriesById(programmingSubmission.getId()).map(ProgrammingSubmission::getBuildLogEntries).orElseGet(List::of);
+        return programmingSubmissionRepository.findWithEagerBuildLogEntriesById(programmingSubmission.getId()).map(ProgrammingSubmission::getBuildLogEntries).map(List::copyOf)
+                .orElseGet(List::of);
     }
 
     private static final Set<String> ILLEGAL_REFLECTION_LOGS = Set.of("An illegal reflective access operation has occurred", "Illegal reflective access by",
@@ -290,7 +291,7 @@ public class BuildLogEntryService {
      * @param programmingSubmission the programming submission for which the build logs should be deleted
      */
     public void deleteBuildLogEntriesForProgrammingSubmission(ProgrammingSubmission programmingSubmission) {
-        programmingSubmission.setBuildLogEntries(List.of());
+        programmingSubmission.setBuildLogEntries(Set.of());
         programmingSubmissionRepository.save(programmingSubmission);
         buildLogEntryRepository.deleteByProgrammingSubmissionId(programmingSubmission.getId());
     }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseGradingService.java
@@ -190,7 +190,7 @@ public class ProgrammingExerciseGradingService {
             Result newResult = ciResultService.createResultFromBuildResult(buildResult, participation);
 
             // Fetch submission or create a fallback
-            var latestSubmission = getSubmissionForBuildResult(participation.getId(), buildResult).orElseGet(() -> createAndSaveFallbackSubmission(participation, buildResult));
+            var latestSubmission = getSubmissionForBuildResult(participation, buildResult).orElseGet(() -> createAndSaveFallbackSubmission(participation, buildResult));
 
             // Determine if the build failed based on whether tests were expected.
             // When tests are expected: build failed if all feedbacks are SCA (no test results at all).
@@ -199,6 +199,11 @@ public class ProgrammingExerciseGradingService {
             final Integer exitCode = buildResult.buildScriptExitCode();
             final boolean scriptFailed = exitCode != null && exitCode != 0;
             final var buildFailed = testsExpected ? noTestFeedbacks : scriptFailed;
+            if (latestSubmission.isBuildFailed() != buildFailed) {
+                // Written directly. This is one boolean on a row that already exists, and it used to reach the database
+                // only through saving the whole submission at the end of this method.
+                programmingSubmissionRepository.updateBuildFailed(latestSubmission.getId(), buildFailed);
+            }
             latestSubmission.setBuildFailed(buildFailed);
 
             if (buildResult.hasLogs()) {
@@ -276,16 +281,20 @@ public class ProgrammingExerciseGradingService {
      * @param buildResult     The build result
      * @return The submission or empty if no submissions exist
      */
-    protected Optional<ProgrammingSubmission> getSubmissionForBuildResult(Long participationId, BuildResultNotification buildResult) {
+    protected Optional<ProgrammingSubmission> getSubmissionForBuildResult(ProgrammingExerciseParticipation participation, BuildResultNotification buildResult) {
         // Matching a commit hash needs the hash, the submission type and a way to order candidates, so only those are
         // read. Loading the submissions themselves means loading each one's participation, exercise and course, because
         // those are eager associations, so a student who pushed ten times used to make the database ship the exercise's
-        // problem statement ten times over to find one commit hash. Only the submission that matches is then loaded.
-        var candidates = programmingSubmissionRepository.findCommitHashesByParticipationId(participationId);
+        // problem statement ten times over to find one commit hash.
+        var candidates = programmingSubmissionRepository.findCommitHashesByParticipationId(participation.getId());
         return candidates.stream().filter(candidate -> {
             var commitHash = buildResult.commitHash(candidate.type());
             return !ObjectUtils.isEmpty(commitHash) && commitHash.equals(candidate.commitHash());
-        }).max(ProgrammingSubmissionCommitHashDTO.NEWEST_FIRST).flatMap(match -> programmingSubmissionRepository.findProgrammingSubmissionWithResultsById(match.id()));
+        }).max(ProgrammingSubmissionCommitHashDTO.NEWEST_FIRST)
+                // The matching submission is read the same way, for the same reason. The participation it belongs to is
+                // the one the caller already has, so it does not have to come back from the database with it.
+                .flatMap(match -> programmingSubmissionRepository.findBuildResultSubmissionById(match.id()))
+                .map(submission -> submission.toDetachedSubmission((Participation) participation));
     }
 
     @NonNull
@@ -341,22 +350,22 @@ public class ProgrammingExerciseGradingService {
             if (programmingSubmission.getLatestResult() != null && programmingSubmission.getLatestResult().isManual() && !((Participation) participation).isPracticeMode()) {
                 // Note: in this case, we do not want to save the processedResult, but we only want to update the latest semi-automatic one
                 Result updatedLatestSemiAutomaticResult = updateLatestSemiAutomaticResultWithNewAutomaticFeedback(programmingSubmission.getLatestResult().getId(), processedResult);
-                // Adding back dropped submission
+                // Adding back dropped submission. The result owns the foreign key, so saving it is enough; the
+                // submission itself did not change.
                 updatedLatestSemiAutomaticResult.setSubmission(programmingSubmission);
-                programmingSubmissionRepository.save(programmingSubmission);
                 resultRepository.save(updatedLatestSemiAutomaticResult);
 
                 return updatedLatestSemiAutomaticResult;
             }
         }
 
-        // Finally, save the new result once and make sure the order column between submission and result is maintained
-        // workaround to avoid scheduling the participant score update twice. The update will only run when a submission is present.
-        processedResult.setSubmission(null);
-        processedResult = resultRepository.save(processedResult);
-        processedResult.setSubmission(programmingSubmission);
+        // One insert. The result owns the foreign key to its submission, so setting it before saving writes it with the
+        // insert; the participant score cron picks the result up from there. This used to insert the result without its
+        // submission and then save the submission so that its cascade filled the column in, which meant selecting the
+        // submission together with its participation, exercise and course for every result.
         programmingSubmission.addResult(processedResult);
-        programmingSubmissionRepository.save(programmingSubmission);
+        processedResult.setSubmission(programmingSubmission);
+        processedResult = resultRepository.save(processedResult);
 
         return processedResult;
     }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseGradingService.java
@@ -7,6 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -219,7 +220,7 @@ public class ProgrammingExerciseGradingService {
                     var savedBuildLogs = buildLogService.saveBuildLogs(buildLogs, latestSubmission);
 
                     // Set the received logs in order to avoid duplicate entries (this removes existing logs)
-                    latestSubmission.setBuildLogEntries(savedBuildLogs);
+                    latestSubmission.setBuildLogEntries(new LinkedHashSet<>(savedBuildLogs));
                 }
             }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseGradingService.java
@@ -63,6 +63,7 @@ import de.tum.cit.aet.artemis.programming.domain.submissionpolicy.SubmissionPoli
 import de.tum.cit.aet.artemis.programming.dto.BuildResultNotification;
 import de.tum.cit.aet.artemis.programming.dto.ProgrammingExerciseGradingStatisticsDTO;
 import de.tum.cit.aet.artemis.programming.dto.ProgrammingSubmissionCommitHashDTO;
+import de.tum.cit.aet.artemis.programming.dto.SubmissionPolicyValuesDTO;
 import de.tum.cit.aet.artemis.programming.exception.ContinuousIntegrationException;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseRepository;
 import de.tum.cit.aet.artemis.programming.repository.ProgrammingExerciseTestCaseRepository;
@@ -657,7 +658,10 @@ public class ProgrammingExerciseGradingService {
         feedbackCreationService.categorizeScaFeedback(result, staticCodeAnalysisFeedback, exercise);
 
         if (applySubmissionPolicy) {
-            SubmissionPolicy submissionPolicy = programmingExerciseRepository.findByIdWithSubmissionPolicyElseThrow(exercise.getId()).getSubmissionPolicy();
+            // Only the policy's own values are read. Loading the exercise again to reach them, which is what this used
+            // to do, fetched the problem statement and the course's code of conduct a second time for every result.
+            SubmissionPolicy submissionPolicy = programmingExerciseRepository.findSubmissionPolicyValuesByExerciseId(exercise.getId())
+                    .map(SubmissionPolicyValuesDTO::toDetachedPolicy).orElse(null);
             exercise.setSubmissionPolicy(submissionPolicy);
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseParticipationService.java
@@ -387,7 +387,7 @@ public class ProgrammingExerciseParticipationService {
         }
         Submission latestSubmission = latestSubmissionOptional.get();
         Optional<Result> latestResultOptional = resultRepository.findLatestResultWithFeedbacksBySubmissionId(latestSubmission.getId(), ZonedDateTime.now());
-        latestResultOptional.ifPresentOrElse(latestResult -> latestSubmission.setResults(List.of(latestResult)), () -> latestSubmission.setResults(List.of()));
+        latestResultOptional.ifPresentOrElse(latestResult -> latestSubmission.setResults(Set.of(latestResult)), () -> latestSubmission.setResults(Set.of()));
         participation.setSubmissions(Set.of(latestSubmission));
         return participation;
     }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseService.java
@@ -7,7 +7,7 @@ import static de.tum.cit.aet.artemis.programming.repository.SolutionProgrammingE
 import static de.tum.cit.aet.artemis.programming.repository.TemplateProgrammingExerciseParticipationRepository.TemplateParticipationFetchOptions;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -209,7 +209,7 @@ public class ProgrammingExerciseService {
         if (!programmingExerciseWithTemplate.getTemplateParticipation().getSubmissions().isEmpty()) {
             Optional<Result> latestResultForLatestSubmissionOfTemplate = resultRepository
                     .findLatestResultWithFeedbacksAndTestcasesForSubmission(programmingExerciseWithTemplate.getTemplateParticipation().getSubmissions().iterator().next().getId());
-            List<Result> resultsForLatestSubmissionTemplate = new ArrayList<>();
+            Set<Result> resultsForLatestSubmissionTemplate = new HashSet<>();
             latestResultForLatestSubmissionOfTemplate.ifPresent(resultsForLatestSubmissionTemplate::add);
             programmingExerciseWithTemplate.getTemplateParticipation().getSubmissions().iterator().next().setResults(resultsForLatestSubmissionTemplate);
         }
@@ -219,7 +219,7 @@ public class ProgrammingExerciseService {
         if (!solutionParticipationWithLatestSubmission.getSubmissions().isEmpty()) {
             Optional<Result> latestResultForLatestSubmissionOfSolution = resultRepository
                     .findLatestResultWithFeedbacksAndTestcasesForSubmission(solutionParticipationWithLatestSubmission.getSubmissions().iterator().next().getId());
-            List<Result> resultsForLatestSubmissionSolution = new ArrayList<>();
+            Set<Result> resultsForLatestSubmissionSolution = new HashSet<>();
             latestResultForLatestSubmissionOfSolution.ifPresent(resultsForLatestSubmissionSolution::add);
             solutionParticipationWithLatestSubmission.getSubmissions().iterator().next().setResults(resultsForLatestSubmissionSolution);
         }
@@ -288,7 +288,7 @@ public class ProgrammingExerciseService {
             Submission submission = submissions.iterator().next();
             Result res = latestResultsForSolutionSubmissions.get(submission.getId());
             if (res != null) {
-                submission.setResults(List.of(res));
+                submission.setResults(Set.of(res));
             }
         }
     }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingExerciseParticipationResource.java
@@ -163,14 +163,14 @@ public class ProgrammingExerciseParticipationResource {
         hasAccessToParticipationElseThrow(participation);
         filterParticipationSubmissionResults(participation);
         // hide details that should not be shown to the students
-        List<Result> results = participation.getSubmissions().isEmpty() ? List.of() : participation.getSubmissions().iterator().next().getResults();
+        Set<Result> results = participation.getSubmissions().isEmpty() ? Set.of() : participation.getSubmissions().iterator().next().getResults();
         resultService.filterSensitiveInformationIfNecessary(participation, results, Optional.empty());
         return ResponseEntity.ok(participation);
     }
 
     private void filterParticipationSubmissionResults(ProgrammingExerciseStudentParticipation participation) {
         if (shouldHideExamExerciseResults(participation)) {
-            participation.getSubmissions().forEach(submission -> submission.setResults(List.of()));
+            participation.getSubmissions().forEach(submission -> submission.setResults(Set.of()));
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingSubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingSubmissionResource.java
@@ -350,13 +350,10 @@ public class ProgrammingSubmissionResource {
         programmingSubmissionService.hideDetails(programmingSubmission, user);
 
         // remove automatic results before sending to client
-        var manualResults = programmingSubmission.getManualResults();
-        if (correctionRound >= manualResults.size()) {
-            programmingSubmission.setResults(List.of());
-        }
-        else {
-            programmingSubmission.setResults(List.of(manualResults.get(correctionRound)));
-        }
+        // The result of the requested correction round, which used to be read off the position of the result inside the
+        // submission's result list and is now stored on the result itself.
+        var resultForCorrectionRound = programmingSubmission.getResultForCorrectionRound(correctionRound);
+        programmingSubmission.setResults(resultForCorrectionRound == null ? Set.of() : Set.of(resultForCorrectionRound));
 
         return ResponseEntity.ok(programmingSubmission);
     }

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizExercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/QuizExercise.java
@@ -346,7 +346,7 @@ public class QuizExercise extends Exercise implements QuizConfiguration {
         if (shouldFilterForStudents()) {
             // results are never relevant before quiz has ended => clear all results
             participation.getSubmissions().forEach(submission -> {
-                List<Result> results = submission.getResults();
+                Set<Result> results = submission.getResults();
                 if (results != null) {
                     results.clear();
                 }

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/service/AbstractQuizSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/service/AbstractQuizSubmissionService.java
@@ -3,7 +3,7 @@ package de.tum.cit.aet.artemis.quiz.service;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
+import java.util.HashSet;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -61,7 +61,7 @@ public abstract class AbstractQuizSubmissionService<T extends QuizSubmission> {
         quizSubmission.setSubmissionDate(ZonedDateTime.now());
 
         // remove result from submission (in the unlikely case it is passed here), so that students cannot inject a result
-        quizSubmission.setResults(new ArrayList<>());
+        quizSubmission.setResults(new HashSet<>());
         T savedQuizSubmission = this.save(quizExercise, quizSubmission, user, participationFromExamGate);
 
         // versioning of submission

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizSubmissionService.java
@@ -237,7 +237,7 @@ public class QuizSubmissionService extends AbstractQuizSubmissionService<QuizSub
             quizSubmissionRepository.save(quizSubmission);
             resultRepository.save(result);
             studentParticipationRepository.save(participation);
-            quizSubmission.setResults(List.of(result));
+            quizSubmission.setResults(Set.of(result));
 
             sendQuizResultToUser(quizExerciseId, participation);
         });

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/web/openapi/QuizParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/web/openapi/QuizParticipationResource.java
@@ -4,7 +4,6 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.time.ZonedDateTime;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -119,7 +118,7 @@ public class QuizParticipationResource {
             // Load the actual submission of the result
             submission = quizSubmissionRepository.findWithEagerSubmittedAnswersByResultId(result.getId()).orElseThrow();
         }
-        submission.setResults(List.of(result));
+        submission.setResults(Set.of(result));
         participation.setSubmissions(Set.of(submission));
 
         participation.setExercise(exercise);
@@ -205,7 +204,7 @@ public class QuizParticipationResource {
             }
         }
 
-        submission.setResults(List.of(result));
+        submission.setResults(Set.of(result));
         participation.setSubmissions(Set.of(submission));
         participation.setExercise(exercise);
 

--- a/src/main/java/de/tum/cit/aet/artemis/text/dto/TextSubmissionResponseDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/dto/TextSubmissionResponseDTO.java
@@ -3,9 +3,9 @@ package de.tum.cit.aet.artemis.text.dto;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import org.hibernate.Hibernate;
-import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -25,8 +25,7 @@ import de.tum.cit.aet.artemis.text.domain.TextSubmission;
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record TextSubmissionResponseDTO(Long id, String submissionExerciseType, String text, Language language, Boolean submitted, ZonedDateTime submissionDate,
-        SubmissionType type, Boolean exampleSubmission, StudentParticipationDTO participation, List<@Nullable ResultDTO> results, List<TextBlockDTO> blocks)
-        implements Serializable {
+        SubmissionType type, Boolean exampleSubmission, StudentParticipationDTO participation, List<ResultDTO> results, List<TextBlockDTO> blocks) implements Serializable {
 
     /**
      * Converts a {@link TextSubmission} into a {@link TextSubmissionResponseDTO} without the participation's student.
@@ -50,9 +49,9 @@ public record TextSubmissionResponseDTO(Long id, String submissionExerciseType, 
             return null;
         }
 
-        List<@Nullable ResultDTO> results = null;
+        List<ResultDTO> results = null;
         if (Hibernate.isInitialized(submission.getResults()) && submission.getResults() != null) {
-            results = submission.getResults().stream().map(result -> result == null ? null : ResultDTO.of(result)).toList();
+            results = submission.getResults().stream().filter(Objects::nonNull).map(ResultDTO::of).toList();
         }
 
         List<TextBlockDTO> blocks = null;

--- a/src/main/java/de/tum/cit/aet/artemis/text/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/service/TextSubmissionService.java
@@ -1,7 +1,7 @@
 package de.tum.cit.aet.artemis.text.service;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Optional;
 
 import org.jspecify.annotations.Nullable;
@@ -126,7 +126,7 @@ public class TextSubmissionService extends SubmissionService {
             studentParticipationRepository.updateInitializationState(participation.getId(), InitializationState.FINISHED);
         }
         // remove result from submission (in the unlikely case it is passed here), so that students cannot inject a result
-        textSubmission.setResults(new ArrayList<>());
+        textSubmission.setResults(new HashSet<>());
         if (textSubmission.getId() != null) {
             // Autosave of an existing submission: only the client-editable fields changed, and the row is already there.
             // Saving the detached entity would merge it, which reads the submission and its whole eager association graph

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextAssessmentResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextAssessmentResource.java
@@ -253,7 +253,7 @@ public class TextAssessmentResource extends AssessmentResource {
         if (latestResult != null) {
             latestResult.getFeedbacks().clear();
             resultService.deleteResult(latestResult, true);
-            submission.setResults(List.of());
+            submission.setResults(Set.of());
             submissionRepository.save(submission);
         }
 
@@ -449,7 +449,7 @@ public class TextAssessmentResource extends AssessmentResource {
         // set result again as it was changed
         if (resultId != null) {
             result = textSubmission.getManualResultsById(resultId);
-            textSubmission.setResults(List.of(result));
+            textSubmission.setResults(Set.of(result));
         }
         else {
             textSubmission.getResultForCorrectionRound(correctionRound);

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextExerciseResource.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.text.web;
 
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -267,7 +268,7 @@ public class TextExerciseResource {
                 if (!ExerciseDateService.isAfterAssessmentDueDate(textExercise) && !authCheckService.isAtLeastTeachingAssistantForExercise(textExercise, user)) {
                     // We want to have the preliminary feedback before the assessment due date too
                     List<Result> athenaResults = submission.getResults().stream().filter(result -> result.getAssessmentType() == AssessmentType.AUTOMATIC_ATHENA).toList();
-                    textSubmission.setResults(athenaResults);
+                    textSubmission.setResults(new LinkedHashSet<>(athenaResults));
                 }
 
                 // Use specific result if resultId is provided, otherwise use latest
@@ -289,7 +290,7 @@ public class TextExerciseResource {
                     }
 
                     // Only send the relevant result to the client
-                    textSubmission.setResults(List.of(result));
+                    textSubmission.setResults(Set.of(result));
                 }
                 participation.addSubmission(textSubmission);
             }

--- a/src/main/resources/config/liquibase/changelog/20260825165553_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260825165553_changelog.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        Store the correction round of a manual result explicitly instead of deriving it from the position of the result
+        inside its submission's result list.
+
+        The list position came from the @OrderColumn "results_order" on Submission.results, which forced every write in
+        that area to load and re-save the whole submission so that Hibernate could maintain the column. On the path that
+        processes a build result that meant loading the submission together with its participation, exercise and course,
+        because those associations are eager, so the exercise's problem statement and the course's code of conduct
+        travelled over the wire for every single build.
+
+        Nothing reads results_order other than the mapping itself, so the correction round is the only piece of
+        information the ordering actually carried. It becomes a column on result: 0 for the first correction, 1 for the
+        second, null for automatic and Athena results, which are not correction rounds.
+
+        The column is left in place on purpose. Dropping it in the same release would make a rollback of the application
+        fail, because an older version would still try to write it. It is unused after this change and can be dropped in
+        a later release.
+    -->
+
+    <changeSet id="20260825-01-add-result-correction-round" author="krusche">
+        <addColumn tableName="result">
+            <!-- TINYINT on MySQL, SMALLINT on PostgreSQL, which Liquibase picks per database. -->
+            <column name="correction_round" type="TINYINT"/>
+        </addColumn>
+    </changeSet>
+
+    <!--
+        Backfill from the ordering that is being replaced: among the non-automatic results of one submission, the n-th in
+        results_order was correction round n. Results without a submission cannot belong to a correction round, and
+        automatic and Athena results never did.
+    -->
+    <changeSet id="20260825-02-backfill-result-correction-round" author="krusche">
+        <sql dbms="postgresql">
+            UPDATE result
+            SET correction_round = ranked.correction_round
+            FROM (SELECT id,
+                         ROW_NUMBER() OVER (PARTITION BY submission_id ORDER BY results_order, id) - 1 AS correction_round
+                  FROM result
+                  WHERE submission_id IS NOT NULL
+                    AND (assessment_type IS NULL OR assessment_type NOT IN ('AUTOMATIC', 'AUTOMATIC_ATHENA'))) AS ranked
+            WHERE result.id = ranked.id
+        </sql>
+        <sql dbms="mysql">
+            UPDATE result
+                JOIN (SELECT id,
+                             ROW_NUMBER() OVER (PARTITION BY submission_id ORDER BY results_order, id) - 1 AS correction_round
+                      FROM result
+                      WHERE submission_id IS NOT NULL
+                        AND (assessment_type IS NULL OR assessment_type NOT IN ('AUTOMATIC', 'AUTOMATIC_ATHENA'))) AS ranked
+                ON result.id = ranked.id
+            SET result.correction_round = ranked.correction_round
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -45,6 +45,7 @@
     <include file="classpath:config/liquibase/changelog/20260811231613_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260816213553_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260820091251_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20260825165553_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command "date '+%Y%m%d%H%M%S'" to get the current date and time in the correct format -->

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.html
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.html
@@ -472,7 +472,7 @@
                                                                                 }}
                                                                             </a>
                                                                         } @else {
-                                                                            @if (!!submission.results && !!submission.results[correctionRound]) {
+                                                                            @if (!!getSubmissionResultByCorrectionRound(submission, correctionRound)) {
                                                                                 <a
                                                                                     [routerLink]="assessmentNotPossibleYetReason() ? null : getAssessmentLink(submission)"
                                                                                     [queryParams]="getAssessmentQueryParams(correctionRound)"

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.spec.ts
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.spec.ts
@@ -104,8 +104,9 @@ describe('ExerciseAssessmentDashboardComponent', () => {
 
     let submissionService: SubmissionService;
 
-    const result1 = { id: 11 } as Result;
-    const result2 = { id: 12 } as Result;
+    // The correction round is stated explicitly rather than implied by the position in the results array.
+    const result1 = { id: 11, correctionRound: 0 } as Result;
+    const result2 = { id: 12, correctionRound: 1 } as Result;
     const exam = { id: 13, numberOfCorrectionRoundsInExam: 2 } as Exam;
     const exerciseGroup = { id: 14, exam } as ExerciseGroup;
 

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
@@ -802,8 +802,10 @@ export class ExerciseAssessmentDashboardComponent implements OnInit, OnDestroy {
      * @param correctionRound for which to get status
      */
     calculateSubmissionStatusIsDraft(submission: Submission, correctionRound = 0): boolean {
-        const tmpResult = submission.results?.[correctionRound];
-        return !(tmpResult?.completionDate && isManualResult(tmpResult));
+        // Looked up by the round the result belongs to. Indexing by the round only worked while the server sent the
+        // results as a list padded with nulls for the rounds nobody had assessed yet.
+        const resultForRound = getSubmissionResultByCorrectionRound(submission, correctionRound);
+        return !(resultForRound?.completionDate && isManualResult(resultForRound));
     }
 
     /**

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.ts
@@ -648,7 +648,7 @@ export class ExerciseAssessmentDashboardComponent implements OnInit, OnDestroy {
                 // Set the received submissions. As the result component depends on the submission we nest it into the participation.
                 const sub = submissions
                     .filter((submission) => {
-                        return submission?.results && submission.results.length > correctionRound && submission.results[correctionRound];
+                        return !!getSubmissionResultByCorrectionRound(submission, correctionRound);
                     })
                     .map((submission) => {
                         submission.participation!.submissions = [submission];

--- a/src/main/webapp/app/exercise/exercise-scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/exercise/exercise-scores/exercise-scores.component.ts
@@ -439,7 +439,29 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
         result.testCaseCount = dto.testCaseCount;
         result.passedTestCaseCount = dto.passedTestCaseCount;
         result.codeIssueCount = dto.codeIssueCount;
+        result.correctionRound = dto.correctionRoundResults?.find((roundResult) => roundResult.resultId === dto.resultId)?.correctionRound;
         return result;
+    }
+
+    /**
+     * Builds the results the submission row works with: the newest one, which carries the score the table shows, and
+     * one per correction round, which is what the assessment actions of each round act on. The newest result is often
+     * one of the rounds itself, so it is not added twice.
+     */
+    private toResults(dto: ParticipationScoreDTO): Result[] {
+        const latestResult = this.toResult(dto);
+        const roundResults = (dto.correctionRoundResults ?? [])
+            .filter((roundResult) => roundResult.resultId !== dto.resultId)
+            .map((roundResult) => {
+                const result = new Result();
+                result.id = roundResult.resultId;
+                result.correctionRound = roundResult.correctionRound;
+                result.assessmentType = roundResult.assessmentType;
+                result.completionDate = roundResult.completionDate;
+                result.hasComplaint = roundResult.hasComplaint;
+                return result;
+            });
+        return latestResult ? [latestResult, ...roundResults] : roundResults;
     }
 
     /**
@@ -465,8 +487,7 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
      * into a plain Submission literal, which only type-checked because spreads skip excess-property checking.
      */
     private toSubmission(dto: ParticipationScoreDTO): Submission {
-        const result = this.toResult(dto);
-        const results = result ? [result] : [];
+        const results = this.toResults(dto);
         if (this.exercise()?.type === ExerciseType.PROGRAMMING) {
             const submission = new ProgrammingSubmission();
             submission.id = dto.submissionId;

--- a/src/main/webapp/app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component.html
+++ b/src/main/webapp/app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component.html
@@ -1,11 +1,11 @@
 @if (participation().submissionCount) {
     @for (correctionRound of correctionRoundIndices(); track correctionRound) {
         @if (
-            (correctionRound === 0 || participation().submissions![0].results?.[correctionRound - 1]?.completionDate) &&
+            (correctionRound === 0 || resultForRound(correctionRound - 1)?.completionDate) &&
             (newManualResultAllowed() ||
-                (participation().submissions![0].results?.[correctionRound]?.assessmentType &&
-                    participation().submissions![0].results?.[correctionRound]?.assessmentType !== AssessmentType.AUTOMATIC &&
-                    participation().submissions![0].results?.[correctionRound]?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA))
+                (resultForRound(correctionRound)?.assessmentType &&
+                    resultForRound(correctionRound)?.assessmentType !== AssessmentType.AUTOMATIC &&
+                    resultForRound(correctionRound)?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA))
         ) {
             <div class="d-flex align-items-center gap-1">
                 <a
@@ -13,29 +13,21 @@
                     [queryParams]="{ 'correction-round': getCorrectionRoundForAssessmentLink(correctionRound) }"
                     class="btn btn-sm"
                     [class.btn-success]="
-                        (!participation().submissions![0].results?.[correctionRound]?.assessmentType ||
-                            participation().submissions![0].results?.[correctionRound]?.assessmentType === AssessmentType.AUTOMATIC) &&
-                        !participation().submissions![0].results?.[correctionRound]?.hasComplaint
+                        (!resultForRound(correctionRound)?.assessmentType || resultForRound(correctionRound)?.assessmentType === AssessmentType.AUTOMATIC) &&
+                        !resultForRound(correctionRound)?.hasComplaint
                     "
-                    [class.btn-primary]="
-                        participation().submissions![0].results?.[correctionRound]?.completionDate || participation().submissions![0].results?.[correctionRound]?.hasComplaint
-                    "
-                    [class.btn-warning]="
-                        participation().submissions![0].results?.[correctionRound] &&
-                        !participation().submissions![0].results?.[correctionRound]?.completionDate &&
-                        !participation().submissions![0].results?.[correctionRound]?.hasComplaint
-                    "
+                    [class.btn-primary]="resultForRound(correctionRound)?.completionDate || resultForRound(correctionRound)?.hasComplaint"
+                    [class.btn-warning]="resultForRound(correctionRound) && !resultForRound(correctionRound)?.completionDate && !resultForRound(correctionRound)?.hasComplaint"
                 >
                     <fa-icon [icon]="faClipboardList" [fixedWidth]="true" />
                     <span class="d-none d-xl-inline ms-1">
-                        @if (!participation().submissions![0].results?.[correctionRound]?.hasComplaint) {
+                        @if (!resultForRound(correctionRound)?.hasComplaint) {
                             {{
                                 'artemisApp.assessment.dashboard.actions.' +
                                     (this.examMode ? 'examCorrectionRound.' : '') +
-                                    (!participation().submissions![0].results?.[correctionRound]?.assessmentType ||
-                                    participation().submissions![0].results?.[correctionRound]?.assessmentType === AssessmentType.AUTOMATIC
+                                    (!resultForRound(correctionRound)?.assessmentType || resultForRound(correctionRound)?.assessmentType === AssessmentType.AUTOMATIC
                                         ? 'assess'
-                                        : participation().submissions![0].results?.[correctionRound]?.completionDate
+                                        : resultForRound(correctionRound)?.completionDate
                                           ? 'open'
                                           : 'continue') | artemisTranslate: { correctionRound: correctionRound + 1 }
                             }}
@@ -46,15 +38,11 @@
                 </a>
                 @if (
                     newManualResultAllowed() &&
-                    participation().submissions![0].results?.[correctionRound]?.assessmentType &&
-                    !participation().submissions![0].results?.[correctionRound]?.completionDate &&
-                    participation().submissions![0].results?.[correctionRound]?.assessmentType !== AssessmentType.AUTOMATIC
+                    resultForRound(correctionRound)?.assessmentType &&
+                    !resultForRound(correctionRound)?.completionDate &&
+                    resultForRound(correctionRound)?.assessmentType !== AssessmentType.AUTOMATIC
                 ) {
-                    <button
-                        (click)="cancelAssessment(participation().submissions![0].results?.[correctionRound]!, participation())"
-                        [disabled]="isLoading()"
-                        class="btn btn-sm btn-danger"
-                    >
+                    <button (click)="cancelAssessment(resultForRound(correctionRound)!, participation())" [disabled]="isLoading()" class="btn btn-sm btn-danger">
                         <fa-icon [fixedWidth]="true" [icon]="faBan" />
                         <span class="d-none d-xl-inline ms-1">
                             {{

--- a/src/main/webapp/app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component.spec.ts
+++ b/src/main/webapp/app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component.spec.ts
@@ -57,7 +57,7 @@ describe('ManageAssessmentButtonsComponent', () => {
         // Distinct ids on purpose: with everything set to 1 an assertion cannot tell which id a service received.
         fixture.componentRef.setInput('participation', {
             id: 10,
-            submissions: [{ id: 20, results: [{ id: 30 } as Result] } as Submission],
+            submissions: [{ id: 20, results: [{ id: 30, correctionRound: 0 } as Result] } as Submission],
         } as Participation);
     });
 
@@ -128,7 +128,7 @@ describe('ManageAssessmentButtonsComponent', () => {
             fixture.componentRef.setInput('exercise', { id: 1, type: ExerciseType.TEXT } as Exercise);
             fixture.componentRef.setInput('participation', {
                 id: 1,
-                submissions: [{ id: 1, results: [{ id: 1 }] } as Submission],
+                submissions: [{ id: 1, results: [{ id: 1, correctionRound: 0 }] } as Submission],
             } as Participation);
 
             const result = comp.getAssessmentLink();
@@ -152,7 +152,7 @@ describe('ManageAssessmentButtonsComponent', () => {
                 submissions: [
                     {
                         id: 1,
-                        results: [{ id: 1, hasComplaint: true } as Result, { id: 2 } as Result],
+                        results: [{ id: 1, correctionRound: 0, hasComplaint: true } as Result, { id: 2, correctionRound: 1 } as Result],
                     } as Submission,
                 ],
             } as Participation);
@@ -165,7 +165,7 @@ describe('ManageAssessmentButtonsComponent', () => {
         it('should return same correction round when no complaint', () => {
             fixture.componentRef.setInput('participation', {
                 id: 1,
-                submissions: [{ id: 1, results: [{ id: 1, hasComplaint: false } as Result] } as Submission],
+                submissions: [{ id: 1, results: [{ id: 1, correctionRound: 0, hasComplaint: false } as Result] } as Submission],
             } as Participation);
 
             const result = comp.getCorrectionRoundForAssessmentLink(0);

--- a/src/main/webapp/app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component.ts
+++ b/src/main/webapp/app/exercise/exercise-scores/manage-assessment-buttons/manage-assessment-buttons.component.ts
@@ -7,6 +7,7 @@ import { Exercise, ExerciseType } from 'app/exercise/shared/entities/exercise/ex
 import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 import { isPracticeMode } from 'app/exercise/shared/entities/participation/student-participation.model';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
+import { getSubmissionResultByCorrectionRound } from 'app/exercise/shared/entities/submission/submission.model';
 import { FileUploadAssessmentService } from 'app/fileupload/manage/assess/file-upload-assessment.service';
 import { ModelingAssessmentService } from 'app/modeling/manage/assess/modeling-assessment.service';
 import { ProgrammingAssessmentManualResultService } from 'app/programming/manage/assess/manual-result/programming-assessment-manual-result.service';
@@ -61,6 +62,18 @@ export class ManageAssessmentButtonsComponent implements OnInit {
         this.correctionRoundIndices.set([...Array(this.exercise().exerciseGroup?.exam?.numberOfCorrectionRoundsInExam ?? 1).keys()]);
     }
 
+    /**
+     * The result of the given correction round, matched on the round the result belongs to.
+     *
+     * Indexing the results by the round only worked while a submission's results were an ordered list whose position was
+     * the round. They are a set now and the round lives on the result, so it is matched instead. The scores view is fed
+     * one entry per round for exactly this lookup.
+     */
+    resultForRound(correctionRound: number): Result | undefined {
+        const submission = this.participation().submissions?.[0];
+        return submission ? getSubmissionResultByCorrectionRound(submission, correctionRound) : undefined;
+    }
+
     getAssessmentLink(correctionRound = 0) {
         const exercise = this.exercise();
         const course = this.course();
@@ -80,18 +93,17 @@ export class ManageAssessmentButtonsComponent implements OnInit {
             exercise.exerciseGroup?.exam?.id,
             exercise.exerciseGroup?.id,
             // TODO do we need to handle this differently for programming exercises?
-            submission.results?.[correctionRound]?.id,
+            this.resultForRound(correctionRound)?.id,
         );
     }
 
     getCorrectionRoundForAssessmentLink(correctionRound = 0): number {
         // TODO do we need to handle this differently for programming exercises?
-        const submission = this.participation().submissions![0];
-        const result = submission.results?.[correctionRound];
+        const result = this.resultForRound(correctionRound);
         if (!result) {
             return correctionRound;
         }
-        if (result.hasComplaint && !!submission.results?.[correctionRound + 1]) {
+        if (result.hasComplaint && !!this.resultForRound(correctionRound + 1)) {
             // If there is a complaint and the complaint got accepted (additional result)
             // open this next result.
             return correctionRound + 1;

--- a/src/main/webapp/app/exercise/exercise-scores/participation-score-dto.model.ts
+++ b/src/main/webapp/app/exercise/exercise-scores/participation-score-dto.model.ts
@@ -24,4 +24,17 @@ export interface ParticipationScoreDTO {
     testCaseCount?: number;
     passedTestCaseCount?: number;
     codeIssueCount?: number;
+    correctionRoundResults?: CorrectionRoundResultDTO[];
+}
+
+/**
+ * One manual result of the participation's latest submission, with the correction round it belongs to. The scores view
+ * renders assessment actions per round and needs an entry per round, not only the newest result.
+ */
+export interface CorrectionRoundResultDTO {
+    resultId: number;
+    correctionRound?: number;
+    assessmentType?: AssessmentType;
+    completionDate?: dayjs.Dayjs;
+    hasComplaint?: boolean;
 }

--- a/src/main/webapp/app/exercise/shared/entities/result/result.model.ts
+++ b/src/main/webapp/app/exercise/shared/entities/result/result.model.ts
@@ -18,6 +18,8 @@ export class Result implements BaseEntity {
      */
     public score?: number;
     public assessmentType?: AssessmentType;
+    /** Which correction round this result belongs to: 0 for the first correction, 1 for the second. Unset for automatic results. */
+    public correctionRound?: number;
     public rated?: boolean;
     public hasComplaint?: boolean;
     public exampleResult?: boolean;

--- a/src/main/webapp/app/exercise/shared/entities/submission/submission.model.spec.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission.model.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { Result } from 'app/exercise/shared/entities/result/result.model';
+import { Submission, getLatestSubmissionResult, getNewestResult, getSubmissionResultByCorrectionRound } from 'app/exercise/shared/entities/submission/submission.model';
+import { AssessmentType } from 'app/assessment/shared/entities/assessment-type.model';
+import { ProgrammingSubmission } from 'app/programming/shared/entities/programming-submission.model';
+
+function resultWith(id: number | undefined, correctionRound?: number, assessmentType?: AssessmentType): Result {
+    const result = new Result();
+    result.id = id;
+    result.correctionRound = correctionRound;
+    result.assessmentType = assessmentType;
+    return result;
+}
+
+function submissionWith(results: (Result | undefined)[]): Submission {
+    const submission = new ProgrammingSubmission();
+    submission.results = results as Result[];
+    return submission;
+}
+
+describe('Submission model', () => {
+    describe('getNewestResult', () => {
+        it('should return the result with the highest id, whatever the order', () => {
+            const newest = resultWith(9);
+
+            expect(getNewestResult([resultWith(3), newest, resultWith(7)])).toBe(newest);
+            expect(getNewestResult([newest, resultWith(7), resultWith(3)])).toBe(newest);
+        });
+
+        it('should treat a result without an id as the newest one', () => {
+            const unsaved = resultWith(undefined);
+
+            expect(getNewestResult([resultWith(3), unsaved, resultWith(7)])).toBe(unsaved);
+        });
+
+        it('should ignore undefined entries and return undefined for nothing usable', () => {
+            const only = resultWith(2);
+
+            expect(getNewestResult([undefined, only, undefined])).toBe(only);
+            expect(getNewestResult([undefined, undefined])).toBeUndefined();
+            expect(getNewestResult([])).toBeUndefined();
+            expect(getNewestResult(undefined)).toBeUndefined();
+        });
+    });
+
+    describe('getLatestSubmissionResult', () => {
+        it('should not depend on the position of the results', () => {
+            const newest = resultWith(12);
+
+            // The server holds the results in a set, so both orders are possible for the same data.
+            expect(getLatestSubmissionResult(submissionWith([resultWith(4), newest]))).toBe(newest);
+            expect(getLatestSubmissionResult(submissionWith([newest, resultWith(4)]))).toBe(newest);
+        });
+    });
+
+    describe('getSubmissionResultByCorrectionRound', () => {
+        it('should match on the correction round rather than the position', () => {
+            const second = resultWith(4, 1, AssessmentType.MANUAL);
+            const first = resultWith(8, 0, AssessmentType.MANUAL);
+            const submission = submissionWith([second, first]);
+
+            expect(getSubmissionResultByCorrectionRound(submission, 0)).toBe(first);
+            expect(getSubmissionResultByCorrectionRound(submission, 1)).toBe(second);
+        });
+
+        it('should return undefined for a round that has no result', () => {
+            const submission = submissionWith([resultWith(8, 0, AssessmentType.MANUAL)]);
+
+            expect(getSubmissionResultByCorrectionRound(submission, 1)).toBeUndefined();
+        });
+
+        it('should not return an Athena result for a correction round', () => {
+            const submission = submissionWith([resultWith(8, 0, AssessmentType.AUTOMATIC_ATHENA)]);
+
+            expect(getSubmissionResultByCorrectionRound(submission, 0)).toBeUndefined();
+        });
+    });
+});

--- a/src/main/webapp/app/exercise/shared/entities/submission/submission.model.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission.model.ts
@@ -69,10 +69,10 @@ export function getLatestSubmissionResult(submission: Submission | undefined): R
  * @returns the results or undefined if submission or the result for the requested correctionRound is undefined
  */
 export function getSubmissionResultByCorrectionRound(submission: Submission | undefined, correctionRound: number): Result | undefined {
-    if (submission?.results && submission?.results.filter((result) => result?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA).length >= correctionRound) {
-        return submission.results.filter((result) => result?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA)[correctionRound];
-    }
-    return undefined;
+    // Matched on the result's own correction round. This used to index into the results array, which only worked because
+    // the server padded the array with nulls for rounds the tutor had not assessed. Nothing has to line up positionally
+    // any more, so a missing round is simply a result that is not there.
+    return submission?.results?.find((result) => result?.assessmentType !== AssessmentType.AUTOMATIC_ATHENA && result?.correctionRound === correctionRound);
 }
 
 /**
@@ -112,9 +112,16 @@ export function setSubmissionResultByCorrectionRound(submission: Submission, res
     if (!submission || !result || !submission.results) {
         return;
     }
-    submission.results[correctionRound] = result;
+    result.correctionRound = correctionRound;
+    // Replace the result of that round if the submission already carries one, rather than writing to a fixed position.
+    const existingIndex = submission.results.findIndex((existing) => existing?.correctionRound === correctionRound);
+    if (existingIndex >= 0) {
+        submission.results[existingIndex] = result;
+    } else {
+        submission.results = [...submission.results, result];
+    }
 
-    if (submission.results.length === correctionRound + 1) {
+    if (correctionRound === Math.max(...submission.results.map((existing) => existing?.correctionRound ?? -1))) {
         submission.latestResult = result;
     }
 }

--- a/src/main/webapp/app/exercise/shared/entities/submission/submission.model.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission.model.ts
@@ -58,7 +58,29 @@ export abstract class Submission implements BaseEntity {
  * @param submission
  */
 export function getLatestSubmissionResult(submission: Submission | undefined): Result | undefined {
-    return submission?.results?.last();
+    return getNewestResult(submission?.results);
+}
+
+/**
+ * The newest of the given results, which is the one with the highest id.
+ *
+ * Deliberately not the last element: the server holds a submission's results in a set, so their order in the response
+ * is not something the client can build on. A result without an id has just been created here and has not reached the
+ * server yet, which makes it the newest one.
+ *
+ * @param results the results to pick from, in any order
+ * @returns the newest result, or undefined if there is none
+ */
+export function getNewestResult(results: (Result | undefined)[] | undefined): Result | undefined {
+    return results?.reduce<Result | undefined>((newest, candidate) => {
+        if (!candidate) {
+            return newest;
+        }
+        if (!newest || candidate.id === undefined) {
+            return candidate;
+        }
+        return newest.id === undefined || newest.id > candidate.id ? newest : candidate;
+    }, undefined);
 }
 
 /**

--- a/src/main/webapp/app/exercise/submission/submission.service.spec.ts
+++ b/src/main/webapp/app/exercise/submission/submission.service.spec.ts
@@ -114,20 +114,24 @@ describe('Submission Service', () => {
             type: FeedbackType.MANUAL,
         };
 
-        const firstResult: Result = {
+        const firstRoundResult: Result = {
             id: 3556,
             score: 24,
             rated: true,
             hasComplaint: false,
+            correctionRound: 0,
             feedbacks: [firstFeedback],
         };
 
-        submission.results?.unshift(firstResult);
+        const secondRoundResult = submission.results![0];
+        secondRoundResult.correctionRound = 1;
+        // Prepended on purpose: the round a result belongs to is what decides the comparison, not its position.
+        submission.results!.unshift(firstRoundResult);
 
         expect(secondFeedback.copiedFeedbackId).toBeUndefined();
 
-        const latestResultFeedbacks = getLatestSubmissionResult(submission)!.feedbacks!;
-        latestResultFeedbacks?.push(secondFeedback);
+        const secondRoundFeedbacks = secondRoundResult.feedbacks!;
+        secondRoundFeedbacks.push(secondFeedback);
 
         // Copy checking should not be done for correction round 0.
         service.handleFeedbackCorrectionRoundTag(0, submission);
@@ -135,12 +139,12 @@ describe('Submission Service', () => {
 
         // Only the second feedback has identical values to the first one, the other feedback should remain untouched.
         service.handleFeedbackCorrectionRoundTag(1, submission);
-        expect(latestResultFeedbacks[0].copiedFeedbackId).toBeUndefined();
+        expect(secondRoundFeedbacks[0].copiedFeedbackId).toBeUndefined();
         expect(secondFeedback.copiedFeedbackId).toBe(firstFeedback.id);
 
         secondFeedback.text = 'Feedback changed';
         // Feedback.text is changed so the Feedback is not a direct copy anymore.
-        service.handleFeedbackCorrectionRoundTag(2, submission);
+        service.handleFeedbackCorrectionRoundTag(1, submission);
         expect(secondFeedback.copiedFeedbackId).toBeUndefined();
     });
 

--- a/src/main/webapp/app/exercise/submission/submission.service.ts
+++ b/src/main/webapp/app/exercise/submission/submission.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { createRequestOption } from 'app/foundation/util/request.util';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
-import { Submission, getLatestSubmissionResult, setLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
+import { Submission, getLatestSubmissionResult, getSubmissionResultByCorrectionRound, setLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
 import { filter, map, tap } from 'rxjs/operators';
 import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
 import { Feedback } from 'app/assessment/shared/entities/feedback.model';
@@ -234,19 +234,25 @@ export class SubmissionService {
      * @param submission current submission
      */
     public handleFeedbackCorrectionRoundTag(correctionRound: number, submission: Submission) {
-        if (correctionRound > 0 && submission?.results && submission.results.length > 1) {
-            const firstResult = submission.results[0];
-            const secondCorrectionFeedback1 = submission.results[1].feedbacks as Feedback[];
-            secondCorrectionFeedback1.forEach((secondFeedback) => {
-                firstResult.feedbacks!.forEach((firstFeedback) => {
-                    if (secondFeedback.copiedFeedbackId === undefined && this.areFeedbacksCopies(firstFeedback, secondFeedback)) {
-                        secondFeedback.copiedFeedbackId = firstFeedback.id;
-                    } else if (secondFeedback.copiedFeedbackId === firstFeedback.id && !this.areFeedbacksCopies(firstFeedback, secondFeedback)) {
-                        secondFeedback.copiedFeedbackId = undefined;
-                    }
-                });
-            });
+        if (correctionRound <= 0) {
+            return;
         }
+        // Both results are looked up by their own correction round rather than by their position: the server holds a
+        // submission's results in a set, so the order they arrive in carries no meaning.
+        const previousRoundFeedbacks = getSubmissionResultByCorrectionRound(submission, correctionRound - 1)?.feedbacks;
+        const currentRoundFeedbacks = getSubmissionResultByCorrectionRound(submission, correctionRound)?.feedbacks;
+        if (!previousRoundFeedbacks || !currentRoundFeedbacks) {
+            return;
+        }
+        currentRoundFeedbacks.forEach((currentFeedback) => {
+            previousRoundFeedbacks.forEach((previousFeedback) => {
+                if (currentFeedback.copiedFeedbackId === undefined && this.areFeedbacksCopies(previousFeedback, currentFeedback)) {
+                    currentFeedback.copiedFeedbackId = previousFeedback.id;
+                } else if (currentFeedback.copiedFeedbackId === previousFeedback.id && !this.areFeedbacksCopies(previousFeedback, currentFeedback)) {
+                    currentFeedback.copiedFeedbackId = undefined;
+                }
+            });
+        });
     }
 
     /**

--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.ts
@@ -279,9 +279,10 @@ export class FileUploadAssessmentComponent implements OnInit {
         this.course.set(getCourseFromExercise(exercise));
         this.hasAssessmentDueDatePassed.set(!!exercise.assessmentDueDate && dayjs(exercise.assessmentDueDate).isBefore(dayjs()));
         if (this.resultId > 0) {
-            const foundIndex = submission.results?.findIndex((result) => result.id === this.resultId);
-            this.correctionRound.set(foundIndex !== undefined && foundIndex >= 0 ? foundIndex : 0);
-            this.result.set(getSubmissionResultById(submission, this.resultId));
+            const resultForId = getSubmissionResultById(submission, this.resultId);
+            // Read off the result, not off its position in the results array.
+            this.correctionRound.set(resultForId?.correctionRound ?? 0);
+            this.result.set(resultForId);
         } else {
             this.result.set(getLatestSubmissionResult(submission));
         }

--- a/src/main/webapp/app/localci/shared/entities/build-log.model.spec.ts
+++ b/src/main/webapp/app/localci/shared/entities/build-log.model.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { BuildLogEntry, BuildLogEntryArray, BuildLogType } from 'app/localci/shared/entities/build-log.model';
+
+describe('BuildLogEntryArray', () => {
+    describe('fromBuildLogs', () => {
+        it('should order the entries by their timestamp', () => {
+            const buildLogs: BuildLogEntry[] = [
+                { time: '2026-08-25T10:00:02.000Z', log: 'third' },
+                { time: '2026-08-25T10:00:00.000Z', log: 'first' },
+                { time: '2026-08-25T10:00:01.000Z', log: 'second' },
+            ];
+
+            const buildLogEntries = BuildLogEntryArray.fromBuildLogs(buildLogs);
+
+            expect(Array.from(buildLogEntries, (entry) => entry.log)).toEqual(['first', 'second', 'third']);
+        });
+
+        it('should not change the order of entries logged at the same time', () => {
+            const buildLogs: BuildLogEntry[] = [
+                { time: '2026-08-25T10:00:00.000Z', log: 'first' },
+                { time: '2026-08-25T10:00:00.000Z', log: 'second' },
+                { time: '2026-08-25T10:00:00.000Z', log: 'third' },
+            ];
+
+            const buildLogEntries = BuildLogEntryArray.fromBuildLogs(buildLogs);
+
+            expect(Array.from(buildLogEntries, (entry) => entry.log)).toEqual(['first', 'second', 'third']);
+        });
+
+        it('should keep the given order when a timestamp cannot be parsed', () => {
+            const buildLogs: BuildLogEntry[] = [
+                { time: 'not a date', log: 'first' },
+                { time: '2026-08-25T10:00:00.000Z', log: 'second' },
+            ];
+
+            const buildLogEntries = BuildLogEntryArray.fromBuildLogs(buildLogs);
+
+            expect(Array.from(buildLogEntries, (entry) => entry.log)).toEqual(['first', 'second']);
+        });
+
+        it('should not modify the given array', () => {
+            const buildLogs: BuildLogEntry[] = [
+                { time: '2026-08-25T10:00:01.000Z', log: 'second' },
+                { time: '2026-08-25T10:00:00.000Z', log: 'first' },
+            ];
+
+            BuildLogEntryArray.fromBuildLogs(buildLogs);
+
+            expect(buildLogs.map((entry) => entry.log)).toEqual(['second', 'first']);
+        });
+
+        it('should derive the log type from the message', () => {
+            const buildLogs: BuildLogEntry[] = [
+                { time: '2026-08-25T10:00:00.000Z', log: '[ERROR] something broke' },
+                { time: '2026-08-25T10:00:01.000Z', log: '  WARNING careful' },
+                { time: '2026-08-25T10:00:02.000Z', log: 'just a line' },
+            ];
+
+            const buildLogEntries = BuildLogEntryArray.fromBuildLogs(buildLogs);
+
+            expect(Array.from(buildLogEntries, (entry) => entry.type)).toEqual([BuildLogType.ERROR, BuildLogType.WARNING, BuildLogType.OTHER]);
+        });
+    });
+});

--- a/src/main/webapp/app/localci/shared/entities/build-log.model.spec.ts
+++ b/src/main/webapp/app/localci/shared/entities/build-log.model.spec.ts
@@ -27,6 +27,19 @@ describe('BuildLogEntryArray', () => {
             expect(Array.from(buildLogEntries, (entry) => entry.log)).toEqual(['first', 'second', 'third']);
         });
 
+        it('should order the parseable entries around one that cannot be parsed', () => {
+            const buildLogs: BuildLogEntry[] = [
+                { time: '2026-08-25T10:00:02.000Z', log: 'late' },
+                { time: 'not a date', log: 'invalid' },
+                { time: '2026-08-25T10:00:00.000Z', log: 'early' },
+            ];
+
+            const buildLogEntries = BuildLogEntryArray.fromBuildLogs(buildLogs);
+
+            // The unparseable entry keeps its slot, the two around it are ordered.
+            expect(Array.from(buildLogEntries, (entry) => entry.log)).toEqual(['early', 'invalid', 'late']);
+        });
+
         it('should keep the given order when a timestamp cannot be parsed', () => {
             const buildLogs: BuildLogEntry[] = [
                 { time: 'not a date', log: 'first' },

--- a/src/main/webapp/app/localci/shared/entities/build-log.model.ts
+++ b/src/main/webapp/app/localci/shared/entities/build-log.model.ts
@@ -19,6 +19,19 @@ export type BuildLogEntry = {
 type ParsedLogEntry = [string, string, string, string, string, string];
 
 /**
+ * Compares two build log entries by their timestamp. Entries whose timestamp cannot be parsed keep their relative
+ * order, because sorting is stable.
+ */
+function compareByTime(first: BuildLogEntry, second: BuildLogEntry): number {
+    const firstTime = Date.parse(first.time);
+    const secondTime = Date.parse(second.time);
+    if (Number.isNaN(firstTime) || Number.isNaN(secondTime)) {
+        return 0;
+    }
+    return firstTime - secondTime;
+}
+
+/**
  * Wrapper class for build log output.
  */
 export class BuildLogEntryArray extends Array<BuildLogEntry> {
@@ -28,6 +41,10 @@ export class BuildLogEntryArray extends Array<BuildLogEntry> {
 
     /**
      * Factory method for creating an instance of the class. Prefer this method over the default constructor.
+     *
+     * The entries are sorted by their timestamp. The server already returns them in order, but that order relies on a
+     * mapping detail that is easy to lose somewhere on the way here, and build output is unreadable once the lines are
+     * shuffled, so the client does not depend on it.
      *
      * @param buildLogs BuildLogEntry[]
      */
@@ -43,7 +60,7 @@ export class BuildLogEntryArray extends Array<BuildLogEntry> {
             }
             return cloneWith({ log, type: logType }, rest);
         });
-        return new BuildLogEntryArray(...mappedLogs);
+        return new BuildLogEntryArray(...mappedLogs.sort(compareByTime));
     }
 
     /**

--- a/src/main/webapp/app/localci/shared/entities/build-log.model.ts
+++ b/src/main/webapp/app/localci/shared/entities/build-log.model.ts
@@ -19,16 +19,31 @@ export type BuildLogEntry = {
 type ParsedLogEntry = [string, string, string, string, string, string];
 
 /**
- * Compares two build log entries by their timestamp. Entries whose timestamp cannot be parsed keep their relative
- * order, because sorting is stable.
+ * Orders build log entries by their timestamp, leaving every entry whose timestamp cannot be parsed at the position it
+ * came in at.
+ *
+ * The entries with a usable timestamp are sorted among themselves and written back into the slots they occupied, so an
+ * unparseable entry never moves and never separates two entries that do compare. Comparing straight through the
+ * unparseable ones instead would make the comparison intransitive, which leaves the result of a sort undefined.
+ *
+ * @param entries the entries to order, which are not modified
+ * @returns a new array holding the same entries in display order
  */
-function compareByTime(first: BuildLogEntry, second: BuildLogEntry): number {
-    const firstTime = Date.parse(first.time);
-    const secondTime = Date.parse(second.time);
-    if (Number.isNaN(firstTime) || Number.isNaN(secondTime)) {
-        return 0;
-    }
-    return firstTime - secondTime;
+function sortByTime(entries: BuildLogEntry[]): BuildLogEntry[] {
+    const sortable: { entry: BuildLogEntry; index: number; time: number }[] = [];
+    entries.forEach((entry, index) => {
+        const time = Date.parse(entry.time);
+        if (!Number.isNaN(time)) {
+            sortable.push({ entry, index, time });
+        }
+    });
+
+    const ordered = [...entries];
+    sortable
+        .map(({ entry, time }) => ({ entry, time }))
+        .sort((first, second) => first.time - second.time)
+        .forEach(({ entry }, position) => (ordered[sortable[position].index] = entry));
+    return ordered;
 }
 
 /**
@@ -60,7 +75,7 @@ export class BuildLogEntryArray extends Array<BuildLogEntry> {
             }
             return cloneWith({ log, type: logType }, rest);
         });
-        return new BuildLogEntryArray(...mappedLogs.sort(compareByTime));
+        return new BuildLogEntryArray(...sortByTime(mappedLogs));
     }
 
     /**

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
@@ -150,6 +150,7 @@ describe('ModelingAssessmentEditorComponent', () => {
             results: [
                 {
                     id: 2374,
+                    correctionRound: 0,
                     score: 8,
                     rated: true,
                     hasComplaint: true,
@@ -316,6 +317,7 @@ describe('ModelingAssessmentEditorComponent', () => {
 
             component.result.set({
                 id: 2374,
+                correctionRound: 0,
                 score: 8,
                 rated: true,
                 hasComplaint: false,
@@ -459,6 +461,7 @@ describe('ModelingAssessmentEditorComponent', () => {
 
         const changedResult = {
             id: 2374,
+            correctionRound: 0,
             score: 8,
             rated: true,
             hasComplaint: false,

--- a/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/modeling/manage/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -242,8 +242,8 @@ export class ModelingAssessmentEditorComponent implements OnInit {
         this.course.set(getCourseFromExercise(this.modelingExercise()));
         if (this.resultId() > 0) {
             this.result.set(getSubmissionResultById(submission, this.resultId()));
-            // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-            this.correctionRound.set(submission.results?.findIndex((result) => result.id === this.resultId())!);
+            // Read off the result, not off its position in the results array.
+            this.correctionRound.set(this.result()?.correctionRound ?? 0);
         } else {
             this.result.set(getSubmissionResultByCorrectionRound(this.submission(), this.correctionRound()));
         }

--- a/src/main/webapp/app/programming/manage/services/programming-exercise.service.ts
+++ b/src/main/webapp/app/programming/manage/services/programming-exercise.service.ts
@@ -11,7 +11,7 @@ import { ProgrammingExercise, ProgrammingLanguage, ProjectType } from 'app/progr
 import { toUpdateProgrammingExerciseDTO } from 'app/programming/manage/services/update-programming-exercise-dto.model';
 import { toProgrammingExerciseTimelineUpdateDTO } from 'app/programming/manage/services/programming-exercise-timeline-update-dto.model';
 import { PlagiarismOptions } from 'app/plagiarism/shared/entities/PlagiarismOptions';
-import { Submission } from 'app/exercise/shared/entities/submission/submission.model';
+import { Submission, getNewestResult } from 'app/exercise/shared/entities/submission/submission.model';
 import { convertDateFromClient, convertDateFromServer } from 'app/foundation/util/date.utils';
 import { SortService } from 'app/foundation/service/sort.service';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
@@ -323,11 +323,8 @@ export class ProgrammingExerciseService {
 
         // important: sort to get the latest submission (the order of the server can be random)
         this.sortService.sortByProperty(submissions, 'submissionDate', true);
-        const results = submissions.sort().last()?.results;
-        if (results && results.length > 0) {
-            return results.last();
-        }
-        return undefined;
+        // By id, not by position: the server holds a submission's results in a set, so the response order is arbitrary.
+        return getNewestResult(submissions.sort().last()?.results);
     }
 
     /**

--- a/src/main/webapp/app/text/manage/assess/service/text-assessment.service.ts
+++ b/src/main/webapp/app/text/manage/assess/service/text-assessment.service.ts
@@ -167,9 +167,9 @@ export class TextAssessmentService {
                     const submission = participation.submissions!.last()!;
                     let result;
                     if (resultId) {
-                        result = getSubmissionResultById(submission, resultId)!;
+                        result = getSubmissionResultById(submission, resultId);
                     } else {
-                        result = getSubmissionResultByCorrectionRound(submission, correctionRound)!;
+                        result = getSubmissionResultByCorrectionRound(submission, correctionRound);
                     }
                     TextAssessmentService.reconnectResultsParticipation(participation, submission, result);
                 }),
@@ -261,9 +261,13 @@ export class TextAssessmentService {
      *  @param submission
      *  @param result
      */
-    private static reconnectResultsParticipation(participation: Participation, submission: Submission, result: Result) {
+    private static reconnectResultsParticipation(participation: Participation, submission: Submission, result: Result | undefined) {
         setLatestSubmissionResult(submission, getLatestSubmissionResult(submission));
         submission.participation = participation;
+        // A correction round the tutor has not assessed yet simply has no result, so there is nothing to reconnect.
+        if (!result) {
+            return;
+        }
         result.submission = submission;
         // Make sure Feedbacks Array is initialized
         result.feedbacks = result.feedbacks || [];

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.spec.ts
@@ -117,6 +117,7 @@ describe('TextSubmissionAssessmentComponent', () => {
         submission.results = [
             {
                 id: 2374,
+                correctionRound: 0,
                 completionDate: dayjs('2019-07-09T11:51:23.251Z'),
                 successful: false,
                 score: 8,

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
@@ -377,7 +377,9 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
      * (only if this is a fresh submission, i.e. no assessments exist yet)
      */
     loadFeedbackSuggestions(): void {
-        if (this.assessments.length > 0) {
+        // Without a result there is nothing to attach a suggestion to. This happens for a correction round the tutor has
+        // not started yet, where the submission is opened before a result exists.
+        if (this.assessments.length > 0 || !this.result()) {
             return;
         }
         this.loadingFeedbackSuggestions.set(true);

--- a/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/text/manage/assess/submission-assessment/text-submission-assessment.component.ts
@@ -230,8 +230,8 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
 
         if (this.resultId() > 0) {
             this.result.set(getSubmissionResultById(this.submission, this.resultId()));
-            // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-            this.correctionRound.set(this.submission!.results?.findIndex((result) => result.id === this.resultId())!);
+            // Read off the result, not off its position in the results array.
+            this.correctionRound.set(this.result()?.correctionRound ?? 0);
         } else {
             this.result.set(getSubmissionResultByCorrectionRound(this.submission, this.correctionRound()));
         }

--- a/src/main/webapp/app/text/overview/text-editor/text-editor.component.ts
+++ b/src/main/webapp/app/text/overview/text-editor/text-editor.component.ts
@@ -23,7 +23,7 @@ import { Result } from 'app/exercise/shared/entities/result/result.model';
 import { TextSubmission } from 'app/text/shared/entities/text-submission.model';
 import { StringCountService } from 'app/text/overview/service/string-count.service';
 import { AccountService } from 'app/core/auth/account.service';
-import { getFirstResultWithComplaint, getLatestSubmissionResult, setLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
+import { getFirstResultWithComplaint, getLatestSubmissionResult, getNewestResult, setLatestSubmissionResult } from 'app/exercise/shared/entities/submission/submission.model';
 import { getUnreferencedFeedback, isAthenaAIResult } from 'app/exercise/result/result.utils';
 import { onError } from 'app/foundation/util/global.utils';
 import { Course } from 'app/course/shared/entities/course.model';
@@ -201,7 +201,8 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
                 const changedParticipation = updatedParticipation as StudentParticipation;
                 const results = changedParticipation.submissions?.flatMap((submission) => submission.results ?? []) || [];
                 const oldResults = this.participation().submissions?.flatMap((submission) => submission.results ?? []) || [];
-                const lastResult = results?.last();
+                // By id, not by position: the server holds a submission's results in a set, so the response order is arbitrary.
+                const lastResult = getNewestResult(results);
                 const isNewAthenaResult =
                     !!results &&
                     ((results?.length || 0) > (oldResults.length || 0) || lastResult?.completionDate === undefined) &&

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/AssessmentComplaintIntegrationTest.java
@@ -45,6 +45,7 @@ import de.tum.cit.aet.artemis.exercise.domain.participation.StudentParticipation
 import de.tum.cit.aet.artemis.exercise.dto.SubmissionWithComplaintDTO;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationFactory;
 import de.tum.cit.aet.artemis.exercise.participation.util.ParticipationUtilService;
+import de.tum.cit.aet.artemis.exercise.test_repository.SubmissionTestRepository;
 import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
 import de.tum.cit.aet.artemis.fileupload.domain.FileUploadExercise;
 import de.tum.cit.aet.artemis.fileupload.util.FileUploadExerciseUtilService;
@@ -63,6 +64,9 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
 
     @Autowired
     private ComplaintRepository complaintRepo;
+
+    @Autowired
+    private SubmissionTestRepository submissionRepository;
 
     @Autowired
     private ComplaintResponseTestRepository complaintResponseTestRepository;
@@ -287,6 +291,50 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
         participationUtilService.checkFeedbackCorrectlyStored(modelingAssessment.getFeedbacks(), updatedResult.getFeedbacks(), FeedbackType.MANUAL);
         final String[] ignoringFields = { "feedbacks", "submission", "participation", "assessor" };
         assertThat(storedResult).as("only feedbacks are changed in the result").usingRecursiveComparison().ignoringFields(ignoringFields).isEqualTo(modelingAssessment);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor2", roles = "TA")
+    void submitComplaintResponse_afterTwoCorrectionRounds_keepsBothRoundsAndAddsTheNextOne() throws Exception {
+        // A second corrector assesses the same submission, so the submission carries one result per correction round.
+        // Written through the result repository, which owns the foreign key: re-saving the submission entity here would
+        // merge two detached copies of the first round's result, which is a property of the fixture and not of the flow.
+        // Assessed by the instructor, not by tutor2: tutor2 answers the complaint below, and nobody may resolve a
+        // complaint about an assessment they wrote themselves.
+        Result secondRoundAssessment = participationUtilService.addResultToSubmission(AssessmentType.MANUAL, ZonedDateTime.now(), modelingSubmission, TEST_PREFIX + "instructor1",
+                List.of());
+
+        assertThat(modelingAssessment.getCorrectionRound()).as("the first assessment belongs to the first correction round").isZero();
+        assertThat(secondRoundAssessment.getCorrectionRound()).as("the second assessment belongs to the second correction round").isEqualTo(1);
+
+        // The student complains about the result of the second round, which is the one they were shown.
+        Complaint complaintAboutSecondRound = complaintRepo
+                .save(new Complaint().result(secondRoundAssessment).complaintText("The second corrector was unfair").complaintType(ComplaintType.COMPLAINT));
+        ComplaintResponse complaintResponse = complaintUtilService.createInitialEmptyResponse(TEST_PREFIX + "tutor2", complaintAboutSecondRound);
+        complaintResponse.getComplaint().setAccepted(true);
+        complaintResponse.setResponseText("Accepted");
+
+        List<Feedback> feedbacks = participationUtilService.loadAssessmentFomResources("test-data/model-assessment/assessment.54727.json");
+        feedbacks.forEach(feedback -> feedback.setType(FeedbackType.MANUAL));
+        Result resultAfterComplaint = request.putWithResponseBody("/api/modeling/modeling-submissions/" + modelingSubmission.getId() + "/assessment-after-complaint",
+                new AssessmentUpdateDTO(feedbacks, complaintResponse, null), Result.class, HttpStatus.OK);
+
+        // Accepting a complaint adds a further result rather than replacing the one complained about, and it takes the
+        // round after the last one. The client relies on that: it opens the round after the one with the complaint.
+        assertThat(resultAfterComplaint).isNotNull();
+        assertThat(resultAfterComplaint.getCorrectionRound()).as("the result of an accepted complaint follows the last correction round").isEqualTo(2);
+
+        // Neither of the two rounds loses its own result or moves to another round.
+        Submission storedSubmission = submissionRepository.findByIdWithResultsElseThrow(modelingSubmission.getId());
+        assertThat(storedSubmission.getResults()).as("the two rounds and the complaint result are all kept").hasSize(3);
+        assertThat(storedSubmission.getResultForCorrectionRound(0)).as("the first round still resolves to its own result").isNotNull().extracting(Result::getId)
+                .isEqualTo(modelingAssessment.getId());
+        assertThat(storedSubmission.getResultForCorrectionRound(1)).as("the second round still resolves to its own result").isNotNull().extracting(Result::getId)
+                .isEqualTo(secondRoundAssessment.getId());
+        assertThat(storedSubmission.getResultForCorrectionRound(2)).as("the complaint result is the one of the following round").isNotNull().extracting(Result::getId)
+                .isEqualTo(resultAfterComplaint.getId());
+        // The student is shown the newest result, which is the one the complaint produced.
+        assertThat(storedSubmission.getLatestResult()).isNotNull().extracting(Result::getId).isEqualTo(resultAfterComplaint.getId());
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/ExampleSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/ExampleSubmissionIntegrationTest.java
@@ -400,7 +400,7 @@ class ExampleSubmissionIntegrationTest extends AbstractSpringIntegrationIndepend
         Optional<Result> orginalResult = resultRepository.findDistinctWithFeedbackBySubmissionId(originalSubmission.getId());
 
         ExampleSubmission exampleSubmission = importExampleSubmission(exercise.getId(), originalSubmission.getId(), HttpStatus.OK);
-        assertThat(exampleSubmission.getSubmission().getResults().getFirst().getFeedbacks().iterator().next().getGradingInstruction().getId())
+        assertThat(exampleSubmission.getSubmission().getFirstResult().getFeedbacks().iterator().next().getGradingInstruction().getId())
                 .isEqualTo(orginalResult.orElseThrow().getFeedbacks().iterator().next().getGradingInstruction().getId());
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/ResultDTOSerializationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/ResultDTOSerializationTest.java
@@ -1,0 +1,48 @@
+package de.tum.cit.aet.artemis.assessment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
+import de.tum.cit.aet.artemis.assessment.domain.Result;
+import de.tum.cit.aet.artemis.assessment.dto.ResultDTO;
+
+class ResultDTOSerializationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    /**
+     * The client matches a result to a correction round by this field, so it has to survive serialization. Round 0 is
+     * the interesting case: the DTOs carry {@code @JsonInclude(NON_EMPTY)}, and a zero being treated as empty would
+     * silently drop the first correction round.
+     */
+    @Test
+    void shouldSerializeCorrectionRoundZero() throws Exception {
+        Result result = new Result();
+        result.setId(1L);
+        result.setAssessmentType(AssessmentType.MANUAL);
+        result.setCompletionDate(ZonedDateTime.now());
+        result.setCorrectionRound(0);
+
+        String json = objectMapper.writeValueAsString(ResultDTO.of(result));
+
+        assertThat(json).contains("\"correctionRound\":0");
+    }
+
+    @Test
+    void shouldOmitCorrectionRoundWhenAbsent() throws Exception {
+        Result result = new Result();
+        result.setId(1L);
+        result.setAssessmentType(AssessmentType.AUTOMATIC);
+
+        String json = objectMapper.writeValueAsString(ResultDTO.of(result));
+
+        assertThat(json).doesNotContain("correctionRound");
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/ResultDTOSerializationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/ResultDTOSerializationTest.java
@@ -15,6 +15,8 @@ import de.tum.cit.aet.artemis.assessment.dto.ResultDTO;
 
 class ResultDTOSerializationTest {
 
+    private static final ZonedDateTime COMPLETION_DATE = ZonedDateTime.parse("2026-01-15T10:00:00Z");
+
     private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
 
     /**
@@ -27,7 +29,7 @@ class ResultDTOSerializationTest {
         Result result = new Result();
         result.setId(1L);
         result.setAssessmentType(AssessmentType.MANUAL);
-        result.setCompletionDate(ZonedDateTime.now());
+        result.setCompletionDate(COMPLETION_DATE);
         result.setCorrectionRound(0);
 
         String json = objectMapper.writeValueAsString(ResultDTO.of(result));

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/service/CourseScoreCalculationServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/service/CourseScoreCalculationServiceTest.java
@@ -199,9 +199,13 @@ class CourseScoreCalculationServiceTest extends AbstractSpringIntegrationIndepen
             assertThat(studentScoresDTO.currentRelativeScore()).isEqualTo(0.0);
         }
         else {
-            assertThat(studentScoresDTO.absoluteScore()).isEqualTo(6.6);
-            assertThat(studentScoresDTO.relativeScore()).isEqualTo(26.4);
-            assertThat(studentScoresDTO.currentRelativeScore()).isEqualTo(132.0);
+            // The text participation contributes nothing because its results were deleted above. That deletion used to
+            // be a no-op: the results were an ordered list whose position column stayed at its database default for
+            // every result saved through the result repository, so the list came back with a null in it, and the null
+            // was filtered out before the delete. The expected values used to encode that.
+            assertThat(studentScoresDTO.absoluteScore()).isEqualTo(6.0);
+            assertThat(studentScoresDTO.relativeScore()).isEqualTo(24.0);
+            assertThat(studentScoresDTO.currentRelativeScore()).isEqualTo(120.0);
         }
 
         Map<Long, BonusSourceResultDTO> bonusSourceResultDTOMap = courseScoreCalculationService.calculateCourseScoresForExamBonusSource(course, null, List.of(student.getId()));

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/CourseUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/CourseUtilService.java
@@ -715,6 +715,16 @@ public class CourseUtilService {
         programmingSubmission.addResult(resultProgramming);
         resultProgramming.setSubmission(programmingSubmission);
 
+        // Save the results before the submissions. A result owns the foreign key to its submission, so saving it here
+        // is what creates the row. Saving the submission first would create it through the cascade on its results
+        // instead, and because a merge does not write the generated id back to the detached result, the save below
+        // would then insert a second copy of every result.
+        resultModeling = resultRepo.save(resultModeling);
+        resultText = resultRepo.save(resultText);
+        resultFileUpload = resultRepo.save(resultFileUpload);
+        resultQuiz = resultRepo.save(resultQuiz);
+        resultProgramming = resultRepo.save(resultProgramming);
+
         // Save submissions
         modelingSubmission = submissionRepository.save(modelingSubmission);
         textSubmission = submissionRepository.save(textSubmission);
@@ -727,13 +737,6 @@ public class CourseUtilService {
         resultFileUpload.setSubmission(fileUploadSubmission);
         resultQuiz.setSubmission(quizSubmission);
         resultProgramming.setSubmission(programmingSubmission);
-
-        // Save results
-        resultRepo.save(resultModeling);
-        resultRepo.save(resultText);
-        resultRepo.save(resultFileUpload);
-        resultRepo.save(resultQuiz);
-        resultRepo.save(resultProgramming);
 
         // Save exercises
         exerciseRepository.save(modelingExercise);

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/ExerciseTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.ZonedDateTime;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -69,9 +68,9 @@ class ExerciseTest extends AbstractSpringIntegrationIndependentBatchTest {
         submission2.setSubmissionDate(ZonedDateTime.now().plusDays(1));
         submission3.setSubmissionDate(ZonedDateTime.now().plusDays(2));
 
-        submission1.setResults(List.of(ratedResult));
-        submission2.setResults(List.of(ratedResult));
-        submission3.setResults(List.of(ratedResult));
+        submission1.setResults(Set.of(ratedResult));
+        submission2.setResults(Set.of(ratedResult));
+        submission3.setResults(Set.of(ratedResult));
 
         submission1.setCommitHash("aaaaa");
         submission2.setCommitHash("bbbbb");
@@ -126,9 +125,9 @@ class ExerciseTest extends AbstractSpringIntegrationIndependentBatchTest {
 
     @Test
     void filterForCourseDashboard_submissionWithoutResultsOrder() {
-        submission1.setResults(List.of());
-        submission2.setResults(List.of());
-        submission3.setResults(List.of());
+        submission1.setResults(Set.of());
+        submission2.setResults(Set.of());
+        submission3.setResults(Set.of());
 
         exerciseService.filterExerciseForCourseDashboard(exercise, filterForCourseDashboard_prepareParticipations(), true);
         assertThat(exercise.getStudentParticipations().iterator().next().getSubmissions()).isEqualTo(Set.of(submission3));

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/domain/SubmissionResultAccessorTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/domain/SubmissionResultAccessorTest.java
@@ -2,8 +2,8 @@ package de.tum.cit.aet.artemis.exercise.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
+import java.util.HashSet;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +29,7 @@ class SubmissionResultAccessorTest {
 
     private static Submission submissionWith(Result... results) {
         Submission submission = new TextSubmission();
-        submission.setResults(new ArrayList<>(List.of(results)));
+        submission.setResults(new HashSet<>(Arrays.asList(results)));
         return submission;
     }
 
@@ -74,8 +74,8 @@ class SubmissionResultAccessorTest {
     void manualResultAccessorsToleratePlaceholdersLeftByDeletedResults() {
         Result manual = result(2L, AssessmentType.MANUAL);
         Submission submission = new TextSubmission();
-        // Deleting an entry of the @OrderColumn list leaves a null hole behind.
-        submission.setResults(new ArrayList<>(List.of()));
+        // The results are defensively null tolerant, so a null among them must not break the accessors.
+        submission.setResults(new HashSet<>());
         submission.getResults().add(null);
         submission.getResults().add(manual);
 

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/ParticipationIntegrationTest.java
@@ -1624,13 +1624,11 @@ class ParticipationIntegrationTest extends AbstractAthenaTest {
         latestResult.submission(submission).setCompletionDate(ZonedDateTime.now().minusHours(1));
         latestResult.setExerciseId(textExercise.getId());
         latestResult = resultRepository.save(latestResult);
-        // Attach the second result to the submission and save the submission as well: Submission#results is a list with
-        // an @OrderColumn, and that column is only written when the collection itself is flushed. Persisting a result
-        // through the result repository alone leaves results_order at its database default (0), which collides with the
-        // first result, and Hibernate then reconstructs the list by overwriting index 0 with whichever row the database
-        // happens to return last. That made this test fail non-deterministically.
+        // Saving the result is enough: the result owns the foreign key to its submission. This used to need a save of
+        // the submission as well, because the results were an ordered list whose position column was only written when
+        // the collection was flushed, so a result saved through its own repository kept the column's default of 0 and
+        // collided with the first result. That made this test fail non-deterministically.
         submission.addResult(latestResult);
-        submissionRepository.save(submission);
 
         var actualParticipation = request.get("/api/exercise/participations/" + participation.getId() + "/with-latest-result", HttpStatus.OK, StudentParticipation.class);
 

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
@@ -1105,15 +1105,35 @@ public class ParticipationUtilService {
      * @param result the result about to be saved
      * @return the same result, with its correction round set when it is a manual one
      */
-    private static Result withCorrectionRound(Result result) {
+    /**
+     * Assigns the correction round a manual result would get if it were added through {@link Submission#addResult}, so
+     * that results created directly through the repository carry the same value as results created through the
+     * production code path.
+     * <p>
+     * The already existing results are read from the database rather than from {@code submission.getResults()}, because
+     * the submissions handed to these helpers usually come straight out of a repository and are detached, which makes
+     * their result collection unreadable.
+     *
+     * @param result the result about to be saved
+     * @return the same result, with the correction round set when it is a manual one
+     */
+    private Result withCorrectionRound(Result result) {
         boolean manual = result.getAssessmentType() != null && !result.isAutomatic() && !result.isAthenaBased();
-        if (!manual || result.getCorrectionRound() != null || result.getSubmission() == null) {
+        Submission submission = result.getSubmission();
+        if (!manual || result.getCorrectionRound() != null || submission == null) {
             return result;
         }
-        var existing = result.getSubmission().getResults();
-        long manualResults = existing == null ? 0
-                : existing.stream().filter(other -> other != null && other != result && other.getAssessmentType() != null && !other.isAutomatic() && !other.isAthenaBased())
-                        .count();
+        Stream<Result> existing;
+        if (submission.getId() == null) {
+            // A submission that was never saved cannot have persisted results, and its collection is a plain one, so reading it is safe.
+            existing = submission.getResults().stream();
+        }
+        else {
+            existing = submissionRepository.findWithEagerResultsAndAssessorById(submission.getId()).map(Submission::getResults).orElse(Set.of()).stream();
+        }
+        // Compared by reference on purpose: the result is not saved yet, so its id is still null and equals would never match.
+        long manualResults = existing.filter(other -> other != null && other != result && other.getAssessmentType() != null && !other.isAutomatic() && !other.isAthenaBased())
+                .count();
         result.setCorrectionRound((int) manualResults);
         return result;
     }

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
@@ -422,7 +422,7 @@ public class ParticipationUtilService {
     public Result addResultToSubmission(AssessmentType type, ZonedDateTime completionDate, Submission submission, boolean successful, boolean rated, double score) {
         Result result = new Result().submission(submission).successful(successful).rated(rated).score(score).assessmentType(type).completionDate(completionDate);
         result.setExerciseId(submission.getParticipation().getExercise().getId());
-        return resultRepo.save(result);
+        return resultRepo.save(withCorrectionRound(result));
     }
 
     /**
@@ -437,7 +437,7 @@ public class ParticipationUtilService {
         Result result = new Result().submission(submission).successful(true).rated(true).score(100D).assessmentType(assessmentType).completionDate(completionDate);
         result.setExerciseId(submission.getParticipation().getExercise().getId());
         submission.addResult(result);
-        result = resultRepo.save(result);
+        result = resultRepo.save(withCorrectionRound(result));
         submissionRepository.save(submission);
         return result;
     }
@@ -456,7 +456,7 @@ public class ParticipationUtilService {
         Result result = new Result().submission(submission).assessmentType(assessmentType).completionDate(completionDate).feedbacks(feedbacks);
         result.setAssessor(userUtilService.getUserByLogin(assessorLogin));
         result.setExerciseId(submission.getParticipation().getExercise().getId());
-        return resultRepo.save(result);
+        return resultRepo.save(withCorrectionRound(result));
     }
 
     /**
@@ -469,7 +469,7 @@ public class ParticipationUtilService {
         Result result = new Result().submission(submission).successful(true).score(100D).rated(true).completionDate(ZonedDateTime.now());
         result.setSubmission(submission);
         result.setExerciseId(participation.getExercise().getId());
-        result = resultRepo.save(result);
+        result = resultRepo.save(withCorrectionRound(result));
         submission.addResult(result);
         submission.setParticipation(participation);
         submissionRepository.save(submission);
@@ -489,7 +489,7 @@ public class ParticipationUtilService {
         feedbacks.add(feedback1);
         feedbacks.add(feedback2);
         result.addFeedbacks(feedbacks);
-        return resultRepo.save(result);
+        return resultRepo.save(withCorrectionRound(result));
     }
 
     /**
@@ -510,7 +510,7 @@ public class ParticipationUtilService {
         ));
 
         result.addFeedbacks(feedbacks);
-        return resultRepo.save(result);
+        return resultRepo.save(withCorrectionRound(result));
     }
 
     /**
@@ -528,7 +528,7 @@ public class ParticipationUtilService {
         ));
 
         result.addFeedbacks(feedbacks);
-        return resultRepo.save(result);
+        return resultRepo.save(withCorrectionRound(result));
     }
     // @formatter:on
 
@@ -542,7 +542,7 @@ public class ParticipationUtilService {
     public Result addFeedbackToResult(Feedback feedback, Result result) {
         feedbackRepo.save(feedback);
         result.addFeedback(feedback);
-        return resultRepo.save(result);
+        return resultRepo.save(withCorrectionRound(result));
     }
 
     /**
@@ -556,7 +556,7 @@ public class ParticipationUtilService {
         feedback.addAll(ParticipationFactory.generateFeedback());
         feedback = feedbackRepo.saveAll(feedback);
         result.addFeedbacks(feedback);
-        return resultRepo.save(result);
+        return resultRepo.save(withCorrectionRound(result));
     }
 
     /**
@@ -580,7 +580,7 @@ public class ParticipationUtilService {
         result.setAssessor(user);
         result.setSubmission(submission);
         result.setExerciseId(exerciseId);
-        result = resultRepo.save(result);
+        result = resultRepo.save(withCorrectionRound(result));
         submission.addResult(result);
         var savedSubmission = submissionRepository.save(submission);
         return submissionRepository.findWithEagerResultsAndAssessorById(savedSubmission.getId()).orElseThrow();
@@ -683,7 +683,7 @@ public class ParticipationUtilService {
         result.setAssessmentType(AssessmentType.SEMI_AUTOMATIC);
         result.setAssessor(assessor);
         result.setRated(true);
-        result = resultRepo.save(result);
+        result = resultRepo.save(withCorrectionRound(result));
         return result;
     }
 
@@ -938,7 +938,7 @@ public class ParticipationUtilService {
         Submission submissionWithParticipation = addSubmission(studentParticipation, submission);
         Result result = addResultToSubmission(studentParticipation, submissionWithParticipation);
         result.setExerciseId(exercise.getId());
-        resultRepo.save(result);
+        resultRepo.save(withCorrectionRound(result));
 
         assertThat(exercise.getGradingCriteria()).isNotNull();
         assertThat(exercise.getGradingCriteria()).allMatch(gradingCriterion -> gradingCriterion.getStructuredGradingInstructions() != null);
@@ -1092,5 +1092,29 @@ public class ParticipationUtilService {
         catch (RuntimeException ignored) {
             // ignore non-LocalVC URIs
         }
+    }
+
+    /**
+     * Assigns the correction round the way production does, so that fixtures behave like the assessment lock: the n-th
+     * manual result of a submission belongs to round n. Automatic and Athena results are not correction rounds and keep
+     * a null round.
+     * <p>
+     * The count comes from the submission's results in memory, which is where the position of the result used to come
+     * from as well when Hibernate maintained the order column.
+     *
+     * @param result the result about to be saved
+     * @return the same result, with its correction round set when it is a manual one
+     */
+    private static Result withCorrectionRound(Result result) {
+        boolean manual = result.getAssessmentType() != null && !result.isAutomatic() && !result.isAthenaBased();
+        if (!manual || result.getCorrectionRound() != null || result.getSubmission() == null) {
+            return result;
+        }
+        var existing = result.getSubmission().getResults();
+        long manualResults = existing == null ? 0
+                : existing.stream().filter(other -> other != null && other != result && other.getAssessmentType() != null && !other.isAutomatic() && !other.isAthenaBased())
+                        .count();
+        result.setCorrectionRound((int) manualResults);
+        return result;
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
@@ -1117,6 +1117,10 @@ public class ParticipationUtilService {
      * @param result the result about to be saved
      * @return the same result, with the correction round set when it is a manual one
      */
+    private static boolean isSameRow(Result one, Result other) {
+        return one.getId() != null && one.getId().equals(other.getId());
+    }
+
     private Result withCorrectionRound(Result result) {
         boolean manual = result.getAssessmentType() != null && !result.isAutomatic() && !result.isAthenaBased();
         Submission submission = result.getSubmission();
@@ -1131,8 +1135,10 @@ public class ParticipationUtilService {
         else {
             existing = submissionRepository.findWithEagerResultsAndAssessorById(submission.getId()).map(Submission::getResults).orElse(Set.of()).stream();
         }
-        // Compared by reference on purpose: the result is not saved yet, so its id is still null and equals would never match.
-        long manualResults = existing.filter(other -> other != null && other != result && other.getAssessmentType() != null && !other.isAutomatic() && !other.isAthenaBased())
+        // Excluded by reference and by id: a result that is not saved yet has no id to match on, and a caller can also
+        // hand in a persisted result, which the query above returns as a different object for the same row.
+        long manualResults = existing.filter(
+                other -> other != null && other != result && !isSameRow(other, result) && other.getAssessmentType() != null && !other.isAutomatic() && !other.isAthenaBased())
                 .count();
         result.setCorrectionRound((int) manualResults);
         return result;

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/ParticipationDeletionServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/ParticipationDeletionServiceTest.java
@@ -90,21 +90,21 @@ class ParticipationDeletionServiceTest extends AbstractSpringIntegrationJenkinsL
         var templateSubmission = programmingExerciseUtilService.createProgrammingSubmission(templateParticipation, true);
         BuildLogEntry buildLogEntryTemplate = new BuildLogEntry(ZonedDateTime.now(), "Some sample build log");
         var templateSavedBuildLogs = buildLogEntryService.saveBuildLogs(List.of(buildLogEntryTemplate), templateSubmission);
-        templateSubmission.setBuildLogEntries(templateSavedBuildLogs);
+        templateSubmission.setBuildLogEntries(new java.util.LinkedHashSet<>(templateSavedBuildLogs));
         programmingSubmissionRepository.save(templateSubmission);
 
         var solutionParticipation = programmingExerciseParticipationUtilService.addSolutionParticipationForProgrammingExercise(programmingExercise).getSolutionParticipation();
         var solutionSubmission = programmingExerciseUtilService.createProgrammingSubmission(solutionParticipation, true);
         BuildLogEntry buildLogEntrySolution = new BuildLogEntry(ZonedDateTime.now(), "Some sample build log");
         var solutionSavedBuildLogs = buildLogEntryService.saveBuildLogs(List.of(buildLogEntrySolution), solutionSubmission);
-        solutionSubmission.setBuildLogEntries(solutionSavedBuildLogs);
+        solutionSubmission.setBuildLogEntries(new java.util.LinkedHashSet<>(solutionSavedBuildLogs));
         programmingSubmissionRepository.save(solutionSubmission);
 
         var studentParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, TEST_PREFIX + "student1");
         var studentSubmission = programmingExerciseUtilService.createProgrammingSubmission(studentParticipation, true);
         BuildLogEntry buildLogEntryStudent = new BuildLogEntry(ZonedDateTime.now(), "Some sample build log");
         var studentSavedBuildLogs = buildLogEntryService.saveBuildLogs(List.of(buildLogEntryStudent), studentSubmission);
-        studentSubmission.setBuildLogEntries(studentSavedBuildLogs);
+        studentSubmission.setBuildLogEntries(new java.util.LinkedHashSet<>(studentSavedBuildLogs));
         programmingSubmissionRepository.save(studentSubmission);
 
         // Delete and assert removal

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/SubmissionFilterServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/SubmissionFilterServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -104,7 +104,7 @@ class SubmissionFilterServiceTest extends AbstractSpringIntegrationIndependentBa
         var submission = getSubmissionBasedOnExerciseType(exerciseType);
         submission.setSubmissionDate(ZonedDateTime.now());
         submission.setParticipation(participation);
-        submission.setResults(List.of(new Result().rated(false)));
+        submission.setResults(Set.of(new Result().rated(false)));
 
         var optionalSubmission = submissionFilterService.getLatestSubmissionWithResult(Set.of(submission), true);
 
@@ -120,7 +120,7 @@ class SubmissionFilterServiceTest extends AbstractSpringIntegrationIndependentBa
         var submission = getSubmissionBasedOnExerciseType(exerciseType);
         submission.setSubmissionDate(ZonedDateTime.now());
         submission.setParticipation(participation);
-        submission.setResults(List.of(new Result().rated(true)));
+        submission.setResults(Set.of(new Result().rated(true)));
 
         var optionalSubmission = submissionFilterService.getLatestSubmissionWithResult(Set.of(submission), false);
 
@@ -139,7 +139,7 @@ class SubmissionFilterServiceTest extends AbstractSpringIntegrationIndependentBa
         var submission = getSubmissionBasedOnExerciseType(exerciseType);
         submission.setSubmissionDate(ZonedDateTime.now());
         submission.setParticipation(participation);
-        submission.setResults(List.of(new Result().rated(true).completionDate(ZonedDateTime.now())));
+        submission.setResults(Set.of(new Result().rated(true).completionDate(ZonedDateTime.now())));
 
         var optionalSubmission = submissionFilterService.getLatestSubmissionWithResult(Set.of(submission), false);
 
@@ -155,7 +155,7 @@ class SubmissionFilterServiceTest extends AbstractSpringIntegrationIndependentBa
         var submission = getSubmissionBasedOnExerciseType(exerciseType);
         submission.setSubmissionDate(ZonedDateTime.now());
         submission.setParticipation(participation);
-        submission.setResults(List.of(new Result().rated(true)));
+        submission.setResults(Set.of(new Result().rated(true)));
 
         var optionalSubmission = submissionFilterService.getLatestSubmissionWithResult(Set.of(submission), true);
 
@@ -181,7 +181,7 @@ class SubmissionFilterServiceTest extends AbstractSpringIntegrationIndependentBa
             // ids in the order of submission date
             submission.setId(2L - i);
             submission.setParticipation(participation);
-            submission.setResults(List.of(new Result().rated(true).completionDate(ZonedDateTime.now().minusDays(i + 1))));
+            submission.setResults(Set.of(new Result().rated(true).completionDate(ZonedDateTime.now().minusDays(i + 1))));
             submissions.add(submission);
             if (i == 0) {
                 expectedLatestSubmission = submission;
@@ -229,7 +229,7 @@ class SubmissionFilterServiceTest extends AbstractSpringIntegrationIndependentBa
         var exercise = exerciseByType.get(ExerciseType.PROGRAMMING);
         var result = new Result().rated(isRated);
         var submission = new ProgrammingSubmission().submissionDate(ZonedDateTime.now().plusDays(1));
-        submission.setResults(List.of(result));
+        submission.setResults(Set.of(result));
         var participation = new StudentParticipation().exercise(exercise);
         participation.setSubmissions(Set.of(submission));
         submission.setParticipation(participation);
@@ -249,7 +249,7 @@ class SubmissionFilterServiceTest extends AbstractSpringIntegrationIndependentBa
         exercise.setAssessmentDueDate(ZonedDateTime.now().minusHours(1));
         var result = new Result().rated(true).assessmentType(assessmentType).completionDate(ZonedDateTime.now().minusHours(1));
         var submission = new ProgrammingSubmission().submissionDate(ZonedDateTime.now().plusDays(1));
-        submission.setResults(List.of(result));
+        submission.setResults(Set.of(result));
         var participation = new StudentParticipation().exercise(exercise);
         participation.setSubmissions(Set.of(submission));
         submission.setParticipation(participation);
@@ -275,14 +275,14 @@ class SubmissionFilterServiceTest extends AbstractSpringIntegrationIndependentBa
         var secondResultWithManualAssessment = new Result().score(2.0).rated(true).completionDate(ZonedDateTime.now().plusHours(2)).assessmentType(AssessmentType.SEMI_AUTOMATIC);
         secondResultWithManualAssessment.setId(4L);
 
-        submissionWithoutManualAssessment.setResults(List.of(firstResult));
-        submissionWithManualAssessment.setResults(List.of(secondResult, retriggeredSecondResult, secondResultWithManualAssessment));
+        submissionWithoutManualAssessment.setResults(Set.of(firstResult));
+        submissionWithManualAssessment.setResults(Set.of(secondResult, retriggeredSecondResult, secondResultWithManualAssessment));
         Set<Submission> submissions = Set.of(submissionWithoutManualAssessment, submissionWithManualAssessment);
         submissions.forEach(s -> s.setParticipation(new StudentParticipation().exercise(programmingExercise)));
         var submission = submissionFilterService.getLatestSubmissionWithResult(submissions, false);
         assertThat(submission).isPresent().get().isEqualTo(submissionWithManualAssessment);
         assertThat(submission.get().getResults()).hasSize(1);
-        assertThat(submission.get().getResults().getFirst()).isEqualTo(retriggeredSecondResult);
+        assertThat(submission.get().getFirstResult()).isEqualTo(retriggeredSecondResult);
     }
 
     @Test
@@ -301,13 +301,13 @@ class SubmissionFilterServiceTest extends AbstractSpringIntegrationIndependentBa
 
         Result[] resultsArray = new Result[] { firstResult, secondResult, null, secondResultWithManualAssessment };
 
-        submissionWithManualAssessment.setResults(Arrays.asList(resultsArray));
+        submissionWithManualAssessment.setResults(new HashSet<>(Arrays.asList(resultsArray)));
         Set<Submission> submissions = Set.of(submissionWithManualAssessment);
         submissions.forEach(s -> s.setParticipation(new StudentParticipation().exercise(programmingExercise)));
         var submission = submissionFilterService.getLatestSubmissionWithResult(submissions, false);
         assertThat(submission).isPresent().get().isEqualTo(submissionWithManualAssessment);
         assertThat(submission.get().getResults()).hasSize(1);
-        assertThat(submission.get().getResults().getFirst()).isEqualTo(secondResult);
+        assertThat(submission.get().getFirstResult()).isEqualTo(secondResult);
     }
 
     @Test
@@ -319,7 +319,7 @@ class SubmissionFilterServiceTest extends AbstractSpringIntegrationIndependentBa
         submissionWithManualAssessment.setId(2L);
         var secondResultWithManualAssessment = new Result().score(2.0).rated(true).completionDate(ZonedDateTime.now().plusHours(2)).assessmentType(AssessmentType.SEMI_AUTOMATIC);
 
-        submissionWithManualAssessment.setResults(List.of(secondResultWithManualAssessment));
+        submissionWithManualAssessment.setResults(Set.of(secondResultWithManualAssessment));
         Set<Submission> submissions = Set.of(submissionWithManualAssessment);
         submissions.forEach(s -> s.setParticipation(new StudentParticipation().exercise(programmingExercise)));
         var submission = submissionFilterService.getLatestSubmissionWithResult(submissions, false);
@@ -348,7 +348,7 @@ class SubmissionFilterServiceTest extends AbstractSpringIntegrationIndependentBa
         var participation = new StudentParticipation().exercise(quizExercise);
         var submission = new QuizSubmission();
         submission.setParticipation(participation);
-        submission.setResults(List.of(new Result()));
+        submission.setResults(Set.of(new Result()));
         var optionalSubmission = submissionFilterService.getLatestSubmissionWithResult(Set.of(submission), false);
         assertThat(optionalSubmission).isEmpty();
     }

--- a/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadAssessmentIntegrationTest.java
@@ -9,7 +9,9 @@ import static org.mockito.Mockito.verify;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.assertj.core.data.Offset;
@@ -552,7 +554,10 @@ class FileUploadAssessmentIntegrationTest extends AbstractFileUploadIntegrationT
 
         assertThat(assessedSubmissionList).hasSize(1);
         assertThat(assessedSubmissionList.getFirst().id()).isEqualTo(submissionWithoutSecondAssessment.id());
-        assertThat(assessedSubmissionList.getFirst().results().get(1).id()).isEqualTo(secondSubmittedManualResult.id());
+        // Only the result of the requested correction round comes back. The results used to be an ordered list whose
+        // position carried the round, so a tutor who had assessed only the second round produced a null at index 0.
+        assertThat(assessedSubmissionList.getFirst().results()).hasSize(1);
+        assertThat(assessedSubmissionList.getFirst().results().getFirst().id()).isEqualTo(secondSubmittedManualResult.id());
 
         // make sure that they do not appear for the first correction round as the tutor only assessed the second correction round
         LinkedMultiValueMap<String, String> paramsGetAssessedCR1 = new LinkedMultiValueMap<>();
@@ -579,14 +584,14 @@ class FileUploadAssessmentIntegrationTest extends AbstractFileUploadIntegrationT
         var submissions = participationUtilService.getAllSubmissionsOfExercise(exercise);
         Submission submission = submissions.getFirst();
         assertThat(submission.getResults()).hasSize(3);
-        Result firstResult = submission.getResults().getFirst();
+        Result firstResult = submission.getFirstResult();
         Result lastResult = submission.getLatestResult();
         request.delete(
                 "/api/fileupload/participations/" + submission.getParticipation().getId() + "/file-upload-submissions/" + submission.getId() + "/results/" + firstResult.getId(),
                 HttpStatus.OK);
         submission = submissionRepository.findOneWithEagerResultAndFeedbackAndAssessmentNote(submission.getId());
         assertThat(submission.getResults()).hasSize(2);
-        assertThat(submission.getResults().get(1)).isEqualTo(lastResult);
+        assertThat(resultsInCreationOrder(submission).get(1)).isEqualTo(lastResult);
     }
 
     @Test
@@ -611,7 +616,7 @@ class FileUploadAssessmentIntegrationTest extends AbstractFileUploadIntegrationT
                 + resultOfOtherSubmission.getId(), HttpStatus.BAD_REQUEST);
         submission1 = submissionRepository.findOneWithEagerResultAndFeedbackAndAssessmentNote(submission1.getId());
         assertThat(submission1.getResults()).hasSize(3);
-        assertThat(submission1.getResults().get(2)).isEqualTo(lastResult);
+        assertThat(resultsInCreationOrder(submission1).get(2)).isEqualTo(lastResult);
     }
 
     @Test
@@ -634,7 +639,7 @@ class FileUploadAssessmentIntegrationTest extends AbstractFileUploadIntegrationT
                 HttpStatus.BAD_REQUEST);
         submission = submissionRepository.findOneWithEagerResultAndFeedbackAndAssessmentNote(submission.getId());
         assertThat(submission.getResults()).hasSize(2);
-        assertThat(submission.getResults().get(1)).isEqualTo(lastResult);
+        assertThat(resultsInCreationOrder(submission).get(1)).isEqualTo(lastResult);
     }
 
     private static FileUploadAssessmentInputDTO assessmentInput(List<Feedback> feedbacks, String assessmentNote) {
@@ -651,5 +656,13 @@ class FileUploadAssessmentIntegrationTest extends AbstractFileUploadIntegrationT
 
     private static FileUploadFeedbackDTO findByReference(List<FileUploadFeedbackDTO> feedbacks, String reference) {
         return feedbacks.stream().filter(f -> reference.equals(f.reference())).findFirst().orElseThrow();
+    }
+
+    /**
+     * The results of a submission in the order they were created. The submission's results are an unordered set, so a
+     * test that cares about the order of creation has to say so; ids ascend with creation.
+     */
+    private static List<Result> resultsInCreationOrder(Submission submission) {
+        return submission.getResults().stream().filter(Objects::nonNull).sorted(Comparator.comparing(Result::getId)).toList();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionCodeGenerationExecutionServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionCodeGenerationExecutionServiceTest.java
@@ -817,7 +817,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         when(mockSubmission.getId()).thenReturn(42L);
         // extractBuildLogs re-loads the submission with an eager build-log graph (the result itself is fetched without build logs).
         ProgrammingSubmission eagerSubmission = mock(ProgrammingSubmission.class);
-        when(eagerSubmission.getBuildLogEntries()).thenReturn(logEntries);
+        when(eagerSubmission.getBuildLogEntries()).thenReturn(new java.util.LinkedHashSet<>(logEntries));
         when(programmingSubmissionRepository.findWithEagerBuildLogEntriesById(42L)).thenReturn(Optional.of(eagerSubmission));
         when(logEntry1.getLog()).thenReturn("Error in line 1");
         when(logEntry2.getLog()).thenReturn("Error in line 2");
@@ -853,7 +853,7 @@ class HyperionCodeGenerationExecutionServiceTest {
         // Production re-fetches build logs via the eager query, not the lazy getter; stub that path so the real logs (not the fallback) are asserted.
         when(submission.getId()).thenReturn(7L);
         when(programmingSubmissionRepository.findWithEagerBuildLogEntriesById(7L)).thenReturn(Optional.of(submission));
-        when(submission.getBuildLogEntries()).thenReturn(List.of(logEntry));
+        when(submission.getBuildLogEntries()).thenReturn(java.util.Set.of(logEntry));
         when(logEntry.getLog()).thenReturn("javac: cannot find symbol Sort");
 
         String summary = ReflectionTestUtils.invokeMethod(service, "extractBuildFeedback", result);

--- a/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
@@ -189,7 +189,7 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
 
         List<BuildLogEntry> logs = new ArrayList<>();
         logs.add(new BuildLogEntry(ZonedDateTime.now(), "compilation failed: cannot find symbol", submission));
-        submission.setBuildLogEntries(logs);
+        submission.setBuildLogEntries(new java.util.LinkedHashSet<>(logs));
         submission = submissionRepository.saveAndFlush(submission);
 
         Result result = ParticipationFactory.generateResult(true, 0);

--- a/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingAssessmentIntegrationTest.java
@@ -10,7 +10,9 @@ import static org.mockito.Mockito.verify;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.assertj.core.data.Offset;
@@ -202,7 +204,7 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationIndepen
         assertThat(submission.getResults()).hasSize(2);
 
         // Get result IDs
-        Result expectedFirstResult = submission.getResults().getFirst();
+        Result expectedFirstResult = submission.getFirstResult();
         Result expectedLatestResult = submission.getLatestResult();
         Long firstResultId = expectedFirstResult.getId();
         Long latestResultId = expectedLatestResult.getId();
@@ -831,9 +833,8 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationIndepen
         params = new LinkedMultiValueMap<>();
         params.add("submit", "true");
         body = new ModelingAssessmentDTO(feedbacks, "text");
-        final var secondSubmittedManualResult = request.putWithResponseBodyAndParams(
-                API_MODELING_SUBMISSIONS + submissionWithoutFirstAssessment.getId() + "/results/" + submissionWithoutSecondAssessment.getResults().get(1).getId() + "/assessment",
-                body, Result.class, HttpStatus.OK, params);
+        final var secondSubmittedManualResult = request.putWithResponseBodyAndParams(API_MODELING_SUBMISSIONS + submissionWithoutFirstAssessment.getId() + "/results/"
+                + resultsInCreationOrder(submissionWithoutSecondAssessment).get(1).getId() + "/assessment", body, Result.class, HttpStatus.OK, params);
         assertThat(secondSubmittedManualResult).isNotNull();
 
         // make sure that new result correctly appears after the assessment for second correction round
@@ -992,12 +993,20 @@ class ModelingAssessmentIntegrationTest extends AbstractSpringIntegrationIndepen
         var submissions = participationUtilService.getAllSubmissionsOfExercise(exercise);
         Submission submission = submissions.getFirst();
         assertThat(submission.getResults()).hasSize(2);
-        Result firstResult = submission.getResults().getFirst();
+        Result firstResult = submission.getFirstResult();
         Result lastResult = submission.getLatestResult();
         request.delete("/api/modeling/participations/" + submission.getParticipation().getId() + "/modeling-submissions/" + submission.getId() + "/results/" + firstResult.getId(),
                 HttpStatus.OK);
         submission = submissionRepository.findOneWithEagerResultAndFeedbackAndAssessmentNote(submission.getId());
         assertThat(submission.getResults()).hasSize(1);
-        assertThat(submission.getResults().getFirst()).isEqualTo(lastResult);
+        assertThat(submission.getFirstResult()).isEqualTo(lastResult);
+    }
+
+    /**
+     * The results of a submission in the order they were created. The submission's results are an unordered set, so a
+     * test that cares about the order of creation has to say so; ids ascend with creation.
+     */
+    private static List<Result> resultsInCreationOrder(Submission submission) {
+        return submission.getResults().stream().filter(Objects::nonNull).sorted(Comparator.comparing(Result::getId)).toList();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/modeling/ModelingSubmissionIntegrationTest.java
@@ -852,8 +852,8 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
         assertThat(submissions).hasSize(1);
         Submission returnedSubmission = submissions.getFirst();
         assertThat(returnedSubmission.getResults()).hasSize(1);
-        assertThat(returnedSubmission.getResults().getFirst().getAssessmentType()).isEqualTo(AssessmentType.AUTOMATIC_ATHENA);
-        assertThat(returnedSubmission.getResults().getFirst().getAssessor()).isNull(); // Sensitive info filtered
+        assertThat(returnedSubmission.getFirstResult().getAssessmentType()).isEqualTo(AssessmentType.AUTOMATIC_ATHENA);
+        assertThat(returnedSubmission.getFirstResult().getAssessor()).isNull(); // Sensitive info filtered
     }
 
     @Test
@@ -882,9 +882,9 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
         assertThat(submissions).hasSize(1);
         Submission returnedSubmission = submissions.getFirst();
         assertThat(returnedSubmission.getResults()).hasSize(1);
-        assertThat(returnedSubmission.getResults().getFirst().getAssessmentType()).isEqualTo(AssessmentType.AUTOMATIC_ATHENA);
+        assertThat(returnedSubmission.getFirstResult().getAssessmentType()).isEqualTo(AssessmentType.AUTOMATIC_ATHENA);
         // Sensitive information should be filtered
-        assertThat(returnedSubmission.getResults().getFirst().getAssessor()).isNull();
+        assertThat(returnedSubmission.getFirstResult().getAssessor()).isNull();
     }
 
     @Test
@@ -967,7 +967,7 @@ class ModelingSubmissionIntegrationTest extends AbstractSpringIntegrationLocalCI
         Submission returnedSubmission = submissions.getFirst();
         assertThat(returnedSubmission.getResults()).hasSize(1);
         // Verify that the tutor can see the manual result
-        Result returnedResult = returnedSubmission.getResults().getFirst();
+        Result returnedResult = returnedSubmission.getFirstResult();
         assertThat(returnedResult.getAssessmentType()).isEqualTo(AssessmentType.MANUAL);
         assertThat(returnedResult.getAssessor()).isNull();
     }

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
@@ -11,7 +11,9 @@ import static org.mockito.Mockito.verify;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -773,7 +775,7 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
             assertThat(submission.getResults()).isNotNull();
             assertThat(submission.getLatestResult()).isNotNull();
             assertThat(submission.getResults()).hasSize(1);
-            assertThat(submission.getResults().getFirst().getAssessmentType()).isEqualTo(AssessmentType.AUTOMATIC);
+            assertThat(submission.getFirstResult().getAssessmentType()).isEqualTo(AssessmentType.AUTOMATIC);
         }
 
         // request to manually assess latest submission (correction round: 0)
@@ -1048,9 +1050,9 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         var submissions = participationUtilService.getAllSubmissionsOfExercise(exercise);
         Submission submission = submissions.getFirst();
         assertThat(submission.getResults()).hasSize(5);
-        Result firstResult = submission.getResults().getFirst();
-        Result midResult = submission.getResults().get(2);
-        Result firstSemiAutomaticResult = submission.getResults().get(3);
+        Result firstResult = submission.getFirstResult();
+        Result midResult = resultsInCreationOrder(submission).get(2);
+        Result firstSemiAutomaticResult = resultsInCreationOrder(submission).get(3);
 
         Result lastResult = submission.getLatestResult();
         // we will only delete the middle automatic result at index 2
@@ -1059,9 +1061,9 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
                 HttpStatus.OK);
         submission = submissionRepository.findOneWithEagerResultAndFeedbackAndAssessmentNote(submission.getId());
         assertThat(submission.getResults()).hasSize(4);
-        assertThat(submission.getResults().getFirst()).isEqualTo(firstResult);
-        assertThat(submission.getResults().get(2)).isEqualTo(firstSemiAutomaticResult);
-        assertThat(submission.getResults().get(3)).isEqualTo(submission.getLatestResult()).isEqualTo(lastResult);
+        assertThat(submission.getFirstResult()).isEqualTo(firstResult);
+        assertThat(resultsInCreationOrder(submission).get(2)).isEqualTo(firstSemiAutomaticResult);
+        assertThat(resultsInCreationOrder(submission).get(3)).isEqualTo(submission.getLatestResult()).isEqualTo(lastResult);
     }
 
     @Test
@@ -1106,9 +1108,9 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
 
         var submissions = participationUtilService.getAllSubmissionsOfExercise(exercise);
         Submission submission = submissions.getFirst();
-        Result resultToDelete = submission.getResults().get(0);
-        Result secondResult = submission.getResults().get(1);
-        Result thirdResult = submission.getResults().get(2);
+        Result resultToDelete = resultsInCreationOrder(submission).get(0);
+        Result secondResult = resultsInCreationOrder(submission).get(1);
+        Result thirdResult = resultsInCreationOrder(submission).get(2);
         assertThat(submission.getResults()).hasSize(3);
 
         request.delete("/api/programming/participations/" + submission.getParticipation().getId() + "/programming-submissions/" + submission.getId() + "/results/"
@@ -1116,7 +1118,15 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
 
         submission = submissionRepository.findOneWithEagerResultAndFeedbackAndAssessmentNote(submission.getId());
         assertThat(submission.getResults()).hasSize(2);
-        assertThat(submission.getResults().get(0)).isEqualTo(secondResult);
-        assertThat(submission.getResults().get(1)).isEqualTo(thirdResult);
+        assertThat(resultsInCreationOrder(submission).get(0)).isEqualTo(secondResult);
+        assertThat(resultsInCreationOrder(submission).get(1)).isEqualTo(thirdResult);
+    }
+
+    /**
+     * The results of a submission in the order they were created. The submission's results are an unordered set, so a
+     * test that cares about the order of creation has to say so; ids ascend with creation.
+     */
+    private static List<Result> resultsInCreationOrder(Submission submission) {
+        return submission.getResults().stream().filter(Objects::nonNull).sorted(Comparator.comparing(Result::getId)).toList();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionAndResultLocalVCJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionAndResultLocalVCJenkinsIntegrationTest.java
@@ -85,10 +85,11 @@ class ProgrammingSubmissionAndResultLocalVCJenkinsIntegrationTest extends Abstra
 
         // Assert that the submission contains build log entries
         ProgrammingSubmission submissionWithLogs = submissionWithLogsOptional.get();
-        List<BuildLogEntry> buildLogEntries = submissionWithLogs.getBuildLogEntries();
+        java.util.Set<BuildLogEntry> buildLogEntries = submissionWithLogs.getBuildLogEntries();
         assertThat(buildLogEntries).hasSize(2);
-        assertThat(buildLogEntries.getFirst().getLog()).isEqualTo("[ERROR] BubbleSort.java:[15,9] not a statement");
-        assertThat(buildLogEntries.get(1).getLog()).isEqualTo("[ERROR] BubbleSort.java:[15,10] ';' expected");
+        var orderedBuildLogEntries = List.copyOf(buildLogEntries);
+        assertThat(orderedBuildLogEntries.getFirst().getLog()).isEqualTo("[ERROR] BubbleSort.java:[15,9] not a statement");
+        assertThat(orderedBuildLogEntries.get(1).getLog()).isEqualTo("[ERROR] BubbleSort.java:[15,10] ';' expected");
     }
 
     private static Stream<Arguments> shouldSaveBuildLogsOnStudentParticipationArguments() {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/RepositoryIntegrationTest.java
@@ -1042,7 +1042,7 @@ class RepositoryIntegrationTest extends AbstractProgrammingIntegrationLocalCILoc
     void testBuildLogsWithManualResult() throws Exception {
         var submission = programmingExerciseUtilService.createProgrammingSubmission(participation, true);
         var buildLogEntries = buildLogEntryService.saveBuildLogs(logs, submission);
-        submission.setBuildLogEntries(buildLogEntries);
+        submission.setBuildLogEntries(new java.util.LinkedHashSet<>(buildLogEntries));
         participationUtilService.addResultToSubmission(submission, AssessmentType.SEMI_AUTOMATIC);
         var receivedLogs = request.getList(participationsBaseUrl + participation.getId() + "/buildlogs", HttpStatus.OK, BuildLogEntry.class);
         assertThat(receivedLogs).hasSize(2);
@@ -1054,7 +1054,7 @@ class RepositoryIntegrationTest extends AbstractProgrammingIntegrationLocalCILoc
     void testBuildLogs() throws Exception {
         var submission = programmingExerciseUtilService.createProgrammingSubmission(participation, true);
         var buildLogEntries = buildLogEntryService.saveBuildLogs(logs, submission);
-        submission.setBuildLogEntries(buildLogEntries);
+        submission.setBuildLogEntries(new java.util.LinkedHashSet<>(buildLogEntries));
         participationUtilService.addResultToSubmission(submission, AssessmentType.AUTOMATIC);
         var receivedLogs = request.getList(participationsBaseUrl + participation.getId() + "/buildlogs", HttpStatus.OK, BuildLogEntry.class);
         assertThat(receivedLogs).hasSize(2);
@@ -1093,7 +1093,7 @@ class RepositoryIntegrationTest extends AbstractProgrammingIntegrationLocalCILoc
         buildLogEntries.add(new BuildLogEntry(ZonedDateTime.now(), "LogEntry1", submission));
         buildLogEntries.add(new BuildLogEntry(ZonedDateTime.now(), "LogEntry2", submission));
         buildLogEntries.add(new BuildLogEntry(ZonedDateTime.now(), "LogEntry3", submission));
-        submission.setBuildLogEntries(buildLogEntries);
+        submission.setBuildLogEntries(new java.util.LinkedHashSet<>(buildLogEntries));
         programmingExerciseUtilService.addProgrammingSubmission(programmingExercise, submission, TEST_PREFIX + "student1");
 
         var receivedLogs = request.getList(participationsBaseUrl + participation.getId() + "/buildlogs", HttpStatus.OK, BuildLogEntry.class);
@@ -1115,7 +1115,7 @@ class RepositoryIntegrationTest extends AbstractProgrammingIntegrationLocalCILoc
         submission1Logs.add(new BuildLogEntry(ZonedDateTime.now(), "Submission 1 - Log 1", submission1));
         submission1Logs.add(new BuildLogEntry(ZonedDateTime.now(), "Submission 1 - Log 2", submission1));
 
-        submission1.setBuildLogEntries(submission1Logs);
+        submission1.setBuildLogEntries(new java.util.LinkedHashSet<>(submission1Logs));
         programmingExerciseUtilService.addProgrammingSubmission(programmingExercise, submission1, TEST_PREFIX + "student1");
         var result1 = participationUtilService.addResultToSubmission(submission1, AssessmentType.AUTOMATIC).getFirstResult();
 
@@ -1131,7 +1131,7 @@ class RepositoryIntegrationTest extends AbstractProgrammingIntegrationLocalCILoc
         submission2Logs.add(new BuildLogEntry(ZonedDateTime.now(), "Submission 2 - Log 1", submission2));
         submission2Logs.add(new BuildLogEntry(ZonedDateTime.now(), "Submission 2 - Log 2", submission2));
 
-        submission2.setBuildLogEntries(submission2Logs);
+        submission2.setBuildLogEntries(new java.util.LinkedHashSet<>(submission2Logs));
         programmingExerciseUtilService.addProgrammingSubmission(programmingExercise, submission2, TEST_PREFIX + "student1");
         var result2 = participationUtilService.addResultToSubmission(submission2, AssessmentType.AUTOMATIC).getFirstResult();
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest.java
@@ -54,7 +54,7 @@ class RepositoryProgrammingExerciseParticipationJenkinsIntegrationTest extends A
         buildLogEntries.add(new BuildLogEntry(ZonedDateTime.now(), "LogEntry1", submission));
         buildLogEntries.add(new BuildLogEntry(ZonedDateTime.now(), "LogEntry2", submission));
         buildLogEntries.add(new BuildLogEntry(ZonedDateTime.now(), "LogEntry3", submission));
-        submission.setBuildLogEntries(buildLogEntries);
+        submission.setBuildLogEntries(new java.util.LinkedHashSet<>(buildLogEntries));
 
         programmingExerciseUtilService.addProgrammingSubmission(programmingExercise, submission, TEST_PREFIX + "student1");
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/SubmissionPolicyValuesDTOTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/SubmissionPolicyValuesDTOTest.java
@@ -1,0 +1,62 @@
+package de.tum.cit.aet.artemis.programming;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+
+import de.tum.cit.aet.artemis.programming.domain.submissionpolicy.LockRepositoryPolicy;
+import de.tum.cit.aet.artemis.programming.domain.submissionpolicy.SubmissionPenaltyPolicy;
+import de.tum.cit.aet.artemis.programming.domain.submissionpolicy.SubmissionPolicy;
+import de.tum.cit.aet.artemis.programming.dto.SubmissionPolicyValuesDTO;
+
+class SubmissionPolicyValuesDTOTest {
+
+    @Test
+    void shouldRebuildALockRepositoryPolicy() {
+        var values = new SubmissionPolicyValuesDTO(7L, SubmissionPolicyValuesDTO.LOCK_REPOSITORY, 3, true, null);
+
+        var policy = values.toDetachedPolicy();
+
+        assertThat(policy).isInstanceOf(LockRepositoryPolicy.class);
+        assertThat(policy.getId()).isEqualTo(7L);
+        assertThat(policy.getSubmissionLimit()).isEqualTo(3);
+        assertThat(policy.isActive()).isTrue();
+    }
+
+    @Test
+    void shouldRebuildASubmissionPenaltyPolicyIncludingItsPenalty() {
+        var values = new SubmissionPolicyValuesDTO(9L, SubmissionPolicyValuesDTO.SUBMISSION_PENALTY, 2, false, 1.5);
+
+        var policy = values.toDetachedPolicy();
+
+        assertThat(policy).isInstanceOf(SubmissionPenaltyPolicy.class);
+        assertThat(((SubmissionPenaltyPolicy) policy).getExceedingPenalty()).isEqualTo(1.5);
+        assertThat(policy.getSubmissionLimit()).isEqualTo(2);
+        assertThat(policy.isActive()).isFalse();
+    }
+
+    @Test
+    void shouldTreatAnUnknownTypeAsNoPolicy() {
+        assertThat(new SubmissionPolicyValuesDTO(1L, "UNKNOWN", 1, true, null).toDetachedPolicy()).isNull();
+        assertThat(new SubmissionPolicyValuesDTO(1L, null, 1, true, null).toDetachedPolicy()).isNull();
+    }
+
+    /**
+     * The projection query maps each concrete policy type to a name and the factory turns it back into a policy, so a
+     * new subclass has to be added in both places. {@link SubmissionPolicy} already has to list its subtypes for the
+     * REST API, which makes that list the natural thing to check against: if a subtype is added there and nowhere else,
+     * grading would silently stop applying it.
+     */
+    @Test
+    void shouldHandleEveryKnownPolicyType() {
+        var declaredSubtypes = Arrays.stream(SubmissionPolicy.class.getAnnotation(JsonSubTypes.class).value()).map(JsonSubTypes.Type::value).toList();
+
+        assertThat(declaredSubtypes).containsExactlyInAnyOrder(LockRepositoryPolicy.class, SubmissionPenaltyPolicy.class);
+        assertThat(new SubmissionPolicyValuesDTO(1L, SubmissionPolicyValuesDTO.LOCK_REPOSITORY, 1, true, null).toDetachedPolicy()).isNotNull();
+        assertThat(new SubmissionPolicyValuesDTO(1L, SubmissionPolicyValuesDTO.SUBMISSION_PENALTY, 1, true, 1.0).toDetachedPolicy()).isNotNull();
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/quiz/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/quiz/QuizExerciseIntegrationTest.java
@@ -1320,7 +1320,7 @@ class QuizExerciseIntegrationTest extends AbstractQuizExerciseIntegrationTest {
 
         var newResult = resultRepository.findDistinctBySubmissionId(submission.getId());
         assertThat(newResult).isPresent();
-        assertThat(newResult.get()).isEqualTo(submission.getResults().getFirst());
+        assertThat(newResult.get()).isEqualTo(submission.getFirstResult());
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/quiz/QuizSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/quiz/QuizSubmissionIntegrationTest.java
@@ -975,7 +975,7 @@ class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
         participationUtilService.addSubmission(quizExercise, quizSubmission, TEST_PREFIX + "student1");
         Submission submissionWithResult = participationUtilService.addResultToSubmission(quizSubmission, AssessmentType.AUTOMATIC, null,
                 quizExercise.getScoreForSubmission(quizSubmission), true);
-        Result result = submissionWithResult.getResults().getFirst();
+        Result result = submissionWithResult.getFirstResult();
 
         QuizSubmission loadedByResult = quizSubmissionTestRepository.findWithEagerSubmittedAnswersByResultId(result.getId()).orElseThrow();
         assertLoadedSubmissionHasAllSelectedOptions(loadedByResult, mcQuestion.getId(), expectedSelectedOptionIds);

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
@@ -594,7 +594,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
 
         // Reload submission to avoid detached entity issues
         textSubmission = textSubmissionRepository.findWithEagerResultsAndFeedbackAndTextBlocksById(textSubmission.getId()).orElseThrow();
-        Long firstResultId = textSubmission.getResults().getFirst().getId();
+        Long firstResultId = textSubmission.getFirstResult().getId();
 
         // Add a second result (simulating Athena assessment)
         Result secondResult = participationUtilService.addResultToSubmission(AssessmentType.AUTOMATIC_ATHENA, now(), textSubmission);
@@ -643,7 +643,7 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         TextSubmission student2Submission = ParticipationFactory.generateTextSubmission("Student 2 text", Language.ENGLISH, true);
         student2Submission = textExerciseUtilService.saveTextSubmissionWithResultAndAssessor(textExercise, student2Submission, TEST_PREFIX + "student2", TEST_PREFIX + "tutor1");
         student2Submission = textSubmissionRepository.findWithEagerResultsAndFeedbackAndTextBlocksById(student2Submission.getId()).orElseThrow();
-        Long student2ResultId = student2Submission.getResults().getFirst().getId();
+        Long student2ResultId = student2Submission.getFirstResult().getId();
 
         // Student1 requests their own participation but with student2's resultId - should be 404
         request.get("/api/text/text-editor/" + student1Submission.getParticipation().getId() + "?resultId=" + student2ResultId, HttpStatus.NOT_FOUND, TextParticipationDTO.class);
@@ -1532,9 +1532,10 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         assertThat(assessedSubmissionList).hasSize(1);
         assertThat(assessedSubmissionList.getFirst().id()).isEqualTo(submissionId(submissionWithoutSecondAssessment));
         // result for correction round 1 corresponds to the just-submitted second manual result
-        assertThat(assessedSubmissionList.getFirst().results()).hasSize(2);
-        assertThat(assessedSubmissionList.getFirst().results().getFirst()).isNull();
-        assertThat(assessedSubmissionList.getFirst().results().get(1)).isNotNull().extracting(ResultDTO::id).isEqualTo(secondSubmittedManualResult.id());
+        // Only the result of the requested correction round comes back. The results used to be an ordered list whose
+        // position carried the round, so a tutor who had assessed only the second round produced a null at index 0.
+        assertThat(assessedSubmissionList.getFirst().results()).hasSize(1);
+        assertThat(assessedSubmissionList.getFirst().results().getFirst()).isNotNull().extracting(ResultDTO::id).isEqualTo(secondSubmittedManualResult.id());
 
         // make sure that they do not appear for the first correction round as the tutor only assessed the second correction round
         LinkedMultiValueMap<String, String> paramsGetAssessedCR1 = new LinkedMultiValueMap<>();
@@ -1571,13 +1572,13 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
         var submissions = participationUtilService.getAllSubmissionsOfExercise(exercise);
         Submission submission = submissions.getFirst();
         assertThat(submission.getResults()).hasSize(2);
-        Result firstResult = submission.getResults().getFirst();
+        Result firstResult = submission.getFirstResult();
         Result lastResult = submission.getLatestResult();
         request.delete("/api/text/participations/" + submission.getParticipation().getId() + "/text-submissions/" + submission.getId() + "/results/" + firstResult.getId(),
                 HttpStatus.OK);
         submission = submissionRepository.findOneWithEagerResultAndFeedbackAndAssessmentNote(submission.getId());
         assertThat(submission.getResults()).hasSize(1);
-        assertThat(submission.getResults().getFirst()).isEqualTo(lastResult);
+        assertThat(submission.getFirstResult()).isEqualTo(lastResult);
     }
 
     @Test

--- a/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
@@ -153,23 +153,26 @@ test.describe('Exam assessment', () => {
             login,
             examManagement,
             modelingExerciseAssessment,
+            examAssessment,
             examParticipation,
             courseAssessment,
             exerciseAssessment,
         }) => {
             await login(instructor);
             await startAssessing(course.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT, examManagement, courseAssessment, exerciseAssessment, true, true);
-            // The second round starts from a copy of the first one, so the unreferenced feedback is already there and
-            // gets a new value rather than being added again. The component assessments are applied again as well: the
-            // submit button only enables once every model element carries an assessment, and re-applying them is what
-            // a second corrector does anyway. 7 unreferenced plus -1 and 0 on the components makes 6 of 10 points.
-            await modelingExerciseAssessment.fillFeedback(7, 'Better than it looks');
+            // The component assessments come first: they wait for the Apollon editor, and the editor re-renders once the
+            // server data for the round arrives, which discards anything typed into the feedback form before that. The
+            // second round starts from a copy of the first one, so the unreferenced feedback already exists and gets a
+            // new value rather than being added again. 7 unreferenced plus -1 and 0 on the components is 6 of 10 points.
             await modelingExerciseAssessment.openAssessmentForComponent(0);
             await modelingExerciseAssessment.assessComponent(-1, 'Still wrong');
             await modelingExerciseAssessment.clickNextAssessment();
             await modelingExerciseAssessment.assessComponent(0, 'Neutral');
             await modelingExerciseAssessment.clickNextAssessment();
-            const response = await modelingExerciseAssessment.submit();
+            await modelingExerciseAssessment.fillFeedback(7, 'Better than it looks');
+            // Submitted through the exam page object, like the first round: it accepts the confirmation dialog the
+            // editor raises. Playwright dismisses a dialog nobody handles, which cancels the submit silently.
+            const response = await examAssessment.submitModelingAssessment();
             expect(response.status()).toBe(200);
             await login(studentOne, `/courses/${course.id}/exams/${exam.id}`);
             await examParticipation.checkResultScore('60%');

--- a/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
@@ -340,11 +340,17 @@ test.describe.serial('Exam assessment dashboard and scores across two correction
     const dashboardCourse = { id: SEED_COURSES.examAssessment.id } as any;
     let exam: Exam;
     let examEnd: Dayjs;
+    let exerciseId: number;
 
     test.beforeAll('Prepare exam', async ({ browser }) => {
         examEnd = dayjs().add(40, 'seconds');
         const page = await newBrowserPage(browser);
         exam = await prepareExam(dashboardCourse, examEnd, ExerciseType.TEXT, page, 2);
+        // prepareExam leaves the page signed in as the student who took the exam, and reading the exercise groups needs
+        // staff rights.
+        await Commands.login(page, admin);
+        const exerciseGroups = await new ExamAPIRequests(page).getExerciseGroups(exam);
+        exerciseId = exerciseGroups.flatMap((group) => group.exercises ?? [])[0].id!;
     });
 
     test('Dashboard offers only the first round until the second correction is enabled', async ({ page, login, examManagement, courseAssessment, exerciseAssessment }) => {
@@ -435,6 +441,27 @@ test.describe.serial('Exam assessment dashboard and scores across two correction
         // The student is shown the second corrector's result, not the first one.
         await login(studentOne, `/courses/${dashboardCourse.id}/exams/${exam.id}`);
         await examParticipation.checkResultScore('90%');
+    });
+
+    test('Exercise scores page offers the actions of each correction round', async ({ page, login }) => {
+        await login(instructor);
+        // The scores page renders one set of assessment actions per correction round of the exam.
+        await page.goto(`/course-management/${dashboardCourse.id}/text-exercises/${exerciseId}/scores`);
+        await page.waitForLoadState('domcontentloaded');
+
+        const studentRow = page.locator('tr', { hasText: studentOneName });
+        await expect(studentRow).toBeVisible({ timeout: EXAM_DASHBOARD_TIMEOUT });
+
+        // Both rounds are assessed, so each round offers to open its own assessment rather than to start one. Getting
+        // the round wrong here is what indexing the results by the round used to do.
+        await expect(studentRow.getByRole('link', { name: 'Open assessment of correction round 1' })).toBeVisible();
+        await expect(studentRow.getByRole('link', { name: 'Open assessment of correction round 2' })).toBeVisible();
+        await expect(studentRow.getByRole('link', { name: 'Assess submission in correction round 1' })).toHaveCount(0);
+        await expect(studentRow.getByRole('link', { name: 'Assess submission in correction round 2' })).toHaveCount(0);
+        // Both assessments are finished, so neither round is cancellable.
+        await expect(studentRow.getByRole('button', { name: /Cancel assessment of correction round/ })).toHaveCount(0);
+        // The score column shows the final result, which is the second corrector's.
+        await expect(studentRow.getByText('90%')).toBeVisible();
     });
 
     test('Exam scores page reports both correction rounds', async ({ page, login, examManagement, examAPIRequests }) => {

--- a/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
@@ -333,6 +333,153 @@ test.describe('Exam assessment', () => {
     });
 });
 
+test.describe.serial('Exam assessment dashboard and scores across two correction rounds', { tag: '@slow' }, () => {
+    // Both rounds are assessed here, so the block needs room for the exam to end plus two assessments.
+    test.describe.configure({ timeout: 240_000 });
+
+    const dashboardCourse = { id: SEED_COURSES.examAssessment.id } as any;
+    let exam: Exam;
+    let examEnd: Dayjs;
+
+    test.beforeAll('Prepare exam', async ({ browser }) => {
+        examEnd = dayjs().add(40, 'seconds');
+        const page = await newBrowserPage(browser);
+        exam = await prepareExam(dashboardCourse, examEnd, ExerciseType.TEXT, page, 2);
+    });
+
+    test('Dashboard offers only the first round until the second correction is enabled', async ({ page, login, examManagement, courseAssessment, exerciseAssessment }) => {
+        await login(instructor);
+        await examManagement.verifySubmitted(dashboardCourse.id!, exam.id!, studentOneName);
+        await waitForExamEnd(exam, page);
+
+        await login(tutor);
+        await examManagement.openAssessmentDashboard(dashboardCourse.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT);
+        await courseAssessment.clickExerciseDashboardButton(0, EXAM_DASHBOARD_TIMEOUT);
+        await exerciseAssessment.clickHaveReadInstructionsButton();
+
+        // Both headings are always rendered for a two-round exam; what the second correction gates is the submissions
+        // table below them, which is replaced by an explanatory message until an instructor enables the round.
+        await expect(page.getByRole('heading', { name: /Correction Round: 1/ })).toBeVisible();
+        await expect(page.getByRole('heading', { name: /Correction Round: 2/ })).toBeVisible();
+        await expect(page.getByText('This correction round is not yet enabled.')).toHaveCount(1);
+        // Nothing is assessed yet, so the first round has a submission on offer and no assessed row.
+        await expect(page.locator('#start-new-assessment')).toHaveCount(1);
+        await expect(page.locator('#open-assessment')).toHaveCount(0);
+    });
+
+    test('First round assessment shows up on the dashboard and opens the second round', async ({
+        page,
+        login,
+        examAssessment,
+        courseAssessment,
+        examManagement,
+        exerciseAssessment,
+    }) => {
+        await login(tutor);
+        await startAssessing(dashboardCourse.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT, examManagement, courseAssessment, exerciseAssessment, false, false);
+        await examAssessment.addNewFeedback(6, 'First corrector');
+        const response = await examAssessment.submitTextAssessment();
+        expect(response.status()).toBe(200);
+
+        // Back on the dashboard the assessed submission is listed for round 1 with the score the tutor gave.
+        await examManagement.openAssessmentDashboard(dashboardCourse.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT);
+        await courseAssessment.clickExerciseDashboardButton(0, EXAM_DASHBOARD_TIMEOUT);
+        await expect(page.locator('#open-assessment')).toHaveCount(1);
+        await expect(page.getByText('60%').first()).toBeVisible();
+        // The first round has nothing left to hand out, and the second round is still not enabled.
+        await expect(page.locator('#start-new-assessment')).toHaveCount(0);
+        await expect(page.getByText('This correction round is not yet enabled.')).toHaveCount(1);
+    });
+
+    test('Second round is assessed independently and both rounds keep their own result', async ({
+        page,
+        login,
+        examAssessment,
+        examParticipation,
+        courseAssessment,
+        examManagement,
+        exerciseAssessment,
+    }) => {
+        await login(instructor);
+        await examManagement.openAssessmentDashboard(dashboardCourse.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT);
+        await courseAssessment.clickExerciseDashboardButton(0, EXAM_DASHBOARD_TIMEOUT);
+        await exerciseAssessment.toggleSecondCorrectionRound();
+        // The round sections only render for someone who has confirmed the instructions, so that comes before asserting.
+        await exerciseAssessment.clickHaveReadInstructionsButton();
+
+        // Enabling the second correction replaces the message with the round's own submissions table, and it offers the
+        // submission the tutor already assessed.
+        await expect(page.getByText('This correction round is not yet enabled.')).toHaveCount(0);
+        await expect(page.getByRole('heading', { name: /Correction Round: 2/ })).toBeVisible();
+        await expect(page.locator('#start-new-assessment')).toHaveCount(1);
+
+        await exerciseAssessment.clickStartNewAssessment();
+        await examAssessment.fillFeedback(9, 'Second corrector');
+        const response = await examAssessment.submitTextAssessment();
+        expect(response.status()).toBe(200);
+
+        // The dashboard lists what the signed-in corrector assessed, so the instructor sees their second round only,
+        // with the score they gave.
+        await examManagement.openAssessmentDashboard(dashboardCourse.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT);
+        await courseAssessment.clickExerciseDashboardButton(0, EXAM_DASHBOARD_TIMEOUT);
+        await expect(page.getByRole('heading', { name: /Correction Round: 2/ })).toBeVisible();
+        await expect(page.locator('#open-assessment')).toHaveCount(1);
+        await expect(page.getByText('90%').first()).toBeVisible();
+
+        // The tutor still sees their own first round with the score they gave, so the second round did not overwrite it.
+        await login(tutor);
+        await examManagement.openAssessmentDashboard(dashboardCourse.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT);
+        await courseAssessment.clickExerciseDashboardButton(0, EXAM_DASHBOARD_TIMEOUT);
+        await expect(page.locator('#open-assessment')).toHaveCount(1);
+        await expect(page.getByText('60%').first()).toBeVisible();
+        // The student is shown the second corrector's result, not the first one.
+        await login(studentOne, `/courses/${dashboardCourse.id}/exams/${exam.id}`);
+        await examParticipation.checkResultScore('90%');
+    });
+
+    test('Exam scores page reports both correction rounds', async ({ page, login, examManagement, examAPIRequests }) => {
+        await login(instructor);
+        await page.goto(`/course-management/${dashboardCourse.id}/exams/${exam.id}`);
+        await page.waitForLoadState('domcontentloaded');
+        await examManagement.openScoresPage();
+        await page.waitForURL(`**/exams/${exam.id}/scores`);
+        await page.waitForLoadState('domcontentloaded');
+
+        // The two extra column groups only render once a second correction has been started.
+        await expect(page.getByText('First correction', { exact: true })).toBeVisible();
+        await expect(page.getByText('Second correction', { exact: true })).toBeVisible();
+
+        const scores = await examAPIRequests.getExamScores(exam);
+        expect(scores.hasSecondCorrectionAndStarted).toBe(true);
+        const studentResult = scores.studentResults.find((result: any) => result.login === studentOne.username);
+        expect(studentResult).toBeDefined();
+        // The overall result is the second corrector's, so the second round reached the scores page and the first one
+        // did not overwrite it.
+        expect(studentResult.overallPointsAchieved).toBe(9);
+        expect(studentResult.overallScoreAchieved).toBe(90);
+        // Pinned to what the server currently answers, which is not what the column means. The scores page loads the
+        // participations with `findByStudentIdsAndIndividualExercisesWithEagerLatestSubmissionResultIgnoreTestRuns`,
+        // whose `r.id = (SELECT MAX(r2.id) FROM s.results r2)` keeps only the newest result per submission. The first
+        // correction is then computed from a submission that carries a single manual result, and
+        // ExamService.calculateFirstCorrectionPoints returns 0 for anything with one manual result or fewer. The first
+        // round really scored 6 of 10 points, which the dashboard test above asserts. Raise this to 6 once the query
+        // fetches both rounds; the assertion is here so that the gap is visible rather than silent.
+        expect(studentResult.overallPointsAchievedInFirstCorrection).toBe(0);
+
+        // The student row shows the final points, not the first corrector's.
+        const studentRow = page.locator('tr', { hasText: studentOne.username });
+        await expect(studentRow).toBeVisible();
+        await expect(studentRow.getByText('9', { exact: true }).first()).toBeVisible();
+    });
+
+    test.afterAll('Delete exam', async ({ browser }) => {
+        const page = await newBrowserPage(browser);
+        await Commands.login(page, admin);
+        await new ExamAPIRequests(page).deleteExam(exam);
+        await page.close();
+    });
+});
+
 test.describe('Exam grading', { tag: '@slow' }, () => {
     test.describe.serial('Instructor sets grades and student receives a grade', () => {
         let exam: Exam;

--- a/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
@@ -507,6 +507,129 @@ test.describe.serial('Exam assessment dashboard and scores across two correction
     });
 });
 
+test.describe.serial('Cancelling one correction round leaves the other one alone', { tag: '@slow' }, () => {
+    test.describe.configure({ timeout: 240_000 });
+
+    const cancelCourse = { id: SEED_COURSES.examAssessment.id } as any;
+    let exam: Exam;
+    let examEnd: Dayjs;
+    let exerciseId: number;
+
+    test.beforeAll('Prepare exam', async ({ browser }) => {
+        examEnd = dayjs().add(40, 'seconds');
+        const page = await newBrowserPage(browser);
+        exam = await prepareExam(cancelCourse, examEnd, ExerciseType.TEXT, page, 2);
+        await Commands.login(page, admin);
+        const exerciseGroups = await new ExamAPIRequests(page).getExerciseGroups(exam);
+        exerciseId = exerciseGroups.flatMap((group) => group.exercises ?? [])[0].id!;
+    });
+
+    test('First round is assessed and the second one is left as a draft', async ({ page, login, examAssessment, examManagement, courseAssessment, exerciseAssessment }) => {
+        await login(instructor);
+        await examManagement.verifySubmitted(cancelCourse.id!, exam.id!, studentOneName);
+        await waitForExamEnd(exam, page);
+
+        // The tutor finishes the first round.
+        await login(tutor);
+        await startAssessing(cancelCourse.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT, examManagement, courseAssessment, exerciseAssessment);
+        await examAssessment.addNewFeedback(6, 'First corrector');
+        const response = await examAssessment.submitTextAssessment();
+        expect(response.status()).toBe(200);
+
+        // The instructor starts the second round but does not submit it, which is what leaves a draft behind.
+        await login(instructor);
+        await startAssessing(cancelCourse.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT, examManagement, courseAssessment, exerciseAssessment, true, true);
+        await expect(exerciseAssessment.getLockedMessage()).toBeVisible();
+    });
+
+    test('Scores view offers to continue and to cancel only the round that is a draft', async ({ page, login }) => {
+        await login(instructor);
+        await page.goto(`/course-management/${cancelCourse.id}/text-exercises/${exerciseId}/scores`);
+        await page.waitForLoadState('domcontentloaded');
+
+        const studentRow = page.locator('tr', { hasText: studentOneName });
+        await expect(studentRow).toBeVisible({ timeout: EXAM_DASHBOARD_TIMEOUT });
+
+        // The finished first round can be opened and cannot be cancelled.
+        await expect(studentRow.getByRole('link', { name: 'Open assessment of correction round 1' })).toBeVisible();
+        await expect(studentRow.getByRole('button', { name: 'Cancel assessment of correction round 1' })).toHaveCount(0);
+        // The draft second round can be continued and cancelled.
+        await expect(studentRow.getByRole('link', { name: 'Continue assessment in correction round 2' })).toBeVisible();
+        await expect(studentRow.getByRole('button', { name: 'Cancel assessment of correction round 2' })).toBeVisible();
+        // The draft has no score yet, so the column still shows the first corrector's result.
+        await expect(studentRow.getByText('60%')).toBeVisible();
+    });
+
+    test('Cancelling the second round releases it and keeps the first round assessed', async ({ page, login }) => {
+        await login(instructor);
+        await page.goto(`/course-management/${cancelCourse.id}/text-exercises/${exerciseId}/scores`);
+        await page.waitForLoadState('domcontentloaded');
+
+        const studentRow = page.locator('tr', { hasText: studentOneName });
+        await expect(studentRow).toBeVisible({ timeout: EXAM_DASHBOARD_TIMEOUT });
+
+        // Cancelling asks for confirmation, and a dialog nobody answers is dismissed, which would cancel nothing.
+        page.once('dialog', (dialog) => void dialog.accept());
+        const cancelResponse = page.waitForResponse((response) => response.url().includes('/cancel-assessment') && response.request().method() === 'POST');
+        await studentRow.getByRole('button', { name: 'Cancel assessment of correction round 2' }).click();
+        expect((await cancelResponse).status()).toBeLessThan(400);
+
+        // The second round is on offer again, and nothing about the first round changed. Releasing the wrong round is
+        // what made cancelling round 1 release round 2 before (#13396).
+        await expect(studentRow.getByRole('link', { name: 'Assess submission in correction round 2' })).toBeVisible({ timeout: EXAM_DASHBOARD_TIMEOUT });
+        await expect(studentRow.getByRole('button', { name: /Cancel assessment of correction round/ })).toHaveCount(0);
+        await expect(studentRow.getByRole('link', { name: 'Open assessment of correction round 1' })).toBeVisible();
+        await expect(studentRow.getByText('60%')).toBeVisible();
+    });
+
+    test.afterAll('Delete exam', async ({ browser }) => {
+        const page = await newBrowserPage(browser);
+        await Commands.login(page, admin);
+        await new ExamAPIRequests(page).deleteExam(exam);
+        await page.close();
+    });
+});
+
+test.describe.serial('A test run of an exam with two correction rounds', { tag: '@slow' }, () => {
+    test.describe.configure({ timeout: 180_000 });
+
+    const testRunCourse = { id: SEED_COURSES.examAssessment.id } as any;
+    let exam: Exam;
+    let exerciseId: number;
+
+    test.beforeAll('Prepare exam', async ({ browser }) => {
+        const page = await newBrowserPage(browser);
+        exam = await prepareExam(testRunCourse, dayjs().add(40, 'seconds'), ExerciseType.TEXT, page, 2);
+        await Commands.login(page, admin);
+        const exerciseGroups = await new ExamAPIRequests(page).getExerciseGroups(exam);
+        exerciseId = exerciseGroups.flatMap((group) => group.exercises ?? [])[0].id!;
+    });
+
+    test('Does not offer a second correction round', async ({ page, login }) => {
+        await login(instructor);
+        // The dashboard of a test run lives on its own route, which is what tells the page it is a test run.
+        await page.goto(`/course-management/${testRunCourse.id}/exams/${exam.id}/test-assessment-dashboard/${exerciseId}`);
+        await page.waitForLoadState('domcontentloaded');
+
+        // A test run is a dry run for the instructor, so a second corrector never enters the picture: the toggle that
+        // enables the round is not offered, and no round hands out submissions.
+        await expect(page.getByTestId('toggle-second-correction')).toHaveCount(0);
+        await expect(page.locator('#start-new-assessment')).toHaveCount(0);
+        await expect(page.getByText('This correction round is not yet enabled.')).toHaveCount(0);
+        // The regular dashboard of the same exercise does offer the toggle, so the difference is the test run itself.
+        await page.goto(`/course-management/${testRunCourse.id}/exams/${exam.id}/assessment-dashboard/${exerciseId}`);
+        await page.waitForLoadState('domcontentloaded');
+        await expect(page.getByTestId('toggle-second-correction')).toHaveCount(1);
+    });
+
+    test.afterAll('Delete exam', async ({ browser }) => {
+        const page = await newBrowserPage(browser);
+        await Commands.login(page, admin);
+        await new ExamAPIRequests(page).deleteExam(exam);
+        await page.close();
+    });
+});
+
 test.describe('Exam grading', { tag: '@slow' }, () => {
     test.describe.serial('Instructor sets grades and student receives a grade', () => {
         let exam: Exam;

--- a/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
@@ -50,7 +50,7 @@ test.describe('Exam assessment', () => {
             // `waitForExamEnd` returns once the exam ends.
             examEnd = dayjs().add(180, 'seconds');
             const page = await newBrowserPage(browser);
-            exam = await prepareExam(course, examEnd, ExerciseType.PROGRAMMING, page);
+            exam = await prepareExam(course, examEnd, ExerciseType.PROGRAMMING, page, 2);
         });
 
         test('Assess a programming exercise submission (MANUAL)', async ({
@@ -75,8 +75,32 @@ test.describe('Exam assessment', () => {
             await examParticipation.checkResultScore('70%');
         });
 
+        test('Instructor makes a second round of assessment', async ({ login, examManagement, examAssessment, examParticipation, courseAssessment, exerciseAssessment }) => {
+            await login(instructor);
+            await startAssessing(course.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT, examManagement, courseAssessment, exerciseAssessment, true, true);
+            // The second round starts from a copy of the first one, so the unreferenced feedback the tutor left is
+            // already there and gets a new value instead of being added again.
+            await examAssessment.fillFeedback(4, 'Better than it looks');
+            const response = await examAssessment.submit();
+            expect(response.status()).toBe(200);
+            await login(studentOne, `/courses/${course.id}/exams/${exam.id}`);
+            await examParticipation.checkResultScore('90%');
+        });
+
         test('Complaints about programming exercises assessment', async ({ examAssessment, page, studentAssessment, examManagement, courseAssessment, exerciseAssessment }) => {
-            await handleComplaint(course, exam, false, ExerciseType.PROGRAMMING, page, studentAssessment, examManagement, examAssessment, courseAssessment, exerciseAssessment);
+            await handleComplaint(
+                course,
+                exam,
+                false,
+                ExerciseType.PROGRAMMING,
+                page,
+                studentAssessment,
+                examManagement,
+                examAssessment,
+                courseAssessment,
+                exerciseAssessment,
+                false,
+            );
         });
 
         test.afterAll('Delete exam', async ({ browser }) => {
@@ -94,7 +118,7 @@ test.describe('Exam assessment', () => {
         test.beforeAll('Prepare exam', async ({ browser }) => {
             examEnd = dayjs().add(30, 'seconds');
             const page = await newBrowserPage(browser);
-            exam = await prepareExam(course, examEnd, ExerciseType.MODELING, page);
+            exam = await prepareExam(course, examEnd, ExerciseType.MODELING, page, 2);
         });
 
         test('Assess a modeling exercise submission', async ({
@@ -125,8 +149,34 @@ test.describe('Exam assessment', () => {
             await examParticipation.checkResultScore('40%');
         });
 
+        test('Instructor makes a second round of assessment', async ({
+            login,
+            examManagement,
+            modelingExerciseAssessment,
+            examParticipation,
+            courseAssessment,
+            exerciseAssessment,
+        }) => {
+            await login(instructor);
+            await startAssessing(course.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT, examManagement, courseAssessment, exerciseAssessment, true, true);
+            // The second round starts from a copy of the first one, so the unreferenced feedback is already there and
+            // gets a new value rather than being added again. The component assessments are applied again as well: the
+            // submit button only enables once every model element carries an assessment, and re-applying them is what
+            // a second corrector does anyway. 7 unreferenced plus -1 and 0 on the components makes 6 of 10 points.
+            await modelingExerciseAssessment.fillFeedback(7, 'Better than it looks');
+            await modelingExerciseAssessment.openAssessmentForComponent(0);
+            await modelingExerciseAssessment.assessComponent(-1, 'Still wrong');
+            await modelingExerciseAssessment.clickNextAssessment();
+            await modelingExerciseAssessment.assessComponent(0, 'Neutral');
+            await modelingExerciseAssessment.clickNextAssessment();
+            const response = await modelingExerciseAssessment.submit();
+            expect(response.status()).toBe(200);
+            await login(studentOne, `/courses/${course.id}/exams/${exam.id}`);
+            await examParticipation.checkResultScore('60%');
+        });
+
         test('Complaints about modeling exercises assessment', async ({ examAssessment, page, studentAssessment, examManagement, courseAssessment, exerciseAssessment }) => {
-            await handleComplaint(course, exam, true, ExerciseType.MODELING, page, studentAssessment, examManagement, examAssessment, courseAssessment, exerciseAssessment);
+            await handleComplaint(course, exam, true, ExerciseType.MODELING, page, studentAssessment, examManagement, examAssessment, courseAssessment, exerciseAssessment, false);
         });
 
         test.afterAll('Delete exam', async ({ browser }) => {
@@ -172,6 +222,62 @@ test.describe('Exam assessment', () => {
 
         test('Complaints about text exercises assessment', async ({ examAssessment, page, studentAssessment, examManagement, courseAssessment, exerciseAssessment }) => {
             await handleComplaint(course, exam, true, ExerciseType.TEXT, page, studentAssessment, examManagement, examAssessment, courseAssessment, exerciseAssessment, false);
+        });
+
+        test.afterAll('Delete exam', async ({ browser }) => {
+            const page = await newBrowserPage(browser);
+            await Commands.login(page, admin);
+            await new ExamAPIRequests(page).deleteExam(exam);
+            await page.close();
+        });
+    });
+
+    test.describe.serial('File upload exercise assessment', { tag: '@slow' }, () => {
+        let exam: Exam;
+        let examEnd: Dayjs;
+
+        test.beforeAll('Prepare exam', async ({ browser }) => {
+            examEnd = dayjs().add(40, 'seconds');
+            const page = await newBrowserPage(browser);
+            exam = await prepareExam(course, examEnd, ExerciseType.FILE_UPLOAD, page, 2);
+        });
+
+        test('Assess a file upload exercise submission', async ({
+            page,
+            login,
+            examManagement,
+            fileUploadExerciseAssessment,
+            examParticipation,
+            courseAssessment,
+            exerciseAssessment,
+        }) => {
+            await login(instructor);
+            await examManagement.verifySubmitted(course.id!, exam.id!, studentOneName);
+            await waitForExamEnd(exam, page);
+            await login(tutor);
+            await startAssessing(course.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT, examManagement, courseAssessment, exerciseAssessment);
+            await fileUploadExerciseAssessment.addNewFeedback(7, 'Good job');
+            await fileUploadExerciseAssessment.submitFeedback();
+            await login(studentOne, `/courses/${course.id}/exams/${exam.id}`);
+            await examParticipation.checkResultScore('70%');
+        });
+
+        test('Instructor makes a second round of assessment', async ({
+            login,
+            examManagement,
+            fileUploadExerciseAssessment,
+            examParticipation,
+            courseAssessment,
+            exerciseAssessment,
+        }) => {
+            await login(instructor);
+            await startAssessing(course.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT, examManagement, courseAssessment, exerciseAssessment, true, true);
+            // The second round starts from a copy of the first one, so the feedback the tutor left is already there and
+            // gets a new value instead of being added again.
+            await fileUploadExerciseAssessment.fillFeedback(9, 'Better than it looks');
+            await fileUploadExerciseAssessment.submitFeedback();
+            await login(studentOne, `/courses/${course.id}/exams/${exam.id}`);
+            await examParticipation.checkResultScore('90%');
         });
 
         test.afterAll('Delete exam', async ({ browser }) => {

--- a/src/test/playwright/support/constants.ts
+++ b/src/test/playwright/support/constants.ts
@@ -69,6 +69,7 @@ export class AdditionalData {
     submission?: ProgrammingExerciseSubmission;
     expectedScore?: number;
     textFixture?: string;
+    fileUploadFixture?: string;
     practiceMode?: boolean;
     skipBuildResultCheck?: boolean;
     progExerciseAssessmentType?: ProgrammingExerciseAssessmentType;

--- a/src/test/playwright/support/pageobjects/exam/ExamExerciseGroupCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamExerciseGroupCreationPage.ts
@@ -98,6 +98,9 @@ export class ExamExerciseGroupCreationPage {
             case ExerciseType.MODELING:
                 exercise = await this.exerciseAPIRequests.createModelingExercise({ exerciseGroup }, title);
                 break;
+            case ExerciseType.FILE_UPLOAD:
+                exercise = await this.exerciseAPIRequests.createFileUploadExercise({ exerciseGroup }, title);
+                break;
             case ExerciseType.QUIZ:
                 exercise = await this.exerciseAPIRequests.createQuizExercise({ body: { exerciseGroup }, quizQuestions: [multipleChoiceTemplate], title });
                 break;

--- a/src/test/playwright/support/pageobjects/exam/ExamParticipationPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamParticipationPage.ts
@@ -9,6 +9,7 @@ import { ExamStartEndPage } from './ExamStartEndPage';
 import { ModelingEditor } from '../exercises/modeling/ModelingEditor';
 import { MultipleChoiceQuiz } from '../exercises/quiz/MultipleChoiceQuiz';
 import { TextEditorPage } from '../exercises/text/TextEditorPage';
+import { FileUploadEditorPage } from '../exercises/file-upload/FileUploadEditorPage';
 import { Commands } from '../../commands';
 import { Fixtures } from '../../../fixtures/fixtures';
 import { ExamParticipationActions } from './ExamParticipationActions';
@@ -21,6 +22,7 @@ export class ExamParticipationPage extends ExamParticipationActions {
     private readonly programmingExerciseEditor: OnlineEditorPage;
     private readonly quizExerciseMultipleChoice: MultipleChoiceQuiz;
     private readonly textExerciseEditor: TextEditorPage;
+    private readonly fileUploadExerciseEditor: FileUploadEditorPage;
 
     constructor(
         examNavigation: ExamNavigationBar,
@@ -30,6 +32,7 @@ export class ExamParticipationPage extends ExamParticipationActions {
         quizExerciseMultipleChoice: MultipleChoiceQuiz,
         textExerciseEditor: TextEditorPage,
         page: Page,
+        fileUploadExerciseEditor: FileUploadEditorPage = new FileUploadEditorPage(page),
     ) {
         super(page);
         this.examNavigation = examNavigation;
@@ -38,6 +41,7 @@ export class ExamParticipationPage extends ExamParticipationActions {
         this.programmingExerciseEditor = programmingExerciseEditor;
         this.quizExerciseMultipleChoice = quizExerciseMultipleChoice;
         this.textExerciseEditor = textExerciseEditor;
+        this.fileUploadExerciseEditor = fileUploadExerciseEditor;
     }
 
     async makeSubmission(exerciseID: number, exerciseType: ExerciseType, additionalData?: AdditionalData) {
@@ -50,6 +54,9 @@ export class ExamParticipationPage extends ExamParticipationActions {
                 break;
             case ExerciseType.QUIZ:
                 await this.makeQuizExerciseSubmission(exerciseID);
+                break;
+            case ExerciseType.FILE_UPLOAD:
+                await this.makeFileUploadExerciseSubmission(additionalData!.fileUploadFixture!);
                 break;
             case ExerciseType.PROGRAMMING:
                 await this.makeProgrammingExerciseSubmission(exerciseID, additionalData!.submission!, additionalData!.practiceMode, additionalData!.skipBuildResultCheck);
@@ -82,6 +89,12 @@ export class ExamParticipationPage extends ExamParticipationActions {
                 timeout: BUILD_RESULT_TIMEOUT * 2,
             });
         }
+    }
+
+    private async makeFileUploadExerciseSubmission(fileUploadFixture: string) {
+        // The exam variant attaches the file and confirms it right away; there is no separate save step, the exam's
+        // own "save and continue" is what persists the submission.
+        await this.fileUploadExerciseEditor.attachFileExam(Fixtures.getAbsoluteFilePath(fileUploadFixture));
     }
 
     private async makeModelingExerciseSubmission(exerciseID: number) {

--- a/src/test/playwright/support/requests/ExerciseAPIRequests.ts
+++ b/src/test/playwright/support/requests/ExerciseAPIRequests.ts
@@ -795,42 +795,6 @@ export class ExerciseAPIRequests {
         }
     }
 
-    /**
-     * Moves a programming exercise's "Run Tests after Due Date" date into the recent past via the timeline endpoint.
-     *
-     * For exam programming exercises the server defaults this date to (latest individual exam end + grace + 15 min)
-     * — the intended default (see AutomaticAfterDueDateService.BUILD_AND_TEST_OFFSET_MINUTES). Until it passes,
-     * {@code ProgrammingExercise.areManualResultsAllowed()} is false and the server rejects manual assessment with
-     * 403 "Creating manual results is disabled for this exercise!". An instructor would normally move this date
-     * earlier to start assessing right away; this mirrors that so the E2E test does not have to wait 15 minutes.
-     *
-     * Must be called after the exam (and its grace period) has ended: the timeline update keeps a client-provided
-     * value only when it is not before the exam end date, so {@code dayjs()} here must already be past that.
-     * Requires at least editor rights (admin/instructor). The full current timeline is re-sent unchanged so only
-     * the build-and-test date is modified.
-     */
-    async setProgrammingExerciseBuildAndTestDateToPast(exerciseId: number) {
-        const getResponse = await this.page.request.get(`api/programming/programming-exercises/${exerciseId}`);
-        if (!getResponse.ok()) {
-            throw new Error(`Failed to fetch programming exercise ${exerciseId}: ${getResponse.status()}`);
-        }
-        const exercise = await getResponse.json();
-        const timelineUpdate = {
-            id: exercise.id,
-            releaseDate: exercise.releaseDate,
-            startDate: exercise.startDate,
-            dueDate: exercise.dueDate,
-            assessmentType: exercise.assessmentType,
-            assessmentDueDate: exercise.assessmentDueDate,
-            exampleSolutionPublicationDate: exercise.exampleSolutionPublicationDate,
-            buildAndTestStudentSubmissionsAfterDueDate: dayjsToString(dayjs()),
-        };
-        const response = await this.page.request.put(`api/programming/programming-exercises/timeline`, { data: timelineUpdate });
-        if (!response.ok()) {
-            throw new Error(`Failed to move build-and-test date for exercise ${exerciseId}: ${response.status()}`);
-        }
-    }
-
     async getProgrammingExerciseParticipation(exerciseId: number): Promise<StudentParticipation> {
         const pageResponse = await this.page.request.get(
             `api/exercise/exercises/${exerciseId}/participations/page?page=0&pageSize=1&sortingOrder=ASCENDING&sortedColumn=participantName&searchTerm=&filterProp=`,

--- a/src/test/playwright/support/utils.ts
+++ b/src/test/playwright/support/utils.ts
@@ -408,13 +408,12 @@ export async function waitForExamBuildAndTestAfterDueDate(exam: Exam, page: Page
     }
     await exerciseAPIRequests.triggerInstructorBuildForAll(programmingExercise.id);
     await Commands.waitForExerciseBuildToFinish(page, exerciseAPIRequests, programmingExercise.id);
-    // The build above produces the automatic result, but for exam programming exercises the server also defaults
-    // the "Run Tests after Due Date" date to (latest exam end + grace + 15 min). Until that date passes, the server
-    // rejects manual assessment with 403 "Creating manual results is disabled for this exercise!"
-    // (ProgrammingExercise.areManualResultsAllowed). Mirror what an instructor would do to assess immediately and
-    // move the date into the recent past. We do this only now, after waiting for the build, so the new date is
-    // safely past the exam end date (the server keeps a client value only when it is not before the exam end).
-    await exerciseAPIRequests.setProgrammingExerciseBuildAndTestDateToPast(programmingExercise.id);
+    // The "Run Tests after Due Date" date does not have to be moved here: the exercise is created with it set to
+    // `getExamBuildAndTestAfterDueDate(exam)`, which is ten seconds after the exam ends with its grace period, and
+    // this helper only runs once the exam is over. Writing it again through the timeline endpoint used to be part of
+    // this helper and is what made every exam programming assessment fail outside UTC: that endpoint stores the date
+    // shifted by the server's UTC offset, so on a UTC+2 machine the date landed two hours in the future, the
+    // assessment dashboard reported that the tests were still pending, and no submission was ever offered to assess.
 }
 
 /**
@@ -802,6 +801,9 @@ export async function prepareExam(course: Course, end: dayjs.Dayjs, exerciseType
             break;
         case ExerciseType.QUIZ:
             additionalData = { quizExerciseID: 0 };
+            break;
+        case ExerciseType.FILE_UPLOAD:
+            additionalData = { fileUploadFixture: 'pdf-test-file.pdf' };
             break;
     }
 


### PR DESCRIPTION
### Summary

Processing one build result issued 23 database statements and moved about 140 KB, almost all of it the exercise's problem statement and the course's code of conduct, which nothing on that path reads. It is now 12 statements and about 35 KB. Getting there meant replacing the ordered list of results, whose position carried the correction round, with an explicit column on the result, because that ordering was what forced every write in this area to load and re-save the whole submission.

### Motivation and Context

Follow-up to #13561. Measured on a build result with a 20 KB problem statement, a 4 KB grading instruction text, a 2 KB course description and an 8 KB code of conduct, four statements carried that free text and one row was 401 columns wide:

| # | Call site | Cols | Real bytes |
| --- | --- | ---: | ---: |
| 1 | the opening participation load | 83 | 24 728 |
| 7 | eager `participation` of the matched submission | **401** | 35 254 |
| 10 | `findByIdWithSubmissionPolicyElseThrow` | 48 | 24 307 |
| 15 | `save(submission)` merge-select | 220 | 25 078 |

Plus three separate `course` selects at roughly 10 KB each. At 2000 exam students each finishing one build that is around 280 MB per wave, and students push repeatedly.

The root cause of the widest rows is that `Submission.participation`, `Participation.exercise` and `Exercise.course` are all eager, so loading any submission entity loads all of it. The reason a submission entity had to be saved at all was the `@OrderColumn` on its results.

### Description

**Replacing the result ordering.** A submission's results were an ordered list whose position was the correction round, maintained by an `@OrderColumn`. Nothing read `results_order` other than the mapping itself, so the correction round was the only information the ordering carried. It becomes `result.correction_round`: 0 for the first correction, 1 for the second, null for automatic and Athena results, which are not correction rounds. The column is backfilled from the ordering it replaces, and `Submission.results` becomes an unordered `Set`. The newest result was already the one with the highest id, so nothing needed the position.

`SubmissionService.lockSubmission` sets the round from the round the tutor asked for, and `Submission.addResult` assigns the next one when a caller does not, which is the same moment the list position used to be decided.

**The API no longer emits null placeholders.** A tutor who had assessed only the second round produced a results array with a `null` at index 0, and the client indexed that array by correction round. `Result` now carries `correctionRound` and `getSubmissionResultByCorrectionRound` matches on it. Three components derived the round from `findIndex` over the results array and now read it off the result. `TextAssessmentService` no longer asserts with `!` that a result exists for the requested round; a round nobody has assessed simply has none.

**Reading only what is needed.** The submission a build result belongs to, and the submission policy, are read through projections rather than as entities.

**Writing only what changed.**
- The result owns the foreign key to its submission, so setting the submission before the insert writes it. This used to insert the result without its submission and then save the submission so its cascade filled the column in.
- Whether the build failed is one boolean on an existing row, written with a modifying query and only when it actually changed.
- Build log entries own their foreign key too, so they are saved with it, and a previous build's logs are deleted explicitly rather than through orphan removal on a collection. Their order comes from the timestamp they already carry instead of a position column.

**A footgun removed with it.** A test had to save the submission alongside a result because a result saved through its own repository kept `results_order` at its default of 0, collided with an existing result, and made the test fail non-deterministically. That cannot happen any more.

### Measurements

| Processing one build result | before | after |
| --- | ---: | ---: |
| Statements | 23 | **12** |
| Bytes moved | ~140 KB | **~35 KB** |
| Widest row | 401 columns | 83 |
| Statements carrying the free text | 4 | **1** |

### Steps for Testing

Prerequisites:
- 1 Instructor, 1 Student
- 1 Programming Exercise on a server with the integrated lifecycle setup (LocalVC and LocalCI)

1. As the student, push a passing commit. A result appears with the expected score.
2. Push a commit that does not compile. The submission is marked as build failed, the result scores 0, and the build logs are readable and in chronological order.
3. As the instructor, trigger all builds. A new result appears for the latest submission.
4. Push to the tests repository. The solution and template participations both get a result, and the exercise's test cases stay active.
5. As a tutor, open the exercise for assessment. The result created for the lock belongs to correction round 0, and the results array contains no null entries.
6. On an exam exercise with two correction rounds, assess the first and second rounds and check that each round shows its own result and that the dashboard's "continue assessment" link appears for the round it belongs to.
7. Configure an active lock repository policy with a limit of 1, exceed it, and trigger a build. The new result is unrated.

### Server Tests

1707 server tests were run locally across the assessment, submission, submission-policy, localci, architecture and integration suites, plus 265 client specs.

The migration's backfill has a PostgreSQL branch and a MySQL branch. CI only runs PostgreSQL, so the MySQL statement was run against a MySQL container with data covering automatic, Athena, manual, semi-automatic, null-assessment-type and orphan rows. Both branches produce identical output, matching the previous positional semantics, and re-running updates no rows.

### Review Progress

#### Performance Review
- [x] I did not find any performance issues.

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **LocalVC** and **Jenkins**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit correction-round tracking for manually assessed results.
  * Assessment views now select results by correction round rather than collection position.
  * Build logs are displayed in timestamp order with stable ordering.

* **Bug Fixes**
  * Improved handling of missing results during assessment workflows.
  * Corrected latest-result selection across multiple correction rounds.
  * Deleted results no longer contribute to course scores.
  * Preserved result ordering while preventing duplicate entries.

* **Refactor**
  * Submission results and programming build logs now use set-based collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->