### PR TITLE
`Development`: Keep the run-tests-after-due-date out of the server time zone

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingExercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingExercise.java
@@ -25,6 +25,8 @@ import jakarta.persistence.OrderColumn;
 import jakarta.persistence.SecondaryTable;
 
 import org.hibernate.Hibernate;
+import org.hibernate.annotations.TimeZoneStorage;
+import org.hibernate.annotations.TimeZoneStorageType;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,6 +101,12 @@ public class ProgrammingExercise extends Exercise {
     private boolean showTestNamesToStudents;
 
     @Nullable
+    // Normalized on purpose. This is the only temporal column on the secondary table, and Hibernate writes a secondary
+    // table with a MERGE whose source casts every parameter, here to "timestamp with time zone". The column itself is
+    // "timestamp without time zone", so the database converted the value using the session time zone and the date moved
+    // by the server's UTC offset on every save. NORMALIZE makes Hibernate bind a plain timestamp in the JDBC time zone
+    // (UTC, see hibernate.jdbc.time_zone), which is what the columns of the main exercise table already receive.
+    @TimeZoneStorage(TimeZoneStorageType.NORMALIZE)
     @Column(name = "build_and_test_student_submissions_after_due_date", table = "programming_exercise_details")
     private ZonedDateTime buildAndTestStudentSubmissionsAfterDueDate;
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseBuildAndTestDateMappingTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseBuildAndTestDateMappingTest.java
@@ -1,0 +1,39 @@
+package de.tum.cit.aet.artemis.programming;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+
+import org.hibernate.annotations.TimeZoneStorage;
+import org.hibernate.annotations.TimeZoneStorageType;
+import org.junit.jupiter.api.Test;
+
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
+
+/**
+ * Guards the time zone mapping of the "Run Tests after Due Date" date.
+ * <p>
+ * The date is the only temporal column of the programming exercise that lives on the secondary table
+ * {@code programming_exercise_details}. Hibernate writes a secondary table with a MERGE whose source casts every
+ * parameter, and for a {@code ZonedDateTime} without an explicit storage strategy that cast is
+ * {@code timestamp with time zone}. The column is {@code timestamp without time zone}, so the database converted the
+ * value with the session time zone and the date moved by the server's UTC offset on every save: an instructor on a
+ * UTC+2 server who set the date to 08:00 got 10:00 stored, and the exam assessment dashboard then reported that the
+ * tests were still pending. {@link TimeZoneStorageType#NORMALIZE} binds a plain timestamp in the JDBC time zone
+ * instead, which is what the main table's date columns already receive.
+ * <p>
+ * This is a mapping assertion rather than a round trip on purpose: the defect only shows up when the server's default
+ * zone is not UTC, and the test JVM runs in UTC, so a save-and-reload would pass either way and protect nothing.
+ */
+class ProgrammingExerciseBuildAndTestDateMappingTest {
+
+    @Test
+    void shouldNormalizeTheBuildAndTestDateSoItDoesNotDependOnTheServersZone() throws NoSuchFieldException {
+        Field field = ProgrammingExercise.class.getDeclaredField("buildAndTestStudentSubmissionsAfterDueDate");
+
+        TimeZoneStorage timeZoneStorage = field.getAnnotation(TimeZoneStorage.class);
+
+        assertThat(timeZoneStorage).as("the build and test date is on a secondary table and needs an explicit time zone storage strategy").isNotNull();
+        assertThat(timeZoneStorage.value()).as("only NORMALIZE binds a plain timestamp, which is what the column's type is").isEqualTo(TimeZoneStorageType.NORMALIZE);
+    }
+}


### PR DESCRIPTION
### Problem

The "Run Tests after Due Date" date of a programming exercise moves by the server's UTC offset every time it is saved.
On a server running at UTC+2, a date set to `08:00Z` is stored as `10:00` and read back as `10:00Z`, so it drifts two
hours further into the future on each save.

Measured against a running server, sending a date through `PUT /api/programming/programming-exercises/timeline`:

| Sent | Expected (UTC) | Stored before | Stored after |
| --- | --- | --- | --- |
| `2035-09-09T06:00:00Z` | `06:00:00` | `08:00:00` | `06:00:00` |
| `2030-01-01T00:00:00Z` | `00:00:00` | `01:00:00` | `00:00:00` |
| `2031-06-01T12:00:00+05:00` | `07:00:00` | `09:00:00` | `07:00:00` |

The offset follows the target date, so a January date moved by one hour and a June date by two: it is the server's zone
being applied, not a constant.

### Cause

The date is the only temporal column of the programming exercise that lives on the secondary table
`programming_exercise_details`. Hibernate writes a secondary table with a `MERGE` whose source casts every parameter,
and for a `ZonedDateTime` with no explicit storage strategy that cast is `timestamp with time zone`:

```sql
merge into programming_exercise_details as t using (
    select cast(? as bigint) id, ...,
           cast(? as timestamp(6) with time zone) build_and_test_student_submissions_after_due_date, ...
```

The column itself is `timestamp without time zone`, so the database converts `timestamptz` to `timestamp` using the
session time zone, which the JDBC driver takes from the server's default zone. The parameter is bound correctly, which
is what made this hard to see:

```
binding parameter (5:TIMESTAMP_UTC) <- [2035-09-09T06:00Z]      -> stored 2035-09-09 08:00
```

The date columns of the main `exercise` table are written with a plain `update ... set due_date=?` and have no such
cast, which is why only this one date drifted. Verified in the same session: `exercise.due_date` and `exam.end_date`
round-trip UTC correctly.

### Solution

Store the column normalized. Hibernate then binds a plain timestamp in the JDBC time zone, which is UTC
(`hibernate.jdbc.time_zone`), so the stored value is the instant that was sent and matches what every other date column
already contains. One annotation, no schema change.

### Why nobody noticed

CI and typical deployments run in UTC, where the conversion is the identity. It surfaced as exam programming
assessment being impossible on a developer machine in CEST: the assessment dashboard read the date, concluded the tests
were still running on the final submissions, and never offered a submission to assess.

### Review

The added test asserts the mapping rather than doing a round trip, deliberately: the defect only appears when the
server's default zone is not UTC, and the test JVM runs in UTC, so a save-and-reload would pass with or without the fix
and would protect nothing. The behaviour itself was verified against a running server, as in the table above.

One visible consequence: the field now serializes with an explicit offset (`2035-09-09T08:00:00+02:00`) instead of `Z`.
It is the same instant, and clients parse both, but it is worth a look during review.

### Steps for testing

1. Run a server in a zone other than UTC (any CET/CEST machine).
2. Open a programming exercise, set "Run Tests after Due Date", save.
3. Reopen the exercise: the date is the one that was entered, and stays put across further saves.

### Testserver states
<!-- Fill in when deploying -->

### Server
- [x] I followed the coding and design guidelines.
- [x] I added multiple integration tests (Spring) where appropriate.

### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when storing and retrieving programming exercise submission deadlines across different server time zones.
  * Prevented time-zone-dependent timestamp conversions for build-and-test submission dates.

* **Tests**
  * Added coverage to verify consistent time-zone handling for these deadlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->