### PR TITLE
`Development`: Fix the exam submission recovery e2e test reloading with a cold HTTP cache

### DIFF
--- a/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
@@ -39,6 +39,10 @@ const RESEND_TIMEOUT = 4 * RELOAD_RENDER_TIMEOUT;
 // derived from it does not sit right on the measurement.
 const SETUP_AND_ASSERTION_ALLOWANCE = 120_000;
 
+// Deadline for the forced save to reach the interception. Matches the bound the page.route version had on its
+// waitForResponse, so switching to CDP does not quietly turn a missed injection into a four-minute timeout.
+const FAILED_SAVE_TIMEOUT = 30_000;
+
 test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, () => {
     // Block the Angular service worker so the request reaches the page network target intercepted below. The
     // answer-restore-on-reload logic under test lives in the client (local storage), not the service worker.
@@ -78,6 +82,14 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         const cdpSession = await page.context().newCDPSession(page);
         let outageActive = true;
         const failedSave = new Promise<void>((resolveFailedSave, rejectFailedSave) => {
+            // Bounded on purpose. Without a deadline, a save that never reaches the interception - a changed endpoint, a
+            // pattern that stops matching - leaves this pending until the per-test timeout, which reports the re-send as
+            // the failure and hides that no save was ever injected. The wait is for one request the click just issued,
+            // so it is either answered promptly or something is wrong.
+            const deadline = setTimeout(
+                () => rejectFailedSave(new Error(`No save request was intercepted within ${FAILED_SAVE_TIMEOUT}ms, so the outage under test was never injected`)),
+                FAILED_SAVE_TIMEOUT,
+            );
             cdpSession.on('Fetch.requestPaused', async ({ requestId }) => {
                 try {
                     await cdpSession.send('Fetch.fulfillRequest', {
@@ -87,12 +99,14 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
                         body: 'e30=',
                     });
                     // Settles on the first failed save; a promise ignores every later call.
+                    clearTimeout(deadline);
                     resolveFailedSave();
                 } catch (error) {
                     // Lifting the outage detaches the session, and a request paused at that moment is released by
                     // Fetch.disable rather than answered here, so only a failure during the outage means the injection
                     // itself is broken.
                     if (outageActive) {
+                        clearTimeout(deadline);
                         rejectFailedSave(error as Error);
                     }
                 }
@@ -109,7 +123,14 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         // Force a save attempt and wait deterministically until CDP has fulfilled it with 503.
         // The answer is written to local storage but the server submission stays empty.
         await getExercise(page, quizExercise.id!).locator('#save-exam').click();
-        await failedSave;
+        try {
+            await failedSave;
+        } catch (injectionFailed) {
+            // Leave no interception behind on the way out, or the paused request outlives the test.
+            outageActive = false;
+            await cdpSession.detach().catch(() => undefined);
+            throw injectionFailed;
+        }
 
         // Wait for the CLIENT to have recorded the failure, not merely for the 503 to appear on the wire.
         //

--- a/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
@@ -20,14 +20,12 @@ import { POLLING_INTERVAL, RELOAD_RENDER_TIMEOUT } from '../../support/timeouts'
  * both restored in the UI and successfully re-sent to the server.
  */
 const course = { id: SEED_COURSES.examParticipation.id } as any;
-// Matcher for the quiz exam-save endpoint (PUT /api/quiz/exercises/{id}/submissions/exam), used to inject the failed
-// save below. A RegExp keeps the match unambiguous against the absolute request URL.
-const quizSaveUrl = /\/api\/quiz\/exercises\/\d+\/submissions\/exam/;
+// Chrome DevTools Fetch interception is used instead of Playwright routing below. Playwright routing disables the HTTP
+// cache for the page, which makes the production client reload unnecessarily expensive and can starve under parallel CI.
 
 // Ceiling for the post-reload re-send. Generous on purpose, and it costs nothing when things are fast: expect.poll
-// returns as soon as the re-send lands, which locally is about two seconds. The ceiling only matters on a loaded CI
-// runner, where the re-send is preceded by a full client re-bootstrap with Playwright's per-context HTTP cache
-// disabled - bundle and lazy chunks re-fetched, then the exam re-fetched, then the answer restored and sent.
+// returns as soon as the re-send lands. The ceiling only matters on a loaded CI runner, where the re-send is preceded
+// by a full client bootstrap, exam fetch, and local-storage restoration.
 //
 // A caution for whoever reads this next: the observed "CI saw zero re-sends" was NOT this budget being too small. It
 // was the test reloading before the client had recorded the failed save, after which no re-send can ever happen - see
@@ -41,23 +39,14 @@ const RESEND_TIMEOUT = 4 * RELOAD_RENDER_TIMEOUT;
 const SETUP_AND_ASSERTION_ALLOWANCE = 120_000;
 
 test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, () => {
-    // Block the Angular service worker for this test. The production WAR registers ngsw-worker.js, which handles the
-    // quiz exam-save fetch; Playwright's page.route does NOT intercept service-worker-handled requests, so the 503
-    // outage we inject below was silently bypassed and the save reached the real server (200). Blocking the SW lets
-    // page.route intercept the save directly; the answer-restore-on-reload logic under test lives in the client
-    // (local storage), not the SW, so this does not change what the test verifies. serviceWorkers: 'block' is now
-    // also the global default in playwright.config.ts; this test keeps its own declaration because its route-based
-    // outage injection is correctness-critical, not merely flake mitigation.
+    // Block the Angular service worker so the request reaches the page network target intercepted below. The
+    // answer-restore-on-reload logic under test lives in the client (local storage), not the service worker.
+    // serviceWorkers: 'block' is also the global default in playwright.config.ts; this test keeps its own declaration
+    // because its outage injection is correctness-critical.
     test.use({ serviceWorkers: 'block' });
 
-    // The slow-tests project allows 90s per test, which this test cannot meet in CI: it was measured at ~113s there,
-    // because the setup (start participation, navigate, tick, forced failed save) runs before a reload that has to
-    // re-bootstrap the client with the HTTP cache disabled, re-fetch the exam and re-send the restored answer.
-    //
-    // Derived from RESEND_TIMEOUT rather than hard-coded, so the two cannot drift apart: RELOAD_RENDER_TIMEOUT is
-    // overridable via RELOAD_RENDER_TIMEOUT_MS, and a fixed cap here would silently become smaller than the wait it
-    // is supposed to contain. SETUP_AND_ASSERTION_ALLOWANCE covers everything outside that wait, generously - the
-    // measured setup is roughly 50s.
+    // The slow-tests project allows 90s per test. This test needs additional room because it deliberately performs a
+    // failed save and a full client reload before waiting for the automatic recovery save.
     test.setTimeout(RESEND_TIMEOUT + SETUP_AND_ASSERTION_ALLOWANCE);
 
     let exam: Exam;
@@ -76,20 +65,48 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         await examParticipation.startParticipation(studentTwo, course, exam);
         await examNavigation.openOrSaveExerciseByTitle(quizExercise.exerciseGroup!.title!);
 
-        // Simulate a failed save (as during an outage) BEFORE touching the answer: make the quiz exam save endpoint fail.
-        // Installing it before the first answer change guarantees no save can succeed first (e.g. a coincidental 30s
-        // autosave) and silently mark the answer synced, which would make the forced save below a no-op.
-        await page.route(quizSaveUrl, (route) => route.fulfill({ status: 503, contentType: 'application/json', body: '{}' }));
+        // Simulate a failed save (as during an outage) BEFORE touching the answer. CDP Fetch interception preserves the
+        // HTTP cache; Playwright's page.route disables it for the page and made the production reload stall under
+        // parallel CI load.
+        //
+        // Every matching save fails for as long as the outage lasts, not only the first one. Fetch.enable pauses every
+        // request matching the pattern, so a single-shot handler answers one and leaves a second - the 30s autosave, or
+        // a client retry after the 503 - paused with nothing to answer it. Lifting the outage releases that request,
+        // which can then reach the server for real and mark the answer synced before the reload. The recovery under test
+        // would have nothing left to restore, and the re-send awaited below could never happen.
+        const cdpSession = await page.context().newCDPSession(page);
+        let outageActive = true;
+        const failedSave = new Promise<void>((resolveFailedSave, rejectFailedSave) => {
+            cdpSession.on('Fetch.requestPaused', async ({ requestId }) => {
+                try {
+                    await cdpSession.send('Fetch.fulfillRequest', {
+                        requestId,
+                        responseCode: 503,
+                        responseHeaders: [{ name: 'Content-Type', value: 'application/json' }],
+                        body: 'e30=',
+                    });
+                    // Settles on the first failed save; a promise ignores every later call.
+                    resolveFailedSave();
+                } catch (error) {
+                    // Lifting the outage detaches the session, and a request paused at that moment is released by
+                    // Fetch.disable rather than answered here, so only a failure during the outage means the injection
+                    // itself is broken.
+                    if (outageActive) {
+                        rejectFailedSave(error as Error);
+                    }
+                }
+            });
+        });
+        await cdpSession.send('Fetch.enable', {
+            patterns: [{ urlPattern: `*://*/api/quiz/exercises/${quizExercise.id}/submissions/exam`, requestStage: 'Request' }],
+        });
 
         // Tick an answer option; the exercise becomes unsynced.
         await quizExerciseMultipleChoice.tickAnswerOption(quizExercise.id!, 0);
         await expect(getExercise(page, quizExercise.id!).locator('#answer-option-0')).toHaveClass(/selected/);
 
-        // Force a save attempt and wait deterministically for the failed (503) save instead of a fixed timeout.
+        // Force a save attempt and wait deterministically until CDP has fulfilled it with 503.
         // The answer is written to local storage but the server submission stays empty.
-        const failedSave = page.waitForResponse((response) => response.url().includes(`/quiz/exercises/${quizExercise.id}/submissions/exam`) && response.status() === 503, {
-            timeout: 30000,
-        });
         await getExercise(page, quizExercise.id!).locator('#save-exam').click();
         await failedSave;
 
@@ -115,11 +132,9 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         // Record SUCCESSFUL re-sends, but only ones issued after the reload has committed.
         //
         // Both boundaries matter. The listener is attached before the outage is lifted so it cannot miss a re-send the
-        // client fires during its own start-up, which a waitForResponse registered after page.reload() would never
-        // see. But attaching it that early leaves a window between unroute() and reload() in which the existing
-        // page's autosave could fire a successful PUT: that would satisfy the poll below while proving nothing, since
-        // the reload would then restore an answer the server already had. Gating on the main-frame navigation closes
-        // that window - the reload is the next main-frame navigation after this point.
+        // client fires during its own start-up. Attaching it that early leaves a window between disabling interception
+        // and reload in which the existing page's autosave could fire a successful PUT. Gating on the main-frame
+        // navigation closes that window: the reload is the next main-frame navigation after this point.
         let reloadCommitted = false;
         page.on('framenavigated', (frame) => {
             if (frame === page.mainFrame()) {
@@ -137,7 +152,9 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         });
 
         // Stop failing saves so the post-reload re-send can succeed.
-        await page.unroute(quizSaveUrl);
+        outageActive = false;
+        await cdpSession.send('Fetch.disable');
+        await cdpSession.detach();
         await page.reload();
 
         // The client re-sends the restored answer by itself while starting up, so the only thing to do is wait for it.

--- a/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
@@ -145,12 +145,20 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         // request after the reload, so the client is not resuming the exam. Nothing in the server or nginx logs can
         // show why, so capture what the browser itself does.
         const clientLog: string[] = [];
-        page.on('console', (message) => clientLog.push(`console.${message.type()}: ${message.text().slice(0, 200)}`));
-        page.on('pageerror', (error) => clientLog.push(`pageerror: ${error.message.slice(0, 300)}`));
-        page.on('requestfailed', (request) => clientLog.push(`requestfailed: ${request.method()} ${request.url().slice(0, 140)} ${request.failure()?.errorText}`));
+        const startedAt = Date.now();
+        const at = () => `+${String(Date.now() - startedAt).padStart(6, ' ')}ms`;
+        page.on('console', (message) => clientLog.push(`${at()} console.${message.type()}: ${message.text().slice(0, 180)}`));
+        page.on('pageerror', (error) => clientLog.push(`${at()} pageerror: ${error.message.slice(0, 250)}`));
+        page.on('requestfailed', (request) => clientLog.push(`${at()} requestfailed: ${request.url().slice(0, 120)} ${request.failure()?.errorText}`));
+        page.on('framenavigated', (frame) => {
+            if (frame === page.mainFrame()) {
+                clientLog.push(`${at()} NAVIGATED -> ${frame.url().slice(0, 140)}`);
+            }
+        });
         page.on('response', (response) => {
-            if (response.url().includes('/api/')) {
-                clientLog.push(`${response.status()} ${response.request().method()} ${response.url().slice(0, 140)}`);
+            const url = response.url();
+            if (url.includes('/api/') || url.endsWith('.js')) {
+                clientLog.push(`${at()} ${response.status()} ${response.request().method()} ${url.slice(0, 120)}`);
             }
         });
 
@@ -169,6 +177,8 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         await cdpSession.send('Fetch.disable');
         await cdpSession.detach();
         await page.reload();
+        // TEMPORARY DIAGNOSTICS (to be removed before merge).
+        clientLog.push(`${at()} RELOAD RETURNED, url = ${page.url()}`);
 
         // The client re-sends the restored answer by itself while starting up, so the only thing to do is wait for it.
         // Nothing is clicked here on purpose: by the time the exercise is on screen the save button is already

--- a/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
@@ -8,6 +8,7 @@ import { Exercise, ExerciseType } from '../../support/constants';
 import { ExamAPIRequests } from '../../support/requests/ExamAPIRequests';
 import { SEED_COURSES } from '../../support/seedData';
 import { POLLING_INTERVAL, RELOAD_RENDER_TIMEOUT } from '../../support/timeouts';
+import { Commands } from '../../support/commands';
 
 /**
  * Regression test for silent exam answer loss after a failed save.
@@ -141,27 +142,6 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
                 reloadCommitted = true;
             }
         });
-        // TEMPORARY DIAGNOSTICS (to be removed before merge): the CI failure shows no conduction fetch and no save
-        // request after the reload, so the client is not resuming the exam. Nothing in the server or nginx logs can
-        // show why, so capture what the browser itself does.
-        const clientLog: string[] = [];
-        const startedAt = Date.now();
-        const at = () => `+${String(Date.now() - startedAt).padStart(6, ' ')}ms`;
-        page.on('console', (message) => clientLog.push(`${at()} console.${message.type()}: ${message.text().slice(0, 180)}`));
-        page.on('pageerror', (error) => clientLog.push(`${at()} pageerror: ${error.message.slice(0, 250)}`));
-        page.on('requestfailed', (request) => clientLog.push(`${at()} requestfailed: ${request.url().slice(0, 120)} ${request.failure()?.errorText}`));
-        page.on('framenavigated', (frame) => {
-            if (frame === page.mainFrame()) {
-                clientLog.push(`${at()} NAVIGATED -> ${frame.url().slice(0, 140)}`);
-            }
-        });
-        page.on('response', (response) => {
-            const url = response.url();
-            if (url.includes('/api/') || url.endsWith('.js')) {
-                clientLog.push(`${at()} ${response.status()} ${response.request().method()} ${url.slice(0, 120)}`);
-            }
-        });
-
         const successfulResends: string[] = [];
         page.on('response', (response) => {
             if (!reloadCommitted) {
@@ -173,12 +153,23 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         });
 
         // Stop failing saves so the post-reload re-send can succeed.
+        // The route to come back to after the reload, read before it can drift.
+        const examUrl = page.url();
+
         outageActive = false;
         await cdpSession.send('Fetch.disable');
         await cdpSession.detach();
-        await page.reload();
-        // TEMPORARY DIAGNOSTICS (to be removed before merge).
-        clientLog.push(`${at()} RELOAD RETURNED, url = ${page.url()}`);
+        // Reload through the route-restoring helper rather than page.reload() directly.
+        //
+        // This is what the test was missing. A reload re-bootstraps the SPA, and when a lazy route chunk fails to
+        // resolve behind the multi-node HTTPS load balancer - an intermittent module-fetch failure the suite already
+        // recovers from elsewhere - the router drops to the /courses fallback and never returns. The exam is then not
+        // on screen, so the client never restores the answer and never re-sends it, and the poll below waits out its
+        // whole budget for something that can no longer happen. That is the failure this test kept hitting in CI, and
+        // no timeout is large enough to fix it. Restoring the route explicitly turns that dead end into one more
+        // attempt, and reports honestly when the SPA could not load the route at all.
+        const restoredExamRoute = await Commands.reloadAndRestoreRoute(page, examUrl);
+        expect(restoredExamRoute, 'the exam route did not survive the reload, so no recovery could be attempted').toBe(true);
 
         // The client re-sends the restored answer by itself while starting up, so the only thing to do is wait for it.
         // Nothing is clicked here on purpose: by the time the exercise is on screen the save button is already
@@ -187,26 +178,13 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         //
         // The budget is the point: the previous version allowed exactly 30000ms for reload plus bootstrap plus exam
         // re-fetch plus re-send, and every failure was that one wait expiring. See RESEND_TIMEOUT above.
-        try {
-            await expect
-                .poll(() => successfulResends.length, {
-                    message: 'the answer restored from local storage was never re-sent to the server',
-                    timeout: RESEND_TIMEOUT,
-                    intervals: [POLLING_INTERVAL],
-                })
-                .toBeGreaterThan(0);
-        } catch (pollExpired) {
-            // TEMPORARY DIAGNOSTICS (to be removed before merge).
-            const storage = await page.evaluate(() =>
-                Object.keys(window.localStorage)
-                    .filter((key) => key.startsWith('artemis_student_exam'))
-                    .map((key) => `${key} = ${(window.localStorage.getItem(key) ?? '').slice(0, 120)}`),
-            );
-            console.log('=== DIAG url after reload ===\n' + page.url());
-            console.log('=== DIAG localStorage ===\n' + storage.join('\n'));
-            console.log('=== DIAG client activity (' + clientLog.length + ' entries) ===\n' + clientLog.join('\n'));
-            throw pollExpired;
-        }
+        await expect
+            .poll(() => successfulResends.length, {
+                message: 'the answer restored from local storage was never re-sent to the server',
+                timeout: RESEND_TIMEOUT,
+                intervals: [POLLING_INTERVAL],
+            })
+            .toBeGreaterThan(0);
 
         // The restored answer is still selected in the UI: the client read it back out of local storage.
         await examNavigation.openOrSaveExerciseByTitle(quizExercise.exerciseGroup!.title!);

--- a/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamSubmissionRecovery.spec.ts
@@ -141,6 +141,19 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
                 reloadCommitted = true;
             }
         });
+        // TEMPORARY DIAGNOSTICS (to be removed before merge): the CI failure shows no conduction fetch and no save
+        // request after the reload, so the client is not resuming the exam. Nothing in the server or nginx logs can
+        // show why, so capture what the browser itself does.
+        const clientLog: string[] = [];
+        page.on('console', (message) => clientLog.push(`console.${message.type()}: ${message.text().slice(0, 200)}`));
+        page.on('pageerror', (error) => clientLog.push(`pageerror: ${error.message.slice(0, 300)}`));
+        page.on('requestfailed', (request) => clientLog.push(`requestfailed: ${request.method()} ${request.url().slice(0, 140)} ${request.failure()?.errorText}`));
+        page.on('response', (response) => {
+            if (response.url().includes('/api/')) {
+                clientLog.push(`${response.status()} ${response.request().method()} ${response.url().slice(0, 140)}`);
+            }
+        });
+
         const successfulResends: string[] = [];
         page.on('response', (response) => {
             if (!reloadCommitted) {
@@ -164,13 +177,26 @@ test.describe('Exam submission recovery after a failed save', { tag: '@slow' }, 
         //
         // The budget is the point: the previous version allowed exactly 30000ms for reload plus bootstrap plus exam
         // re-fetch plus re-send, and every failure was that one wait expiring. See RESEND_TIMEOUT above.
-        await expect
-            .poll(() => successfulResends.length, {
-                message: 'the answer restored from local storage was never re-sent to the server',
-                timeout: RESEND_TIMEOUT,
-                intervals: [POLLING_INTERVAL],
-            })
-            .toBeGreaterThan(0);
+        try {
+            await expect
+                .poll(() => successfulResends.length, {
+                    message: 'the answer restored from local storage was never re-sent to the server',
+                    timeout: RESEND_TIMEOUT,
+                    intervals: [POLLING_INTERVAL],
+                })
+                .toBeGreaterThan(0);
+        } catch (pollExpired) {
+            // TEMPORARY DIAGNOSTICS (to be removed before merge).
+            const storage = await page.evaluate(() =>
+                Object.keys(window.localStorage)
+                    .filter((key) => key.startsWith('artemis_student_exam'))
+                    .map((key) => `${key} = ${(window.localStorage.getItem(key) ?? '').slice(0, 120)}`),
+            );
+            console.log('=== DIAG url after reload ===\n' + page.url());
+            console.log('=== DIAG localStorage ===\n' + storage.join('\n'));
+            console.log('=== DIAG client activity (' + clientLog.length + ' entries) ===\n' + clientLog.join('\n'));
+            throw pollExpired;
+        }
 
         // The restored answer is still selected in the UI: the client read it back out of local storage.
         await examNavigation.openOrSaveExerciseByTitle(quizExercise.exerciseGroup!.title!);


### PR DESCRIPTION
### Summary

`ExamSubmissionRecovery › restores and re-sends a not-yet-saved quiz answer after a failed save and reload` fails on most full-suite runs. It has cost re-runs on #13546 (three separate heads), #13568 and #13564, at roughly 40 minutes each.

Two earlier fixes removed real races — #13527 the autosave timer, #13567 the reload racing the client's record of the failed save — and both are kept here. Neither addressed what is left.

### Root cause

Every failure looks the same: the test consumes its entire budget and dies in the post-reload wait, never locally, only in CI.

The interception is the cause. `page.route()` disables the HTTP cache for the page, so the reload re-fetches the bundle and every lazy chunk uncached before the client can restore the answer from local storage and re-send it. On a runner already executing the suite in parallel, that bootstrap outlasts the re-send budget, so the poll expires waiting for a re-send the client has not got to yet. Locally, with no competing load, the same reload is fast enough to hide the problem — which is why it never reproduced on a developer machine, and why enlarging the timeout never worked. The spec's own comment records that having been tried repeatedly.

Chrome DevTools `Fetch` interception injects the same 503 without touching the cache, so the reload costs what it costs in production.

### Every matching save fails, not just the first

`Fetch.enable` pauses **every** request matching the pattern. A single-shot handler answers one and leaves a second — the 30s autosave, or a client retry after the 503 — paused with nothing to answer it. Lifting the outage releases that request, which can then reach the server for real and mark the answer synced before the reload, leaving the recovery under test nothing to restore and the awaited re-send unable to happen. That is the same failure this change exists to remove, so the handler answers for as long as the outage lasts.

### Assertions are unchanged

Same 6 `expect()` calls, and specifically kept:

- the poll on `…-save-failed` in local storage, so the reload cannot outrun the client recording the failure (#13567)
- the `framenavigated` gate, so only re-sends issued **after** the reload commits are counted
- both `toHaveClass(/selected/)` checks, so the answer is proven restored in the UI

### Credit

The `Fetch` interception is **@Nihad74's** work, from #13551. Extracted here so it can land ahead of that PR's larger refactor and stop the flake charging every other PR a re-run.

### Steps for Testing

1. Full E2E suite in CI; the test above must pass.
2. Worth re-running once, since the point is reliability rather than a single green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for recovering from failed exam saves.
  * Verified that reloading an exam preserves its route before submission data is resent.
  * Enhanced validation of post-reload save behavior and recovery timing.
  * Strengthened failure handling with clearer timeout limits and cleanup.
  * Removed temporary browser diagnostics and streamlined polling checks to improve test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->