### PR TITLE
`Development`: Restore the exam summary route after the reload in e2e tests

### DIFF
--- a/src/test/playwright/e2e/exam/ExamParticipation.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamParticipation.spec.ts
@@ -238,11 +238,18 @@ test.describe('Exam participation', () => {
             await examParticipation.verifyTextExerciseOnFinalPage(textExercise.id!, textExercise.additionalData!.textFixture!);
             await examParticipation.checkExamTitle(examTitle);
 
-            await page.reload();
+            // Reload through the route-restoring helper rather than page.reload() directly. A reload re-bootstraps the
+            // SPA, and when a lazy route chunk fails to resolve behind the multi-node HTTPS load balancer the router
+            // drops to the /courses fallback and never returns. The summary is then not on screen, and the assertions
+            // below wait for content that cannot appear - which is how this test failed on develop. Restoring the route
+            // turns that dead end into one more attempt, and reports honestly when the SPA could not load the route.
+            const summaryUrl = page.url();
+            const restoredSummary = await Commands.reloadAndRestoreRoute(page, summaryUrl);
+            expect(restoredSummary, 'the exam summary route did not survive the reload').toBe(true);
 
-            // First assertion after the reload absorbs the full client re-bootstrap: the summary view lazy-loads its
-            // chunks and Playwright disables the HTTP cache per context, so the default 10s expect timeout is not
-            // enough under parallel CI load. checkExamTitle renders in the same pass and keeps the default.
+            // First assertion after the reload still absorbs the full client re-bootstrap: the summary view lazy-loads
+            // its chunks, so the default 10s expect timeout is not enough under parallel CI load. checkExamTitle
+            // renders in the same pass and keeps the default.
             await examParticipation.verifyTextExerciseOnFinalPage(textExercise.id!, textExercise.additionalData!.textFixture!, RELOAD_RENDER_TIMEOUT);
             await examParticipation.checkExamTitle(examTitle);
 


### PR DESCRIPTION
### Summary

`Exam participation › Early hand-in with continue and reload page › Reloads exam result page and ensures that everything is as expected` failed on develop in `fc8e5c46` (369 passed, 2 flaky, 1 failed).

The test reloads and then asserts on summary content. A reload re-bootstraps the SPA, and when a lazy route chunk fails to resolve behind the multi-node HTTPS load balancer the router drops to the `/courses` fallback and never navigates back. The summary is then not on screen, so the assertions wait for content that cannot appear.

The test already carried the remedy that does not work — `test.slow()` plus a raised first-assertion timeout, attributed to the disabled HTTP cache. No budget is large enough for a page that is on the wrong route.

### The fix

Same one as #13573, whose pattern this matches exactly and which has five consecutive clean first-attempt CI runs behind it: reload through `Commands.reloadAndRestoreRoute` and assert the route survived, so a genuinely dead SPA fails immediately with a clear message instead of after a long silent wait.

The other two `page.reload()` calls in this file are deliberately untouched: one is immediately followed by a `page.goto`, which carries the same recovery through the `page` fixture, and the other refreshes credentials in a `beforeEach`.

### Steps for Testing

1. The E2E suite; this test must pass.
2. Worth repeating, since the point is reliability rather than one green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved exam result reload coverage by verifying that users return to the correct summary page after a reload.
  * Added validation to ensure route restoration succeeds before checking exam summary details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->