### PR TITLE
`Development`: Require the parent to be set for nine database relations

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Complaint.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Complaint.java
@@ -51,7 +51,7 @@ public class Complaint extends DomainObject {
     private ComplaintResponse complaintResponse;
 
     @OneToOne
-    @JoinColumn(unique = true)
+    @JoinColumn(unique = true, nullable = false)
     private Result result;
 
     @ManyToOne

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/ComplaintResponse.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/ComplaintResponse.java
@@ -43,7 +43,7 @@ public class ComplaintResponse extends AbstractAuditingEntity {
     private ZonedDateTime submittedTime;
 
     @OneToOne
-    @JoinColumn(unique = true)
+    @JoinColumn(unique = true, nullable = false)
     @JsonIgnoreProperties(value = "complaintResponse", allowSetters = true)
     private Complaint complaint;
 

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradeStep.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/GradeStep.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
@@ -31,6 +32,7 @@ public class GradeStep extends DomainObject {
 
     @ManyToOne
     @JsonIgnoreProperties(value = "gradeSteps", allowSetters = true)
+    @JoinColumn(nullable = false)
     private GradingScale gradingScale;
 
     @Column(name = "lower_bound_percentage")

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Result.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/domain/Result.java
@@ -90,6 +90,7 @@ public class Result extends DomainObject implements Comparable<Result> {
 
     @ManyToOne
     @JsonIgnoreProperties({ "results" })
+    @JoinColumn(nullable = false)
     private Submission submission;
 
     // Stored as a Set: feedback ordering is not semantically meaningful — every consumer that cares about

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ComplaintResponseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/repository/ComplaintResponseRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import de.tum.cit.aet.artemis.assessment.domain.Complaint;
 import de.tum.cit.aet.artemis.assessment.domain.ComplaintResponse;
 import de.tum.cit.aet.artemis.assessment.domain.ComplaintType;
 import de.tum.cit.aet.artemis.assessment.dto.dashboard.ExerciseMapEntryDTO;
@@ -121,4 +122,19 @@ public interface ComplaintResponseRepository extends ArtemisJpaRepository<Compla
     @Modifying
     @Query("DELETE FROM ComplaintResponse cr WHERE cr.complaint.id IN (SELECT c.id FROM Complaint c WHERE c.result.id = :resultId)")
     void deleteByComplaint_Result_Id(@Param("resultId") long resultId);
+
+    /**
+     * Delete the complaint response with the given id.
+     * <p>
+     * Implemented as a bulk JPQL delete for the same reason as {@link #deleteByComplaint_Result_Id(long)}: removing the
+     * entity through the persistence context would load the eagerly-fetched {@link Complaint} alongside it, and the
+     * still-managed complaint's inverse {@code complaintResponse} association would then point at the removed response,
+     * making the flush fail. The bulk delete loads nothing into the session.
+     *
+     * @param complaintResponseId the id of the complaint response to delete
+     */
+    @Transactional // ok because of delete
+    @Modifying
+    @Query("DELETE FROM ComplaintResponse cr WHERE cr.id = :complaintResponseId")
+    void deleteResponseById(@Param("complaintResponseId") long complaintResponseId);
 }

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ComplaintResponseService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ComplaintResponseService.java
@@ -78,8 +78,7 @@ public class ComplaintResponseService {
         if (blockedByLock(complaintResponseRepresentingLock, user)) {
             throw new ComplaintResponseLockedException(complaintResponseRepresentingLock);
         }
-        complaintResponseRepresentingLock = disassociateComplaintAndComplaintResponse(complaint, complaintResponseRepresentingLock);
-        complaintResponseRepository.deleteById(complaintResponseRepresentingLock.getId());
+        deleteComplaintResponseRepresentingLock(complaint, complaintResponseRepresentingLock);
         log.debug("Removed empty complaint and thus lock for complaint with id : {}", complaint.getId());
     }
 
@@ -126,8 +125,7 @@ public class ComplaintResponseService {
             throw new ComplaintResponseLockedException(complaintResponseRepresentingLock);
         }
 
-        complaintResponseRepresentingLock = disassociateComplaintAndComplaintResponse(complaint, complaintResponseRepresentingLock);
-        complaintResponseRepository.deleteById(complaintResponseRepresentingLock.getId());
+        deleteComplaintResponseRepresentingLock(complaint, complaintResponseRepresentingLock);
 
         ComplaintResponse refreshedEmptyComplaintResponse = new ComplaintResponse();
         refreshedEmptyComplaintResponse.setReviewer(user); // owner of the lock
@@ -137,14 +135,21 @@ public class ComplaintResponseService {
         return persistedComplaintResponse;
     }
 
-    private ComplaintResponse disassociateComplaintAndComplaintResponse(Complaint complaint, ComplaintResponse complaintResponseRepresentingLock) {
-        // we need to remove the relationship between the complaint and the complaint response as we otherwise cannot delete the ComplaintResponse
-        // we need the save method calls to make the PersistenceContext aware of the changes
+    /**
+     * Deletes the empty complaint response that represents the lock on the given complaint.
+     * <p>
+     * The complaint is the inverse side of this one-to-one and holds no column of its own, so nothing in the database
+     * points at the response and the row can go away in a single statement. This used to save the response with its
+     * complaint set to null first, which left a row without a parent behind for the length of one statement and stood
+     * in the way of requiring the column to be set. Clearing the back reference afterwards keeps the complaint that the
+     * caller holds consistent with the database.
+     *
+     * @param complaint                         the complaint the lock belongs to
+     * @param complaintResponseRepresentingLock the empty complaint response to delete
+     */
+    private void deleteComplaintResponseRepresentingLock(Complaint complaint, ComplaintResponse complaintResponseRepresentingLock) {
+        complaintResponseRepository.deleteResponseById(complaintResponseRepresentingLock.getId());
         complaint.setComplaintResponse(null);
-        complaintRepository.save(complaint);
-        complaintResponseRepresentingLock.setComplaint(null);
-        complaintResponseRepresentingLock = complaintResponseRepository.save(complaintResponseRepresentingLock);
-        return complaintResponseRepresentingLock;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
@@ -569,8 +569,10 @@ public class ResultService {
     }
 
     private void handleFeedbackPersistence(Feedback feedback, Result result, Map<Long, LongFeedbackText> longFeedbackTextMap) {
-        // Temporarily detach feedback from the parent result to avoid Hibernate issues
-        feedback.setResult(null);
+        // The feedback owns the foreign key to its result, so it is saved together with it. This used to detach the
+        // feedback first, which was needed while a result held its feedback in an ordered list and which wrote a row
+        // without a parent for as long as the surrounding save took.
+        feedback.setResult(result);
 
         // Connect old long feedback text to the feedback before saving, otherwise it would be deleted
         if (feedback.getId() != null && feedback.getHasLongFeedbackText()) {
@@ -587,11 +589,7 @@ public class ResultService {
             }
         }
 
-        // Persist the feedback entity without the parent association
-        feedback = feedbackRepository.saveAndFlush(feedback);
-
-        // Restore associations to the result
-        feedback.setResult(result);
+        feedbackRepository.saveAndFlush(feedback);
     }
 
     @NonNull

--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/AnswerPost.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/AnswerPost.java
@@ -39,6 +39,7 @@ public class AnswerPost extends Posting {
 
     @ManyToOne
     @JsonIncludeProperties({ "id", "exercise", "lecture", "course", "courseWideContext", "conversation", "author" })
+    @JoinColumn(nullable = false)
     private Post post;
 
     @Transient

--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/ConversationParticipant.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/ConversationParticipant.java
@@ -4,6 +4,7 @@ import java.time.ZonedDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
@@ -24,6 +25,7 @@ public class ConversationParticipant extends DomainObject {
 
     @ManyToOne
     @JsonIgnore
+    @JoinColumn(nullable = false)
     private Conversation conversation;
 
     @ManyToOne

--- a/src/main/java/de/tum/cit/aet/artemis/exam/domain/Exam.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/domain/Exam.java
@@ -143,7 +143,7 @@ public class Exam extends DomainObject {
     private ZonedDateTime exampleSolutionPublicationDate;
 
     @ManyToOne
-    @JoinColumn(name = "course_id")
+    @JoinColumn(name = "course_id", nullable = false)
     private Course course;
 
     @OneToMany(mappedBy = "exam", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamQuizService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamQuizService.java
@@ -92,8 +92,6 @@ public class ExamQuizService {
                     quizSubmission.calculateAndUpdateScores(quizExercise.getQuizQuestions());
                     result.evaluateQuizSubmission(quizExercise);
                     result.setExerciseId(quizExercise.getId());
-                    // remove submission to follow save order for ordered collections
-                    result.setSubmission(null);
                     if (studentExam.isTestExam()) {
                         result.rated(true);
                     }
@@ -108,7 +106,6 @@ public class ExamQuizService {
                     if (participation.getId() == null) {
                         studentParticipationRepository.save(participation);
                     }
-                    result.setSubmission(quizSubmission);
                     quizSubmission.addResult(result);
                 }
                 else {

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
@@ -322,8 +322,14 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      * @param result the result to add
      */
     public void addResult(Result result) {
-        if (result != null && result.getCorrectionRound() == null && !result.isAutomatic() && !result.isAthenaBased()) {
-            result.setCorrectionRound(countCorrectionRoundResults(result));
+        if (result != null) {
+            if (result.getCorrectionRound() == null && !result.isAutomatic() && !result.isAthenaBased()) {
+                result.setCorrectionRound(countCorrectionRoundResults(result));
+            }
+            // Keep both ends of the association in sync. The results are mapped on the inverse side and cascade, so
+            // without this Hibernate inserts the cascaded result with an empty submission_id and only fills it in with
+            // a follow-up update, which a not-null constraint on the column rightly rejects.
+            result.setSubmission(this);
         }
         this.results.add(result);
     }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ExerciseImportService.java
@@ -203,15 +203,9 @@ public abstract class ExerciseImportService {
         newResult.setScore(originalResult.getScore());
         newResult.copyProgrammingExerciseCounters(originalResult);
         newResult.setFeedbacks(copyFeedback(originalResult.getFeedbacks(), newResult, gradingInstructionCopyTracker));
-        // Cut relationship to parent because result is an ordered collection
-        newResult.setSubmission(null);
-
-        newResult = resultRepository.save(newResult);
-
-        // Restore relationship to parent.
         newResult.setSubmission(newSubmission);
 
-        return newResult;
+        return resultRepository.save(newResult);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
@@ -455,6 +455,8 @@ public class SubmissionService {
         }
         Result newResult = new Result();
         setExerciseIdFromSubmission(submission, newResult);
+        // Set before copying the feedback, which saves the result: the result owns the foreign key to its submission.
+        newResult.setSubmission(submission);
         copyFeedbackToNewResult(newResult, oldResult);
         return copyResultContentAndAddToSubmission(submission, newResult, oldResult);
     }
@@ -472,6 +474,9 @@ public class SubmissionService {
     public Result createResultAfterComplaintResponse(Submission submission, Result oldResult, List<Feedback> feedbacks, String assessmentNoteText) {
         Result newResult = new Result();
         setExerciseIdFromSubmission(submission, newResult);
+        // Set before the first save below: copyFeedbackToResult saves the result, and the result owns the foreign key
+        // to its submission, so leaving it for copyResultContentAndAddToSubmission would insert a result without one.
+        newResult.setSubmission(submission);
         updateAssessmentNoteAfterComplaintResponse(newResult, assessmentNoteText, submission.getLatestResult().getAssessor());
         copyFeedbackToResult(newResult, feedbacks);
         newResult = copyResultContentAndAddToSubmission(submission, newResult, oldResult);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/build/BuildLogEntry.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/build/BuildLogEntry.java
@@ -5,6 +5,7 @@ import java.time.ZonedDateTime;
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingSubmission;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
@@ -33,6 +34,7 @@ public class BuildLogEntry extends DomainObject {
 
     @ManyToOne
     @JsonIgnore
+    @JoinColumn(nullable = false)
     private ProgrammingSubmission programmingSubmission;
 
     public BuildLogEntry(ZonedDateTime time, String log) {

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizSubmissionService.java
@@ -169,8 +169,10 @@ public class QuizSubmissionService extends AbstractQuizSubmissionService<QuizSub
         quizSubmission.addResult(result);
         quizSubmission.setParticipation(participation);
 
-        quizSubmissionRepository.save(quizSubmission);
+        // Save the result before the submission. The submission holds it in a collection that cascades, so saving the
+        // submission while the result is still unsaved would let the cascade write one row and this save another.
         result = resultRepository.save(result);
+        quizSubmissionRepository.save(quizSubmission);
 
         // Update the quiz statistics asynchronously: statistics are only relevant for instructors, so the student must
         // not wait for them. Previously this ran a full recalculation synchronously, iterating every participation of

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/service/QuizSubmissionService.java
@@ -161,21 +161,16 @@ public class QuizSubmissionService extends AbstractQuizSubmissionService<QuizSub
         result.setRated(false);
         result.setAssessmentType(AssessmentType.AUTOMATIC);
         result.setCompletionDate(ZonedDateTime.now());
-        // save result
-        result = resultRepository.save(result);
-
-        // setup result - submission relation
+        // The result owns the foreign key to its submission, so it is set before the result is written. This used to
+        // save the result first and attach the submission afterwards, which stored a result without a submission.
         result.setSubmission(quizSubmission);
         // calculate score and update result accordingly
         result.evaluateQuizSubmission(quizExercise);
         quizSubmission.addResult(result);
         quizSubmission.setParticipation(participation);
 
-        // save submission to set result index column
         quizSubmissionRepository.save(quizSubmission);
-
-        // save result to store score
-        resultRepository.save(result);
+        result = resultRepository.save(result);
 
         // Update the quiz statistics asynchronously: statistics are only relevant for instructors, so the student must
         // not wait for them. Previously this ran a full recalculation synchronously, iterating every participation of

--- a/src/main/resources/config/liquibase/changelog/20260827090000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260827090000_changelog.xml
@@ -24,11 +24,18 @@
         removing one belongs in the exam deletion service, not in a changelog. An exam without a course cannot be
         created through the application, so the expectation is that the precondition simply passes.
 
-        Four further columns were considered and left out. feedback.result_id, lecture.course_id, exercise_group.exam_id
-        and grading_criterion.exercise_id are all held by their parent in a mapped-by collection that cascades, and
-        Hibernate inserts such a child before it writes the key, filling it in with a later update. That is invisible
-        while the column allows null and fails immediately once it does not. Requiring these columns means giving every
-        place that adds to one of those collections the back reference first, which is a change of its own.
+        Three further columns were tried and left out. feedback.result_id, exercise_group.exam_id and
+        grading_criterion.exercise_id are held by their parent in a mapped-by collection that cascades, and Hibernate
+        inserts such a child before it writes the key, filling it in with a later update. That is invisible while the
+        column allows null and fails immediately once it does not. Requiring these columns means giving every place that
+        adds to one of those collections the back reference first, the way Submission.addResult now does, which is a
+        change of its own. Around fifty owning associations sit behind a cascading collection like this, so the same
+        applies well beyond the three.
+
+        lecture.course_id was tried too and fails for a different reason: two tests write a lecture without a course on
+        purpose to check that the attachment endpoints reject it, and a course fixture nulls the column so it can save
+        the lecture early and read its id. Nothing in the mapping stands in the way, so this one only needs those three
+        places reworked.
 
         submission.participation_id is left out as well: an example submission is stored as a submission without a
         participation, so that column can only be required once example submissions have their own participation.

--- a/src/main/resources/config/liquibase/changelog/20260827090000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260827090000_changelog.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        Require the parent of a row to be set.
+
+        Every one of these columns already has a foreign key with ON DELETE RESTRICT, so no row can point at a parent
+        that was deleted: the delete fails instead. The only way a row without a parent comes about is the column being
+        null, which is what these constraints rule out from now on. A row without a parent carries no meaning for any of
+        them: a result nobody can attribute to a student, a complaint about nothing, a build log of no submission, a
+        grade step outside a scale.
+
+        Each column is handled by its own pair of changesets, one clearing the rows that have no parent and one adding
+        the constraint, so a single column can be left out without touching the rest.
+
+        The constraint changesets are guarded by a precondition that no such row is left. Adding a not-null constraint to
+        a column that still holds a null fails, and a failing changeset stops the application from starting, which is a
+        far worse outcome than the column staying nullable. With the guard the changeset is marked as run and the server
+        comes up; the column then needs a look and a changelog of its own.
+
+        Rows are only deleted where their own dependants can be cleared along with them. exam.course_id is therefore
+        left as it is: an exam is reachable through exercise groups, student exams, grading scales and exam users, and
+        removing one belongs in the exam deletion service, not in a changelog. An exam without a course cannot be
+        created through the application, so the expectation is that the precondition simply passes.
+
+        Four further columns were considered and left out. feedback.result_id, lecture.course_id, exercise_group.exam_id
+        and grading_criterion.exercise_id are all held by their parent in a mapped-by collection that cascades, and
+        Hibernate inserts such a child before it writes the key, filling it in with a later update. That is invisible
+        while the column allows null and fails immediately once it does not. Requiring these columns means giving every
+        place that adds to one of those collections the back reference first, which is a change of its own.
+
+        submission.participation_id is left out as well: an example submission is stored as a submission without a
+        participation, so that column can only be required once example submissions have their own participation.
+
+        participation.exercise_id is left out too, and for a different reason. A programming exercise points at its
+        template and solution participation through exercise.template_participation_id and
+        exercise.solution_participation_id, so for those two the foreign key runs the other way and they carry no
+        exercise of their own. Requiring the column would delete the template and solution participation of every
+        programming exercise.
+    -->
+
+    <changeSet id="20260827090000-01-delete-results-without-submission" author="krusche">
+        <comment>Remove results that belong to no submission, along with everything that hangs off them.</comment>
+        <sql>
+            DELETE FROM long_feedback_text WHERE feedback_id IN (SELECT id FROM feedback WHERE result_id IN (SELECT id FROM result WHERE submission_id IS NULL));
+            DELETE FROM text_block WHERE feedback_id IN (SELECT id FROM feedback WHERE result_id IN (SELECT id FROM result WHERE submission_id IS NULL));
+            DELETE FROM feedback WHERE result_id IN (SELECT id FROM result WHERE submission_id IS NULL);
+            DELETE FROM result_rating WHERE result_id IN (SELECT id FROM result WHERE submission_id IS NULL);
+            DELETE FROM assessment_note WHERE result_id IN (SELECT id FROM result WHERE submission_id IS NULL);
+            DELETE FROM complaint_response WHERE complaint_id IN (SELECT id FROM complaint WHERE result_id IN (SELECT id FROM result WHERE submission_id IS NULL));
+            DELETE FROM complaint WHERE result_id IN (SELECT id FROM result WHERE submission_id IS NULL);
+            UPDATE participant_score SET last_result_id = NULL WHERE last_result_id IN (SELECT id FROM result WHERE submission_id IS NULL);
+            UPDATE participant_score SET last_rated_result_id = NULL WHERE last_rated_result_id IN (SELECT id FROM result WHERE submission_id IS NULL);
+            UPDATE build_job SET result_id = NULL WHERE result_id IN (SELECT id FROM result WHERE submission_id IS NULL);
+            DELETE FROM result WHERE submission_id IS NULL;
+        </sql>
+    </changeSet>
+    <changeSet id="20260827090000-02-result-submission-not-null" author="krusche">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM result WHERE submission_id IS NULL</sqlCheck>
+        </preConditions>
+        <addNotNullConstraint tableName="result" columnName="submission_id" columnDataType="bigint"/>
+    </changeSet>
+
+    <changeSet id="20260827090000-03-delete-complaints-without-result" author="krusche">
+        <comment>Remove complaints that are about no result, along with their responses.</comment>
+        <sql>
+            DELETE FROM complaint_response WHERE complaint_id IN (SELECT id FROM complaint WHERE result_id IS NULL);
+            DELETE FROM complaint WHERE result_id IS NULL;
+        </sql>
+    </changeSet>
+    <changeSet id="20260827090000-04-complaint-result-not-null" author="krusche">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM complaint WHERE result_id IS NULL</sqlCheck>
+        </preConditions>
+        <addNotNullConstraint tableName="complaint" columnName="result_id" columnDataType="bigint"/>
+    </changeSet>
+
+    <changeSet id="20260827090000-05-delete-complaint-responses-without-complaint" author="krusche">
+        <delete tableName="complaint_response">
+            <where>complaint_id IS NULL</where>
+        </delete>
+    </changeSet>
+    <changeSet id="20260827090000-06-complaint-response-complaint-not-null" author="krusche">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM complaint_response WHERE complaint_id IS NULL</sqlCheck>
+        </preConditions>
+        <addNotNullConstraint tableName="complaint_response" columnName="complaint_id" columnDataType="bigint"/>
+    </changeSet>
+
+    <changeSet id="20260827090000-07-delete-build-logs-without-submission" author="krusche">
+        <delete tableName="build_log_entry">
+            <where>programming_submission_id IS NULL</where>
+        </delete>
+    </changeSet>
+    <changeSet id="20260827090000-08-build-log-entry-submission-not-null" author="krusche">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM build_log_entry WHERE programming_submission_id IS NULL</sqlCheck>
+        </preConditions>
+        <addNotNullConstraint tableName="build_log_entry" columnName="programming_submission_id" columnDataType="bigint"/>
+    </changeSet>
+
+    <changeSet id="20260827090000-09-delete-assessment-notes-without-result" author="krusche">
+        <delete tableName="assessment_note">
+            <where>result_id IS NULL</where>
+        </delete>
+    </changeSet>
+    <changeSet id="20260827090000-10-assessment-note-result-not-null" author="krusche">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM assessment_note WHERE result_id IS NULL</sqlCheck>
+        </preConditions>
+        <addNotNullConstraint tableName="assessment_note" columnName="result_id" columnDataType="bigint"/>
+    </changeSet>
+
+    <changeSet id="20260827090000-11-delete-grade-steps-without-scale" author="krusche">
+        <delete tableName="grade_step">
+            <where>grading_scale_id IS NULL</where>
+        </delete>
+    </changeSet>
+    <changeSet id="20260827090000-12-grade-step-scale-not-null" author="krusche">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM grade_step WHERE grading_scale_id IS NULL</sqlCheck>
+        </preConditions>
+        <addNotNullConstraint tableName="grade_step" columnName="grading_scale_id" columnDataType="bigint"/>
+    </changeSet>
+
+    <changeSet id="20260827090000-13-exam-course-not-null" author="krusche">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM exam WHERE course_id IS NULL</sqlCheck>
+        </preConditions>
+        <addNotNullConstraint tableName="exam" columnName="course_id" columnDataType="bigint"/>
+    </changeSet>
+
+    <changeSet id="20260827090000-14-delete-conversation-participants-without-conversation" author="krusche">
+        <delete tableName="conversation_participant">
+            <where>conversation_id IS NULL</where>
+        </delete>
+    </changeSet>
+    <changeSet id="20260827090000-15-conversation-participant-conversation-not-null" author="krusche">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM conversation_participant WHERE conversation_id IS NULL</sqlCheck>
+        </preConditions>
+        <addNotNullConstraint tableName="conversation_participant" columnName="conversation_id" columnDataType="bigint"/>
+    </changeSet>
+
+    <changeSet id="20260827090000-16-delete-answer-posts-without-post" author="krusche">
+        <comment>Remove answers that belong to no post, along with the reactions to them.</comment>
+        <sql>
+            DELETE FROM reaction WHERE answer_post_id IN (SELECT id FROM answer_post WHERE post_id IS NULL);
+            DELETE FROM answer_post WHERE post_id IS NULL;
+        </sql>
+    </changeSet>
+    <changeSet id="20260827090000-17-answer-post-post-not-null" author="krusche">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM answer_post WHERE post_id IS NULL</sqlCheck>
+        </preConditions>
+        <addNotNullConstraint tableName="answer_post" columnName="post_id" columnDataType="bigint"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -55,6 +55,7 @@
     <include file="classpath:config/liquibase/changelog/20260825120000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260825165553_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260825170000_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20260827090000_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command "date '+%Y%m%d%H%M%S'" to get the current date and time in the correct format -->

--- a/src/test/java/de/tum/cit/aet/artemis/core/CleanupIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/CleanupIntegrationTest.java
@@ -189,8 +189,11 @@ class CleanupIntegrationTest extends AbstractSpringIntegrationJenkinsLocalVCTest
         orphanTeamScore.setExercise(oldExercise);
         orphanTeamScore = teamScoreRepository.save(orphanTeamScore);
 
+        // A result always belongs to a submission, so an orphan result is one whose submission has no participation.
+        var submissionWithoutParticipation = submissionRepository.save(new TextSubmission());
         var orphanResult = new Result();
         orphanResult.setExerciseId(oldExercise.getId());
+        orphanResult.setSubmission(submissionWithoutParticipation);
         orphanResult = resultRepository.save(orphanResult);
 
         orphanFeedback.setResult(orphanResult);

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/SubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/SubmissionIntegrationTest.java
@@ -68,12 +68,12 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentBatc
         submission = submissionRepository.save(submission);
 
         Result result1 = new Result().assessmentType(assessmentType).score(100D).rated(true).exerciseId(textExercise.getId());
-        result1 = resultRepository.save(result1);
         result1.setSubmission(submission);
+        result1 = resultRepository.save(result1);
 
         Result result2 = new Result().assessmentType(assessmentType).score(200D).rated(true).exerciseId(textExercise.getId());
-        result2 = resultRepository.save(result2);
         result2.setSubmission(submission);
+        result2 = resultRepository.save(result2);
 
         submission.addResult(result1);
         submission.addResult(result2);
@@ -96,15 +96,15 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentBatc
         submission = submissionRepository.save(submission);
 
         Result result1 = new Result().assessmentType(assessmentType).score(100D).rated(true).exerciseId(textExercise.getId());
-        result1 = resultRepository.save(result1);
         result1.setSubmission(submission);
+        result1 = resultRepository.save(result1);
 
         submission.addResult(result1);
         submission = submissionRepository.save(submission);
 
         Result result2 = new Result().assessmentType(assessmentType).score(200D).rated(true).exerciseId(textExercise.getId());
-        result2 = resultRepository.save(result2);
         result2.setSubmission(submission);
+        result2 = resultRepository.save(result2);
 
         submission.addResult(result2);
         submission = submissionRepository.save(submission);
@@ -126,15 +126,15 @@ class SubmissionIntegrationTest extends AbstractSpringIntegrationIndependentBatc
         submission = submissionRepository.save(submission);
 
         Result result1 = new Result().assessmentType(assessmentType).score(100D).rated(true).exerciseId(textExercise.getId());
-        result1 = resultRepository.save(result1);
         result1.setSubmission(submission);
+        result1 = resultRepository.save(result1);
 
         submission.addResult(result1);
         submission = submissionRepository.save(submission);
 
         Result result2 = new Result().assessmentType(assessmentType).score(200D).rated(true).exerciseId(textExercise.getId());
-        result2 = resultRepository.save(result2);
         result2.setSubmission(submission);
+        result2 = resultRepository.save(result2);
 
         submission.addResult(result2);
         submission = submissionRepository.save(submission);

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/SubmissionServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/SubmissionServiceTest.java
@@ -694,8 +694,11 @@ class SubmissionServiceTest extends AbstractSpringIntegrationIndependentBatchTes
         oldResult.setExerciseId(examTextExercise.getId());
         oldResult.setFeedbacks(oldFeedbacks);
 
+        // Copying the feedback saves the new result, so it needs the submission it belongs to.
+        Submission submission = participationUtilService.addSubmission(examTextExercise, new TextSubmission(), TEST_PREFIX + "student1");
         Result newResult = new Result();
         newResult.setExerciseId(examTextExercise.getId());
+        newResult.setSubmission(submission);
 
         Set<Feedback> newFeedbacks = submissionService.copyFeedbackToNewResult(newResult, oldResult);
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingAssessmentIntegrationTest.java
@@ -566,6 +566,7 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         var result = new Result().feedbacks(List.of(manualLongFeedback)).score(0.0);
         result.setRated(true);
         result.setExerciseId(programmingExercise.getId());
+        result.setSubmission(programmingSubmission);
         result = resultRepository.save(result);
 
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -587,6 +588,7 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         manualLongFeedback.setDetailText(longText);
         var result = new Result().feedbacks(List.of(manualLongFeedback)).score(0.0).rated(true);
         result.setExerciseId(programmingExercise.getId());
+        result.setSubmission(programmingSubmission);
         result = resultRepository.save(result);
 
         var newLongText = "def".repeat(5000);
@@ -952,10 +954,10 @@ class ProgrammingAssessmentIntegrationTest extends AbstractProgrammingIntegratio
         initialResult.setHasComplaint(true);
         initialResult.setAssessmentType(AssessmentType.SEMI_AUTOMATIC);
         initialResult.setExerciseId(programmingExercise.getId());
+        initialResult.setSubmission(programmingSubmission);
         initialResult = resultRepository.save(initialResult);
 
         programmingSubmission.addResult(initialResult);
-        initialResult.setSubmission(programmingSubmission);
         programmingSubmission = submissionRepository.save(programmingSubmission);
 
         // complaining

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseParticipationIntegrationTest.java
@@ -617,14 +617,9 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractProgrammin
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void testGetLatestPendingSubmissionIfNotExists_student() throws Exception {
-        // Submission has a result, therefore not considered pending.
-
-        Result result = new Result();
-        result.setExerciseId(programmingExercise.getId());
-        result = resultRepository.save(result);
+        // The submission has no result yet and its submission date is old enough, so it counts as pending.
         ProgrammingSubmission submission = (ProgrammingSubmission) new ProgrammingSubmission().submissionDate(ZonedDateTime.now().minusSeconds(61L));
         submission = programmingExerciseUtilService.addProgrammingSubmission(programmingExercise, submission, TEST_PREFIX + "student1");
-        submission.addResult(result);
         Submission returnedSubmission = request.getNullable(participationsBaseUrl + submission.getParticipation().getId() + "/latest-pending-submission", HttpStatus.OK,
                 ProgrammingSubmission.class);
         assertThat(returnedSubmission).isEqualTo(submission);
@@ -633,13 +628,9 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractProgrammin
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void testGetLatestPendingSubmissionIfNotExists_ta() throws Exception {
-        // Submission has a result, therefore not considered pending.
-        Result result = new Result();
-        result.setExerciseId(programmingExercise.getId());
-        result = resultRepository.save(result);
+        // The submission has no result yet and its submission date is old enough, so it counts as pending.
         ProgrammingSubmission submission = (ProgrammingSubmission) new ProgrammingSubmission().submissionDate(ZonedDateTime.now().minusSeconds(61L));
         submission = programmingExerciseUtilService.addProgrammingSubmission(programmingExercise, submission, TEST_PREFIX + "student1");
-        submission.addResult(result);
         Submission returnedSubmission = request.getNullable(participationsBaseUrl + submission.getParticipation().getId() + "/latest-pending-submission", HttpStatus.OK,
                 ProgrammingSubmission.class);
         assertThat(returnedSubmission).isEqualTo(submission);
@@ -648,13 +639,9 @@ class ProgrammingExerciseParticipationIntegrationTest extends AbstractProgrammin
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testGetLatestPendingSubmissionIfNotExists_instructor() throws Exception {
-        // Submission has a result, therefore not considered pending.
-        Result result = new Result();
-        result.setExerciseId(programmingExercise.getId());
-        result = resultRepository.save(result);
+        // The submission has no result yet and its submission date is old enough, so it counts as pending.
         ProgrammingSubmission submission = (ProgrammingSubmission) new ProgrammingSubmission().submissionDate(ZonedDateTime.now().minusSeconds(61L));
         submission = programmingExerciseUtilService.addProgrammingSubmission(programmingExercise, submission, TEST_PREFIX + "student1");
-        submission.addResult(result);
         Submission returnedSubmission = request.getNullable(participationsBaseUrl + submission.getParticipation().getId() + "/latest-pending-submission", HttpStatus.OK,
                 ProgrammingSubmission.class);
         assertThat(returnedSubmission).isEqualTo(submission);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseUtilService.java
@@ -940,15 +940,14 @@ public class ProgrammingExerciseUtilService {
     public Result addTemplateSubmissionWithResult(ProgrammingExercise programmingExercise) {
         var templateParticipation = programmingExercise.getTemplateParticipation();
         ProgrammingSubmission submission = new ProgrammingSubmission();
+        submission.setParticipation(templateParticipation);
+        templateParticipation.addSubmission(submission);
         submission = submissionRepository.save(submission);
-        // TODO check if it needs to be persisted like before
         Result result = new Result();
         result.setExerciseId(programmingExercise.getId());
-        templateParticipation.addSubmission(submission);
-        submission.setParticipation(templateParticipation);
+        // Adding the result to the submission also gives it the back reference it is written with, so one save is
+        // enough. Saving the submission again here would let the cascade write a second result for the same submission.
         submission.addResult(result);
-        submission = submissionRepository.save(submission);
-        result.setSubmission(submission);
         result = resultRepo.save(result);
         templateProgrammingExerciseParticipationTestRepo.save(templateParticipation);
         return result;
@@ -962,19 +961,18 @@ public class ProgrammingExerciseUtilService {
      * @return the newly created result
      */
     public Result addSolutionSubmissionWithResult(ProgrammingExercise programmingExercise) {
-        var templateParticipation = programmingExercise.getSolutionParticipation();
+        var solutionParticipation = programmingExercise.getSolutionParticipation();
         ProgrammingSubmission submission = new ProgrammingSubmission();
+        submission.setParticipation(solutionParticipation);
+        solutionParticipation.addSubmission(submission);
         submission = submissionRepository.save(submission);
         Result result = new Result();
         result.setExerciseId(programmingExercise.getId());
-        templateParticipation.addSubmission(submission);
-        submission.setParticipation(templateParticipation);
+        // Adding the result to the submission also gives it the back reference it is written with, so one save is
+        // enough. Saving the submission again here would let the cascade write a second result for the same submission.
         submission.addResult(result);
-        submission = submissionRepository.save(submission);
-        result.setSubmission(submission);
-
         result = resultRepo.save(result);
-        solutionProgrammingExerciseParticipationRepository.save(templateParticipation);
+        solutionProgrammingExerciseParticipationRepository.save(solutionParticipation);
         return result;
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/quiz/QuizSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/quiz/QuizSubmissionIntegrationTest.java
@@ -38,6 +38,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.assessment.domain.Result;
+import de.tum.cit.aet.artemis.assessment.test_repository.ResultTestRepository;
 import de.tum.cit.aet.artemis.core.config.Constants;
 import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.exam.domain.ExerciseGroup;
@@ -99,6 +100,9 @@ class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Autowired
     private QuizSubmissionTestRepository quizSubmissionTestRepository;
+
+    @Autowired
+    private ResultTestRepository resultTestRepository;
 
     @Autowired
     private ParticipationTestRepository participationRepository;
@@ -394,6 +398,9 @@ class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationIndependent
         // all submission are saved to the database
         assertThat(quizSubmissionTestRepository.findByParticipation_Exercise_Id(quizExercise.getId())).hasSize(NUMBER_OF_STUDENTS);
         assertThat(participationRepository.findByExerciseId(quizExercise.getId())).hasSize(NUMBER_OF_STUDENTS);
+        // exactly one result per submission: the submission is saved with the result already attached, so the cascade
+        // and the explicit save of the result must not each write a row of their own
+        assertThat(resultTestRepository.findAllBySubmissionParticipationExerciseId(quizExercise.getId())).hasSize(NUMBER_OF_STUDENTS);
 
         // update the statistics
         QuizExercise quizExerciseWithStatistic = quizExerciseTestRepository.findByIdWithQuestionsAndStatisticsElseThrow(quizExercise.getId());


### PR DESCRIPTION
### Summary

Nine foreign key columns whose parent is conceptually mandatory allowed `NULL`, so the database accepted rows nobody
can attribute to anything: a result belonging to no submission, a complaint about no result, a build log of no
submission, a grade step outside a grading scale. This adds the missing not-null constraints, and removes the five
places in the server that deliberately wrote such a row.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context

Artemis has an admin job that sweeps up rows without a parent (Administration > Cleanup > Orphans). The job exists
because the schema lets those rows be written in the first place. Most of the columns involved are only nullable
because the original JHipster generator made every association optional, and the code then grew a set of workarounds
that wrote a row without its parent on purpose.

The workarounds all come from the same place. While a result held its feedback in an ordered list and a submission held
its results in one, Hibernate renumbered the order column on every write, and the way around the resulting save-order
problems was to cut the link to the parent, save, and put the link back. Those ordered lists are gone (#13570), so the
detours are no longer needed, and with them gone the columns can require a value.

This picks up the schema part of #11902, which was closed in January without being merged.

### Description

**Constraints added.** One changelog, one pair of changesets per column: one clearing the rows that have no parent,
one adding the constraint.

| Column | Parent |
|---|---|
| `result.submission_id` | submission |
| `complaint.result_id` | result |
| `complaint_response.complaint_id` | complaint |
| `build_log_entry.programming_submission_id` | programming submission |
| `assessment_note.result_id` | result |
| `grade_step.grading_scale_id` | grading scale |
| `exam.course_id` | course |
| `conversation_participant.conversation_id` | conversation |
| `answer_post.post_id` | post |

`Result.assessmentNote` already declared `nullable = false` on the mapping; only the column did not have it. The other
eight entities now say so as well, so the mapping and the schema agree.

**Rows are only removed where their own dependants can go with them.** All of these foreign keys are
`ON DELETE RESTRICT`, so deleting a parent-less row fails if anything still points at it. The changelog therefore
deletes in dependency order: for a result, its long feedback texts, text blocks, feedback, ratings, assessment note and
complaints go first, and the participant scores and build jobs that reference it are detached. `exam.course_id` gets no
delete at all: an exam is reachable through exercise groups, student exams, grading scales and exam users, and removing
one belongs in the exam deletion service, not in a changelog.

**Every constraint changeset is guarded.** Adding a not-null constraint to a column that still holds a `NULL` fails,
and a failing changeset stops Artemis from starting. Each one is preceded by a precondition that no such row is left,
with `onFail="MARK_RAN"`, so in the worst case the column stays nullable and the server comes up.

**Server changes.** Five paths wrote a row without a parent and no longer do:

- `ExamQuizService` set the result's submission to `null` before saving it and restored it afterwards.
- `ExerciseImportService` did the same when copying an example result.
- `ResultService` detached each feedback from its result before saving it.
- `QuizSubmissionService.submitForPractice` saved the result first and attached the submission afterwards.
- `SubmissionService` created the result for a second correction round and for an accepted complaint before giving it
  its submission, and the feedback copy in between saves the result.

`Submission.addResult` now sets the result's back reference. The results are mapped on the inverse side and cascade, so
without it Hibernate inserted a cascaded result with an empty `submission_id` and filled it in with a later update,
which the constraint rightly rejects.

That has a consequence worth calling out for reviewers. Once the back reference is set, saving the submission while the
result is still unsaved makes the cascade write a row of its own, and a later save of the same result object writes a
second one, because a submission that already exists is merged rather than persisted and the merge fills in the id on a
copy. `submitForPractice` did exactly that and produced two results per practice quiz submission. The result is now
saved before the submission, and `QuizSubmissionIntegrationTest.testQuizSubmitPractice` asserts the row count so the
mistake cannot come back unnoticed. Every other place that adds a result to a submission was checked: they either save
the result first or the submission is new, in which case the cascade persists the very object that is saved again.

Removing the lock on a complaint used to save the complaint response with its complaint set to `null` before deleting
it, leaving a row without a parent for the length of one statement. It now deletes the row directly, through a bulk
query for the same reason the sibling delete in `ComplaintResponseRepository` uses one: loading the response pulls in
its complaint, and the still-managed complaint's inverse association would then point at the removed row.

**Columns considered and left out.** `feedback.result_id`, `exercise_group.exam_id` and `grading_criterion.exercise_id`
are held by their parent in a `mappedBy` collection that cascades. Hibernate inserts such a child before it writes the
key and fills it in with a later update, which is invisible while the column allows `NULL` and fails at once when it
does not. Requiring them means giving every place that adds to one of those collections the back reference first, plus
the save-order review described above. Around fifty owning associations sit behind a cascading collection, so this
applies well beyond the three.

`lecture.course_id` was tried as well and fails for a different reason, worth recording because the mapping does not
stand in the way at all: `Course.lectures` has no cascade. What breaks is a course fixture that nulls the column so it
can save the lecture early and read its id, and two tests that store a lecture without a course on purpose to check that
the attachment endpoints answer `400`. The constraint makes that state unreachable, so those tests and the branches they
cover need a decision of their own.

`submission.participation_id` stays nullable because an example submission is stored as a submission without a
participation. It can follow once example submissions have their own participation.

`participation.exercise_id` stays nullable for a different reason, and it is worth recording because #11902 would have
deleted the rows: a programming exercise points at its template and solution participation through
`exercise.template_participation_id` and `exercise.solution_participation_id`, so for those two the foreign key runs the
other way and they hold no exercise of their own. Requiring the column would delete the template and solution
participation of every programming exercise.

### Steps for Testing

CI covers PostgreSQL only, so the changelog was also run against MySQL 9 by hand, twice. Once against an empty database,
where the whole changelog applies. Once against a database built from the changelog up to the previous changeset, seeded
with a result that has no submission plus its long feedback text, text block, feedback, rating, assessment note,
complaint and complaint response, a participant score and a build job pointing at it, and one parent-less row for each
of the other eight columns. With foreign key checks on, the migration removed the orphans and their dependants without a
single foreign key error, kept the participant score and the build job while nulling their references to the deleted
result, and left an exam without a course untouched: its constraint was skipped by the precondition and `exam.course_id`
stayed nullable, which is exactly the outcome that keeps a server with unexpected data starting up.

The change is a schema and persistence one with no user-facing surface, so the rest of the interest is that nothing
broke.

Prerequisites:
- 1 Instructor, 1 Tutor, 2 Students
- 1 Course with a text exercise and a quiz, and 1 exam with two correction rounds

1. Start Artemis against a database with existing data and confirm the changelog applies and the server comes up.
2. As a student, participate in the quiz in practice mode. Confirm a score is shown.
3. As a student, submit the text exercise. As a tutor, assess it, then complain as the student and accept the complaint
   as the tutor. Confirm the new result appears with the copied feedback.
4. As an instructor, import the text exercise including its example submissions. Confirm the example results came over.
5. Run a programming exercise build and open the build logs of the submission.
6. As a tutor, take the lock on a complaint, let it run out, and take it again as another tutor.
7. As an admin, open Administration > Cleanup and run the orphan count. Confirm it reports no results without a parent.

#### Exam Mode Testing

Prerequisites:
- 1 Instructor, 2 Tutors, 2 Students
- 1 Exam with a text exercise and a quiz, two correction rounds

1. As students, participate in and submit the exam.
2. Assess every submission in the first correction round, then in the second.
3. Confirm the second round starts from the first round's feedback and that both rounds show up in the assessment
   dashboard and in the exam scores.
4. Confirm the quiz was evaluated and the participation kept its attempt number and initialization date.

### Review Progress

#### Code Review
- [x] Code Review 1
#### Manual Tests
- [x] Test 1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence of assessment results and submissions, preventing missing associations and duplicate result records.
  * Strengthened relationship validation to prevent incomplete assessment, communication, exam, and programming records.
  * Improved complaint-response removal and refresh behavior.
  * Ensured feedback and copied results are saved with their correct submission associations.
* **Tests**
  * Expanded coverage for result persistence, orphan cleanup, pending submissions, complaint overrides, and practice quiz submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->