### PR TITLE
`Development`: Await the solution build before submitting in the programming e2e tests

### DIFF
--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseParticipation.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseParticipation.spec.ts
@@ -37,6 +37,12 @@ test.describe('Programming exercise basic submissions', { tag: '@slow' }, () => 
             test.beforeEach('Setup programming exercise', async ({ login, exerciseAPIRequests }) => {
                 await login(admin);
                 exercise = await exerciseAPIRequests.createProgrammingExercise({ course, programmingLanguage });
+                // Wait for the solution build before any student submission. Artemis creates an exercise's test cases only
+                // from the solution participation's build result (ProgrammingExerciseGradingService), and a student result
+                // graded before those exist falls through to the case that returns the result untouched - so its score stays
+                // at the placeholder 0 and nothing ever re-grades it. The C solution build takes ~70s because one template
+                // test runs to its own timeout, which is long enough for a ~12s student build to overtake it and assert 0%.
+                await exerciseAPIRequests.waitForSolutionBuild(exercise.id!);
             });
 
             test('Makes a submission using code editor', async ({ courseOverview, programmingExerciseOverview, programmingExerciseEditor }) => {
@@ -74,6 +80,12 @@ test.describe('Programming exercise basic submissions', { tag: '@slow' }, () => 
         test.beforeEach('Setup programming exercise', async ({ login, exerciseAPIRequests }) => {
             await login(admin);
             exercise = await exerciseAPIRequests.createProgrammingExercise({ course, programmingLanguage: ProgrammingLanguage.C });
+            // Wait for the solution build before any student submission. Artemis creates an exercise's test cases only
+            // from the solution participation's build result (ProgrammingExerciseGradingService), and a student result
+            // graded before those exist falls through to the case that returns the result untouched - so its score stays
+            // at the placeholder 0 and nothing ever re-grades it. The C solution build takes ~70s because one template
+            // test runs to its own timeout, which is long enough for a ~12s student build to overtake it and assert 0%.
+            await exerciseAPIRequests.waitForSolutionBuild(exercise.id!);
         });
 
         test('Re-renders the sidebar card (building then result) on a websocket result without reloading', async ({
@@ -133,6 +145,12 @@ test.describe('Programming exercise basic submissions', { tag: '@slow' }, () => 
         test.beforeEach('Setup programming exercise', async ({ login, exerciseAPIRequests }) => {
             await login(admin);
             exercise = await exerciseAPIRequests.createProgrammingExercise({ course, programmingLanguage: ProgrammingLanguage.C });
+            // Wait for the solution build before any student submission. Artemis creates an exercise's test cases only
+            // from the solution participation's build result (ProgrammingExerciseGradingService), and a student result
+            // graded before those exist falls through to the case that returns the result untouched - so its score stays
+            // at the placeholder 0 and nothing ever re-grades it. The C solution build takes ~70s because one template
+            // test runs to its own timeout, which is long enough for a ~12s student build to overtake it and assert 0%.
+            await exerciseAPIRequests.waitForSolutionBuild(exercise.id!);
         });
 
         test('Sidebar card leaves "Not yet started" right after starting (no reload)', async ({ page, login, courseOverview }) => {
@@ -163,6 +181,12 @@ test.describe('Programming exercise basic submissions', { tag: '@slow' }, () => 
         test.beforeEach('Setup programming exercise', async ({ login, exerciseAPIRequests }) => {
             await login(admin);
             exercise = await exerciseAPIRequests.createProgrammingExercise({ course, programmingLanguage: ProgrammingLanguage.C });
+            // Wait for the solution build before any student submission. Artemis creates an exercise's test cases only
+            // from the solution participation's build result (ProgrammingExerciseGradingService), and a student result
+            // graded before those exist falls through to the case that returns the result untouched - so its score stays
+            // at the placeholder 0 and nothing ever re-grades it. The C solution build takes ~70s because one template
+            // test runs to its own timeout, which is long enough for a ~12s student build to overtake it and assert 0%.
+            await exerciseAPIRequests.waitForSolutionBuild(exercise.id!);
         });
 
         test('Renders the result-only badge in the finished build jobs table', async ({ login, page, programmingExerciseOverview, programmingExerciseEditor }) => {
@@ -190,6 +214,12 @@ test.describe('Programming exercise advanced participation', { tag: '@slow' }, (
         test.beforeEach('Setup programming exercise', async ({ login, exerciseAPIRequests }) => {
             await login(admin);
             exercise = await exerciseAPIRequests.createProgrammingExercise({ course, programmingLanguage: ProgrammingLanguage.C });
+            // Wait for the solution build before any student submission. Artemis creates an exercise's test cases only
+            // from the solution participation's build result (ProgrammingExerciseGradingService), and a student result
+            // graded before those exist falls through to the case that returns the result untouched - so its score stays
+            // at the placeholder 0 and nothing ever re-grades it. The C solution build takes ~70s because one template
+            // test runs to its own timeout, which is long enough for a ~12s student build to overtake it and assert 0%.
+            await exerciseAPIRequests.waitForSolutionBuild(exercise.id!);
         });
 
         test('Makes a git submission through HTTPS using token', async ({ programmingExerciseOverview, waitForParticipationBuildToFinish }) => {
@@ -257,6 +287,12 @@ test.describe('Programming exercise advanced participation', { tag: '@slow' }, (
                 mode: ExerciseMode.TEAM,
                 teamAssignmentConfig,
             });
+            // Wait for the solution build before any team submission. Artemis creates an exercise's test cases only
+            // from the solution participation's build result (ProgrammingExerciseGradingService), and a student result
+            // graded before those exist falls through to the case that returns the result untouched - so its score stays
+            // at the placeholder 0 and nothing ever re-grades it. The C solution build takes ~70s because one template
+            // test runs to its own timeout, which is long enough for a ~12s team build to overtake it and assert 0%.
+            await exerciseAPIRequests.waitForSolutionBuild(exercise.id!);
         });
 
         test.beforeEach('Create an exercise team', async ({ login, userManagementAPIRequests, exerciseAPIRequests }) => {
@@ -384,6 +420,12 @@ test.describe('Programming exercise advanced participation', { tag: '@slow' }, (
         test.beforeEach('Setup programming exercise', async ({ login, exerciseAPIRequests }) => {
             await login(admin);
             exercise = await exerciseAPIRequests.createProgrammingExercise({ course, programmingLanguage: ProgrammingLanguage.C });
+            // Wait for the solution build before any student submission. Artemis creates an exercise's test cases only
+            // from the solution participation's build result (ProgrammingExerciseGradingService), and a student result
+            // graded before those exist falls through to the case that returns the result untouched - so its score stays
+            // at the placeholder 0 and nothing ever re-grades it. The C solution build takes ~70s because one template
+            // test runs to its own timeout, which is long enough for a ~12s student build to overtake it and assert 0%.
+            await exerciseAPIRequests.waitForSolutionBuild(exercise.id!);
         });
 
         test('Makes a git submission through HTTPS', async ({


### PR DESCRIPTION
### Summary

22 of the 41 real E2E failures on develop over the last ~20 runs are in `ProgrammingExerciseParticipation.spec.ts`, all of one shape: `Expected non-zero score but got 0% for participation N` or a `#result-score` that never leaves 0%.

**The builds are not failing.** Every queued job produced a result (204/204 and 218/218 in the two runs measured), no build exceeded 76s against a 120s `BUILD_RESULT_TIMEOUT`, build-slot utilisation is ~30%, and queue wait is p90 6.7s. A timeout increase would fix nothing — the UI displays the wrong score for the entire wait, so waiting longer cannot repair it.

### Root cause: a grading order race

Artemis creates an exercise's test cases **only** from the solution participation's build result — the extract call in `ProgrammingExerciseGradingService` is guarded by `participation instanceof SolutionProgrammingExerciseParticipation`.

A student result graded while that set is still empty satisfies neither case 1 (`!relevantTestCases.isEmpty()`) nor case 2 (`!testCases.isEmpty()`) of `calculateScoreForResult`, so it falls into case 3 — *"we just return the original result without changing it"*. The score keeps the placeholder `0` that `createResultFromBuildResult` assigned, and nothing re-grades it: `updateAllResults` is reachable only from the instructor re-evaluate endpoint and the due-date event.

The window is wide because one C template test runs to its own per-test timeout, making the solution build take ~70s while a student build takes ~12s. Raising that per-test timeout from 30s to 60s (#13488, 2026-08-18) roughly doubled the window, which matches when this cluster appeared.

The correlation is exact in the logs: in every failing instance the student result was processed **before** the solution result (deltas −0.8s to −41.6s, 12/12 with no counterexample); in the passing instances the order was reversed.

### The fix

`waitForSolutionBuild` already exists for precisely this reason — it polls `GET /test-cases` until non-empty and its docstring names the race — but it had a **single call site**, in `ProgrammingExerciseStaticCodeAnalysis.spec.ts`. This adds it to all seven exercise creations in this spec.

Coherence check: the SCA spec already calls it and still fails ~6 times, which is consistent with those failures having a different cause. They are out of scope here.

### The server-side defect, and why it is not fixed here

A student who submits before the solution build finishes keeps a permanent 0%. That is a genuine defect worth fixing, but **not** by re-grading later: `filterAutomaticFeedbacksWithoutTestCase` removes every feedback whose `testCase` is null — which is exactly the state feedback is left in when it is created against an empty test-case set — and `createFeedbackForNotExecutedTests` would then recompute 0. A naive re-grade repairs nothing and destroys the surviving evidence. It needs a name-based relink or an ordering guarantee, and its own PR.

### Steps for Testing

1. The E2E suite. `ProgrammingExerciseParticipation` must pass.
2. Worth repeating a few times: the point is reliability, and the pre-change failure rate for this spec was roughly one test per run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved programming exercise end-to-end test reliability by waiting for solution builds to complete before submissions are graded.
  * Added this readiness check across individual and team submission scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->