### PR TITLE
`Development`: Upload the playwright failure artifacts the e2e run already records

### DIFF
--- a/.github/actions/e2e-teardown/action.yml
+++ b/.github/actions/e2e-teardown/action.yml
@@ -38,6 +38,20 @@ runs:
         name: E2E Client Coverage Report${{ inputs.artifact-name-suffix && format(' {0}', inputs.artifact-name-suffix) || '' }}
         path: src/test/playwright/test-reports/client-coverage
 
+    - name: Upload Playwright Failure Artifacts
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: Playwright Failure Artifacts${{ inputs.artifact-name-suffix && format(' {0}', inputs.artifact-name-suffix) || '' }}
+        # playwright.config.ts records a trace and a video on the first retry, and Playwright writes an
+        # error-context.md beside them; all of it lands in test-results/ and was being deleted with the runner.
+        # Every investigation of an E2E failure so far has had to be reconstructed from interleaved container
+        # logs because the artifact that answers the question directly was never uploaded.
+        # Only failing and retried tests leave anything here, so on a green run this uploads nothing.
+        path: src/test/playwright/test-results
+        if-no-files-found: ignore
+        retention-days: 7
+
     - name: Run cleanup script (after E2E)
       shell: bash
       # Best-effort: tearing down containers/networks must not flip the E2E job result.


### PR DESCRIPTION
### Summary

`playwright.config.ts` records a trace and a video on the first retry (`trace: 'on-first-retry'`), and Playwright writes an `error-context.md` beside them. All of it lands in `src/test/playwright/test-results/`.

`.github/actions/e2e-teardown` uploads only `test-reports/*.xml` and the client coverage directory, so **the failure artifacts are deleted with the runner**.

### Why it matters

Every E2E flake investigation this month had to be reconstructed from ~80 MB of interleaved docker-compose logs, because the artifact that answers the question directly was already captured and then discarded. Twice a throwaway diagnostic commit had to be pushed to CI to recover information the run had in hand — for #13573 that cost two extra CI cycles.

### Cost

None on green runs: only failing and retried tests write to that directory, and `if-no-files-found: ignore` keeps the step silent. Retention is 7 days.

### Steps for Testing

1. Any E2E run with a failing or retried test should produce a `Playwright Failure Artifacts` artifact containing `trace.zip`, `video.webm` and `error-context.md`.
2. A fully green run should produce no such artifact and no warning.