### PR TITLE
`LocalVC`: Document the clone credential requirement for Hades

### DIFF
--- a/documentation/docs/admin/hades-setup.mdx
+++ b/documentation/docs/admin/hades-setup.mdx
@@ -51,6 +51,10 @@ artemis:
 You also still need `artemis.version-control` (LocalVC) configured, since builds are triggered against exercise repositories hosted there — see the
 `version-control` section in [Jenkins and LocalVC Setup](/admin/jenkins-localvc#artemis-configuration) for the relevant fields.
 
+The Hades clone container clones the exercise repositories from LocalVC over HTTPS using `artemis.version-control.build-agent-git-username` and `build-agent-git-password`.
+A Hades node runs the `localvc` and `hades` profiles (not `localci`), so - like a Jenkins-with-LocalVC setup - it authenticates clones with this shared credential pair rather than the per-build-job clone tokens that Integrated Code Lifecycle build agents use.
+Both must be set and `artemis.version-control.build-agent-use-ssh` must stay `false`: since [#13515](https://github.com/ls1intum/Artemis/pull/13515) the node refuses to start otherwise, and the password is what authorizes every Hades clone.
+
 In addition, you have to start Artemis with the profiles `hades` and `localvc` so that the correct adapters will be used, e.g.:
 
 ```


### PR DESCRIPTION
Follow-up doc note on `feature/hades-integration`.

After the develop merge (#13515), a Hades node authenticates its LocalVC clones with the shared `build-agent-git-username`/`build-agent-git-password` (like a Jenkins-with-LocalVC setup, since it runs `localvc,hades` not `localci`). Both must be set and `build-agent-use-ssh` must stay `false`, or the node refuses to start. This documents that in `hades-setup.mdx`.

The matching Helm-chart change (pinned Hades images + the same credential note) is in #13419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L3XaQ6aEF2kyw6Vqjt49m