### PR TITLE
`Development`: Log the status a build agent information publish actually stores

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentInformationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentInformationService.java
@@ -180,8 +180,17 @@ public class BuildAgentInformationService {
                 // Add/update
                 BuildAgentInformation info = getUpdatedLocalBuildAgentInformation(recentBuildJob, isPaused, isPausedDueToFailures, consecutiveFailures);
 
-                log.debug("Updating build agent info: key='{}', name='{}', memberAddress='{}', displayName='{}'", agentKey, info.buildAgent().name(),
-                        info.buildAgent().memberAddress(), info.buildAgent().displayName());
+                // The status is logged because it is the field this map is consulted for, and it was the one field this
+                // line omitted. Every caller passes the pause state in as an argument that it read before taking the
+                // lock, so a publish that was already in flight can carry a stale value and overwrite a pause another
+                // thread has just written. testBuildAgentPausesAfterConsecutiveFailures times out waiting for
+                // SELF_PAUSED in about 3 of 71 runs, and the run that was investigated made 1826 publishes through
+                // here - so an overwrite is entirely plausible and was impossible to confirm, because no log line said
+                // what any of those publishes actually stored.
+                log.debug(
+                        "Updating build agent info: key='{}', name='{}', memberAddress='{}', displayName='{}', status='{}', isPaused={}, isPausedDueToFailures={}, consecutiveFailures={}",
+                        agentKey, info.buildAgent().name(), info.buildAgent().memberAddress(), info.buildAgent().displayName(), info.status(), isPaused, isPausedDueToFailures,
+                        consecutiveFailures);
 
                 // Use the agent's short name as key for stable identification
                 distributedDataAccessService.getDistributedBuildAgentInformation().put(agentKey, info);


### PR DESCRIPTION
### Summary

`BuildAgentIntegrationTest.testBuildAgentPausesAfterConsecutiveFailures` times out waiting for the agent to reach `SELF_PAUSED` in roughly **3 of 71** runs. Why cannot currently be established from a failed run, and this closes that gap rather than guessing at a fix.

### The gap

Every caller of `updateLocalBuildAgentInformation` passes the pause state in as an argument **it read before the lock is taken**:

```java
buildAgentInformationService.updateLocalBuildAgentInformationWithRecentJob(finishedJob, isPaused.get(), ...);
```

The map write itself is correctly guarded by `lock(agentKey)` … `unlock(agentKey)`, but the *value* is already stale by then. So a publish that was in flight when another thread wrote a pause can overwrite it — which would explain the timeout exactly.

It is also **unconfirmed**, because the only debug line recording these publishes names the key, agent name, member address and display name — and not the status, the one field this map is consulted for. `grep 'info.status()'` in the service returns 0.

The investigated run (`develop` job 97734699919) made **1826 publishes** through that line, so the channel is enabled in CI and carries plenty of data; it simply omits the field that matters.

### The change

Adds the published `status` and the three pause-related arguments to that line. The next occurrence then shows directly whether a stale publish overwrote the pause, or whether the agent never reached the failure threshold at all.

### What this deliberately does not do

**It does not fix the suspected race.** Reading the pause state inside the lock instead of accepting it as an argument is a change to how cluster state is written, and the current evidence does not distinguish that cause from the alternative. Shipping it now would be a guess.

That restraint is deliberate: on the neighbouring C-template flake I twice implemented a plausible fix and twice had it disproved by baselining, and eight prior interventions on that cluster since 2021 show the cost of acting before the evidence is in. This is the same shape of contribution as #13583 — make the failure diagnosable first.

### Testing

`BuildAgentIntegrationTest` and the architecture rules: 75/75 green. `compileJava`, `checkstyleMain`, `spotlessApply` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved diagnostic logging for build agent updates, including status, pause state, and consecutive failure information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->