### PR TITLE
`Development`: Link the C sanitizer binaries non-PIE

### DIFF
--- a/src/main/resources/templates/c/gcc/exercise/Makefile
+++ b/src/main/resources/templates/c/gcc/exercise/Makefile
@@ -22,6 +22,19 @@ endif
 # -g					Generates debug information to be used by GDB debugger
 WFLAGS = -Wall -Wextra -Wpedantic -g
 
+# Flags that only the sanitizer targets (asan, ubsan, lsan) receive.
+# -fno-pie -no-pie  Link at a fixed low load address instead of a randomised one. GCC's address and
+#                   leak sanitizer runtimes reserve a fixed region at 0x600000000000 (96 TiB) for
+#                   their allocator, and a position-independent executable can be loaded inside it
+#                   on a host with vm.mmap_rnd_bits=32 (the kernel default since 6.5, so Ubuntu
+#                   24.04 among others). The sanitizer then dies before main() in an endless loop of
+#                   "AddressSanitizer:DEADLYSIGNAL" lines and never exits. A non-PIE executable is
+#                   loaded at 0x400000 and cannot collide. libsanitizer made the allocator base
+#                   dynamic in GCC 14, so these two flags are unnecessary with that or newer.
+#                   See https://github.com/google/sanitizers/issues/1614
+SANITIZER_FLAGS = -fno-pie -no-pie
+
+
 # Compile without sanitizers and disable optimisation
 # $(SOURCE): 	        Input file(s)
 # $(INCLUDEDIRS:%=-I%)  Include directories
@@ -45,7 +58,7 @@ helloWorld: FORCE
 # -fsanitize=address:	Address sanitizer
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 asan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=address
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=address
 
 # Compile with undefined behavior sanitizer enabled
 # $(SOURCE): 			Input file(s)
@@ -59,7 +72,7 @@ asan: FORCE
 # -fsanitize=undefined:	Fast undefined behavior check
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 ubsan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=undefined
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=undefined
 
 # Compile with leak sanitizer enabled
 # $(SOURCE): 		    Input file(s)
@@ -73,7 +86,7 @@ ubsan: FORCE
 # -fsanitize=leak	    Basic memory leak sanitizer
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 lsan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=leak
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=leak
 
 # Compile with GCC static analysis enabled
 # $(SOURCE): 			Input file(s)

--- a/src/main/resources/templates/c/gcc/solution/Makefile
+++ b/src/main/resources/templates/c/gcc/solution/Makefile
@@ -22,6 +22,19 @@ endif
 # -g					Generates debug information to be used by GDB debugger
 WFLAGS = -Wall -Wextra -Wpedantic -g
 
+# Flags that only the sanitizer targets (asan, ubsan, lsan) receive.
+# -fno-pie -no-pie  Link at a fixed low load address instead of a randomised one. GCC's address and
+#                   leak sanitizer runtimes reserve a fixed region at 0x600000000000 (96 TiB) for
+#                   their allocator, and a position-independent executable can be loaded inside it
+#                   on a host with vm.mmap_rnd_bits=32 (the kernel default since 6.5, so Ubuntu
+#                   24.04 among others). The sanitizer then dies before main() in an endless loop of
+#                   "AddressSanitizer:DEADLYSIGNAL" lines and never exits. A non-PIE executable is
+#                   loaded at 0x400000 and cannot collide. libsanitizer made the allocator base
+#                   dynamic in GCC 14, so these two flags are unnecessary with that or newer.
+#                   See https://github.com/google/sanitizers/issues/1614
+SANITIZER_FLAGS = -fno-pie -no-pie
+
+
 # Compile without sanitizers and disable optimisation
 # $(SOURCE): 	        Input file(s)
 # $(INCLUDEDIRS:%=-I%)  Include directories
@@ -45,7 +58,7 @@ helloWorld: FORCE
 # -fsanitize=address:	Address sanitizer
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 asan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=address
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=address
 
 # Compile with undefined behavior sanitizer enabled
 # $(SOURCE): 			Input file(s)
@@ -59,7 +72,7 @@ asan: FORCE
 # -fsanitize=undefined:	Fast undefined behavior check
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 ubsan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=undefined
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=undefined
 
 # Compile with leak sanitizer enabled
 # $(SOURCE): 		    Input file(s)
@@ -73,7 +86,7 @@ ubsan: FORCE
 # -fsanitize=leak	    Basic memory leak sanitizer
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 lsan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=leak
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=leak
 
 # Compile with GCC static analysis enabled
 # $(SOURCE): 			Input file(s)

--- a/src/main/resources/templates/c/gcc/test/Makefile
+++ b/src/main/resources/templates/c/gcc/test/Makefile
@@ -22,9 +22,25 @@ endif
 # -g					Generates debug information to be used by GDB debugger
 WFLAGS = -Wall -Wextra -Wpedantic -g
 
-# Disable malloc shadowing when building sanitizer binaries to avoid
-# conflicts with sanitizer allocator/runtime interception.
-SANITIZER_FLAGS = -DGBS_DISABLE_MALLOC_SHADOW
+# Flags that only the sanitizer targets (asan, ubsan, lsan) receive.
+# -DGBS_DISABLE_MALLOC_SHADOW  The tester's malloc shadow conflicts with the sanitizer allocator,
+#                              so the shadow leaves malloc alone in these builds.
+# -fno-pie -no-pie             Link at a fixed low load address instead of a randomised one. GCC's
+#                              address and leak sanitizer runtimes reserve a fixed 4 TiB region at
+#                              0x600000000000 (96 TiB) for their allocator, while a
+#                              position-independent executable is loaded at 0x555555554000
+#                              (85.33 TiB) plus up to ((2^vm.mmap_rnd_bits) - 1) << 12 bytes. On a
+#                              host with vm.mmap_rnd_bits=32 - the kernel default since 6.5, so
+#                              Ubuntu 24.04 among others - that offset reaches 16 TiB, which places
+#                              the executable inside the reserved region in roughly one run out of
+#                              four. The sanitizer then dies before main() in an endless loop of
+#                              "AddressSanitizer:DEADLYSIGNAL" lines, printing no report and never
+#                              exiting, which the tester can only report as a timeout. A non-PIE
+#                              executable is loaded at 0x400000 and cannot collide at any entropy
+#                              setting. libsanitizer made the allocator base dynamic in GCC 14; drop
+#                              these two flags once the build image ships that or newer.
+#                              See https://github.com/google/sanitizers/issues/1614
+SANITIZER_FLAGS = -DGBS_DISABLE_MALLOC_SHADOW -fno-pie -no-pie
 
 # Compile without sanitizers and disable optimisation
 # $(SOURCE): 	        Input file(s)


### PR DESCRIPTION
### Problem

`TestOutputASan [FAIL]: timeout` has been flaking in the C programming-exercise tests for years, on a
hello-world submission that is correct. It is the cause of the recurring reds in
`LocalCIDockerImageIntegrationTest > setupCExerciseWithGcc_usesConfiguredDockerImage()` and in the
static-code-analysis E2E tests. Eight earlier attempts, including two timeout increases, did not fix it,
because the fault is not in the submission, the tester, or the timeout.

GCC's address and leak sanitizer runtimes reserve a **fixed** 4 TiB region at `0x600000000000` (96 TiB)
for their allocator. A position-independent executable is loaded at `ELF_ET_DYN_BASE` = `0x555555554000`
(85.33 TiB) plus a random offset of up to `((2^vm.mmap_rnd_bits) - 1) << 12` bytes. With
`vm.mmap_rnd_bits=32` — the kernel default since 6.5, so Ubuntu 24.04 — that offset reaches 16 TiB, giving
a load base anywhere in [85.33 TiB, 101.33 TiB). The reserved region [96 TiB, 100 TiB) sits inside that
range, so the executable lands on top of the sanitizer's own allocator in roughly one run out of four.

When it does, the sanitizer dies before `main()` in an endless loop of bare
`AddressSanitizer:DEADLYSIGNAL` lines, prints no report and never exits, which the tester can only
report as a timeout. This is [google/sanitizers#1614](https://github.com/google/sanitizers/issues/1614);
libsanitizer made the allocator base dynamic in GCC 14, and the build image ships GCC 12.2.0.

It matches every observation: `TestOutputUBSan` has never flaked (UBSan reserves nothing), `TestOutputLSan`
flakes rarely (LSan reserves the same region), and nobody could reproduce it on an Apple-silicon machine —
under emulation the x86_64 guest is loaded at exactly `0x555555554000` with zero randomization, and on
arm64 the PIE base is ~187 TiB while the sanitizer regions end at 32 TiB, so arm64 is structurally immune.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Changes affecting Programming Exercises
- [x] I verified the change in the configured C build image (`ls1tum/artemis-c-minimal-docker:1.0.0`) on both `linux/amd64` and `linux/arm64`, with the template solution and with the `kill`-shadow submission the integration test uses.

### Description

Add `-fno-pie -no-pie` to `SANITIZER_FLAGS` in the C GCC test Makefile, which
`templates/phases/c/gcc.yaml` copies over the assignment Makefile on every build. The flag reaches only
the `asan`, `ubsan` and `lsan` targets; `helloWorld` and `staticAnalysis` keep PIE. A non-PIE executable
is loaded at a fixed `0x400000` and cannot intersect the reserved region at any entropy setting.

The exercise and solution Makefiles get the same two flags. They are overwritten by the test Makefile
during a build, so this changes nothing in CI — it only helps a student who runs `make asan` locally on a
recent kernel and hits the identical wall.

Tradeoff: the three sanitizer binaries lose ASLR. They run student code inside the build container, where
the container is the security boundary, and the non-sanitizer targets are unaffected.

### Steps for Testing

Measured in the configured build image (`ls1tum/artemis-c-minimal-docker:1.0.0`, Debian 12, GCC 12.2.0):

1. `readelf -h` on the built binaries: `asan.out`, `ubsan.out` and `lsan.out` change from
   `DYN` with a kernel-chosen base to `EXEC` with `first LOAD 0x0000000000400000`; `helloWorld.out` stays `DYN`.
2. `/proc/self/maps` from inside an ASan binary shows the reserved region beginning at `600000000000`,
   confirming the address the fix moves away from.
3. The full tester (`python3 Tests.py`) with the template solution: **8/8 SUCCESS** on `linux/amd64` and
   `linux/arm64`, before and after.
4. The full tester with the exact `kill`-shadow submission from
   `LocalCIDockerImageIntegrationTest`: **8/8 SUCCESS**, `TestOutputASan` in 1.17 s.
5. `make helloWorld|asan|ubsan|lsan|staticAnalysis` against the student-facing Makefile: all five build and
   print `Hello world!`.

The collision cannot be reproduced on an Apple-silicon host, for the reason given above, so the
confirmation that the flake is gone has to come from CI on the Ubuntu 24.04 runners.

### Follow-ups (not in this PR)

- Ask infra to set `vm.mmap_rnd_bits=28` on the runner fleet. That is the upstream-documented workaround
  and it would also cover the other sanitizer-using exercise images (fact, vhdl, assembler), which this
  Makefile change does not.
- Bump the C image to a GCC >= 14 base when it is next rebuilt; that is the real upstream fix. The
  Dockerfile is not in this repository.
- `TestResultXmlParser.extractMessage` prefers the bare `message="timeout"` over the `<failure>` body, which
  is why every occurrence so far was undiagnosable from the CI logs alone.

