### PR TITLE
`Programming exercises`: Do not lose a build job that starts while the agent is paused

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobManagementService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobManagementService.java
@@ -588,20 +588,24 @@ public class BuildJobManagementService {
      * Cancel the build job for the given buildJobId.
      *
      * @param buildJobId The id of the build job that should be cancelled.
+     * @return {@code true} if the job was still running and this call stopped it, {@code false} if there was nothing
+     *         left to stop because it had already finished or was never registered. A caller that puts cancelled
+     *         jobs back on the queue has to check this: re-queueing a job that finished on its own would run the
+     *         same build a second time.
      */
-    void cancelBuildJob(String buildJobId) {
+    boolean cancelBuildJob(String buildJobId) {
         Future<BuildResult> future = runningFutures.get(buildJobId);
-        if (future != null) {
-            try {
-                cancelledBuildJobs.add(buildJobId);
-                future.cancel(true); // Attempt to interrupt the build job
-            }
-            catch (CancellationException e) {
-                log.warn("Build job already cancelled or completed for id {}", buildJobId);
-            }
-        }
-        else {
+        if (future == null) {
             log.warn("Could not cancel build job with id {} as it was not found in the running build jobs", buildJobId);
+            return false;
+        }
+        try {
+            cancelledBuildJobs.add(buildJobId);
+            return future.cancel(true); // Attempt to interrupt the build job
+        }
+        catch (CancellationException e) {
+            log.warn("Build job already cancelled or completed for id {}", buildJobId);
+            return false;
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobManagementService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobManagementService.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -353,8 +354,22 @@ public class BuildJobManagementService {
                 buildLogsMap.appendBuildLogEntry(buildJobItem.id(), msg);
                 throw new CompletionException(msg, null);
             }
-            future = buildAgentConfiguration.getBuildExecutor().submit(buildJob);
-            runningFutures.put(buildJobItem.id(), future);
+            // Register the job before it can start running. submit() hands the task to a worker thread before it
+            // returns, so registering afterwards left a window in which the build was already executing while
+            // runningFutures was still empty. A cancel or pause arriving in that window concluded that nothing was
+            // running: the pause then skipped its grace period and closed the build agent services underneath the
+            // job, which kept running until it hit the build timeout and was reported to the student as a failure.
+            // Executing the task only after the registration keeps "registered" strictly ahead of "running".
+            FutureTask<BuildResult> task = new FutureTask<>(buildJob);
+            runningFutures.put(buildJobItem.id(), task);
+            try {
+                buildAgentConfiguration.getBuildExecutor().execute(task);
+            }
+            catch (RuntimeException notAccepted) {
+                runningFutures.remove(buildJobItem.id());
+                throw notAccepted;
+            }
+            future = task;
         }
         finally {
             jobLifecycleLock.unlock();

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
@@ -967,7 +967,8 @@ public class SharedQueueProcessingService {
      *                          was initiated administratively or for maintenance.
      */
     private void pauseBuildAgent(boolean dueToFailures) {
-        // Collect running job futures outside the lock so we can wait on them without holding it.
+        // Collect the running jobs and their futures outside the lock so we can wait on them without holding it.
+        Set<String> runningBuildJobIds = Set.of();
         List<CompletableFuture<BuildResult>> runningFuturesWrapper = List.of();
 
         agentStateTransitionLock.lock();
@@ -990,7 +991,7 @@ public class SharedQueueProcessingService {
             buildAgentInformationService.updateLocalBuildAgentInformation(isPaused.get(), dueToFailures, consecutiveBuildJobFailures.get());
 
             log.info("Gracefully cancelling running build jobs");
-            Set<String> runningBuildJobIds = buildJobManagementService.getRunningBuildJobIds();
+            runningBuildJobIds = buildJobManagementService.getRunningBuildJobIds();
             if (runningBuildJobIds.isEmpty()) {
                 log.info("No running build jobs to cancel");
             }
@@ -1004,12 +1005,27 @@ public class SharedQueueProcessingService {
         }
 
         // Outside of the lock: wait for running jobs to finish up to the configured grace period.
-        if (!runningFuturesWrapper.isEmpty()) {
+        //
+        // The decision is driven by the running job ids rather than by the futures collected for them: a job that is
+        // in the middle of being submitted is registered as running before its awaitable future exists, so an empty
+        // list of futures does not mean the node is idle. Skipping this block in that case used to lose the job -
+        // it was neither awaited nor cancelled nor put back on the queue.
+        if (!runningBuildJobIds.isEmpty()) {
+            boolean everyRunningJobIsAwaitable = runningFuturesWrapper.size() == runningBuildJobIds.size();
             CompletableFuture<Void> allFuturesWrapper = CompletableFuture.allOf(runningFuturesWrapper.toArray(new CompletableFuture[0]));
 
             try {
                 allFuturesWrapper.get(pauseGracePeriodSeconds, TimeUnit.SECONDS);
-                log.info("All running build jobs finished during grace period");
+                if (everyRunningJobIsAwaitable) {
+                    log.info("All running build jobs finished during grace period");
+                }
+                else {
+                    // Finishing the wait does not prove the node is idle here, because at least one running job had no
+                    // future to await. Such a job has only just started, so it would not have finished within the grace
+                    // period either; cancel it now rather than leave it running on a paused agent.
+                    log.warn("Only {} of {} running build jobs could be awaited, enforcing cancellation for the rest", runningFuturesWrapper.size(), runningBuildJobIds.size());
+                    handleTimeoutAndCancelRunningJobs();
+                }
             }
             catch (TimeoutException e) {
                 log.warn("Not all running build jobs finished within {} seconds, enforcing cancellation", pauseGracePeriodSeconds, e);

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
@@ -4,6 +4,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_BUILDAGENT;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -1066,8 +1067,20 @@ public class SharedQueueProcessingService {
             }
         }
 
-        // After handling all running jobs, close the underlying services of the build agent.
-        buildAgentConfiguration.closeBuildAgentServices();
+        // Close the services under the transition lock, and only while this pause is still the one in effect. The wait
+        // above runs without the lock, so a resume can have completed in the meantime and reopened these services;
+        // closing them afterwards would leave an agent that reports itself as active with no executor to run anything.
+        agentStateTransitionLock.lock();
+        try {
+            if (!isPaused.get()) {
+                log.info("Build agent was resumed while it was pausing, so its services stay open");
+                return;
+            }
+            buildAgentConfiguration.closeBuildAgentServices();
+        }
+        finally {
+            agentStateTransitionLock.unlock();
+        }
     }
 
     private void handleTimeoutAndCancelRunningJobs() {
@@ -1079,8 +1092,9 @@ public class SharedQueueProcessingService {
      * Cancels the given build jobs and puts them back on the distributed queue so another agent can pick them up.
      * <p>
      * The ids are intersected with the jobs that are still running, so a job that finished while the caller was making
-     * up its mind is left alone rather than re-queued behind its own result. Does nothing if the agent was resumed in
-     * the meantime.
+     * up its mind is left alone rather than re-queued behind its own result. A job can also finish in the window
+     * between that snapshot and the cancellation itself, so only the jobs that cancellation actually stopped are put
+     * back on the queue. Does nothing if the agent was resumed in the meantime.
      *
      * @param buildJobIds the ids of the build jobs to cancel and re-queue
      */
@@ -1094,10 +1108,27 @@ public class SharedQueueProcessingService {
         if (jobsToCancel.isEmpty()) {
             return;
         }
-        List<BuildJobQueueItem> jobsToRequeue = distributedDataAccessService.getDistributedProcessingJobs().getAll(jobsToCancel).values().stream().toList();
-        jobsToCancel.forEach(buildJobManagementService::cancelBuildJob);
+        Map<String, BuildJobQueueItem> processingJobs = distributedDataAccessService.getDistributedProcessingJobs().getAll(jobsToCancel);
+        Set<String> cancelledJobIds = new HashSet<>();
+        List<BuildJobQueueItem> jobsToRequeue = new ArrayList<>();
+        for (String buildJobId : jobsToCancel) {
+            if (!buildJobManagementService.cancelBuildJob(buildJobId)) {
+                // Nothing was stopped, so the job finished on its own between the snapshot above and this call and its
+                // result is already on its way. Re-queueing it here would run the same build a second time.
+                log.debug("Build job {} finished before it could be cancelled, so it is not put back on the queue", buildJobId);
+                continue;
+            }
+            cancelledJobIds.add(buildJobId);
+            BuildJobQueueItem processingJob = processingJobs.get(buildJobId);
+            if (processingJob != null) {
+                jobsToRequeue.add(processingJob);
+            }
+        }
+        if (jobsToRequeue.isEmpty()) {
+            return;
+        }
         distributedDataAccessService.getDistributedBuildJobQueue().addAll(jobsToRequeue);
-        log.info("Cancelled running build jobs and added them back to the queue with Ids {}", jobsToCancel);
+        log.info("Cancelled running build jobs and added them back to the queue with Ids {}", cancelledJobIds);
         log.debug("Cancelled running build jobs: {}", jobsToRequeue);
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
@@ -1014,22 +1014,19 @@ public class SharedQueueProcessingService {
             boolean everyRunningJobIsAwaitable = runningFuturesWrapper.size() == runningBuildJobIds.size();
             CompletableFuture<Void> allFuturesWrapper = CompletableFuture.allOf(runningFuturesWrapper.toArray(new CompletableFuture[0]));
 
-            // Only one outcome proves the node is idle: the wait completed and it covered every running job. Every
-            // other outcome - a timeout, an awaited job that failed and so ended the wait early, an interrupt, or a
-            // running job that had no future to await - leaves jobs that have to be cancelled and re-queued before
-            // the build agent services close underneath them.
-            boolean nodeIsIdle = false;
+            // allOf completes once every future it was given has completed, so a job that failed still counts as
+            // finished - it only makes the wait end exceptionally. What the wait can never cover is a job that was
+            // still being submitted when the pause began and so had no future to await yet.
+            boolean allAwaitedJobsFinished = false;
             try {
                 allFuturesWrapper.get(pauseGracePeriodSeconds, TimeUnit.SECONDS);
-                if (everyRunningJobIsAwaitable) {
-                    log.info("All running build jobs finished during grace period");
-                    nodeIsIdle = true;
-                }
-                else {
-                    // A job that was still being submitted when the pause began has only just started, so it would not
-                    // have finished within the grace period either.
-                    log.warn("Only {} of {} running build jobs could be awaited, enforcing cancellation for the rest", runningFuturesWrapper.size(), runningBuildJobIds.size());
-                }
+                allAwaitedJobsFinished = true;
+            }
+            catch (ExecutionException e) {
+                // A build that ended in failure is still a build that ended. Cancelling here would re-queue a job whose
+                // result is on its way to being published, so this counts as finished like any other completion.
+                allAwaitedJobsFinished = true;
+                log.warn("A build job finished exceptionally during the pause grace period", e);
             }
             catch (TimeoutException e) {
                 log.warn("Not all running build jobs finished within {} seconds, enforcing cancellation", pauseGracePeriodSeconds, e);
@@ -1038,13 +1035,16 @@ public class SharedQueueProcessingService {
                 Thread.currentThread().interrupt();
                 log.error("Interrupted while waiting for running build jobs to finish", e);
             }
-            catch (ExecutionException e) {
-                // One awaited job finished exceptionally, which ends the wait for every one of them, so the others may
-                // still be running.
-                log.error("Error while waiting for running build jobs to finish", e);
-            }
 
-            if (!nodeIsIdle) {
+            if (allAwaitedJobsFinished && everyRunningJobIsAwaitable) {
+                log.info("All running build jobs finished during grace period");
+            }
+            else {
+                if (allAwaitedJobsFinished) {
+                    // The jobs left over here have only just started, so they would not have finished within the grace
+                    // period either; cancel them rather than leave them running on a paused agent.
+                    log.warn("Only {} of {} running build jobs could be awaited, enforcing cancellation for the rest", runningFuturesWrapper.size(), runningBuildJobIds.size());
+                }
                 handleTimeoutAndCancelRunningJobs();
             }
         }

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
@@ -1014,29 +1014,38 @@ public class SharedQueueProcessingService {
             boolean everyRunningJobIsAwaitable = runningFuturesWrapper.size() == runningBuildJobIds.size();
             CompletableFuture<Void> allFuturesWrapper = CompletableFuture.allOf(runningFuturesWrapper.toArray(new CompletableFuture[0]));
 
+            // Only one outcome proves the node is idle: the wait completed and it covered every running job. Every
+            // other outcome - a timeout, an awaited job that failed and so ended the wait early, an interrupt, or a
+            // running job that had no future to await - leaves jobs that have to be cancelled and re-queued before
+            // the build agent services close underneath them.
+            boolean nodeIsIdle = false;
             try {
                 allFuturesWrapper.get(pauseGracePeriodSeconds, TimeUnit.SECONDS);
                 if (everyRunningJobIsAwaitable) {
                     log.info("All running build jobs finished during grace period");
+                    nodeIsIdle = true;
                 }
                 else {
-                    // Finishing the wait does not prove the node is idle here, because at least one running job had no
-                    // future to await. Such a job has only just started, so it would not have finished within the grace
-                    // period either; cancel it now rather than leave it running on a paused agent.
+                    // A job that was still being submitted when the pause began has only just started, so it would not
+                    // have finished within the grace period either.
                     log.warn("Only {} of {} running build jobs could be awaited, enforcing cancellation for the rest", runningFuturesWrapper.size(), runningBuildJobIds.size());
-                    handleTimeoutAndCancelRunningJobs();
                 }
             }
             catch (TimeoutException e) {
                 log.warn("Not all running build jobs finished within {} seconds, enforcing cancellation", pauseGracePeriodSeconds, e);
-                handleTimeoutAndCancelRunningJobs();
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 log.error("Interrupted while waiting for running build jobs to finish", e);
             }
             catch (ExecutionException e) {
+                // One awaited job finished exceptionally, which ends the wait for every one of them, so the others may
+                // still be running.
                 log.error("Error while waiting for running build jobs to finish", e);
+            }
+
+            if (!nodeIsIdle) {
+                handleTimeoutAndCancelRunningJobs();
             }
         }
 

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
@@ -4,9 +4,10 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_BUILDAGENT;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
@@ -969,6 +970,7 @@ public class SharedQueueProcessingService {
     private void pauseBuildAgent(boolean dueToFailures) {
         // Collect the running jobs and their futures outside the lock so we can wait on them without holding it.
         Set<String> runningBuildJobIds = Set.of();
+        Set<String> awaitableBuildJobIds = Set.of();
         List<CompletableFuture<BuildResult>> runningFuturesWrapper = List.of();
 
         agentStateTransitionLock.lock();
@@ -996,7 +998,17 @@ public class SharedQueueProcessingService {
                 log.info("No running build jobs to cancel");
             }
             else {
-                runningFuturesWrapper = runningBuildJobIds.stream().map(buildJobManagementService::getRunningBuildJobFutureWrapper).filter(Objects::nonNull).toList();
+                // Keep the ids alongside the futures: a job that is still being submitted is registered as running
+                // before its public future exists, and only those jobs may be cancelled once the wait has finished.
+                Map<String, CompletableFuture<BuildResult>> awaitableJobs = new LinkedHashMap<>();
+                for (String runningBuildJobId : runningBuildJobIds) {
+                    CompletableFuture<BuildResult> wrapper = buildJobManagementService.getRunningBuildJobFutureWrapper(runningBuildJobId);
+                    if (wrapper != null) {
+                        awaitableJobs.put(runningBuildJobId, wrapper);
+                    }
+                }
+                awaitableBuildJobIds = Set.copyOf(awaitableJobs.keySet());
+                runningFuturesWrapper = List.copyOf(awaitableJobs.values());
             }
             // We intentionally do NOT wait for the futures while holding the lock.
         }
@@ -1011,7 +1023,7 @@ public class SharedQueueProcessingService {
         // list of futures does not mean the node is idle. Skipping this block in that case used to lose the job -
         // it was neither awaited nor cancelled nor put back on the queue.
         if (!runningBuildJobIds.isEmpty()) {
-            boolean everyRunningJobIsAwaitable = runningFuturesWrapper.size() == runningBuildJobIds.size();
+            boolean everyRunningJobIsAwaitable = awaitableBuildJobIds.size() == runningBuildJobIds.size();
             CompletableFuture<Void> allFuturesWrapper = CompletableFuture.allOf(runningFuturesWrapper.toArray(new CompletableFuture[0]));
 
             // allOf completes once every future it was given has completed, so a job that failed still counts as
@@ -1039,12 +1051,17 @@ public class SharedQueueProcessingService {
             if (allAwaitedJobsFinished && everyRunningJobIsAwaitable) {
                 log.info("All running build jobs finished during grace period");
             }
+            else if (allAwaitedJobsFinished) {
+                // Every awaited job has finished, so only the ones that had no future to await can still be running.
+                // Cancelling the awaited ones as well would risk re-queueing a job whose result is on its way to being
+                // published: allOf completes with the futures it was given, while the stage that takes a finished job
+                // out of the running maps runs separately and need not have run yet.
+                Set<String> neverAwaited = new HashSet<>(runningBuildJobIds);
+                neverAwaited.removeAll(awaitableBuildJobIds);
+                log.warn("{} of {} running build jobs had no future to await, enforcing cancellation for those", neverAwaited.size(), runningBuildJobIds.size());
+                cancelAndRequeueRunningBuildJobs(neverAwaited);
+            }
             else {
-                if (allAwaitedJobsFinished) {
-                    // The jobs left over here have only just started, so they would not have finished within the grace
-                    // period either; cancel them rather than leave them running on a paused agent.
-                    log.warn("Only {} of {} running build jobs could be awaited, enforcing cancellation for the rest", runningFuturesWrapper.size(), runningBuildJobIds.size());
-                }
                 handleTimeoutAndCancelRunningJobs();
             }
         }
@@ -1054,19 +1071,34 @@ public class SharedQueueProcessingService {
     }
 
     private void handleTimeoutAndCancelRunningJobs() {
+        log.info("Grace period exceeded. Cancelling running build jobs.");
+        cancelAndRequeueRunningBuildJobs(buildJobManagementService.getRunningBuildJobIds());
+    }
+
+    /**
+     * Cancels the given build jobs and puts them back on the distributed queue so another agent can pick them up.
+     * <p>
+     * The ids are intersected with the jobs that are still running, so a job that finished while the caller was making
+     * up its mind is left alone rather than re-queued behind its own result. Does nothing if the agent was resumed in
+     * the meantime.
+     *
+     * @param buildJobIds the ids of the build jobs to cancel and re-queue
+     */
+    private void cancelAndRequeueRunningBuildJobs(Set<String> buildJobIds) {
         if (!isPaused.get()) {
             log.info("Build agent was resumed before the build jobs could be cancelled");
             return;
         }
-        log.info("Grace period exceeded. Cancelling running build jobs.");
-
-        Set<String> runningBuildJobIdsAfterGracePeriod = buildJobManagementService.getRunningBuildJobIds();
-        List<BuildJobQueueItem> runningBuildJobsAfterGracePeriod = distributedDataAccessService.getDistributedProcessingJobs().getAll(runningBuildJobIdsAfterGracePeriod).values()
-                .stream().toList();
-        runningBuildJobIdsAfterGracePeriod.forEach(buildJobManagementService::cancelBuildJob);
-        distributedDataAccessService.getDistributedBuildJobQueue().addAll(runningBuildJobsAfterGracePeriod);
-        log.info("Cancelled running build jobs and added them back to the queue with Ids {}", runningBuildJobIdsAfterGracePeriod);
-        log.debug("Cancelled running build jobs: {}", runningBuildJobsAfterGracePeriod);
+        Set<String> jobsToCancel = new HashSet<>(buildJobManagementService.getRunningBuildJobIds());
+        jobsToCancel.retainAll(buildJobIds);
+        if (jobsToCancel.isEmpty()) {
+            return;
+        }
+        List<BuildJobQueueItem> jobsToRequeue = distributedDataAccessService.getDistributedProcessingJobs().getAll(jobsToCancel).values().stream().toList();
+        jobsToCancel.forEach(buildJobManagementService::cancelBuildJob);
+        distributedDataAccessService.getDistributedBuildJobQueue().addAll(jobsToRequeue);
+        log.info("Cancelled running build jobs and added them back to the queue with Ids {}", jobsToCancel);
+        log.debug("Cancelled running build jobs: {}", jobsToRequeue);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingService.java
@@ -959,6 +959,10 @@ public class SharedQueueProcessingService {
      * {@link #agentStateTransitionLock} while waiting for running jobs to complete.
      * This avoids potential deadlocks where completion callbacks of those futures
      * might themselves try to acquire the same lock or update build-agent state.</li>
+     * <li>Because of that, a resume can complete while the wait is in progress. Everything
+     * the method does <em>after</em> the wait is irreversible - cancelling and re-queueing
+     * jobs, and closing the services - so it retakes {@link #agentStateTransitionLock} and
+     * re-checks {@code isPaused} inside it, and does nothing when a resume got there first.</li>
      * <li>The distributed build-agent information is updated immediately after setting
      * {@code isPaused = true}, so other nodes and services can already treat the agent
      * as paused while it is still finishing or cancelling in-flight jobs.</li>
@@ -1023,14 +1027,14 @@ public class SharedQueueProcessingService {
         // in the middle of being submitted is registered as running before its awaitable future exists, so an empty
         // list of futures does not mean the node is idle. Skipping this block in that case used to lose the job -
         // it was neither awaited nor cancelled nor put back on the queue.
+        boolean everyRunningJobIsAwaitable = awaitableBuildJobIds.size() == runningBuildJobIds.size();
+        boolean allAwaitedJobsFinished = false;
         if (!runningBuildJobIds.isEmpty()) {
-            boolean everyRunningJobIsAwaitable = awaitableBuildJobIds.size() == runningBuildJobIds.size();
             CompletableFuture<Void> allFuturesWrapper = CompletableFuture.allOf(runningFuturesWrapper.toArray(new CompletableFuture[0]));
 
             // allOf completes once every future it was given has completed, so a job that failed still counts as
             // finished - it only makes the wait end exceptionally. What the wait can never cover is a job that was
             // still being submitted when the pause began and so had no future to await yet.
-            boolean allAwaitedJobsFinished = false;
             try {
                 allFuturesWrapper.get(pauseGracePeriodSeconds, TimeUnit.SECONDS);
                 allAwaitedJobsFinished = true;
@@ -1049,32 +1053,37 @@ public class SharedQueueProcessingService {
                 log.error("Interrupted while waiting for running build jobs to finish", e);
             }
 
-            if (allAwaitedJobsFinished && everyRunningJobIsAwaitable) {
-                log.info("All running build jobs finished during grace period");
-            }
-            else if (allAwaitedJobsFinished) {
-                // Every awaited job has finished, so only the ones that had no future to await can still be running.
-                // Cancelling the awaited ones as well would risk re-queueing a job whose result is on its way to being
-                // published: allOf completes with the futures it was given, while the stage that takes a finished job
-                // out of the running maps runs separately and need not have run yet.
-                Set<String> neverAwaited = new HashSet<>(runningBuildJobIds);
-                neverAwaited.removeAll(awaitableBuildJobIds);
-                log.warn("{} of {} running build jobs had no future to await, enforcing cancellation for those", neverAwaited.size(), runningBuildJobIds.size());
-                cancelAndRequeueRunningBuildJobs(neverAwaited);
-            }
-            else {
-                handleTimeoutAndCancelRunningJobs();
-            }
         }
 
-        // Close the services under the transition lock, and only while this pause is still the one in effect. The wait
-        // above runs without the lock, so a resume can have completed in the meantime and reopened these services;
-        // closing them afterwards would leave an agent that reports itself as active with no executor to run anything.
+        // The wait above deliberately runs without the lock, so a resume can complete while it is in progress.
+        // Everything that follows is irreversible - cancelling and re-queueing jobs, and closing the services the agent
+        // runs on - so it happens under the transition lock with the paused state re-checked inside it. Either this
+        // pause is still the one in effect and it finishes its work, or a resume got there first and it does nothing:
+        // cancelling a resumed agent's jobs would throw away builds it had just been told to keep running, and closing
+        // its services would leave it reporting itself as active with no executor.
         agentStateTransitionLock.lock();
         try {
             if (!isPaused.get()) {
-                log.info("Build agent was resumed while it was pausing, so its services stay open");
+                log.info("Build agent was resumed while it was pausing, so its build jobs and services are left alone");
                 return;
+            }
+            if (!runningBuildJobIds.isEmpty()) {
+                if (allAwaitedJobsFinished && everyRunningJobIsAwaitable) {
+                    log.info("All running build jobs finished during grace period");
+                }
+                else if (allAwaitedJobsFinished) {
+                    // Every awaited job has finished, so only the ones that had no future to await can still be
+                    // running. Cancelling the awaited ones as well would risk re-queueing a job whose result is on its
+                    // way to being published: allOf completes with the futures it was given, while the stage that takes
+                    // a finished job out of the running maps runs separately and need not have run yet.
+                    Set<String> neverAwaited = new HashSet<>(runningBuildJobIds);
+                    neverAwaited.removeAll(awaitableBuildJobIds);
+                    log.warn("{} of {} running build jobs had no future to await, enforcing cancellation for those", neverAwaited.size(), runningBuildJobIds.size());
+                    cancelAndRequeueRunningBuildJobs(neverAwaited);
+                }
+                else {
+                    handleTimeoutAndCancelRunningJobs();
+                }
             }
             buildAgentConfiguration.closeBuildAgentServices();
         }
@@ -1094,15 +1103,14 @@ public class SharedQueueProcessingService {
      * The ids are intersected with the jobs that are still running, so a job that finished while the caller was making
      * up its mind is left alone rather than re-queued behind its own result. A job can also finish in the window
      * between that snapshot and the cancellation itself, so only the jobs that cancellation actually stopped are put
-     * back on the queue. Does nothing if the agent was resumed in the meantime.
+     * back on the queue.
+     * <p>
+     * Must be called while holding {@link #agentStateTransitionLock} and only after confirming that the agent is still
+     * paused, so that a resume cannot land between that check and the cancellation and lose the jobs it just took over.
      *
      * @param buildJobIds the ids of the build jobs to cancel and re-queue
      */
     private void cancelAndRequeueRunningBuildJobs(Set<String> buildJobIds) {
-        if (!isPaused.get()) {
-            log.info("Build agent was resumed before the build jobs could be cancelled");
-            return;
-        }
         Set<String> jobsToCancel = new HashSet<>(buildJobManagementService.getRunningBuildJobIds());
         jobsToCancel.retainAll(buildJobIds);
         if (jobsToCancel.isEmpty()) {

--- a/src/test/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingServicePauseTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingServicePauseTest.java
@@ -135,13 +135,32 @@ class SharedQueueProcessingServicePauseTest {
     }
 
     @Test
-    void doesNotCloseTheServicesWhenTheAgentWasResumedWhilePausing() {
-        when(buildJobManagementService.getRunningBuildJobIds()).thenReturn(Set.of());
-        // A resume completed while the pause was between releasing the transition lock and closing the services.
+    void leavesTheJobsOfAnAgentThatWasResumedWhilePausingAlone() {
+        when(buildJobManagementService.getRunningBuildJobIds()).thenReturn(Set.of(JOB_ID));
+        when(buildJobManagementService.getRunningBuildJobFutureWrapper(JOB_ID)).thenReturn(null);
+        resumeWhileThePauseIsInProgress();
+
+        pause();
+
+        // The resumed agent was told to keep running these jobs, so cancelling and re-queueing them here would throw
+        // away builds that are legitimately in flight.
+        verify(buildJobManagementService, never()).cancelBuildJob(anyString());
+        verify(buildJobQueue, never()).addAll(any());
+        verify(buildAgentConfiguration, never()).closeBuildAgentServices();
+    }
+
+    private void resumeWhileThePauseIsInProgress() {
         doAnswer(invocation -> {
             ((AtomicBoolean) ReflectionTestUtils.getField(service, "isPaused")).set(false);
             return null;
         }).when(buildAgentInformationService).updateLocalBuildAgentInformation(anyBoolean(), anyBoolean(), anyInt());
+    }
+
+    @Test
+    void doesNotCloseTheServicesWhenTheAgentWasResumedWhilePausing() {
+        when(buildJobManagementService.getRunningBuildJobIds()).thenReturn(Set.of());
+        // A resume completed while the pause was between releasing the transition lock and closing the services.
+        resumeWhileThePauseIsInProgress();
 
         pause();
 

--- a/src/test/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingServicePauseTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/buildagent/service/SharedQueueProcessingServicePauseTest.java
@@ -1,0 +1,150 @@
+package de.tum.cit.aet.artemis.buildagent.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import de.tum.cit.aet.artemis.buildagent.BuildAgentConfiguration;
+import de.tum.cit.aet.artemis.buildagent.dto.BuildJobQueueItem;
+import de.tum.cit.aet.artemis.core.service.distributed.api.map.DistributedMap;
+import de.tum.cit.aet.artemis.core.service.distributed.api.queue.DistributedQueue;
+import de.tum.cit.aet.artemis.localci.service.DistributedDataAccessService;
+
+/**
+ * Pausing a build agent while a job is still being submitted.
+ * <p>
+ * A job is registered as running before its public future exists, so for a short window the agent reports a running job
+ * that nothing can be awaited on. The pause has to notice that and cancel the job anyway: skipping it left the build
+ * running on an agent whose services were about to be closed, and the student saw the resulting build timeout as a
+ * failed build.
+ * <p>
+ * A unit test rather than an integration test on purpose. The window is shorter than a millisecond, so the only way to
+ * hit it in a running agent is to hold the submission open artificially; driving the pause against a build job
+ * management service that reports exactly this state tests the same branch without a sleep in production code.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SharedQueueProcessingServicePauseTest {
+
+    private static final String JOB_ID = "job-being-submitted";
+
+    private static final String AGENT_NAME = "test-agent";
+
+    @Mock
+    private BuildAgentConfiguration buildAgentConfiguration;
+
+    @Mock
+    private BuildJobManagementService buildJobManagementService;
+
+    @Mock
+    private BuildAgentInformationService buildAgentInformationService;
+
+    @Mock
+    private DistributedDataAccessService distributedDataAccessService;
+
+    @Mock
+    private DistributedQueue<BuildJobQueueItem> buildJobQueue;
+
+    @Mock
+    private DistributedMap<String, BuildJobQueueItem> processingJobs;
+
+    @Mock
+    private BuildJobQueueItem runningJob;
+
+    private SharedQueueProcessingService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SharedQueueProcessingService(buildAgentConfiguration, buildJobManagementService, null, null, null, null, buildAgentInformationService,
+                distributedDataAccessService);
+        ReflectionTestUtils.setField(service, "buildAgentShortName", AGENT_NAME);
+        ReflectionTestUtils.setField(service, "pauseGracePeriodSeconds", 1);
+        ReflectionTestUtils.setField(service, "isPaused", new AtomicBoolean(false));
+
+        when(distributedDataAccessService.getLocalMemberAddress()).thenReturn("localhost");
+        when(distributedDataAccessService.isInstanceRunning()).thenReturn(false);
+        when(distributedDataAccessService.getDistributedBuildJobQueue()).thenReturn(buildJobQueue);
+        when(distributedDataAccessService.getDistributedProcessingJobs()).thenReturn(processingJobs);
+        lenient().when(processingJobs.getAll(anySet())).thenReturn(Map.of(JOB_ID, runningJob));
+    }
+
+    private void pause() {
+        ReflectionTestUtils.invokeMethod(service, "pauseBuildAgent", false);
+    }
+
+    @Test
+    void cancelsAndRequeuesAJobThatIsStillBeingSubmitted() {
+        // Registered as running, but its public future has not been published yet - the window this guards.
+        when(buildJobManagementService.getRunningBuildJobIds()).thenReturn(Set.of(JOB_ID));
+        when(buildJobManagementService.getRunningBuildJobFutureWrapper(JOB_ID)).thenReturn(null);
+        when(buildJobManagementService.cancelBuildJob(JOB_ID)).thenReturn(true);
+
+        pause();
+
+        verify(buildJobManagementService).cancelBuildJob(JOB_ID);
+        ArgumentCaptor<List<BuildJobQueueItem>> requeued = ArgumentCaptor.captor();
+        verify(buildJobQueue).addAll(requeued.capture());
+        assertThat(requeued.getValue()).as("the job has to go back on the queue so another agent picks it up").containsExactly(runningJob);
+    }
+
+    @Test
+    void doesNotRequeueAJobThatFinishedBeforeItCouldBeCancelled() {
+        when(buildJobManagementService.getRunningBuildJobIds()).thenReturn(Set.of(JOB_ID));
+        when(buildJobManagementService.getRunningBuildJobFutureWrapper(JOB_ID)).thenReturn(null);
+        // The job completed between the snapshot and the cancellation, so there was nothing left to stop.
+        when(buildJobManagementService.cancelBuildJob(JOB_ID)).thenReturn(false);
+
+        pause();
+
+        verify(buildJobQueue, never()).addAll(any());
+    }
+
+    @Test
+    void leavesAJobAloneWhenItsFutureCompletedDuringTheGracePeriod() {
+        when(buildJobManagementService.getRunningBuildJobIds()).thenReturn(Set.of(JOB_ID));
+        when(buildJobManagementService.getRunningBuildJobFutureWrapper(JOB_ID)).thenReturn(CompletableFuture.completedFuture(null));
+
+        pause();
+
+        verify(buildJobManagementService, never()).cancelBuildJob(anyString());
+        verify(buildJobQueue, never()).addAll(any());
+    }
+
+    @Test
+    void doesNotCloseTheServicesWhenTheAgentWasResumedWhilePausing() {
+        when(buildJobManagementService.getRunningBuildJobIds()).thenReturn(Set.of());
+        // A resume completed while the pause was between releasing the transition lock and closing the services.
+        doAnswer(invocation -> {
+            ((AtomicBoolean) ReflectionTestUtils.getField(service, "isPaused")).set(false);
+            return null;
+        }).when(buildAgentInformationService).updateLocalBuildAgentInformation(anyBoolean(), anyBoolean(), anyInt());
+
+        pause();
+
+        verify(buildAgentConfiguration, never()).closeBuildAgentServices();
+    }
+}


### PR DESCRIPTION
### Problem

`BuildAgentIntegrationTest > testPauseBuildAgentBehavior()` fails intermittently in CI, timing out
after a minute while waiting for a cancelled build job to be put back on the queue. Behind it is a
production defect: a build job that starts in the moment an agent is paused is silently lost.

A job is registered in `runningFutures` only *after* it has been handed to the executor, and
`submit()` gives the task to a worker thread before it returns. In the window between the two, the
build is already running while the agent still reports no running jobs. The `jobLifecycleLock` javadoc
already describes exactly this window for cancellation; the pause path never participated in it.

A pause arriving in that window takes the empty set at face value: it skips the grace period, cancels
nothing, puts nothing back on the queue, and then closes the build agent services underneath the still
running job. The job runs on until it hits the build timeout and is reported to the student as a
failed build.

The CI log of the failing run shows it directly — the build job starts at `18:25:06.427`, and one
millisecond later the pause logs:

```
18:25:06.427 | local-ci-build-1 | BuildJobExecutionService : ~~~ Start Build Job dummy-id-4d69270c ~~~
18:25:06.428 | nPool-1-worker-1 | SharedQueueProcessingService : Pausing build agent with address localhost
18:25:06.428 | nPool-1-worker-1 | SharedQueueProcessingService : Gracefully cancelling running build jobs
18:25:06.428 | nPool-1-worker-1 | SharedQueueProcessingService : No running build jobs to cancel
```

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).

### Description

Two changes, both in the registration ordering:

1. `BuildJobManagementService.executeBuildJob` wraps the work in a `FutureTask` and executes it only
   after registering it in `runningFutures`, so *registered* is strictly ahead of *running*. A
   rejected execution unregisters the job again.
2. `SharedQueueProcessingService.pauseBuildAgent` stops treating an empty list of awaitable futures as
   an idle node. A job's public future is registered after the job can start, so a job that is still
   being submitted is running but not yet awaitable. The decision now comes from the running job ids,
   and cancellation is enforced when the futures do not cover all of them.

Change 1 alone is not enough — it only moves which of the two maps is stale — which is why both are here.

### Steps for Testing

Verified by reproducing the race deterministically rather than by waiting for the flake:

1. On unchanged code, insert `Thread.sleep(50)` between `submit()` and the `runningFutures`
   registration. `testPauseBuildAgentBehavior` fails exactly as CI does: `ConditionTimeoutException`
   after one minute, preceded by `No running build jobs to cancel`.
2. With this change, move the same probe into the remaining window (before the public future is
   registered). The test passes, and the log shows the new path doing its job:
   `Only 0 of 1 running build jobs could be awaited, enforcing cancellation for the rest`, followed by
   `Cancelled running build jobs and added them back to the queue`.
3. Probe removed: the whole `buildagent` and `localci` test packages pass.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build-agent reliability when pausing or cancelling jobs.
  * Prevented jobs from being overlooked while starting or during pause transitions.
  * Correctly handled jobs that finish during a pause operation.
  * Ensured unfinished jobs are safely cancelled and requeued when the grace period expires or is interrupted.
  * Reduced the risk of services shutting down while a job is starting.
  * Improved handling when a build job cannot be scheduled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->