### PR TITLE
`Development`: Give each jenkins test context its own weaviate collection

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/core/util/CourseTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/CourseTestService.java
@@ -665,6 +665,12 @@ public class CourseTestService {
             }
         }
 
+        // Indexing is asynchronous, so wait for it to land before deleting. An upsert that completes after the
+        // deletion has swept the collection would leave a row the deletion can no longer remove.
+        for (Long exerciseId : allExerciseIds) {
+            WeaviateTestUtil.awaitExerciseInWeaviate(weaviateService, exerciseId);
+        }
+
         for (Course course : courses) {
             if (!course.getExercises().isEmpty()) {
                 groupNotificationService.notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(course.getExercises().iterator().next());

--- a/src/test/java/de/tum/cit/aet/artemis/globalsearch/util/WeaviateTestUtil.java
+++ b/src/test/java/de/tum/cit/aet/artemis/globalsearch/util/WeaviateTestUtil.java
@@ -80,6 +80,26 @@ public final class WeaviateTestUtil {
     }
 
     /**
+     * Waits until the exercise is present in Weaviate, without asserting on any of its properties.
+     * <p>
+     * Indexing runs asynchronously, so a test that indexes an exercise and then deletes its course needs this barrier:
+     * without it the upsert can land after the deletion has already swept the collection, leaving behind a row that
+     * the deletion can no longer remove and that the test then reports as a cleanup failure.
+     *
+     * @param weaviateService the Weaviate service to query (may be {@code null} if Docker is unavailable)
+     * @param exerciseId      the ID of the exercise that should be indexed
+     */
+    public static void awaitExerciseInWeaviate(WeaviateService weaviateService, long exerciseId) throws Exception {
+        if (shouldSkipWeaviateAssertions(weaviateService)) {
+            return;
+        }
+        await().atMost(Duration.ofSeconds(30)).untilAsserted(() -> {
+            var properties = queryExerciseProperties(weaviateService, exerciseId);
+            assertThat(properties).as("Exercise %d should be indexed in Weaviate before its course is deleted", exerciseId).isNotNull();
+        });
+    }
+
+    /**
      * Asserts that the exercise exists in Weaviate and its core properties match the given exercise.
      * Skips if Docker is not available. Fails if Docker is available but WeaviateService is null.
      *

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationJenkinsLocalVCBatchTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationJenkinsLocalVCBatchTest.java
@@ -55,7 +55,8 @@ public abstract class AbstractSpringIntegrationJenkinsLocalVCBatchTest extends A
         registry.add("artemis.version-control.ssh-port", () -> sshPort);
         registry.add("artemis.version-control.ssh-template-clone-url", () -> "ssh://git@localhost:" + sshPort + "/");
 
-        // Override parent's Weaviate configuration with a unique prefix for this test context
+        // Every test context needs its own Weaviate collection: they share the container but have separate
+        // databases whose entity ids overlap, so one shared collection lets them observe each other's rows.
         de.tum.cit.aet.artemis.shared.WeaviateTestConfiguration.registerWeaviateProperties(registry, weaviateContainer, "JenkinsLocalVC_Batch_");
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationJenkinsLocalVCTemplateTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationJenkinsLocalVCTemplateTest.java
@@ -56,7 +56,8 @@ public abstract class AbstractSpringIntegrationJenkinsLocalVCTemplateTest extend
         registry.add("artemis.version-control.ssh-port", () -> sshPort);
         registry.add("artemis.version-control.ssh-template-clone-url", () -> "ssh://git@localhost:" + sshPort + "/");
 
-        // Override parent's Weaviate configuration with a unique prefix for this test context
+        // Every test context needs its own Weaviate collection: they share the container but have separate
+        // databases whose entity ids overlap, so one shared collection lets them observe each other's rows.
         de.tum.cit.aet.artemis.shared.WeaviateTestConfiguration.registerWeaviateProperties(registry, weaviateContainer, "JenkinsLocalVC_Template_");
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationJenkinsLocalVCTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationJenkinsLocalVCTest.java
@@ -50,7 +50,8 @@ public abstract class AbstractSpringIntegrationJenkinsLocalVCTest extends Abstra
         registry.add("artemis.version-control.ssh-port", () -> sshPort);
         registry.add("artemis.version-control.ssh-template-clone-url", () -> "ssh://git@localhost:" + sshPort + "/");
 
-        // Override parent's Weaviate configuration with a unique prefix for this test context
+        // Every test context needs its own Weaviate collection: they share the container but have separate
+        // databases whose entity ids overlap, so one shared collection lets them observe each other's rows.
         de.tum.cit.aet.artemis.shared.WeaviateTestConfiguration.registerWeaviateProperties(registry, weaviateContainer, "JenkinsLocalVC_Main_");
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationJenkinsLocalVCTestBase.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationJenkinsLocalVCTestBase.java
@@ -17,8 +17,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.testcontainers.weaviate.WeaviateContainer;
 
@@ -37,7 +35,6 @@ import de.tum.cit.aet.artemis.programming.domain.ProgrammingExerciseStudentParti
 import de.tum.cit.aet.artemis.programming.domain.RepositoryType;
 import de.tum.cit.aet.artemis.programming.service.ProgrammingMessagingService;
 import de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseFactory;
-import de.tum.cit.aet.artemis.shared.WeaviateTestConfiguration;
 import de.tum.cit.aet.artemis.shared.WeaviateTestContainerFactory;
 
 /**
@@ -48,16 +45,15 @@ public abstract class AbstractSpringIntegrationJenkinsLocalVCTestBase extends Ab
 
     protected static final WeaviateContainer weaviateContainer;
 
-    private static final String UNIQUE_COLLECTION_PREFIX = "JenkinsLocalVC_";
-
     static {
         weaviateContainer = WeaviateTestContainerFactory.getContainer();
     }
 
-    @DynamicPropertySource
-    static void registerWeaviateProperties(DynamicPropertyRegistry registry) {
-        WeaviateTestConfiguration.registerWeaviateProperties(registry, weaviateContainer, UNIQUE_COLLECTION_PREFIX);
-    }
+    // The Weaviate properties, including the collection prefix, are deliberately registered by each concrete subclass
+    // rather than here. Spring invokes @DynamicPropertySource methods from the subclass upwards and every registration
+    // is a last-write-wins put, so a registration in this class would run last and silently overwrite the prefix each
+    // subclass sets. All three subclasses run against the same Weaviate container but have their own database, and
+    // entity ids overlap between them, so sharing one collection makes them observe each other's rows.
 
     // please only use this to verify method calls using Mockito. Do not mock methods, instead mock the communication with Jenkins using the corresponding RestTemplate.
     @MockitoSpyBean


### PR DESCRIPTION
### Problem

`CourseLocalVCJenkinsIntegrationTest > testDeleteCourseWithPermission()` fails intermittently with

```
[Exercise 454 should not exist in Weaviate]
expected: null
... "exercise_type"="text", "is_exam_exercise"=true ...
```

The test creates no exam exercises at all, and the assertion already waits 30 seconds, so it is
neither a missing de-index nor a short timing gap. The leftover row belongs to a **different Spring
test context**.

The three Jenkins LocalVC contexts each register their own Weaviate collection prefix —
`JenkinsLocalVC_Main_`, `JenkinsLocalVC_Batch_`, `JenkinsLocalVC_Template_` — and all three were
silently ignored. Spring invokes `@DynamicPropertySource` methods from the subclass upwards, and every
registration is a last-write-wins put on the registry, so the registration in the shared base class ran
**last** and overwrote whatever prefix the subclass had set. All three resolved to
`Test_JenkinsLocalVC_` and shared a single collection.

Those contexts have separate databases whose entity ids overlap, and they run concurrently under
distinct `@ResourceLock`s. So exercise 454 in the batch context's database and exercise 454 in the main
context's database wrote to the same collection, and a course deletion in one could not remove the
other's row.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).

### Description

Register the Weaviate properties only in the three concrete subclasses, and not in the base they share.
The base keeps the container; nothing extends it directly, and each subclass already registers the
complete set of properties through the same helper, so no context loses configuration.

Separately, the test fired `upsertExerciseAsync` and went straight on to delete the courses. An upsert
that landed after the deletion had swept the collection left behind a row the deletion could no longer
remove — a second, independent way for the same assertion to fail. The test now waits for the indexing
to land before deleting.

### Steps for Testing

1. Read the effective prefix back from each context with a temporary `@Value` probe. Before: the main
   and batch contexts both report `Test_JenkinsLocalVC_`. After: they report
   `Test_JenkinsLocalVC_Main_` and `Test_JenkinsLocalVC_Batch_`, and the logs show two separate
   collections being created concurrently.
2. Run the three classes that share this collection and use Weaviate assertions together —
   `CourseLocalVCJenkinsIntegrationTest` (batch), `ExamIntegrationTest` (batch) and
   `ExerciseGroupIntegrationJenkinsLocalVCTest` (main, the one that indexes exam exercises): **415
   tests, 0 failures**.

The `Independent` and `LocalCILocalVC` families were checked for the same shape and are not affected:
the former registers the prefix in only one class per context, and the latter is a single context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by waiting for exercises to finish indexing before cleanup operations.
  * Added safeguards for asynchronously indexed search data during test execution.
  * Isolated search index collections across test contexts to prevent overlapping test data from interfering.

* **Documentation**
  * Clarified how search index collections are configured and isolated for integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->