### PR TITLE
`Development`: Apply the non-PIE sanitizer flags only on Linux

### DIFF
--- a/src/main/resources/templates/c/gcc/exercise/Makefile
+++ b/src/main/resources/templates/c/gcc/exercise/Makefile
@@ -22,6 +22,22 @@ endif
 # -g					Generates debug information to be used by GDB debugger
 WFLAGS = -Wall -Wextra -Wpedantic -g
 
+# Flags that only the sanitizer targets (asan, ubsan, lsan) receive, and only on Linux.
+#
+# GCC's address and leak sanitizer runtimes reserve a fixed region at 0x600000000000 for their allocator. The
+# Linux kernel loads a position-independent executable at a randomised address that can fall inside that
+# region - on a host with vm.mmap_rnd_bits=32, the default since kernel 6.5, about one run in four. The
+# sanitizer then dies before main() in an endless loop of "AddressSanitizer:DEADLYSIGNAL" lines and never
+# exits. Linking non-PIE puts the executable at a fixed low address where it cannot collide.
+#
+# This is a Linux kernel layout problem, so the flags are only set there. macOS does not lay memory out this
+# way and Apple clang has no use for -no-pie, which combined with -Werror below would fail the build.
+ifeq ($(shell uname -s),Linux)
+SANITIZER_FLAGS = -fno-pie -no-pie
+else
+SANITIZER_FLAGS =
+endif
+
 # Compile without sanitizers and disable optimisation
 # $(SOURCE): 	        Input file(s)
 # $(INCLUDEDIRS:%=-I%)  Include directories
@@ -45,7 +61,7 @@ helloWorld: FORCE
 # -fsanitize=address:	Address sanitizer
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 asan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=address
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=address
 
 # Compile with undefined behavior sanitizer enabled
 # $(SOURCE): 			Input file(s)
@@ -59,7 +75,7 @@ asan: FORCE
 # -fsanitize=undefined:	Fast undefined behavior check
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 ubsan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=undefined
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=undefined
 
 # Compile with leak sanitizer enabled
 # $(SOURCE): 		    Input file(s)
@@ -73,7 +89,7 @@ ubsan: FORCE
 # -fsanitize=leak	    Basic memory leak sanitizer
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 lsan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=leak
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=leak
 
 # Compile with GCC static analysis enabled
 # $(SOURCE): 			Input file(s)

--- a/src/main/resources/templates/c/gcc/exercise/Makefile
+++ b/src/main/resources/templates/c/gcc/exercise/Makefile
@@ -22,19 +22,6 @@ endif
 # -g					Generates debug information to be used by GDB debugger
 WFLAGS = -Wall -Wextra -Wpedantic -g
 
-# Flags that only the sanitizer targets (asan, ubsan, lsan) receive.
-# -fno-pie -no-pie  Link at a fixed low load address instead of a randomised one. GCC's address and
-#                   leak sanitizer runtimes reserve a fixed region at 0x600000000000 (96 TiB) for
-#                   their allocator, and a position-independent executable can be loaded inside it
-#                   on a host with vm.mmap_rnd_bits=32 (the kernel default since 6.5, so Ubuntu
-#                   24.04 among others). The sanitizer then dies before main() in an endless loop of
-#                   "AddressSanitizer:DEADLYSIGNAL" lines and never exits. A non-PIE executable is
-#                   loaded at 0x400000 and cannot collide. libsanitizer made the allocator base
-#                   dynamic in GCC 14, so these two flags are unnecessary with that or newer.
-#                   See https://github.com/google/sanitizers/issues/1614
-SANITIZER_FLAGS = -fno-pie -no-pie
-
-
 # Compile without sanitizers and disable optimisation
 # $(SOURCE): 	        Input file(s)
 # $(INCLUDEDIRS:%=-I%)  Include directories
@@ -58,7 +45,7 @@ helloWorld: FORCE
 # -fsanitize=address:	Address sanitizer
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 asan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=address
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=address
 
 # Compile with undefined behavior sanitizer enabled
 # $(SOURCE): 			Input file(s)
@@ -72,7 +59,7 @@ asan: FORCE
 # -fsanitize=undefined:	Fast undefined behavior check
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 ubsan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=undefined
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=undefined
 
 # Compile with leak sanitizer enabled
 # $(SOURCE): 		    Input file(s)
@@ -86,7 +73,7 @@ ubsan: FORCE
 # -fsanitize=leak	    Basic memory leak sanitizer
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 lsan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=leak
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=leak
 
 # Compile with GCC static analysis enabled
 # $(SOURCE): 			Input file(s)

--- a/src/main/resources/templates/c/gcc/solution/Makefile
+++ b/src/main/resources/templates/c/gcc/solution/Makefile
@@ -22,6 +22,22 @@ endif
 # -g					Generates debug information to be used by GDB debugger
 WFLAGS = -Wall -Wextra -Wpedantic -g
 
+# Flags that only the sanitizer targets (asan, ubsan, lsan) receive, and only on Linux.
+#
+# GCC's address and leak sanitizer runtimes reserve a fixed region at 0x600000000000 for their allocator. The
+# Linux kernel loads a position-independent executable at a randomised address that can fall inside that
+# region - on a host with vm.mmap_rnd_bits=32, the default since kernel 6.5, about one run in four. The
+# sanitizer then dies before main() in an endless loop of "AddressSanitizer:DEADLYSIGNAL" lines and never
+# exits. Linking non-PIE puts the executable at a fixed low address where it cannot collide.
+#
+# This is a Linux kernel layout problem, so the flags are only set there. macOS does not lay memory out this
+# way and Apple clang has no use for -no-pie, which combined with -Werror below would fail the build.
+ifeq ($(shell uname -s),Linux)
+SANITIZER_FLAGS = -fno-pie -no-pie
+else
+SANITIZER_FLAGS =
+endif
+
 # Compile without sanitizers and disable optimisation
 # $(SOURCE): 	        Input file(s)
 # $(INCLUDEDIRS:%=-I%)  Include directories
@@ -45,7 +61,7 @@ helloWorld: FORCE
 # -fsanitize=address:	Address sanitizer
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 asan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=address
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=address
 
 # Compile with undefined behavior sanitizer enabled
 # $(SOURCE): 			Input file(s)
@@ -59,7 +75,7 @@ asan: FORCE
 # -fsanitize=undefined:	Fast undefined behavior check
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 ubsan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=undefined
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=undefined
 
 # Compile with leak sanitizer enabled
 # $(SOURCE): 		    Input file(s)
@@ -73,7 +89,7 @@ ubsan: FORCE
 # -fsanitize=leak	    Basic memory leak sanitizer
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 lsan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=leak
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=leak
 
 # Compile with GCC static analysis enabled
 # $(SOURCE): 			Input file(s)

--- a/src/main/resources/templates/c/gcc/solution/Makefile
+++ b/src/main/resources/templates/c/gcc/solution/Makefile
@@ -22,19 +22,6 @@ endif
 # -g					Generates debug information to be used by GDB debugger
 WFLAGS = -Wall -Wextra -Wpedantic -g
 
-# Flags that only the sanitizer targets (asan, ubsan, lsan) receive.
-# -fno-pie -no-pie  Link at a fixed low load address instead of a randomised one. GCC's address and
-#                   leak sanitizer runtimes reserve a fixed region at 0x600000000000 (96 TiB) for
-#                   their allocator, and a position-independent executable can be loaded inside it
-#                   on a host with vm.mmap_rnd_bits=32 (the kernel default since 6.5, so Ubuntu
-#                   24.04 among others). The sanitizer then dies before main() in an endless loop of
-#                   "AddressSanitizer:DEADLYSIGNAL" lines and never exits. A non-PIE executable is
-#                   loaded at 0x400000 and cannot collide. libsanitizer made the allocator base
-#                   dynamic in GCC 14, so these two flags are unnecessary with that or newer.
-#                   See https://github.com/google/sanitizers/issues/1614
-SANITIZER_FLAGS = -fno-pie -no-pie
-
-
 # Compile without sanitizers and disable optimisation
 # $(SOURCE): 	        Input file(s)
 # $(INCLUDEDIRS:%=-I%)  Include directories
@@ -58,7 +45,7 @@ helloWorld: FORCE
 # -fsanitize=address:	Address sanitizer
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 asan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=address
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=address
 
 # Compile with undefined behavior sanitizer enabled
 # $(SOURCE): 			Input file(s)
@@ -72,7 +59,7 @@ asan: FORCE
 # -fsanitize=undefined:	Fast undefined behavior check
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 ubsan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=undefined
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=undefined
 
 # Compile with leak sanitizer enabled
 # $(SOURCE): 		    Input file(s)
@@ -86,7 +73,7 @@ ubsan: FORCE
 # -fsanitize=leak	    Basic memory leak sanitizer
 #                       (https://gcc.gnu.org/onlinedocs/gcc-5.3.0/gcc/Debugging-Options.html#index-fsanitize_003dundefined-652)
 lsan: FORCE
-	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) $(SANITIZER_FLAGS) -Werror -fsanitize=leak
+	$(CC) $(SOURCE) $(INCLUDEDIRS:%=-I%) -o $@.out -std=c11 -O0 $(WFLAGS) -Werror -fsanitize=leak
 
 # Compile with GCC static analysis enabled
 # $(SOURCE): 			Input file(s)


### PR DESCRIPTION
### Problem

#13594 added `-fno-pie -no-pie` to three Makefiles. Only one of them needed it.

`templates/c/gcc/test/Makefile` is copied over the assignment Makefile on every build
(`templates/phases/c/gcc.yaml:31`) and always compiles inside the Linux build image — that is where the
sanitizer allocator collision happens and where the flags were measured.

`exercise/Makefile` and `solution/Makefile` are different: they ship into the assignment and solution
repositories, and students and instructors compile them on their own machines. On macOS the `gcc` those
Makefiles default to is Apple clang, which has no use for `-no-pie` and reports it through
`-Wunused-command-line-argument`. The sanitizer recipes already pass `-Werror`, so that warning became a
hard error:

```
clang: error: argument unused during compilation: '-no-pie' [-Werror,-Wunused-command-line-argument]
```

`make asan`, `make ubsan` and `make lsan` therefore stopped working for every student on a Mac. CI never
saw it, because CI only ever builds the test Makefile, in the Linux image.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Changes affecting Programming Exercises
- [x] I verified the student-facing Makefiles build their sanitizer targets on macOS and in the Linux build image on both amd64 and arm64, and that the test Makefile CI builds is untouched.

### Description

Set the flags in the student Makefiles only on Linux:

```make
ifeq ($(shell uname -s),Linux)
SANITIZER_FLAGS = -fno-pie -no-pie
else
SANITIZER_FLAGS =
endif
```

The guard is on the operating system because that is where the problem is, not as a stand-in for a
compiler capability check. The collision comes from the Linux kernel loading a position-independent
executable at `ELF_ET_DYN_BASE` plus up to `((2^vm.mmap_rnd_bits) - 1) << 12` bytes, which can land inside
the fixed region GCC's address and leak sanitizer runtimes reserve for their allocator. macOS does not lay
memory out that way, so omitting the flags there is correct rather than a compromise.

`test/Makefile` is unchanged, so the fix from #13594 is fully preserved for CI and the build agents.

I also considered probing the compiler instead (`$(shell ... -Werror -x c - -o /dev/null && echo ...)`).
It works — I tested it — but it answers a different question, costs a compiler invocation on every `make`
including `make helloWorld`, fails opaquely where `/dev/null` is not a usable source, and silently drops
the fix if the probe errors for an unrelated reason. In a file students read and edit, the explicit
`uname` guard is the better trade.

### Steps for Testing

One identical `helloWorld.c` compiled through the exercise Makefile.

macOS, Apple clang 21.0.0 on arm64:

| target | current `develop` | this PR |
|---|---|---|
| `make asan` | fails | passes, `asan.out` prints `Hello world!` |
| `make ubsan` | fails | passes |

`make lsan` fails on macOS in both, because LeakSanitizer is unsupported by Apple clang on arm64 — that
predates #13594 and is unaffected here.

Linux, in the configured build image `ls1tum/artemis-c-minimal-docker:1.0.0`:

| target | result | ELF type |
|---|---|---|
| `make helloWorld` | passes | `DYN` (still position-independent) |
| `make asan` / `ubsan` / `lsan` | pass | `EXEC` (the fix applied) |
| `make staticAnalysis` | passes | `DYN` |

Confirmed on `linux/amd64` and `linux/arm64`. The test Makefile is not modified, so the C build-image
integration test and the SCA E2E tests compile with exactly the same flags as before.
