### PR TITLE
`Development`: Let a skipped not-null constraint be tried again on the next start

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20260827090000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260827090000_changelog.xml
@@ -16,8 +16,13 @@
 
         The constraint changesets are guarded by a precondition that no such row is left. Adding a not-null constraint to
         a column that still holds a null fails, and a failing changeset stops the application from starting, which is a
-        far worse outcome than the column staying nullable. With the guard the changeset is marked as run and the server
-        comes up; the column then needs a look and a changelog of its own.
+        far worse outcome than the column staying nullable.
+
+        The guard is onFail="CONTINUE" rather than MARK_RAN on purpose. CONTINUE skips the changeset without writing it
+        to databasechangelog, so the server starts, a warning is logged, and the constraint is tried again on the next
+        start. Once the rows that have no parent are dealt with, the column is constrained by itself. MARK_RAN would
+        record the changeset as done and the column would stay nullable on that installation for good, with only a new
+        changelog able to put it right.
 
         Rows are only deleted where their own dependants can be cleared along with them. exam.course_id is therefore
         left as it is: an exam is reachable through exercise groups, student exams, grading scales and exam users, and
@@ -64,7 +69,7 @@
         </sql>
     </changeSet>
     <changeSet id="20260827090000-02-result-submission-not-null" author="krusche">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onFail="CONTINUE">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM result WHERE submission_id IS NULL</sqlCheck>
         </preConditions>
         <addNotNullConstraint tableName="result" columnName="submission_id" columnDataType="bigint"/>
@@ -78,7 +83,7 @@
         </sql>
     </changeSet>
     <changeSet id="20260827090000-04-complaint-result-not-null" author="krusche">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onFail="CONTINUE">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM complaint WHERE result_id IS NULL</sqlCheck>
         </preConditions>
         <addNotNullConstraint tableName="complaint" columnName="result_id" columnDataType="bigint"/>
@@ -90,7 +95,7 @@
         </delete>
     </changeSet>
     <changeSet id="20260827090000-06-complaint-response-complaint-not-null" author="krusche">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onFail="CONTINUE">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM complaint_response WHERE complaint_id IS NULL</sqlCheck>
         </preConditions>
         <addNotNullConstraint tableName="complaint_response" columnName="complaint_id" columnDataType="bigint"/>
@@ -102,7 +107,7 @@
         </delete>
     </changeSet>
     <changeSet id="20260827090000-08-build-log-entry-submission-not-null" author="krusche">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onFail="CONTINUE">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM build_log_entry WHERE programming_submission_id IS NULL</sqlCheck>
         </preConditions>
         <addNotNullConstraint tableName="build_log_entry" columnName="programming_submission_id" columnDataType="bigint"/>
@@ -114,7 +119,7 @@
         </delete>
     </changeSet>
     <changeSet id="20260827090000-10-assessment-note-result-not-null" author="krusche">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onFail="CONTINUE">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM assessment_note WHERE result_id IS NULL</sqlCheck>
         </preConditions>
         <addNotNullConstraint tableName="assessment_note" columnName="result_id" columnDataType="bigint"/>
@@ -126,14 +131,14 @@
         </delete>
     </changeSet>
     <changeSet id="20260827090000-12-grade-step-scale-not-null" author="krusche">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onFail="CONTINUE">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM grade_step WHERE grading_scale_id IS NULL</sqlCheck>
         </preConditions>
         <addNotNullConstraint tableName="grade_step" columnName="grading_scale_id" columnDataType="bigint"/>
     </changeSet>
 
     <changeSet id="20260827090000-13-exam-course-not-null" author="krusche">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onFail="CONTINUE">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM exam WHERE course_id IS NULL</sqlCheck>
         </preConditions>
         <addNotNullConstraint tableName="exam" columnName="course_id" columnDataType="bigint"/>
@@ -145,7 +150,7 @@
         </delete>
     </changeSet>
     <changeSet id="20260827090000-15-conversation-participant-conversation-not-null" author="krusche">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onFail="CONTINUE">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM conversation_participant WHERE conversation_id IS NULL</sqlCheck>
         </preConditions>
         <addNotNullConstraint tableName="conversation_participant" columnName="conversation_id" columnDataType="bigint"/>
@@ -159,7 +164,7 @@
         </sql>
     </changeSet>
     <changeSet id="20260827090000-17-answer-post-post-not-null" author="krusche">
-        <preConditions onFail="MARK_RAN">
+        <preConditions onFail="CONTINUE">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM answer_post WHERE post_id IS NULL</sqlCheck>
         </preConditions>
         <addNotNullConstraint tableName="answer_post" columnName="post_id" columnDataType="bigint"/>


### PR DESCRIPTION
### Summary

The not-null constraints added in #13581 are each guarded by a precondition, so that a row without a parent leaves the
column nullable instead of stopping the server from starting. The guard used `onFail="MARK_RAN"`, which records the
changeset as done and never tries it again. This changes the nine guards to `onFail="CONTINUE"`, which skips without
recording, so the constraint is applied by itself once the data is sound.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).

### Motivation and Context

Every constraint changeset in #13581 asks first whether any row still has no parent. If one does, adding the constraint
would fail, and a failing changeset stops Artemis from starting, so the guard is there on purpose.

`MARK_RAN` skips the changeset but writes it to `databasechangelog` as if it had run. An installation that trips the
precondition would keep the column nullable for good: even after an administrator cleans up the rows, Liquibase never
looks at the changeset again, and only a new changelog with a new id could put it right. The entity would meanwhile go
on declaring `nullable = false`, so the mapping and the schema would disagree with nothing to bring them back together.

`exam.course_id` is the one most likely to hit this. It is the only column in that changelog whose changeset has no
delete in front of it, because an exam can only be removed through the exam deletion service and not from a changelog.

### Description

The nine `onFail="MARK_RAN"` guards become `onFail="CONTINUE"`. `CONTINUE` skips the changeset without recording it, so
the server still starts, a warning is logged, and the constraint is tried again on the next start.

The cost is that the `SELECT COUNT(*)` runs again on every start until it passes. That only affects an installation
that actually has such a row, and it stops as soon as the constraint applies.

### Steps for Testing

Verified against MySQL, on the changelog of the follow-up batch which uses the same guards:

1. Build the schema up to the changeset before the batch, then store one `student_exam` with no exam.
2. Apply the changelog. The constraint changeset is skipped, `student_exam.exam_id` stays nullable, and
   `DATABASECHANGELOG` holds **no** row for it, while a sibling changeset that did apply holds one.
3. Give the row its exam, the way an administrator would.
4. Apply the same changelog again. The changeset runs and `student_exam.exam_id` becomes `NOT NULL`.

With `MARK_RAN` step 4 does nothing, which is the behaviour this changes.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
