### PR TITLE
`Development`: Report the coverage badge from our own CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -178,8 +178,9 @@ The one exception is the `deploy-docs` **job** in `ci.yml`, which carries a job-
 `concurrency: { group: pages, cancel-in-progress: false }`. Job-level concurrency is safe (it is
 not the reusable-workflow lock that #3205 warns about), and the repo-global `pages` group is what
 serializes every GitHub Pages deploy — across umbrella runs and against the manual redeploy in
-`deploy-documentation.yml`. `coverage-badge` uses a job-level group for the same reason: to
-serialize its pushes to the `badges` branch across back-to-back develop pushes.
+`deploy-documentation.yml`. `coverage-badge` deliberately has **no** job-level group: the umbrella's
+own `ci-${{ github.ref }}` group already serializes develop runs end to end, and nothing outside
+`ci.yml` writes the `badges` branch.
 
 ## The coverage badge
 
@@ -197,14 +198,25 @@ than publishing a worse one:
 
 1. The job runs only when `test` **succeeded**. A run with a flaky failure has artificially low
    coverage — tests that never ran cover nothing — so it is never published.
-2. `compute-coverage-badge.mjs` refuses a report that is missing, unparseable, or measured/covered
-   zero lines.
+2. `compute-coverage-badge.mjs` refuses a report that is missing, truncated, or measured/covered
+   zero lines. Truncation matters more than it sounds: the parser anchors on the last `</package>`,
+   so a report cut short mid-package would otherwise read a *sourcefile*-level counter and publish a
+   small but entirely plausible wrong number. It therefore asserts that nothing but report-level
+   counters separates that anchor from `</report>`.
 3. It refuses a value whose combined line **total** collapsed below half the published total. That
-   catches a vanished module report without freezing on a genuine regression, which leaves the
-   denominator intact.
+   catches a vanished module report without freezing on a genuine coverage regression, which leaves
+   the denominator intact.
 
 Every rejection is a no-op: the job exits 0 without committing, and Shields keeps serving the last
 good file. Nothing about the badge can turn `develop` red.
+
+**Guard 3 latches, by construction.** It compares against the last *published* total, which only
+advances when something is published. So a legitimate halving of the combined line total — a large
+module deleted, or Vitest's `include` narrowed — trips it on every subsequent develop push rather
+than settling. That is why the script exits **4** for a tripped guard and **3** for the routine
+"value unchanged" case: the job turns 4 into a `::warning::`, which is the only signal that would
+make such a freeze noticeable. The escape hatch is a manual re-seed, documented in
+[the script's README](../../supporting_scripts/code-coverage/coverage-badge/README.md).
 
 Commits land on `badges` only, never on `develop`, and only when the rendered value actually
 changes. Between changes the file's `exact`/`sha`/`updatedAt` fields go stale by design — they feed

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,6 +32,7 @@ ci.yml                                                            (single entry 
 │
 │   DEPLOY — develop only, never on a PR:
 ├── deploy-docs                  (publishes the docs to GitHub Pages; needs `docs`; job-level `pages` concurrency)
+├── coverage-badge               (publishes the README coverage figure to the orphan `badges` branch; needs a GREEN `test`)
 │
 ├── all-required-ci-passed       (jq gate over the required jobs — excludes the advisory codeql/coverage-report — the required check)
 └── ci-summary                   (Gantt timeline + per-job table; informational)
@@ -177,7 +178,41 @@ The one exception is the `deploy-docs` **job** in `ci.yml`, which carries a job-
 `concurrency: { group: pages, cancel-in-progress: false }`. Job-level concurrency is safe (it is
 not the reusable-workflow lock that #3205 warns about), and the repo-global `pages` group is what
 serializes every GitHub Pages deploy — across umbrella runs and against the manual redeploy in
-`deploy-documentation.yml`.
+`deploy-documentation.yml`. `coverage-badge` uses a job-level group for the same reason: to
+serialize its pushes to the `badges` branch across back-to-back develop pushes.
+
+## The coverage badge
+
+The `coverage` badge in the root `README.md` is served by Shields from `coverage.json` on the
+orphan **`badges`** branch. `ci.yml`'s `coverage-badge` job recomputes it on every `develop` push,
+from the same `Server JaCoCo XML` and `Client Coverage Summaries` artifacts the `test` job already
+uploads — no test re-run. The figure is
+`(server.covered + client.covered) / (server.total + client.total)` over **lines**, the one metric
+JaCoCo and Vitest both emit natively, so it is weighted by codebase size rather than being a mean
+of two percentages. E2E contributes nothing: `ci-e2e.yml` is black-box Playwright with no JaCoCo
+agent and no instrumented client build, so it produces no coverage data.
+
+**The badge is deliberately sticky.** Three guards each cause the previous value to stand rather
+than publishing a worse one:
+
+1. The job runs only when `test` **succeeded**. A run with a flaky failure has artificially low
+   coverage — tests that never ran cover nothing — so it is never published.
+2. `compute-coverage-badge.mjs` refuses a report that is missing, unparseable, or measured/covered
+   zero lines.
+3. It refuses a value whose combined line **total** collapsed below half the published total. That
+   catches a vanished module report without freezing on a genuine regression, which leaves the
+   denominator intact.
+
+Every rejection is a no-op: the job exits 0 without committing, and Shields keeps serving the last
+good file. Nothing about the badge can turn `develop` red.
+
+Commits land on `badges` only, never on `develop`, and only when the rendered value actually
+changes. Between changes the file's `exact`/`sha`/`updatedAt` fields go stale by design — they feed
+only the coarse guard in (3), which does not need to be current. Nothing loops: no push trigger in
+this repo matches `badges`, and GitHub does not fire workflows for `GITHUB_TOKEN` pushes.
+
+The logic is unit-tested in `supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.spec.mjs`,
+which runs as part of `pnpm run test:rules` in the client test job.
 
 ## Adding a new CI check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,10 +421,10 @@ jobs:
       # Sole purpose: pushing coverage.json to the orphan `badges` branch. Nothing here runs
       # PR-author code — the job only reads artifacts the trusted `test` job produced.
       contents: write
-    # Serializes back-to-back develop pushes so two runs cannot race to push the same branch.
-    concurrency:
-      group: coverage-badge
-      cancel-in-progress: false
+    # No job-level `concurrency:` here, deliberately. The umbrella's own `ci-${{ github.ref }}` group
+    # (cancel-in-progress false for push) already serializes develop runs end to end, so two of these
+    # can never be in flight at once. Unlike `deploy-docs`, nothing outside this file writes `badges`,
+    # so a second group would only add a way for the job to be cancelled while pending.
     steps:
       - name: Check out the badge tooling
         uses: actions/checkout@v6
@@ -467,6 +467,15 @@ jobs:
           name: Client Coverage Summaries
           path: client-coverage
 
+      # Pinned rather than relying on the runner image's Node, matching the `coverage-report` job
+      # above: without it a runner-image change degrades to exit 127, which this job would swallow as
+      # a warning and the badge would silently stop updating.
+      - name: Setup Node.js
+        if: steps.badges-checkout.outcome == 'success'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
       - name: Compute and publish the coverage badge
         if: steps.badges-checkout.outcome == 'success'
         env:
@@ -486,9 +495,17 @@ jobs:
           status=$?
           set -e
 
-          # Exit 3 covers both an unchanged value and a tripped guard; the script printed which.
+          # 3 is the healthy no-op (nothing moved). 4 means a guard rejected the value, which
+          # warrants a warning: the collapse guard latches on the last published total, so a
+          # legitimate halving of the codebase would otherwise freeze the badge invisibly.
           if [ "$status" -eq 3 ]; then
-            echo "::notice::Coverage badge not republished; the published value stands (reason logged above)."
+            echo "::notice::Coverage badge unchanged; the published value stands."
+            exit 0
+          fi
+          if [ "$status" -eq 4 ]; then
+            echo "::warning::Coverage badge guard rejected the computed value (reason logged above);" \
+                 "the published value stands. If this repeats on every push, re-seed the branch as" \
+                 "described in supporting_scripts/code-coverage/coverage-badge/README.md."
             exit 0
           fi
           if [ "$status" -ne 0 ]; then
@@ -496,18 +513,30 @@ jobs:
             exit 0
           fi
 
-          cd badges-branch
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add coverage.json
-          # Defensive: the script only exits 0 when the value changed, so an empty diff would mean
-          # the two disagree. Nothing to push either way.
-          if git diff --cached --quiet; then
-            echo "::notice::Coverage badge file is byte-identical; nothing to push."
-            exit 0
+          # Every command is checked explicitly rather than leaning on `set -e`: `set -e` is
+          # suspended inside an `if` condition (and inside subshells within one), and this job must
+          # never turn develop red — a badge that could not be pushed is a warning, not a failure.
+          publish_badge() {
+            cd badges-branch || return 1
+            git config user.name 'github-actions[bot]' || return 1
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com' || return 1
+            git add coverage.json || return 1
+            # Defensive: the script only exits 0 when the value changed, so an empty diff would mean
+            # the two disagree. Nothing to push either way.
+            if git diff --cached --quiet; then
+              echo "::notice::Coverage badge file is byte-identical; nothing to push."
+              return 0
+            fi
+            local message
+            message=$(jq -r .message coverage.json) || return 1
+            git commit -m "Update the coverage badge to ${message}" || return 1
+            git push origin HEAD:badges || return 1
+          }
+
+          if ! publish_badge; then
+            echo "::warning::Could not publish the coverage badge; the published value stands."
           fi
-          git commit -m "Update the coverage badge to $(jq -r .message coverage.json)"
-          git push origin HEAD:badges || echo "::warning::Could not push the coverage badge; the next develop push will retry."
+          exit 0
 
   translation:
     name: Check Translation Keys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,6 +396,119 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v5
 
+  # Publishes the combined server + client line-coverage figure that the README badge renders,
+  # replacing the Codacy coverage badge (Codacy stopped reporting a value and the badge read 0%).
+  #
+  # Develop-push only, and gated on `test` having SUCCEEDED — that gate is the stability property.
+  # Coverage from a partially failed run is artificially low (tests that never ran cover nothing), so
+  # republishing it would make the badge dip on ambient flakiness. Skipping instead leaves the last
+  # published value in place, which is what we want a flaky run to do.
+  #
+  # The value lands on the orphan `badges` branch, never on develop, so this adds no commits to the
+  # mainline history. Two independent reasons it cannot loop: no workflow triggers on `badges` (every
+  # push trigger in this repo filters to develop/main/release/*), and GitHub does not fire workflows
+  # for pushes made with GITHUB_TOKEN.
+  #
+  # ADVISORY: never in another job's `needs:` and never gating. Every failure path warns and exits 0,
+  # because a badge that could not be recomputed must not turn develop red.
+  coverage-badge:
+    name: Publish Coverage Badge
+    needs: test
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.test.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # Sole purpose: pushing coverage.json to the orphan `badges` branch. Nothing here runs
+      # PR-author code — the job only reads artifacts the trusted `test` job produced.
+      contents: write
+    # Serializes back-to-back develop pushes so two runs cannot race to push the same branch.
+    concurrency:
+      group: coverage-badge
+      cancel-in-progress: false
+    steps:
+      - name: Check out the badge tooling
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: supporting_scripts/code-coverage/coverage-badge
+          # This checkout only supplies the script; the push happens from the `badges` checkout below.
+          persist-credentials: false
+
+      - name: Check out the badges branch
+        id: badges-checkout
+        # `continue-on-error` keeps the job advisory: if the orphan branch is missing or unreadable,
+        # the guard step below warns and every later step no-ops.
+        continue-on-error: true
+        uses: actions/checkout@v6
+        with:
+          ref: badges
+          path: badges-branch
+          fetch-depth: 1
+
+      - name: Warn when the badges branch is unavailable
+        if: steps.badges-checkout.outcome != 'success'
+        run: |
+          echo "::warning::Could not check out the 'badges' branch, so the published coverage badge stands." \
+               "If the branch was deleted, re-seed it as described in" \
+               "supporting_scripts/code-coverage/coverage-badge/README.md."
+
+      - name: Download the server JaCoCo report
+        if: steps.badges-checkout.outcome == 'success'
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: Server JaCoCo XML
+          path: server-coverage
+
+      - name: Download the client coverage summary
+        if: steps.badges-checkout.outcome == 'success'
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: Client Coverage Summaries
+          path: client-coverage
+
+      - name: Compute and publish the coverage badge
+        if: steps.badges-checkout.outcome == 'success'
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -Eeuo pipefail
+
+          # Exit 0 publishes, 3 deliberately keeps the previous value, anything else is unexpected.
+          # `set +e` around the call so a non-zero status is inspected rather than killing the step.
+          set +e
+          node supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs \
+            --jacoco server-coverage/aggregated/jacocoTestReport.xml \
+            --vitest client-coverage/coverage-summary.json \
+            --previous badges-branch/coverage.json \
+            --out badges-branch/coverage.json \
+            --sha "$COMMIT_SHA"
+          status=$?
+          set -e
+
+          # Exit 3 covers both an unchanged value and a tripped guard; the script printed which.
+          if [ "$status" -eq 3 ]; then
+            echo "::notice::Coverage badge not republished; the published value stands (reason logged above)."
+            exit 0
+          fi
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::Coverage badge computation failed (exit ${status}); keeping the published value."
+            exit 0
+          fi
+
+          cd badges-branch
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add coverage.json
+          # Defensive: the script only exits 0 when the value changed, so an empty diff would mean
+          # the two disagree. Nothing to push either way.
+          if git diff --cached --quiet; then
+            echo "::notice::Coverage badge file is byte-identical; nothing to push."
+            exit 0
+          fi
+          git commit -m "Update the coverage badge to $(jq -r .message coverage.json)"
+          git push origin HEAD:badges || echo "::warning::Could not push the coverage badge; the next develop push will retry."
+
   translation:
     name: Check Translation Keys
     needs: detect-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,14 +409,16 @@ jobs:
   # push trigger in this repo filters to develop/main/release/*), and GitHub does not fire workflows
   # for pushes made with GITHUB_TOKEN.
   #
-  # ADVISORY: never in another job's `needs:` and never gating. Every failure path warns and exits 0,
-  # because a badge that could not be recomputed must not turn develop red.
+  # ADVISORY: never in another job's `needs:` and never gating. Scripted failure paths warn and exit
+  # 0; job-level `continue-on-error` is the final safety net for action/runner failures, because a
+  # badge that could not be recomputed must not turn develop red.
   coverage-badge:
     name: Publish Coverage Badge
     needs: test
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.test.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    continue-on-error: true
     permissions:
       # Sole purpose: pushing coverage.json to the orphan `badges` branch. Nothing here runs
       # PR-author code — the job only reads artifacts the trusted `test` job produced.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ their own infrastructure.
 [![CI](https://github.com/ls1intum/Artemis/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/ls1intum/Artemis/actions/workflows/ci.yml)
 [![Documentation](https://github.com/ls1intum/Artemis/actions/workflows/deploy-documentation.yml/badge.svg?event=push)](https://docs.artemis.tum.de)
 [![Code Quality Status](https://app.codacy.com/project/badge/Grade/89860aea5fa74d998ec884f1a875ed0c)](https://www.codacy.com/gh/ls1intum/Artemis?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ls1intum/Artemis&amp;utm_campaign=Badge_Grade)
-[![Coverage Status](https://app.codacy.com/project/badge/Coverage/89860aea5fa74d998ec884f1a875ed0c)](https://www.codacy.com/gh/ls1intum/Artemis?utm_source=github.com&utm_medium=referral&utm_content=ls1intum/Artemis&utm_campaign=Badge_Coverage)
+[![Coverage Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fls1intum%2FArtemis%2Fbadges%2Fcoverage.json)](https://github.com/ls1intum/Artemis/actions/workflows/ci.yml)
 [![Latest version](https://img.shields.io/github/v/tag/ls1intum/Artemis?label=%20Latest%20version&sort=semver)](https://github.com/ls1intum/Artemis/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/ls1intum/Artemis/badge)](https://scorecard.dev/viewer/?uri=github.com/ls1intum/Artemis)

--- a/supporting_scripts/code-coverage/coverage-badge/README.md
+++ b/supporting_scripts/code-coverage/coverage-badge/README.md
@@ -52,13 +52,22 @@ gh run download <run-id> -n "Server JaCoCo XML" -n "Client Coverage Summaries" -
 
 ## Exit codes
 
-| Code | Meaning |
-| ---- | ------- |
-| `0`  | A new value was computed and written to `--out`. |
-| `3`  | Deliberately kept the previous value (a guard tripped, or the value is unchanged). The reason is printed. |
-| `1`  | Bad invocation. |
+| Code | Meaning                                                                            |
+| ---- | ---------------------------------------------------------------------------------- |
+| `0`  | A new value was computed and written to `--out`.                                   |
+| `3`  | The value is unchanged — the routine no-op. CI logs a notice.                      |
+| `4`  | A guard rejected the computed value; the reason is printed. CI logs a **warning**. |
+| `1`  | Bad invocation.                                                                    |
 
-Exit `3` is a normal outcome, not a failure — it is how the badge stays stable across a flaky run.
+Neither `3` nor `4` is a failure: both leave the published value standing, which is how the badge
+stays stable across a flaky run. They are split because a repeating `4` is worth investigating while
+a repeating `3` is just a quiet week.
+
+The collapse guard **latches**: it compares against the last _published_ total, and that total only
+advances when a value is published. A legitimate halving of the combined line count — a large module
+deleted, or Vitest's `include` narrowed — therefore trips it on every subsequent develop push instead
+of settling, and the badge freezes until someone re-seeds. The `::warning::` on exit `4` is what
+makes that visible; the re-seed below is the fix.
 
 ## Re-seeding the `badges` branch
 

--- a/supporting_scripts/code-coverage/coverage-badge/README.md
+++ b/supporting_scripts/code-coverage/coverage-badge/README.md
@@ -1,0 +1,90 @@
+# Coverage badge
+
+Computes the combined server + client coverage figure shown by the `coverage` badge in the root
+`README.md`, replacing the Codacy coverage badge that stopped reporting a value.
+
+`ci.yml`'s `coverage-badge` job runs this on every `develop` push and publishes the result to
+`coverage.json` on the orphan **`badges`** branch, which Shields renders via its endpoint API. The
+full CI contract — triggers, permissions, and why the badge is sticky — is documented in
+[`.github/workflows/README.md`](../../../.github/workflows/README.md#the-coverage-badge).
+
+## What it measures
+
+```
+(server.covered + client.covered) / (server.total + client.total)
+```
+
+over **lines**, taken from the report-level `<counter type="LINE">` of the aggregated JaCoCo report
+and from `total.lines` of the Vitest `coverage-summary.json`. Lines are the only metric both tools
+emit natively. Summing the raw counts rather than averaging the two percentages means the figure is
+weighted by codebase size.
+
+The two metrics are not semantically identical — JaCoCo counts lines of compiled bytecode, Istanbul
+counts instrumented TypeScript lines — so this is a deliberately rough combined figure, not an exact
+one. E2E contributes nothing: `ci-e2e.yml` is black-box Playwright with no JaCoCo agent and no
+instrumented client build, so it emits no coverage data.
+
+## Running it locally
+
+Both inputs are produced by the normal test tasks:
+
+```bash
+./gradlew test jacocoTestReport -x webapp   # build/reports/jacoco/aggregated/jacocoTestReport.xml
+pnpm run vitest:coverage                    # build/test-results/vitest/coverage/coverage-summary.json
+```
+
+```bash
+node supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs \
+  --jacoco build/reports/jacoco/aggregated/jacocoTestReport.xml \
+  --vitest build/test-results/vitest/coverage/coverage-summary.json \
+  --out /tmp/coverage.json
+```
+
+To reproduce exactly what CI would publish, add `--previous` (the currently published file) and
+`--sha`. Without a full test run the numbers will be lower than CI's, since a partial run leaves
+most lines uncovered.
+
+You can also feed it the artifacts from a green `develop` run instead of running the suites:
+
+```bash
+gh run download <run-id> -n "Server JaCoCo XML" -n "Client Coverage Summaries" -D /tmp/cov
+```
+
+## Exit codes
+
+| Code | Meaning |
+| ---- | ------- |
+| `0`  | A new value was computed and written to `--out`. |
+| `3`  | Deliberately kept the previous value (a guard tripped, or the value is unchanged). The reason is printed. |
+| `1`  | Bad invocation. |
+
+Exit `3` is a normal outcome, not a failure — it is how the badge stays stable across a flaky run.
+
+## Re-seeding the `badges` branch
+
+The CI job never creates the branch — if `badges` is deleted, the job warns and the badge breaks
+until someone recreates it. Build the value from a green `develop` run, then push an orphan commit
+(plumbing commands, so no branch switch and no working-tree churn):
+
+```bash
+gh run download <green-develop-run-id> -n "Server JaCoCo XML" -n "Client Coverage Summaries" -D /tmp/cov
+node supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs \
+  --jacoco "/tmp/cov/Server JaCoCo XML/aggregated/jacocoTestReport.xml" \
+  --vitest "/tmp/cov/Client Coverage Summaries/coverage-summary.json" \
+  --out coverage.json --sha <commit-sha>
+
+BLOB=$(git hash-object -w coverage.json)
+TREE=$(printf '100644 blob %s\tcoverage.json\n' "$BLOB" | git mktree)
+COMMIT=$(git commit-tree "$TREE" -m 'Seed the coverage badge')
+git push origin "$COMMIT":refs/heads/badges
+rm coverage.json
+```
+
+## Tests
+
+`compute-coverage-badge.spec.mjs` covers the parsers and each guard. It runs in CI as part of the
+client test job:
+
+```bash
+pnpm run test:rules
+```

--- a/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs
+++ b/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs
@@ -23,7 +23,11 @@
  *                                   --out <coverage.json> \
  *                                   [--previous <coverage.json>] [--sha <commit-sha>]
  *
- * Exit codes: 0 = wrote a new badge, 3 = deliberately kept the previous badge, 1 = bad invocation.
+ * Exit codes: 0 = wrote a new badge, 3 = the value is unchanged (the healthy no-op), 4 = a guard
+ * rejected the computed value, 1 = bad invocation. 3 and 4 are split because the collapse guard
+ * LATCHES: it compares against the last *published* total, which only advances when something is
+ * published, so a legitimate halving of the codebase would refuse forever. CI therefore surfaces 4
+ * as a warning, which is the only thing that makes such a freeze visible. See the README.
  */
 
 import fs from 'fs';
@@ -35,6 +39,11 @@ import { pathToFileURL } from 'url';
  * published total. That is the "a module's report went missing" guard: a partial report shrinks the
  * denominator drastically, while a genuine coverage regression leaves it essentially unchanged. The
  * band is deliberately wide so the badge can never freeze on a real regression.
+ *
+ * Note the guard latches: it compares against the last *published* total, which only moves when a
+ * value is published. A legitimate halving of the codebase (a large module deleted, or the Vitest
+ * `include` narrowed) therefore trips it on every subsequent push until someone re-seeds the branch.
+ * That is why it exits 4 rather than 3 — CI turns 4 into a warning so the freeze is noticed.
  */
 export const MIN_TOTAL_RATIO = 0.5;
 
@@ -76,9 +85,20 @@ export function parseJacocoLines(xml) {
     if (lastPackageEnd === -1) {
         return undefined;
     }
+    const tail = xml.slice(lastPackageEnd + '</package>'.length);
+    // Everything after the final `</package>` must be report-level counters and nothing else.
+    // Asserting that shape is what makes a mis-anchored parse fail loudly instead of quietly:
+    // in a truncated report `lastIndexOf` lands on an EARLIER package's close, and the next LINE
+    // counter then belongs to a `<sourcefile>` — a small but entirely plausible pair of numbers
+    // that would sail past the guards below and publish a wrong badge. The same assertion rejects
+    // a `<group>`-structured aggregate, where the tail would carry a `</group>` and the counter
+    // read would be one group's total rather than the report's.
+    if (!/^\s*(?:<counter\b[^>]*\/>\s*)*<\/report>\s*$/.test(tail)) {
+        return undefined;
+    }
     // Attributes are matched individually rather than as a fixed `missed`/`covered` pair, so a
     // JaCoCo version that reorders them does not silently stop matching.
-    const lineCounter = xml.slice(lastPackageEnd).match(/<counter\b[^>]*\btype="LINE"[^>]*\/>/);
+    const lineCounter = tail.match(/<counter\b[^>]*\btype="LINE"[^>]*\/>/);
     if (!lineCounter) {
         return undefined;
     }
@@ -117,24 +137,24 @@ export function parseVitestLines(summary) {
  * @param {object} [options.previous] the currently published coverage.json, absent on the very first run
  * @param {string} [options.sha] the commit the value was computed from
  * @param {string} [options.now] ISO timestamp to stamp the value with
- * @returns {{status: 'publish', badge: object} | {status: 'skip', reason: string}}
+ * @returns {{status: 'publish', badge: object} | {status: 'skip', kind: 'unchanged' | 'guard', reason: string}}
  */
 export function computeBadge({ jacocoXml, vitestSummary, previous, sha, now } = {}) {
     const server = parseJacocoLines(jacocoXml);
     if (!server) {
-        return { status: 'skip', reason: 'the server JaCoCo report is missing or has no report-level LINE counter' };
+        return { status: 'skip', kind: 'guard', reason: 'the server JaCoCo report is missing, truncated, or has no report-level LINE counter' };
     }
     const client = parseVitestLines(vitestSummary);
     if (!client) {
-        return { status: 'skip', reason: 'the client Vitest summary is missing or has no total.lines counts' };
+        return { status: 'skip', kind: 'guard', reason: 'the client Vitest summary is missing or has no total.lines counts' };
     }
     // A report that parsed but measured nothing means the run produced no usable data, not that the
     // codebase is untested.
     if (server.total === 0 || client.total === 0) {
-        return { status: 'skip', reason: 'a coverage report measured zero lines' };
+        return { status: 'skip', kind: 'guard', reason: 'a coverage report measured zero lines' };
     }
     if (server.covered === 0 || client.covered === 0) {
-        return { status: 'skip', reason: 'a coverage report covered zero lines' };
+        return { status: 'skip', kind: 'guard', reason: 'a coverage report covered zero lines' };
     }
 
     const combined = { covered: server.covered + client.covered, total: server.total + client.total };
@@ -142,6 +162,7 @@ export function computeBadge({ jacocoXml, vitestSummary, previous, sha, now } = 
     if (Number.isFinite(previousTotal) && combined.total < previousTotal * MIN_TOTAL_RATIO) {
         return {
             status: 'skip',
+            kind: 'guard',
             reason: `the combined line total collapsed from ${previousTotal} to ${combined.total}, which indicates a partial report rather than a coverage change`,
         };
     }
@@ -150,7 +171,7 @@ export function computeBadge({ jacocoXml, vitestSummary, previous, sha, now } = 
     const message = `${pct.toFixed(1)}%`;
     // Nothing visible changed, so committing would only add noise to the badges branch.
     if (previous?.message === message) {
-        return { status: 'skip', reason: `the value is unchanged at ${message}` };
+        return { status: 'skip', kind: 'unchanged', reason: `the value is unchanged at ${message}` };
     }
 
     return {
@@ -238,7 +259,7 @@ function main() {
 
     if (result.status === 'skip') {
         console.log(`Keeping the previously published coverage badge: ${result.reason}.`);
-        process.exit(3);
+        process.exit(result.kind === 'unchanged' ? 3 : 4);
     }
 
     fs.mkdirSync(path.dirname(path.resolve(args.out)), { recursive: true });

--- a/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs
+++ b/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs
@@ -1,0 +1,254 @@
+/**
+ * Computes the combined server + client line-coverage value that the README badge renders.
+ *
+ * Reads the two coverage reports CI already produces on every `develop` push (see ci-test.yml) and
+ * folds them into a single percentage, weighted implicitly by codebase size:
+ *
+ *     (server.covered + client.covered) / (server.total + client.total)
+ *
+ * Lines are the only metric both tools emit natively — JaCoCo's report-level `<counter type="LINE">`
+ * and Vitest's `total.lines` — so they are what the badge combines. The two are not semantically
+ * identical (JaCoCo counts lines of compiled bytecode, Istanbul counts instrumented TS lines), which
+ * is why the badge is documented as a rough combined figure rather than an exact one.
+ *
+ * E2E is deliberately absent: `ci-e2e.yml` runs Playwright black-box against a Docker stack with no
+ * JaCoCo agent and no instrumented client build, so it emits no coverage data to fold in.
+ *
+ * The exported functions are pure so that the guards below can be unit-tested against fixtures; all
+ * file IO and process-exit handling lives in the CLI wrapper at the bottom.
+ *
+ * Usage:
+ *   node compute-coverage-badge.mjs --jacoco <aggregated/jacocoTestReport.xml> \
+ *                                   --vitest <coverage-summary.json> \
+ *                                   --out <coverage.json> \
+ *                                   [--previous <coverage.json>] [--sha <commit-sha>]
+ *
+ * Exit codes: 0 = wrote a new badge, 3 = deliberately kept the previous badge, 1 = bad invocation.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+/**
+ * A new value is rejected when the combined line total falls below this fraction of the previously
+ * published total. That is the "a module's report went missing" guard: a partial report shrinks the
+ * denominator drastically, while a genuine coverage regression leaves it essentially unchanged. The
+ * band is deliberately wide so the badge can never freeze on a real regression.
+ */
+export const MIN_TOTAL_RATIO = 0.5;
+
+/** Shields badge colours, highest threshold first. */
+const COLOR_THRESHOLDS = [
+    { min: 90, color: 'brightgreen' },
+    { min: 80, color: 'green' },
+    { min: 70, color: 'yellowgreen' },
+    { min: 60, color: 'yellow' },
+    { min: 50, color: 'orange' },
+    { min: 0, color: 'red' },
+];
+
+/**
+ * Picks the Shields colour for a coverage percentage.
+ * @param {number} pct coverage percentage in [0, 100]
+ * @returns {string} a Shields colour name
+ */
+export function colorFor(pct) {
+    return COLOR_THRESHOLDS.find((threshold) => pct >= threshold.min).color;
+}
+
+/**
+ * Extracts the report-level LINE counter from a JaCoCo XML report.
+ *
+ * JaCoCo repeats `<counter>` at method, class, package and report level, so summing every match
+ * would multiply-count the same lines. The report-level counters are the only ones that follow the
+ * final `</package>`, which is what this slices on. A report with no packages carries no totals
+ * either and is treated as unparseable.
+ *
+ * @param {string} xml the full JaCoCo XML report
+ * @returns {{covered: number, total: number} | undefined} undefined when no report-level LINE counter exists
+ */
+export function parseJacocoLines(xml) {
+    if (typeof xml !== 'string') {
+        return undefined;
+    }
+    const lastPackageEnd = xml.lastIndexOf('</package>');
+    if (lastPackageEnd === -1) {
+        return undefined;
+    }
+    // Attributes are matched individually rather than as a fixed `missed`/`covered` pair, so a
+    // JaCoCo version that reorders them does not silently stop matching.
+    const lineCounter = xml.slice(lastPackageEnd).match(/<counter\b[^>]*\btype="LINE"[^>]*\/>/);
+    if (!lineCounter) {
+        return undefined;
+    }
+    const missed = lineCounter[0].match(/\bmissed="(\d+)"/);
+    const covered = lineCounter[0].match(/\bcovered="(\d+)"/);
+    if (!missed || !covered) {
+        return undefined;
+    }
+    const missedCount = Number(missed[1]);
+    const coveredCount = Number(covered[1]);
+    return { covered: coveredCount, total: coveredCount + missedCount };
+}
+
+/**
+ * Extracts the aggregate line counts from an Istanbul/Vitest `coverage-summary.json`.
+ * @param {unknown} summary the parsed coverage summary
+ * @returns {{covered: number, total: number} | undefined} undefined when the totals are absent or non-numeric
+ */
+export function parseVitestLines(summary) {
+    const lines = summary?.total?.lines;
+    if (!lines || !Number.isFinite(lines.covered) || !Number.isFinite(lines.total)) {
+        return undefined;
+    }
+    return { covered: lines.covered, total: lines.total };
+}
+
+/**
+ * Decides whether to publish a new badge value, applying the stability guards.
+ *
+ * Every rejection keeps the previously published value, which is what makes the badge stable across
+ * a flaky run: the caller simply does not commit, and Shields keeps serving the last good file.
+ *
+ * @param {object} options
+ * @param {string} [options.jacocoXml] the aggregated JaCoCo XML report, absent when the artifact is missing
+ * @param {unknown} [options.vitestSummary] the parsed Vitest coverage summary, absent when the artifact is missing
+ * @param {object} [options.previous] the currently published coverage.json, absent on the very first run
+ * @param {string} [options.sha] the commit the value was computed from
+ * @param {string} [options.now] ISO timestamp to stamp the value with
+ * @returns {{status: 'publish', badge: object} | {status: 'skip', reason: string}}
+ */
+export function computeBadge({ jacocoXml, vitestSummary, previous, sha, now } = {}) {
+    const server = parseJacocoLines(jacocoXml);
+    if (!server) {
+        return { status: 'skip', reason: 'the server JaCoCo report is missing or has no report-level LINE counter' };
+    }
+    const client = parseVitestLines(vitestSummary);
+    if (!client) {
+        return { status: 'skip', reason: 'the client Vitest summary is missing or has no total.lines counts' };
+    }
+    // A report that parsed but measured nothing means the run produced no usable data, not that the
+    // codebase is untested.
+    if (server.total === 0 || client.total === 0) {
+        return { status: 'skip', reason: 'a coverage report measured zero lines' };
+    }
+    if (server.covered === 0 || client.covered === 0) {
+        return { status: 'skip', reason: 'a coverage report covered zero lines' };
+    }
+
+    const combined = { covered: server.covered + client.covered, total: server.total + client.total };
+    const previousTotal = previous?.combined?.total;
+    if (Number.isFinite(previousTotal) && combined.total < previousTotal * MIN_TOTAL_RATIO) {
+        return {
+            status: 'skip',
+            reason: `the combined line total collapsed from ${previousTotal} to ${combined.total}, which indicates a partial report rather than a coverage change`,
+        };
+    }
+
+    const pct = (combined.covered / combined.total) * 100;
+    const message = `${pct.toFixed(1)}%`;
+    // Nothing visible changed, so committing would only add noise to the badges branch.
+    if (previous?.message === message) {
+        return { status: 'skip', reason: `the value is unchanged at ${message}` };
+    }
+
+    return {
+        status: 'publish',
+        badge: {
+            schemaVersion: 1,
+            label: 'coverage',
+            message,
+            color: colorFor(pct),
+            exact: Math.round(pct * 100) / 100,
+            server,
+            client,
+            combined,
+            sha,
+            updatedAt: now,
+        },
+    };
+}
+
+/**
+ * Reads a file, returning undefined rather than throwing when it is absent or unreadable — a missing
+ * artifact is an expected outcome the guards handle, not an error.
+ * @param {string | undefined} filePath
+ * @returns {string | undefined}
+ */
+function readFileIfPresent(filePath) {
+    if (!filePath || !fs.existsSync(filePath)) {
+        return undefined;
+    }
+    try {
+        return fs.readFileSync(filePath, 'utf-8');
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Parses JSON, returning undefined rather than throwing on malformed input.
+ * @param {string | undefined} raw
+ * @returns {unknown}
+ */
+function parseJsonIfValid(raw) {
+    if (raw === undefined) {
+        return undefined;
+    }
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Minimal `--flag value` parser; unknown flags are ignored so the workflow can pass extras.
+ * @param {string[]} argv
+ * @returns {Record<string, string>}
+ */
+function parseArgs(argv) {
+    const args = {};
+    for (let i = 0; i < argv.length; i += 1) {
+        if (argv[i].startsWith('--')) {
+            args[argv[i].slice(2)] = argv[i + 1];
+            i += 1;
+        }
+    }
+    return args;
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (!args.jacoco || !args.vitest || !args.out) {
+        console.error('Usage: compute-coverage-badge.mjs --jacoco <report.xml> --vitest <summary.json> --out <coverage.json> [--previous <coverage.json>] [--sha <sha>]');
+        process.exit(1);
+    }
+
+    // `--previous` and `--out` are deliberately the same file in CI. That is safe because every read
+    // happens while evaluating these arguments, strictly before the write below.
+    const result = computeBadge({
+        jacocoXml: readFileIfPresent(args.jacoco),
+        vitestSummary: parseJsonIfValid(readFileIfPresent(args.vitest)),
+        previous: parseJsonIfValid(readFileIfPresent(args.previous)),
+        sha: args.sha,
+        now: new Date().toISOString(),
+    });
+
+    if (result.status === 'skip') {
+        console.log(`Keeping the previously published coverage badge: ${result.reason}.`);
+        process.exit(3);
+    }
+
+    fs.mkdirSync(path.dirname(path.resolve(args.out)), { recursive: true });
+    fs.writeFileSync(args.out, `${JSON.stringify(result.badge, undefined, 2)}\n`);
+    const { message, server, client } = result.badge;
+    console.log(`Coverage badge: ${message} (server ${server.covered}/${server.total} lines, client ${client.covered}/${client.total} lines).`);
+    process.exit(0);
+}
+
+// Only run the CLI when executed directly, so the spec can import the pure functions.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+}

--- a/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs
+++ b/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs
@@ -119,10 +119,17 @@ export function parseJacocoLines(xml) {
  */
 export function parseVitestLines(summary) {
     const lines = summary?.total?.lines;
-    if (!lines || !Number.isFinite(lines.covered) || !Number.isFinite(lines.total)) {
+    if (!lines) {
         return undefined;
     }
-    return { covered: lines.covered, total: lines.total };
+    const { covered, total } = lines;
+    // Istanbul never emits counts like these, but this function feeds a number that gets published
+    // unattended, so a corrupt summary must not become a >100% badge. `total === 0` is deliberately
+    // NOT rejected here: computeBadge reports it more precisely as "measured zero lines".
+    if (!Number.isSafeInteger(covered) || !Number.isSafeInteger(total) || covered < 0 || total < 0 || covered > total) {
+        return undefined;
+    }
+    return { covered, total };
 }
 
 /**

--- a/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs
+++ b/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs
@@ -176,8 +176,9 @@ export function computeBadge({ jacocoXml, vitestSummary, previous, sha, now } = 
 
     const pct = (combined.covered / combined.total) * 100;
     const message = `${pct.toFixed(1)}%`;
+    const color = colorFor(pct);
     // Nothing visible changed, so committing would only add noise to the badges branch.
-    if (previous?.message === message) {
+    if (previous?.message === message && previous?.color === color) {
         return { status: 'skip', kind: 'unchanged', reason: `the value is unchanged at ${message}` };
     }
 
@@ -187,7 +188,7 @@ export function computeBadge({ jacocoXml, vitestSummary, previous, sha, now } = 
             schemaVersion: 1,
             label: 'coverage',
             message,
-            color: colorFor(pct),
+            color,
             exact: Math.round(pct * 100) / 100,
             server,
             client,

--- a/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.spec.mjs
+++ b/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.spec.mjs
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import { colorFor, computeBadge, parseJacocoLines, parseVitestLines } from './compute-coverage-badge.mjs';
+
+/**
+ * Builds a JaCoCo report whose shape matches the real aggregated report: per-package counters that
+ * must be ignored, followed by the report-level counters that must be read.
+ */
+function jacocoReport({ missed = 11652, covered = 74256, packages = 1 } = {}) {
+    const packageBlocks = Array.from(
+        { length: packages },
+        (unused, index) =>
+            `<package name="de/tum/cit/aet/artemis/pkg${index}">` +
+            `<counter type="INSTRUCTION" missed="7" covered="318"/>` +
+            `<counter type="LINE" missed="999" covered="999"/>` +
+            `</package>`,
+    ).join('');
+    return (
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><report name="Artemis">` +
+        packageBlocks +
+        `<counter type="INSTRUCTION" missed="60587" covered="383401"/>` +
+        `<counter type="LINE" missed="${missed}" covered="${covered}"/>` +
+        `<counter type="CLASS" missed="151" covered="3129"/>` +
+        `</report>`
+    );
+}
+
+function vitestSummary({ total = 78212, covered = 70728 } = {}) {
+    return { total: { lines: { total, covered, skipped: 0, pct: 90.43 } } };
+}
+
+/** A published badge matching the fixtures above, used as the `previous` value. */
+function publishedBadge({ message = '88.3%', total = 164120 } = {}) {
+    return { schemaVersion: 1, label: 'coverage', message, combined: { covered: 144984, total } };
+}
+
+describe('parseJacocoLines', () => {
+    it('reads the report-level LINE counter and ignores the per-package ones', () => {
+        // Two packages each carry a decoy LINE counter of 999/999; summing them all would inflate the result.
+        expect(parseJacocoLines(jacocoReport({ packages: 2 }))).toEqual({ covered: 74256, total: 85908 });
+    });
+
+    it('tolerates the attribute order being swapped', () => {
+        const xml = '<report><package name="p"></package><counter covered="30" type="LINE" missed="70"/></report>';
+        expect(parseJacocoLines(xml)).toEqual({ covered: 30, total: 100 });
+    });
+
+    it('returns undefined for a report with no packages, which carries no totals', () => {
+        expect(parseJacocoLines('<report name="Artemis"></report>')).toBeUndefined();
+    });
+
+    it('returns undefined when the report has packages but no report-level LINE counter', () => {
+        expect(parseJacocoLines('<report><package name="p"></package><counter type="CLASS" missed="1" covered="2"/></report>')).toBeUndefined();
+    });
+
+    it('returns undefined for truncated or absent input', () => {
+        expect(parseJacocoLines(undefined)).toBeUndefined();
+        expect(parseJacocoLines('<?xml version="1.0"?><report name="Artemis"><package name="p">')).toBeUndefined();
+    });
+});
+
+describe('parseVitestLines', () => {
+    it('reads total.lines', () => {
+        expect(parseVitestLines(vitestSummary())).toEqual({ covered: 70728, total: 78212 });
+    });
+
+    it('returns undefined when the totals are absent or non-numeric', () => {
+        expect(parseVitestLines(undefined)).toBeUndefined();
+        expect(parseVitestLines({})).toBeUndefined();
+        expect(parseVitestLines({ total: {} })).toBeUndefined();
+        expect(parseVitestLines({ total: { lines: { total: 'n/a', covered: 1 } } })).toBeUndefined();
+    });
+});
+
+describe('colorFor', () => {
+    it('maps percentages onto Shields colours at the band boundaries', () => {
+        expect(colorFor(90)).toBe('brightgreen');
+        expect(colorFor(89.9)).toBe('green');
+        expect(colorFor(80)).toBe('green');
+        expect(colorFor(70)).toBe('yellowgreen');
+        expect(colorFor(60)).toBe('yellow');
+        expect(colorFor(50)).toBe('orange');
+        expect(colorFor(49.9)).toBe('red');
+        expect(colorFor(0)).toBe('red');
+    });
+});
+
+describe('computeBadge', () => {
+    const validInputs = { jacocoXml: jacocoReport(), vitestSummary: vitestSummary() };
+
+    it('combines server and client lines weighted by size', () => {
+        const result = computeBadge({ ...validInputs, sha: 'e62c69b', now: '2026-08-29T10:00:00Z' });
+
+        // (74256 + 70728) / (85908 + 78212) = 144984 / 164120 = 88.34%
+        expect(result).toEqual({
+            status: 'publish',
+            badge: {
+                schemaVersion: 1,
+                label: 'coverage',
+                message: '88.3%',
+                color: 'green',
+                exact: 88.34,
+                server: { covered: 74256, total: 85908 },
+                client: { covered: 70728, total: 78212 },
+                combined: { covered: 144984, total: 164120 },
+                sha: 'e62c69b',
+                updatedAt: '2026-08-29T10:00:00Z',
+            },
+        });
+    });
+
+    it('weights by codebase size rather than averaging the two percentages', () => {
+        // A tiny 0%-covered client next to a large 90%-covered server must barely move the number;
+        // a naive mean of the two percentages would report 45%.
+        const result = computeBadge({
+            jacocoXml: jacocoReport({ covered: 90000, missed: 10000 }),
+            vitestSummary: vitestSummary({ covered: 1, total: 100 }),
+        });
+        expect(result.status).toBe('publish');
+        expect(result.badge.message).toBe('89.9%');
+    });
+
+    it('publishes on the very first run, when nothing has been published yet', () => {
+        expect(computeBadge({ ...validInputs, previous: undefined }).status).toBe('publish');
+    });
+
+    it('keeps the previous badge when the server report is missing', () => {
+        const result = computeBadge({ vitestSummary: vitestSummary() });
+        expect(result.status).toBe('skip');
+        expect(result.reason).toContain('server JaCoCo report is missing');
+    });
+
+    it('keeps the previous badge when the client summary is missing', () => {
+        const result = computeBadge({ jacocoXml: jacocoReport() });
+        expect(result.status).toBe('skip');
+        expect(result.reason).toContain('client Vitest summary is missing');
+    });
+
+    it('keeps the previous badge when a report measured zero lines', () => {
+        const result = computeBadge({ jacocoXml: jacocoReport({ covered: 0, missed: 0 }), vitestSummary: vitestSummary() });
+        expect(result.status).toBe('skip');
+        expect(result.reason).toContain('zero lines');
+    });
+
+    it('keeps the previous badge when a report covered zero lines', () => {
+        const result = computeBadge({ jacocoXml: jacocoReport({ covered: 0, missed: 85908 }), vitestSummary: vitestSummary() });
+        expect(result.status).toBe('skip');
+        expect(result.reason).toContain('covered zero lines');
+    });
+
+    it('keeps the previous badge when the line total collapses, which means a partial report', () => {
+        // Only the client half survived: 78212 is well under half of the published 164120.
+        const result = computeBadge({
+            jacocoXml: jacocoReport({ covered: 100, missed: 20 }),
+            vitestSummary: vitestSummary(),
+            previous: publishedBadge(),
+        });
+        expect(result.status).toBe('skip');
+        expect(result.reason).toContain('collapsed');
+    });
+
+    it('still publishes a genuine coverage regression, which leaves the total intact', () => {
+        // Half the server lines stop being covered, but the denominator is unchanged, so the guard
+        // must not fire — otherwise the badge would freeze at its best-ever value.
+        const result = computeBadge({
+            jacocoXml: jacocoReport({ covered: 37128, missed: 48780 }),
+            vitestSummary: vitestSummary(),
+            previous: publishedBadge(),
+        });
+        expect(result.status).toBe('publish');
+        expect(result.badge.message).toBe('65.7%');
+    });
+
+    it('does not republish an unchanged value, so the badges branch stays quiet', () => {
+        const result = computeBadge({ ...validInputs, previous: publishedBadge({ message: '88.3%' }) });
+        expect(result.status).toBe('skip');
+        expect(result.reason).toContain('unchanged');
+    });
+
+    it('republishes once the first decimal moves', () => {
+        const result = computeBadge({ ...validInputs, previous: publishedBadge({ message: '88.2%' }) });
+        expect(result.status).toBe('publish');
+        expect(result.badge.message).toBe('88.3%');
+    });
+
+    it('ignores a previous value that carries no combined total', () => {
+        const result = computeBadge({ ...validInputs, previous: { message: '1.0%' } });
+        expect(result.status).toBe('publish');
+    });
+});

--- a/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.spec.mjs
+++ b/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.spec.mjs
@@ -34,8 +34,8 @@ function vitestSummary({ total = 78212, covered = 70728 } = {}) {
 }
 
 /** A published badge matching the fixtures above, used as the `previous` value. */
-function publishedBadge({ message = '88.3%', total = 164120 } = {}) {
-    return { schemaVersion: 1, label: 'coverage', message, combined: { covered: 144984, total } };
+function publishedBadge({ message = '88.3%', color = 'green', total = 164120 } = {}) {
+    return { schemaVersion: 1, label: 'coverage', message, color, combined: { covered: 144984, total } };
 }
 
 describe('parseJacocoLines', () => {
@@ -218,6 +218,18 @@ describe('computeBadge', () => {
         const result = computeBadge({ ...validInputs, previous: publishedBadge({ message: '88.3%' }) });
         expect(result.status).toBe('skip');
         expect(result.reason).toContain('unchanged');
+    });
+
+    it('republishes when the rounded message is unchanged but the colour threshold moved', () => {
+        const result = computeBadge({
+            jacocoXml: jacocoReport({ covered: 4498, missed: 502 }),
+            vitestSummary: vitestSummary({ covered: 4498, total: 5000 }),
+            previous: publishedBadge({ message: '90.0%', color: 'brightgreen', total: 10000 }),
+        });
+
+        // 8996 / 10000 = 89.96%, which rounds to 90.0% but belongs to the green band.
+        expect(result.status).toBe('publish');
+        expect(result.badge).toMatchObject({ message: '90.0%', color: 'green' });
     });
 
     it('separates the healthy no-op from a tripped guard, which CI reports differently', () => {

--- a/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.spec.mjs
+++ b/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.spec.mjs
@@ -101,6 +101,17 @@ describe('parseVitestLines', () => {
         expect(parseVitestLines({ total: {} })).toBeUndefined();
         expect(parseVitestLines({ total: { lines: { total: 'n/a', covered: 1 } } })).toBeUndefined();
     });
+
+    it('rejects counts that are impossible, rather than publishing a nonsense percentage', () => {
+        // A badge is published unattended, so covered > total must not become ">100%".
+        expect(parseVitestLines(vitestSummary({ covered: 1000000, total: 1 }))).toBeUndefined();
+        expect(parseVitestLines(vitestSummary({ covered: -1, total: 100 }))).toBeUndefined();
+        expect(parseVitestLines(vitestSummary({ covered: 1, total: -100 }))).toBeUndefined();
+        expect(parseVitestLines(vitestSummary({ covered: 1.5, total: 100 }))).toBeUndefined();
+        expect(parseVitestLines(vitestSummary({ covered: 1, total: Number.MAX_SAFE_INTEGER + 2 }))).toBeUndefined();
+        // The boundary case is legitimate: a fully covered client.
+        expect(parseVitestLines(vitestSummary({ covered: 100, total: 100 }))).toEqual({ covered: 100, total: 100 });
+    });
 });
 
 describe('colorFor', () => {

--- a/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.spec.mjs
+++ b/supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.spec.mjs
@@ -1,3 +1,8 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 import { colorFor, computeBadge, parseJacocoLines, parseVitestLines } from './compute-coverage-badge.mjs';
 
@@ -55,6 +60,33 @@ describe('parseJacocoLines', () => {
     it('returns undefined for truncated or absent input', () => {
         expect(parseJacocoLines(undefined)).toBeUndefined();
         expect(parseJacocoLines('<?xml version="1.0"?><report name="Artemis"><package name="p">')).toBeUndefined();
+    });
+
+    it('rejects a report truncated mid-package instead of reading a sourcefile-level counter', () => {
+        // The dangerous case: the upload was cut short partway through a later package. Anchoring on
+        // the last `</package>` then lands on an EARLIER package's close, and the next LINE counter
+        // belongs to a <sourcefile> — small, plausible numbers that would publish a wrong badge.
+        const truncated =
+            `<report name="Artemis">` +
+            `<package name="a"><counter type="LINE" missed="10" covered="90"/></package>` +
+            `<package name="b"><sourcefile name="B.java"><counter type="LINE" missed="7" covered="13"/></sourcefile>`;
+        expect(parseJacocoLines(truncated)).toBeUndefined();
+    });
+
+    it('rejects a <group>-structured aggregate rather than reporting one group as the total', () => {
+        // Ant/Maven aggregates nest packages inside <group>. Gradle does not emit this shape, but if
+        // it ever did, the naive anchor would read the last group's counter as the report total.
+        const grouped =
+            `<report name="Artemis">` +
+            `<group name="one"><package name="a"></package><counter type="LINE" missed="1000" covered="9000"/></group>` +
+            `<group name="two"><package name="b"></package><counter type="LINE" missed="5" covered="5"/></group>` +
+            `<counter type="LINE" missed="1005" covered="9005"/></report>`;
+        expect(parseJacocoLines(grouped)).toBeUndefined();
+    });
+
+    it('accepts the real report shape, where only counters separate the last package from </report>', () => {
+        const withWhitespace = '<report><package name="p"></package>\n  <counter type="LINE" missed="1" covered="9"/>\n</report>\n';
+        expect(parseJacocoLines(withWhitespace)).toEqual({ covered: 9, total: 10 });
     });
 });
 
@@ -138,7 +170,8 @@ describe('computeBadge', () => {
     it('keeps the previous badge when a report measured zero lines', () => {
         const result = computeBadge({ jacocoXml: jacocoReport({ covered: 0, missed: 0 }), vitestSummary: vitestSummary() });
         expect(result.status).toBe('skip');
-        expect(result.reason).toContain('zero lines');
+        // 'measured', not just 'zero lines' — the covered-zero case below carries a similar message.
+        expect(result.reason).toContain('measured zero lines');
     });
 
     it('keeps the previous badge when a report covered zero lines', () => {
@@ -176,6 +209,20 @@ describe('computeBadge', () => {
         expect(result.reason).toContain('unchanged');
     });
 
+    it('separates the healthy no-op from a tripped guard, which CI reports differently', () => {
+        // An unchanged value is routine; a tripped guard is not, because the collapse guard latches
+        // on the last published total and would otherwise freeze the badge with no signal.
+        expect(computeBadge({ ...validInputs, previous: publishedBadge() }).kind).toBe('unchanged');
+        expect(computeBadge({ vitestSummary: vitestSummary() }).kind).toBe('guard');
+        expect(
+            computeBadge({
+                jacocoXml: jacocoReport({ covered: 100, missed: 20 }),
+                vitestSummary: vitestSummary(),
+                previous: publishedBadge(),
+            }).kind,
+        ).toBe('guard');
+    });
+
     it('republishes once the first decimal moves', () => {
         const result = computeBadge({ ...validInputs, previous: publishedBadge({ message: '88.2%' }) });
         expect(result.status).toBe('publish');
@@ -185,5 +232,67 @@ describe('computeBadge', () => {
     it('ignores a previous value that carries no combined total', () => {
         const result = computeBadge({ ...validInputs, previous: { message: '1.0%' } });
         expect(result.status).toBe('publish');
+    });
+});
+
+describe('the CLI', () => {
+    const script = fileURLToPath(new URL('./compute-coverage-badge.mjs', import.meta.url));
+
+    /** Runs the script in a throwaway directory. Arguments starting with `@` resolve into that directory. */
+    function run(args, files = {}) {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'coverage-badge-'));
+        for (const [name, contents] of Object.entries(files)) {
+            fs.writeFileSync(path.join(dir, name), contents);
+        }
+        const resolved = args.map((arg) => (arg.startsWith('@') ? path.join(dir, arg.slice(1)) : arg));
+        const result = spawnSync(process.execPath, [script, ...resolved], { encoding: 'utf-8' });
+        return { dir, code: result.status, stdout: result.stdout };
+    }
+
+    const reports = { 'report.xml': jacocoReport(), 'summary.json': JSON.stringify(vitestSummary()) };
+
+    it('exits 0 and writes the badge when nothing has been published yet', () => {
+        const { dir, code, stdout } = run(['--jacoco', '@report.xml', '--vitest', '@summary.json', '--out', '@coverage.json'], reports);
+
+        expect(code).toBe(0);
+        expect(stdout).toContain('88.3%');
+        expect(JSON.parse(fs.readFileSync(path.join(dir, 'coverage.json'), 'utf-8'))).toMatchObject({ message: '88.3%', color: 'green' });
+    });
+
+    it('reads --previous before writing when both name the same file, as CI invokes it', () => {
+        // CI aliases --previous and --out. Were the write to happen first, the "previous" read would
+        // see the value just written and the unchanged-check would be meaningless.
+        const previous = JSON.stringify({ ...publishedBadge({ message: '10.0%' }), color: 'red' });
+        const { dir, code, stdout } = run(['--jacoco', '@report.xml', '--vitest', '@summary.json', '--previous', '@coverage.json', '--out', '@coverage.json'], {
+            ...reports,
+            'coverage.json': previous,
+        });
+
+        expect(code).toBe(0);
+        expect(stdout).toContain('88.3%');
+        expect(JSON.parse(fs.readFileSync(path.join(dir, 'coverage.json'), 'utf-8')).message).toBe('88.3%');
+    });
+
+    it('exits 3 and leaves the file untouched when the value is unchanged', () => {
+        const previous = JSON.stringify(publishedBadge({ message: '88.3%' }));
+        const { dir, code, stdout } = run(['--jacoco', '@report.xml', '--vitest', '@summary.json', '--previous', '@coverage.json', '--out', '@coverage.json'], {
+            ...reports,
+            'coverage.json': previous,
+        });
+
+        expect(code).toBe(3);
+        expect(stdout).toContain('unchanged');
+        expect(fs.readFileSync(path.join(dir, 'coverage.json'), 'utf-8')).toBe(previous);
+    });
+
+    it('exits 4 when a guard rejects the value, which CI surfaces as a warning', () => {
+        const { code, stdout } = run(['--jacoco', '@missing.xml', '--vitest', '@summary.json', '--out', '@coverage.json'], reports);
+
+        expect(code).toBe(4);
+        expect(stdout).toContain('missing');
+    });
+
+    it('exits 1 on a bad invocation', () => {
+        expect(run(['--jacoco', '@report.xml'], reports).code).toBe(1);
     });
 });


### PR DESCRIPTION
### Summary

The `coverage` badge in our README was served by Codacy, which stopped reporting a value and rendered a red **0%**. This replaces it with a figure computed from the coverage reports our own CI already produces, published to an orphan `badges` branch and rendered by Shields.

The new badge reads **88.3%** — [live badge](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fls1intum%2FArtemis%2Fbadges%2Fcoverage.json), [source data](https://github.com/ls1intum/Artemis/blob/badges/coverage.json).

### Checklist

#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).
- [x] I verified the change against real CI data: the script was run against the coverage artifacts of green `develop` run [33246317875](https://github.com/ls1intum/Artemis/actions/runs/33246317875), and the resulting badge renders from the seeded `badges` branch.

This PR touches only CI tooling and the README, so the Server, Client, and Programming Exercise checklist sections do not apply and have been removed. It also cannot be exercised on a test server: the job runs only on a `develop` push, so its first live execution is after merge — which is why every failure path is a no-op that leaves the seeded value standing.

### Motivation and Context

The badge has been wrong for a while and misrepresents the project to anyone landing on the repository. Codacy is no longer a dependable source for it, but we already compute everything needed: `ci-test.yml` uploads a `Server JaCoCo XML` artifact and a `Client Coverage Summaries` artifact on every `develop` push, where the full suite runs (`run_all_tests: true`). Nothing new needs to be measured — only combined and published.

The other requirement was stability: a single flaky test must not be able to knock the badge down, and a run whose coverage could not be computed should keep reporting the previous value.

### Description

**A new develop-only `coverage-badge` job in `ci.yml`.** It downloads the two artifacts the `test` job already produced in the same run — so no test is re-run — and combines them:

```
(server.covered + client.covered) / (server.total + client.total)
```

over **lines**, the one metric JaCoCo and Vitest both emit natively. Summing raw counts rather than averaging two percentages means the result is weighted by codebase size. The figure is deliberately a rough combined one: JaCoCo counts lines of compiled bytecode and Istanbul counts instrumented TypeScript lines, so the two are close but not semantically identical.

**Storage.** The result is written to `coverage.json` on a new orphan **`badges`** branch, in the Shields endpoint schema. Nothing lands on `develop`, so the mainline history is untouched. This mirrors the existing `shields` branch already used for the testserver badges; a separate branch avoids racing with that branch's external writer (Helios).

Two independent reasons this cannot loop: no push trigger in this repo matches `badges` (they all filter to `develop`/`main`/`release/*`), and GitHub does not fire workflows for pushes made with `GITHUB_TOKEN`.

**Stability — three guards, each of which leaves the previous value served:**

1. The job runs only when `test` **succeeded**. Coverage from a partially failed run is artificially low, because tests that never ran cover nothing, so publishing it would make the badge dip on ambient flakiness.
2. `compute-coverage-badge.mjs` rejects a report that is missing, unparseable, or that measured/covered zero lines.
3. It rejects a value whose combined line **total** collapsed below half the published total. That catches a vanished module report while still publishing a genuine regression, which leaves the denominator intact — so the badge can never freeze at its best-ever value.

Every rejection is a no-op: the job exits 0 without committing, and Shields keeps serving the last good file. No failure path can turn `develop` red.

Commits land on `badges` only when the rendered value actually changes.

**E2E is not included.** `ci-e2e.yml` runs black-box Playwright against a Docker stack with no JaCoCo agent on the server JVM and no instrumented client build, so it emits no coverage data at all. Adding it would mean instrumenting that stack, which is a much larger and flakiness-prone change. The script and the stored JSON keep server and client as separate components, so adding a third is a contained follow-up.

**Files**

| File | Change |
| --- | --- |
| `.github/workflows/ci.yml` | new advisory `coverage-badge` job |
| `supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs` | new; pure functions plus a thin CLI |
| `supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.spec.mjs` | new; 20 tests |
| `supporting_scripts/code-coverage/coverage-badge/README.md` | new; local usage, exit codes, re-seeding |
| `.github/workflows/README.md` | documents the job and the guards |
| `README.md` | badge swap |

### Steps for Testing

This is CI/build tooling with no user-facing surface, so it is verifiable from the repository rather than on a test server.

1. Confirm the badge at the top of this branch's `README.md` renders **88.3%** in green rather than 0%.
2. Confirm the published data is real: [`badges/coverage.json`](https://github.com/ls1intum/Artemis/blob/badges/coverage.json). Server `74256/85908` lines and client `70728/78212` lines were taken from green develop run [33246317875](https://github.com/ls1intum/Artemis/actions/runs/33246317875) (`e62c69b`), which seeded the branch.
3. Run the unit tests: `pnpm run test:rules` (the spec is picked up by `rules/vitest.config.mjs`, which already globs `supporting_scripts/**/*.spec.mjs`, so it runs in the existing client test job — no workflow wiring needed).
4. Reproduce the number from CI artifacts without running the suites:
   ```bash
   gh run download 33246317875 -n "Server JaCoCo XML" -n "Client Coverage Summaries" -D /tmp/cov
   node supporting_scripts/code-coverage/coverage-badge/compute-coverage-badge.mjs \
     --jacoco "/tmp/cov/Server JaCoCo XML/aggregated/jacocoTestReport.xml" \
     --vitest "/tmp/cov/Client Coverage Summaries/coverage-summary.json" \
     --out /tmp/coverage.json
   # Coverage badge: 88.3% (server 74256/85908 lines, client 70728/78212 lines).
   ```
5. Exercise the guards, which are what make the badge stable. Each should print a reason and exit `3` without writing:
   ```bash
   # unchanged value
   node ... --previous /tmp/coverage.json --out /tmp/out.json ; echo $?   # 3
   # missing server report
   node ... --jacoco /tmp/nope.xml --out /tmp/out.json ; echo $?          # 3
   ```
6. Confirm the job is genuinely advisory: it is in no other job's `needs:`, is absent from `all-required-ci-passed`, and every failure path ends in `exit 0`.

The job itself only runs on a `develop` push, so its first real execution is after merge. If it misbehaves it warns and the seeded value stands.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2

#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-08-30 20:07:27 UTC_


### Screenshots

Before — Codacy, stuck at 0%:

<img src="https://img.shields.io/badge/coverage-0%25-red" alt="coverage 0%">

After — computed from our own CI:

<img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fls1intum%2FArtemis%2Fbadges%2Fcoverage.json" alt="coverage 88.3%">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a combined server and client code-coverage badge for the README.
  - Coverage reports now publish automatically to GitHub Pages.
  - Badge updates detect missing, invalid, unchanged, truncated, or suspiciously collapsed reports.
  - Badge colors refresh when coverage crosses a threshold, even if the displayed percentage is unchanged.

- **Documentation**
  - Documented coverage validation, publishing behavior, exit codes, guard warnings, and recovery procedures.
  - Updated the README badge link and image source.

- **Tests**
  - Added coverage for parsing, calculations, colors, safeguards, and command-line outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->