### PR TITLE
`Development`: Improve LTI launch redirect validation

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/lti/web/open/PublicLtiResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/web/open/PublicLtiResource.java
@@ -72,7 +72,7 @@ public class PublicLtiResource {
         }
 
         URI redirectUrl = UriComponentsBuilder.fromPath(LOGIN_REDIRECT_CLIENT_PATH).queryParam("state", state).queryParam("id_token", idToken).build().encode().toUri();
-        log.info("redirect to url: {}", redirectUrl);
+        log.info("LTI redirect generated for client path {}", LOGIN_REDIRECT_CLIENT_PATH);
         return ResponseEntity.status(HttpStatus.FOUND).location(redirectUrl).build();
     }
 
@@ -88,7 +88,7 @@ public class PublicLtiResource {
             return !parsedToken.getJWTClaimsSet().getExpirationTime().before(Date.from(Instant.now()));
         }
         catch (ParseException e) {
-            log.info("LTI request: JWT token is invalid: {}", token, e);
+            log.info("LTI request contains an invalid JWT token", e);
             return false;
         }
     }

--- a/src/main/java/de/tum/cit/aet/artemis/lti/web/open/PublicLtiResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/web/open/PublicLtiResource.java
@@ -4,8 +4,7 @@ import static de.tum.cit.aet.artemis.lti.config.CustomLti13Configurer.LTI13_DEEP
 import static de.tum.cit.aet.artemis.lti.config.CustomLti13Configurer.LTI13_LOGIN_REDIRECT_PROXY;
 
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import java.net.URI;
 import java.text.ParseException;
 import java.time.Instant;
 import java.util.Date;
@@ -49,7 +48,7 @@ public class PublicLtiResource {
      *
      * @param request  HTTP request
      * @param response HTTP response
-     * @return the ResponseEntity with status 200 (OK)
+     * @return the response containing the application-local redirect location
      * @throws IOException If an input or output exception occurs
      */
     @PostMapping({ LTI13_LOGIN_REDIRECT_PROXY, LTI13_DEEPLINK_REDIRECT })
@@ -72,14 +71,9 @@ public class PublicLtiResource {
             return ResponseEntity.ok().build();
         }
 
-        UriComponentsBuilder uriBuilder = buildRedirect(request);
-        uriBuilder.path(LOGIN_REDIRECT_CLIENT_PATH);
-        uriBuilder.queryParam("state", URLEncoder.encode(state, StandardCharsets.UTF_8));
-        uriBuilder.queryParam("id_token", URLEncoder.encode(idToken, StandardCharsets.UTF_8));
-        String redirectUrl = uriBuilder.build().toString();
+        URI redirectUrl = UriComponentsBuilder.fromPath(LOGIN_REDIRECT_CLIENT_PATH).queryParam("state", state).queryParam("id_token", idToken).build().encode().toUri();
         log.info("redirect to url: {}", redirectUrl);
-        response.sendRedirect(redirectUrl); // Redirect using user-provided values is safe because user-provided values are used in the query parameters, not the url itself
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.FOUND).location(redirectUrl).build();
     }
 
     /**
@@ -109,13 +103,5 @@ public class PublicLtiResource {
         String message = "Illegal parameter on oauth2 authorization response: id_token";
         log.error(message);
         response.sendError(HttpStatus.BAD_REQUEST.value(), message);
-    }
-
-    private UriComponentsBuilder buildRedirect(HttpServletRequest request) {
-        UriComponentsBuilder redirectUrlComponentsBuilder = UriComponentsBuilder.newInstance().scheme(request.getScheme()).host(request.getServerName());
-        if (request.getServerPort() != 80 && request.getServerPort() != 443) {
-            redirectUrlComponentsBuilder.port(request.getServerPort());
-        }
-        return redirectUrlComponentsBuilder;
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/lti/Lti13LaunchIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/Lti13LaunchIntegrationTest.java
@@ -199,6 +199,8 @@ class Lti13LaunchIntegrationTest extends AbstractLtiIntegrationTest {
     }
 
     private void validateRedirect(URI locationHeader, String token) {
+        assertThat(locationHeader.isAbsolute()).isFalse();
+        assertThat(locationHeader.getHost()).isNull();
         assertThat(locationHeader.getPath()).isEqualTo("/lti/launch");
 
         List<NameValuePair> params = URLEncodedUtils.parse(locationHeader, StandardCharsets.UTF_8);


### PR DESCRIPTION
### Summary

Improve validation for LTI launch routing.

### Checklist

#### General

- [x] I tested all changes locally with focused integration and architecture tests.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server

- [x] I strictly followed the server coding and design guidelines and the REST API guidelines.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

Consistent validation keeps launch routing local to the application and makes the flow easier to reason about.

### Description

- Keep LTI launch routing application-local.
- Extend the integration assertions for the updated behavior.

### Steps for Testing

1. Complete an LTI launch.
2. Verify that the client receives the application-local launch location.
3. Run the focused integration and architecture tests.

### Test Commands

```shell
./gradlew spotlessCheck checkstyleMain -x webapp
./gradlew test -x webapp --tests de.tum.cit.aet.artemis.lti.Lti13LaunchIntegrationTest --tests de.tum.cit.aet.artemis.lti.architecture.*
```