### PR TITLE
`Exercises`: Fix empty content view on the exercise management overview

### DIFF
--- a/src/main/webapp/app/course/manage/exercises/course-management-exercises.component.html
+++ b/src/main/webapp/app/course/manage/exercises/course-management-exercises.component.html
@@ -123,7 +123,18 @@
         </ng-template>
     }
 
-    @if (loaded() && cards().length === 0) {
+    @if (loaded() && exerciseCount() === 0) {
+        <div class="text-center py-5 text-muted-color">
+            <fa-icon [icon]="faList" size="2x" class="mb-3" aria-hidden="true" />
+            <p class="mb-2" jhiTranslate="artemisApp.exerciseManagement.noExercisesYet"></p>
+            @if (course()?.isAtLeastEditor) {
+                <tum-ui-button size="small" [attr.data-testid]="'create-first-exercise-button'" (clicked)="openCreateModal()">
+                    <fa-icon [icon]="faPlus" />
+                    <span class="ms-1" jhiTranslate="global.generic.create"></span>
+                </tum-ui-button>
+            }
+        </div>
+    } @else if (loaded() && cards().length === 0) {
         <tum-ui-message severity="secondary">
             <span jhiTranslate="artemisApp.exerciseManagement.noExercisesMatch" [translateValues]="{ search: search() }"></span>
         </tum-ui-message>

--- a/src/main/webapp/app/course/manage/exercises/course-management-exercises.component.spec.ts
+++ b/src/main/webapp/app/course/manage/exercises/course-management-exercises.component.spec.ts
@@ -15,7 +15,8 @@ import { ModelingExerciseService } from 'app/modeling/manage/services/modeling-e
 import { ProgrammingExerciseService } from 'app/programming/manage/services/programming-exercise.service';
 import { DeleteDialogService } from 'app/shared-ui/delete-dialog/service/delete-dialog.service';
 import { AlertService } from 'app/foundation/service/alert.service';
-import { MockProvider } from 'ng-mocks';
+import { MockComponent, MockProvider } from 'ng-mocks';
+import { ProgrammingExerciseEditSelectedComponent } from 'app/programming/manage/edit-selected/programming-exercise-edit-selected.component';
 import { Course } from 'app/course/shared/entities/course.model';
 import { Exercise, ExerciseType } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { QuizExercise, QuizMode, QuizStatus } from 'app/quiz/shared/entities/quiz-exercise.model';
@@ -26,6 +27,8 @@ import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.serv
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { PROFILE_LOCALCI } from 'app/app.constants';
 import { TranslateService } from '@ngx-translate/core';
+import { DialogService } from 'primeng/dynamicdialog';
+import { MockDialogService } from 'test/helpers/mocks/service/mock-dialog.service';
 
 describe('Course Management Exercises Component', () => {
     let comp: CourseManagementExercisesComponent;
@@ -45,7 +48,7 @@ describe('Course Management Exercises Component', () => {
     const parentRoute = {
         data: of({}),
     } as any as ActivatedRoute;
-    const route = { parent: parentRoute, queryParams: of({}) } as any as ActivatedRoute;
+    const route = { parent: parentRoute, queryParams: of({}), url: of([]) } as any as ActivatedRoute;
 
     beforeEach(async () => {
         exercises = buildExercises();
@@ -73,10 +76,19 @@ describe('Course Management Exercises Component', () => {
                 MockProvider(ModelingExerciseService),
                 MockProvider(ProgrammingExerciseService),
                 { provide: ProfileService, useClass: MockProfileService },
+                { provide: DialogService, useClass: MockDialogService },
                 provideHttpClient(),
                 provideHttpClientTesting(),
             ],
-        }).compileComponents();
+        })
+            // The edit-selected modal is always instantiated (visibility is an input, not an @if), and its nested
+            // timeline component pulls in ActivatedRoute.snapshot/Athena wiring that is irrelevant to this page's
+            // empty-state rendering, so it is swapped for a stub whenever the template is actually rendered.
+            .overrideComponent(CourseManagementExercisesComponent, {
+                remove: { imports: [ProgrammingExerciseEditSelectedComponent] },
+                add: { imports: [MockComponent(ProgrammingExerciseEditSelectedComponent)] },
+            })
+            .compileComponents();
 
         fixture = TestBed.createComponent(CourseManagementExercisesComponent);
         comp = fixture.componentInstance;
@@ -141,6 +153,36 @@ describe('Course Management Exercises Component', () => {
         comp.onSearchChange('zzz_nomatch_zzz');
         const filteredCount = comp.cards().reduce((sum, b) => sum + b.exercises.length, 0);
         expect(filteredCount).toBeLessThan(initialCount);
+    });
+
+    it('shows the empty-state message and a create button when the course has no exercises at all', () => {
+        course.exercises = [];
+        comp.ngOnInit();
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('[data-testid="create-first-exercise-button"]')).not.toBeNull();
+        expect(fixture.nativeElement.textContent).toContain('artemisApp.exerciseManagement.noExercisesYet');
+        expect(fixture.nativeElement.textContent).not.toContain('artemisApp.exerciseManagement.noExercisesMatch');
+    });
+
+    it('does not show the create-first button in the empty state to non-editors', () => {
+        course.exercises = [];
+        course.isAtLeastEditor = false;
+        comp.ngOnInit();
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('[data-testid="create-first-exercise-button"]')).toBeNull();
+        expect(fixture.nativeElement.textContent).toContain('artemisApp.exerciseManagement.noExercisesYet');
+    });
+
+    it('shows the search-empty message, not the empty-course state, when a search matches nothing but exercises exist', () => {
+        comp.ngOnInit();
+        comp.onSearchChange('zzz_nomatch_zzz');
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement.querySelector('[data-testid="create-first-exercise-button"]')).toBeNull();
+        expect(fixture.nativeElement.textContent).toContain('artemisApp.exerciseManagement.noExercisesMatch');
+        expect(fixture.nativeElement.textContent).not.toContain('artemisApp.exerciseManagement.noExercisesYet');
     });
 
     it('should only mark itself loaded after the initial load (gating the empty state)', () => {

--- a/src/main/webapp/app/course/manage/exercises/course-management-exercises.component.spec.ts
+++ b/src/main/webapp/app/course/manage/exercises/course-management-exercises.component.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { HttpErrorResponse, HttpResponse, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
@@ -163,6 +164,18 @@ describe('Course Management Exercises Component', () => {
         expect(fixture.nativeElement.querySelector('[data-testid="create-first-exercise-button"]')).not.toBeNull();
         expect(fixture.nativeElement.textContent).toContain('artemisApp.exerciseManagement.noExercisesYet');
         expect(fixture.nativeElement.textContent).not.toContain('artemisApp.exerciseManagement.noExercisesMatch');
+    });
+
+    it('opens the create modal when the create-first-exercise button is clicked', () => {
+        course.exercises = [];
+        comp.ngOnInit();
+        fixture.detectChanges();
+
+        const createFirstButton = fixture.debugElement.query(By.css('[data-testid="create-first-exercise-button"]'));
+        createFirstButton.triggerEventHandler('clicked', null);
+
+        expect(comp.addModalVisible()).toBe(true);
+        expect(comp.addModalMode()).toBe('create');
     });
 
     it('does not show the create-first button in the empty state to non-editors', () => {

--- a/src/main/webapp/app/course/manage/exercises/course-management-exercises.component.ts
+++ b/src/main/webapp/app/course/manage/exercises/course-management-exercises.component.ts
@@ -112,6 +112,7 @@ export class CourseManagementExercisesComponent implements OnInit {
     protected readonly faWrench = faWrench;
     protected readonly faCheckDouble = faCheckDouble;
     protected readonly faLayerGroup = faLayerGroup;
+    protected readonly faList = faList;
     protected readonly ExerciseType = ExerciseType;
 
     readonly viewOptions: { labelKey: string; value: ExerciseManagementView; icon: IconProp }[] = [

--- a/src/main/webapp/i18n/de/exerciseManagement.json
+++ b/src/main/webapp/i18n/de/exerciseManagement.json
@@ -18,6 +18,7 @@
                 "group": "Gruppe"
             },
             "noExercisesMatch": "Keine Aufgaben stimmen mit \"{{ search }}\" überein.",
+            "noExercisesYet": "In diesem Kurs wurden noch keine Aufgaben erstellt.",
             "selection": {
                 "count": "{{ count }} ausgewählt",
                 "deselectAll": "Auswahl aufheben",

--- a/src/main/webapp/i18n/en/exerciseManagement.json
+++ b/src/main/webapp/i18n/en/exerciseManagement.json
@@ -18,6 +18,7 @@
                 "group": "Group"
             },
             "noExercisesMatch": "No exercises match \"{{ search }}\".",
+            "noExercisesYet": "No exercises have been created in this course yet.",
             "selection": {
                 "count": "{{ count }} selected",
                 "deselectAll": "Deselect all",


### PR DESCRIPTION
### Summary
On the `Course Management → Exercises` overview, a course with zero exercises showed the same message as an empty search result (`No exercises match ""`.), which reads like a bug rather than a genuinely empty course. This PR adds a dedicated empty-content view — an icon, a clear "no exercises yet" message, and, for editors/instructors, a "Create" button that opens the existing create-exercise modal — while leaving the original search-empty message unchanged for actual empty search results.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

<!--
#### Server
- [ ] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) and too complex database calls.
- [ ] I **strictly** followed the principle of **data economy** for all database calls.
- [ ] I **strictly** followed the server coding and design guidelines and the REST API guidelines.
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the guidelines and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.
-->

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the client coding guidelines.
- [x] I **strictly** followed the AET UI-UX guidelines.
- [x] Following the theming guidelines, I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the test guidelines.
<!-- - [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons). -->
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

<!--
#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **LocalVC** and **Jenkins**.
-->

### Motivation and Context
The exercise management overview reused its search-empty-result message for a genuinely empty course, which is confusing for instructors setting up a new course and gives no obvious way to create the first exercise from that view.

Closes #13531

### Description
- Split the single `@if (loaded() && cards().length === 0)` block in `course-management-exercises.component.html` into two states: `@if (loaded() && exerciseCount() === 0)` for a course with no exercises at all, and `@else if (loaded() && cards().length === 0)` for the original search-empty case (unchanged)
- Added a dedicated empty-course view: icon, "No exercises have been created in this course yet." message, and (for `course().isAtLeastEditor`) a "Create" button (`data-testid="create-first-exercise-button"`) that calls the existing `openCreateModal()`
- Exposed `faList` as a `protected readonly` field on `CourseManagementExercisesComponent` so the template can bind the new icon (the `exerciseCount` computed signal already existed and needed no changes)
- Added the `noExercisesYet` i18n key to both `src/main/webapp/i18n/en/exerciseManagement.json` and `src/main/webapp/i18n/de/exerciseManagement.json`
- Added three Vitest tests: empty course shows the message + create button for editors, empty course hides the create button for non-editors, and a search matching nothing (with exercises present) still shows the original search-empty message and not the new one

### Steps for Testing
Prerequisites:
- [ 1 Instructor or Editor ]
- [ 1 Tutor (non-editor) ]
- [ 1 Course with zero exercises, to which you can add one ]

1. Go to Artemis and log in as an instructor/editor.
2. Create a new course with zero exercises (or use one you know has none), and open `Course Management → Exercises`.
3. Verify the page shows "No exercises have been created in this course yet." with a small icon, plus a "Create" button — not the old `No exercises match "".` message.
4. Click "Create" and verify it opens the same create-exercise modal as the title bar's "Create" action.
5. Log in as a tutor (non-editor) on that same empty course and verify the empty-state message still shows but the "Create" button does not.
6. Add at least one exercise to the course, reopen the Exercises page, type a search term that matches nothing (e.g. `zzz_no_match`) into the search box, and verify it now shows the original `No exercises match "zzz_no_match".` message instead of the empty-course message.
7. Clear the search and verify the exercise list reappears normally.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Performance Review
<!-- - [ ] I (as a reviewer) confirm that the server changes are implemented with a very good performance even for very large courses with more than 2000 students. -->
- [x] I (as a reviewer) confirm that the client changes are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
<!--
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
-->

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| course-management-exercises.component.ts | 99.57% | 489 | 109 | 22.3 |

_Last updated: 2026-08-31 12:51:38 UTC_


### Screenshots

Warning message:

<img width="1916" height="917" alt="1_message" src="https://github.com/user-attachments/assets/b6f338f7-dd3a-4fd8-a240-a7d0ef16a259" />

Exercise creation modal on button click:

<img width="1918" height="913" alt="2_modal" src="https://github.com/user-attachments/assets/7b4176cc-a846-49a2-a3e8-cac60493e0b2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated empty state for courses with no exercises.
  * Editors can use a button to create the first exercise.
  * Added English and German messaging for the new empty state.

* **Bug Fixes**
  * Improved empty-state handling so searches with no matches display the appropriate message instead of the no-exercises state.

* **Tests**
  * Added coverage for empty courses, editor permissions, and searches without matching exercises.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->