### PR TITLE
`Lectures`: Fix missing heading in the course sidebar

### DIFF
--- a/src/main/webapp/app/lecture/shared/course-lectures/course-lectures.component.spec.ts
+++ b/src/main/webapp/app/lecture/shared/course-lectures/course-lectures.component.spec.ts
@@ -115,7 +115,7 @@ describe('CourseLecturesComponent', () => {
 
         component.ngOnInit();
         firstLectures.next([{ id: 11, title: 'Old lecture' }]);
-        component.setPageTitle('Old lecture');
+        component.setPageTitle('overview.lectures');
         expect(component.lectures()?.[0].title).toBe('Old lecture');
         expect(component.accordionLectureGroups).toBe(oldGroups);
         expect(firstLectures.observed).toBe(true);
@@ -130,7 +130,9 @@ describe('CourseLecturesComponent', () => {
         expect(component.sortedLectures).toEqual([]);
         expect(component.sidebarLectures).toEqual([]);
         expect(Object.values(component.accordionLectureGroups).every((group) => group.entityData.length === 0)).toBe(true);
-        expect(component.pageTitle()).toBe('');
+        // The sidebar heading is set once by the parent when the tab is activated, before this component reloads its
+        // course-specific state; resetting it here would leave the sidebar without a "Lectures" heading.
+        expect(component.pageTitle()).toBe('overview.lectures');
         expect(firstLectures.observed).toBe(false);
         expect(firstCourseUpdates.observed).toBe(false);
         expect(secondLectures.observed).toBe(true);

--- a/src/main/webapp/app/lecture/shared/course-lectures/course-lectures.component.ts
+++ b/src/main/webapp/app/lecture/shared/course-lectures/course-lectures.component.ts
@@ -120,7 +120,6 @@ export class CourseLecturesComponent implements OnInit, OnDestroy, SidebarView {
         this.accordionLectureGroups = DEFAULT_UNIT_GROUPS;
         this.sortedLectures = [];
         this.sidebarLectures = [];
-        this.pageTitle.set('');
 
         this.courseUpdatesSubscription = this.courseStorageService.subscribeToCourseUpdates(courseId).subscribe((course: Course) => {
             this.course.set(course);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary
The "Lectures" heading above the sidebar search box was missing on the course lectures page, even though the equivalent "Exercises" heading shows up fine on the exercises page. This PR fixes the underlying state bug so the heading is displayed correctly again.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
On `/courses/:courseId/lectures`, the sidebar never showed its "Lectures" title, unlike every other sidebar tab (e.g. "Exercises"). This made the lectures tab feel inconsistent and made it harder to tell which section of the course you were in when the sidebar was scrolled or the page was shared as a screenshot.

### Description
`CourseLecturesComponent` resets its `pageTitle` signal back to an empty string whenever it (re-)activates for a course, as part of clearing out the previous course's state. The parent `CourseOverviewComponent` sets that same signal to the translated tab title (`overview.lectures`) once, when the router activates the tab. Because the reset ran after the parent's title was set, the title was cleared and never restored, so the sidebar rendered without a heading.

`CourseExercisesComponent` never resets its `pageTitle` in the same way, which is why the "Exercises" tab was never affected.

The reset was introduced in #12999, which moved the lectures tab to load its own per-course state instead of receiving it from the parent. The regression seems to have gone unnoticed because the reset itself was correct in intent (clearing stale per-course state); it just happened to also clear a value it doesn't own.

The fix removes the unnecessary reset in `CourseLecturesComponent`, since the page title doesn't depend on which course is active and doesn't need to be cleared on course switches.

### Steps for Testing
Prerequisites:
- 1 Student (or Instructor)
- 1 Course with at least one lecture

1. Log in to Artemis
2. Navigate to a course and open the "Lectures" tab
3. Confirm the sidebar shows a "Lectures" heading above the search box, matching the "Exercises" heading on the exercises tab
4. Switch to another course and back, and confirm the heading is still shown

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| course-lectures.component.ts | 98.03% | 203 | 56 | 27.6 |

_Last updated: 2026-08-31 10:28:43 UTC_


### Screenshots

**Before:** heading missing above the search box

<img width="1382" height="753" alt="before-fix-lectures-sidebar" src="https://github.com/user-attachments/assets/bd92265f-6d4c-4f29-8cd1-8025827f2079" />


**After:** "Lectures" heading shown, matching the "Exercises" tab

<img width="1382" height="753" alt="after-fix-lectures-sidebar" src="https://github.com/user-attachments/assets/cc29d6f7-88a1-45a8-bfab-c8169180f459" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the standardized “overview.lectures” page title when switching between courses.
  * Prevented the page title from being cleared during course changes and reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->