### PR TITLE
`Development`: Send local password setup email for newly created SAML2 users

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/account/security/SAML2Service.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/SAML2Service.java
@@ -149,11 +149,13 @@ public class SAML2Service {
 
             if (saml2EnablePassword.isPresent() && Boolean.TRUE.equals(saml2EnablePassword.get())) {
                 log.debug("Sending SAML2 creation mail");
-                if (userService.prepareUserForPasswordReset(user.get())) {
+                if (userService.prepareExternalUserForPasswordSetup(user.get())) {
                     mailService.sendSAML2SetPasswordMail(MailRecipientDTO.withRecoveryKey(user.get(), null, userRecoveryKeyService.findResetKey(user.get().getId())));
                 }
                 else {
-                    log.error("User {} was created but could not be found in the database!", user.get());
+                    // Reachable only if createUser ever stops activating the account outright; kept so a change there
+                    // fails loud instead of the account silently never getting its password-setup mail.
+                    log.error("SAML2 user {} was created but is not activated, so no password-setup mail was sent.", user.get());
                 }
             }
         }

--- a/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserService.java
@@ -335,10 +335,32 @@ public class UserService {
      */
     public boolean prepareUserForPasswordReset(User user) {
         if (user.getActivated() && user.isInternal()) {
-            userRecoveryKeyService.storeResetKey(user.getId(), RandomUtil.generateResetKey(), Instant.now());
+            issueResetKey(user);
             return true;
         }
         return false;
+    }
+
+    /**
+     * Set password-setup data for an externally managed user (e.g. a SAML2 account) if eligible.
+     * <p>
+     * Unlike {@link #prepareUserForPasswordReset(User)}, this does not require {@code user.isInternal()}: an
+     * externally managed account can still be given a local Artemis password as a fallback login without becoming an
+     * internal account, so the {@code internal} flag is left untouched.
+     *
+     * @param user externally managed user who should be able to set a local password
+     * @return true if the user is eligible
+     */
+    public boolean prepareExternalUserForPasswordSetup(User user) {
+        if (user.getActivated()) {
+            issueResetKey(user);
+            return true;
+        }
+        return false;
+    }
+
+    private void issueResetKey(User user) {
+        userRecoveryKeyService.storeResetKey(user.getId(), RandomUtil.generateResetKey(), Instant.now());
     }
 
     /**

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -60,7 +60,7 @@ spring:
 
 server:
     port: 8080
-    url: http://localhost
+    url: http://localhost:${server.port}
 # ===================================================================
 # JHipster specific properties
 #

--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserSaml2IntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserSaml2IntegrationTest.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.account.authentication;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.verify;
 
 import java.util.HashMap;
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -20,9 +22,12 @@ import org.springframework.security.test.context.TestSecurityContextHolder;
 
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.security.SAML2Service;
+import de.tum.cit.aet.artemis.account.service.UserRecoveryKeyService;
 import de.tum.cit.aet.artemis.account.service.user.PasswordService;
+import de.tum.cit.aet.artemis.core.dto.vm.KeyAndPasswordVM;
 import de.tum.cit.aet.artemis.core.dto.vm.LoginVM;
 import de.tum.cit.aet.artemis.core.web.open.PublicUserJwtResource;
+import de.tum.cit.aet.artemis.notification.dto.MailRecipientDTO;
 import de.tum.cit.aet.artemis.shared.base.AbstractSpringIntegrationLocalVCSamlTest;
 
 /**
@@ -38,6 +43,9 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
 
     @Autowired
     private PasswordService passwordService;
+
+    @Autowired
+    private UserRecoveryKeyService userRecoveryKeyService;
 
     @AfterEach
     void clearExistingUser() {
@@ -69,6 +77,42 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
 
         assertStudentExists();
         assertRegistrationNumber(STUDENT_REGISTRATION_NUMBER);
+    }
+
+    /**
+     * This test checks that a first SAML2 login with local password setup enabled (see {@code application-saml2.yml})
+     * issues a reset credential, sends the SAML2 set-password mail with the plaintext one-time secret, keeps the
+     * created account external, and that the link it carries can be redeemed to set a local password.
+     *
+     * @throws Exception if something went wrong.
+     */
+    @Test
+    void testValidSaml2RegistrationSendsPasswordSetupMail() throws Exception {
+        assertStudentNotExists();
+
+        authenticate(createPrincipal(STUDENT_REGISTRATION_NUMBER));
+
+        User createdUser = userUtilService.getUserByLogin(STUDENT_NAME);
+        assertThat(createdUser.isInternal()).as("SAML2 accounts must remain externally managed").isFalse();
+        assertThat(createdUser.getActivated()).isTrue();
+
+        String resetKey = userRecoveryKeyService.findResetKey(createdUser.getId());
+        assertThat(resetKey).as("A reset credential should have been issued for the new SAML2 user").isNotBlank();
+
+        ArgumentCaptor<MailRecipientDTO> mailRecipientCaptor = ArgumentCaptor.forClass(MailRecipientDTO.class);
+        verify(mailService).sendSAML2SetPasswordMail(mailRecipientCaptor.capture());
+        assertThat(mailRecipientCaptor.getValue().login()).isEqualTo(STUDENT_NAME);
+        assertThat(mailRecipientCaptor.getValue().resetKey()).isEqualTo(resetKey);
+
+        // The link the mail carries can be redeemed to set a local password, without the account becoming internal.
+        KeyAndPasswordVM finishResetData = new KeyAndPasswordVM();
+        finishResetData.setKey(resetKey);
+        finishResetData.setNewPassword(STUDENT_PASSWORD);
+        request.postWithoutLocation("/api/core/public/account/reset-password/finish", finishResetData, HttpStatus.OK, null);
+
+        User userAfterPasswordSetup = userUtilService.getUserByLogin(STUDENT_NAME);
+        assertThat(passwordService.checkPasswordMatch(STUDENT_PASSWORD, userAfterPasswordSetup.getPassword())).isTrue();
+        assertThat(userAfterPasswordSetup.isInternal()).as("Setting a local password must not flip the account to internal").isFalse();
     }
 
     /**


### PR DESCRIPTION
### Summary
When SAML2 login is configured with local password setup enabled (`info.saml2.enablePassword: true`), a newly created SAML2 user never received the password-setup email. The eligibility check reused for this purpose required an internal account, but every freshly created SAML2 account is explicitly marked external, so the check silently failed for every single SAML2 user and logged a misleading error instead. This PR adds a dedicated eligibility path for externally managed accounts and fixes a local-dev config bug (found while manually verifying this fix) that made the resulting mail link unreachable.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the server coding and design guidelines and the REST API guidelines.
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
<!-- - [ ] I added pre-authorization annotations according to the guidelines and checked the course groups for all new REST Calls (security). -->
- [x] I documented the Java code using JavaDoc style.

<!--
#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data.
- [ ] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [ ] I **strictly** followed the client coding guidelines.
- [ ] I **strictly** followed the AET UI-UX guidelines.
- [ ] Following the theming guidelines, I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the test guidelines.
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.
-->

<!--
#### Changes affecting Programming Exercises
- [ ] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **LocalVC** and **Jenkins**.
-->

### Motivation and Context
`SAML2Service#handleAuthentication` gated the SAML2 password-setup mail behind `UserService#prepareUserForPasswordReset`, which requires `user.isInternal() == true`. `SAML2Service#createUser` always sets `internal = false` on a freshly created SAML2 account, so this check rejected every single new SAML2 user, logging the misleading `"...could not be found in the database"` and leaving new SSO users with no way to set a local password for Git/VCS access.

Closes #13610

### Description
- Extracted the reset-key-issuing logic out of `UserService#prepareUserForPasswordReset` into a private `issueResetKey(User)` helper.
- Added `UserService#prepareExternalUserForPasswordSetup(User)` — an eligibility check for externally managed accounts that only requires `user.getActivated()`, not `isInternal()` — reusing `issueResetKey` so both eligibility checks issue the credential the same way.
- Updated `SAML2Service#handleAuthentication` to call `prepareExternalUserForPasswordSetup` instead of `prepareUserForPasswordReset` when sending the SAML2 creation mail, and corrected the log message in the (now effectively unreachable) `else` branch to describe the real condition being checked.
- Fixed `application-dev.yml`: `server.url` was hardcoded to `http://localhost` with no port even though `server.port: 8080` is set right above it, so every `@Value("${server.url}")` consumer — including the mail `BASE_URL` used to build this exact password-setup link — produced an unreachable URL locally. Changed to `http://localhost:${server.port}`. Found while manually verifying this fix; unrelated to the `internal`/eligibility bug itself but blocked verifying it.
- Added `UserSaml2IntegrationTest#testValidSaml2RegistrationSendsPasswordSetupMail`: authenticates a brand-new SAML2 principal and asserts a reset credential was issued, the mail was sent with that exact key, the account stayed `internal == false`, and that the key can actually be redeemed via `POST /api/core/public/account/reset-password/finish` to set a working local password without flipping the account to internal.

### Steps for Testing

#### Locally
Prerequisites:
- Docker (Desktop or Engine), OpenSSL, JDK 25, Node 24 + `corepack enable` for pnpm 11
- SAML2 test IdP: see `documentation/docs/developer/keycloak-saml2-setup.mdx`

1. Start the lightweight containers:
   ```bash
   docker compose --env-file .env -f docker/mysql.yml up -d
   docker compose --env-file .env -f docker/saml-test.yml up -d
   docker compose --env-file .env -f docker/mailpit.yml up -d
   ```
2. Generate a SAML2 signing certificate (once) and reference it, together with `artemis.user-management.saml2.enabled: true`, `info.saml2.enablePassword: true`, and a full `saml2:` pattern block (**including `lang-key-pattern`** — omitting it throws a `NullPointerException` in `SAML2Service#substituteAttributes` on first login) in `src/main/resources/config/application-local.yml`. Also set `spring.mail.host/port` to mailpit (`localhost:1025`) and `jhipster.mail.from` to something other than the `artemis@localhost` default, or mail sending is silently skipped.
3. Start the server: `./gradlew bootRun --args='--spring.profiles.active=dev,localci,localvc,artemis,scheduling,core,local'` (use `localci`, not `jenkins` — the `jenkins` profile requires a real, configured Jenkins instance and will fail to start without one).
4. Open `http://localhost:8080`, click **SAML2 Login**, and sign in as `saml2user1` / `password` (or `saml2user2` — must be an identity with no existing Artemis account, so the account-creation code path runs).
5. Verify login succeeds and lands in Artemis.
6. Open `http://localhost:8025` (Mailpit) and verify the **Set-Password mail** arrived, with a working link (`http://localhost:8080/account/reset/finish?key=...`).
7. Follow the link and set a local password. Note: you will **not** be able to subsequently log in with that password through the normal login form — `LoginOptionsService` only offers the password field for `internal == true` accounts, and this account intentionally stays external. The password is for Git/VCS auth and external services (e.g. Jenkins), not the Artemis web login. Instead, verify in the admin user list that the account is still shown as external (not "internal").

#### On a Helios test server
Prerequisites:
- A test server with SAML2 configured against a real or test IdP and `info.saml2.enablePassword: true` (see `documentation/docs/developer/keycloak-saml2-setup.mdx` for the local reference config to adapt; the exact IdP/credentials setup on the target server is environment-specific and outside this PR's scope)
- A mail-catching setup (or real SMTP) reachable from that server so the sent mail can actually be inspected

1. Deploy this branch/PR to a test server via [Helios CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd). (TS3 or e-mail login support
2. Confirm the target environment has SAML2 enabled (`artemis.user-management.saml2.enabled: true`) and `info.saml2.enablePassword: true`; check the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list) if unsure which environments have this configured.
3. Log in via the configured SAML2 IdP with an identity that has no existing account on that server.
4. Verify the account is created (external, activated) and the password-setup mail is delivered to whatever mail sink that environment uses.
5. Follow the link, set a local password, and verify (via the admin user list) the account remains external. As above, this password is for Git/VCS access, not the Artemis web login form.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Performance Review
<!-- - [ ] I (as a reviewer) confirm that the client changes are implemented with a very good performance even for very large courses with more than 2000 students. -->
- [ ] I (as a reviewer) confirm that the server changes are implemented with a very good performance even for very large courses with more than 2000 students.
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
<!--
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
-->

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| SAML2Service.java | 95.45% | 181 |
| UserService.java | 90.88% | 514 |

_Last updated: 2026-08-31 11:58:42 UTC_


### Screenshots

1. Enter the username "saml2user1"

<img width="1920" height="923" alt="1_username" src="https://github.com/user-attachments/assets/faced39c-42d0-4fc0-b899-04d53d643857" />

2. Login using the "SAML2 Login" button

<img width="1920" height="924" alt="2_saml_login" src="https://github.com/user-attachments/assets/4bc81519-9680-4ae5-93d5-c2261d2ecd95" />

3. Enter the corresponding password

<img width="1920" height="925" alt="3_login_password_hidden" src="https://github.com/user-attachments/assets/ac35eac0-e6c4-421d-b83c-cc5ada4bb299" />

4. Check mailpit for the confirmation email

<img width="1920" height="924" alt="4_mailpit_mail" src="https://github.com/user-attachments/assets/9a88bc55-4015-4180-a85f-567f14ed94fb" />

5. Click the password reset link and set a new password

<img width="1920" height="927" alt="5_new_password" src="https://github.com/user-attachments/assets/0c4b4423-fa8c-4679-a289-80d34ad05272" />

6. Login as "artemis_admin" and verify that "saml2user1" is still not an internal user

<img width="1920" height="924" alt="6_saml_user_external" src="https://github.com/user-attachments/assets/4573dc85-4d50-48af-831f-83e4c9ac8768" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password setup for newly created SAML accounts.
  * SAML users now remain externally managed and activated while receiving password-setup instructions.
  * Completed password setup no longer changes the account’s external status.
* **Tests**
  * Added coverage for the SAML account creation and password setup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->