### PR TITLE
`General`: Fix a stray underline next to the profile picture in the navigation bar

### DIFF
--- a/src/main/webapp/app/core/navbar/navbar.scss
+++ b/src/main/webapp/app/core/navbar/navbar.scss
@@ -14,8 +14,14 @@
 Navbar
 ========================================================================== */
 
-/* Don't underline the menu items on hover */
-a:not(.btn):hover {
+/*
+ * Don't underline the menu items on hover. `global.scss` underlines every hovered anchor with an `!important`
+ * rule that carries three `:not()` clauses, so this override has to match that clause count before Angular's
+ * `[_ngcontent]` attribute tips the specificity in its favour — with fewer clauses the global rule wins and the
+ * underline reappears. On the account menu that is especially visible: the avatar covers the stretch of the
+ * underline behind it, so all that surfaces is a short blue dash next to the image.
+ */
+a:not(.btn):not(.tum-ui-btn):not(.tab-link):hover {
     text-decoration: none !important;
 }
 


### PR DESCRIPTION
### Summary
Hovering the profile picture in the top right corner of the navigation bar painted a short blue dash right next to the avatar. It is the hover underline of the account menu link: the avatar covers the part of the underline that runs behind the image, so only the small stretch between the image and the dropdown caret stays visible. This PR restores the navbar's existing "no underline on hover" rule so it actually applies again.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
\`navbar.scss\` has always carried a rule commented "Don't underline the menu items on hover". It stopped working: \`global.scss\` underlines every hovered anchor with

\`\`\`scss
a:not(.btn):not(.tum-ui-btn):not(.tab-link):hover {
    text-decoration: underline !important;
}
\`\`\`

Both declarations are \`!important\`, so the winner is decided by specificity. The global selector scores (0, 4, 1). The navbar override was \`a:not(.btn):hover\`, which Angular's view encapsulation emits as \`a[_ngcontent-…]:not(.btn):hover\` — (0, 3, 1). The global rule therefore won and every navbar link was underlined on hover.

That is barely noticeable on links that consist of text, but the account menu contains only the avatar image. Text decoration of an inline box is painted underneath the content of its descendants, so the image hides the underline where it overlaps it. What is left is the piece between the right edge of the avatar and the caret — the reported blue dash. It sits above the bottom edge of the image because \`.profile-image\` uses \`margin: -10px 0\`, which lifts the baseline by 10px.

### Description
Added the two missing \`:not()\` clauses to the navbar override so it matches the clause count of the global rule; the \`[_ngcontent]\` attribute Angular appends then tips the specificity to (0, 5, 1) and the override wins. Extended the comment above the rule to explain why the clause count matters, so the next edit does not silently break it again.

The hover affordance is unchanged: navbar links still switch to \`var(--link-color)\` on hover, they are just no longer underlined — which is what the rule always intended.

### Steps for Testing
Prerequisites:
- 1 User with a profile picture

1. Log in to Artemis.
2. Hover over the profile picture in the top right corner of the navigation bar.
3. Verify that no blue dash appears next to the avatar and that the icon still changes color on hover.
4. Hover over the other navigation bar links (breadcrumbs, the language selector, the student/management switch) and verify that they change color but are not underlined.
5. Verify the same in the dark theme.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-01 19:28:42 UTC_


### Screenshots
Hovering the account menu, zoomed 4x.

Before — the blue dash next to the avatar:

After — no dash, the color change on hover is kept:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated navbar hover styling to prevent unintended hover effects on button and tab-link elements.
  * Improved styling guidance comments for more consistent navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->