### PR TITLE
`General`: Fix the alignment of the semester and date fields on the course request page

### DIFF
--- a/src/main/webapp/app/course/request/course-request-form.component.html
+++ b/src/main/webapp/app/course/request/course-request-form.component.html
@@ -51,7 +51,9 @@
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-3">
-        <div class="flex flex-col gap-2">
+        <!-- No gap between the label and the control: jhi-date-time-picker renders its label right above its input,
+             so an extra gap here would push the semester dropdown below the two date fields next to it. -->
+        <div class="flex flex-col">
             <label class="font-semibold" [for]="idPrefix() + 'semester'" jhiTranslate="artemisApp.courseRequest.form.semester"></label>
             <p-select
                 [inputId]="idPrefix() + 'semester'"
@@ -61,7 +63,7 @@
                 [invalid]="(form().get('semester')?.invalid && form().get('semester')?.touched) ?? false"
             />
             @if (form().get('semester')?.invalid && form().get('semester')?.touched) {
-                <small class="text-state-danger" jhiTranslate="entity.validation.required"></small>
+                <small class="text-state-danger mt-1" jhiTranslate="entity.validation.required"></small>
             }
         </div>
         <div class="flex flex-col gap-2">


### PR DESCRIPTION
### Summary
On the "Request a new course" page, the semester dropdown sat 8px lower than the start date and end date fields next to it. All three controls now share the same top edge.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
The three fields sit in the same \`grid grid-cols-3\` row, but they are built differently. The semester column declares its own label and control inside a \`flex flex-col gap-2\` wrapper, so Tailwind's \`gap-2\` adds 8px between the label and the select. The two date columns delegate to \`jhi-date-time-picker\`, which renders its label directly above its input with no gap at all.

The labels line up, so the offset only shows on the controls. Measured before the fix (viewport 1280px):

| Element | Top | Bottom | Height |
|---|---|---|---|
| Semester select | 450.6 | 492.6 | 42 |
| Start date input | 442.6 | 484.6 | 42 |
| End date input | 442.6 | 484.6 | 42 |

### Description
Removed \`gap-2\` from the semester column so its label sits directly above the select, matching what the date picker does, and added a comment recording why the gap must not come back. The validation message below the select keeps its spacing through an explicit \`mt-1\`, which is the same margin the date picker uses for its own message.

After the fix all three controls report \`top: 442.6\`, \`bottom: 484.6\`, \`height: 42\`, and the row is 8px shorter.

### Steps for Testing
Prerequisites:
- 1 Student (or any logged-in user)

1. Log in to Artemis.
2. Navigate to \`/course-requests\`.
3. Verify that the semester dropdown, the start date field and the end date field are aligned at the top and have the same height.
4. Submit the form without a reason and verify that the semester validation message still appears with sensible spacing below the dropdown.
5. Reduce the window width below the \`md\` breakpoint and verify that the three fields stack correctly.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/).

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-01 19:27:25 UTC_


### Screenshots
Screenshots to be attached here by drag and drop. Until then, the measured offsets from `/course-requests` on this branch:

| Top edge (px) | Semester select | Start date | End date | Row height |
|---|--:|--:|--:|--:|
| Before | 445.3 | 437.3 | 437.3 | 71.6 |
| After | 437.3 | 437.3 | 437.3 | 63.6 |

All three controls are 42 px tall in both states; only the starting offset differed. Measured with `getBoundingClientRect()` at a 1280x1100 viewport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing in the course request form’s semester field.
  * Added spacing above the semester validation message for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
