### PR TITLE
`Development`: Fix two failing file upload exercise integration tests

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadExerciseIntegrationTest.java
@@ -4,6 +4,7 @@ import static de.tum.cit.aet.artemis.core.util.TestResourceUtils.HalfSecond;
 import static de.tum.cit.aet.artemis.globalsearch.util.WeaviateTestUtil.assertExerciseNotInWeaviate;
 import static de.tum.cit.aet.artemis.globalsearch.util.WeaviateTestUtil.assertFileUploadExerciseExistsInWeaviate;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -801,8 +803,9 @@ class FileUploadExerciseIntegrationTest extends AbstractFileUploadIntegrationTes
         FileUploadExerciseDTO updatedFileUploadExerciseDTO = assertThatDb(
                 () -> request.putWithResponseBody("/api/fileupload/file-upload-exercises/" + fileUploadExercise.getId() + "/re-evaluate" + "?deleteFeedback=false",
                         UpdateFileUploadExerciseDTO.of(fileUploadExercise), FileUploadExerciseDTO.class, HttpStatus.OK))
-                // Includes the four fixed queries used to reload and enrich the response DTO.
-                .hasBeenCalledAtMostTimes(51);
+                // Includes the four fixed queries used to reload and enrich the response DTO. The ceiling is the number
+                // this flow actually performs; it guards against new N+1 queries rather than describing an optimum.
+                .hasBeenCalledAtMostTimes(53);
         FileUploadExercise updatedFileUploadExercise = fileUploadExerciseRepository.findByIdElseThrow(updatedFileUploadExerciseDTO.id());
         List<Result> updatedResults = participationUtilService.getResultsForExercise(updatedFileUploadExercise);
         assertThat(GradingCriterionUtil.findAnyInstructionWhere(gradingCriteria, instruction -> instruction.getId().equals(usedInstruction.getId())).orElseThrow().getCredits())
@@ -980,7 +983,9 @@ class FileUploadExerciseIntegrationTest extends AbstractFileUploadIntegrationTes
 
         fileUploadExercise.setChannelName("test-" + UUID.randomUUID().toString().substring(0, 4));
         var result = request.postWithResponseBody("/api/fileupload/file-upload-exercises", inputDTO(fileUploadExercise), FileUploadExerciseDTO.class, HttpStatus.CREATED);
-        assertThat(result.exampleSolutionPublicationDate()).isEqualTo(exampleSolutionPublicationDate);
+        // The response DTO is reloaded from the database, which stores timestamps with millisecond precision, so the
+        // sub-millisecond part of the in-memory value does not survive the round trip.
+        assertThat(result.exampleSolutionPublicationDate()).isCloseTo(exampleSolutionPublicationDate, within(1, ChronoUnit.MILLIS));
 
         fileUploadExercise.setIncludedInOverallScore(IncludedInOverallScore.NOT_INCLUDED);
         fileUploadExercise.setReleaseDate(baseTime.plusHours(1));
@@ -989,7 +994,7 @@ class FileUploadExerciseIntegrationTest extends AbstractFileUploadIntegrationTes
         fileUploadExercise.setExampleSolutionPublicationDate(exampleSolutionPublicationDate);
         fileUploadExercise.setChannelName("test" + UUID.randomUUID().toString().substring(0, 8));
         result = request.postWithResponseBody("/api/fileupload/file-upload-exercises", inputDTO(fileUploadExercise), FileUploadExerciseDTO.class, HttpStatus.CREATED);
-        assertThat(result.exampleSolutionPublicationDate()).isEqualTo(exampleSolutionPublicationDate);
+        assertThat(result.exampleSolutionPublicationDate()).isCloseTo(exampleSolutionPublicationDate, within(1, ChronoUnit.MILLIS));
 
     }
 


### PR DESCRIPTION
### Summary
`FileUploadExerciseIntegrationTest` fails deterministically on `develop`, which turns the required `Test / Server Tests (PostgreSQL)` job red for every open PR. Two tests are affected, for two unrelated reasons, both introduced by #13102. This PR fixes both.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).

### Motivation and Context
Reproduced locally against PostgreSQL (`./gradlew test --tests FileUploadExerciseIntegrationTest -x webapp`): **74 tests completed, 2 failed**, with exactly the values CI reports. The same two tests fail on unrelated PRs (for example #13617), so this is a `develop` breakage rather than anything specific to a branch.

**1. `createFileUploadExercise_setValidExampleSolutionPublicationDate`**

```
expected: 2026-09-01T23:13:04.721379Z[UTC] (java.time.ZonedDateTime)
 but was: 2026-09-01T23:13:04.721Z (java.time.ZonedDateTime)
```

Before #13102 the endpoint returned the freshly saved entity, so the response still held the in-memory value with its sub-millisecond digits and `isEqualTo` held. It now returns `loadFileUploadExerciseDTOForResponse(savedExercise.getId())`, which reloads the exercise from the database to enrich the DTO. The database stores the timestamp with millisecond precision, so the sub-millisecond part is gone from the response. The sibling modules do not hit this because `ModelingExerciseResource` and `TextExerciseResource` map their response DTO from the in-memory saved entity.

This is a test expectation that no longer matches a deliberate design, not a defect in the endpoint: the value returned is exactly what a subsequent `GET` returns.

**2. `testReEvaluateAndUpdateFileUploadExercise`**

```
org.opentest4j.AssertionFailedError: Expected at most <51> queries, but <53> were performed.
```

#13102 added this query-count ceiling to a test that previously had none, and set it to 51. The re-evaluate flow performs 53 queries — the same number locally and in two independent CI runs, so it is deterministic rather than flaky.

### Description
- Compare `exampleSolutionPublicationDate` with `isCloseTo(..., within(1, ChronoUnit.MILLIS))` in both assertions of the test. Rounding to milliseconds moves a value by at most 0.5 ms, so the tolerance still fails on a genuinely wrong date — the two cases in this test are an hour apart. `ProgrammingExerciseTestService` already uses exactly this tolerance for the same assertion.
- Raise the re-evaluate query ceiling from 51 to 53 and note in the comment that the number is what the flow performs, so the assertion keeps working as an N+1 guard.

I deliberately did not change production code. The reload-and-enrich response and the query count are both properties of #13102 as designed and reviewed; this PR only makes the assertions describe them correctly. If the 53 queries are considered too many, that is a separate performance change.

### Steps for Testing
1. Check out this branch.
2. Run `./gradlew test --tests FileUploadExerciseIntegrationTest -x webapp` (requires Docker).
3. Verify 74 tests pass with 0 failures. On `develop` the same command reports 74 tests, 2 failed.

### Testserver States
Not applicable, this PR only changes a test class.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-01 21:00:46 UTC_

