### PR TITLE
Programming exercises: Rate-limit the git-backed online editor endpoints per user

### DIFF
--- a/documentation/docs/admin/production-setup/security.mdx
+++ b/documentation/docs/admin/production-setup/security.mdx
@@ -452,6 +452,7 @@ artemis:
     account-management-requests-per-minute: 5
     authentication-requests-per-minute: 30
     login-options-requests-per-minute: 30
+    repository-editor-requests-per-minute: 120
 ```
 
 ### Where It Is Enforced
@@ -464,5 +465,8 @@ artemis:
 - Username/password login
 - WebAuthn authentication
 - Git over SSH and HTTP operations
+- Git-backed online-editor endpoints (reading, writing and committing files in participation, test and auxiliary
+  repositories). Counted per user rather than per address, because each call checks out and pulls the working copy
+  on the server and the editor is used by many students at once, often behind one shared address.
 
 We plan to add the rate-limit to more endpoints (like Oauth2) in the future.

--- a/src/main/java/de/tum/cit/aet/artemis/admin/service/RateLimitConfigurationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/admin/service/RateLimitConfigurationService.java
@@ -121,6 +121,7 @@ public class RateLimitConfigurationService {
             case AI_SEARCH_PIPELINE -> properties.getAiSearchPipelineRequestsPerMinute() != null ? properties.getAiSearchPipelineRequestsPerMinute() : type.getDefaultRpm();
             case BUILD_AGENT_CLONE_TOKEN ->
                 properties.getBuildAgentCloneTokenRequestsPerMinute() != null ? properties.getBuildAgentCloneTokenRequestsPerMinute() : type.getDefaultRpm();
+            case REPOSITORY_EDITOR -> properties.getRepositoryEditorRequestsPerMinute() != null ? properties.getRepositoryEditorRequestsPerMinute() : type.getDefaultRpm();
         };
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/admin/service/RateLimitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/admin/service/RateLimitService.java
@@ -51,7 +51,7 @@ public class RateLimitService {
     }
 
     /**
-     * Enforces rate limiting by consuming 1 token from a per-minute bucket.
+     * Enforces rate limiting by consuming 1 token from a per-minute bucket counted per client address.
      * Throws {@link RateLimitExceededException} if the rate limit is exceeded.
      *
      * @param clientId identifier for the client (typically an IP address)
@@ -59,9 +59,26 @@ public class RateLimitService {
      * @throws RateLimitExceededException if the rate limit is exceeded
      */
     public void enforcePerMinute(IPAddress clientId, RateLimitType rpmType) {
+        enforcePerMinute(clientId, String.valueOf(clientId), rpmType);
+    }
+
+    /**
+     * Enforces rate limiting by consuming 1 token from a per-minute bucket counted against {@code countingKey}.
+     * Throws {@link RateLimitExceededException} if the rate limit is exceeded.
+     * <p>
+     * The counting key decides who shares a budget (a client address, or {@code "user:" + login} for per-user
+     * limits). Exemption stays address-based on purpose: {@code exemptionAddress} is still checked against the
+     * configured exempt addresses, so a load generator listed there bypasses the limit even on a per-user endpoint.
+     *
+     * @param exemptionAddress the client address used only for the exempt-address check (may be {@code null})
+     * @param countingKey      the identity the limit is counted against (must not be {@code null})
+     * @param rpmType          the rate limit type to determine the RPM configuration
+     * @throws RateLimitExceededException if the rate limit is exceeded
+     */
+    public void enforcePerMinute(IPAddress exemptionAddress, String countingKey, RateLimitType rpmType) {
         // Skip rate limiting if disabled globally or disabled via feature toggle
         if (!configurationService.isRateLimitingEnabled() || !featureToggleService.isFeatureEnabled(Feature.RateLimit)) {
-            log.debug("Rate limiting is disabled globally, skipping enforcement for client {} at {}", clientId, rpmType.name());
+            log.debug("Rate limiting is disabled globally, skipping enforcement for {} at {}", countingKey, rpmType.name());
             return;
         }
 
@@ -69,20 +86,20 @@ public class RateLimitService {
         // generator drives thousands of requests from one address, and any finite bucket would still
         // throttle it partway through a run and quietly turn the measurement into a measurement of the
         // limiter.
-        if (configurationService.isExempt(clientId)) {
-            log.debug("Client {} is exempt from rate limiting, skipping enforcement at {}", clientId, rpmType.name());
+        if (configurationService.isExempt(exemptionAddress)) {
+            log.debug("Client {} is exempt from rate limiting, skipping enforcement at {}", exemptionAddress, rpmType.name());
             return;
         }
 
-        Bucket bucket = getOrCreatePerMinuteBucket(clientId, rpmType, configurationService.getEffectiveRpm(rpmType));
+        Bucket bucket = getOrCreatePerMinuteBucket(countingKey, rpmType, configurationService.getEffectiveRpm(rpmType));
         ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
         if (!probe.isConsumed()) {
             long seconds = Math.max(1, probe.getNanosToWaitForRefill() / 1_000_000_000L);
-            log.warn("Rate limit exceeded for client {} at {}, retry after {} seconds", clientId, rpmType.name(), seconds);
+            log.warn("Rate limit exceeded for {} at {}, retry after {} seconds", countingKey, rpmType.name(), seconds);
             throw new RateLimitExceededException(seconds);
         }
 
-        log.debug("Rate limit check passed for client {} at {}, remaining tokens: {}", clientId, rpmType.name(), probe.getRemainingTokens());
+        log.debug("Rate limit check passed for {} at {}, remaining tokens: {}", countingKey, rpmType.name(), probe.getRemainingTokens());
     }
 
     /**
@@ -102,7 +119,7 @@ public class RateLimitService {
         if (!configurationService.isRateLimitingEnabled() || !featureToggleService.isFeatureEnabled(Feature.RateLimit) || configurationService.isExempt(clientId)) {
             return true;
         }
-        return getOrCreatePerMinuteBucket(clientId, rpmType, configurationService.getEffectiveRpm(rpmType)).getAvailableTokens() > 0;
+        return getOrCreatePerMinuteBucket(String.valueOf(clientId), rpmType, configurationService.getEffectiveRpm(rpmType)).getAvailableTokens() > 0;
     }
 
     /**
@@ -118,13 +135,13 @@ public class RateLimitService {
         if (!configurationService.isRateLimitingEnabled() || !featureToggleService.isFeatureEnabled(Feature.RateLimit) || configurationService.isExempt(clientId)) {
             return;
         }
-        getOrCreatePerMinuteBucket(clientId, rpmType, configurationService.getEffectiveRpm(rpmType)).tryConsume(1);
+        getOrCreatePerMinuteBucket(String.valueOf(clientId), rpmType, configurationService.getEffectiveRpm(rpmType)).tryConsume(1);
     }
 
-    private Bucket getOrCreatePerMinuteBucket(IPAddress clientId, RateLimitType rpmType, int rpm) {
+    private Bucket getOrCreatePerMinuteBucket(String countingKey, RateLimitType rpmType, int rpm) {
         BucketConfiguration cfg = perMinuteCfgCache.computeIfAbsent(rpm, RateLimitConfig::perMinute);
         // Include the rate-limit type in the bucket key so two types with the same RPM do not share a bucket.
-        return proxyManager.getProxy("type=" + rpmType.name() + "#rpm=" + rpm + "#" + clientId, () -> cfg);
+        return proxyManager.getProxy("type=" + rpmType.name() + "#rpm=" + rpm + "#" + countingKey, () -> cfg);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/RateLimitingProperties.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/RateLimitingProperties.java
@@ -79,6 +79,12 @@ public class RateLimitingProperties {
      */
     private Integer buildAgentCloneTokenRequestsPerMinute;
 
+    /**
+     * Requests per minute for the git-backed online-editor endpoints, counted per user.
+     * If not specified, uses the default from {@link de.tum.cit.aet.artemis.core.security.RateLimitType#REPOSITORY_EDITOR}.
+     */
+    private Integer repositoryEditorRequestsPerMinute;
+
     public List<String> getExemptAddresses() {
         return exemptAddresses;
     }
@@ -141,5 +147,13 @@ public class RateLimitingProperties {
 
     public void setAiSearchPipelineRequestsPerMinute(Integer aiSearchPipelineRequestsPerMinute) {
         this.aiSearchPipelineRequestsPerMinute = aiSearchPipelineRequestsPerMinute;
+    }
+
+    public Integer getRepositoryEditorRequestsPerMinute() {
+        return repositoryEditorRequestsPerMinute;
+    }
+
+    public void setRepositoryEditorRequestsPerMinute(Integer repositoryEditorRequestsPerMinute) {
+        this.repositoryEditorRequestsPerMinute = repositoryEditorRequestsPerMinute;
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/RateLimitKey.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/RateLimitKey.java
@@ -1,0 +1,24 @@
+package de.tum.cit.aet.artemis.core.security;
+
+/**
+ * Identity that a rate limit counts requests against.
+ * <p>
+ * The bucket key is built from this identity, so it decides who shares a budget. Most limits protect an
+ * unauthenticated or credential-checking path and therefore count per client address ({@link #IP}). Limits on
+ * authenticated, per-user work count per user ({@link #USER}) instead, so that many users behind one shared
+ * address (for example a whole campus network behind NAT) do not drain a single common budget.
+ */
+public enum RateLimitKey {
+
+    /**
+     * Count per client address. The default, and the right shape for unauthenticated or credential-checking
+     * endpoints where no stable user identity is available yet.
+     */
+    IP,
+
+    /**
+     * Count per authenticated user. Suitable for authenticated endpoints whose cost is attributable to the acting
+     * user, so that users sharing a source address do not throttle one another.
+     */
+    USER
+}

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/RateLimitType.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/RateLimitType.java
@@ -78,7 +78,25 @@ public enum RateLimitType {
      * <p>
      * Default: 120 requests per minute per client.
      */
-    AI_SEARCH_PIPELINE(120);
+    AI_SEARCH_PIPELINE(120),
+
+    /**
+     * Rate limit for the git-backed online-editor endpoints (reading, writing, committing files in a participation,
+     * test or auxiliary repository).
+     * <p>
+     * Every one of these calls checks out and pulls the working copy on the server, so a cheap client request turns
+     * into a much more expensive git operation (amplification). Without a limit a single authenticated user can drive
+     * unbounded server load through many or parallel calls.
+     * <p>
+     * Counted per user rather than per client address (see {@code RateLimitKey.USER}): the editor is used by many
+     * students at once during an exam, often behind a single campus address (NAT), so a per-address limit would
+     * throttle legitimate concurrent use. The default is generous enough for interactive human editing while still
+     * bounding automated abuse; it only applies where {@code artemis.rate-limiting.enabled} is switched on, and
+     * {@code artemis.rate-limiting.repository-editor-requests-per-minute} overrides it.
+     * <p>
+     * Default: 120 requests per minute per user.
+     */
+    REPOSITORY_EDITOR(120);
 
     private final int defaultRpm;
 

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/LimitRequestsPerMinute.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/LimitRequestsPerMinute.java
@@ -5,6 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import de.tum.cit.aet.artemis.core.security.RateLimitKey;
 import de.tum.cit.aet.artemis.core.security.RateLimitType;
 
 /**
@@ -14,7 +15,8 @@ import de.tum.cit.aet.artemis.core.security.RateLimitType;
  *
  * <p>
  * Use {@link #type()} to specify a predefined rate limit type, which allows for configuration-based overrides
- * of the default RPM values defined in {@link RateLimitType}.
+ * of the default RPM values defined in {@link RateLimitType}. Use {@link #key()} to choose whether the limit is
+ * counted per client address or per authenticated user.
  * </p>
  */
 @Target({ ElementType.METHOD, ElementType.TYPE })
@@ -27,4 +29,12 @@ public @interface LimitRequestsPerMinute {
      * @return the rate limit type
      */
     RateLimitType type() default RateLimitType.AUTHENTICATION;
+
+    /**
+     * Identity the limit is counted against. Defaults to {@link RateLimitKey#IP} so existing usages keep counting
+     * per client address; use {@link RateLimitKey#USER} on authenticated endpoints that should be limited per user.
+     *
+     * @return the rate limit key
+     */
+    RateLimitKey key() default RateLimitKey.IP;
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/LimitRequestsPerMinuteAspect.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/annotations/LimitRequestsPerMinuteAspect.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.core.security.annotations;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.lang.reflect.Method;
+import java.util.Optional;
 
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Component;
 
 import de.tum.cit.aet.artemis.admin.service.RateLimitConfigurationService;
 import de.tum.cit.aet.artemis.admin.service.RateLimitService;
+import de.tum.cit.aet.artemis.core.security.RateLimitKey;
+import de.tum.cit.aet.artemis.core.security.SecurityUtils;
 import inet.ipaddr.IPAddress;
 
 /**
@@ -59,18 +62,47 @@ public class LimitRequestsPerMinuteAspect {
     @Before("@annotation(LimitRequestsPerMinute) || @within(LimitRequestsPerMinute)")
     public void checkRateLimit(JoinPoint joinPoint) throws Throwable {
         Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
-        LimitRequestsPerMinute annotation = method.getAnnotation(LimitRequestsPerMinute.class);
-
-        if (annotation == null) {
-            annotation = method.getDeclaringClass().getAnnotation(LimitRequestsPerMinute.class);
-        }
+        LimitRequestsPerMinute annotation = resolveAnnotation(method, joinPoint.getTarget());
 
         if (annotation == null) {
             return;
         }
 
-        IPAddress clientId = rateLimitService.resolveClientId();
+        IPAddress clientAddress = rateLimitService.resolveClientId();
 
-        rateLimitService.enforcePerMinute(clientId, annotation.type());
+        if (annotation.key() == RateLimitKey.USER) {
+            Optional<String> login = SecurityUtils.getCurrentUserLogin();
+            if (login.isPresent()) {
+                // Count per user so that users sharing one source address (for example a campus network behind NAT)
+                // do not drain a common budget. Exemption stays address-based, so the client address is still passed.
+                rateLimitService.enforcePerMinute(clientAddress, "user:" + login.get(), annotation.type());
+                return;
+            }
+            // No authenticated principal (not expected on endpoints guarded by @EnforceAtLeastStudent): fall back to
+            // counting per client address so the endpoint is never left unlimited.
+        }
+
+        rateLimitService.enforcePerMinute(clientAddress, annotation.type());
+    }
+
+    /**
+     * Resolves the annotation from the method, else the runtime target class, else the declaring class.
+     * <p>
+     * Checking the runtime target class covers a class-level annotation on the concrete controller even when the
+     * intercepted method is declared on a superclass, so a class-level limit cannot be silently missed.
+     *
+     * @param method the intercepted method
+     * @param target the target object of the intercepted call (may be {@code null})
+     * @return the resolved annotation, or {@code null} if none applies
+     */
+    private static LimitRequestsPerMinute resolveAnnotation(Method method, Object target) {
+        LimitRequestsPerMinute annotation = method.getAnnotation(LimitRequestsPerMinute.class);
+        if (annotation == null && target != null) {
+            annotation = target.getClass().getAnnotation(LimitRequestsPerMinute.class);
+        }
+        if (annotation == null) {
+            annotation = method.getDeclaringClass().getAnnotation(LimitRequestsPerMinute.class);
+        }
+        return annotation;
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/AuxiliaryRepositoryResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/AuxiliaryRepositoryResource.java
@@ -31,7 +31,10 @@ import org.springframework.web.server.ResponseStatusException;
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.exception.AccessForbiddenException;
+import de.tum.cit.aet.artemis.core.security.RateLimitKey;
+import de.tum.cit.aet.artemis.core.security.RateLimitType;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastTutor;
+import de.tum.cit.aet.artemis.core.security.annotations.LimitRequestsPerMinute;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
 import de.tum.cit.aet.artemis.core.service.feature.Feature;
 import de.tum.cit.aet.artemis.core.service.feature.FeatureToggle;
@@ -56,6 +59,10 @@ import de.tum.cit.aet.artemis.programming.service.RepositoryService;
 @Lazy
 @RestController
 @RequestMapping({ "api/programming/auxiliary-repositories/", "api/programming/auxiliary-repository/" })
+// Every editor endpoint here checks out and pulls the working copy on the server, so a cheap request turns into a
+// much more expensive git operation. Limit them per user (see F-010) so a single account cannot drive unbounded load;
+// the limit only applies where rate limiting is switched on (off by default).
+@LimitRequestsPerMinute(type = RateLimitType.REPOSITORY_EDITOR, key = RateLimitKey.USER)
 public class AuxiliaryRepositoryResource extends RepositoryResource {
 
     private final AuxiliaryRepositoryRepository auxiliaryRepositoryRepository;

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/RepositoryProgrammingExerciseParticipationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/RepositoryProgrammingExerciseParticipationResource.java
@@ -33,11 +33,14 @@ import de.tum.cit.aet.artemis.account.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.exception.AccessForbiddenException;
 import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
+import de.tum.cit.aet.artemis.core.security.RateLimitKey;
+import de.tum.cit.aet.artemis.core.security.RateLimitType;
 import de.tum.cit.aet.artemis.core.security.Role;
 import de.tum.cit.aet.artemis.core.security.allowedTools.AllowedTools;
 import de.tum.cit.aet.artemis.core.security.allowedTools.ToolTokenType;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastStudent;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastTutor;
+import de.tum.cit.aet.artemis.core.security.annotations.LimitRequestsPerMinute;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
 import de.tum.cit.aet.artemis.core.service.feature.Feature;
 import de.tum.cit.aet.artemis.core.service.feature.FeatureToggle;
@@ -73,6 +76,10 @@ import de.tum.cit.aet.artemis.programming.service.RepositoryService;
 @Lazy
 @RestController
 @RequestMapping("api/programming/")
+// Every editor endpoint here checks out and pulls the working copy on the server, so a cheap request turns into a
+// much more expensive git operation. Limit them per user (see F-010) so a single account cannot drive unbounded load;
+// the limit only applies where rate limiting is switched on (off by default).
+@LimitRequestsPerMinute(type = RateLimitType.REPOSITORY_EDITOR, key = RateLimitKey.USER)
 public class RepositoryProgrammingExerciseParticipationResource extends RepositoryResource {
 
     private final ParticipationAuthorizationCheckService participationAuthCheckService;

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/TestRepositoryResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/repository/TestRepositoryResource.java
@@ -31,7 +31,10 @@ import org.springframework.web.server.ResponseStatusException;
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.exception.AccessForbiddenException;
+import de.tum.cit.aet.artemis.core.security.RateLimitKey;
+import de.tum.cit.aet.artemis.core.security.RateLimitType;
 import de.tum.cit.aet.artemis.core.security.annotations.EnforceAtLeastTutor;
+import de.tum.cit.aet.artemis.core.security.annotations.LimitRequestsPerMinute;
 import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
 import de.tum.cit.aet.artemis.core.service.feature.Feature;
 import de.tum.cit.aet.artemis.core.service.feature.FeatureToggle;
@@ -54,6 +57,10 @@ import de.tum.cit.aet.artemis.programming.service.RepositoryService;
 @Lazy
 @RestController
 @RequestMapping("api/programming/")
+// Every editor endpoint here checks out and pulls the working copy on the server, so a cheap request turns into a
+// much more expensive git operation. Limit them per user (see F-010) so a single account cannot drive unbounded load;
+// the limit only applies where rate limiting is switched on (off by default).
+@LimitRequestsPerMinute(type = RateLimitType.REPOSITORY_EDITOR, key = RateLimitKey.USER)
 public class TestRepositoryResource extends RepositoryResource {
 
     public TestRepositoryResource(UserRepository userRepository, AuthorizationCheckService authCheckService, GitService gitService, RepositoryService repositoryService,

--- a/src/main/resources/config/application-artemis.yml
+++ b/src/main/resources/config/application-artemis.yml
@@ -107,6 +107,8 @@ artemis:
     account-management-requests-per-minute: 5
     authentication-requests-per-minute: 30
     login-options-requests-per-minute: 30
+    # Git-backed online-editor endpoints, counted per user (each call checks out and pulls the working copy).
+    repository-editor-requests-per-minute: 120
     # Addresses exempt from every rate limit, as literal IPv4/IPv6 addresses or CIDR blocks. The limits
     # are per client address, which protects against one abusive client but throttles a load generator
     # almost immediately, since a benchmark drives thousands of logins from a single address. Leave

--- a/src/test/java/de/tum/cit/aet/artemis/admin/service/RateLimitConfigurationServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/admin/service/RateLimitConfigurationServiceTest.java
@@ -121,4 +121,22 @@ class RateLimitConfigurationServiceTest {
 
         assertThat(rpm).isEqualTo(RateLimitType.PROBLEM_STATEMENT_RENDERING.getDefaultRpm()); // 30
     }
+
+    @Test
+    void testGetEffectiveRpm_RepositoryEditor_WithCustomValue_ShouldReturnCustomValue() {
+        when(properties.getRepositoryEditorRequestsPerMinute()).thenReturn(200);
+
+        int rpm = configurationService.getEffectiveRpm(RateLimitType.REPOSITORY_EDITOR);
+
+        assertThat(rpm).isEqualTo(200);
+    }
+
+    @Test
+    void testGetEffectiveRpm_RepositoryEditor_WithNullValue_ShouldReturnDefault() {
+        when(properties.getRepositoryEditorRequestsPerMinute()).thenReturn(null);
+
+        int rpm = configurationService.getEffectiveRpm(RateLimitType.REPOSITORY_EDITOR);
+
+        assertThat(rpm).isEqualTo(RateLimitType.REPOSITORY_EDITOR.getDefaultRpm()); // 120
+    }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/admin/service/RateLimitServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/admin/service/RateLimitServiceTest.java
@@ -126,6 +126,37 @@ class RateLimitServiceTest {
     }
 
     @Test
+    void testEnforcePerMinute_WithCountingKey_ShouldUseCountingKeyInBucketKey() throws AddressStringException {
+        when(configurationService.isRateLimitingEnabled()).thenReturn(true);
+        when(featureToggleService.isFeatureEnabled(any())).thenReturn(true);
+        when(configurationService.getEffectiveRpm(RateLimitType.REPOSITORY_EDITOR)).thenReturn(120);
+        when(proxyManager.getProxy(anyString(), any())).thenReturn(bucketProxy);
+        when(bucketProxy.tryConsumeAndReturnRemaining(1)).thenReturn(consumptionProbe);
+        when(consumptionProbe.isConsumed()).thenReturn(true);
+
+        IPAddress address = new IPAddressString("192.168.1.1").toAddress();
+        rateLimitService.enforcePerMinute(address, "user:alice", RateLimitType.REPOSITORY_EDITOR);
+
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(proxyManager).getProxy(keyCaptor.capture(), any());
+        // The bucket must be keyed by the supplied counting key (the user), not by the client address.
+        assertThat(keyCaptor.getValue()).contains(RateLimitType.REPOSITORY_EDITOR.name()).contains("user:alice").doesNotContain("192.168.1.1");
+    }
+
+    @Test
+    void testEnforcePerMinute_WithCountingKey_WhenExemptAddress_ShouldSkip() throws AddressStringException {
+        when(configurationService.isRateLimitingEnabled()).thenReturn(true);
+        when(featureToggleService.isFeatureEnabled(any())).thenReturn(true);
+        IPAddress address = new IPAddressString("192.168.1.1").toAddress();
+        when(configurationService.isExempt(address)).thenReturn(true);
+
+        rateLimitService.enforcePerMinute(address, "user:alice", RateLimitType.REPOSITORY_EDITOR);
+
+        // An exempt address bypasses the limit even on the per-user path, so no bucket is touched.
+        verify(proxyManager, never()).getProxy(anyString(), any());
+    }
+
+    @Test
     void testEnforcePerMinute_EvenIfSpringTestProfile_ShouldStillEnforce() throws AddressStringException {
         when(configurationService.isRateLimitingEnabled()).thenReturn(true);
         when(featureToggleService.isFeatureEnabled(any())).thenReturn(true);

--- a/src/test/java/de/tum/cit/aet/artemis/core/security/annotations/LimitRequestsPerMinuteAspectTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/security/annotations/LimitRequestsPerMinuteAspectTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
+import java.util.Optional;
 
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
@@ -13,11 +14,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import de.tum.cit.aet.artemis.admin.service.RateLimitConfigurationService;
 import de.tum.cit.aet.artemis.admin.service.RateLimitService;
+import de.tum.cit.aet.artemis.core.security.RateLimitKey;
 import de.tum.cit.aet.artemis.core.security.RateLimitType;
+import de.tum.cit.aet.artemis.core.security.SecurityUtils;
+import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
 
 @ExtendWith(MockitoExtension.class)
@@ -89,6 +95,55 @@ class LimitRequestsPerMinuteAspectTest {
         verify(rateLimitService).enforcePerMinute(new IPAddressString("192.168.1.1").toAddress(), RateLimitType.AUTHENTICATION);
     }
 
+    @Test
+    void testAspect_WithUserKey_ShouldEnforcePerUser() throws Throwable {
+        Method method = TestService.class.getMethod("methodWithUserKeyedRateLimit");
+        when(joinPoint.getSignature()).thenReturn(methodSignature);
+        when(methodSignature.getMethod()).thenReturn(method);
+        IPAddress clientAddress = new IPAddressString("192.168.1.1").toAddress();
+        when(rateLimitService.resolveClientId()).thenReturn(clientAddress);
+
+        try (MockedStatic<SecurityUtils> securityUtils = Mockito.mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUserLogin).thenReturn(Optional.of("alice"));
+
+            aspect.checkRateLimit(joinPoint);
+        }
+
+        verify(rateLimitService).enforcePerMinute(clientAddress, "user:alice", RateLimitType.REPOSITORY_EDITOR);
+    }
+
+    @Test
+    void testAspect_WithUserKey_NoAuthenticatedUser_ShouldFallBackToClientAddress() throws Throwable {
+        Method method = TestService.class.getMethod("methodWithUserKeyedRateLimit");
+        when(joinPoint.getSignature()).thenReturn(methodSignature);
+        when(methodSignature.getMethod()).thenReturn(method);
+        IPAddress clientAddress = new IPAddressString("192.168.1.1").toAddress();
+        when(rateLimitService.resolveClientId()).thenReturn(clientAddress);
+
+        try (MockedStatic<SecurityUtils> securityUtils = Mockito.mockStatic(SecurityUtils.class)) {
+            securityUtils.when(SecurityUtils::getCurrentUserLogin).thenReturn(Optional.empty());
+
+            aspect.checkRateLimit(joinPoint);
+        }
+
+        verify(rateLimitService).enforcePerMinute(clientAddress, RateLimitType.REPOSITORY_EDITOR);
+    }
+
+    @Test
+    void testAspect_WithClassLevelAnnotationOnRuntimeTargetOnly_ShouldResolveViaTargetClass() throws Throwable {
+        // The intercepted method is declared on a superclass that carries no annotation; only the concrete runtime
+        // target class is annotated. This mirrors the repository editor controllers, whose limit sits on the class.
+        Method method = BaseWithoutRateLimit.class.getMethod("inheritedMethod");
+        when(joinPoint.getSignature()).thenReturn(methodSignature);
+        when(methodSignature.getMethod()).thenReturn(method);
+        when(joinPoint.getTarget()).thenReturn(new AnnotatedSubclass());
+        when(rateLimitService.resolveClientId()).thenReturn(new IPAddressString("192.168.1.1").toAddress());
+
+        aspect.checkRateLimit(joinPoint);
+
+        verify(rateLimitService).enforcePerMinute(new IPAddressString("192.168.1.1").toAddress(), RateLimitType.AUTHENTICATION);
+    }
+
     public static class TestService {
 
         @LimitRequestsPerMinute(type = RateLimitType.ACCOUNT_MANAGEMENT)
@@ -98,6 +153,11 @@ class LimitRequestsPerMinuteAspectTest {
 
         @LimitRequestsPerMinute // Uses default type (AUTHENTICATION)
         public void methodWithDefaultTypeRateLimit() {
+            // Test method
+        }
+
+        @LimitRequestsPerMinute(type = RateLimitType.REPOSITORY_EDITOR, key = RateLimitKey.USER)
+        public void methodWithUserKeyedRateLimit() {
             // Test method
         }
 
@@ -112,5 +172,17 @@ class LimitRequestsPerMinuteAspectTest {
         public void methodInClassWithRateLimit() {
             // Test method
         }
+    }
+
+    public static class BaseWithoutRateLimit {
+
+        public void inheritedMethod() {
+            // Declared on the superclass, without any rate-limit annotation
+        }
+    }
+
+    @LimitRequestsPerMinute(type = RateLimitType.AUTHENTICATION)
+    public static class AnnotatedSubclass extends BaseWithoutRateLimit {
+        // Inherits inheritedMethod() and carries the class-level annotation on the concrete type
     }
 }


### PR DESCRIPTION
### Summary

The git-backed online-editor REST endpoints (participation, test and auxiliary repositories) carried no rate limit, so they stayed unlimited even when rate limiting was enabled. Every read or write checks out and pulls the working copy on the server, turning a cheap request into a much more expensive git operation (amplification), which let a single authenticated user drive unbounded server load. This PR adds a **per-user** rate limit for these endpoints. Rate limiting stays **off by default**; this only extends its coverage for installations that switch it on.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api#authorization) and checked the course groups for all new REST Calls (security).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

Reported internally as security finding **F-010** (Repository access / online editor). Artemis rate limiting is annotation-based and opt-in: only endpoints carrying `@LimitRequestsPerMinute` (or a few explicit `enforcePerMinute` call sites) are covered. The online-editor endpoints carried no such annotation, so they were never throttled, not even with `artemis.rate-limiting.enabled: true`. Because each call performs a git checkout with pull of the working copy (`getRepository(..., pullOnCheckout=true, ...)`), a single authenticated student can generate disproportionate server load through many or parallel calls.

The limit is counted **per user** rather than per client address on purpose: the online editor is used by many students at the same time, often behind a single campus address (NAT). A per-address limit would throttle legitimate concurrent use, so the finding explicitly asked for a user-based limit.

### Description

- New `RateLimitType.REPOSITORY_EDITOR` (default **120 requests/min per user**), configurable via `artemis.rate-limiting.repository-editor-requests-per-minute`.
- New `RateLimitKey` enum (`IP` / `USER`) and a `key()` member on `@LimitRequestsPerMinute` (defaults to `IP`, so all existing usages are unchanged).
- `LimitRequestsPerMinuteAspect` resolves the current user for `key = USER` (`SecurityUtils.getCurrentUserLogin()`, counting key `"user:<login>"`), and falls back to the client address if no principal is present. Annotation resolution is hardened to read the runtime target class in addition to the method and declaring class.
- `RateLimitService` gains an overload `enforcePerMinute(IPAddress exemptionAddress, String countingKey, RateLimitType)` that keeps the existing address-based exemption while counting against the given key; the existing IP-based overload and bucket key are preserved (backward compatible, multi-node bucket keys unchanged in shape).
- The three editor controllers (`RepositoryProgrammingExerciseParticipationResource`, `TestRepositoryResource`, `AuxiliaryRepositoryResource`) are annotated at class level so every editor endpoint is covered.
- Admin docs (`security.mdx`) and `application-artemis.yml` updated.

Out of scope (tracked separately): the second part of F-010 about the git-handshake limiter itself; that is a different root cause in the JGit servlet path and deserves its own PR.

### Steps for Testing
Rate limiting is off by default, so it has to be switched on for testing. Use a small editor limit so the limit triggers after only a few calls.

**Prerequisites**

- Two students, each with a programming-exercise participation that has a repository (integrated setup: LocalVC). The second student is only needed for the per-user check (step 5).
- Start Artemis with rate limiting enabled and a low editor limit, either via run arguments:
  - `--artemis.rate-limiting.enabled=true --artemis.rate-limiting.repository-editor-requests-per-minute=5`
  - or in your local `application-local.yml`:
    ```yaml
    artemis:
      rate-limiting:
        enabled: true
        repository-editor-requests-per-minute: 5
    ```

> **Note:** the limit is read only at start-up, so changing it requires a restart. Enabling `enabled` also switches the internal rate-limit feature on automatically, no extra flag needed.

**Main flow (throttling now applies)**

1. Log in as the first student.
2. Open the online code editor for the participation (or call the endpoint directly). The first call may take a few seconds because the server checks out the repository.
3. Send more than 5 requests in quick succession (within a few seconds) to `GET api/programming/participations/{participationId}/repository/files` (with the student's `jwt` cookie), for example by repeatedly reloading the file tree or opening files.
4. **Expected:** the first 5 requests return `HTTP 200`; from the 6th within the same window the endpoint returns **`HTTP 429 Too Many Requests`** with a `Retry-After` header. The budget refills continuously (about 1 request every 12 s at a limit of 5), so after roughly a minute without calls it is full again. Because of this continuous refill, the requests must be sent quickly; spacing them out prevents the 429.

**Per-user keying**

5. While the first student is still throttled (same minute), send up to 5 requests as the second student from the same machine/IP. **Expected:** those requests return `HTTP 200`. The second student has an independent budget and is not affected by the first student's throttling. This is what makes it safe behind a shared campus address (NAT).

**Default-off and backward compatibility**

6. Restart without the rate-limiting arguments (default configuration) and confirm the editor is never throttled (no 429), matching current production behaviour.
7. With rate limiting enabled, confirm the existing limits still work. Quickest check: `GET api/core/public/activate?key=anything` returns `HTTP 200/4xx` for the first 5 calls and `429` from the 6th (ACCOUNT_MANAGEMENT, 5/min, counted per address). The login path `POST api/core/public/authenticate` also stays limited, but at 30/min per address it needs over 30 attempts to trip.


Automated tests (all green locally): `RateLimitServiceTest`, `RateLimitConfigurationServiceTest`, `LimitRequestsPerMinuteAspectTest` (user keying, IP fallback, runtime-target-class resolution, and the new `REPOSITORY_EDITOR` type). `spotlessCheck`, `checkstyleMain` and the affected `*ArchitectureTest`s pass.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/35103635585) did not pass (`failure`). Coverage below may be partial.

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| RateLimitConfigurationService.java | 93.75% | 71 |
| RateLimitService.java | 77.78% | 96 |
| RateLimitingProperties.java | 23.33% | 77 |
| RateLimitKey.java | 100.00% | 5 |
| RateLimitType.java | 100.00% | 17 |
| LimitRequestsPerMinute.java | 100.00% | 13 |
| LimitRequestsPerMinuteAspect.java | 100.00% | 55 |
| AuxiliaryRepositoryResource.java | 100.00% | 183 |
| RepositoryProgrammingExerciseParticipationResource.java | 96.26% | 324 |
| TestRepositoryResource.java | 77.50% | 177 |

_Last updated: 2026-09-16 14:29:59 UTC_


### Screenshots
<img width="1531" height="501" alt="Screen93" src="https://github.com/user-attachments/assets/e04806dd-e593-4609-90d4-1c1b1a654543" />

<img width="792" height="130" alt="Screen94" src="https://github.com/user-attachments/assets/ba4ce0bc-3a7b-4216-96c2-5227ce18e6d2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable rate limiting for repository editor operations.
  * Repository editor requests are limited per authenticated user, with a default of 120 requests per minute.
  * Applied protection to participation, test, and auxiliary repository editor endpoints.
  * Added documentation for configuring and understanding repository editor rate limits.

* **Bug Fixes**
  * Improved rate-limit handling for class-level endpoint annotations and unauthenticated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->