### PR TITLE
`Development`: Update the production deployment workflow

### DIFF
--- a/.github/workflows/prod-like-deployment.yml
+++ b/.github/workflows/prod-like-deployment.yml
@@ -102,8 +102,8 @@ jobs:
           chmod 700 ~/.ssh
 
           # Write private key
-          echo "$DEPLOYMENT_SSH_KEY" | sed 's/\\n/\n/g' > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
+          echo "$DEPLOYMENT_SSH_KEY" | sed 's/\\n/\n/g' > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
 
           # Write known hosts
           echo "$DEPLOYMENT_HOST_PUBLIC_KEYS" > ~/.ssh/known_hosts
@@ -125,11 +125,6 @@ jobs:
           ansible-galaxy collection install -r requirements.yml --force
           ansible-galaxy install -r requirements.yml --force
           ansible-galaxy install -r ~/.ansible/collections/ansible_collections/ls1intum/artemis/requirements.yml
-
-      - name: Set Vault token
-        run: |
-          echo "${{ secrets.VAULT_TOKEN }}" > ~/.vault-token
-          export VAULT_TOKEN=$(cat ~/.vault-token)
 
       - name: Download artifact
         uses: actions/download-artifact@v8
@@ -178,7 +173,5 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          rm -f ~/.ssh/id_rsa
-          rm -f ~/.vault-token
-          unset VAULT_TOKEN
+          rm -f ~/.ssh/id_ed25519
           rm -rf /tmp/artifact/*


### PR DESCRIPTION
### Summary
The production deployment workflow wrote the deployment SSH key to `~/.ssh/id_rsa` and provisioned a HashiCorp Vault token that the Ansible playbook no longer uses. This PR stores the key under the matching `~/.ssh/id_ed25519` identity name and removes the Vault token step, so no unused secret is written to the self-hosted runner's home directory.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
Two leftovers in `.github/workflows/prod-like-deployment.yml`:

1. **Wrong key filename.** The deployment key is an Ed25519 key, but the workflow wrote it to `~/.ssh/id_rsa`. OpenSSH reads the key material regardless of the filename, so this worked, but the name is misleading on a *self-hosted* runner whose `~/.ssh` is persistent and shared between runs — a real `id_rsa` would collide with it, and the `Cleanup` step deletes a file that isn't named after what it holds.

2. **Dead Vault step.** The `Set Vault token` step wrote `secrets.VAULT_TOKEN` to `~/.vault-token` and exported `VAULT_TOKEN`. The `export` never had any effect — environment variables do not survive across GitHub Actions steps — so the only thing it did was drop a long-lived Vault token onto the runner's disk. The Ansible playbook does not perform any Vault lookups, so the token is unused. Writing an unused credential to a persistent runner is needless exposure.

No functional change to what gets deployed.

### Description
- `Setup SSH and Known Hosts`: write the private key to `~/.ssh/id_ed25519` instead of `~/.ssh/id_rsa` (`chmod 600` unchanged).
- Removed the `Set Vault token` step entirely.
- `Cleanup`: remove `~/.ssh/id_ed25519`; dropped the now-obsolete `rm -f ~/.vault-token` and `unset VAULT_TOKEN`.

The `VAULT_TOKEN` repository/environment secret is now unreferenced and can be deleted in the repository settings.

> [!NOTE]
> Please double-check that nothing outside this repository consumes `~/.vault-token` from the deployment runner — the playbook lives in `ls1intum/artemis-ansible`, so it was not verified here.

### Steps for Testing
This workflow can only be exercised by an actual deployment (`workflow_dispatch`, self-hosted `artemis-prod-deployment` runner).

1. Trigger the "Deploy Artemis with Ansible" workflow for this branch against a staging environment via Helios or the GitHub UI.
2. Verify the `Setup SSH and Known Hosts` step succeeds and that the subsequent `Deploy Artemis` step authenticates against the deployment hosts (SSH still works with the renamed identity file).
3. Verify the run no longer contains a `Set Vault token` step and that `Deploy Artemis` completes without any Vault-related error.
4. Verify `Verify deployment health` reports `UP` and the staging server serves the deployed version.
5. On the runner, confirm `~/.vault-token` is no longer created and that `~/.ssh/id_ed25519` is removed by the `Cleanup` step.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Deployment to a staging server succeeds and reports healthy