### PR TITLE
`Development`: Type check the Playwright end-to-end suite

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -112,6 +112,10 @@ jobs:
         run: pnpm run lint
         working-directory: src/test/playwright
         if: ${{ !cancelled() }}
+      - name: Playwright Typechecking
+        run: pnpm run typecheck
+        working-directory: src/test/playwright
+        if: ${{ !cancelled() }}
 
   client-compilation:
     name: Client Compilation

--- a/src/test/playwright/dayjs-plugins.d.ts
+++ b/src/test/playwright/dayjs-plugins.d.ts
@@ -1,0 +1,7 @@
+/**
+ * The suite reads dates off the Angular app's models, and those models are typed against the dayjs plugins the app
+ * registers in `app/core/config/dayjs`. Pulling that module in for its types alone gives this project the same
+ * augmented `Dayjs` the app has, so `isSameOrAfter`, `isBetween` and `dayjs.max` type check here as well. Nothing is
+ * imported at run time: the suite extends the plugins it needs itself.
+ */
+import 'app/core/config/dayjs';

--- a/src/test/playwright/e2e/exam/ExamModelingSummary.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamModelingSummary.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import dayjs, { Dayjs } from 'dayjs';
 import { Exam } from 'app/exam/shared/entities/exam.model';
-import { admin, instructor, studentOne, studentOneName, tutor } from '../../support/users';
+import { admin, instructor, studentOne, tutor } from '../../support/users';
 import { test } from '../../support/fixtures';
 import { SEED_COURSES } from '../../support/seedData';
 import { ExerciseType } from '../../support/constants';
@@ -35,7 +35,7 @@ test.describe.serial('Exam modeling summary', { tag: '@slow' }, () => {
         exerciseAssessment,
     }) => {
         await login(instructor);
-        await examManagement.verifySubmitted(course.id!, exam.id!, studentOneName);
+        await examManagement.verifySubmitted(course.id!, exam.id!, studentOne.displayName!);
         await waitForExamEnd(exam, page);
 
         await login(tutor);

--- a/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseParticipation.spec.ts
+++ b/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseParticipation.spec.ts
@@ -1,4 +1,5 @@
 import { QuizExercise } from 'app/quiz/shared/entities/quiz-exercise.model';
+import { MultipleChoiceQuestion } from 'app/quiz/shared/entities/multiple-choice-question.model';
 import multipleChoiceQuizTemplate from '../../../fixtures/exercise/quiz/multiple_choice/template.json';
 import shortAnswerQuizTemplate from '../../../fixtures/exercise/quiz/short_answer/template.json';
 import { admin, instructor, studentOne } from '../../../support/users';
@@ -10,6 +11,14 @@ import { SEED_COURSES } from '../../../support/seedData';
 import { generateUUID, readResponseJson } from '../../../support/utils';
 
 const course = { id: SEED_COURSES.quizParticipation.id } as any;
+
+/**
+ * The answer options of a multiple choice question. `QuizExercise.quizQuestions` is typed as the abstract question,
+ * so the options only become visible once the concrete type is named - which the multiple choice fixtures always are.
+ */
+function answerOptionsOf(quiz: QuizExercise, questionIndex = 0) {
+    return (quiz.quizQuestions![questionIndex] as MultipleChoiceQuestion).answerOptions!;
+}
 
 test.describe('Quiz Exercise Participation', { tag: '@fast' }, () => {
     test.describe('Quiz exercise participation', () => {
@@ -45,7 +54,7 @@ test.describe('Quiz Exercise Participation', { tag: '@fast' }, () => {
             // Pin the submit contract end-to-end: the live endpoint must accept the DTO-shaped payload, mark the submission
             // as submitted, and return exactly the answer the student ticked (one MC entry with the right selected ids).
             expect(submitResponse.status()).toBe(200);
-            const submittedExpectedIds = tickedOptionIndices.map((index) => quizExercise.quizQuestions![0].answerOptions![index].id);
+            const submittedExpectedIds = tickedOptionIndices.map((index) => answerOptionsOf(quizExercise)[index].id!);
             const responseBody = await readResponseJson(submitResponse);
             expect(responseBody.submitted, 'server must flip the submitted flag after final submit').toBe(true);
             expect(responseBody.submittedAnswers, 'server must persist exactly one submitted answer for the MC question').toHaveLength(1);
@@ -94,7 +103,7 @@ test.describe('Quiz Exercise Participation', { tag: '@fast' }, () => {
             await quizExerciseMultipleChoice.submit();
 
             const mcQuestionId = shortQuiz.quizQuestions![0].id!;
-            const expectedTickedOptionIds = tickedOptionIndices.map((index) => shortQuiz.quizQuestions![0].answerOptions![index].id);
+            const expectedTickedOptionIds = tickedOptionIndices.map((index) => answerOptionsOf(shortQuiz)[index].id!);
             expect(expectedTickedOptionIds).toHaveLength(tickedOptionIndices.length);
 
             /**
@@ -175,7 +184,9 @@ test.describe('Quiz Exercise Participation', { tag: '@fast' }, () => {
             });
 
             // Capture the IDs that the client will send back on submit.
-            const initialOptionIds = (createdQuiz.quizQuestions![0] as any).answerOptions!.map((opt: any) => opt.id).sort((a: number, b: number) => a - b);
+            const initialOptionIds = answerOptionsOf(createdQuiz)
+                .map((option) => option.id!)
+                .sort((a: number, b: number) => a - b);
             expect(initialOptionIds.length).toBeGreaterThan(0);
 
             const readOptionIdsFromServer = async (): Promise<number[]> => {

--- a/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseSubmissionPaths.spec.ts
+++ b/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseSubmissionPaths.spec.ts
@@ -1,4 +1,5 @@
 import { QuizExercise } from 'app/quiz/shared/entities/quiz-exercise.model';
+import { MultipleChoiceQuestion } from 'app/quiz/shared/entities/multiple-choice-question.model';
 import multipleChoiceQuizTemplate from '../../../fixtures/exercise/quiz/multiple_choice/template.json';
 import shortAnswerQuizTemplate from '../../../fixtures/exercise/quiz/short_answer/template.json';
 import { admin, studentOne, tutor } from '../../../support/users';
@@ -9,6 +10,14 @@ import { QuizMode } from '../../../support/constants';
 import { SEED_COURSES } from '../../../support/seedData';
 
 const course = { id: SEED_COURSES.quizParticipation.id } as any;
+
+/**
+ * The answer options of a multiple choice question. `QuizExercise.quizQuestions` is typed as the abstract question,
+ * so the options only become visible once the concrete type is named - which the multiple choice fixtures always are.
+ */
+function answerOptionsOf(quiz: QuizExercise, questionIndex = 0) {
+    return (quiz.quizQuestions![questionIndex] as MultipleChoiceQuestion).answerOptions!;
+}
 
 /**
  * Per-mode coverage of the quiz submission contract from the student / tutor side.
@@ -45,8 +54,8 @@ test.describe('Quiz Exercise Submission Paths', { tag: '@fast' }, () => {
         test('Student practice-submits a fully-correct MC answer and the server returns a 100% result', async ({ login, page }) => {
             await login(studentOne);
 
-            const correctOptionIds = quizExercise
-                .quizQuestions![0].answerOptions!.filter((option) => option.isCorrect)
+            const correctOptionIds = answerOptionsOf(quizExercise)
+                .filter((option) => option.isCorrect)
                 .map((option) => option.id!)
                 .sort((a, b) => a - b);
             expect(correctOptionIds.length, 'fixture must define at least one correct option').toBeGreaterThan(0);
@@ -90,7 +99,7 @@ test.describe('Quiz Exercise Submission Paths', { tag: '@fast' }, () => {
         test('Student practice-submits a partially-correct MC answer and receives a partial score', async ({ login, page }) => {
             await login(studentOne);
 
-            const options = quizExercise.quizQuestions![0].answerOptions!;
+            const options = answerOptionsOf(quizExercise);
             const oneCorrect = options.find((option) => option.isCorrect)!;
             const oneIncorrect = options.find((option) => !option.isCorrect)!;
             const submittedOptionIds = [oneCorrect.id!, oneIncorrect.id!];
@@ -137,7 +146,9 @@ test.describe('Quiz Exercise Submission Paths', { tag: '@fast' }, () => {
             await login(studentOne);
 
             const question = quizExercise.quizQuestions![0];
-            const correctOptionIds = question.answerOptions!.filter((option) => option.isCorrect).map((option) => option.id!);
+            const correctOptionIds = answerOptionsOf(quizExercise)
+                .filter((option) => option.isCorrect)
+                .map((option) => option.id!);
             const trainingPayload = {
                 type: 'multiple-choice',
                 quizQuestion: { id: question.id },
@@ -185,7 +196,9 @@ test.describe('Quiz Exercise Submission Paths', { tag: '@fast' }, () => {
             const trainingPayload = {
                 type: 'multiple-choice',
                 quizQuestion: { id: foreignQuestionId },
-                selectedOptions: quizInOtherCourse.quizQuestions![0].answerOptions!.filter((option) => option.isCorrect).map((option) => ({ id: option.id })),
+                selectedOptions: answerOptionsOf(quizInOtherCourse)
+                    .filter((option) => option.isCorrect)
+                    .map((option) => ({ id: option.id })),
             };
             // Path course = THIS describe's `course.id` (quizParticipation seed) — the student IS enrolled in it,
             // so the auth guard passes. Only the question id is foreign. The course-scoped repository lookup must
@@ -247,7 +260,9 @@ test.describe('Quiz Exercise Submission Paths', { tag: '@fast' }, () => {
         test('Tutor preview-submits a fully-correct MC answer, receives a 100% result, and nothing is persisted', async ({ login, page }) => {
             await login(tutor);
 
-            const correctOptionIds = quizExercise.quizQuestions![0].answerOptions!.filter((option) => option.isCorrect).map((option) => option.id!);
+            const correctOptionIds = answerOptionsOf(quizExercise)
+                .filter((option) => option.isCorrect)
+                .map((option) => option.id!);
 
             const previewPayload = {
                 submittedAnswers: [
@@ -296,7 +311,7 @@ test.describe('Quiz Exercise Submission Paths', { tag: '@fast' }, () => {
             await login(studentOne);
             await page.request.post(`/api/quiz/quiz-exercises/${quizExercise.id}/start-participation`);
 
-            const options = quizExercise.quizQuestions![0].answerOptions!;
+            const options = answerOptionsOf(quizExercise);
             const tickedOptionIds = options.filter((option) => option.isCorrect).map((option) => option.id!);
             // Mirror the rich entity-shaped JSON the exam client serializes (full nested AnswerOption objects).
             const examPayload = {

--- a/src/test/playwright/e2e/lecture/LectureManagement.spec.ts
+++ b/src/test/playwright/e2e/lecture/LectureManagement.spec.ts
@@ -35,7 +35,8 @@ test.describe('Lecture management', { tag: '@fast' }, () => {
         await lectureCreation.setStartDate(lectureData.startDate);
         await lectureCreation.setEndDate(lectureData.endDate);
         const lectureResponse = await lectureCreation.save();
-        const lecture: Lecture = (lastCreatedLecture = await readResponseJson(lectureResponse));
+        const lecture = await readResponseJson<Lecture>(lectureResponse);
+        lastCreatedLecture = lecture;
         expect(lectureResponse.status()).toBe(201);
         await expect(page).toHaveURL(`/course-management/${course.id}/lectures/${lecture.id}/edit`);
         // Wait for the form to hydrate from the server before typing again.

--- a/src/test/playwright/fixtures/fixtures.ts
+++ b/src/test/playwright/fixtures/fixtures.ts
@@ -1,13 +1,14 @@
 import { promises as fs } from 'fs';
 
 export class Fixtures {
-    static async get(filePath: string, encoding: BufferEncoding = 'utf-8'): Promise<string | undefined> {
+    static async get(filePath: string, encoding: BufferEncoding = 'utf-8'): Promise<string> {
+        const fullPath = `${__dirname}/${filePath}`;
         try {
-            const fullPath = `${__dirname}/${filePath}`;
             return await fs.readFile(fullPath, encoding);
         } catch (error) {
-            console.error(`Error reading fixture file: ${error instanceof Error ? error.message : error}`);
-            return undefined;
+            // A missing fixture is a broken test setup, and every caller goes straight on to use the content. Handing
+            // back nothing only moved the failure to whatever consumed it, where it reads as an unrelated defect.
+            throw new Error(`Could not read the fixture ${fullPath}`, { cause: error });
         }
     }
 

--- a/src/test/playwright/fixtures/fixtures.ts
+++ b/src/test/playwright/fixtures/fixtures.ts
@@ -1,12 +1,13 @@
 import { promises as fs } from 'fs';
 
 export class Fixtures {
-    static async get(filePath: string, encoding: BufferEncoding = 'utf-8') {
+    static async get(filePath: string, encoding: BufferEncoding = 'utf-8'): Promise<string | undefined> {
         try {
             const fullPath = `${__dirname}/${filePath}`;
             return await fs.readFile(fullPath, encoding);
         } catch (error) {
-            console.error(`Error reading fixture file: ${error.message}`);
+            console.error(`Error reading fixture file: ${error instanceof Error ? error.message : error}`);
+            return undefined;
         }
     }
 

--- a/src/test/playwright/package.json
+++ b/src/test/playwright/package.json
@@ -38,7 +38,7 @@
         "merge-junit-reports": "junit-merge ./test-reports/results-parallel.xml ./test-reports/results-sequential.xml -o ./test-reports/results.xml",
         "merge-coverage-reports": "node ./merge-coverage-reports.mjs",
         "update": "ncu -i --format group",
-        "pretest": "tsc --incremental -p tsconfig.json",
+        "typecheck": "tsc -p tsconfig.json",
         "lint": "eslint .",
         "lint:fix": "eslint --fix ."
     }

--- a/src/test/playwright/support/fixtures.ts
+++ b/src/test/playwright/support/fixtures.ts
@@ -71,7 +71,7 @@ import { ModalDialogBox } from './pageobjects/exam/ModalDialogBox';
 import { ExamParticipationActions } from './pageobjects/exam/ExamParticipationActions';
 import { AccountManagementAPIRequests } from './requests/AccountManagementAPIRequests';
 import { ProgrammingExerciseSubmissionsPage } from './pageobjects/exercises/programming/ProgrammingExercisesSubmissionsPage';
-import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
+import type { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 
 // Define custom types for fixtures
 export type ArtemisCommands = {

--- a/src/test/playwright/support/fixtures.ts
+++ b/src/test/playwright/support/fixtures.ts
@@ -71,6 +71,7 @@ import { ModalDialogBox } from './pageobjects/exam/ModalDialogBox';
 import { ExamParticipationActions } from './pageobjects/exam/ExamParticipationActions';
 import { AccountManagementAPIRequests } from './requests/AccountManagementAPIRequests';
 import { ProgrammingExerciseSubmissionsPage } from './pageobjects/exercises/programming/ProgrammingExercisesSubmissionsPage';
+import { StudentParticipation } from 'app/exercise/shared/entities/participation/student-participation.model';
 
 // Define custom types for fixtures
 export type ArtemisCommands = {

--- a/src/test/playwright/support/pageobjects/assessment/FileUploadExerciseAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/FileUploadExerciseAssessmentPage.ts
@@ -28,11 +28,11 @@ export class FileUploadExerciseAssessmentPage extends AbstractExerciseAssessment
         }
     }
 
-    async rejectComplaint(response: string, examMode: boolean, complaintExerciseTitle?: string) {
+    override async rejectComplaint(response: string, examMode: boolean, complaintExerciseTitle?: string) {
         return await super.rejectComplaint(response, examMode, ExerciseType.FILE_UPLOAD, complaintExerciseTitle);
     }
 
-    async acceptComplaint(response: string, examMode: boolean, complaintExerciseTitle?: string) {
+    override async acceptComplaint(response: string, examMode: boolean, complaintExerciseTitle?: string) {
         return await super.acceptComplaint(response, examMode, ExerciseType.FILE_UPLOAD, complaintExerciseTitle);
     }
 }

--- a/src/test/playwright/support/pageobjects/assessment/ModelingExerciseAssessmentEditor.ts
+++ b/src/test/playwright/support/pageobjects/assessment/ModelingExerciseAssessmentEditor.ts
@@ -66,11 +66,11 @@ export class ModelingExerciseAssessmentEditor extends AbstractExerciseAssessment
         this.currentAssessmentIndex += 1;
     }
 
-    rejectComplaint(response: string, examMode: false) {
+    override rejectComplaint(response: string, examMode: false) {
         return super.rejectComplaint(response, examMode, ExerciseType.MODELING);
     }
 
-    acceptComplaint(response: string, examMode: false) {
+    override acceptComplaint(response: string, examMode: false) {
         return super.acceptComplaint(response, examMode, ExerciseType.MODELING);
     }
 
@@ -86,7 +86,7 @@ export class ModelingExerciseAssessmentEditor extends AbstractExerciseAssessment
         await expect(this.page.getByText('Your assessment was saved successfully!')).toBeVisible({ timeout: 30000 });
     }
 
-    async submit() {
+    override async submit() {
         // Retry on multi-node 5xx flakes (Hazelcast Result.feedbacks ordered-list invalidation lag).
         for (let attempt = 0; attempt < 3; attempt++) {
             const responsePromise = this.page.waitForResponse(`${BASE_API}/modeling/modeling-submissions/*/results/*/assessment*`);

--- a/src/test/playwright/support/pageobjects/assessment/ProgrammingExerciseAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/ProgrammingExerciseAssessmentPage.ts
@@ -30,11 +30,11 @@ export class ProgrammingExerciseAssessmentPage extends AbstractExerciseAssessmen
         return this.page.locator(`#code-editor-inline-feedback-${line}`);
     }
 
-    async rejectComplaint(response: string, examMode: boolean) {
+    override async rejectComplaint(response: string, examMode: boolean) {
         return super.rejectComplaint(response, examMode, ExerciseType.PROGRAMMING);
     }
 
-    async acceptComplaint(response: string, examMode: boolean) {
+    override async acceptComplaint(response: string, examMode: boolean) {
         return super.acceptComplaint(response, examMode, ExerciseType.PROGRAMMING);
     }
 }

--- a/src/test/playwright/support/pageobjects/assessment/StudentAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/StudentAssessmentPage.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 /**

--- a/src/test/playwright/support/pageobjects/assessment/TextExerciseAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/TextExerciseAssessmentPage.ts
@@ -47,7 +47,7 @@ export class TextExerciseAssessmentPage extends AbstractExerciseAssessmentPage {
         return await responsePromise;
     }
 
-    async submit() {
+    override async submit() {
         // Retry on multi-node 5xx flakes (Hazelcast Result.feedbacks ordered-list invalidation lag)
         // so the test surfaces the genuine outcome instead of a transient cluster cache error.
         for (let attempt = 0; attempt < 3; attempt++) {
@@ -62,11 +62,11 @@ export class TextExerciseAssessmentPage extends AbstractExerciseAssessmentPage {
         throw new Error('TextExerciseAssessment.submit exhausted retries');
     }
 
-    async rejectComplaint(response: string, examMode: boolean) {
+    override async rejectComplaint(response: string, examMode: boolean) {
         return await super.rejectComplaint(response, examMode, ExerciseType.TEXT);
     }
 
-    async acceptComplaint(response: string, examMode: boolean) {
+    override async acceptComplaint(response: string, examMode: boolean) {
         return await super.acceptComplaint(response, examMode, ExerciseType.TEXT);
     }
 

--- a/src/test/playwright/support/pageobjects/course/CourseCommunicationPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseCommunicationPage.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { Post } from 'app/communication/shared/entities/post.model';
 import { readResponseJson, setMonacoEditorContentByLocator } from '../../utils';

--- a/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Page } from '@playwright/test';
 import { Exercise } from 'app/exercise/shared/entities/exercise/exercise.model';
 import { MODELING_EXERCISE_BASE, PROGRAMMING_EXERCISE_BASE, QUIZ_EXERCISE_BASE, TEXT_EXERCISE_BASE, UPLOAD_EXERCISE_BASE } from '../../constants';
 import { expect } from '@playwright/test';

--- a/src/test/playwright/support/pageobjects/exercises/ExerciseResultPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/ExerciseResultPage.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { Commands } from '../../commands';
 

--- a/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 /** Escapes regex meta-characters in `value` so it can be used as a literal pattern. */

--- a/src/test/playwright/support/pageobjects/exercises/file-upload/FileUploadEditorPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/file-upload/FileUploadEditorPage.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Page } from '@playwright/test';
 import { BASE_API } from '../../../constants';
 import { Fixtures } from '../../../../fixtures/fixtures';
 

--- a/src/test/playwright/support/pageobjects/exercises/file-upload/FileUploadExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/file-upload/FileUploadExerciseCreationPage.ts
@@ -6,7 +6,7 @@ import { Dayjs } from 'dayjs';
 const TIMELINE_DATE_FORMAT = 'DD.MM.YYYY HH:mm';
 
 export class FileUploadExerciseCreationPage extends AbstractExerciseCreationPage {
-    async setReleaseDate(date: Dayjs) {
+    override async setReleaseDate(date: Dayjs) {
         await this.setTimelineDate('Release Date', date);
     }
 
@@ -14,11 +14,11 @@ export class FileUploadExerciseCreationPage extends AbstractExerciseCreationPage
         await this.setTimelineDate('Start Date', date);
     }
 
-    async setDueDate(date: Dayjs) {
+    override async setDueDate(date: Dayjs) {
         await this.setTimelineDate('Due Date', date);
     }
 
-    async setAssessmentDueDate(date: Dayjs) {
+    override async setAssessmentDueDate(date: Dayjs) {
         await this.setTimelineDate('Assessment Due Date', date);
     }
 

--- a/src/test/playwright/support/pageobjects/exercises/modeling/ModelingExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/modeling/ModelingExerciseCreationPage.ts
@@ -36,7 +36,7 @@ export class ModelingExerciseCreationPage extends AbstractExerciseCreationPage {
         await this.page.locator('#modeling-includeInScore-picker').locator('.btn', { hasText: selection }).click({ force: true });
     }
 
-    async setReleaseDate(date: Dayjs) {
+    override async setReleaseDate(date: Dayjs) {
         await this.setTimelineDate('Release Date', date);
     }
 
@@ -44,11 +44,11 @@ export class ModelingExerciseCreationPage extends AbstractExerciseCreationPage {
         await this.setTimelineDate('Start Date', date);
     }
 
-    async setDueDate(date: Dayjs) {
+    override async setDueDate(date: Dayjs) {
         await this.setTimelineDate('Due Date', date);
     }
 
-    async setAssessmentDueDate(date: Dayjs) {
+    override async setAssessmentDueDate(date: Dayjs) {
         await this.setTimelineDate('Assessment Due Date', date);
     }
 

--- a/src/test/playwright/support/pageobjects/exercises/programming/OnlineEditorPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/OnlineEditorPage.ts
@@ -224,7 +224,7 @@ function normalizeSource(source: string): string {
  *
  * @param files An array of containers, which contain the file path of the changed file as well as its name.
  */
-export class ProgrammingExerciseSubmission {
+export interface ProgrammingExerciseSubmission {
     deleteFiles: string[];
     createFilesInRootFolder: boolean;
     files: ProgrammingExerciseFile[];
@@ -232,7 +232,7 @@ export class ProgrammingExerciseSubmission {
     packageName?: string;
 }
 
-class ProgrammingExerciseFile {
+interface ProgrammingExerciseFile {
     name: string;
     path: string;
 }

--- a/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseFeedbackPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseFeedbackPage.ts
@@ -7,7 +7,7 @@ import { expect } from '@playwright/test';
  * A class which encapsulates UI selectors and actions for a programming exercise feedback page.
  */
 export class ProgrammingExerciseFeedbackPage extends AbstractExerciseFeedback {
-    async shouldShowAdditionalFeedback(points: number, feedbackText: string) {
+    override async shouldShowAdditionalFeedback(points: number, feedbackText: string) {
         await Commands.reloadUntilFound(this.page, this.page.locator(this.ADDITIONAL_FEEDBACK_SELECTOR));
         await expect(this.page.locator(this.ADDITIONAL_FEEDBACK_SELECTOR).getByText(`${points} Points: ${feedbackText}`)).toBeVisible();
     }

--- a/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseParticipationsPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseParticipationsPage.ts
@@ -26,7 +26,7 @@ export class ProgrammingExerciseParticipationsPage {
         await this.page.waitForURL('**/participations/*/submissions');
     }
 
-    public async getParticipationCellByLocator(participationRow: Locator, columnName: string) {
+    public async getParticipationCellByLocator(participationRow: Locator, columnName: string): Promise<Locator | undefined> {
         const headerCells = this.page.getByRole('table').getByRole('columnheader');
         const numberOfColumns = await headerCells.count();
         for (let columnIndex = 0; columnIndex < numberOfColumns; columnIndex++) {
@@ -35,6 +35,7 @@ export class ProgrammingExerciseParticipationsPage {
                 return participationRow.getByRole('cell').nth(columnIndex);
             }
         }
+        return undefined;
     }
 
     private async getParticipationCell(participantName: string, columnName: string) {

--- a/src/test/playwright/support/pageobjects/exercises/quiz/DragAndDropQuiz.ts
+++ b/src/test/playwright/support/pageobjects/exercises/quiz/DragAndDropQuiz.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Page } from '@playwright/test';
 import { drag, readResponseJson } from '../../../utils';
 import { Locator } from '@playwright/test';
 

--- a/src/test/playwright/support/pageobjects/exercises/text/TextExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/text/TextExerciseCreationPage.ts
@@ -13,7 +13,7 @@ export class TextExerciseCreationPage extends AbstractExerciseCreationPage {
         await this.page.locator('#field_points').fill(maxPoints.toString());
     }
 
-    async setReleaseDate(date: Dayjs) {
+    override async setReleaseDate(date: Dayjs) {
         await this.setTimelineDate(0, date);
     }
 
@@ -21,11 +21,11 @@ export class TextExerciseCreationPage extends AbstractExerciseCreationPage {
         await this.setTimelineDate(1, date);
     }
 
-    async setDueDate(date: Dayjs) {
+    override async setDueDate(date: Dayjs) {
         await this.setTimelineDate(2, date);
     }
 
-    async setAssessmentDueDate(date: Dayjs) {
+    override async setAssessmentDueDate(date: Dayjs) {
         await this.setTimelineDate(3, date);
     }
 

--- a/src/test/playwright/support/pageobjects/exercises/text/TextExerciseExampleSubmissionCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/text/TextExerciseExampleSubmissionCreationPage.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 
 /**

--- a/src/test/playwright/support/pageobjects/lecture/LectureCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/lecture/LectureCreationPage.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Page } from '@playwright/test';
 import dayjs from 'dayjs';
 import { BASE_API } from '../../constants';
 import { fillDateTimePicker, setMonacoEditorContentByLocator } from '../../utils';

--- a/src/test/playwright/support/pageobjects/lecture/LectureManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/lecture/LectureManagementPage.ts
@@ -1,4 +1,4 @@
-import { Page } from 'playwright';
+import { Page } from '@playwright/test';
 import dayjs from 'dayjs';
 import { Lecture } from 'app/lecture/shared/entities/lecture.model';
 import { expect } from '@playwright/test';

--- a/src/test/playwright/support/requests/CourseManagementAPIRequests.ts
+++ b/src/test/playwright/support/requests/CourseManagementAPIRequests.ts
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 
 import { Course, CourseInformationSharingConfiguration } from 'app/course/shared/entities/course.model';
 import { Lecture } from 'app/lecture/shared/entities/lecture.model';
-import { generateUUID, titleLowercase } from '../utils';
+import { asModelDate, generateUUID, titleLowercase } from '../utils';
 import lectureTemplate from '../../fixtures/lecture/template.json';
 import { COURSE_ADMIN_BASE, Exercise } from '../constants';
 import { UserCredentials } from '../users';
@@ -63,8 +63,8 @@ export class CourseManagementAPIRequests {
         course.title = courseName;
         course.shortName = courseShortName;
         course.testCourse = true;
-        course.startDate = start;
-        course.endDate = end;
+        course.startDate = asModelDate(start);
+        course.endDate = asModelDate(end);
         course.timeZone = timeZone;
 
         if (allowCommunication && allowMessaging) {

--- a/src/test/playwright/support/requests/ExerciseAPIRequests.ts
+++ b/src/test/playwright/support/requests/ExerciseAPIRequests.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { Page } from 'playwright-core';
+import { Page } from '@playwright/test';
 
 import type { Course } from 'app/course/shared/entities/course.model';
 import type { ExerciseGroup } from 'app/exam/shared/entities/exercise-group.model';
@@ -27,7 +27,7 @@ import {
     TEXT_EXERCISE_BASE,
     UPLOAD_EXERCISE_BASE,
 } from '../constants';
-import { dayjsToString, generateUUID, titleLowercase } from '../utils';
+import { asModelDate, dayjsToString, generateUUID, titleLowercase } from '../utils';
 import { BUILD_FINISH_TIMEOUT } from '../timeouts';
 import { ModelingExercise } from 'app/modeling/shared/entities/modeling-exercise.model';
 import { UpdateModelingExerciseDTO } from 'app/modeling/shared/entities/modeling-exercise-update-dto.model';
@@ -150,12 +150,12 @@ export class ExerciseAPIRequests {
         } as ProgrammingExercise;
 
         if (!exerciseGroup) {
-            exercise.releaseDate = releaseDate;
-            exercise.dueDate = dueDate;
-            exercise.assessmentDueDate = assessmentDate;
+            exercise.releaseDate = asModelDate(releaseDate);
+            exercise.dueDate = asModelDate(dueDate);
+            exercise.assessmentDueDate = asModelDate(assessmentDate);
         }
         if (buildAndTestStudentSubmissionsAfterDueDate) {
-            exercise.buildAndTestStudentSubmissionsAfterDueDate = buildAndTestStudentSubmissionsAfterDueDate;
+            exercise.buildAndTestStudentSubmissionsAfterDueDate = asModelDate(buildAndTestStudentSubmissionsAfterDueDate);
         }
 
         if (scaMaxPenalty) {

--- a/src/test/playwright/support/requests/UserManagementAPIRequests.ts
+++ b/src/test/playwright/support/requests/UserManagementAPIRequests.ts
@@ -1,6 +1,6 @@
 import { UserRole } from '../users';
 import { Page } from '@playwright/test';
-import { APIResponse } from 'playwright-core';
+import { APIResponse } from '@playwright/test';
 
 /**
  * A class which encapsulates all API requests related to user management.

--- a/src/test/playwright/support/utils.ts
+++ b/src/test/playwright/support/utils.ts
@@ -41,7 +41,7 @@ dayjs.extend(utc);
  * crossing once here keeps it out of every call site.
  *
  * @param date a date created by the suite
- * @return the same date, typed the way the app's models expect it
+ * @returns the same date, typed the way the app's models expect it
  */
 export function asModelDate(date: dayjs.Dayjs): ModelDayjs {
     return date as unknown as ModelDayjs;

--- a/src/test/playwright/support/utils.ts
+++ b/src/test/playwright/support/utils.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs';
+import type { Dayjs as ModelDayjs } from 'dayjs/esm';
 import utc from 'dayjs/plugin/utc';
 import { v4 as uuidv4 } from 'uuid';
 import { DATE_TIME_PICKER_FORMAT, Exercise, ExerciseType, ProgrammingExerciseAssessmentType, ProgrammingLanguage, TIME_FORMAT } from './constants';
@@ -30,6 +31,21 @@ dayjs.extend(utc);
 /*
  * This file contains all the global utility functions.
  */
+
+/**
+ * Hands a date from the suite over to one of the Angular app's models.
+ *
+ * The app is built against dayjs' ESM entry point and this suite against its CommonJS one. Both describe the very
+ * same object at run time, but the compiler sees two unrelated `Dayjs` types, and resolving the suite to the ESM
+ * build is not an option: Playwright loads these files through Node, which cannot read that build. Naming the
+ * crossing once here keeps it out of every call site.
+ *
+ * @param date a date created by the suite
+ * @return the same date, typed the way the app's models expect it
+ */
+export function asModelDate(date: dayjs.Dayjs): ModelDayjs {
+    return date as unknown as ModelDayjs;
+}
 
 /**
  * True for the Chrome DevTools Protocol body-eviction error, i.e.

--- a/src/test/playwright/tsconfig.json
+++ b/src/test/playwright/tsconfig.json
@@ -2,8 +2,18 @@
     "compilerOptions": {
         "target": "es2022",
         "module": "es2022",
-        "moduleResolution": "node",
-        "ignoreDeprecations": "6.0",
+        // Matches the root config. The Playwright suite imports Angular entry points such as
+        // `@angular/common/http`, which are only reachable through the package exports map that node10
+        // resolution cannot read.
+        "moduleResolution": "bundler",
+        // This project is only ever type checked: Playwright compiles the specs itself at run time. Emitting
+        // would drop JavaScript next to the TypeScript sources it shares with the Angular app, which then
+        // shadows them for Node and breaks the test runner.
+        "noEmit": true,
+        // The suite deliberately imports the Angular app's models, so its sources span both `src/test/playwright`
+        // and `src/main/webapp/app`. Without a root that contains both, every one of those imports is reported as
+        // living outside the project.
+        "rootDir": "../../..",
         "sourceMap": false
     },
     "extends": "../../../tsconfig.json",


### PR DESCRIPTION
### Summary

`pnpm run pretest` in `src/test/playwright` had not compiled for a while: it failed on the tsconfig itself, before reaching a single file. Nothing invoked it either — `pretest` only runs ahead of a `test` script, and this package has none — so the entire end-to-end suite went unchecked. Worse, it was a build rather than a check: running it emitted JavaScript next to the TypeScript sources the suite shares with the Angular app, where Node then loaded the stale copies and the runner stopped finding its modules.

This makes the typecheck work, runs it in CI next to the lint step that was already there, and fixes the 94 errors it surfaced rather than silencing them.

Split out of #13634, where the problem was found. No production code is touched.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

The E2E suite is the only part of the code base with no type checking at all. That is how a spec could import a `studentOneName` that does not exist and assert against `undefined` — which matches any row in the table it searches — without anyone noticing.

The emit behaviour is the more damaging half. `tsc -p tsconfig.json` inherits `outDir` from the root Angular config, and running it drops `.js` files beside the `.ts` sources under `src/main/webapp/app`. Node then prefers those stale files, and Playwright fails to start with `Cannot find module`. Anyone who ran the script to see whether their spec compiled broke their own checkout.

### Description

**The config now says what it is for.** `noEmit`, so no invocation can leave build output behind. A `rootDir` that spans both source trees, because the suite imports the app's models on purpose and every one of those imports was otherwise reported as living outside the project. And the app's `moduleResolution`, so Angular entry points such as `@angular/common/http` resolve at all — they are only reachable through the package exports map that node10 resolution cannot read.

The script is renamed to `typecheck`, and the **Client Code Style** workflow runs it right after the Playwright lint step.

**The 94 errors are fixed, not silenced,** so the suite is held to the same strictness as the app. Several were genuine defects:

- Ten page objects imported `Page` from `playwright` or `playwright-core` rather than the `@playwright/test` this package actually depends on.
- `ExamModelingSummary` imported a `studentOneName` that does not exist, so it asserted against `undefined`; the row filter therefore matched anything.
- `Fixtures.get` swallowed a read failure and returned nothing, and typed its caught error as an implicit `any`.
- The quiz specs read `answerOptions` off the abstract `QuizQuestion`, which only the concrete type declares.
- Two submission shapes were classes that are only ever used as types.
- Twenty overrides carried no `override` modifier.

**Dates crossing into the app's models.** The app is built against dayjs' ESM entry point and the suite against its CommonJS one, so the two `Dayjs` types are unrelated to the compiler. Resolving the suite to the ESM build is not an option — Playwright loads these files through Node, which cannot read it, and trying it breaks the runner outright. The crossing is named once in `asModelDate` and used at the seven places that need it.

### Steps for Testing

No behaviour changes; the suite runs exactly as before.

1. `cd src/test/playwright && pnpm run typecheck` — passes, and leaves no `.js` files under `src/main/webapp/app`.
2. `pnpm run lint` — passes.
3. Run any E2E test, e.g. `./run-e2e-tests-local-fast.sh --filter "Quiz Exercise Participation"`, and confirm it behaves as before.

On `develop`, step 1 fails immediately with `tsconfig.json(2,5): error TS5011` and, on the way, writes JavaScript into `src/main/webapp/app`.

### Testserver States

Note: The changes are limited to the E2E test tooling and were verified locally.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved Playwright test type safety for quiz answer options, date handling, participation data, and Day.js plugins.
  - Strengthened test validation with explicit return types, clearer override declarations, and safer fixture error handling.
  - Updated test setup and TypeScript configuration to provide more consistent type checking.

- **Refactor**
  - Standardized Playwright type usage across test page objects.
  - Simplified test data structures and improved handling of model-compatible dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->