### PR TITLE
`Development`: Improve agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,3 @@
 # Repository Guidelines
 
-All project conventions, build commands, coding standards, and contribution guidelines are maintained in **[CLAUDE.md](./CLAUDE.md)** — the single source of truth for AI coding assistants working in this repository.
-
-Please refer to `CLAUDE.md` for:
-- Project structure and module organization
-- Build, test, and development commands
-- Coding style and naming conventions (Java, TypeScript/Angular, general)
-- Testing guidelines
-- Commit and pull request guidelines
+Before making changes, read and follow **[CLAUDE.md](./CLAUDE.md)** in full; it is the single source of truth for AI coding assistants working in this repository.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ Organized by feature module:
 - No wildcard imports (Spotless enforces)
 - Package-by-feature organization
 - 4-space indentation
-- Avoid `@Transactional` scope
+- **Do not define transaction boundaries in services or controllers.** `@Transactional`, `TransactionTemplate`, and `PlatformTransactionManager` are forbidden there. Transaction boundaries may only be defined inside repositories, typically for modifying queries.
 - Do not inject `EntityManager` or `EntityManagerFactory` directly into services or controllers; all persistence operations must go through Spring Data repositories
 - Use DTOs (Java records) for REST endpoints
 - Prefer constructor injection for Spring beans


### PR DESCRIPTION
### Summary

Make `CLAUDE.md` the unambiguous source of truth for AI coding assistants and turn the existing transaction guidance into an explicit repository-only rule.

### Checklist

#### General

- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

### Motivation and Context

The previous `AGENTS.md` wording could be read as a summary of `CLAUDE.md`, which allowed assistants to proceed without reading the complete instructions. The transaction guidance was also phrased as a preference even though Artemis deliberately avoids service- and controller-level transaction boundaries.

### Description

- Reduce `AGENTS.md` to a direct instruction to read and follow `CLAUDE.md` in full before changing the repository.
- Explicitly forbid transaction boundaries in services and controllers and allow them only at the repository boundary.

### Steps for Testing

1. Open `AGENTS.md` and verify that it points to `CLAUDE.md` as the single source of truth.
2. Open the Java coding conventions in `CLAUDE.md` and verify that transaction boundaries are explicitly restricted to repositories.
3. Run `git diff --check origin/develop...HEAD`.
