### PR TITLE
`Development`: Fix three failing email changed notification tests

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/notification/notifications/service/MailServiceEmailIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/notifications/service/MailServiceEmailIntegrationTest.java
@@ -268,7 +268,7 @@ class MailServiceEmailIntegrationTest extends AbstractSpringIntegrationIndepende
     @Test
     void emailChangedEmail_shouldRenderAndDeliverInEnglish() throws Exception {
         testMailSendingService.buildAndSendSync(MailRecipientDTO.from(recipient), "email.notification.emailChanged.title", "mail/notification/emailChangedEmail",
-                new HashMap<>(Map.of("newEmail", "new-address@tum.de")));
+                new HashMap<>(Map.of("emailRemoved", false, "newEmail", "new-address@tum.de")));
 
         String body = getDeliveredEmailBody();
         assertThat(body).contains("new-address@tum.de");
@@ -281,7 +281,7 @@ class MailServiceEmailIntegrationTest extends AbstractSpringIntegrationIndepende
         recipient.setLangKey("de");
 
         testMailSendingService.buildAndSendSync(MailRecipientDTO.from(recipient), "email.notification.emailChanged.title", "mail/notification/emailChangedEmail",
-                new HashMap<>(Map.of("newEmail", "new-address@tum.de")));
+                new HashMap<>(Map.of("emailRemoved", false, "newEmail", "new-address@tum.de")));
 
         String body = getDeliveredEmailBody();
         assertThat(body).contains("new-address@tum.de");
@@ -293,7 +293,7 @@ class MailServiceEmailIntegrationTest extends AbstractSpringIntegrationIndepende
         // The address reaches the template from user input, so it has to be escaped. The template uses th:text for
         // exactly this reason; th:utext would turn a crafted address into live markup in the recipient's client.
         testMailSendingService.buildAndSendSync(MailRecipientDTO.from(recipient), "email.notification.emailChanged.title", "mail/notification/emailChangedEmail",
-                new HashMap<>(Map.of("newEmail", "<script>alert(1)</script>@tum.de")));
+                new HashMap<>(Map.of("emailRemoved", false, "newEmail", "<script>alert(1)</script>@tum.de")));
 
         String body = getDeliveredEmailBody();
         assertThat(body).doesNotContain("<script>alert(1)</script>");


### PR DESCRIPTION
### Summary

Three tests in `MailServiceEmailIntegrationTest` fail on `develop`. They pass only `newEmail` to the email changed template, which branches on `${!emailRemoved}`, so the variable is null, SpEL cannot convert null to boolean, and the mail is never built. The tests now pass the flag the production caller already passes.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context

`develop` is currently red. `emailChangedEmail.html` chooses between the changed and the removed wording with `th:if="${!emailRemoved}"`, and `AccountSecurityEventService` supplies the flag on its only call:

```java
Map.of("emailRemoved", newEmail == null, "newEmail", newEmail == null ? "" : newEmail)
```

The three tests supplied only `newEmail`. `emailRemoved` was therefore null, `!null` failed SpEL conversion with `EL1001E: Type conversion problem, cannot convert from null to boolean`, and `MailSendingService.buildAndSend` caught the resulting `TemplateProcessingException`, logged it and returned false. No message reached the mailbox, so each test failed asserting on an empty inbox.

Production is unaffected: the only caller sets the flag. This is a test that did not mirror its caller.

One of the three, `emailChangedEmail_shouldEscapeTheAddressRatherThanRenderItAsMarkup`, checks that a crafted address is escaped rather than rendered as live markup in the recipient's client. Since the mail was never built, that escaping was not being verified at all, which is the main reason not to leave this sitting on `develop`.

Why it was not caught: the last green `develop` run was `ef5f400499` at 08:19Z, before #13611 landed. The CI run for #13611's merge commit `e2017f856f` was cancelled by the next merge, so the failure was never reported.

### Description

Pass `emailRemoved` alongside `newEmail` at the three call sites, matching `AccountSecurityEventService`. No production code changes.

I deliberately did not make the template tolerate a missing flag. A missing variable is a programming error, and it currently fails loudly in the log rather than silently sending the wrong wording.

Suggested follow-up, not included here to keep this small: the template's other branch, `emailRemoved = true` for the address removed variant, has no test at all.

### Steps for Testing

```bash
./gradlew test -x webapp --tests MailServiceEmailIntegrationTest
```

Before: 32 tests, 29 successes, 3 failures.
After: 32 tests, 32 successes, 0 failures.

### Review Progress
#### Code Review
- [x] Code Review 1
- [ ] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-04 11:04:30 UTC_

