### PR TITLE
`Development`: Pin the serial version identifier of user

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/account/domain/User.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/domain/User.java
@@ -62,6 +62,16 @@ import de.tum.cit.aet.artemis.tutorialgroup.domain.TutorialGroupRegistration;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class User extends AbstractAuditingEntity implements Participant {
 
+    /**
+     * Pinned to the value the JVM computed for this class before {@code canonicalEmail} was added. Instances of this
+     * class travel through the distributed store, so during a rolling upgrade a node on the older build deserializes
+     * what a node on the newer one wrote. A computed identifier covers the public methods as well as the fields, so
+     * adding a method changes it and the older node rejects the stream with an {@code InvalidClassException} even
+     * though the data itself is unchanged. Declaring it keeps that decision out of the hands of ordinary refactoring:
+     * change it only when the fields change in a way an older build genuinely cannot read.
+     */
+    private static final long serialVersionUID = 441942758530231977L;
+
     public static final String IRIS_BOT_LOGIN = "iris_bot";
 
     @NonNull

--- a/src/main/java/de/tum/cit/aet/artemis/account/domain/User.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/domain/User.java
@@ -63,12 +63,20 @@ import de.tum.cit.aet.artemis.tutorialgroup.domain.TutorialGroupRegistration;
 public class User extends AbstractAuditingEntity implements Participant {
 
     /**
-     * Pinned to the value the JVM computed for this class before {@code canonicalEmail} was added. Instances of this
-     * class travel through the distributed store, so during a rolling upgrade a node on the older build deserializes
-     * what a node on the newer one wrote. A computed identifier covers the public methods as well as the fields, so
-     * adding a method changes it and the older node rejects the stream with an {@code InvalidClassException} even
-     * though the data itself is unchanged. Declaring it keeps that decision out of the hands of ordinary refactoring:
-     * change it only when the fields change in a way an older build genuinely cannot read.
+     * The value the JVM computed for this class before {@code canonicalEmail} was added, pinned so that ordinary
+     * refactoring cannot move it.
+     * <p>
+     * Instances of this class reach the distributed store as map values, inside the cached collections that
+     * {@code BackwardCompatibleSerializationCodec} encodes with Java serialization rather than with Kryo, and there
+     * this identifier is the compatibility check: a node deserializing a value written by a node on the other build
+     * rejects the stream with an {@code InvalidClassException} when it disagrees. A computed identifier covers the
+     * public methods as well as the fields, so merely adding a method moves it, even though the encoded data is
+     * unchanged.
+     * <p>
+     * The number itself means nothing beyond being the one already-deployed builds compute, which is exactly why it
+     * cannot be tidied into something friendlier: a different value keeps the incompatibility instead of removing it.
+     * Change it only together with a bump of {@code DistributedDataSchema.VERSION}, when the fields really do change
+     * into something an older build cannot read.
      */
     private static final long serialVersionUID = 441942758530231977L;
 


### PR DESCRIPTION
### Summary

`DistributedDataSurfaceTest` fails on `develop`. #13611 added `User.canonicalEmail`, which changed the serial version identifier the JVM computes for `User`, because a computed identifier covers the public methods and not only the fields. `User` travels through the distributed store, so an older node in a rolling upgrade would reject what a newer one writes. The identifier is now declared and pinned to its previous value.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

`develop` is red on `DistributedDataSurfaceTest`. The whole diff against the recorded surface is one line, and the field list either side of it is byte for byte identical:

```
- class ...account.domain.User serialVersionUID=441942758530231977 serializable=true [boolean activated, ...]
+ class ...account.domain.User serialVersionUID=5317788233488093470 serializable=true [boolean activated, ...]
```

`User` declares no identifier, so the JVM computes one from the class shape, and that computation covers the public methods as well as the fields. #13611 added

```java
public static String canonicalEmail(String email)
```

which moved the identifier without touching a single field.

That is a real incompatibility rather than a stale snapshot. `User` instances are stored in the distributed store, so during a rolling upgrade a node on the older build deserializes what a node on the newer build wrote, and a mismatched identifier makes it reject the stream with an `InvalidClassException` even though the data is unchanged.

Why not the two easier routes:

- **Regenerating the recorded surface** would turn CI green and ship the incompatibility. The recorded file is supposed to describe the wire format, and the wire format really did change.
- **Bumping `DistributedDataSchema.VERSION`** does not fit its contract, which is a stored shape an older or newer build cannot read after a component was "added, removed, reordered or retyped". None of that happened here, and a bump discards the queued builds on every deploy, which the class javadoc explicitly sets out to avoid.

Pinning the identifier restores exact compatibility, needs no surface edit and no version bump, and takes `User`'s wire format out of the reach of ordinary refactoring. `Authority` in the same package already declares one.

### Description

Declare `serialVersionUID` on `User`, pinned to `441942758530231977L`, the value from before `canonicalEmail` was added, with a comment explaining when it may be changed.

Worth a separate look, not included here: most entities in the recorded surface still carry computed identifiers, so each of them is one added public method away from the same latent break. A rule that requires an explicit identifier on everything reachable from the distributed store would close that off.

### Steps for Testing

```bash
./gradlew test --tests DistributedDataSurfaceTest -x webapp
```

On `develop`: 1 test, 1 failure.
With this change: 1 test, 1 success. `spotlessCheck` and `checkstyleMain` also pass.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| User.java | 81.60% | 356 |

_Last updated: 2026-09-04 12:34:24 UTC_

