### PR TITLE
`Development`: Dismiss the passkey reminder in the FormStatusBar test

### DIFF
--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseManagement.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseManagement.spec.ts
@@ -56,6 +56,10 @@ test.describe('Programming Exercise Management', { tag: '@fast' }, () => {
             programmingExerciseCreation,
         }) => {
             await login(admin, '/');
+            // Same overlay as in the test above, and the same silent symptom: without this, the double click in
+            // createProgrammingExercise is spent dismissing the backdrop and opening the menu, so the page stays on the
+            // exercise list and waitForURL below times out after a minute with nothing to say why.
+            await dismissPasskeyReminderIfPresent(page);
             await navigationBar.openCourseManagement();
             await courseManagement.openExercisesOfCourse(course.id!);
             await courseManagementExercises.createProgrammingExercise();


### PR DESCRIPTION
### Summary

The `FormStatusBar` test in `ProgrammingExerciseManagement.spec.ts` fails in CI with a bare one minute timeout. It is the passkey reminder overlay swallowing a click, the same cause that was fixed for the sibling test in the same block. This adds the missing dismissal, so both tests that reach `createProgrammingExercise` are covered.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

The failure gives nothing away on its own:

```
Error: page.waitForURL: Test timeout of 60000ms exceeded.
=========================== logs ===========================
waiting for navigation to "**/programming-exercises/new**" until "load"
  navigated to "https://artemis-nginx/course-management/9014/exercises"
============================================================
  at e2e/exercise/programming/ProgrammingExerciseManagement.spec.ts:62:24
```

The last line is the tell: the page never left the exercise list. `createProgrammingExercise` clicks twice, and the passkey reminder is a CDK overlay whose backdrop absorbs the first click **without failing it**, so the second click only opens the create menu. Nothing errors, no navigation happens, and the test dies a minute later on `waitForURL`, pointing at a line that is not the problem.

This was diagnosed and fixed for `Creates a new programming exercise` in #13497, which carries the explanation as a comment. The fix covered one of the two tests in that block; this one runs the identical preamble and was missed.

A sweep of the whole Playwright suite confirms these two are the only tests that reach `createProgrammingExercise`, so there is no third instance waiting.

### Description

Dismiss the reminder after logging in, as the sibling test does, with a comment recording why the symptom looks unrelated to its cause.

### Steps for Testing

```bash
./run-e2e-tests-local-fast.sh --filter "FormStatusBar"
```

The overlay appears only for an account that has not dismissed it, which is why this reproduces in CI rather than on a warm local profile. Verified: prettier, `eslint`, and the Playwright `tsc` project all pass.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end test reliability for programming exercise management by handling the passkey setup reminder before creating an exercise.
  - Ensured scrolling and navigation checks complete consistently when the reminder overlay is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->