### PR TITLE
`Development`: Say when a data export could not include a repository

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/admin/service/export/DataExportExerciseCreationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/admin/service/export/DataExportExerciseCreationService.java
@@ -204,7 +204,7 @@ public class DataExportExerciseCreationService {
         note.add("include this file, which records what went wrong:");
         note.add("");
         note.addAll(repositoryExportErrors.stream().map(error -> "* " + error).toList());
-        Files.write(exerciseDir.resolve("REPOSITORIES_MISSING.md"), note, StandardCharsets.UTF_8);
+        FileUtils.writeLines(exerciseDir.resolve("REPOSITORIES_MISSING.md").toFile(), StandardCharsets.UTF_8.name(), note);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/admin/service/export/DataExportExerciseCreationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/admin/service/export/DataExportExerciseCreationService.java
@@ -163,10 +163,48 @@ public class DataExportExerciseCreationService {
 
         // NOTE: repositoryExportOptions.filterLateSubmissions must be false here because we do not want to filter any submissions for the data export.
         // The export asks for the history: a data export is the student's own copy of their work, so their commits belong in it.
-        programmingExerciseExportService.exportStudentRepositories(programmingExercise, listOfProgrammingExerciseParticipations, Map.of(), exerciseDir,
-                Collections.synchronizedList(new ArrayList<>()), repositoryExportOptions, RepositoryExportContent.WITH_HISTORY);
+        List<String> repositoryExportErrors = Collections.synchronizedList(new ArrayList<>());
+        programmingExerciseExportService.exportStudentRepositories(programmingExercise, listOfProgrammingExerciseParticipations, Map.of(), exerciseDir, repositoryExportErrors,
+                repositoryExportOptions, RepositoryExportContent.WITH_HISTORY);
+        reportMissingRepositories(programmingExercise, exerciseDir, repositoryExportErrors);
 
         createPlagiarismCaseInfoExport(programmingExercise, exerciseDir, user.getId());
+    }
+
+    /**
+     * Records the repositories that could not be exported, next to the exercise they belong to.
+     * <p>
+     * {@code exportStudentRepositories} reports a repository it could not export by adding to the list it is handed
+     * and carrying on with the others, which is the right behaviour: one unreachable repository should not cost the
+     * student the rest of their data. What must not happen is what happened before, where the list was a throwaway
+     * that nobody read: the export then looked complete while the student's own code was missing from it, and neither
+     * they nor an administrator had any way of telling. The course archive already writes its failures into the
+     * archive for the same reason, as {@code exportErrors.txt}.
+     *
+     * @param programmingExercise    the exercise being exported
+     * @param exerciseDir            the directory holding that exercise
+     * @param repositoryExportErrors what {@code exportStudentRepositories} could not export, empty when all of it worked
+     * @throws IOException if the note cannot be written
+     */
+    private void reportMissingRepositories(ProgrammingExercise programmingExercise, Path exerciseDir, List<String> repositoryExportErrors) throws IOException {
+        if (repositoryExportErrors.isEmpty()) {
+            return;
+        }
+
+        log.error("Data export for programming exercise {} ('{}') is missing {} repository/repositories: {}", programmingExercise.getId(), programmingExercise.getTitle(),
+                repositoryExportErrors.size(), String.join(" | ", repositoryExportErrors));
+
+        List<String> note = new ArrayList<>();
+        note.add("# Repositories missing from this export");
+        note.add("");
+        note.add("Your submitted code for this exercise could not be added to the export. The rest of your data for it,");
+        note.add("such as your submissions and results, is present.");
+        note.add("");
+        note.add("Please request a new export. If it is missing again, contact your instructor or an administrator and");
+        note.add("include this file, which records what went wrong:");
+        note.add("");
+        note.addAll(repositoryExportErrors.stream().map(error -> "* " + error).toList());
+        Files.write(exerciseDir.resolve("REPOSITORIES_MISSING.md"), note, StandardCharsets.UTF_8);
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/admin/service/export/DataExportExerciseCreationServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/admin/service/export/DataExportExerciseCreationServiceTest.java
@@ -1,0 +1,94 @@
+package de.tum.cit.aet.artemis.admin.service.export;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import de.tum.cit.aet.artemis.account.domain.User;
+import de.tum.cit.aet.artemis.assessment.repository.ComplaintRepository;
+import de.tum.cit.aet.artemis.assessment.service.ResultService;
+import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
+import de.tum.cit.aet.artemis.course.domain.Course;
+import de.tum.cit.aet.artemis.exercise.repository.ExerciseRepository;
+import de.tum.cit.aet.artemis.programming.domain.ProgrammingExercise;
+import de.tum.cit.aet.artemis.programming.service.ProgrammingExerciseExportService;
+import de.tum.cit.aet.artemis.programming.service.ProgrammingFeedbackSynthesizerService;
+
+/**
+ * A data export is the student's own copy of their work, so an export that quietly lacks their code is the one outcome
+ * that must not happen: it looks complete and is wrong, and neither the student nor an administrator can tell.
+ */
+class DataExportExerciseCreationServiceTest {
+
+    private static final String NOTE = "REPOSITORIES_MISSING.md";
+
+    private ProgrammingExerciseExportService programmingExerciseExportService;
+
+    private DataExportExerciseCreationService dataExportExerciseCreationService;
+
+    private ProgrammingExercise programmingExercise;
+
+    private User student;
+
+    @TempDir
+    Path exercisesDir;
+
+    @BeforeEach
+    void setUp() {
+        programmingExerciseExportService = mock(ProgrammingExerciseExportService.class);
+        dataExportExerciseCreationService = new DataExportExerciseCreationService(programmingExerciseExportService, mock(DataExportQuizExerciseCreationService.class),
+                Optional.empty(), Optional.empty(), mock(ComplaintRepository.class), mock(ExerciseRepository.class), mock(ResultService.class),
+                mock(AuthorizationCheckService.class), mock(ProgrammingFeedbackSynthesizerService.class));
+
+        programmingExercise = new ProgrammingExercise();
+        programmingExercise.setId(1L);
+        programmingExercise.setTitle("Sorting Algorithms");
+        programmingExercise.setCourse(new Course());
+
+        student = new User();
+        student.setId(7L);
+    }
+
+    @Test
+    void shouldRecordTheRepositoriesItCouldNotExport() throws Exception {
+        // The export service reports a repository it could not export by adding to the list it is handed, and carries
+        // on with the others. That list used to be a throwaway that nobody read.
+        doAnswer(invocation -> {
+            invocation.getArgument(4, List.class).add("Failed to export the student repository with participation: 42");
+            return List.of();
+        }).when(programmingExerciseExportService).exportStudentRepositories(any(), any(), any(), any(), anyList(), any(), any());
+
+        dataExportExerciseCreationService.createProgrammingExerciseExport(programmingExercise, exercisesDir, student);
+
+        Path note = exerciseDirectory().resolve(NOTE);
+        assertThat(note).as("an export missing the student's code has to say so").exists();
+        assertThat(Files.readString(note)).contains("participation: 42").contains("request a new export");
+    }
+
+    @Test
+    void shouldNotLeaveANoteWhenEveryRepositoryWasExported() throws Exception {
+        dataExportExerciseCreationService.createProgrammingExerciseExport(programmingExercise, exercisesDir, student);
+
+        assertThat(exerciseDirectory().resolve(NOTE)).as("a complete export must not worry the student").doesNotExist();
+    }
+
+    /**
+     * @return the directory the export created for the exercise, whose name carries its sanitized title
+     */
+    private Path exerciseDirectory() throws Exception {
+        try (var entries = Files.list(exercisesDir)) {
+            return entries.findFirst().orElseThrow(() -> new AssertionError("the export did not create a directory for the exercise"));
+        }
+    }
+}

--- a/src/test/playwright/e2e/admin/DataExport.spec.ts
+++ b/src/test/playwright/e2e/admin/DataExport.spec.ts
@@ -60,8 +60,15 @@ test.describe('Personal data export', { tag: '@slow' }, () => {
 
     test.afterEach('Deletes the course and the student', async ({ page, login, courseManagementAPIRequests }) => {
         await login(admin);
-        await courseManagementAPIRequests.deleteCourse(course, admin);
-        await page.request.delete(`api/account/admin/users/${student.username}`);
+        try {
+            await courseManagementAPIRequests.deleteCourse(course, admin);
+        } finally {
+            // In a finally, so that a course deletion which exhausts its retries does not leave the account behind, and
+            // asserted, so that a cleanup which silently stops working shows up as a failure rather than as accounts
+            // accumulating in the database.
+            const response = await page.request.delete(`api/account/admin/users/${student.username}`);
+            expect(response.ok(), 'the student this test created has to be removed again').toBe(true);
+        }
     });
 
     test('Exports a repository as a walkable repository directory rather than a nested archive', async ({ page, login }) => {

--- a/src/test/playwright/e2e/admin/DataExport.spec.ts
+++ b/src/test/playwright/e2e/admin/DataExport.spec.ts
@@ -2,15 +2,16 @@ import * as fs from 'fs';
 import * as os from 'os';
 import path from 'path';
 import dayjs from 'dayjs';
-import { Page, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 import { Course } from 'app/course/shared/entities/course.model';
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 import { Participation } from 'app/exercise/shared/entities/participation/participation.model';
 
 import { test } from '../../support/fixtures';
-import { admin, studentOne } from '../../support/users';
+import { UserCredentials, UserRole, admin } from '../../support/users';
 import { ProjectType } from '../../support/constants';
+import { generateUUID } from '../../support/utils';
 import javaPartiallySuccessfulSubmission from '../../fixtures/exercise/programming/java/partially_successful/submission.json';
 import { downloadArchive, expectUsableGitRepository, extractArchive, readArchiveEntries } from '../../support/ArchiveInspector';
 
@@ -23,30 +24,25 @@ import { downloadArchive, expectUsableGitRepository, extractArchive, readArchive
 
 const EXECUTABLE_MODE = 0o755;
 
-/**
- * Deletes every data export the given user still has, so the table holds exactly the one the test creates.
- *
- * @param page  the page to issue the requests from, logged in as an administrator
- * @param login the user whose exports are removed
- */
-async function removeExistingDataExports(page: Page, login: string) {
-    const response = await page.request.get('api/admin/data-exports?page=0&size=200&sort=id,desc');
-    expect(response.ok(), 'the existing data exports have to be readable to clean them up').toBe(true);
-    for (const dataExport of (await response.json()) as { id: number; userLogin: string }[]) {
-        if (dataExport.userLogin === login) {
-            await page.request.delete(`api/admin/data-exports/${dataExport.id}`);
-        }
-    }
-}
-
 test.describe('Personal data export', { tag: '@slow' }, () => {
     let course: Course;
     let exercise: ProgrammingExercise;
+    let student: UserCredentials;
 
-    test.beforeEach('Creates a programming participation to export', async ({ page, login, courseManagementAPIRequests, exerciseAPIRequests }) => {
+    test.beforeEach('Creates a programming participation to export', async ({ page, login, courseManagementAPIRequests, exerciseAPIRequests, userManagementAPIRequests }) => {
         await login(admin);
+
+        // A student of this test's own, rather than one of the shared fixtures. A personal data export covers every
+        // course its subject ever joined, and a shared student collects courses from every other spec in the run,
+        // so the work this test asks for would grow with the suite until it outlasts any wait. Its own student has
+        // exactly the one course below, whatever else is running.
+        const studentLogin = `artemis_export_${generateUUID()}`;
+        student = { username: studentLogin, password: studentLogin };
+        const created = await userManagementAPIRequests.createUser(student.username, student.password, UserRole.Student);
+        expect(created.ok(), 'the export needs a student of its own, so creating one has to succeed').toBe(true);
+
         course = await courseManagementAPIRequests.createCourse();
-        await courseManagementAPIRequests.addStudentToCourse(course, studentOne);
+        await courseManagementAPIRequests.addStudentToCourse(course, student);
         exercise = await exerciseAPIRequests.createProgrammingExercise({
             course,
             projectType: ProjectType.GRADLE_GRADLE,
@@ -54,21 +50,18 @@ test.describe('Personal data export', { tag: '@slow' }, () => {
             dueDate: dayjs().add(1, 'day'),
         });
 
-        await login(studentOne);
+        await login(student);
         const response = await exerciseAPIRequests.startExerciseParticipation(exercise.id!);
         const participation: Participation = await response.json();
         await exerciseAPIRequests.makeProgrammingExerciseSubmission(participation.id!, javaPartiallySuccessfulSubmission);
 
-        // Earlier runs leave downloadable exports behind for the same student. The table only renders a download
-        // button once an export is ready, so a leftover would be the one the test downloads while the new export is
-        // still being created - and it belongs to a different course.
         await login(admin);
-        await removeExistingDataExports(page, studentOne.username);
     });
 
-    test.afterEach('Deletes the course', async ({ login, courseManagementAPIRequests }) => {
+    test.afterEach('Deletes the course and the student', async ({ page, login, courseManagementAPIRequests }) => {
         await login(admin);
         await courseManagementAPIRequests.deleteCourse(course, admin);
+        await page.request.delete(`api/account/admin/users/${student.username}`);
     });
 
     test('Exports a repository as a walkable repository directory rather than a nested archive', async ({ page, login }) => {
@@ -78,8 +71,8 @@ test.describe('Personal data export', { tag: '@slow' }, () => {
         await login(admin, '/admin/data-exports');
         await page.getByTestId('create-export-btn').click();
 
-        await page.locator('#typeahead-search').fill(studentOne.username);
-        await page.getByRole('option').filter({ hasText: studentOne.username }).first().click();
+        await page.locator('#typeahead-search').fill(student.username);
+        await page.getByRole('option').filter({ hasText: student.username }).first().click();
         await page.getByTestId('execute-now-radio').click();
         await page.getByTestId('submit-btn').click();
 

--- a/src/test/playwright/support/requests/UserManagementAPIRequests.ts
+++ b/src/test/playwright/support/requests/UserManagementAPIRequests.ts
@@ -13,7 +13,11 @@ export class UserManagementAPIRequests {
     }
 
     /**
-     * Creates a new user
+     * Creates a new user that can authenticate with the given password.
+     *
+     * `internal` matters and is not a detail: an account that is not internally managed authenticates against the
+     * external directory, so the password below would never be used and the new user could not log in at all.
+     *
      * @param username the username of the new user
      * @param password the password of the new user
      * @param role the role of the new user
@@ -27,6 +31,7 @@ export class UserManagementAPIRequests {
                 lastName: username,
                 email: username + '@example.com',
                 authorities: [role],
+                internal: true,
             },
         });
     }


### PR DESCRIPTION
### Summary

The personal data export could leave the student's own code out of the archive and still look complete. `exportStudentRepositories` reports a repository it could not export by adding to the list it is handed, and the data export passed a list it never read. The failures are now logged at error level and written into the export as `REPOSITORIES_MISSING.md`, next to the exercise they belong to.

This also explains the intermittent failure of `DataExport.spec.ts` on `develop`.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

`DataExportExerciseCreationService.createProgrammingExerciseExport` called:

```java
programmingExerciseExportService.exportStudentRepositories(programmingExercise, listOfProgrammingExerciseParticipations, Map.of(), exerciseDir,
        Collections.synchronizedList(new ArrayList<>()), repositoryExportOptions, RepositoryExportContent.WITH_HISTORY);
```

That fifth argument is `List<String> exportErrors`. The export service catches a per-participation failure, appends a message to it and continues with the others, which is the right behaviour: one unreachable repository should not cost the student the rest of their data. But the list was constructed inline and dropped, so a failure left no trace anywhere. The export contained the CSV files and no code, and looked exactly like an export for a student who had never submitted anything.

For the one export whose entire purpose is handing somebody their own data, silently omitting part of it is the wrong failure mode. It is also the shape of the intermittent `DataExport.spec.ts` failure on `develop`: the archive came back holding only

```
README.md
general_user_information.csv
course_.../messages_posts_reactions.csv
conversation_participations.csv
```

with no repository directory at all, so the assertion for the participation could not find one.

The course archive already handles this case, writing its failures into the archive as `exportErrors.txt` (`CourseExamExportService`). The personal export discarded the same information.

### Description

Keep the list, and when it is not empty:

* log at error level, with the exercise and the messages, so an administrator can see it happened;
* write `REPOSITORIES_MISSING.md` into the exercise directory, telling the student their code for that exercise is missing, that the rest of their data for it is present, and to request a new export, followed by the recorded messages.

Nothing else changes: an export with every repository present is byte for byte what it was, and a failing repository still does not abort the rest of the export.

### The second failure mode, also fixed

The same test fails the other way too, timing out after 300 seconds, and that has a different cause. A personal data export covers every course its subject ever joined, and the test asked for an export of the shared `studentOne`, which collects courses from every other spec in the run. The work therefore grew with the suite until it outlasted the 240 second wait. The test knew about the accumulation and worked around it, asserting only on the entries belonging to the course it had created, rather than not causing it.

It now creates its own student, so the export covers exactly one course with one participation whatever else is running. Locally the test goes from timing out to finishing in about four seconds, stable over three consecutive runs.

The workaround disappears with the cause. `removeExistingDataExports` existed because an earlier run could leave a downloadable export behind for the shared student, and the table would offer that one while the new export was still being created. A student that exists only for this test can have no leftovers, so the helper is gone.

**This needed a fix in `UserManagementAPIRequests.createUser`**, which is worth its own note: it took a password but created an *externally managed* account. Such an account authenticates against the external directory, so the password was never usable and the new user could not log in at all. Creating a user and then logging in as them answered `401`. Verified against a running server before and after: the account now authenticates on the first try. No spec used `createUser` before this one, which is presumably why it went unnoticed.

### Steps for Testing

```bash
./gradlew test --tests DataExportExerciseCreationServiceTest --tests DataExportCreationServiceTest -x webapp
```

15 tests pass. The two new ones pin both directions, and the one that matters fails without the change:

```
java.lang.AssertionError: [an export missing the student's code has to say so]
```

For the end-to-end test:

```bash
./run-e2e-tests-local-fast.sh --filter "Personal data export"
```

It passed three consecutive runs in about four seconds each, against a server built from this branch.

By hand, on a test server: request a personal data export for a student with a programming participation and confirm the archive holds the repository directory and no `REPOSITORIES_MISSING.md`.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**Note:** Some tests in the [Test job](https://github.com/ls1intum/Artemis/actions/runs/33899389482) did not pass (`failure`). Coverage below may be partial.

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| DataExportExerciseCreationService.java | not found (modified) | 363 |

_Last updated: 2026-09-04 18:11:35 UTC_

