### PR TITLE
`Development`: Size the data export's thread pools to its actual work

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/admin/service/DataExportScheduleService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/admin/service/DataExportScheduleService.java
@@ -88,12 +88,15 @@ public class DataExportScheduleService {
         // One export at a time. What an export spends its time on is git operations on one student's repositories, so
         // ten at once multiplied the load on the version control server without making any single one of them finish
         // sooner. The place for that concurrency is inside an export, across the exercises it has to read.
-        Instant budgetExhaustedAt = Instant.now().plus(CREATION_BUDGET);
+        Instant startedAt = Instant.now();
+        Instant budgetExhaustedAt = startedAt.plus(CREATION_BUDGET);
         int attempted = 0;
         for (var dataExport : dataExportsToBeCreated) {
             if (Instant.now().isAfter(budgetExhaustedAt)) {
-                log.info("Stopping after {} minutes, having attempted {} of {} pending data exports. The rest are picked up by the next run.", CREATION_BUDGET.toMinutes(),
-                        attempted, dataExportsToBeCreated.size());
+                // The elapsed time, not the budget: the check runs after an export has finished, so the run is past
+                // the budget by however long that last export took.
+                log.info("Stopping after {} minutes, past the {} minute budget, having attempted {} of {} pending data exports. The rest are picked up by the next run.",
+                        Duration.between(startedAt, Instant.now()).toMinutes(), CREATION_BUDGET.toMinutes(), attempted, dataExportsToBeCreated.size());
                 break;
             }
             createDataExport(dataExport, successfulDataExports);

--- a/src/main/java/de/tum/cit/aet/artemis/admin/service/DataExportScheduleService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/admin/service/DataExportScheduleService.java
@@ -2,13 +2,12 @@ package de.tum.cit.aet.artemis.admin.service;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE_AND_SCHEDULING;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -52,6 +51,14 @@ public class DataExportScheduleService {
 
     private static final Logger log = LoggerFactory.getLogger(DataExportScheduleService.class);
 
+    /**
+     * How long the nightly run keeps starting exports.
+     * <p>
+     * The job runs at 4 am by default and the next one at 5 am, so it stops in time for that. A request it did not
+     * reach stays pending and is picked up by the following run.
+     */
+    private static final Duration CREATION_BUDGET = Duration.ofMinutes(60);
+
     public DataExportScheduleService(DataExportRepository dataExportRepository, DataExportCreationService dataExportCreationService, DataExportService dataExportService,
             ProfileService profileService, MailService mailService, UserService userService) {
         this.dataExportRepository = dataExportRepository;
@@ -68,7 +75,7 @@ public class DataExportScheduleService {
      * Deleted will be all data exports that have a creation date older than seven days
      */
     @Scheduled(cron = "${artemis.scheduling.data-export-creation-time: 0 0 4 * * *}")
-    public void createDataExportsAndDeleteOldOnes() throws InterruptedException {
+    public void createDataExportsAndDeleteOldOnes() {
         if (profileService.isDevActive()) {
             // do not execute this in a development environment
             // NOTE: if you want to test this locally, please comment it out, but do not commit the changes
@@ -76,29 +83,33 @@ public class DataExportScheduleService {
         }
         SecurityUtils.setSystemAuthorizationObject();
         log.info("Creating data exports and deleting old ones");
-        Set<DataExport> successfulDataExports = Collections.synchronizedSet(new HashSet<>());
+        Set<DataExport> successfulDataExports = new HashSet<>();
         var dataExportsToBeCreated = dataExportRepository.findAllToBeCreated();
-        try (ExecutorService executor = Executors.newFixedThreadPool(10)) {
-            dataExportsToBeCreated.forEach(dataExport -> executor.execute(() -> createDataExport(dataExport, successfulDataExports)));
-            executor.shutdown();
-            ZonedDateTime thresholdDate = ZonedDateTime.now().minusDays(7);
-            var dataExportsToBeDeleted = dataExportRepository.findAllToBeDeleted(thresholdDate);
-            dataExportsToBeDeleted.forEach(this::deleteDataExport);
-            Optional<User> admin = userService.findInternalAdminUser();
-            if (admin.isEmpty()) {
-                log.warn("No internal admin user found. Cannot send email to admin about successful creation of data exports.");
-                return;
+        // One export at a time. What an export spends its time on is git operations on one student's repositories, so
+        // ten at once multiplied the load on the version control server without making any single one of them finish
+        // sooner. The place for that concurrency is inside an export, across the exercises it has to read.
+        Instant budgetExhaustedAt = Instant.now().plus(CREATION_BUDGET);
+        int attempted = 0;
+        for (var dataExport : dataExportsToBeCreated) {
+            if (Instant.now().isAfter(budgetExhaustedAt)) {
+                log.info("Stopping after {} minutes, having attempted {} of {} pending data exports. The rest are picked up by the next run.", CREATION_BUDGET.toMinutes(),
+                        attempted, dataExportsToBeCreated.size());
+                break;
             }
-            // This job runs at 4 am by default and the next scheduled job runs at 5 am, so we should allow 60 minutes for the creation.
-            // If the creation doesn't finish within 60 minutes, all pending exports will be picked up when the job runs the next time.
-            if (!executor.awaitTermination(60, java.util.concurrent.TimeUnit.MINUTES)) {
-                log.info("Not all pending data exports could be created within 60 minutes.");
-                executor.shutdownNow();
-            }
-            if (!successfulDataExports.isEmpty()) {
-                Set<DataExportEmailDTO> dataExportDtos = successfulDataExports.stream().map(DataExportEmailDTO::from).collect(Collectors.toSet());
-                mailService.sendSuccessfulDataExportsEmailToAdmin(MailRecipientDTO.from(admin.get()), dataExportDtos);
-            }
+            createDataExport(dataExport, successfulDataExports);
+            attempted++;
+        }
+        ZonedDateTime thresholdDate = ZonedDateTime.now().minusDays(7);
+        var dataExportsToBeDeleted = dataExportRepository.findAllToBeDeleted(thresholdDate);
+        dataExportsToBeDeleted.forEach(this::deleteDataExport);
+        Optional<User> admin = userService.findInternalAdminUser();
+        if (admin.isEmpty()) {
+            log.warn("No internal admin user found. Cannot send email to admin about successful creation of data exports.");
+            return;
+        }
+        if (!successfulDataExports.isEmpty()) {
+            Set<DataExportEmailDTO> dataExportDtos = successfulDataExports.stream().map(DataExportEmailDTO::from).collect(Collectors.toSet());
+            mailService.sendSuccessfulDataExportsEmailToAdmin(MailRecipientDTO.from(admin.get()), dataExportDtos);
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseExportService.java
@@ -128,6 +128,14 @@ public class ProgrammingExerciseExportService extends ExerciseWithSubmissionsExp
      */
     private static final long CHECKOUT_DIRECTORY_BACKSTOP_DELETION_DELAY_IN_MINUTES = 60;
 
+    /**
+     * The widest a repository export runs, reached only when there are at least that many repositories to export.
+     * <p>
+     * A course archive has hundreds and wants the width. A data export has one repository per exercise, and sizing the
+     * pool to the work keeps it from starting a thread to hand a single git operation to.
+     */
+    private static final int MAX_CONCURRENT_REPOSITORY_EXPORTS = 10;
+
     public ProgrammingExerciseExportService(ProgrammingExerciseRepository programmingExerciseRepository, ProgrammingExerciseTaskService programmingExerciseTaskService,
             StudentParticipationRepository studentParticipationRepository, FileService fileService, GitService gitService, GitRepositoryExportService gitRepositoryExportService,
             RepositoryExportGitService repositoryExportGitService, ZipFileService zipFileService, MappingJackson2HttpMessageConverter springMvcJacksonConverter,
@@ -543,32 +551,41 @@ public class ProgrammingExerciseExportService extends ExerciseWithSubmissionsExp
         List<Path> exportedStudentRepositoriesPaths = Collections.synchronizedList(new ArrayList<>());
         AtomicBoolean anonymizationFailed = new AtomicBoolean(false);
 
-        log.info("export student repositories for programming exercise {} in parallel", programmingExercise.getId());
-        try (var threadPool = Executors.newFixedThreadPool(10)) {
-            var futures = participations.stream().map(participation -> CompletableFuture.runAsync(() -> {
-                try {
-                    var relevantCommitHash = participationCommitHashes.get(participation.getId());
-                    log.debug("invoke exportStudentRepository for participation {}", participation.getId());
-                    Path repoOutputPath = exportStudentRepository(programmingExercise, participation, repositoryExportOptions, relevantCommitHash, checkoutDir, outputDir, content);
-                    if (repoOutputPath != null) {
-                        exportedStudentRepositoriesPaths.add(repoOutputPath);
-                    }
+        List<Runnable> exports = participations.stream().map(participation -> (Runnable) () -> {
+            try {
+                var relevantCommitHash = participationCommitHashes.get(participation.getId());
+                log.debug("invoke exportStudentRepository for participation {}", participation.getId());
+                Path repoOutputPath = exportStudentRepository(programmingExercise, participation, repositoryExportOptions, relevantCommitHash, checkoutDir, outputDir, content);
+                if (repoOutputPath != null) {
+                    exportedStudentRepositoriesPaths.add(repoOutputPath);
                 }
-                catch (Exception exception) {
-                    var error = "Failed to export the student repository with participation: " + participation.getId() + " for programming exercise '"
-                            + programmingExercise.getTitle() + "' (id: " + programmingExercise.getId() + ") because the repository couldn't be downloaded. ";
-                    exportErrors.add(error);
-                    if (repositoryExportOptions.anonymizeRepository() && exception instanceof GitException) {
-                        anonymizationFailed.set(true);
-                    }
-                }
-            }, threadPool).toCompletableFuture()).toArray(CompletableFuture[]::new);
-            // wait until all operations finish
-            CompletableFuture.allOf(futures).thenRun(threadPool::shutdown).join();
-            deleteCheckoutDirectory(checkoutDir);
-            if (anonymizationFailed.get()) {
-                throw new GitException("Anonymization failed for one or more repositories");
             }
+            catch (Exception exception) {
+                var error = "Failed to export the student repository with participation: " + participation.getId() + " for programming exercise '" + programmingExercise.getTitle()
+                        + "' (id: " + programmingExercise.getId() + ") because the repository couldn't be downloaded. ";
+                exportErrors.add(error);
+                if (repositoryExportOptions.anonymizeRepository() && exception instanceof GitException) {
+                    anonymizationFailed.set(true);
+                }
+            }
+        }).toList();
+
+        if (exports.size() <= 1) {
+            // A single repository, which is what a data export asks for, runs here rather than on a thread of its own.
+            log.info("export the student repositories of programming exercise {} on the calling thread", programmingExerciseId);
+            exports.forEach(Runnable::run);
+        }
+        else {
+            int concurrency = Math.min(exports.size(), MAX_CONCURRENT_REPOSITORY_EXPORTS);
+            log.info("export {} student repositories for programming exercise {} on {} threads", exports.size(), programmingExerciseId, concurrency);
+            try (var threadPool = Executors.newFixedThreadPool(concurrency)) {
+                // wait until all operations finish
+                CompletableFuture.allOf(exports.stream().map(export -> CompletableFuture.runAsync(export, threadPool)).toArray(CompletableFuture[]::new)).join();
+            }
+        }
+        deleteCheckoutDirectory(checkoutDir);
+        if (anonymizationFailed.get()) {
+            throw new GitException("Anonymization failed for one or more repositories");
         }
         return exportedStudentRepositoriesPaths;
     }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseExportService.java
@@ -550,6 +550,10 @@ public class ProgrammingExerciseExportService extends ExerciseWithSubmissionsExp
 
         List<Path> exportedStudentRepositoriesPaths = Collections.synchronizedList(new ArrayList<>());
         AtomicBoolean anonymizationFailed = new AtomicBoolean(false);
+        // The tasks below collect their errors here rather than into the caller's list, because that list is not
+        // required to be thread safe and exportStudentRepositoriesToZipFile passes a plain ArrayList. They are handed
+        // over once the tasks have finished, on the thread that called this.
+        List<String> collectedExportErrors = Collections.synchronizedList(new ArrayList<>());
 
         List<Runnable> exports = participations.stream().map(participation -> (Runnable) () -> {
             try {
@@ -563,7 +567,7 @@ public class ProgrammingExerciseExportService extends ExerciseWithSubmissionsExp
             catch (Exception exception) {
                 var error = "Failed to export the student repository with participation: " + participation.getId() + " for programming exercise '" + programmingExercise.getTitle()
                         + "' (id: " + programmingExercise.getId() + ") because the repository couldn't be downloaded. ";
-                exportErrors.add(error);
+                collectedExportErrors.add(error);
                 if (repositoryExportOptions.anonymizeRepository() && exception instanceof GitException) {
                     anonymizationFailed.set(true);
                 }
@@ -583,6 +587,9 @@ public class ProgrammingExerciseExportService extends ExerciseWithSubmissionsExp
                 CompletableFuture.allOf(exports.stream().map(export -> CompletableFuture.runAsync(export, threadPool)).toArray(CompletableFuture[]::new)).join();
             }
         }
+        // Before the anonymization check below, so that a caller still learns which repositories failed even when the
+        // export ends in that exception.
+        exportErrors.addAll(collectedExportErrors);
         deleteCheckoutDirectory(checkoutDir);
         if (anonymizationFailed.get()) {
             throw new GitException("Anonymization failed for one or more repositories");

--- a/src/test/java/de/tum/cit/aet/artemis/admin/service/DataExportScheduleServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/admin/service/DataExportScheduleServiceTest.java
@@ -59,7 +59,7 @@ class DataExportScheduleServiceTest extends AbstractSpringIntegrationIndependent
 
     @ParameterizedTest
     @MethodSource("provideDataExportStatesAndExpectedToBeCreated")
-    void testScheduledCronTaskCreatesDataExports(DataExportState state, boolean shouldBeCreated) throws InterruptedException {
+    void testScheduledCronTaskCreatesDataExports(DataExportState state, boolean shouldBeCreated) {
         dataExportRepository.deleteAll();
         var dataExport = createDataExportWithState(state);
         dataExportScheduleService.createDataExportsAndDeleteOldOnes();
@@ -76,7 +76,7 @@ class DataExportScheduleServiceTest extends AbstractSpringIntegrationIndependent
     }
 
     @Test
-    void testScheduledCronTaskSendsEmailToAdminAboutSuccessfulDataExports() throws InterruptedException {
+    void testScheduledCronTaskSendsEmailToAdminAboutSuccessfulDataExports() {
         dataExportRepository.deleteAll();
         createDataExportWithState(DataExportState.REQUESTED);
         createDataExportWithState(DataExportState.REQUESTED);
@@ -97,7 +97,7 @@ class DataExportScheduleServiceTest extends AbstractSpringIntegrationIndependent
 
     @ParameterizedTest
     @MethodSource("provideCreationDatesAndExpectedToDelete")
-    void testScheduledCronTaskDeletesOldDataExports(ZonedDateTime creationDate, DataExportState state, boolean shouldDelete) throws InterruptedException {
+    void testScheduledCronTaskDeletesOldDataExports(ZonedDateTime creationDate, DataExportState state, boolean shouldDelete) {
         var dataExport = createDataExportWithCreationDateAndState(creationDate, state);
         doNothing().when(fileService).schedulePathForDeletion(any(), anyLong());
         var dataExportId = dataExport.getId();

--- a/src/test/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseExportServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseExportServiceTest.java
@@ -191,6 +191,36 @@ class ProgrammingExerciseExportServiceTest extends AbstractSpringIntegrationLoca
         }
     }
 
+    /**
+     * More than one repository runs on a thread pool, and the tasks there collect their errors separately from the
+     * list the caller passed, because that list is not required to be thread safe. This asserts the handover back to
+     * the caller: without it a multi-repository export would report no errors at all, and the course archive would
+     * tell an instructor nothing about the repository it skipped.
+     */
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void testExportStudentRepositories_shouldReportAnUnreadableRepositoryAlongsideTheOnesItExported() throws Exception {
+        List<ProgrammingExerciseStudentParticipation> participations = new ArrayList<>(seedStudentParticipations(TEST_PREFIX + "student1"));
+        var unreadable = (ProgrammingExerciseStudentParticipation) participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise,
+                TEST_PREFIX + "student2");
+        // A URI for a repository that was never created on disk, as left behind by a failed participation setup.
+        String projectKey = programmingExercise.getProjectKey();
+        String missingSlug = localVCLocalCITestService.getRepositorySlug(projectKey, "never-created");
+        unreadable.setRepositoryUri(localVCLocalCITestService.buildLocalVCUri(TEST_PREFIX + "student2", projectKey, missingSlug));
+        participations.add(studentParticipationTestRepository.save(unreadable));
+
+        Path outputDir = tempFileUtilService.createTempDirectory("archival-export-partial");
+        // Deliberately a plain list, which is what exportStudentRepositoriesToZipFile passes.
+        List<String> exportErrors = new ArrayList<>();
+
+        List<Path> exportedRepositories = programmingExerciseExportService.exportStudentRepositories(programmingExercise, participations, Map.of(), outputDir, exportErrors,
+                ARCHIVAL_OPTIONS, RepositoryExportContent.WORKING_TREE_ONLY);
+
+        assertThat(participations).as("two repositories, so that the pool is used rather than the single-repository path").hasSize(2);
+        assertThat(exportedRepositories).as("the readable repository still has to be exported").hasSize(1);
+        assertThat(exportErrors).as("an export that skipped a repository has to say which one").anyMatch(error -> error.contains(unreadable.getId().toString()));
+    }
+
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testExportStudentRepositories_shouldNameTheZipAfterTheParticipant() throws Exception {


### PR DESCRIPTION
### Summary

The data export created thread pools that did no work. The nightly job ran ten students' exports at once, and inside each export every programming exercise allocated a ten-thread pool to hand a single git operation to one thread while the calling thread blocked. Both pools are now sized to the work that exists.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

Two questions about the export's threading, both of which turned out to have the same answer: the concurrency was in the wrong place.

The nightly job ran up to ten data exports at once. What an export spends its time on is git operations against the version control server for one student's repositories, so ten at once multiplied the load on that server without making any single export finish sooner.

Inside an export, `exportStudentRepositories` created `Executors.newFixedThreadPool(10)` once per programming exercise. That method was written for course archival, which passes hundreds of participations. A data export passes the participations of one student in one exercise, so normally one. `newFixedThreadPool` creates its core threads on demand rather than up front, so this was not ten threads per exercise, but it was still a pool allocation and a thread handover per exercise for work the calling thread then waited on, which is strictly slower than running it inline.

### Description

`DataExportScheduleService` creates the pending exports one after another. The sixty minute budget is kept, now as a named `CREATION_BUDGET` checked before each export, so the job still finishes before the next scheduled run and logs how many requests it left pending for the next one. The executor, its `awaitTermination` and the `synchronizedSet` it needed are gone, and so is the `throws InterruptedException` that only existed for it. Deletion of old exports now happens after the creations instead of racing them.

`ProgrammingExerciseExportService.exportStudentRepositories` builds one task per participation and then decides how to run them. A single repository runs on the calling thread with no pool. More than one gets a pool of `Math.min(count, MAX_CONCURRENT_REPOSITORY_EXPORTS)`, so a course archive keeps the full width of ten while a data export creates no executor at all. The `10` is now a named constant, and the log line no longer claims a single repository is exported "in parallel".

This does trade batch throughput at night for lower load and lower latency per export. The concurrency that would pay it back belongs inside a single export, across the exercises it reads, which is also what an admin triggered export would want. That is deliberately not in this pull request: it changes the export's error aggregation and needs a persistence session per worker, so it deserves its own change and its own tests.

### Steps for Testing

Prerequisites:
- 1 Admin
- 2 Students, each with participations in at least two programming exercises
- 1 Course with a programming exercise several students participated in, for the archive path

The creation job is cron driven and returns immediately under the dev profile, so on a test server either wait for it or set `artemis.scheduling.data-export-creation-time` to a cron a minute or two out.

1. Log in as each student and request a data export from the account page, so that more than one is pending at the same time.
2. Let the creation job run.
3. Download both exports and confirm each contains the repository of every programming exercise that student participated in, with its history. This is the part the change could break: the exports now run one after another rather than together.
4. Check the server log. A single repository is now reported as exported on the calling thread, with no thread count.
5. As the admin, archive the course from the course management page, and confirm the archive still contains every student's repository and that the log reports the number of threads it used, which is ten once there are at least ten repositories.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.

### Review Progress

#### Code Review
- [x] Code Review 1

#### Manual Tests
- [x] Test 1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Scheduled data exports now process pending requests within a defined time window, making scheduled runs more predictable.
  * Student repository exports now support controlled parallel processing for more efficient handling of multiple repositories.
  * Export processing continues when an individual repository cannot be read, while reporting the affected repository for follow-up.
  * Cleanup and anonymization steps are performed after repository exports finish, ensuring orderly completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->