### PR TITLE
`Development`: Stop killing server test runs that are only slow

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -41,7 +41,7 @@ jobs:
     name: Server Tests (PostgreSQL)
     runs-on: aet-large-ubuntu
     # Outermost bound of the hang ladder: watchdog 45m (run_with_hang_dump.sh) < Gradle Test timeout
-    # 55m (gradle/test.gradle) < this 80m. Keep it above 55 so a hang fails as a deterministic Gradle
+    # 70m (gradle/test.gradle) < this 80m. Keep it above 70 so a hang fails as a deterministic Gradle
     # `failure`, not an opaque job-level `cancelled`.
     timeout-minutes: 80
     permissions:

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -6,12 +6,24 @@ import java.time.Duration
 // Taken from here: https://stackoverflow.com/questions/3963708/gradle-how-to-display-test-results-in-the-console-in-real-time
 tasks.withType(Test).configureEach {
 
-    // Hard backstop against a hung test/deadlock (suite normally finishes in ~30 min). On timeout the
-    // build fails as `failure`, not the opaque `cancelled` a GitHub job-timeout produces, so the merge
-    // gate shows a real failure. A global JUnit per-method timeout is deliberately NOT used:
-    // SAME_THREAD cannot interrupt a deadlock, and SEPARATE_THREAD breaks the ~288 tests relying on the
-    // thread-bound Spring SecurityContext (@WithMockUser).
-    timeout = Duration.ofMinutes(55)
+    // Hard backstop against a hung test/deadlock. On timeout the build fails as `failure`, not the
+    // opaque `cancelled` a GitHub job-timeout produces, so the merge gate shows a real failure. A global
+    // JUnit per-method timeout is deliberately NOT used: SAME_THREAD cannot interrupt a deadlock, and
+    // SEPARATE_THREAD breaks the ~288 tests relying on the thread-bound Spring SecurityContext
+    // (@WithMockUser).
+    //
+    // 70 minutes rather than the 55 this was set to when the hang ladder was introduced. The median run
+    // is ~30 min, but wall time roughly doubles on a loaded runner. Measured on 2026-09-04: green runs
+    // of 29, 29, 30, 30, 31, 33, 45, 48 and 51 minutes, and four runs killed here at 57 to 58 minutes
+    // with zero test failures, each still completing tests seconds before the kill. 55 sat about six
+    // minutes above the legitimate maximum run_with_hang_dump.sh already documents ("40-49 min on a
+    // loaded runner"), so a load spike failed the build instead of a defect.
+    //
+    // This does not weaken hang detection, because this timer never told a hang from a slow run.
+    // run_with_hang_dump.sh does, by watching for output silence, and still dumps threads from about
+    // minute 45. What is left for this bound to catch is a hang that keeps producing output, and it
+    // stays under the job's own 80-minute cap so that case still fails as a Gradle failure.
+    timeout = Duration.ofMinutes(70)
 
     jvmArgs += "-javaagent:${configurations.mockitoAgent.asPath}"
     // Required by the Weaviate Java client v6, which uses Gson's reflection-based serialization on internal java.lang classes.

--- a/supporting_scripts/run_with_hang_dump.sh
+++ b/supporting_scripts/run_with_hang_dump.sh
@@ -6,12 +6,12 @@
 # Usage: run_with_hang_dump.sh <command> [args...]
 set -euo pipefail
 
-# The window this watchdog works in, all of it inside the 55-minute Gradle Test task timeout:
+# The window this watchdog works in, all of it inside the 70-minute Gradle Test task timeout:
 #   - nothing happens before EARLIEST_DUMP_MINUTES, so a normal run is never touched
 #   - between then and LATEST_DUMP_MINUTES a dump starts as soon as the run goes quiet
 #   - after LATEST_DUMP_MINUTES no dump is started, leaving DUMP_PHASE_SECONDS for the dump itself
 readonly EARLIEST_DUMP_MINUTES=45
-readonly LATEST_DUMP_MINUTES=50
+readonly LATEST_DUMP_MINUTES=65
 # The suite is only considered hung if it also stopped producing output. The full run legitimately takes
 # 40-49 min on a loaded runner while still making progress, and dumping a live JVM costs it a safepoint
 # pause, so an elapsed-time gate on its own fired on runs that were merely slow.
@@ -81,7 +81,7 @@ watch_for_hang() {
 
         # Both windows are measured against the clock, not by counting polls. A loaded runner can resume a
         # sleep late, and accumulating POLL_SECONDS would then under-count real time - enough drift and a
-        # dump could start after the real deadline and still be running when Gradle kills the task at 55 min.
+        # dump could start after the real deadline and still be running when Gradle kills the task at 70 min.
         elapsed=$(( $(now) - started_at ))
 
         local size


### PR DESCRIPTION
### Summary

`Server Tests` fails with zero failing tests. The run ends on `Timeout has been exceeded` from the Gradle task timeout, which was calibrated for a suite that finishes in 30 minutes and is crossed whenever a loaded runner takes twice that. The bound moves from 55 to 70 minutes and the watchdog's dump deadline moves with it.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

`Server Tests` has been failing without a failing test. The evidence from one such run:

```
|  Results: FAILURE (15148 tests, 15065 successes, 0 failures, 83 skipped)  |
...
* What went wrong:
Execution failed for task ':test'
> Timeout has been exceeded
```

Nothing hung. The last test passed at 18:10:41 and the kill landed at 18:10:53, so the suite was still making progress twelve seconds before it was killed.

It is not a bad runner either. `Server Tests` durations across roughly thirty runs on 2026-09-04:

| result | durations (minutes) |
| --- | --- |
| success | 29, 29, 30, 30, 31, 33, 45, 48, 51 |
| killed by the timeout | 57, 57, 58, 58 |

The four kills were on four different runners (`github-xl-1`, `github-l-19`, `github-l-10`, `github-l-13`), and `github-l-10` produced both a 30 minute and a 57 minute run. The suite's median is about 30 minutes and its wall time roughly doubles under load, which puts the top of the distribution past a 55 minute bound.

A per-class comparison of a 29 minute green run against the killed one shows the slowdown is spread across every heavy class rather than concentrated in one, which is what resource starvation looks like and not what a single pathological test looks like:

| class | green 29 min run | killed run |
| --- | --- | --- |
| `StudentExamIntegrationTest` | 4.1 min | 23.5 min |
| `ParticipationIntegrationTest` | 0.2 min | 9.4 min |
| `LocalVCIntegrationTest` | 0.0 min | 5.3 min |
| total reported slow-test time | 13.6 min | 75.1 min |

55 minutes was set when the hang ladder was introduced (#12954) and never revisited. It sat about six minutes above the legitimate maximum that `run_with_hang_dump.sh` already documents in its own comment: "The full run legitimately takes 40-49 min on a loaded runner while still making progress".

### Description

The Gradle `:test` bound moves to 70 minutes, still below the job's 80 minute cap so that a hang defeating it fails as a deterministic Gradle `failure` rather than an opaque job-level `cancelled`. The watchdog's `LATEST_DUMP_MINUTES` moves from 50 to 65 so its documented invariant still holds: a dump started at the last permitted moment finishes 0.8 minutes before the kill, the same margin the original numbers left. Every comment that stated the old number is updated, in `gradle/test.gradle`, `supporting_scripts/run_with_hang_dump.sh` and `.github/workflows/ci-test.yml`.

Hang detection is not weakened. The Gradle timer never distinguished a hang from a slow run. `run_with_hang_dump.sh` does, by watching for output silence, and it still starts dumping threads from minute 45. What the Gradle bound is left to catch is a hang that keeps producing output, and that case is now caught at 70 minutes instead of 55. That later detection is the price of no longer failing healthy runs, and it only applies to a hang that is never silent.

What this does not address is why the suite needs 30 minutes at rest and twice that under load. The largest single contributor is `StudentExamIntegrationTest`: 132 test methods, each rebuilding a fixture of two users, a course, four exams (two of them with text, modeling and programming exercises), four student exams, and the programming exercise and Jenkins mock setup. It amplifies 5.7x under load, the most in the suite. Shrinking that fixture, or sharding the job, is what would create real headroom, and belongs in its own change.

### Steps for Testing

This changes only CI bounds, so the check is that the ladder is still ordered and nothing was left stale.

1. Confirm the ordering, which this PR asserts numerically: watchdog earliest 45 < watchdog latest 65, a dump begun at 65 finishes by 69.2, Gradle kills at 70, the job caps at 80.
2. `bash -n supporting_scripts/run_with_hang_dump.sh` parses.
3. `./gradlew help` configures, so `gradle/test.gradle` is still valid.
4. Confirm no file still uses 55 as the active bound: `grep -rnE 'ofMinutes\(55\)|55m \(gradle|55-minute Gradle|task at 55 min' gradle/test.gradle supporting_scripts/run_with_hang_dump.sh .github/workflows/ci-test.yml` returns nothing. The two remaining mentions of 55 in `gradle/test.gradle` are deliberate, recording what the value used to be and why it was wrong.
5. Watch `Server Tests` on this PR and the next few merges. A run in the 45 to 58 minute range should now pass instead of being killed.

### Testserver States
> [!NOTE]
> These badges show the state of the test servers.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the automated test timeout window to accommodate longer-running test executions.
  * Updated the hang-detection timing and related documentation to align with the extended test window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->