### PR TITLE
`Notifications`: Preserve single line breaks in course notification emails

### DIFF
--- a/.github/workflows/ci-bean-instantiations.yml
+++ b/.github/workflows/ci-bean-instantiations.yml
@@ -26,7 +26,9 @@ jobs:
       MAX_STARTUP_DEPENDENCY_CHAIN_LENGTH: 10
       MAX_DEFERRED_CHAIN_LENGTH: 16
       MIN_INSTANTIATED_BEANS: 20
-      MAX_INSTANTIATED_BEANS: 158
+      # 159 rather than 158 since the per-node title cache: the notification cache service reaches
+      # TitleCacheConfiguration at startup.
+      MAX_INSTANTIATED_BEANS: 159
       MIN_DEFERRED_CHAIN_LENGTH: 1
 
     steps:

--- a/src/main/java/de/tum/cit/aet/artemis/notification/service/CourseNotificationEmailService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/service/CourseNotificationEmailService.java
@@ -189,7 +189,11 @@ public class CourseNotificationEmailService extends CourseNotificationBroadcastS
      */
     private String renderMarkdown(String preRenderMarkdown) {
         Parser parser = Parser.builder().build();
-        HtmlRenderer renderer = HtmlRenderer.builder()
+        // A single newline is a soft break in Markdown, which CommonMark renders as a plain newline and every mail
+        // client then collapses into a space, so an announcement arrives with its lines merged. The web client keeps
+        // such a break visible, so rendering it as <br> is what makes the e-mail read the way its author wrote it.
+        // The tag survives the sanitization below because the safelist allows it.
+        HtmlRenderer renderer = HtmlRenderer.builder().softbreak("<br>")
                 .attributeProviderFactory(attributeContext -> new MarkdownRelativeToAbsolutePathAttributeProvider(artemisServerUrl.toString()))
                 .nodeRendererFactory(new MarkdownImageBlockRendererFactory(artemisServerUrl.toString())).build();
         String renderedHtml = renderer.render(parser.parse(preRenderMarkdown));

--- a/src/test/java/de/tum/cit/aet/artemis/notification/service/CourseNotificationEmailServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/service/CourseNotificationEmailServiceTest.java
@@ -50,6 +50,8 @@ import de.tum.cit.aet.artemis.notification.service.notifications.MarkdownCustomR
 
 class CourseNotificationEmailServiceTest {
 
+    private static final ZonedDateTime FIXED_CREATION_DATE = ZonedDateTime.parse("2025-01-15T10:00:00+01:00");
+
     private CourseNotificationEmailService courseNotificationEmailService;
 
     @Mock
@@ -290,7 +292,7 @@ class CourseNotificationEmailServiceTest {
     @Test
     void shouldRenderSingleLineBreaksInMarkdownAsHtmlLineBreaks() {
         User recipient = createUser("user1", "en");
-        CourseNotificationDTO notification = new CourseNotificationDTO("newAnnouncementNotification", 1L, 123L, ZonedDateTime.now(), CourseNotificationCategory.COMMUNICATION,
+        CourseNotificationDTO notification = new CourseNotificationDTO("newAnnouncementNotification", 1L, 123L, FIXED_CREATION_DATE, CourseNotificationCategory.COMMUNICATION,
                 "Test Course", null, new NewAnnouncementPayloadDTO(1L, "Test Announcement", "first line\nsecond line\n\nnext paragraph", "Test Author", null, 2L, 3L), "/");
 
         when(messageSource.getMessage(anyString(), any(), any(Locale.class))).thenReturn("Test Subject");

--- a/src/test/java/de/tum/cit/aet/artemis/notification/service/CourseNotificationEmailServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/service/CourseNotificationEmailServiceTest.java
@@ -43,6 +43,7 @@ import de.tum.cit.aet.artemis.notification.dto.CourseNotificationDTO;
 import de.tum.cit.aet.artemis.notification.dto.CourseNotificationRecipientDTO;
 import de.tum.cit.aet.artemis.notification.dto.MailRecipientDTO;
 import de.tum.cit.aet.artemis.notification.dto.payload.ExerciseOpenForPracticePayloadDTO;
+import de.tum.cit.aet.artemis.notification.dto.payload.NewAnnouncementPayloadDTO;
 import de.tum.cit.aet.artemis.notification.service.notifications.MailSendingService;
 import de.tum.cit.aet.artemis.notification.service.notifications.MarkdownCustomLinkRendererService;
 import de.tum.cit.aet.artemis.notification.service.notifications.MarkdownCustomReferenceRendererService;
@@ -277,6 +278,34 @@ class CourseNotificationEmailServiceTest {
             assertThat(contextParameters).containsEntry("exerciseTitle", "Test Exercise").containsEntry("exerciseId", 1L).containsEntry("courseTitle", "Test Course");
             assertThat(capturedContext.getVariable("creationDate")).isEqualTo(creationDate);
             assertThat(capturedContext.getVariable("category")).isEqualTo(category);
+        });
+    }
+
+    /**
+     * A single newline is a soft break in Markdown, and rendering it as a plain newline lets every mail client collapse
+     * it into a space, so an announcement written over several lines arrived as one run-on line. The e-mail has to show
+     * the break the same way the web client does, while a blank line still has to start a new paragraph rather than
+     * turning into a second break.
+     */
+    @Test
+    void shouldRenderSingleLineBreaksInMarkdownAsHtmlLineBreaks() {
+        User recipient = createUser("user1", "en");
+        CourseNotificationDTO notification = new CourseNotificationDTO("newAnnouncementNotification", 1L, 123L, ZonedDateTime.now(), CourseNotificationCategory.COMMUNICATION,
+                "Test Course", null, new NewAnnouncementPayloadDTO(1L, "Test Announcement", "first line\nsecond line\n\nnext paragraph", "Test Author", null, 2L, 3L), "/");
+
+        when(messageSource.getMessage(anyString(), any(), any(Locale.class))).thenReturn("Test Subject");
+        when(templateEngine.process(anyString(), any(Context.class))).thenReturn("Test Content");
+        when(markdownCustomLinkRendererService.render(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(markdownCustomReferenceRendererService.render(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        courseNotificationEmailService.sendCourseNotification(notification, List.of(CourseNotificationRecipientDTO.from(recipient)));
+
+        Awaitility.await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+            verify(templateEngine).process(anyString(), contextCaptor.capture());
+
+            @SuppressWarnings("unchecked")
+            var renderedParameters = (Map<String, Object>) contextCaptor.getValue().getVariable("parameters");
+            assertThat((String) renderedParameters.get("postMarkdownContent")).isEqualToIgnoringWhitespace("<p>first line<br>second line</p><p>next paragraph</p>");
         });
     }
 


### PR DESCRIPTION
### Summary
Single line breaks in an announcement were lost in the notification email: the Markdown soft break was rendered as a plain newline, which every mail client collapses into a space, so the text arrived as one run-on line while the web client showed it correctly. The e-mail markdown renderer now emits `<br>` for soft breaks, so the mail matches what the author wrote and what Artemis displays.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
Fixes #11954.

When an instructor writes an announcement with single line breaks, the editor, the preview and the published announcement all keep those breaks, but the email notification merges the lines. Only paragraphs separated by a blank line survive. The email should read the way the author wrote it.

This is a redo of #12279 by @dogusaytok, which was approved twice and then closed as stale. Both touched files have since moved from the `communication` module to the `notification` module and the notification payload became typed, so the fix and the test are ported to the current code.

### Description
`CourseNotificationEmailService.renderMarkdown` now builds the CommonMark `HtmlRenderer` with `.softbreak("<br>")`. A single newline in the Markdown therefore becomes a literal `<br>` instead of a newline in the HTML, which mail clients render as a line break. The Jsoup `Safelist` used for sanitization right below already allows `br`, so the tag passes through unchanged. Blank lines keep producing separate paragraphs.

Added `shouldRenderSingleLineBreaksInMarkdownAsHtmlLineBreaks` to `CourseNotificationEmailServiceTest`, which asserts both halves of the behaviour: a single newline renders as `<br>`, and a blank line still starts a new paragraph. Verified that it fails on develop without the fix (rendered `<p>first line second line</p>`) and passes with it.

Also raises `MAX_INSTANTIATED_BEANS` in `.github/workflows/ci-bean-instantiations.yml` from 158 to 159. This is unrelated to the line breaks and is folded in here because it currently fails the required bean instantiation check on every open pull request: the per-node title cache added `TitleCacheConfiguration` to the startup graph, reached from the notification cache service, without the threshold following. The startup bean graph of this branch's run confirms it (`courseNotificationCacheService -> titleCacheConfiguration`).

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Course with the announcement channel enabled
- A local mail server (e.g. Mailpit) or a test inbox

1. Log in to Artemis as an instructor.
2. Navigate to the course, open **Communication** and select the **Announcement** channel.
3. Post an announcement with single line breaks (press Enter once between the lines) and a paragraph separated by a blank line.
4. Open the student's inbox on the test mail server (the mail arrives within about a minute).
5. Verify that the single line breaks appear in the email exactly as in the Artemis editor, and that the blank line still separates two paragraphs.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| CourseNotificationEmailService.java | 98.46% | 140 |

_Last updated: 2026-09-05 07:57:08 UTC_


### Screenshots
Not applicable, the change only affects the rendered email content. See the before/after screenshots in #11954 and #12279.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed email rendering so single line breaks in Markdown remain visible as line breaks instead of collapsing into spaces.
  - Blank lines continue to separate content into distinct paragraphs.
  - Improved readability of multiline announcement content across supported email clients.

- **Tests**
  - Added coverage for multiline announcement content in notification emails.
  - Verified that line breaks and paragraph spacing are preserved in rendered messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
