### PR TITLE
`Development`: Repair the two admin end-to-end tests broken by permanent user deletion

### DIFF
--- a/src/test/playwright/e2e/admin/DataExport.spec.ts
+++ b/src/test/playwright/e2e/admin/DataExport.spec.ts
@@ -58,7 +58,7 @@ test.describe('Personal data export', { tag: '@slow' }, () => {
         await login(admin);
     });
 
-    test.afterEach('Deletes the course and the student', async ({ page, login, courseManagementAPIRequests }) => {
+    test.afterEach('Deletes the course and the student', async ({ login, courseManagementAPIRequests, userManagementAPIRequests }) => {
         await login(admin);
         try {
             await courseManagementAPIRequests.deleteCourse(course, admin);
@@ -66,7 +66,7 @@ test.describe('Personal data export', { tag: '@slow' }, () => {
             // In a finally, so that a course deletion which exhausts its retries does not leave the account behind, and
             // asserted, so that a cleanup which silently stops working shows up as a failure rather than as accounts
             // accumulating in the database.
-            const response = await page.request.delete(`api/account/admin/users/${student.username}`);
+            const response = await userManagementAPIRequests.deleteUser(student.username);
             expect(response.ok(), 'the student this test created has to be removed again').toBe(true);
         }
     });

--- a/src/test/playwright/e2e/admin/UserDeletion.spec.ts
+++ b/src/test/playwright/e2e/admin/UserDeletion.spec.ts
@@ -97,21 +97,14 @@ test.describe('Retention-aware user deletion', { tag: '@fast' }, () => {
         return dialog;
     }
 
-    test.afterEach('Delete data left by a failed scenario', async ({ page, login, courseManagementAPIRequests }) => {
+    test.afterEach('Delete data left by a failed scenario', async ({ login, courseManagementAPIRequests, userManagementAPIRequests }) => {
         await login(admin);
         for (const userLogin of createdUsers) {
-            const userResponse = await page.request.get(`/api/account/admin/users/${userLogin}`);
+            const userResponse = await userManagementAPIRequests.getUser(userLogin);
             if (userResponse.status() === 404) {
                 continue;
             }
-            const impactResponse = await page.request.post('/api/account/admin/users/deletion-impact', { data: { logins: [userLogin] } });
-            if (!impactResponse.ok()) {
-                continue;
-            }
-            const impact = (await impactResponse.json()) as DeletionImpact;
-            await page.request.delete('/api/account/admin/users', {
-                data: { users: impact.users.map((user) => ({ login: user.login, impactFingerprint: user.impactFingerprint })) },
-            });
+            await userManagementAPIRequests.deleteUser(userLogin);
         }
         createdUsers.clear();
         for (const course of createdCourses) {
@@ -176,10 +169,13 @@ test.describe('Retention-aware user deletion', { tag: '@fast' }, () => {
         await page.getByRole('button', { name: 'Delete not enrolled users' }).click();
         const [notEnrolled, impact] = await Promise.all([notEnrolledResponse, impactResponse]);
 
-        const notEnrolledLogins = (await notEnrolled.json()) as string[];
+        // Both bodies are read before anything is asserted on either. Chromium keeps a response body only until the
+        // page moves on from it, and reading one of them late failed in CI with "No data found for resource with
+        // given identifier" while the assertions in between gave it time to be dropped.
+        const [notEnrolledLogins, deletionImpact] = (await Promise.all([notEnrolled.json(), impact.json()])) as [string[], DeletionImpact];
         expect(notEnrolledLogins).toContain(userLogin);
         expect(notEnrolledLogins).not.toContain('iris_bot');
-        expect(((await impact.json()) as DeletionImpact).users.map((user) => user.login)).toContain(userLogin);
+        expect(deletionImpact.users.map((user) => user.login)).toContain(userLogin);
         const dialog = page.getByRole('dialog', { name: 'Permanently delete user data' });
         await expect(dialog).toBeVisible();
         await expect(dialog.getByTestId('confirm-delete-users').getByRole('button')).toBeDisabled();

--- a/src/test/playwright/e2e/admin/UserDeletion.spec.ts
+++ b/src/test/playwright/e2e/admin/UserDeletion.spec.ts
@@ -104,7 +104,11 @@ test.describe('Retention-aware user deletion', { tag: '@fast' }, () => {
             if (userResponse.status() === 404) {
                 continue;
             }
-            await userManagementAPIRequests.deleteUser(userLogin);
+            // Asserted rather than ignored: this teardown swallowing a failed deletion is how the export spec's
+            // cleanup could rot unnoticed until it broke, and a scenario that leaves its users behind pollutes the
+            // runs after it.
+            const deletionResponse = await userManagementAPIRequests.deleteUser(userLogin);
+            expect(deletionResponse.ok(), `cleaning up ${userLogin} failed with ${deletionResponse.status()}: ${await deletionResponse.text()}`).toBe(true);
         }
         createdUsers.clear();
         for (const course of createdCourses) {
@@ -162,17 +166,18 @@ test.describe('Retention-aware user deletion', { tag: '@fast' }, () => {
         const userLogin = await createUser(userManagementAPIRequests, 'not_enrolled');
         await page.goto('/admin/user-management');
 
-        const notEnrolledResponse = page.waitForResponse(
-            (response) => response.url().endsWith('/api/account/admin/users/not-enrolled') && response.request().method() === 'GET' && response.status() === 200,
-        );
-        const impactResponse = page.waitForResponse((response) => response.url().endsWith('/api/account/admin/users/deletion-impact') && response.status() === 200);
+        // Each body is read the moment its own response arrives rather than after both have, because Chromium keeps a
+        // response body only until the page moves on from it. Waiting for the second response, and then asserting,
+        // gave the first one time to be dropped, which failed in CI with "No data found for resource with given
+        // identifier".
+        const notEnrolledLoginsPromise = page
+            .waitForResponse((response) => response.url().endsWith('/api/account/admin/users/not-enrolled') && response.request().method() === 'GET' && response.status() === 200)
+            .then((response) => response.json() as Promise<string[]>);
+        const deletionImpactPromise = page
+            .waitForResponse((response) => response.url().endsWith('/api/account/admin/users/deletion-impact') && response.status() === 200)
+            .then((response) => response.json() as Promise<DeletionImpact>);
         await page.getByRole('button', { name: 'Delete not enrolled users' }).click();
-        const [notEnrolled, impact] = await Promise.all([notEnrolledResponse, impactResponse]);
-
-        // Both bodies are read before anything is asserted on either. Chromium keeps a response body only until the
-        // page moves on from it, and reading one of them late failed in CI with "No data found for resource with
-        // given identifier" while the assertions in between gave it time to be dropped.
-        const [notEnrolledLogins, deletionImpact] = (await Promise.all([notEnrolled.json(), impact.json()])) as [string[], DeletionImpact];
+        const [notEnrolledLogins, deletionImpact] = await Promise.all([notEnrolledLoginsPromise, deletionImpactPromise]);
         expect(notEnrolledLogins).toContain(userLogin);
         expect(notEnrolledLogins).not.toContain('iris_bot');
         expect(deletionImpact.users.map((user) => user.login)).toContain(userLogin);
@@ -395,16 +400,18 @@ test.describe('Retention-aware user deletion', { tag: '@fast' }, () => {
 
         const dialog = page.getByRole('dialog', { name: 'Permanently delete user data' });
         await dialog.getByRole('textbox').fill('2');
-        const deletionResponse = page.waitForResponse(
-            (response) => response.url().endsWith('/api/account/admin/users') && response.request().method() === 'DELETE' && response.status() === 200,
-        );
+        // As above: the deletion result is read as its response arrives. The refreshed impact request that this
+        // deletion triggers is enough for Chromium to drop the deletion body before both responses are in hand.
+        const deletionResultsPromise = page
+            .waitForResponse((response) => response.url().endsWith('/api/account/admin/users') && response.request().method() === 'DELETE' && response.status() === 200)
+            .then((response) => response.json());
         const refreshedImpactResponse = page.waitForResponse(
             (response) => response.url().endsWith('/api/account/admin/users/deletion-impact') && response.request().method() === 'POST' && response.status() === 200,
         );
         await dialog.getByTestId('confirm-delete-users').getByRole('button').click();
-        const [deletion, refreshedImpact] = await Promise.all([deletionResponse, refreshedImpactResponse]);
+        const [deletionResults, refreshedImpact] = await Promise.all([deletionResultsPromise, refreshedImpactResponse]);
 
-        expect(await deletion.json()).toEqual([
+        expect(deletionResults).toEqual([
             { userId: expect.any(Number), login: firstLogin, status: 'DELETED', reason: null },
             { userId: expect.any(Number), login: secondLogin, status: 'PLAN_CHANGED', reason: 'impactChanged' },
         ]);

--- a/src/test/playwright/support/requests/UserManagementAPIRequests.ts
+++ b/src/test/playwright/support/requests/UserManagementAPIRequests.ts
@@ -45,20 +45,22 @@ export class UserManagementAPIRequests {
      *
      * Deletion confirms against the impact the administrator was shown, so the current fingerprint has to be fetched
      * first and handed back with the request. A bare `DELETE api/account/admin/users/{login}` is rejected with 400
-     * because its body is required, and a stale fingerprint is rejected with 409, so both steps belong together and
-     * live here rather than in each spec that has to clean up after itself.
+     * because its body is required, and a stale fingerprint with 409, so both steps belong together and live here
+     * rather than in each spec that has to clean up after itself.
+     *
+     * The single-user endpoint is used on purpose: it answers 200 only when the account is really gone, and 409 or
+     * 403 when the plan changed or retention refused it. The bulk endpoint reports the same outcomes per user inside
+     * a body it always returns with 200, so a caller checking the status alone would read a refusal as a success.
      *
      * @param username the login of the user to delete
      * @returns the deletion response, or the impact response when that already failed
      */
     async deleteUser(username: string): Promise<APIResponse> {
-        const impactResponse = await this.page.request.post('api/account/admin/users/deletion-impact', { data: { logins: [username] } });
+        const impactResponse = await this.page.request.get(`api/account/admin/users/${username}/deletion-impact`);
         if (!impactResponse.ok()) {
             return impactResponse;
         }
-        const impact = (await impactResponse.json()) as { users: { login: string; impactFingerprint: string }[] };
-        return await this.page.request.delete('api/account/admin/users', {
-            data: { users: impact.users.map((user) => ({ login: user.login, impactFingerprint: user.impactFingerprint })) },
-        });
+        const impact = (await impactResponse.json()) as { impactFingerprint: string };
+        return await this.page.request.delete(`api/account/admin/users/${username}`, { data: { impactFingerprint: impact.impactFingerprint } });
     }
 }

--- a/src/test/playwright/support/requests/UserManagementAPIRequests.ts
+++ b/src/test/playwright/support/requests/UserManagementAPIRequests.ts
@@ -39,4 +39,26 @@ export class UserManagementAPIRequests {
     async getUser(username: string): Promise<APIResponse> {
         return await this.page.request.get(`api/account/admin/users/${username}`);
     }
+
+    /**
+     * Permanently deletes a user.
+     *
+     * Deletion confirms against the impact the administrator was shown, so the current fingerprint has to be fetched
+     * first and handed back with the request. A bare `DELETE api/account/admin/users/{login}` is rejected with 400
+     * because its body is required, and a stale fingerprint is rejected with 409, so both steps belong together and
+     * live here rather than in each spec that has to clean up after itself.
+     *
+     * @param username the login of the user to delete
+     * @returns the deletion response, or the impact response when that already failed
+     */
+    async deleteUser(username: string): Promise<APIResponse> {
+        const impactResponse = await this.page.request.post('api/account/admin/users/deletion-impact', { data: { logins: [username] } });
+        if (!impactResponse.ok()) {
+            return impactResponse;
+        }
+        const impact = (await impactResponse.json()) as { users: { login: string; impactFingerprint: string }[] };
+        return await this.page.request.delete('api/account/admin/users', {
+            data: { users: impact.users.map((user) => ({ login: user.login, impactFingerprint: user.impactFingerprint })) },
+        });
+    }
 }


### PR DESCRIPTION
### Summary
Two admin end-to-end tests have been failing on every branch since retention-aware permanent deletion landed (#13624). They are unrelated to each other and neither is flaky: both fail deterministically, and the second one only on CI. This repairs both.

### Motivation and Context
`Personal data export › Exports a repository as a walkable repository directory rather than a nested archive` and `Retention-aware user deletion › previews not-enrolled users without deleting before confirmation` show up as red on every open pull request, so every author has to decide again whether the failure is theirs. They are currently visible on #13657, #13655, #13649, #13612 and #13617.

### Description

**The data export could no longer clean up after itself.** Its `afterEach` removed the student it had created with a bare `DELETE api/account/admin/users/{login}`. That endpoint now takes a required body carrying the fingerprint of the impact the administrator was shown:

```java
public ResponseEntity<UserDeletionResultDTO> deleteUser(@PathVariable String login, @Valid @RequestBody PermanentUserDeletionRequestDTO request)
```

so the bodiless request is answered with `400 Failed to read request`, and the assertion that the account was removed fails. Reproduced directly against a local server: without a body `400`, with a body but a stale fingerprint `409 PLAN_CHANGED`.

Deleting a user is therefore a two-step operation now: ask for the impact, then delete quoting its fingerprint. `UserDeletion.spec.ts` already spelled that out inline for its own cleanup, which is why only the export broke. The sequence moves into `UserManagementAPIRequests.deleteUser` and both specs call it, so the next spec that has to remove an account does not have to rediscover the contract.

**The not-enrolled preview read a response body too late.** It captures two responses, then asserts on the first body before reading the second:

```ts
const notEnrolledLogins = (await notEnrolled.json()) as string[];
expect(notEnrolledLogins).toContain(userLogin);
expect(notEnrolledLogins).not.toContain('iris_bot');
expect(((await impact.json()) as DeletionImpact).users.map((user) => user.login)).toContain(userLogin);
```

Chromium keeps a response body only until the page moves on from it, so the second read failed on CI with `Protocol error (Network.getResponseBody): No data found for resource with given identifier`. It passes locally because the window is short there. Both bodies are now read before either is asserted on, which is what the Playwright error text asks for ("Read response.body() before triggering any navigation"). `serviceWorkers: 'block'` is already set, so the service worker is not the amplifier here.

I swept the rest of the suite for the same pattern (a captured response whose body is read more than two lines later); these were the only two occurrences and both are in the line above.

### Steps for Testing
No product behaviour changes; this only touches the Playwright suite.

1. Run the two specs: `./run-e2e-tests-local-fast.sh --filter "DataExport|UserDeletion"`
2. All seven tests pass.

Before the change, `Personal data export` fails locally with `the student this test created has to be removed again`.

### Testserver States
Not needed, the change is limited to end-to-end tests.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated user cleanup reliability during personal data export and user deletion tests.
  * Reduced intermittent CI failures by ensuring response data is captured before assertions.
  * Standardized test user removal through a shared request workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->