### PR TITLE
`Development`: Give the archive download button a stable test hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,18 @@ Organized by feature module:
     - The script automatically kills processes on ports 8080, 9000, and 7921 before starting
     - Use `--filter "TestName"` to run specific tests; supports regex patterns (e.g., `--filter "Quiz|Exam"`)
     - After the first run, reuse running services with `--skip-server --skip-client --skip-db`
+    - **Never edit files under `src/main/webapp` while a run is in progress** — the dev server rebuilds and reloads the
+      page in the browsers Playwright is driving, which fails whichever test is mid-action and looks like a product bug
+- **E2E locators: `data-testid` first.** Reach for `page.getByTestId()` (or `[data-testid="..."]` when it has to be
+  combined with another attribute, as in `page.locator('[data-testid="archive-download-button"][data-mode="Course"]')`).
+    - **Never bind a locator to a styling class.** Bootstrap, PrimeNG and Tailwind class names describe how an element
+      looks, so a restyle silently breaks the test and nothing in the diff points at it. `button.btn-primary` in the two
+      archive specs is what made them wait ~11 minutes each once that button became a TUM UI button.
+    - Use an `id` only when it already exists for a production reason (a label `for`, an `aria-*` reference, an anchor
+      target). An id that exists only so a test can find something should be a `data-testid` instead: the test id is a
+      contract that tells the next person editing the template that a test depends on it.
+    - When adding a hook, name it after what the element is, kebab-cased (`archive-download-button`)
+    - Full rules: `documentation/docs/developer/e2e-testing-playwright.mdx` (### 3. Use uniquely identifiable locators)
 - Add screenshots for UI changes in PRs
 - Verify linting before submitting: `pnpm run lint`, `./gradlew checkstyleMain -x webapp`
 

--- a/documentation/docs/developer/e2e-testing-playwright.mdx
+++ b/documentation/docs/developer/e2e-testing-playwright.mdx
@@ -385,19 +385,37 @@ test('Test name', async ({ fixtureName }) => {
 ### 3. Use uniquely identifiable locators
 
 Use unique locators to identify elements on the page. Playwright throws an error when interacting with a locator
-that matches multiple elements on the page. To ensure uniqueness, use locators based on the element's
-`data-testid`, `id`, unique `class` or a combination of these attributes.
+that matches multiple elements on the page. Reach for locators in this order:
 
-Avoid using the `nth()` method or the `nth-child` selector, as they rely on the element's position in the DOM
-hierarchy. Use these methods only when iterating over multiple similar elements.
-
-Avoid using locators that are prone to change. If a component lacks a unique selector,
-add a `data-testid` attribute with a unique value to its template. This ensures that the component is easily
-identifiable, making tests less likely to break when there are changes to the component.
+1. `data-testid`, through `page.getByTestId()` or `[data-testid="..."]` when it has to be combined with another
+   attribute. This is the default attribute Playwright looks for and the one to add when an element has no hook yet.
+2. An `id`, but only when that id already exists for a production reason of its own, such as a `for` on a label, an
+   `aria-describedby`, or an anchor target. An id that exists only so that a test can find something is a
+   `data-testid` wearing the wrong name.
+3. Text-based and role-based locators, for the rare case where the user-facing text *is* the thing under test.
 
 Prefer `data-testid` over text-based and role-based locators as the primary strategy. Text-based and role-based
 locators break whenever display text or component structure changes — turning a UI rename into a test failure
 unrelated to any regression. A `data-testid` attribute survives UI refactors as long as the attribute itself is preserved.
+
+<Callout variant={CalloutVariant.danger}>
+
+    Never bind a locator to a class that exists for styling. Bootstrap, PrimeNG and Tailwind class names describe how
+    an element looks, so restyling it silently breaks every test that hunted for it that way, and nothing in the diff
+    points at the tests.
+
+    Both archive tests used to find the download button as `button.btn-primary[data-mode="Course"]`. When that button
+    became a TUM UI button, the class disappeared and both tests waited about eleven minutes each for an element that
+    could no longer exist.
+
+</Callout>
+
+Avoid using the `nth()` method or the `nth-child` selector, as they rely on the element's position in the DOM
+hierarchy. Use these methods only when iterating over multiple similar elements.
+
+A `data-testid` is a contract: it tells whoever edits that template that a test depends on the element, which an id or
+a class never does. Keep the value stable and kebab-cased, and name it after what the element *is*
+(`archive-download-button`) rather than where it currently sits.
 
 ### 4. Consider actionability of elements
 

--- a/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.html
+++ b/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.html
@@ -15,7 +15,14 @@
         </button>
     }
     @if (displayDownloadArchiveButton()) {
-        <button [disabled]="isBeingArchived()" type="button" [attr.data-mode]="archiveMode()" class="btn btn-sm btn-primary" (click)="downloadArchive()">
+        <button
+            [disabled]="isBeingArchived()"
+            type="button"
+            [attr.data-mode]="archiveMode()"
+            data-testid="archive-download-button"
+            class="btn btn-sm btn-primary"
+            (click)="downloadArchive()"
+        >
             <fa-icon [icon]="faDownload" />&nbsp;
             <span jhiTranslate="artemisApp.courseExamArchive.downloadArchive"></span>
         </button>

--- a/src/test/playwright/e2e/course/CourseArchive.spec.ts
+++ b/src/test/playwright/e2e/course/CourseArchive.spec.ts
@@ -77,7 +77,7 @@ test.describe('Course archive', { tag: '@slow' }, () => {
 
         await page.reload();
         const { filePath, suggestedFilename } = await downloadArchive(page, async () => {
-            await page.locator('button.btn-primary[data-mode="Course"]').click();
+            await page.locator('[data-testid="archive-download-button"][data-mode="Course"]').click();
         });
 
         expect(suggestedFilename).toMatch(/\.zip$/);

--- a/src/test/playwright/e2e/exam/ExamArchive.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamArchive.spec.ts
@@ -59,7 +59,7 @@ test.describe('Exam archive', { tag: '@slow' }, () => {
         await page.locator('.modal-footer .btn-warning').click();
 
         // Archiving runs asynchronously; the download button only appears once the archive is on disk.
-        const downloadButton = page.locator('button.btn-primary[data-mode="Exam"]');
+        const downloadButton = page.locator('[data-testid="archive-download-button"][data-mode="Exam"]');
         await expect(async () => {
             await page.reload();
             await expect(downloadButton).toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
### Summary
The two archive end-to-end tests find the download button by a Bootstrap utility class, `button.btn-primary[data-mode="…"]`. That ties a test to how the button is styled, so restyling it breaks the test with no hint that the two are related. The button gets a stable `id` and both tests use it.

### Motivation and Context
The button next to it is already found by `#archiveButton[data-mode="…"]`, so the download button is the odd one out rather than this being a new convention.

This is not theoretical. In #13617 the button moves from `class="btn btn-sm btn-primary"` to the TUM UI button, and both `Course archive` and `Exam archive` then wait for an element that cannot exist any more until they time out, roughly eleven minutes each. Nothing in that diff points at the archive tests, and the failure reads as an archiving problem rather than a selector problem.

These tests pass on `develop` today, so this PR is a hardening change and not a repair: `btn-primary` is still on the button here, and the tests would keep passing either way. The point is that the next restyle should not be able to break them.

### Description
- `data-testid="archive-download-button"` on the download button, next to the `data-mode` attribute the tests already qualify on. The class stays, so nothing about the styling changes.
- `CourseArchive.spec.ts` and `ExamArchive.spec.ts` select on that instead of the class.

A test id rather than an id: it is the attribute Playwright looks for by default, it is what the recent work in this repository reaches for, and unlike an id it says out loud that a test depends on it, so the next restyle has a reason to keep it. Combining it with the existing `data-mode` qualifier follows the shape already used elsewhere, for example `page.locator('[data-testid="user-row"]', ...)` in `UserDeletion.spec.ts`.

The sibling `#archiveButton` is left alone. An id is not tied to styling, so it is not fragile in the way the class was, and changing it here would only widen the overlap with #13617 in the same file for no gain.

### Steps for Testing
No product behaviour changes; the button keeps its markup and its styling.

1. `./run-e2e-tests-local-fast.sh --filter "CourseArchive|ExamArchive"`
2. Both tests pass.

The confirmation step in both tests still selects `.modal-footer .btn-warning`. That button belongs to the shared archive warning dialog rather than to this component, and giving it a hook of its own would reach further than one test seam, so it is left for a separate change.

### Note on #13617
#13617 carries the same three-line change so that its own end-to-end run is green while it is in review. The two specs are changed identically and merge cleanly; the component is the same one-attribute addition on either side of its restyle, so the overlap resolves when that branch next merges `develop`.

### Testserver States
Not needed, the change is limited to a test hook.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved course and exam archive download test reliability by using a dedicated button identifier instead of styling-based selectors.

* **Documentation**
  * Updated Playwright guidance to prioritize stable test identifiers and production-purpose IDs over styling classes or generic selectors.
  * Added guidance for creating descriptive, stable test hooks and avoiding application changes during test runs.

* **Refactor**
  * Added a dedicated identifier to the archive download button without changing its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->