### PR TITLE
`Development`: Give the end-to-end tests hooks of their own

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,6 +307,14 @@ Organized by feature module:
       target). An id that exists only so a test can find something should be a `data-testid` instead: the test id is a
       contract that tells the next person editing the template that a test depends on it.
     - When adding a hook, name it after what the element is, kebab-cased (`archive-download-button`)
+    - For markup a third party renders, use its structural API, not its classes: PrimeNG's `[pt]` pass-through carries
+      a `data-testid` onto any internal section (declare it as a component field, not a template literal), a `pc`-prefixed
+      section forwards to a component so the attribute goes on its `root`, and `data-p-icon` separates two elements that
+      share one section. `page.getByRole('dialog')` covers "whichever dialog is open". Monaco is the one exception: it
+      builds its own DOM and its decoration API takes only a class name, so say so in a comment.
+    - Asserting a state class is not the same as locating by one. Find the element by its own hook, then assert the
+      class, and only when the library exposes that state no other way. Artemis-owned markup should expose an attribute
+      (`data-selected`, `data-invalid`) instead.
     - Full rules: `documentation/docs/developer/e2e-testing-playwright.mdx` (### 3. Use uniquely identifiable locators)
 - Add screenshots for UI changes in PRs
 - Verify linting before submitting: `pnpm run lint`, `./gradlew checkstyleMain -x webapp`

--- a/documentation/docs/developer/e2e-testing-playwright.mdx
+++ b/documentation/docs/developer/e2e-testing-playwright.mdx
@@ -1,6 +1,6 @@
-import Callout from "../../src/components/Callout/Callout";
-import {CalloutVariant} from "../../src/components/Callout/Callout.types";
-import Image, {ImageSize} from "../../src/components/Image/Image";
+import Callout from '../../src/components/Callout/Callout';
+import { CalloutVariant } from '../../src/components/Callout/Callout.types';
+import Image, { ImageSize } from '../../src/components/Image/Image';
 
 import e2eHwSwMapping from './assets/playwright_hw_sw_mapping.png';
 import e2eCiPipelineSsd from './assets/playwright_ci_pipeline_ssd.png';
@@ -122,18 +122,18 @@ After the first run, services stay running. Skip startup for faster re-runs:
 
 **Available options:**
 
-| Flag | Description |
-|------|-------------|
-| `--stop` | Kill server, client, and database; exit |
+| Flag                 | Description                                                                            |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| `--stop`             | Kill server, client, and database; exit                                                |
 | `--filter <pattern>` | Run only tests matching the pattern (supports regex, e.g., `"Quiz"` or `"Quiz\|Exam"`) |
-| `--skip-server` | Reuse already-running server |
-| `--skip-client` | Reuse already-running client |
-| `--skip-db` | Reuse already-running PostgreSQL |
-| `--headed` | Run Playwright in headed mode (visible browser) |
-| `--ui` | Open Playwright UI mode for interactive debugging |
-| `--video` | Enable video recording (off by default to save CPU) |
-| `--coverage` | Enable coverage collection (off by default, requires extra memory) |
-| `--debug` | Show server and client output inline (normally only in log files) |
+| `--skip-server`      | Reuse already-running server                                                           |
+| `--skip-client`      | Reuse already-running client                                                           |
+| `--skip-db`          | Reuse already-running PostgreSQL                                                       |
+| `--headed`           | Run Playwright in headed mode (visible browser)                                        |
+| `--ui`               | Open Playwright UI mode for interactive debugging                                      |
+| `--video`            | Enable video recording (off by default to save CPU)                                    |
+| `--coverage`         | Enable coverage collection (off by default, requires extra memory)                     |
+| `--debug`            | Show server and client output inline (normally only in log files)                      |
 
 Logs and PID files are stored in the `.e2e-local/` directory (gitignored).
 
@@ -172,6 +172,7 @@ SLOW_TEST_TIMEOUT_SECONDS=90
 <Callout variant={CalloutVariant.info}>
 
     <code>BASE_URL=http://localhost:9000</code> is correct for manual setup where the Angular dev server runs on port 9000.
+
 The committed <code>playwright.env</code> defaults to <code>BASE_URL=https://localhost</code> (no port, HTTPS) for the Docker-based setup.
 
 </Callout>
@@ -246,6 +247,7 @@ file.
 <Callout variant={CalloutVariant.warning}>
 
     Using more worker processes divides the available computing resources, giving each worker fewer resources. Using too
+
 many workers can lead to resource contention, slowing down individual test execution and potentially causing
 timeouts.
 
@@ -258,10 +260,10 @@ sequentially, while running test files in parallel, set the `fullyParallel` opti
 
 Playwright is configured with two test projects that determine the per-test timeout budget:
 
-| Project | Tag | Timeout (local) | Timeout (CI) | Use for |
-|---------|-----|-----------------|--------------|---------|
-| `fast-tests` | `@fast` or no tag | 45 s | 60 s | Tests that complete quickly and do not involve long-running background jobs |
-| `slow-tests` | `@slow` | 90 s | 90 s | Tests that wait for CI/CD builds, large data processing, or other asynchronous operations |
+| Project      | Tag               | Timeout (local) | Timeout (CI) | Use for                                                                                   |
+| ------------ | ----------------- | --------------- | ------------ | ----------------------------------------------------------------------------------------- |
+| `fast-tests` | `@fast` or no tag | 45 s            | 60 s         | Tests that complete quickly and do not involve long-running background jobs               |
+| `slow-tests` | `@slow`           | 90 s            | 90 s         | Tests that wait for CI/CD builds, large data processing, or other asynchronous operations |
 
 Tag a test suite with `{ tag: '@slow' }` when it involves build pipelines or polling for background jobs; otherwise omit the tag (defaults to `fast-tests`):
 
@@ -360,7 +362,7 @@ To create a fixture, define its instance inside a corresponding existing type or
 ```typescript
 export type ArtemisPageObjects = {
     loginPage: LoginPage;
-}
+};
 ```
 
 Ensure the base test (`base`) extends the fixture type. Define a fixture with the relevant name and return the
@@ -369,8 +371,8 @@ desired instance as an argument of `use()` function as below:
 ```typescript
 export const test = base.extend<ArtemisPageObjects>({
     loginPage: async ({ page }, use) => {
-      await use(new LoginPage(page));
-    }
+        await use(new LoginPage(page));
+    },
 });
 ```
 
@@ -392,7 +394,7 @@ that matches multiple elements on the page. Reach for locators in this order:
 2. An `id`, but only when that id already exists for a production reason of its own, such as a `for` on a label, an
    `aria-describedby`, or an anchor target. An id that exists only so that a test can find something is a
    `data-testid` wearing the wrong name.
-3. Text-based and role-based locators, for the rare case where the user-facing text *is* the thing under test.
+3. Text-based and role-based locators, for the rare case where the user-facing text _is_ the thing under test.
 
 Prefer `data-testid` over text-based and role-based locators as the primary strategy. Text-based and role-based
 locators break whenever display text or component structure changes — turning a UI rename into a test failure
@@ -414,7 +416,7 @@ Avoid using the `nth()` method or the `nth-child` selector, as they rely on the 
 hierarchy. Use these methods only when iterating over multiple similar elements.
 
 A `data-testid` is a contract: it tells whoever edits that template that a test depends on the element, which an id or
-a class never does. Keep the value stable and kebab-cased, and name it after what the element *is*
+a class never does. Keep the value stable and kebab-cased, and name it after what the element _is_
 (`archive-download-button`) rather than where it currently sits.
 
 #### Markup you do not own
@@ -455,12 +457,13 @@ Monaco classes, and say in a comment why the class is there.
 
 #### Asserting a state class is not the same as finding an element by one
 
-The rule above is about *finding* elements. Asserting that an element carries a state class is a different thing, and
+The rule above is about _finding_ elements. Asserting that an element carries a state class is a different thing, and
 it is fine when the library exposes that state in no other way. Find the element by its own hook first, then assert
 the class on it:
 
 ```typescript
-// PrimeNG marks the selected day with a class and offers no attribute or ARIA state for it.
+// As of PrimeNG 21.1.9 the day cell carries `data-date` but marks the selection only with a class: no attribute
+// and no ARIA state says which day is selected. Re-check this when PrimeNG is upgraded.
 await expect(panel.locator(`[data-testid="date-picker-day"][data-date="${key}"]`)).toHaveClass(/p-datepicker-day-selected/);
 ```
 
@@ -471,7 +474,7 @@ such as `data-selected` or `data-invalid`, and assert on it.
 
 Checking for the state of an element before interacting with it is crucial to avoid flaky behavior. Actions like
 clicking a button or typing into an input field require a particular state from the element, such as visible and
-enabled, which makes it actionable.  Playwright ensures that the elements you interact with are actionable before
+enabled, which makes it actionable. Playwright ensures that the elements you interact with are actionable before
 performing such actions.
 
 However, some complex interactions may require additional checks to ensure the element is in the desired state. For
@@ -486,6 +489,7 @@ const urlText = await this.page.locator('.clone-url').innerText();
 <Callout variant={CalloutVariant.warning}>
 
     Avoid using <code>page.waitForSelector()</code> function to wait for an element to appear on the page. This function
+
 waits for the visibility in the DOM, but it does not guarantee that the element is actionable. Always
 prefer the <code>waitFor()</code> function of a locator instead.
 
@@ -501,6 +505,7 @@ await page.waitForLoadState('load');
 <Callout variant={CalloutVariant.warning}>
 
     Waiting for the page load state is not recommended if we are only interested in specific elements appearing on
+
 the page - use <code>waitFor()</code> function of a locator instead.
 
 </Callout>
@@ -530,15 +535,20 @@ the pull request; Phase 2 runs all remaining tests, but only when Phase 1 passes
 This architecture ensures developers receive targeted feedback within minutes for the tests most likely to surface
 a regression, while still running the full suite before merge.
 
-<Image src={e2eCiPipelineSsd} alt="Two-phase CI pipeline activity diagram showing Developer, CI Pipeline, Helios, and Reports Dashboard swimlanes" size={ImageSize.large} caption="Two-phase CI pipeline activity diagram. Phase 1 runs change-relevant tests first. If Phase 1 passes, Phase 2 runs the remaining tests. Both phases query Helios for flakiness scores and upload artifacts to the Reports Dashboard before posting the PR comment." />
+<Image
+    src={e2eCiPipelineSsd}
+    alt="Two-phase CI pipeline activity diagram showing Developer, CI Pipeline, Helios, and Reports Dashboard swimlanes"
+    size={ImageSize.large}
+    caption="Two-phase CI pipeline activity diagram. Phase 1 runs change-relevant tests first. If Phase 1 passes, Phase 2 runs the remaining tests. Both phases query Helios for flakiness scores and upload artifacts to the Reports Dashboard before posting the PR comment."
+/>
 
 **Observed performance** (across 89 measured runs):
 
-| Metric | Phase 1 | Phase 2 | Full suite (single-phase baseline) |
-|--------|--------:|--------:|----------------------------------:|
-| Median duration | 4.3 min | 23.8 min | 27.7 min |
-| P90 duration | 8.3 min | 29.4 min | 32.2 min |
-| Pass rate | 82% | 64.4% (of runs that reach it) | — |
+| Metric          | Phase 1 |                       Phase 2 | Full suite (single-phase baseline) |
+| --------------- | ------: | ----------------------------: | ---------------------------------: |
+| Median duration | 4.3 min |                      23.8 min |                           27.7 min |
+| P90 duration    | 8.3 min |                      29.4 min |                           32.2 min |
+| Pass rate       |     82% | 64.4% (of runs that reach it) |                                  — |
 
 When Phase 1 detects a failure, developers receive feedback within approximately four minutes and Phase 2
 does not consume compute resources.
@@ -553,56 +563,41 @@ All `testPaths` and `allTestPaths` entries are resolved relative to `src/test/pl
 
 ```json
 {
-  "allTestPaths": [
-    "e2e/atlas/",
-    "e2e/course/",
-    "e2e/exam/ExamAssessment.spec.ts",
-    "e2e/exam/ExamChecklists.spec.ts",
-    "e2e/exam/ExamCreationDeletion.spec.ts",
-    "e2e/exam/ExamDateVerification.spec.ts",
-    "e2e/exam/ExamManagement.spec.ts",
-    "e2e/exam/ExamParticipation.spec.ts",
-    "e2e/exam/ExamResults.spec.ts",
-    "e2e/exam/ExamTestRun.spec.ts",
-    "e2e/exam/test-exam/",
-    "e2e/exercise/ExerciseImport.spec.ts",
-    "e2e/exercise/file-upload/",
-    "e2e/exercise/modeling/",
-    "e2e/exercise/programming/",
-    "e2e/exercise/quiz-exercise/",
-    "e2e/exercise/text/",
-    "e2e/lecture/",
-    "e2e/Login.spec.ts",
-    "e2e/Logout.spec.ts",
-    "e2e/SystemHealth.spec.ts"
-  ],
-  "mappings": {
-    "atlas": {
-      "sourcePaths": [
-        "src/main/java/de/tum/cit/aet/artemis/atlas/",
-        "src/main/webapp/app/atlas/"
-      ],
-      "testPaths": ["e2e/atlas/"]
+    "allTestPaths": [
+        "e2e/atlas/",
+        "e2e/course/",
+        "e2e/exam/ExamAssessment.spec.ts",
+        "e2e/exam/ExamChecklists.spec.ts",
+        "e2e/exam/ExamCreationDeletion.spec.ts",
+        "e2e/exam/ExamDateVerification.spec.ts",
+        "e2e/exam/ExamManagement.spec.ts",
+        "e2e/exam/ExamParticipation.spec.ts",
+        "e2e/exam/ExamResults.spec.ts",
+        "e2e/exam/ExamTestRun.spec.ts",
+        "e2e/exam/test-exam/",
+        "e2e/exercise/ExerciseImport.spec.ts",
+        "e2e/exercise/file-upload/",
+        "e2e/exercise/modeling/",
+        "e2e/exercise/programming/",
+        "e2e/exercise/quiz-exercise/",
+        "e2e/exercise/text/",
+        "e2e/lecture/",
+        "e2e/Login.spec.ts",
+        "e2e/Logout.spec.ts",
+        "e2e/SystemHealth.spec.ts"
+    ],
+    "mappings": {
+        "atlas": {
+            "sourcePaths": ["src/main/java/de/tum/cit/aet/artemis/atlas/", "src/main/webapp/app/atlas/"],
+            "testPaths": ["e2e/atlas/"]
+        },
+        "exam": {
+            "sourcePaths": ["src/main/java/de/tum/cit/aet/artemis/exam/", "src/main/webapp/app/exam/"],
+            "testPaths": ["e2e/exam/"]
+        }
     },
-    "exam": {
-      "sourcePaths": [
-        "src/main/java/de/tum/cit/aet/artemis/exam/",
-        "src/main/webapp/app/exam/"
-      ],
-      "testPaths": ["e2e/exam/"]
-    }
-  },
-  "alwaysRunTests": [
-    "e2e/Login.spec.ts",
-    "e2e/Logout.spec.ts",
-    "e2e/SystemHealth.spec.ts"
-  ],
-  "runAllTestsPatterns": [
-    "src/main/resources/config/",
-    "docker/",
-    "build.gradle",
-    "angular.json"
-  ]
+    "alwaysRunTests": ["e2e/Login.spec.ts", "e2e/Logout.spec.ts", "e2e/SystemHealth.spec.ts"],
+    "runAllTestsPatterns": ["src/main/resources/config/", "docker/", "build.gradle", "angular.json"]
 }
 ```
 
@@ -611,6 +606,7 @@ The union of the test paths from all matched modules, plus the `alwaysRunTests` 
 The remaining entries from `allTestPaths` form the Phase 2 set.
 
 **Special cases:**
+
 - If a changed file matches a `runAllTestsPatterns` entry (e.g., a Docker or Gradle file), the pipeline runs all tests in a single job.
 - If only Playwright spec files were changed, Phase 2 is skipped and only Phase 1 runs.
 - If no module mapping is found for a changed file, it falls through to Phase 2.
@@ -626,6 +622,7 @@ a collapsible section listing each failed test name and its duration; and a flak
 tests when Helios data is available.
 
 Three outcomes are possible:
+
 1. **Both phases pass** — example: [PR #12516](https://github.com/ls1intum/Artemis/pull/12516)
 2. **Phase 1 passes, Phase 2 fails** — example: [PR #12489](https://github.com/ls1intum/Artemis/pull/12489)
 3. **Phase 1 fails, Phase 2 skipped** — example: [PR #12487](https://github.com/ls1intum/Artemis/pull/12487)
@@ -651,7 +648,12 @@ accessible from the link in the PR comment. It provides:
 Every execution of the Playwright test suite requires the Artemis server and client to be deployed and started.
 The runner starts all required services using Docker Compose and executes Playwright tests on the host.
 
-<Image src={e2eHwSwMapping} alt="Hardware-software mapping showing five nodes: Developer Machine, GitHub, Self-Hosted CI Runner, Reports Dashboard, and Helios" size={ImageSize.large} caption="Hardware-software mapping of the E2E testing infrastructure. The Developer Machine pushes to GitHub, which triggers the Actions Orchestrator. The Self-Hosted CI Runner executes tests and sends results to the Reports Dashboard and PR comments via the Report and Communication Handler. The Helios node provides flakiness scores." />
+<Image
+    src={e2eHwSwMapping}
+    alt="Hardware-software mapping showing five nodes: Developer Machine, GitHub, Self-Hosted CI Runner, Reports Dashboard, and Helios"
+    size={ImageSize.large}
+    caption="Hardware-software mapping of the E2E testing infrastructure. The Developer Machine pushes to GitHub, which triggers the Actions Orchestrator. The Self-Hosted CI Runner executes tests and sends results to the Reports Dashboard and PR comments via the Report and Communication Handler. The Helios node provides flakiness scores."
+/>
 
 E2E tests run on self-hosted runners (not GitHub-hosted) because they require substantial compute resources.
 Self-hosted runners do not start from a clean state between jobs; the pipeline explicitly cleans up leftover
@@ -706,228 +708,255 @@ This step does not apply to CI, where Playwright runs directly on the host (not 
 
 When a new Artemis module is created or an existing module is significantly reorganized, update
 `.ci/E2E-tests/e2e-test-mapping.json`:
+
 1. Add a new entry to `mappings` with the module's `sourcePaths` and `testPaths`.
 2. Add all new test paths to `allTestPaths` so Phase 2 covers them on unrelated PRs.
 
 ## Functionalities Covered
 
 <table>
-  <thead>
-    <tr>
-      <th>Category</th>
-      <th>Functionality</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td rowspan="6"><strong>Atlas</strong></td>
-      <td>Competency Management</td>
-      <td>Creating, editing, and deleting competencies; setting taxonomy levels and mastery thresholds; soft-deleting with linked exercise warnings</td>
-    </tr>
-    <tr>
-      <td>Competency–Exercise Interactions</td>
-      <td>Linking and unlinking exercises to competencies; verifying that exercise progress contributes to competency mastery</td>
-    </tr>
-    <tr>
-      <td>Competency–Lecture Unit Interactions</td>
-      <td>Linking lecture units to competencies; verifying lecture unit completion updates competency progress</td>
-    </tr>
-    <tr>
-      <td>Competency Import</td>
-      <td>Importing competencies from other courses; verifying imported data integrity</td>
-    </tr>
-    <tr>
-      <td>Learning Path Management</td>
-      <td>Enabling learning paths in a course; verifying the learning path activation flow</td>
-    </tr>
-    <tr>
-      <td>Student Competency Progress View</td>
-      <td>Student competency overview, mastery indicators, judgment of learning ratings, and progress tracking across lecture units and exercises</td>
-    </tr>
-    <tr>
-      <td rowspan="3"><strong>Courses</strong></td>
-      <td>Course Management</td>
-      <td>Creating, editing, deleting courses; adding/removing students from a course</td>
-    </tr>
-    <tr>
-      <td>Course Exercise</td>
-      <td>Tests filtering exercises based on their title</td>
-    </tr>
-    <tr>
-      <td>Course Communication</td>
-      <td>Messaging within courses, including channel creation, group chats, student participation, and message interactions</td>
-    </tr>
-    <tr>
-      <td rowspan="10"><strong>Exams</strong></td>
-      <td>Exam Management</td>
-      <td>Manage exam students and exercise groups</td>
-    </tr>
-    <tr>
-      <td>Exam Creation & Deletion</td>
-      <td>Creating, editing, and deleting exams</td>
-    </tr>
-    <tr>
-      <td>Exam Participation</td>
-      <td>Early & normal hand-in, exam exercise participation for text, modeling, quiz, programming (Git SSH/HTTPS) exercises, exam announcements</td>
-    </tr>
-    <tr>
-      <td>Exam Assessment</td>
-      <td>Assessing modeling, text, quiz and programming exercise submissions in exams, including complaint handling</td>
-    </tr>
-    <tr>
-      <td>Exam Checklists</td>
-      <td>Exam setup checks, including student registration, exercise groups, and exam publication</td>
-    </tr>
-    <tr>
-      <td>Exam Date Verification</td>
-      <td>Exams appear/disappear based on visibility dates</td>
-    </tr>
-    <tr>
-      <td>Exam Results</td>
-      <td>Exam result overviews for text, quiz, modeling, and programming exercises</td>
-    </tr>
-    <tr>
-      <td>Exam Test Runs</td>
-      <td>Creating, managing, and deleting exam test runs</td>
-    </tr>
-    <tr>
-      <td>Exam Statistics</td>
-      <td>Exam statistics is displayed correctly</td>
-    </tr>
-    <tr>
-      <td>PlantUML Diagram Isolation</td>
-      <td>PlantUML diagrams in exam exercises render in isolation without leaking state between participants</td>
-    </tr>
-    <tr>
-      <td rowspan="5"><strong>Test Exams</strong></td>
-      <td>Test Exam Creation & Deletion</td>
-      <td>Creating and deleting test exams</td>
-    </tr>
-    <tr>
-      <td>Test Exam Management</td>
-      <td>Managing test exam configuration and settings</td>
-    </tr>
-    <tr>
-      <td>Test Exam Participation</td>
-      <td>Participating in test exams as a student</td>
-    </tr>
-    <tr>
-      <td>Test Exam Student Exams</td>
-      <td>Generating and managing individual student exam instances</td>
-    </tr>
-    <tr>
-      <td>Test Exam Test Runs</td>
-      <td>Creating and managing test runs within a test exam</td>
-    </tr>
-    <tr>
-      <td><strong>Exercises</strong></td>
-      <td>Exercise Import</td>
-      <td>Importing text, quiz, modeling & programming exercises</td>
-    </tr>
-    <tr>
-      <td rowspan="3"><strong>File Upload Exercises</strong></td>
-      <td>Management</td>
-      <td>Creating and deleting file upload exercises</td>
-    </tr>
-    <tr>
-      <td>Participation</td>
-      <td>Students can participate in a file upload exercise</td>
-    </tr>
-    <tr>
-      <td>Assessment & Feedback</td>
-      <td>Assessing submissions, student feedback visibility, and complaint handling</td>
-    </tr>
-    <tr>
-      <td rowspan="4"><strong>Modeling Exercises</strong></td>
-      <td>Management</td>
-      <td>Creating, editing, and deleting modeling exercises</td>
-    </tr>
-    <tr>
-      <td>Visibility Controls</td>
-      <td>Students can access released/unreleased exercises</td>
-    </tr>
-    <tr>
-      <td>Participation</td>
-      <td>Students can start and submit models</td>
-    </tr>
-    <tr>
-      <td>Assessment & Complaints</td>
-      <td>Instructor and tutor assessments, student feedback, and complaint resolution</td>
-    </tr>
-    <tr>
-      <td rowspan="5"><strong>Programming Exercises</strong></td>
-      <td>Management</td>
-      <td>Creating and deleting programming exercises</td>
-    </tr>
-    <tr>
-      <td>Team Management</td>
-      <td>Forming and managing exercise teams</td>
-    </tr>
-    <tr>
-      <td>Assessment</td>
-      <td>Assessing programming exercise submissions</td>
-    </tr>
-    <tr>
-      <td>Participation</td>
-      <td>Submitting code through the code editor and Git (HTTPS & SSH), submissions for Java, C, and Python, team participation</td>
-    </tr>
-    <tr>
-      <td>Static Code Analysis</td>
-      <td>Configuring SCA grading and handling submissions with SCA errors</td>
-    </tr>
-    <tr>
-      <td rowspan="5"><strong>Quiz Exercises</strong></td>
-      <td>Management</td>
-      <td>Creating quizzes with multiple-choice, short-answer, and drag-and-drop questions</td>
-    </tr>
-    <tr>
-      <td>Deletion & Export</td>
-      <td>Ensures quizzes can be deleted and exported</td>
-    </tr>
-    <tr>
-      <td>Participation</td>
-      <td>Tests student participation in hidden, scheduled, and batch-based quizzes</td>
-    </tr>
-    <tr>
-      <td>Assessment</td>
-      <td>Verifies automatic assessment for multiple-choice and short-answer quizzes</td>
-    </tr>
-    <tr>
-      <td>Drag-and-Drop Mechanics</td>
-      <td>Ensures correct placement of draggable quiz elements</td>
-    </tr>
-    <tr>
-      <td rowspan="3"><strong>Text Exercises</strong></td>
-      <td>Management</td>
-      <td>Creating and deleting text exercises</td>
-    </tr>
-    <tr>
-      <td>Participation</td>
-      <td>Ensures students can submit text exercises</td>
-    </tr>
-    <tr>
-      <td>Assessment & Complaints</td>
-      <td>Tests instructor assessments, feedback visibility, and complaint handling</td>
-    </tr>
-    <tr>
-      <td><strong>Lectures</strong></td>
-      <td>Lecture Management</td>
-      <td>Creating and deleting lectures, managing existing lectures</td>
-    </tr>
-    <tr>
-      <td rowspan="2"><strong>Authentication</strong></td>
-      <td>Logging in</td>
-      <td>Logging in via UI and programmatically, login failures</td>
-    </tr>
-    <tr>
-      <td>Logging out</td>
-      <td>Logging out successfully and canceling logout</td>
-    </tr>
-    <tr>
-      <td><strong>System Status</strong></td>
-      <td>System status indicators</td>
-      <td>Continuous integration & VC server health; Database, Hazelcast, and WebSocket health; Readiness and ping checks</td>
-    </tr>
-  </tbody>
+    <thead>
+        <tr>
+            <th>Category</th>
+            <th>Functionality</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td rowspan="6">
+                <strong>Atlas</strong>
+            </td>
+            <td>Competency Management</td>
+            <td>Creating, editing, and deleting competencies; setting taxonomy levels and mastery thresholds; soft-deleting with linked exercise warnings</td>
+        </tr>
+        <tr>
+            <td>Competency–Exercise Interactions</td>
+            <td>Linking and unlinking exercises to competencies; verifying that exercise progress contributes to competency mastery</td>
+        </tr>
+        <tr>
+            <td>Competency–Lecture Unit Interactions</td>
+            <td>Linking lecture units to competencies; verifying lecture unit completion updates competency progress</td>
+        </tr>
+        <tr>
+            <td>Competency Import</td>
+            <td>Importing competencies from other courses; verifying imported data integrity</td>
+        </tr>
+        <tr>
+            <td>Learning Path Management</td>
+            <td>Enabling learning paths in a course; verifying the learning path activation flow</td>
+        </tr>
+        <tr>
+            <td>Student Competency Progress View</td>
+            <td>Student competency overview, mastery indicators, judgment of learning ratings, and progress tracking across lecture units and exercises</td>
+        </tr>
+        <tr>
+            <td rowspan="3">
+                <strong>Courses</strong>
+            </td>
+            <td>Course Management</td>
+            <td>Creating, editing, deleting courses; adding/removing students from a course</td>
+        </tr>
+        <tr>
+            <td>Course Exercise</td>
+            <td>Tests filtering exercises based on their title</td>
+        </tr>
+        <tr>
+            <td>Course Communication</td>
+            <td>Messaging within courses, including channel creation, group chats, student participation, and message interactions</td>
+        </tr>
+        <tr>
+            <td rowspan="10">
+                <strong>Exams</strong>
+            </td>
+            <td>Exam Management</td>
+            <td>Manage exam students and exercise groups</td>
+        </tr>
+        <tr>
+            <td>Exam Creation & Deletion</td>
+            <td>Creating, editing, and deleting exams</td>
+        </tr>
+        <tr>
+            <td>Exam Participation</td>
+            <td>Early & normal hand-in, exam exercise participation for text, modeling, quiz, programming (Git SSH/HTTPS) exercises, exam announcements</td>
+        </tr>
+        <tr>
+            <td>Exam Assessment</td>
+            <td>Assessing modeling, text, quiz and programming exercise submissions in exams, including complaint handling</td>
+        </tr>
+        <tr>
+            <td>Exam Checklists</td>
+            <td>Exam setup checks, including student registration, exercise groups, and exam publication</td>
+        </tr>
+        <tr>
+            <td>Exam Date Verification</td>
+            <td>Exams appear/disappear based on visibility dates</td>
+        </tr>
+        <tr>
+            <td>Exam Results</td>
+            <td>Exam result overviews for text, quiz, modeling, and programming exercises</td>
+        </tr>
+        <tr>
+            <td>Exam Test Runs</td>
+            <td>Creating, managing, and deleting exam test runs</td>
+        </tr>
+        <tr>
+            <td>Exam Statistics</td>
+            <td>Exam statistics is displayed correctly</td>
+        </tr>
+        <tr>
+            <td>PlantUML Diagram Isolation</td>
+            <td>PlantUML diagrams in exam exercises render in isolation without leaking state between participants</td>
+        </tr>
+        <tr>
+            <td rowspan="5">
+                <strong>Test Exams</strong>
+            </td>
+            <td>Test Exam Creation & Deletion</td>
+            <td>Creating and deleting test exams</td>
+        </tr>
+        <tr>
+            <td>Test Exam Management</td>
+            <td>Managing test exam configuration and settings</td>
+        </tr>
+        <tr>
+            <td>Test Exam Participation</td>
+            <td>Participating in test exams as a student</td>
+        </tr>
+        <tr>
+            <td>Test Exam Student Exams</td>
+            <td>Generating and managing individual student exam instances</td>
+        </tr>
+        <tr>
+            <td>Test Exam Test Runs</td>
+            <td>Creating and managing test runs within a test exam</td>
+        </tr>
+        <tr>
+            <td>
+                <strong>Exercises</strong>
+            </td>
+            <td>Exercise Import</td>
+            <td>Importing text, quiz, modeling & programming exercises</td>
+        </tr>
+        <tr>
+            <td rowspan="3">
+                <strong>File Upload Exercises</strong>
+            </td>
+            <td>Management</td>
+            <td>Creating and deleting file upload exercises</td>
+        </tr>
+        <tr>
+            <td>Participation</td>
+            <td>Students can participate in a file upload exercise</td>
+        </tr>
+        <tr>
+            <td>Assessment & Feedback</td>
+            <td>Assessing submissions, student feedback visibility, and complaint handling</td>
+        </tr>
+        <tr>
+            <td rowspan="4">
+                <strong>Modeling Exercises</strong>
+            </td>
+            <td>Management</td>
+            <td>Creating, editing, and deleting modeling exercises</td>
+        </tr>
+        <tr>
+            <td>Visibility Controls</td>
+            <td>Students can access released/unreleased exercises</td>
+        </tr>
+        <tr>
+            <td>Participation</td>
+            <td>Students can start and submit models</td>
+        </tr>
+        <tr>
+            <td>Assessment & Complaints</td>
+            <td>Instructor and tutor assessments, student feedback, and complaint resolution</td>
+        </tr>
+        <tr>
+            <td rowspan="5">
+                <strong>Programming Exercises</strong>
+            </td>
+            <td>Management</td>
+            <td>Creating and deleting programming exercises</td>
+        </tr>
+        <tr>
+            <td>Team Management</td>
+            <td>Forming and managing exercise teams</td>
+        </tr>
+        <tr>
+            <td>Assessment</td>
+            <td>Assessing programming exercise submissions</td>
+        </tr>
+        <tr>
+            <td>Participation</td>
+            <td>Submitting code through the code editor and Git (HTTPS & SSH), submissions for Java, C, and Python, team participation</td>
+        </tr>
+        <tr>
+            <td>Static Code Analysis</td>
+            <td>Configuring SCA grading and handling submissions with SCA errors</td>
+        </tr>
+        <tr>
+            <td rowspan="5">
+                <strong>Quiz Exercises</strong>
+            </td>
+            <td>Management</td>
+            <td>Creating quizzes with multiple-choice, short-answer, and drag-and-drop questions</td>
+        </tr>
+        <tr>
+            <td>Deletion & Export</td>
+            <td>Ensures quizzes can be deleted and exported</td>
+        </tr>
+        <tr>
+            <td>Participation</td>
+            <td>Tests student participation in hidden, scheduled, and batch-based quizzes</td>
+        </tr>
+        <tr>
+            <td>Assessment</td>
+            <td>Verifies automatic assessment for multiple-choice and short-answer quizzes</td>
+        </tr>
+        <tr>
+            <td>Drag-and-Drop Mechanics</td>
+            <td>Ensures correct placement of draggable quiz elements</td>
+        </tr>
+        <tr>
+            <td rowspan="3">
+                <strong>Text Exercises</strong>
+            </td>
+            <td>Management</td>
+            <td>Creating and deleting text exercises</td>
+        </tr>
+        <tr>
+            <td>Participation</td>
+            <td>Ensures students can submit text exercises</td>
+        </tr>
+        <tr>
+            <td>Assessment & Complaints</td>
+            <td>Tests instructor assessments, feedback visibility, and complaint handling</td>
+        </tr>
+        <tr>
+            <td>
+                <strong>Lectures</strong>
+            </td>
+            <td>Lecture Management</td>
+            <td>Creating and deleting lectures, managing existing lectures</td>
+        </tr>
+        <tr>
+            <td rowspan="2">
+                <strong>Authentication</strong>
+            </td>
+            <td>Logging in</td>
+            <td>Logging in via UI and programmatically, login failures</td>
+        </tr>
+        <tr>
+            <td>Logging out</td>
+            <td>Logging out successfully and canceling logout</td>
+        </tr>
+        <tr>
+            <td>
+                <strong>System Status</strong>
+            </td>
+            <td>System status indicators</td>
+            <td>Continuous integration & VC server health; Database, Hazelcast, and WebSocket health; Readiness and ping checks</td>
+        </tr>
+    </tbody>
 </table>

--- a/documentation/docs/developer/e2e-testing-playwright.mdx
+++ b/documentation/docs/developer/e2e-testing-playwright.mdx
@@ -417,6 +417,56 @@ A `data-testid` is a contract: it tells whoever edits that template that a test 
 a class never does. Keep the value stable and kebab-cased, and name it after what the element *is*
 (`archive-download-button`) rather than where it currently sits.
 
+#### Markup you do not own
+
+PrimeNG, Monaco and Apollon render their own DOM, so there is no template to put a `data-testid` in. That is not a
+reason to fall back on their class names: those are as much a styling detail as Bootstrap's, and they change between
+major versions.
+
+PrimeNG answers this with the [pass-through API](https://primeng.org/passthrough). `[pt]` names each internal section
+of a component, so the attribute lands where the class hunt used to be. Declare it as a component field rather than a
+template literal, so change detection does not hand the component a fresh object on every cycle:
+
+```typescript
+protected readonly passThrough = {
+    root: { 'data-testid': 'date-picker' },
+    panel: { 'data-testid': 'date-picker-panel' },
+    day: { 'data-testid': 'date-picker-day' },
+};
+```
+
+```html
+<p-datepicker [pt]="passThrough" ... />
+```
+
+Two details are worth knowing. A section whose name starts with `pc` forwards to a whole PrimeNG component, so the
+attribute belongs on that component's root: `{ pcToggleButton: { root: { 'data-testid': 'example-solution-toggle' } } }`.
+And where one section renders more than one element, PrimeNG's own structural attributes tell them apart, without
+reaching for a class: the date picker's calendar and clear affordances are both `inputIcon`, and are found as
+`[data-p-icon="calendar"]` and `[data-p-icon="times"]`.
+
+For a helper that means "whichever dialog is currently open", ask for the role instead of naming a framework:
+`page.getByRole('dialog')` matches the PrimeNG and the ng-bootstrap dialog alike.
+
+Monaco is the one documented exception. It builds the editor, the code lines and the suggest widget itself, and its
+decoration API accepts a class name and nothing else, so `.monaco-editor`, `.view-line` and `.suggest-widget` have to
+be named directly. Scope them through a `data-testid` on the component that hosts the editor rather than through more
+Monaco classes, and say in a comment why the class is there.
+
+#### Asserting a state class is not the same as finding an element by one
+
+The rule above is about *finding* elements. Asserting that an element carries a state class is a different thing, and
+it is fine when the library exposes that state in no other way. Find the element by its own hook first, then assert
+the class on it:
+
+```typescript
+// PrimeNG marks the selected day with a class and offers no attribute or ARIA state for it.
+await expect(panel.locator(`[data-testid="date-picker-day"][data-date="${key}"]`)).toHaveClass(/p-datepicker-day-selected/);
+```
+
+For markup Artemis owns, do not settle for that: give the element an attribute that says what the test wants to know,
+such as `data-selected` or `data-invalid`, and assert on it.
+
 ### 4. Consider actionability of elements
 
 Checking for the state of an element before interacting with it is crucial to avoid flaky behavior. Actions like

--- a/src/main/webapp/app/admin/health/health.component.html
+++ b/src/main/webapp/app/admin/health/health.component.html
@@ -6,7 +6,7 @@
         </tum-ui-button>
     </div>
     <div class="overflow-x-auto">
-        <table tumUiTable [striped]="true" id="healthCheck" aria-describedby="health-page-heading">
+        <table tumUiTable [striped]="true" data-testid="healthCheck" aria-describedby="health-page-heading">
             <thead>
                 <tr>
                     <!-- w-full on the first column collapses the other two to their content width. -->
@@ -57,7 +57,7 @@
                             </td>
                         </tr>
                     }
-                    <tr id="websocketConnection">
+                    <tr data-testid="websocketConnection">
                         <td>Websocket Connection (Client -&gt; Server)</td>
                         <td data-testid="status-cell">
                             <tum-ui-tag [severity]="websocketConnected() ? 'success' : 'danger'" data-testid="status-tag">

--- a/src/main/webapp/app/assessment/manage/assessment-header/assessment-header.component.html
+++ b/src/main/webapp/app/assessment/manage/assessment-header/assessment-header.component.html
@@ -81,7 +81,12 @@
                 }
             }
             @if (isAssessor() && (!hasComplaint() || exercise()?.isAtLeastInstructor)) {
-                <span id="assessmentLockedCurrentUser" class="text-danger m-2" style="font-size: 65%" jhiTranslate="artemisApp.assessment.assessmentLockedCurrentUser"></span>
+                <span
+                    data-testid="assessmentLockedCurrentUser"
+                    class="text-danger m-2"
+                    style="font-size: 65%"
+                    jhiTranslate="artemisApp.assessment.assessmentLockedCurrentUser"
+                ></span>
             }
             <!-- Highlight the difference between first and second correction -->
             @if (!isProgrammingExercise() && result() && correctionRound() > 0) {
@@ -168,7 +173,7 @@
                 @if (assessNextVisible) {
                     <button
                         class="btn m-1 btn-success"
-                        id="assessNextButton"
+                        data-testid="assessNextButton"
                         [disabled]="assessNextDisabled"
                         (click)="nextSubmission.emit(); sendAssessNextEventToAnalytics()"
                         [ngbTooltip]="nextSubmissionShortcut"

--- a/src/main/webapp/app/assessment/manage/assessment-instructions/expandable-section/expandable-section.component.html
+++ b/src/main/webapp/app/assessment/manage/assessment-instructions/expandable-section/expandable-section.component.html
@@ -14,6 +14,6 @@
         <ng-content select="[expandableSectionHeaderActions]" />
     </div>
 }
-<div [ngbCollapse]="isCollapsed()">
+<div data-testid="expandable-section-content" [ngbCollapse]="isCollapsed()">
     <ng-content />
 </div>

--- a/src/main/webapp/app/assessment/manage/complaint-response/complaint-response.component.html
+++ b/src/main/webapp/app/assessment/manage/complaint-response/complaint-response.component.html
@@ -11,7 +11,7 @@
                 >:
             </p>
             <textarea
-                id="complainResponseTextArea"
+                data-testid="complainResponseTextArea"
                 class="col-12 px-1"
                 rows="4"
                 [(ngModel)]="complaint.complaintResponse.responseText"

--- a/src/main/webapp/app/assessment/manage/list-of-complaints/list-of-complaints.component.html
+++ b/src/main/webapp/app/assessment/manage/list-of-complaints/list-of-complaints.component.html
@@ -181,7 +181,7 @@
                             {{ calculateComplaintLockStatus(complaint) }}
                         </td>
                         <td class="text-center">
-                            <button class="btn btn-primary btn-sm" (click)="openAssessmentEditor(complaint)" id="show-complaint">
+                            <button class="btn btn-primary btn-sm" (click)="openAssessmentEditor(complaint)" data-testid="show-complaint">
                                 <fa-icon [icon]="faFolderOpen" [fixedWidth]="true" />
                                 @if (complaintType() === ComplaintType.COMPLAINT) {
                                     <span jhiTranslate="artemisApp.exerciseAssessmentDashboard.showComplaint"></span>

--- a/src/main/webapp/app/assessment/overview/complaint-request/complaint-request.component.html
+++ b/src/main/webapp/app/assessment/overview/complaint-request/complaint-request.component.html
@@ -9,11 +9,12 @@
         @if (complaint().accepted === true) {
             <span
                 class="badge bg-success"
+                data-testid="complaint-status-badge"
                 [jhiTranslate]="complaint().complaintType === ComplaintType.COMPLAINT ? 'artemisApp.complaint.acceptedLong' : 'artemisApp.moreFeedback.acceptedLong'"
             ></span>
         }
         @if (complaint().accepted === false) {
-            <span class="badge bg-danger" jhiTranslate="artemisApp.complaint.rejectedLong"></span>
+            <span class="badge bg-danger" data-testid="complaint-status-badge" jhiTranslate="artemisApp.complaint.rejectedLong"></span>
         }
     </p>
     <textarea

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/assessment-dashboard-information.component.html
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/assessment-dashboard-information.component.html
@@ -41,7 +41,7 @@
                             <div class="col-5">
                                 @if (course()?.isAtLeastInstructor) {
                                     <div>
-                                        <a id="open-complaints" [routerLink]="complaintsLink()">
+                                        <a data-testid="open-complaints" [routerLink]="complaintsLink()">
                                             {{ complaints().done }} / {{ complaints().total }} ({{ complaints().doneToTotalPercentage }})
                                         </a>
                                         |

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/assessment-dashboard.component.html
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/assessment-dashboard.component.html
@@ -206,7 +206,11 @@
                                 <td>
                                     @if (!exercise.teamMode) {
                                         <ng-container>
-                                            <a id="open-exercise-dashboard" [routerLink]="getAssessmentDashboardLinkForExercise(exercise)" class="btn btn-info btn-sm me-1 mb-1">
+                                            <a
+                                                data-testid="open-exercise-dashboard"
+                                                [routerLink]="getAssessmentDashboardLinkForExercise(exercise)"
+                                                class="btn btn-info btn-sm me-1 mb-1"
+                                            >
                                                 <span class="d-md-inline" jhiTranslate="entity.action.exerciseDashboard"></span>
                                             </a>
                                         </ng-container>

--- a/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.html
+++ b/src/main/webapp/app/assessment/shared/assessment-dashboard/exercise-dashboard/exercise-assessment-dashboard.component.html
@@ -239,7 +239,7 @@
             <div class="col-12 text-center mt-2 mb-4">
                 <p jhiTranslate="artemisApp.exerciseAssessmentDashboard.pleaseContactIfUnclear"></p>
 
-                <button id="participate-in-assessment" class="btn btn-primary p-1" (click)="readInstruction()" [disabled]="isLoading()">
+                <button data-testid="participate-in-assessment" class="btn btn-primary p-1" (click)="readInstruction()" [disabled]="isLoading()">
                     @if (exercise().gradingInstructions && exercise().gradingInstructions!.length > 0) {
                         <span jhiTranslate="artemisApp.exerciseAssessmentDashboard.readAndUnderstood"></span>
                     }
@@ -419,7 +419,7 @@
                                                             <td>
                                                                 <span [pTooltip]="assessmentNotPossibleYetTooltip()">
                                                                     <a
-                                                                        id="start-new-assessment"
+                                                                        data-testid="start-new-assessment"
                                                                         class="btn btn-success btn-sm"
                                                                         [routerLink]="assessmentNotPossibleYetReason() ? null : getAssessmentLink('new')"
                                                                         [queryParams]="getAssessmentQueryParams(correctionRound)"
@@ -477,7 +477,7 @@
                                                                                     [routerLink]="assessmentNotPossibleYetReason() ? null : getAssessmentLink(submission)"
                                                                                     [queryParams]="getAssessmentQueryParams(correctionRound)"
                                                                                     class="btn btn-primary btn-sm"
-                                                                                    id="open-assessment"
+                                                                                    data-testid="open-assessment"
                                                                                     [class.disabled]="!!assessmentNotPossibleYetReason()"
                                                                                     [attr.aria-disabled]="!!assessmentNotPossibleYetReason() || null"
                                                                                     [attr.tabindex]="assessmentNotPossibleYetReason() ? -1 : null"
@@ -604,7 +604,7 @@
                                                             [routerLink]="getAssessmentLink(submissionWithComplaint.submission)"
                                                             [queryParams]="getComplaintQueryParams(submissionWithComplaint.complaint)"
                                                             class="btn btn-success btn-sm"
-                                                            id="evaluate-complaint"
+                                                            data-testid="evaluate-complaint"
                                                         >
                                                             <fa-icon [icon]="faFolderOpen" [fixedWidth]="true" />
                                                             {{ 'artemisApp.exerciseAssessmentDashboard.evaluateComplaint' | artemisTranslate }}

--- a/src/main/webapp/app/atlas/manage/competency-management/competency-management.component.html
+++ b/src/main/webapp/app/atlas/manage/competency-management/competency-management.component.html
@@ -18,7 +18,7 @@
                 <fa-icon [icon]="faEdit" />
                 <span jhiTranslate="artemisApp.courseCompetency.manage.editRelationsButton"></span>
             </button>
-            <button class="btn btn-primary btn-sm" id="courseCompetencyImportAllButton" (click)="openImportAllModal()">
+            <button class="btn btn-primary btn-sm" data-testid="courseCompetencyImportAllButton" (click)="openImportAllModal()">
                 <fa-icon [icon]="faFileImport" />
                 <span jhiTranslate="artemisApp.courseCompetency.manage.importAllButton"></span>
             </button>

--- a/src/main/webapp/app/atlas/manage/taxonomy-select/taxonomy-select.component.html
+++ b/src/main/webapp/app/atlas/manage/taxonomy-select/taxonomy-select.component.html
@@ -1,4 +1,14 @@
-<p-select [formControl]="form()" [inputId]="selectId()" [options]="taxonomyOptions" optionLabel="value" optionValue="value" [showClear]="true" styleClass="w-full" appendTo="body">
+<p-select
+    [pt]="{ listContainer: { 'data-testid': 'taxonomy-select-overlay' }, option: { 'data-testid': 'taxonomy-select-option' } }"
+    [formControl]="form()"
+    [inputId]="selectId()"
+    [options]="taxonomyOptions"
+    optionLabel="value"
+    optionValue="value"
+    [showClear]="true"
+    styleClass="w-full"
+    appendTo="body"
+>
     <ng-template let-option #item>
         <span class="whitespace-pre">{{ option.indent }}&boxur; </span>
         <span [jhiTranslate]="'artemisApp.courseCompetency.taxonomies.' + option.value"></span>

--- a/src/main/webapp/app/atlas/overview/competency-card/competency-card.component.html
+++ b/src/main/webapp/app/atlas/overview/competency-card/competency-card.component.html
@@ -29,7 +29,7 @@
                 <h4 class="m-0">
                     {{ competency()?.title }}
                     @if (isMastered) {
-                        <span class="badge text-white text-bg-success" jhiTranslate="artemisApp.competency.mastered"></span>
+                        <span class="badge text-white text-bg-success" data-testid="competency-mastered-badge" jhiTranslate="artemisApp.competency.mastered"></span>
                     }
                     @if (competency()?.optional) {
                         <span id="optional-badge" class="badge text-white bg-warning" jhiTranslate="artemisApp.competency.optional"></span>

--- a/src/main/webapp/app/atlas/overview/course-competencies/course-competencies-details.component.html
+++ b/src/main/webapp/app/atlas/overview/course-competencies/course-competencies-details.component.html
@@ -21,7 +21,7 @@
                         />
                         <span>{{ competency!.title }}</span>
                         @if (isMastered) {
-                            <span class="badge text-white text-bg-success" jhiTranslate="artemisApp.competency.mastered"></span>
+                            <span class="badge text-white text-bg-success" data-testid="competency-mastered-badge" jhiTranslate="artemisApp.competency.mastered"></span>
                         }
                         @if (competency.optional) {
                             <span class="badge text-white bg-warning" jhiTranslate="artemisApp.competency.optional"></span>

--- a/src/main/webapp/app/atlas/overview/course-competencies/course-competencies.component.html
+++ b/src/main/webapp/app/atlas/overview/course-competencies/course-competencies.component.html
@@ -30,7 +30,8 @@
     </div>
     <div class="col-12 col-lg-3 offset-lg-1">
         <h3 class="mt-3" jhiTranslate="artemisApp.competency.table.panelHeader"></h3>
-        <span class="badge bg-dark">{{ countMasteredCompetencies }} / {{ countCompetencies }}</span> {{ 'artemisApp.competency.mastered' | artemisTranslate }}
+        <span class="badge bg-dark" data-testid="competencies-mastered-count">{{ countMasteredCompetencies }} / {{ countCompetencies }}</span>
+        {{ 'artemisApp.competency.mastered' | artemisTranslate }}
         <dl class="mt-3">
             <dt jhiTranslate="artemisApp.competency.progress"></dt>
             <dd jhiTranslate="artemisApp.competency.progressDescription"></dd>

--- a/src/main/webapp/app/communication/answer-post/answer-post.component.html
+++ b/src/main/webapp/app/communication/answer-post/answer-post.component.html
@@ -137,28 +137,28 @@
 
 <!-- Right-Click Dropdown -->
 @if (showDropdown()) {
-    <div [ngStyle]="{ position: 'fixed', 'top.px': dropdownPosition().y, 'left.px': dropdownPosition().x }" class="dropdown-menu show">
-        <button class="dropdown-item d-flex" (click)="addReaction($event)">
+    <div [ngStyle]="{ position: 'fixed', 'top.px': dropdownPosition().y, 'left.px': dropdownPosition().x }" class="dropdown-menu show" data-testid="posting-context-menu">
+        <button class="dropdown-item d-flex" (click)="addReaction($event)" data-testid="posting-menu-react">
             <fa-icon [icon]="faSmile" class="item-icon" />
             <span jhiTranslate="artemisApp.metis.post.addReaction"></span>
         </button>
         @if (mayEdit()) {
-            <button class="dropdown-item d-flex" (click)="editPosting()">
+            <button class="dropdown-item d-flex" (click)="editPosting()" data-testid="posting-menu-edit">
                 <fa-icon [icon]="faPencilAlt" class="item-icon" />
                 <span jhiTranslate="artemisApp.metis.post.editMessage"></span>
             </button>
         }
         @if (mayDelete()) {
-            <button class="dropdown-item d-flex" (click)="deletePost()">
+            <button class="dropdown-item d-flex" (click)="deletePost()" data-testid="posting-menu-delete">
                 <fa-icon [icon]="faTrash" class="item-icon" />
                 <span jhiTranslate="artemisApp.metis.answerPost.deleteAnswer"></span>
             </button>
         }
-        <button class="dropdown-item d-flex" (click)="toggleSavePost()">
+        <button class="dropdown-item d-flex" (click)="toggleSavePost()" data-testid="posting-menu-bookmark">
             <fa-icon [icon]="posting()?.isSaved ? faBookmark : farBookmark" class="item-icon" />
             <span [jhiTranslate]="posting()?.isSaved ? 'artemisApp.metis.post.removeBookmarkPost' : 'artemisApp.metis.post.bookmarkPost'"></span>
         </button>
-        <button class="dropdown-item d-flex forward" (click)="forwardMessage()">
+        <button class="dropdown-item d-flex" (click)="forwardMessage()" data-testid="posting-menu-forward">
             <fa-icon [icon]="faShare" class="item-icon" />
             <span jhiTranslate="artemisApp.metis.post.forwardMessage"></span>
         </button>

--- a/src/main/webapp/app/communication/course-conversations-components/dialogs/channels-create-dialog/channel-form/channel-form.component.html
+++ b/src/main/webapp/app/communication/course-conversations-components/dialogs/channels-create-dialog/channel-form/channel-form.component.html
@@ -52,7 +52,14 @@
                 <div>
                     <div class="form-group">
                         <label class="d-block" jhiTranslate="artemisApp.dialogs.createChannel.channelForm.isPublicInput.label"></label>
-                        <p-selectbutton formControlName="isPublic" [options]="visibilityOptions()" optionLabel="label" optionValue="value" [allowEmpty]="false" />
+                        <p-selectbutton
+                            data-testid="channel-visibility-select"
+                            formControlName="isPublic"
+                            [options]="visibilityOptions()"
+                            optionLabel="label"
+                            optionValue="value"
+                            [allowEmpty]="false"
+                        />
                         <small
                             id="isPublicHelp"
                             class="form-text text-body-secondary d-block"
@@ -64,7 +71,14 @@
                 <div>
                     <div class="form-group">
                         <label class="d-block" jhiTranslate="artemisApp.dialogs.createChannel.channelForm.isCourseWideChannelInput.label"></label>
-                        <p-selectbutton formControlName="isCourseWideChannel" [options]="scopeOptions()" optionLabel="label" optionValue="value" [allowEmpty]="false" />
+                        <p-selectbutton
+                            data-testid="channel-scope-select"
+                            formControlName="isCourseWideChannel"
+                            [options]="scopeOptions()"
+                            optionLabel="label"
+                            optionValue="value"
+                            [allowEmpty]="false"
+                        />
                         <small
                             id="isCourseWideChannelHelp"
                             class="form-text text-body-secondary d-block"
@@ -76,7 +90,14 @@
                 <div>
                     <div class="form-group">
                         <label class="d-block" jhiTranslate="artemisApp.dialogs.createChannel.channelForm.isAnnouncementChannelInput.label"></label>
-                        <p-selectbutton formControlName="isAnnouncementChannel" [options]="typeOptions()" optionLabel="label" optionValue="value" [allowEmpty]="false" />
+                        <p-selectbutton
+                            data-testid="channel-type-select"
+                            formControlName="isAnnouncementChannel"
+                            [options]="typeOptions()"
+                            optionLabel="label"
+                            optionValue="value"
+                            [allowEmpty]="false"
+                        />
                         <small
                             id="isAnnouncementChannelHelp"
                             class="form-text text-body-secondary d-block"

--- a/src/main/webapp/app/communication/course-conversations-components/dialogs/channels-create-dialog/channel-form/channel-form.component.html
+++ b/src/main/webapp/app/communication/course-conversations-components/dialogs/channels-create-dialog/channel-form/channel-form.component.html
@@ -18,7 +18,7 @@
                         />
                     </div>
                     @if (nameControl?.invalid && (nameControl?.dirty || nameControl?.touched)) {
-                        <div class="alert alert-danger">
+                        <div class="alert alert-danger" data-testid="channel-name-error">
                             @if (nameControl?.errors?.required) {
                                 <div jhiTranslate="artemisApp.dialogs.createChannel.channelForm.nameInput.requiredValidationError"></div>
                             }

--- a/src/main/webapp/app/communication/course-conversations-components/dialogs/channels-overview-dialog/channel-item/channel-item.component.html
+++ b/src/main/webapp/app/communication/course-conversations-components/dialogs/channels-overview-dialog/channel-item/channel-item.component.html
@@ -7,7 +7,7 @@
             <span>{{ channel().name }}</span>
         </div>
         @if (channel().isMember) {
-            <span class="badge bg-success rounded-pill">{{ 'artemisApp.dialogs.channelOverview.channelItem.joined:' | artemisTranslate }}</span>
+            <span class="badge bg-success rounded-pill" data-testid="channel-joined-badge">{{ 'artemisApp.dialogs.channelOverview.channelItem.joined:' | artemisTranslate }}</span>
         }
         <span> {{ channel().numberOfMembers }} {{ 'artemisApp.dialogs.channelOverview.channelItem.members' | artemisTranslate }}</span>
         @if (channel().description && channel().description!.length > 0) {

--- a/src/main/webapp/app/communication/course-conversations-components/dialogs/channels-overview-dialog/channels-overview-dialog.component.html
+++ b/src/main/webapp/app/communication/course-conversations-components/dialogs/channels-overview-dialog/channels-overview-dialog.component.html
@@ -1,6 +1,6 @@
 <jhi-loading-indicator-container [isLoading]="isLoading()">
     @if (isInitialized) {
-        <div class="channels-overview">
+        <div class="channels-overview" data-testid="channels-overview-dialog">
             <div class="modal-header">
                 <h4 class="modal-title">
                     <span>{{ 'artemisApp.dialogs.channelOverview.title' | artemisTranslate: { courseTitle: course()?.title } }}</span>
@@ -14,7 +14,7 @@
                         <div class="table-wrapper-scroll-y scrollbar">
                             <ul class="list-group">
                                 @for (channel of channels(); track channel.id) {
-                                    <li [id]="'channel-' + channel.id" class="list-group-item">
+                                    <li [attr.data-channel-id]="channel.id" data-testid="channel-overview-item" class="list-group-item">
                                         <jhi-channel-item [channel]="channel" (channelAction)="onChannelAction($event)" />
                                     </li>
                                 }

--- a/src/main/webapp/app/communication/course-conversations-components/dialogs/conversation-detail-dialog/conversation-detail-dialog.component.html
+++ b/src/main/webapp/app/communication/course-conversations-components/dialogs/conversation-detail-dialog/conversation-detail-dialog.component.html
@@ -33,7 +33,7 @@
                     }
                 }
             </h4>
-            <button type="button" class="btn-close" (click)="clear()"></button>
+            <button type="button" class="btn-close" data-testid="conversation-detail-close-button" (click)="clear()"></button>
         </div>
         <div>
             <ul class="nav nav-tabs">

--- a/src/main/webapp/app/communication/course-conversations-components/dialogs/conversation-detail-dialog/conversation-detail-dialog.component.html
+++ b/src/main/webapp/app/communication/course-conversations-components/dialogs/conversation-detail-dialog/conversation-detail-dialog.component.html
@@ -58,6 +58,7 @@
                     </li>
                     <li class="nav-item settings-tab">
                         <a
+                            data-testid="conversation-settings-tab"
                             class="nav-link"
                             [class.active]="selectedTab === Tabs.SETTINGS"
                             role="button"

--- a/src/main/webapp/app/communication/course-conversations-components/forward-message-dialog/forward-message-dialog.component.html
+++ b/src/main/webapp/app/communication/course-conversations-components/forward-message-dialog/forward-message-dialog.component.html
@@ -37,6 +37,7 @@
                 @for (option of filteredOptions(); track option) {
                     <li
                         class="list-group-item list-group-item-action"
+                        data-testid="forward-destination-option"
                         [ngClass]="{ 'channel-option': option.type === 'channel', 'chat-option': option.type === 'chat' }"
                         (mousedown)="selectOption(option)"
                     >
@@ -124,6 +125,7 @@
     <button
         type="button"
         class="btn btn-primary"
+        data-testid="forward-send-button"
         [disabled]="!hasSelections() || !isMessageValid()"
         (click)="send()"
         jhiTranslate="artemisApp.conversationsLayout.sendMessage"

--- a/src/main/webapp/app/communication/course-conversations-components/layout/conversation-header/conversation-header.component.html
+++ b/src/main/webapp/app/communication/course-conversations-components/layout/conversation-header/conversation-header.component.html
@@ -6,7 +6,7 @@
                     <button class="btn btn-sm btn-outline-secondary d-inline-block d-sm-none me-2" (click)="openSidebar()">
                         <fa-icon [icon]="faChevronLeft" />
                     </button>
-                    <h4 class="pointer d-inline-block rounded py-2 info mb-0" (click)="openConversationDetailDialog($event, INFO)">
+                    <h4 class="pointer d-inline-block rounded py-2 info mb-0" data-testid="conversation-name" (click)="openConversationDetailDialog($event, INFO)">
                         @if (activeConversationAsChannel(); as activeConversationAsChannel) {
                             <jhi-channel-icon [isPublic]="activeConversationAsChannel.isPublic!" [isAnnouncementChannel]="activeConversationAsChannel.isAnnouncementChannel!" />
                         }

--- a/src/main/webapp/app/communication/course-conversations-components/layout/conversation-header/conversation-header.component.html
+++ b/src/main/webapp/app/communication/course-conversations-components/layout/conversation-header/conversation-header.component.html
@@ -101,7 +101,7 @@
             @if (activeConversationAsChannel(); as activeConversationAsChannel) {
                 @if (activeConversationAsChannel.topic && activeConversationAsChannel.topic.length > 0) {
                     <div class="text-body-secondary d-flex justify-content-between px-2">
-                        <span id="conversation-topic" class="d-inline-block mw-100">{{ activeConversationAsChannel.topic }}</span>
+                        <span data-testid="conversation-topic" class="d-inline-block mw-100">{{ activeConversationAsChannel.topic }}</span>
                     </div>
                 }
             }

--- a/src/main/webapp/app/communication/course-users-selector/course-users-selector.component.html
+++ b/src/main/webapp/app/communication/course-users-selector/course-users-selector.component.html
@@ -29,7 +29,7 @@
             data-form-type="other"
         />
         <ng-template #resultTemplate let-user="result">
-            <div class="d-flex align-items-center">
+            <div class="d-flex align-items-center" data-testid="user-search-result">
                 <jhi-profile-picture
                     [imageSizeInRem]="'1.1'"
                     [fontSizeInRem]="'0.5'"

--- a/src/main/webapp/app/communication/post/post.component.html
+++ b/src/main/webapp/app/communication/post/post.component.html
@@ -183,43 +183,43 @@
 
 <!-- Right-Click Dropdown -->
 @if (showDropdown()) {
-    <div [ngStyle]="{ position: 'fixed', 'top.px': dropdownPosition().y, 'left.px': dropdownPosition().x }" class="dropdown-menu show">
-        <button class="dropdown-item d-flex" (click)="addReaction($event)">
+    <div [ngStyle]="{ position: 'fixed', 'top.px': dropdownPosition().y, 'left.px': dropdownPosition().x }" class="dropdown-menu show" data-testid="posting-context-menu">
+        <button class="dropdown-item d-flex" (click)="addReaction($event)" data-testid="posting-menu-react">
             <fa-icon [icon]="faSmile" class="item-icon" />
             <span jhiTranslate="artemisApp.metis.post.addReaction"></span>
         </button>
         @if (canPin()) {
-            <button class="dropdown-item d-flex" (click)="togglePin()">
+            <button class="dropdown-item d-flex" (click)="togglePin()" data-testid="posting-menu-pin">
                 <fa-icon [icon]="faThumbtack" class="item-icon" />
                 <span [jhiTranslate]="checkIfPinned() === DisplayPriority.PINNED ? 'artemisApp.metis.post.unpinMessage' : 'artemisApp.metis.post.pinMessage'"></span>
             </button>
         }
         @if (mayEdit()) {
-            <button class="dropdown-item d-flex editIcon" (click)="editPosting()">
+            <button class="dropdown-item d-flex" (click)="editPosting()" data-testid="posting-menu-edit">
                 <fa-icon [icon]="faPencilAlt" class="item-icon" />
                 <span jhiTranslate="artemisApp.metis.post.editMessage"></span>
             </button>
         }
         @if (mayDelete()) {
-            <button class="dropdown-item d-flex deleteIcon" (click)="deletePost()">
+            <button class="dropdown-item d-flex" (click)="deletePost()" data-testid="posting-menu-delete">
                 <fa-icon [icon]="faTrash" class="item-icon" />
                 <span jhiTranslate="artemisApp.metis.post.deleteMessage"></span>
             </button>
         }
-        <button class="dropdown-item d-flex" (click)="isCommunicationPage() ? openThread.emit() : reactionsBarComponent()?.openAnswerView()">
+        <button class="dropdown-item d-flex" (click)="isCommunicationPage() ? openThread.emit() : reactionsBarComponent()?.openAnswerView()" data-testid="posting-menu-reply">
             <fa-icon [icon]="faComments" class="item-icon" />
             <span jhiTranslate="artemisApp.metis.post.replyMessage"></span>
         </button>
-        <button class="dropdown-item d-flex" (click)="toggleSavePost()">
+        <button class="dropdown-item d-flex" (click)="toggleSavePost()" data-testid="posting-menu-bookmark">
             <fa-icon [icon]="posting()?.isSaved ? faBookmark : farBookmark" class="item-icon" />
             <span [jhiTranslate]="posting()?.isSaved ? 'artemisApp.metis.post.removeBookmarkPost' : 'artemisApp.metis.post.bookmarkPost'"></span>
         </button>
-        <button class="dropdown-item d-flex forward" (click)="forwardMessage()">
+        <button class="dropdown-item d-flex" (click)="forwardMessage()" data-testid="posting-menu-forward">
             <fa-icon [icon]="faShare" class="item-icon" />
             <span jhiTranslate="artemisApp.metis.post.forwardMessage"></span>
         </button>
         @if (canMarkAsUnread()) {
-            <button class="dropdown-item d-flex" (click)="markMessageAsUnread()">
+            <button class="dropdown-item d-flex" (click)="markMessageAsUnread()" data-testid="posting-menu-mark-unread">
                 <fa-icon [icon]="faEnvelopeOpenText" class="item-icon" />
                 <span jhiTranslate="artemisApp.metis.post.markAsUnread"></span>
             </button>

--- a/src/main/webapp/app/communication/posting-footer/posting-footer.component.html
+++ b/src/main/webapp/app/communication/posting-footer/posting-footer.component.html
@@ -31,7 +31,7 @@
         }
     </div>
 }
-<div class="new-reply-inline-input" [ngClass]="{ 'ms-4 my-3': !isCommunicationPage() && showAnswers() }">
+<div class="new-reply-inline-input" data-testid="inline-reply-input" [ngClass]="{ 'ms-4 my-3': !isCommunicationPage() && showAnswers() }">
     <!-- rendered during the first reply to a post -->
     <ng-container #createEditAnswerPostContainer />
     <jhi-answer-post-create-edit-modal

--- a/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.html
+++ b/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.html
@@ -102,14 +102,19 @@
 
         <!-- Edit button -->
         @if (!isEmojiCount() && mayEdit()) {
-            <button class="reaction-button clickable px-2 fs-small edit" (click)="editPosting()" [ngbTooltip]="'artemisApp.metis.editPosting' | artemisTranslate">
+            <button
+                class="reaction-button clickable px-2 fs-small"
+                data-testid="posting-reaction-edit"
+                (click)="editPosting()"
+                [ngbTooltip]="'artemisApp.metis.editPosting' | artemisTranslate"
+            >
                 <fa-icon [icon]="faPencilAlt" />
             </button>
         }
         <jhi-post-create-edit-modal #createEditModal [posting]="posting()!" [isCommunicationPage]="isCommunicationPage()!" (isModalOpen)="isModalOpen.emit()" />
         <!-- Delete button -->
         @if (!isEmojiCount() && mayDelete()) {
-            <button class="reaction-button clickable fs-small">
+            <button class="reaction-button clickable fs-small" data-testid="posting-reaction-delete">
                 <jhi-confirm-icon
                     iconSize="sm"
                     (confirmEvent)="deletePosting()"

--- a/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.html
+++ b/src/main/webapp/app/communication/shared/course-conversations/course-conversations.component.html
@@ -6,7 +6,7 @@
             <div class="module-bg px-3 py-3 scrollable-content">
                 <jhi-course-conversations-code-of-conduct [course]="currentCourse" />
                 <button
-                    id="acceptCodeOfConductButton"
+                    data-testid="acceptCodeOfConductButton"
                     class="btn btn-primary"
                     type="button"
                     (click)="acceptCodeOfConduct()"

--- a/src/main/webapp/app/core/alert/alert-overlay.component.html
+++ b/src/main/webapp/app/core/alert/alert-overlay.component.html
@@ -11,7 +11,7 @@
 @for (alert of alerts(); track alert) {
     <div class="alert-animation-wrapper" animate.enter="alert-entering" animate.leave="alert-leaving">
         <div class="alert-wrap">
-            <div class="alert-inner" [ngClass]="alert.type.containerClassName">
+            <div class="alert-inner" data-testid="alert" [attr.data-alert-type]="alert.type.containerClassName" [ngClass]="alert.type.containerClassName">
                 <div class="left">
                     <fa-icon [icon]="alert.type.icon" size="2x" />
                     <div class="message" [innerHTML]="alert.message"></div>

--- a/src/main/webapp/app/core/home/home.component.html
+++ b/src/main/webapp/app/core/home/home.component.html
@@ -191,7 +191,7 @@
 
                         <div class="d-flex flex-column gap-2">
                             <tum-ui-button
-                                id="passkey-login-button"
+                                data-testid="passkey-login-button"
                                 type="button"
                                 severity="primary"
                                 variant="outlined"

--- a/src/main/webapp/app/core/layouts/footer/footer.component.html
+++ b/src/main/webapp/app/core/layouts/footer/footer.component.html
@@ -2,8 +2,8 @@
     <div class="footer-text justify-start gap-3 flex-nowrap flex items-baseline">
         <a [routerLink]="['/about']" id="about" jhiTranslate="aboutUs" class="shrink-0"></a>
         <a [href]="FEEDBACK_URL" id="feedback" jhiTranslate="feedback" class="shrink-0" target="_blank"></a>
-        <a [href]="RELEASE_URL" id="releases" jhiTranslate="releases" class="shrink-0" target="_blank"></a>
-        <a [routerLink]="['/privacy']" id="privacy" jhiTranslate="artemisApp.legal.privacy" class="shrink-0"></a>
+        <a [href]="RELEASE_URL" data-testid="releases" jhiTranslate="releases" class="shrink-0" target="_blank"></a>
+        <a [routerLink]="['/privacy']" data-testid="privacy" jhiTranslate="artemisApp.legal.privacy" class="shrink-0"></a>
         <a [routerLink]="['/imprint']" id="imprint" jhiTranslate="artemisApp.legal.imprint.title" class="shrink-0"></a>
         @if (!isProduction() || isTestServer()) {
             <span class="shrink-0 footer-git footer-git-responsive">

--- a/src/main/webapp/app/core/navbar/navbar.component.html
+++ b/src/main/webapp/app/core/navbar/navbar.component.html
@@ -107,7 +107,7 @@
                     }
                     <li>
                         @if (currAccount()) {
-                            <a class="dropdown-item" (click)="logout()" id="logout">
+                            <a class="dropdown-item" (click)="logout()" data-testid="logout">
                                 <fa-icon [icon]="faSignOutAlt" [fixedWidth]="true" />
                                 <span jhiTranslate="global.menu.account.logout"></span>
                             </a>

--- a/src/main/webapp/app/course/manage/exercises/exercise-row/exercise-table.component.html
+++ b/src/main/webapp/app/course/manage/exercises/exercise-row/exercise-table.component.html
@@ -62,7 +62,7 @@
                                 />
                             </td>
                         }
-                        <td class="col-title">
+                        <td class="col-title" data-testid="exercise-row-title">
                             @if (showTypeIcon()) {
                                 <fa-icon [icon]="row.icon" [fixedWidth]="true" class="text-muted me-1" />
                             }
@@ -90,7 +90,7 @@
                                 }
                             </div>
                         </td>
-                        <td class="text-nowrap col-points">
+                        <td class="text-nowrap col-points" data-testid="exercise-row-points">
                             <div class="d-flex flex-column">
                                 <span>
                                     {{ row.exercise.maxPoints }}pts

--- a/src/main/webapp/app/course/manage/onboarding/course-onboarding.component.html
+++ b/src/main/webapp/app/course/manage/onboarding/course-onboarding.component.html
@@ -1,12 +1,19 @@
-<div class="onboarding-wizard">
+<div class="onboarding-wizard" data-testid="onboarding-wizard">
     <div class="onboarding-header">
         <h2 jhiTranslate="artemisApp.course.onboarding.title"></h2>
         <p class="onboarding-subtitle" jhiTranslate="artemisApp.course.onboarding.subtitle"></p>
     </div>
 
-    <div class="step-indicator">
+    <div class="step-indicator" data-testid="onboarding-step-indicator">
         @for (step of stepKeys; track step; let i = $index) {
-            <div class="step-item" [class.active]="activeStep() === i" [class.completed]="activeStep() > i" (click)="goToStep(i)">
+            <div
+                class="step-item"
+                data-testid="onboarding-step"
+                [attr.data-step-state]="activeStep() === i ? 'active' : activeStep() > i ? 'completed' : 'upcoming'"
+                [class.active]="activeStep() === i"
+                [class.completed]="activeStep() > i"
+                (click)="goToStep(i)"
+            >
                 <div class="step-circle">
                     @if (activeStep() > i) {
                         <fa-icon [icon]="faCheck" />
@@ -22,7 +29,7 @@
         }
     </div>
 
-    <div class="onboarding-content">
+    <div class="onboarding-content" data-testid="onboarding-content">
         @switch (activeStep()) {
             @case (0) {
                 <jhi-onboarding-general-settings [course]="course()" (courseUpdated)="onCourseUpdated($event)" />

--- a/src/main/webapp/app/course/manage/onboarding/course-onboarding.component.html
+++ b/src/main/webapp/app/course/manage/onboarding/course-onboarding.component.html
@@ -45,7 +45,7 @@
     <div class="onboarding-footer">
         <div class="footer-left">
             @if (!isFirstStep()) {
-                <button class="btn btn-secondary" (click)="previousStep()" [disabled]="isSaving()">
+                <button data-testid="onboarding-previous-button" class="btn btn-secondary" (click)="previousStep()" [disabled]="isSaving()">
                     <fa-icon [icon]="faChevronLeft" class="me-1" />
                     <span jhiTranslate="artemisApp.course.onboarding.actions.previous"></span>
                 </button>
@@ -53,7 +53,7 @@
         </div>
         <div class="footer-right">
             @if (canFinish()) {
-                <button class="btn btn-success" (click)="finishSetup()" [disabled]="isSaving()">
+                <button data-testid="onboarding-finish-button" class="btn btn-success" (click)="finishSetup()" [disabled]="isSaving()">
                     @if (isSaving()) {
                         <span jhiTranslate="artemisApp.course.onboarding.actions.saving"></span>
                     } @else {
@@ -62,12 +62,12 @@
                     }
                 </button>
             } @else if (isLastStep()) {
-                <button class="btn btn-primary" (click)="goToCourse()">
+                <button data-testid="onboarding-go-to-course-button" class="btn btn-primary" (click)="goToCourse()">
                     <span jhiTranslate="artemisApp.course.onboarding.actions.goToCourse"></span>
                     <fa-icon [icon]="faChevronRight" class="ms-1" />
                 </button>
             } @else {
-                <button class="btn btn-primary" (click)="nextStep()" [disabled]="isSaving()">
+                <button data-testid="onboarding-next-button" class="btn btn-primary" (click)="nextStep()" [disabled]="isSaving()">
                     @if (isSaving()) {
                         <span jhiTranslate="artemisApp.course.onboarding.actions.saving"></span>
                     } @else {

--- a/src/main/webapp/app/course/manage/onboarding/pages/onboarding-assessment-ai.component.html
+++ b/src/main/webapp/app/course/manage/onboarding/pages/onboarding-assessment-ai.component.html
@@ -47,7 +47,7 @@
             <div class="feature-toggle">
                 <button
                     type="button"
-                    id="onboarding_complaintsEnabled"
+                    data-testid="onboarding_complaintsEnabled"
                     class="toggle-btn"
                     [ngClass]="{ 'active-enabled': complaintsToggled() }"
                     [attr.aria-pressed]="complaintsToggled()"

--- a/src/main/webapp/app/course/manage/onboarding/pages/onboarding-communication.component.html
+++ b/src/main/webapp/app/course/manage/onboarding/pages/onboarding-communication.component.html
@@ -17,7 +17,7 @@
             <div class="feature-toggle">
                 <button
                     type="button"
-                    id="onboarding_communicationEnabled"
+                    data-testid="onboarding_communicationEnabled"
                     class="toggle-btn"
                     [ngClass]="{ 'active-enabled': communicationEnabled }"
                     [attr.aria-pressed]="communicationEnabled"

--- a/src/main/webapp/app/course/manage/onboarding/pages/onboarding-enrollment.component.html
+++ b/src/main/webapp/app/course/manage/onboarding/pages/onboarding-enrollment.component.html
@@ -50,7 +50,7 @@
             <div class="feature-toggle">
                 <button
                     type="button"
-                    id="onboarding_enrollmentEnabled"
+                    data-testid="onboarding_enrollmentEnabled"
                     class="toggle-btn"
                     [ngClass]="{ 'active-enabled': course().enrollmentEnabled }"
                     [attr.aria-pressed]="course().enrollmentEnabled"

--- a/src/main/webapp/app/course/manage/onboarding/pages/onboarding-explore.component.html
+++ b/src/main/webapp/app/course/manage/onboarding/pages/onboarding-explore.component.html
@@ -16,7 +16,7 @@
     </div>
     <div class="step-body">
         <div class="explore-grid">
-            <a [routerLink]="['/course-management', course().id, 'exercises']" class="explore-card explore-card--exercises">
+            <a [routerLink]="['/course-management', course().id, 'exercises']" data-testid="onboarding-explore-card" class="explore-card explore-card--exercises">
                 <div class="explore-icon-wrapper">
                     <fa-icon [icon]="faCode" />
                 </div>
@@ -29,7 +29,7 @@
             </a>
 
             @if (lectureEnabled) {
-                <a [routerLink]="['/course-management', course().id, 'lectures']" class="explore-card explore-card--lectures">
+                <a [routerLink]="['/course-management', course().id, 'lectures']" data-testid="onboarding-explore-card" class="explore-card explore-card--lectures">
                     <div class="explore-icon-wrapper">
                         <fa-icon [icon]="faChalkboardTeacher" />
                     </div>
@@ -43,7 +43,7 @@
             }
 
             @if (tutorialGroupEnabled) {
-                <a [routerLink]="['/course-management', course().id, 'tutorial-groups']" class="explore-card explore-card--tutorial">
+                <a [routerLink]="['/course-management', course().id, 'tutorial-groups']" data-testid="onboarding-explore-card" class="explore-card explore-card--tutorial">
                     <div class="explore-icon-wrapper">
                         <fa-icon [icon]="faUsers" />
                     </div>
@@ -57,7 +57,7 @@
             }
 
             @if (examEnabled) {
-                <a [routerLink]="['/course-management', course().id, 'exams']" class="explore-card explore-card--exams">
+                <a [routerLink]="['/course-management', course().id, 'exams']" data-testid="onboarding-explore-card" class="explore-card explore-card--exams">
                     <div class="explore-icon-wrapper">
                         <fa-icon [icon]="faFileAlt" />
                     </div>
@@ -71,7 +71,11 @@
             }
 
             @if (atlasEnabled) {
-                <a [routerLink]="['/course-management', course().id, 'competency-management']" class="explore-card explore-card--competencies">
+                <a
+                    [routerLink]="['/course-management', course().id, 'competency-management']"
+                    data-testid="onboarding-explore-card"
+                    class="explore-card explore-card--competencies"
+                >
                     <div class="explore-icon-wrapper">
                         <fa-icon [icon]="faBullseye" />
                     </div>
@@ -84,7 +88,7 @@
                 </a>
             }
 
-            <a [routerLink]="['/course-management', course().id, 'faqs']" class="explore-card explore-card--faqs">
+            <a [routerLink]="['/course-management', course().id, 'faqs']" data-testid="onboarding-explore-card" class="explore-card explore-card--faqs">
                 <div class="explore-icon-wrapper">
                     <fa-icon [icon]="faQuestion" />
                 </div>

--- a/src/main/webapp/app/course/manage/user-management-dropdown/user-management-dropdown.component.html
+++ b/src/main/webapp/app/course/manage/user-management-dropdown/user-management-dropdown.component.html
@@ -1,5 +1,5 @@
 <div ngbDropdown container="body" class="d-inline">
-    <button id="user-management-dropdown" class="user-mgmt-btn" ngbDropdownToggle>
+    <button data-testid="user-management-dropdown" class="user-mgmt-btn" ngbDropdownToggle>
         <fa-icon [icon]="faUser" />
         <span class="d-none d-sm-inline"> {{ 'global.menu.admin.userManagement' | artemisTranslate }}</span>
     </button>

--- a/src/main/webapp/app/course/overview/exercise-details/exercise-split-panel/exercise-split-panel.component.html
+++ b/src/main/webapp/app/course/overview/exercise-details/exercise-split-panel/exercise-split-panel.component.html
@@ -21,7 +21,12 @@
                 <jhi-reset-repo-button [exercise]="exercise()" [participations]="exercise().studentParticipations!" [smallButtons]="false" />
             }
             @if (exampleSolutionInfo()?.exampleSolutionPublished) {
-                <p-panel [header]="'artemisApp.exercise.exampleSolution' | artemisTranslate" [toggleable]="true" [collapsed]="true">
+                <p-panel
+                    [pt]="{ pcToggleButton: { root: { 'data-testid': 'example-solution-toggle' } } }"
+                    [header]="'artemisApp.exercise.exampleSolution' | artemisTranslate"
+                    [toggleable]="true"
+                    [collapsed]="true"
+                >
                     <dl class="row-md jh-entity-details markdown-preview">
                         @if (exampleSolutionInfo()?.exampleSolutionUML && exampleSolutionInfo()?.modelingExercise) {
                             <dd>

--- a/src/main/webapp/app/course/shared/course-group/course-group.component.html
+++ b/src/main/webapp/app/course/shared/course-group/course-group.component.html
@@ -30,6 +30,7 @@
     <!-- Combined search/add autocomplete: filters the loaded member list and adds new members -->
     <ng-template #tableActionsRef>
         <p-autocomplete
+            [pt]="{ option: { 'data-testid': 'user-autocomplete-option' } }"
             size="small"
             [suggestions]="userSuggestions()"
             [placeholder]="'artemisApp.course.courseGroup.searchForUsers' | artemisTranslate"

--- a/src/main/webapp/app/course/sidebar/sidebar.component.html
+++ b/src/main/webapp/app/course/sidebar/sidebar.component.html
@@ -31,7 +31,7 @@
 
                             @if (inCommunication()) {
                                 <div class="ms-2" ngbDropdown>
-                                    <button type="button" class="btn btn-primary btn-sm square-button" ngbDropdownToggle>
+                                    <button type="button" data-testid="sidebar-create-menu-button" class="btn btn-primary btn-sm square-button" ngbDropdownToggle>
                                         <fa-icon [icon]="faPlusCircle" class="item-icon" />
                                     </button>
 

--- a/src/main/webapp/app/editor/markdown-editor/monaco/markdown-editor-monaco.component.html
+++ b/src/main/webapp/app/editor/markdown-editor/monaco/markdown-editor-monaco.component.html
@@ -152,7 +152,11 @@
         </div>
 
         <!-- Edit content: always rendered so the Monaco editor is never destroyed; visibility toggled by the active tab. -->
-        <div class="markdown-editor markdown-editor-wrapper flex-col border border-[var(--border-color)]" [ngClass]="{ flex: inEditMode(), hidden: !inEditMode() }">
+        <div
+            class="markdown-editor markdown-editor-wrapper flex-col border border-[var(--border-color)]"
+            data-testid="markdown-editor"
+            [ngClass]="{ flex: inEditMode(), hidden: !inEditMode() }"
+        >
             @if (mode() === 'diff') {
                 @if (renderSideBySide()) {
                     <!-- Split-view column headers so users know which side is which -->

--- a/src/main/webapp/app/exam/manage/exam-management/exam-management.component.html
+++ b/src/main/webapp/app/exam/manage/exam-management/exam-management.component.html
@@ -10,7 +10,7 @@
                     <fa-icon [icon]="faFileImport" />
                     <span jhiTranslate="artemisApp.examManagement.importExam"></span>
                 </a>
-                <a class="btn btn-primary btn-sm jh-create-entity create-exam" id="create-exam" [routerLink]="['new']">
+                <a class="btn btn-primary btn-sm jh-create-entity create-exam" data-testid="create-exam" [routerLink]="['new']">
                     <fa-icon [icon]="faPlus" />
                     <span jhiTranslate="artemisApp.examManagement.createExam"></span>
                 </a>

--- a/src/main/webapp/app/exam/manage/exams/detail/exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/exams/detail/exam-detail.component.html
@@ -2,7 +2,7 @@
     <div class="col-11">
         @if (exam()) {
             <div>
-                <h2 id="exam-detail-title">
+                <h2 data-testid="exam-detail-title">
                     @if (!exam().testExam) {
                         <span class="badge bg-success" jhiTranslate="artemisApp.examManagement.testExam.realExam"></span>
                     }
@@ -72,7 +72,7 @@
                             <fa-icon [icon]="faUndo" />
                         </button>
                         <button
-                            id="exam-delete"
+                            data-testid="exam-delete"
                             jhiDeleteButton
                             [buttonSize]="buttonSize"
                             [entityTitle]="exam().title || ''"

--- a/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-announcement-dialog/exam-live-announcement-create-button.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-announcement-dialog/exam-live-announcement-create-button.component.html
@@ -1,4 +1,4 @@
-<button id="announcement-create-button" class="btn btn-md btn-warning" [disabled]="!announcementCreationAllowed()" (click)="openDialog($event)">
+<button data-testid="announcement-create-button" class="btn btn-md btn-warning" [disabled]="!announcementCreationAllowed()" (click)="openDialog($event)">
     <fa-icon [icon]="faBullhorn" />
     <span class="d-none d-md-inline" jhiTranslate="artemisApp.examManagement.announcementCreate.button"></span>
 </button>

--- a/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist.component.html
@@ -593,7 +593,7 @@
                                 </ul>
                             </td>
                             <td>
-                                <a id="editButton_publish" [routerLink]="getExamRoutesByIdentifier()('edit')" class="btn btn-warning">
+                                <a data-testid="editButton_publish" [routerLink]="getExamRoutesByIdentifier()('edit')" class="btn btn-warning">
                                     <fa-icon [icon]="faWrench" />&nbsp;<span jhiTranslate="entity.action.edit"></span>
                                 </a>
                             </td>
@@ -631,7 +631,7 @@
                                 </ul>
                             </td>
                             <td>
-                                <a id="editButton_review" [routerLink]="getExamRoutesByIdentifier()('edit')" class="btn btn-warning">
+                                <a data-testid="editButton_review" [routerLink]="getExamRoutesByIdentifier()('edit')" class="btn btn-warning">
                                     <fa-icon [icon]="faWrench" />&nbsp;<span jhiTranslate="entity.action.edit"></span>
                                 </a>
                             </td>

--- a/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-edit-workingtime-dialog/exam-edit-working-time.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-edit-workingtime-dialog/exam-edit-working-time.component.html
@@ -1,4 +1,4 @@
-<button id="edit-working-time-button" class="btn btn-md btn-warning" [disabled]="!workingTimeChangeAllowed()" (click)="openDialog($event)">
+<button data-testid="edit-working-time-button" class="btn btn-md btn-warning" [disabled]="!workingTimeChangeAllowed()" (click)="openDialog($event)">
     <fa-icon [icon]="faHourglassHalf" />
     <span class="d-none d-md-inline" jhiTranslate="artemisApp.examManagement.editWorkingTime.title"></span>
 </button>

--- a/src/main/webapp/app/exam/manage/exams/exam-import/exam-import-progress-dialog.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-import/exam-import-progress-dialog.component.html
@@ -69,7 +69,7 @@
             }
         }
         <div class="d-flex justify-content-end mt-4">
-            <button id="exam-import-progress-dismiss" type="button" class="btn btn-primary" (click)="onDismiss()">
+            <button data-testid="exam-import-progress-dismiss" type="button" class="btn btn-primary" (click)="onDismiss()">
                 {{ 'artemisApp.examManagement.import.progress.dismiss' | artemisTranslate }}
             </button>
         </div>

--- a/src/main/webapp/app/exam/manage/exams/exam-mode-picker/exam-mode-picker.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-mode-picker/exam-mode-picker.component.html
@@ -1,4 +1,4 @@
-<div id="exam-mode-picker" class="d-flex align-items-start">
+<div data-testid="exam-mode-picker" class="d-flex align-items-start">
     <div class="btn-group" [ngClass]="{ disabled: disableInput() }">
         <div
             id="standard-mode"
@@ -10,7 +10,7 @@
             jhiTranslate="artemisApp.examManagement.testExam.realExam"
         ></div>
         <div
-            id="test-mode"
+            data-testid="test-mode"
             class="btn btn-default"
             [class.btn-primary]="exam().testExam"
             [class.btn-default]="!exam().testExam"

--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -1,5 +1,5 @@
 <div *titleBarTitle class="flex items-center">
-    <h5 class="mb-0" id="exercise-groups-title">
+    <h5 class="mb-0" data-testid="exercise-groups-title">
         <span><span jhiTranslate="artemisApp.examManagement.exerciseGroups"></span> ({{ exerciseGroupCount() }})</span>
     </h5>
 </div>

--- a/src/main/webapp/app/exam/manage/exercise-groups/group-edit-modal/exam-exercise-group-edit-modal.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/group-edit-modal/exam-exercise-group-edit-modal.component.html
@@ -22,7 +22,7 @@
         <tum-ui-button severity="secondary" variant="text" (clicked)="onCancel()">
             <span jhiTranslate="entity.action.cancel"></span>
         </tum-ui-button>
-        <tum-ui-button id="save-group" [disabled]="!isTitleValid()" (clicked)="onSave()">
+        <tum-ui-button data-testid="save-group" [disabled]="!isTitleValid()" (clicked)="onSave()">
             <span jhiTranslate="entity.action.save"></span>
         </tum-ui-button>
     </ng-template>

--- a/src/main/webapp/app/exam/manage/students/exam-students-menu-button/exam-students-menu-button.component.html
+++ b/src/main/webapp/app/exam/manage/students/exam-students-menu-button/exam-students-menu-button.component.html
@@ -1,4 +1,4 @@
-<p-menu #menu [model]="model()" [popup]="true" appendTo="body">
+<p-menu #menu [model]="model()" [popup]="true" appendTo="body" [pt]="{ item: { 'data-testid': 'exam-students-menu-entry' } }">
     <ng-template #item let-item>
         <span data-testid="exam-students-menu-item" class="p-menu-item-link" [class]="item.styleClass || ''" [title]="item.tooltip ? (item.tooltip | artemisTranslate) : ''">
             @if (item.icon) {

--- a/src/main/webapp/app/exam/manage/students/exam-students-menu-button/exam-students-menu-button.component.html
+++ b/src/main/webapp/app/exam/manage/students/exam-students-menu-button/exam-students-menu-button.component.html
@@ -1,6 +1,6 @@
 <p-menu #menu [model]="model()" [popup]="true" appendTo="body">
     <ng-template #item let-item>
-        <span class="p-menu-item-link" [class]="item.styleClass || ''" [title]="item.tooltip ? (item.tooltip | artemisTranslate) : ''">
+        <span data-testid="exam-students-menu-item" class="p-menu-item-link" [class]="item.styleClass || ''" [title]="item.tooltip ? (item.tooltip | artemisTranslate) : ''">
             @if (item.icon) {
                 <i [class]="item.icon + ' me-1'"></i>
             }

--- a/src/main/webapp/app/exam/overview/exam-bar/exam-bar.component.html
+++ b/src/main/webapp/app/exam/overview/exam-bar/exam-bar.component.html
@@ -14,7 +14,7 @@
                 />
                 <jhi-exam-live-events-button [examStartDate]="examStartDate()" />
                 @if (!isEndView()) {
-                    <button id="hand-in-early" class="btn btn-sm btn-danger ms-2" aria-label="Hand In Early" (click)="handInEarly()">
+                    <button data-testid="hand-in-early" class="btn btn-sm btn-danger ms-2" aria-label="Hand In Early" (click)="handInEarly()">
                         <div class="d-flex justify-content-between">
                             <span>
                                 <fa-icon [fixedWidth]="true" [icon]="faDoorClosed" />

--- a/src/main/webapp/app/exam/overview/exam-cover/exam-participation-cover.component.html
+++ b/src/main/webapp/app/exam/overview/exam-cover/exam-participation-cover.component.html
@@ -81,7 +81,7 @@
             </div>
         </div>
         <ng-container #startButton>
-            <button id="start-exam" [disabled]="!startButtonEnabled || waitingForExamStart() || isFetching()" type="submit" (click)="startExam()" class="btn btn-primary">
+            <button data-testid="start-exam" [disabled]="!startButtonEnabled || waitingForExamStart() || isFetching()" type="submit" (click)="startExam()" class="btn btn-primary">
                 <span jhiTranslate="artemisApp.exam.startExam"></span>
             </button>
             @if (!startButtonEnabled) {
@@ -106,7 +106,7 @@
         }
     } @else {
         <div class="d-flex justify-content-between">
-            <h4 id="exam-finished-title">
+            <h4 data-testid="exam-finished-title">
                 <span
                     jhiTranslate="artemisApp.examParticipation.finish"
                     [translateValues]="{
@@ -207,7 +207,7 @@
                     <span jhiTranslate="artemisApp.examParticipation.continueAfterHandInEarly"></span>
                 </button>
             }
-            <button id="end-exam" [disabled]="!endButtonEnabled" type="submit" (click)="submitExam()" class="btn btn-primary">
+            <button data-testid="end-exam" [disabled]="!endButtonEnabled" type="submit" (click)="submitExam()" class="btn btn-primary">
                 @if (submitInProgress()) {
                     <fa-icon class="me-1" [icon]="faSpinner" animation="spin" />
                 } @else {

--- a/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.html
+++ b/src/main/webapp/app/exam/overview/exam-participation/exam-participation.component.html
@@ -235,7 +235,7 @@
                     ></button>
                 } @else {
                     <p
-                        id="examSummaryUnavailableHint"
+                        data-testid="examSummaryUnavailableHint"
                         class="mb-0"
                         jhiTranslate="artemisApp.examParticipation.submissionSuccessful.summaryAvailableFrom"
                         [translateValues]="{ date: exam().examSummaryPublicationDate | artemisDate }"

--- a/src/main/webapp/app/exam/overview/exercises/file-upload/file-upload-exam-submission.component.html
+++ b/src/main/webapp/app/exam/overview/exercises/file-upload/file-upload-exam-submission.component.html
@@ -29,7 +29,7 @@
                                 <div class="col-4">
                                     <button
                                         class="btn btn-primary"
-                                        id="file-upload-submit"
+                                        data-testid="file-upload-submit"
                                         (click)="saveUploadedFile()"
                                         jhiTranslate="artemisApp.examParticipation.uploadFile"
                                     ></button>

--- a/src/main/webapp/app/exam/overview/general-information/exam-general-information.component.html
+++ b/src/main/webapp/app/exam/overview/general-information/exam-general-information.component.html
@@ -32,7 +32,7 @@
                     </tr>
                 }
                 @if (exam()?.title) {
-                    <tr id="exam-title">
+                    <tr data-testid="exam-title">
                         <th>{{ 'artemisApp.examManagement.examTitle' | artemisTranslate }}:</th>
                         <td>{{ exam().title }}</td>
                     </tr>

--- a/src/main/webapp/app/exam/overview/summary/exam-result-summary.component.html
+++ b/src/main/webapp/app/exam/overview/summary/exam-result-summary.component.html
@@ -33,7 +33,7 @@
     </div>
 }
 @if (studentExam() && studentExam().exercises && studentExam().exam?.course && studentExamGradeInfoDTO()) {
-    <div class="mb-4" id="exam-summary-result-overview">
+    <div class="mb-4" data-testid="exam-summary-result-overview">
         <jhi-exam-result-overview
             [studentExamWithGrade]="studentExamGradeInfoDTO()!"
             [isGradingKeyCollapsed]="isGradingKeyCollapsed()"

--- a/src/main/webapp/app/exam/overview/summary/exercises/header/exam-result-summary-exercise-card-header.component.html
+++ b/src/main/webapp/app/exam/overview/summary/exercises/header/exam-result-summary-exercise-card-header.component.html
@@ -8,7 +8,7 @@
             &nbsp;
             {{ exercise().exerciseGroup?.title }}
         </h5>
-        <div class="ms-3" id="exercise-result-score">
+        <div class="ms-3" data-testid="exercise-result-score">
             @if (resultsPublished() && exerciseInfo()?.achievedPoints !== undefined) {
                 <div class="d-flex">
                     [{{ exerciseInfo()?.achievedPoints }} / {{ exercise().maxPoints }} {{ 'artemisApp.examParticipation.exercisePoints' | artemisTranslate }}]

--- a/src/main/webapp/app/exam/overview/timer/exam-timer.component.html
+++ b/src/main/webapp/app/exam/overview/timer/exam-timer.component.html
@@ -1,6 +1,6 @@
 <div class="col-auto mb-0 timer px-1">
     {{ 'artemisApp.examParticipation.' + (isEndView() ? 'timerEndView' : 'timer') | artemisTranslate }}
 </div>
-<div class="col-auto text-overflow remaining-time m-0 px-0" [class.critical]="isCriticalTime()" id="displayTime">
+<div class="col-auto text-overflow remaining-time m-0 px-0" [class.critical]="isCriticalTime()" data-testid="displayTime">
     {{ displayTime$ | async }}
 </div>

--- a/src/main/webapp/app/exam/shared/events/exam-live-event.component.html
+++ b/src/main/webapp/app/exam/shared/events/exam-live-event.component.html
@@ -71,13 +71,13 @@
     </div>
     <div class="d-flex gap-2">
         @if (showAcknowledge()) {
-            <button class="btn btn-primary w-100 mt-2" (click)="acknowledgeEvent()">
+            <button class="btn btn-primary w-100 mt-2" data-testid="live-event-action-button" (click)="acknowledgeEvent()">
                 <fa-icon [icon]="faCheck" />
                 <span jhiTranslate="artemisApp.exam.events.acknowledge"></span>
             </button>
         }
         @if (event().eventType === ExamLiveEventType.PROBLEM_STATEMENT_UPDATE) {
-            <button class="btn btn-primary w-100 mt-2" (click)="navigateToExercise()">
+            <button class="btn btn-primary w-100 mt-2" data-testid="live-event-action-button" (click)="navigateToExercise()">
                 <span jhiTranslate="artemisApp.exam.events.navigateToExercise"></span>
             </button>
         }

--- a/src/main/webapp/app/exam/shared/events/exam-live-event.component.html
+++ b/src/main/webapp/app/exam/shared/events/exam-live-event.component.html
@@ -1,16 +1,16 @@
 <div class="event-wrapper" [ngClass]="event().eventType">
     <div class="headline">
-        <div class="type">
+        <div class="type" data-testid="live-event-type">
             {{ 'artemisApp.exam.events.type.' + event().eventType | artemisTranslate }}
         </div>
     </div>
-    <div class="date">
+    <div class="date" data-testid="live-event-date">
         <span><fa-icon [icon]="faPaperPlane" /> {{ event().createdDate | artemisDate }}</span>
         @if (event().acknowledgeTimestamps?.user) {
             <span>| <fa-icon [icon]="faEye" /> {{ event().acknowledgeTimestamps!.user! | artemisDate: 'time' }}</span>
         }
     </div>
-    <div class="content">
+    <div class="content" data-testid="live-event-content">
         @switch (event().eventType) {
             @case (ExamLiveEventType.EXAM_WIDE_ANNOUNCEMENT) {
                 <div [jhiMarkdown]="examWideAnnouncementEvent.text"></div>

--- a/src/main/webapp/app/exercise/difficulty-picker/difficulty-picker.component.html
+++ b/src/main/webapp/app/exercise/difficulty-picker/difficulty-picker.component.html
@@ -1,23 +1,27 @@
 <div class="btn-group">
     <div
+        data-testid="picker-option"
         class="btn"
         [ngClass]="{ 'btn-primary selected': !exercise().difficulty, 'btn-default': exercise().difficulty }"
         (click)="setDifficulty(undefined)"
         jhiTranslate="artemisApp.exercise.noLevel"
     ></div>
     <div
+        data-testid="picker-option"
         class="btn"
         [ngClass]="{ 'btn-success selected': exercise().difficulty === DifficultyLevel.EASY, 'btn-default': exercise().difficulty !== DifficultyLevel.EASY }"
         (click)="setDifficulty(DifficultyLevel.EASY)"
         jhiTranslate="artemisApp.exercise.easy"
     ></div>
     <div
+        data-testid="picker-option"
         class="btn btn-default"
         [ngClass]="{ 'btn-warning selected': exercise().difficulty === DifficultyLevel.MEDIUM, 'btn-default': exercise().difficulty !== DifficultyLevel.MEDIUM }"
         (click)="setDifficulty(DifficultyLevel.MEDIUM)"
         jhiTranslate="artemisApp.exercise.medium"
     ></div>
     <div
+        data-testid="picker-option"
         class="btn btn-default"
         [ngClass]="{ 'btn-danger selected': exercise().difficulty === DifficultyLevel.HARD, 'btn-default': exercise().difficulty !== DifficultyLevel.HARD }"
         (click)="setDifficulty(DifficultyLevel.HARD)"

--- a/src/main/webapp/app/exercise/example-submission/example-submissions.component.html
+++ b/src/main/webapp/app/exercise/example-submission/example-submissions.component.html
@@ -15,7 +15,7 @@
                     </a>
                 }
                 @if (exercise().course!.isAtLeastEditor) {
-                    <a id="import-example-submission" class="btn btn-primary me-1 mb-1" (click)="openImportModal()">
+                    <a data-testid="import-example-submission" class="btn btn-primary me-1 mb-1" (click)="openImportModal()">
                         <fa-icon [icon]="faPlus" />
                         <fa-icon class="d-xl-none" [icon]="faFont" />
                         <span class="d-none d-xl-inline" jhiTranslate="artemisApp.exampleSubmission.useAsExampleSubmission"></span>

--- a/src/main/webapp/app/exercise/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
+++ b/src/main/webapp/app/exercise/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
@@ -57,7 +57,7 @@
         }
         <!-- Example Submission -->
         @if (exercise.isAtLeastEditor && (exercise.type === ExerciseType.MODELING || exercise.type === ExerciseType.TEXT)) {
-            <a [routerLink]="baseResource() + 'example-submissions'" class="btn btn-success btn-sm" id="example-submissions-button">
+            <a [routerLink]="baseResource() + 'example-submissions'" class="btn btn-success btn-sm" data-testid="example-submissions-button">
                 <fa-icon [icon]="faBook" />
                 <span class="d-none d-md-inline" jhiTranslate="entity.action.exampleSubmissions"></span>
             </a>

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-header-actions/exercise-header-actions.component.html
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-header-actions/exercise-header-actions.component.html
@@ -40,7 +40,7 @@
                 #submitPopoverRef="ngbPopover"
             >
                 <button
-                    id="submit-exercise-popover"
+                    data-testid="submit-exercise-popover"
                     jhi-exercise-action-button
                     [buttonIcon]="faPaperPlane"
                     [buttonLabel]="'entity.action.submit' | artemisTranslate"

--- a/src/main/webapp/app/exercise/exercise-headers/exercise-headers-information/exercise-headers-information.component.html
+++ b/src/main/webapp/app/exercise/exercise-headers/exercise-headers-information/exercise-headers-information.component.html
@@ -1,5 +1,5 @@
 @if (exercise()) {
-    <div id="exercise-headers-information" class="align-self-stretch d-flex flex-row flex-wrap align-items-stretch gap-2 overflow-auto">
+    <div data-testid="exercise-headers-information" class="align-self-stretch d-flex flex-row flex-wrap align-items-stretch gap-2 overflow-auto">
         @for (informationBoxItem of informationBoxItems(); track $index) {
             @if (informationBoxItem.content.type === 'submissionStatus') {
                 @let historyClickable = interactive() && sortedHistoryResults().length;

--- a/src/main/webapp/app/exercise/exercise-headers/participation-mode-toggle/participation-mode-toggle.component.html
+++ b/src/main/webapp/app/exercise/exercise-headers/participation-mode-toggle/participation-mode-toggle.component.html
@@ -16,7 +16,7 @@
                 size="small"
             >
                 <ng-template #item let-option>
-                    <span class="participation-mode__item" [attr.id]="option.value + '-mode-button'">
+                    <span class="participation-mode__item" [attr.data-testid]="option.value + '-mode-button'" [attr.data-selected]="mode() === option.value">
                         <fa-icon [icon]="option.icon" />
                         <span [jhiTranslate]="option.label"></span>
                     </span>

--- a/src/main/webapp/app/exercise/feedback/feedback.component.html
+++ b/src/main/webapp/app/exercise/feedback/feedback.component.html
@@ -21,7 +21,7 @@
 
     <!-- Loading state -->
     @if (isLoading()) {
-        <div class="text-muted-color flex justify-center" id="result-detail-spinner">
+        <div class="text-muted-color flex justify-center" data-testid="result-detail-spinner">
             <fa-icon animation="spin" size="lg" [icon]="faCircleNotch" />
         </div>
     } @else {
@@ -80,7 +80,7 @@
 
                 @if (scoreChartVisible() && result().submission?.participation?.exercise) {
                     <div class="mb-12">
-                        <div id="feedback-chart" class="chart-space h-20">
+                        <div data-testid="feedback-chart" class="chart-space h-20">
                             <p-chart
                                 type="bar"
                                 [data]="scoreChartData()"

--- a/src/main/webapp/app/exercise/included-in-overall-score-picker/included-in-overall-score-picker.component.html
+++ b/src/main/webapp/app/exercise/included-in-overall-score-picker/included-in-overall-score-picker.component.html
@@ -1,5 +1,6 @@
 <div class="btn-group">
     <div
+        data-testid="picker-option"
         class="btn"
         [ngClass]="{
             'btn-primary selected': includedInOverallScore() === IncludedInOverallScore.INCLUDED_COMPLETELY,
@@ -9,6 +10,7 @@
         jhiTranslate="artemisApp.exercise.yes"
     ></div>
     <div
+        data-testid="picker-option"
         class="btn btn-default"
         [ngClass]="{
             'btn-primary selected': includedInOverallScore() === IncludedInOverallScore.INCLUDED_AS_BONUS,
@@ -19,6 +21,7 @@
     ></div>
     @if (allowNotIncluded()) {
         <div
+            data-testid="picker-option"
             class="btn btn-default"
             [ngClass]="{
                 'btn-primary selected': includedInOverallScore() === IncludedInOverallScore.NOT_INCLUDED,

--- a/src/main/webapp/app/exercise/mode-picker/mode-picker.component.html
+++ b/src/main/webapp/app/exercise/mode-picker/mode-picker.component.html
@@ -1,7 +1,13 @@
 <div class="d-flex align-items-start">
     <div class="btn-group" [ngClass]="{ disabled: disabled() }">
         @for (option of options(); track option) {
-            <div class="btn" [class.disabled]="disabled()" [ngClass]="value() === option.value ? option.btnClass : 'btn-default'" (click)="setMode(option.value)">
+            <div
+                class="btn"
+                data-testid="mode-picker-option"
+                [class.disabled]="disabled()"
+                [ngClass]="value() === option.value ? option.btnClass : 'btn-default'"
+                (click)="setMode(option.value)"
+            >
                 {{ option.label ?? (option.labelKey | artemisTranslate) }}
             </div>
         }

--- a/src/main/webapp/app/exercise/mode-picker/mode-picker.component.html
+++ b/src/main/webapp/app/exercise/mode-picker/mode-picker.component.html
@@ -1,13 +1,7 @@
 <div class="d-flex align-items-start">
     <div class="btn-group" [ngClass]="{ disabled: disabled() }">
         @for (option of options(); track option) {
-            <div
-                class="btn"
-                data-testid="mode-picker-option"
-                [class.disabled]="disabled()"
-                [ngClass]="value() === option.value ? option.btnClass : 'btn-default'"
-                (click)="setMode(option.value)"
-            >
+            <div class="btn" [class.disabled]="disabled()" [ngClass]="value() === option.value ? option.btnClass : 'btn-default'" (click)="setMode(option.value)">
                 {{ option.label ?? (option.labelKey | artemisTranslate) }}
             </div>
         }

--- a/src/main/webapp/app/exercise/team/team-owner-search/team-owner-search.component.html
+++ b/src/main/webapp/app/exercise/team/team-owner-search/team-owner-search.component.html
@@ -1,6 +1,6 @@
 <input
     #instance="ngbTypeahead"
-    id="owner-search-input"
+    data-testid="owner-search-input"
     name="search-filter"
     type="text"
     class="form-control"

--- a/src/main/webapp/app/exercise/team/team-student-search/team-student-search.component.html
+++ b/src/main/webapp/app/exercise/team/team-student-search/team-student-search.component.html
@@ -1,6 +1,6 @@
 <input
     #ngbTypeahead
-    id="student-search-input"
+    data-testid="student-search-input"
     name="search-filter"
     type="text"
     class="form-control"

--- a/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.html
+++ b/src/main/webapp/app/fileupload/manage/assess/file-upload-assessment.component.html
@@ -33,7 +33,7 @@
                 <div left-body>
                     <div class="row">
                         @if (submission()?.filePathUrl; as filePathUrl) {
-                            <div class="col-12 card-text" id="e2e-download-file">
+                            <div class="col-12 card-text" data-testid="e2e-download-file">
                                 <a class="text-primary" (click)="downloadFile(filePathUrl)" jhiTranslate="artemisApp.fileUploadAssessment.submissionFile"></a>
                                 <span class="ms-2 badge bg-info">{{ attachmentExtension(filePathUrl) | uppercase }}</span>
                             </div>

--- a/src/main/webapp/app/iris/overview/context-selection/context-selection.component.html
+++ b/src/main/webapp/app/iris/overview/context-selection/context-selection.component.html
@@ -8,7 +8,11 @@
         <p-select
             [attr.aria-label]="'artemisApp.iris.contextSelection.label' | artemisTranslate"
             [disabled]="disabled()"
-            [pt]="{ header: { style: 'padding-left: 12px; padding-right: 12px;' } }"
+            [pt]="{
+                header: { style: 'padding-left: 12px; padding-right: 12px;' },
+                listContainer: { 'data-testid': 'iris-context-overlay' },
+                option: { 'data-testid': 'iris-context-option' },
+            }"
             [options]="allGroups()"
             [group]="true"
             optionGroupLabel="label"

--- a/src/main/webapp/app/lecture/manage/lecture-attachments/lecture-attachments.component.html
+++ b/src/main/webapp/app/lecture/manage/lecture-attachments/lecture-attachments.component.html
@@ -196,7 +196,7 @@
                     <a
                         [routerLink]="['/course-management', lecture().course?.id, `lectures`, lecture().id, 'unit-management', 'attachment-video-units', 'create']"
                         class="btn btn-primary me-2"
-                        id="add-attachment"
+                        data-testid="add-attachment"
                     >
                         <span jhiTranslate="entity.action.addAttachment"></span>
                     </a>

--- a/src/main/webapp/app/lecture/manage/lecture-units/unit-creation-card/unit-creation-card.component.html
+++ b/src/main/webapp/app/lecture/manage/lecture-units/unit-creation-card/unit-creation-card.component.html
@@ -1,4 +1,4 @@
-<div class="container" id="unit-creation">
+<div class="container" data-testid="unit-creation">
     <div class="d-flex justify-content-center flex-wrap gap-1 align-items-center">
         <div class="text-center text-primary me-2">{{ 'artemisApp.lectureUnit.unitCreationCard.title' | artemisTranslate }}:</div>
         <div class="d-flex justify-content-center flex-wrap gap-1 align-items-center">

--- a/src/main/webapp/app/lecture/manage/lecture/lecture.component.html
+++ b/src/main/webapp/app/lecture/manage/lecture/lecture.component.html
@@ -150,7 +150,7 @@
                                             <button
                                                 class="mt-1"
                                                 jhiDeleteButton
-                                                id="delete-lecture"
+                                                data-testid="delete-lecture"
                                                 [entityTitle]="lecture.title || ''"
                                                 deleteQuestion="artemisApp.lecture.delete.question"
                                                 deleteConfirmationText="artemisApp.lecture.delete.typeNameToConfirm"

--- a/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.component.html
@@ -37,7 +37,8 @@
                 }
                 @if (this.lectureUnit().completed !== undefined && !isPresentationMode() && isVisibleToStudents()) {
                     <fa-icon
-                        id="completed-checkbox"
+                        data-testid="lecture-unit-completion-icon"
+                        [attr.data-completed]="!!this.lectureUnit().completed"
                         [ngClass]="{ 'text-body-secondary': !this.lectureUnit().completed, 'text-success': this.lectureUnit().completed }"
                         size="lg"
                         [icon]="this.lectureUnit().completed ? faCheckCircle : faCircle"

--- a/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.component.spec.ts
+++ b/src/main/webapp/app/lecture/overview/course-lectures/lecture-unit/lecture-unit.component.spec.ts
@@ -98,7 +98,7 @@ describe('LectureUnitComponent', () => {
 
         fixture.detectChanges();
 
-        const completedCheckbox = fixture.debugElement.query(By.css('#completed-checkbox'));
+        const completedCheckbox = fixture.debugElement.query(By.css('[data-testid="lecture-unit-completion-icon"]'));
         completedCheckbox.nativeElement.click();
 
         expect(toggleCompletionSpy).toHaveBeenCalledTimes(1);

--- a/src/main/webapp/app/logos/llm-selection-popup.component.html
+++ b/src/main/webapp/app/logos/llm-selection-popup.component.html
@@ -1,6 +1,7 @@
 @if (isVisible()) {
     <div
         class="modal-backdrop"
+        data-testid="llm-selection-modal"
         [class.dark-theme]="themeService.currentTheme() === Theme.DARK"
         (click)="onBackdropClick($event)"
         role="dialog"
@@ -16,7 +17,15 @@
 
             <div class="options-container">
                 <!-- Cloud AI Card -->
-                <div class="option-card cloud-card" tabindex="0" role="button" (click)="selectCloud()" (keydown.enter)="selectCloud()" (keydown.space)="selectCloud()">
+                <div
+                    class="option-card cloud-card"
+                    data-testid="llm-selection-cloud-option"
+                    tabindex="0"
+                    role="button"
+                    (click)="selectCloud()"
+                    (keydown.enter)="selectCloud()"
+                    (keydown.space)="selectCloud()"
+                >
                     <div class="icons-wrapper">
                         <div class="icon-container">
                             <div class="icon-circle azure">

--- a/src/main/webapp/app/modeling/manage/example-modeling/example-modeling-submission.component.html
+++ b/src/main/webapp/app/modeling/manage/example-modeling/example-modeling-submission.component.html
@@ -48,7 +48,7 @@
                         <button type="button" tumUiButton size="small" (click)="upsertExampleModelingSubmission()">
                             <fa-icon [icon]="faSave" />
                             @if (isNewSubmission()) {
-                                <span jhiTranslate="artemisApp.modelingExercise.createNewExampleSubmission" id="new-modeling-example-submission"></span>
+                                <span jhiTranslate="artemisApp.modelingExercise.createNewExampleSubmission" data-testid="new-modeling-example-submission"></span>
                             } @else {
                                 <span jhiTranslate="artemisApp.modelingExercise.saveExampleSubmission"></span>
                             }
@@ -104,7 +104,7 @@
                                         class="artemis-apollon-chrome-action apollon-chrome-iconbtn apollon-chrome-iconbtn--toggle"
                                         aria-pressed="false"
                                         (click)="showAssessment()"
-                                        id="show-modeling-example-assessment"
+                                        data-testid="show-modeling-example-assessment"
                                     >
                                         <fa-icon [icon]="faClipboardCheck" />
                                         <span jhiTranslate="artemisApp.exampleSubmission.assessmentMode"></span>

--- a/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.html
+++ b/src/main/webapp/app/modeling/manage/update/modeling-exercise-update.component.html
@@ -36,7 +36,7 @@
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.difficulty"></label>
             <div>
-                <jhi-difficulty-picker [exercise]="modelingExercise" id="modeling-difficulty-picker" />
+                <jhi-difficulty-picker [exercise]="modelingExercise" data-testid="modeling-difficulty-picker" />
             </div>
         </div>
         <jhi-team-config-form-group class="form-element" [exercise]="modelingExercise" [isImport]="isImport()" />
@@ -129,7 +129,7 @@
                             [(includedInOverallScore)]="modelingExercise.includedInOverallScore"
                             (includedInOverallScoreChange)="validateDate()"
                             [allowNotIncluded]="!isExamMode()"
-                            id="modeling-includeInScore-picker"
+                            data-testid="modeling-includeInScore-picker"
                         />
                     </div>
                 </div>

--- a/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.component.html
+++ b/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.component.html
@@ -91,7 +91,7 @@
                                                                     <span jhiTranslate="artemisApp.modelingSubmission.assessment.onDiagram"></span>
                                                                     <span class="feedback-group__count">{{ referencedFeedback?.length }}</span>
                                                                 </h4>
-                                                                <ul class="feedback-list" id="component-feedback-table">
+                                                                <ul class="feedback-list" data-testid="component-feedback-table">
                                                                     @for (feedback of referencedFeedback; track feedback.id) {
                                                                         <li
                                                                             class="feedback-row"

--- a/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-inline-feedback/code-editor-tutor-assessment-inline-feedback.component.html
+++ b/src/main/webapp/app/programming/manage/assess/code-editor-tutor-assessment-inline-feedback/code-editor-tutor-assessment-inline-feedback.component.html
@@ -80,7 +80,7 @@
                         <fa-icon [icon]="faTrashAlt" />
                     </button>
                 }
-                <button id="feedback-save" type="submit" [disabled]="feedback.credits === undefined" class="btn btn-primary btn-sm" (click)="updateFeedback()">
+                <button data-testid="feedback-save" type="submit" [disabled]="feedback.credits === undefined" class="btn btn-primary btn-sm" (click)="updateFeedback()">
                     <fa-icon [icon]="faSave" />&nbsp;<span jhiTranslate="entity.action.save"></span>
                 </button>
             </div>

--- a/src/main/webapp/app/programming/manage/code-editor/build-output/code-editor-build-output.component.html
+++ b/src/main/webapp/app/programming/manage/code-editor/build-output/code-editor-build-output.component.html
@@ -1,4 +1,4 @@
-<div id="cardBuildOutput" class="card border build-output">
+<div data-testid="cardBuildOutput" class="card border build-output">
     <div [class]="secondaryHeader() ? 'card-second-header' : 'card-header code-editor-panel-header d-flex'" (click)="toggleEditorCollapse($event)">
         <h3 class="card-title">
             <fa-icon [icon]="faTerminal" />

--- a/src/main/webapp/app/programming/manage/code-editor/file-browser/code-editor-file-browser.component.html
+++ b/src/main/webapp/app/programming/manage/code-editor/file-browser/code-editor-file-browser.component.html
@@ -1,4 +1,4 @@
-<div id="cardFiles" class="card file-browser" [ngStyle]="collapsed() ? { height: '250px' } : { height: '100%' }">
+<div data-testid="cardFiles" class="card file-browser" [ngStyle]="collapsed() ? { height: '250px' } : { height: '100%' }">
     <div class="card-header code-editor-panel-header d-flex justify-content-center" [class.d-none]="!showHeader()" (click)="toggleEditorCollapse($event)">
         <h3 class="card-title justify-content-center">
             @if (!collapsed()) {

--- a/src/main/webapp/app/programming/manage/code-editor/file-browser/create-node/code-editor-file-browser-create-node.component.html
+++ b/src/main/webapp/app/programming/manage/code-editor/file-browser/create-node/code-editor-file-browser-create-node.component.html
@@ -1,4 +1,4 @@
-<li class="list-group-item border-0" id="file-browser-create-node">
+<li class="list-group-item border-0" data-testid="file-browser-create-node">
     <fa-icon aria-hidden="true" [icon]="createFileType() === FileType.FILE ? faFile : faFolder" [fixedWidth]="true" />
     <span class="ms-1"
         ><input

--- a/src/main/webapp/app/programming/manage/code-editor/file-browser/delete/code-editor-file-browser-delete.component.html
+++ b/src/main/webapp/app/programming/manage/code-editor/file-browser/delete/code-editor-file-browser-delete.component.html
@@ -21,7 +21,7 @@
             <fa-icon [icon]="faBan" />&nbsp;<span jhiTranslate="entity.action.cancel"></span>
         </button>
         <button type="submit" class="btn btn-danger" [disabled]="!deleteForm.valid">
-            <fa-icon id="delete-file" [icon]="faTrashAlt" />&nbsp;<span jhiTranslate="artemisApp.editor.fileBrowser.delete"></span>
+            <fa-icon data-testid="delete-file" [icon]="faTrashAlt" />&nbsp;<span jhiTranslate="artemisApp.editor.fileBrowser.delete"></span>
         </button>
     </div>
 </form>

--- a/src/main/webapp/app/programming/manage/code-editor/file-browser/file/code-editor-file-browser-file.component.html
+++ b/src/main/webapp/app/programming/manage/code-editor/file-browser/file/code-editor-file-browser-file.component.html
@@ -5,7 +5,7 @@
     [class.node-selected]="item().checked"
     [class.text-danger]="!item().checked && hasError()"
     [class.bg-warning]="hasChanges()"
-    id="file-browser-file"
+    data-testid="file-browser-file"
 >
     <fa-icon aria-hidden="true" [icon]="faFile" [fixedWidth]="true" />
     <span class="file-label-group">
@@ -38,7 +38,7 @@
                 <fa-icon id="file-browser-file-edit" [icon]="faEdit" title="{{ 'artemisApp.editor.fileBrowser.renameFile' | artemisTranslate }}" />
             </button>
             <button (click)="deleteNode($event)" class="btn btn-small">
-                <fa-icon id="file-browser-file-delete" [icon]="faTrash" title="{{ 'artemisApp.editor.fileBrowser.deleteFile' | artemisTranslate }}" />
+                <fa-icon data-testid="file-browser-file-delete" [icon]="faTrash" title="{{ 'artemisApp.editor.fileBrowser.deleteFile' | artemisTranslate }}" />
             </button>
         </span>
     }

--- a/src/main/webapp/app/programming/manage/code-editor/file-browser/folder/code-editor-file-browser-folder.component.html
+++ b/src/main/webapp/app/programming/manage/code-editor/file-browser/folder/code-editor-file-browser-folder.component.html
@@ -29,7 +29,7 @@
     @if (!disableActions()) {
         <span class="file-icons">
             <button (click)="setCreatingNodeInFolder($event, FileType.FILE)" class="btn btn-small">
-                <fa-icon id="file-browser-folder-create-file" [icon]="faFile" title="{{ 'artemisApp.editor.fileBrowser.createFile' | artemisTranslate }}" />
+                <fa-icon data-testid="file-browser-folder-create-file" [icon]="faFile" title="{{ 'artemisApp.editor.fileBrowser.createFile' | artemisTranslate }}" />
             </button>
             <button (click)="setCreatingNodeInFolder($event, FileType.FOLDER)" class="btn btn-small">
                 <fa-icon [icon]="faFolder" title="{{ 'artemisApp.editor.fileBrowser.createFolder' | artemisTranslate }}" />

--- a/src/main/webapp/app/programming/manage/grading/table-actions/programming-exercise-grading-table-actions.component.html
+++ b/src/main/webapp/app/programming/manage/grading/table-actions/programming-exercise-grading-table-actions.component.html
@@ -5,7 +5,7 @@
     </button>
 }
 <button
-    id="save-table-button"
+    data-testid="save-table-button"
     class="btn btn-primary ms-3 my-3"
     jhiTranslate="artemisApp.programmingExercise.configureGrading.save"
     (click)="onSave.emit()"

--- a/src/main/webapp/app/programming/manage/update/switch-edit-mode-button/switch-edit-mode-button.component.html
+++ b/src/main/webapp/app/programming/manage/update/switch-edit-mode-button/switch-edit-mode-button.component.html
@@ -1,5 +1,5 @@
 <jhi-button
-    id="switch-edit-mode-button"
+    data-testid="switch-edit-mode-button"
     [btnType]="ButtonType.PRIMARY"
     [btnSize]="buttonSize()"
     [icon]="faHandShakeAngle"

--- a/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.component.html
+++ b/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.component.html
@@ -24,7 +24,7 @@
                 <ng-content select="[editorSidebarLeft]" />
                 <!-- Required for resizing; don't remove empty span -->
                 @if (!fileBrowserIsCollapsed()) {
-                    <fa-icon [icon]="faGripLinesVertical" id="draggableIconForFileBrowser" class="rg-sidebar-left">
+                    <fa-icon [icon]="faGripLinesVertical" data-testid="draggableIconForFileBrowser" class="rg-sidebar-left">
                         <span></span>
                     </fa-icon>
                 }

--- a/src/main/webapp/app/quiz/manage/apollon-diagrams/create-form/apollon-diagram-create-form.component.html
+++ b/src/main/webapp/app/quiz/manage/apollon-diagrams/create-form/apollon-diagram-create-form.component.html
@@ -25,7 +25,7 @@
         <button type="button" tumUiButton severity="secondary" variant="outlined" size="small" (click)="dismiss()">
             <span jhiTranslate="entity.action.cancel"></span>
         </button>
-        <button id="save-dnd-quiz" type="submit" tumUiButton severity="primary" size="small" [disabled]="editForm.form.invalid || isSaving()">
+        <button data-testid="save-dnd-quiz" type="submit" tumUiButton severity="primary" size="small" [disabled]="editForm.form.invalid || isSaving()">
             <fa-icon [icon]="faSave" />
             <span jhiTranslate="global.generic.create"></span>
         </button>

--- a/src/main/webapp/app/quiz/manage/apollon-diagrams/detail/apollon-diagram-detail.component.html
+++ b/src/main/webapp/app/quiz/manage/apollon-diagrams/detail/apollon-diagram-detail.component.html
@@ -103,7 +103,7 @@
         <span jhiTranslate="artemisApp.apollonDiagram.detail.save"></span>
     </button>
     <span [tumUiTooltip]="generateHint()">
-        <button id="generate-quiz-exercise" type="button" tumUiButton severity="primary" size="small" [disabled]="!canGenerate()" (click)="generateExercise()">
+        <button data-testid="generate-quiz-exercise" type="button" tumUiButton severity="primary" size="small" [disabled]="!canGenerate()" (click)="generateExercise()">
             <span jhiTranslate="artemisApp.apollonDiagram.detail.createLabel"></span>
         </button>
     </span>

--- a/src/main/webapp/app/quiz/manage/apollon-diagrams/list/apollon-diagram-list.component.html
+++ b/src/main/webapp/app/quiz/manage/apollon-diagrams/list/apollon-diagram-list.component.html
@@ -16,7 +16,7 @@
 
 <div class="apollon-diagram-list__body flex min-h-0 grow flex-col gap-3 px-4">
     <div class="shrink-0">
-        <button type="button" tumUiButton severity="primary" size="small" id="create-apollon-diagram" (click)="openCreateDiagramDialog(internalCourseId())">
+        <button type="button" tumUiButton severity="primary" size="small" data-testid="create-apollon-diagram" (click)="openCreateDiagramDialog(internalCourseId())">
             <fa-icon [icon]="faPlus" />
             <span jhiTranslate="artemisApp.apollonDiagram.home.createLabel"></span>
         </button>

--- a/src/main/webapp/app/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
+++ b/src/main/webapp/app/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
@@ -12,7 +12,7 @@
             <div class="question-title">
                 <input
                     pInputText
-                    id="drag-and-drop-question-title"
+                    data-testid="drag-and-drop-question-title"
                     [(ngModel)]="question().title"
                     (ngModelChange)="questionUpdated.emit()"
                     placeholder="{{ 'artemisApp.quizExercise.placeholder.shortQuestionTitle' | artemisTranslate }}"
@@ -233,7 +233,7 @@
             <div class="question-options row d-flex justify-content-start">
                 <div class="input-group col-lg-7 col-md-8 col-sm-8 col-xs-10 drag-item-file">
                     <div class="input-group-prepend">
-                        <button class="btn btn-outline-secondary" id="background-file-input-button" (click)="backgroundFileInput.click()">
+                        <button class="btn btn-outline-secondary" data-testid="background-file-input-button" (click)="backgroundFileInput.click()">
                             <fa-icon [icon]="faPlus" />
                             @if (!reEvaluationInProgress()) {
                                 <span jhiTranslate="artemisApp.dragAndDropQuestion.selectBackgroundPicture" class="no-flex-shrink"></span>
@@ -449,7 +449,7 @@
                         }
                     </button>
                     <input #dragItemFileInput id="dragItemFileInput{{ questionIndex() }}" type="file" accept="image/*" [hidden]="true" (change)="createImageDragItem($event)" />
-                    <button class="btn btn-outline-secondary me-2" id="add-text-drag-item" (click)="addTextDragItem()">
+                    <button class="btn btn-outline-secondary me-2" data-testid="add-text-drag-item" (click)="addTextDragItem()">
                         <fa-icon [icon]="faPlus" />
                         <span jhiTranslate="artemisApp.dragAndDropQuestion.addDragItemText"></span>
                     </button>

--- a/src/main/webapp/app/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
+++ b/src/main/webapp/app/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
@@ -271,7 +271,14 @@
                         [alt]="'artemisApp.dragAndDropQuestion.noBackgroundPicture' | artemisTranslate"
                         style="visibility: hidden"
                     />
-                    <div #clickLayer class="click-layer" (mousedown)="backgroundMouseDown()" [ngClass]="{ disabled: !question().backgroundFilePath || !backgroundReady() }">
+                    <div
+                        #clickLayer
+                        class="click-layer"
+                        data-testid="drag-and-drop-click-layer"
+                        [attr.data-ready]="!!question().backgroundFilePath && backgroundReady()"
+                        (mousedown)="backgroundMouseDown()"
+                        [ngClass]="{ disabled: !question().backgroundFilePath || !backgroundReady() }"
+                    >
                         @if (backgroundReady()) {
                             @for (dropLocation of question().dropLocations ?? []; track dropLocation) {
                                 <div

--- a/src/main/webapp/app/quiz/manage/list-edit/quiz-question-list-edit.component.html
+++ b/src/main/webapp/app/quiz/manage/list-edit/quiz-question-list-edit.component.html
@@ -73,19 +73,19 @@
             }
             @if (!disabled()) {
                 <div class="add-question-actions">
-                    <button id="quiz-add-mc-question" class="add-question-btn" (click)="addMultipleChoiceQuestion()">
+                    <button data-testid="quiz-add-mc-question" class="add-question-btn" (click)="addMultipleChoiceQuestion()">
                         <fa-icon [icon]="faPlus" />
                         <span jhiTranslate="artemisApp.quizExercise.addMultipleChoiceQuestion"></span>
                     </button>
-                    <button id="quiz-add-dnd-question" class="add-question-btn" (click)="addDragAndDropQuestion()">
+                    <button data-testid="quiz-add-dnd-question" class="add-question-btn" (click)="addDragAndDropQuestion()">
                         <fa-icon [icon]="faPlus" />
                         <span jhiTranslate="artemisApp.quizExercise.addDragAndDropQuestion"></span>
                     </button>
-                    <button id="quiz-import-apollon-dnd-question" class="add-question-btn" (click)="importApollonDragAndDropQuestion()">
+                    <button data-testid="quiz-import-apollon-dnd-question" class="add-question-btn" (click)="importApollonDragAndDropQuestion()">
                         <fa-icon [icon]="faPlus" />
                         <span jhiTranslate="artemisApp.quizExercise.addApollonDragAndDropQuestion"></span>
                     </button>
-                    <button id="quiz-add-short-answer-question" class="add-question-btn" (click)="addShortAnswerQuestion()">
+                    <button data-testid="quiz-add-short-answer-question" class="add-question-btn" (click)="addShortAnswerQuestion()">
                         <fa-icon [icon]="faPlus" />
                         <span jhiTranslate="artemisApp.quizExercise.addShortAnswerQuestion"></span>
                     </button>

--- a/src/main/webapp/app/quiz/manage/manage-buttons/quiz-exercise-manage-buttons.component.html
+++ b/src/main/webapp/app/quiz/manage/manage-buttons/quiz-exercise-manage-buttons.component.html
@@ -21,7 +21,7 @@
             </a>
         </div>
         <div class="{{ isDetailPage() ? 'd-flex' : 'btn-group-vertical me-1 mb-1' }} ">
-            <a id="preview-quiz" [routerLink]="[baseUrl(), 'quiz-exercises', quizExercise().id, 'preview']" class="btn btn-success btn-sm me-1 mb-1">
+            <a data-testid="preview-quiz" [routerLink]="[baseUrl(), 'quiz-exercises', quizExercise().id, 'preview']" class="btn btn-success btn-sm me-1 mb-1">
                 <fa-icon [icon]="faEye" />
                 <span class="d-none d-md-inline" jhiTranslate="artemisApp.quizExercise.preview"></span>
             </a>

--- a/src/main/webapp/app/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
+++ b/src/main/webapp/app/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
@@ -11,7 +11,7 @@
             </button>
             <div class="question-title">
                 <input
-                    id="mc-question-title"
+                    data-testid="mc-question-title"
                     pInputText
                     [(ngModel)]="question().title"
                     (ngModelChange)="questionUpdated.emit()"

--- a/src/main/webapp/app/quiz/manage/short-answer-question/short-answer-question-edit.component.html
+++ b/src/main/webapp/app/quiz/manage/short-answer-question/short-answer-question-edit.component.html
@@ -453,7 +453,7 @@
                     <div class="btn btn-outline-secondary active" jhiTranslate="artemisApp.shortAnswerQuestion.editor.text"></div>
                     <div
                         class="btn btn-outline-secondary"
-                        id="short-answer-show-visual"
+                        data-testid="short-answer-show-visual"
                         jhiTranslate="artemisApp.shortAnswerQuestion.editor.visual"
                         (click)="togglePreview()"
                     ></div>

--- a/src/main/webapp/app/quiz/manage/update/quiz-ai-generation-modal/quiz-ai-generation-modal.component.html
+++ b/src/main/webapp/app/quiz/manage/update/quiz-ai-generation-modal/quiz-ai-generation-modal.component.html
@@ -8,6 +8,7 @@
     [style]="{ width: '90vw', 'max-width': '84rem' }"
     [contentStyle]="{ padding: '1.25rem' }"
     styleClass="quiz-ai-generation-modal"
+    [pt]="{ root: { 'data-testid': 'quiz-ai-generation-modal' }, header: { 'data-testid': 'quiz-ai-generation-modal-header' } }"
     [breakpoints]="{ '1200px': '96vw' }"
     appendTo="body"
 >
@@ -72,6 +73,7 @@
                         </span>
                     </div>
                     <p-multiselect
+                        [pt]="{ overlay: { 'data-testid': 'quiz-ai-competency-overlay' }, option: { 'data-testid': 'quiz-ai-competency-option' } }"
                         inputId="quiz-ai-competencies"
                         [options]="courseCompetencies()"
                         [ngModel]="selectedCompetencies()"

--- a/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.html
+++ b/src/main/webapp/app/quiz/manage/update/quiz-exercise-update.component.html
@@ -418,7 +418,7 @@
                                 </button>
                             }
                             <button
-                                id="quiz-save"
+                                data-testid="quiz-save"
                                 class="footer-save-btn"
                                 (click)="validateItemLimit()"
                                 [disabled]="isSaveDisabled()"

--- a/src/main/webapp/app/quiz/overview/course-training/quiz-training-dialog.component.html
+++ b/src/main/webapp/app/quiz/overview/course-training/quiz-training-dialog.component.html
@@ -1,4 +1,12 @@
-<p-dialog [(visible)]="visible" [modal]="true" [closable]="closable()" [style]="{ width: '600px', height: 'auto' }" appendTo="body" [draggable]="false">
+<p-dialog
+    [pt]="{ root: { 'data-testid': 'quiz-training-dialog' }, mask: { 'data-testid': 'quiz-training-dialog-mask' } }"
+    [(visible)]="visible"
+    [modal]="true"
+    [closable]="closable()"
+    [style]="{ width: '600px', height: 'auto' }"
+    appendTo="body"
+    [draggable]="false"
+>
     <ng-template #header>
         <h5 jhiTranslate="artemisApp.quizTraining.theQuizTraining"></h5>
     </ng-template>
@@ -29,7 +37,7 @@
             </span>
         </div>
         <ng-template #footer>
-            <jhi-button [title]="'artemisApp.quizTraining.confirm'" [disabled]="saveDisabled()" (onClick)="save.emit()" />
+            <jhi-button data-testid="quiz-training-confirm-button" [title]="'artemisApp.quizTraining.confirm'" [disabled]="saveDisabled()" (onClick)="save.emit()" />
         </ng-template>
     }
 </p-dialog>

--- a/src/main/webapp/app/quiz/overview/participation/quiz-participation.component.html
+++ b/src/main/webapp/app/quiz/overview/participation/quiz-participation.component.html
@@ -63,7 +63,7 @@
                                     <!-- Show the submit button only in preview mode(). In live and practice modes submission() is handled by the quiz flow; solution mode() is read-only. -->
                                     @if (mode() === 'preview') {
                                         <jhi-button
-                                            id="submit-quiz"
+                                            data-testid="submit-quiz"
                                             (onClick)="submitExercise()"
                                             [btnSize]="ButtonSize.SMALL"
                                             [btnType]="ButtonType.PRIMARY"
@@ -319,13 +319,13 @@
                         @if (quizExercise().quizMode === QuizMode.BATCHED && (quizExercise().remainingNumberOfAttempts ?? 1) > 0) {
                             <div jhiTranslate="artemisApp.quizExercise.quizInstructions.enterPassword"></div>
                             <div class="join-batch-row">
-                                <input id="join-patch-password" [(ngModel)]="password" (keyup.enter)="joinBatch()" />
-                                <jhi-button id="join-batch" [title]="'artemisApp.quizExercise.join'" [btnType]="ButtonType.SUCCESS" (onClick)="joinBatch()" />
+                                <input data-testid="join-patch-password" [(ngModel)]="password" (keyup.enter)="joinBatch()" />
+                                <jhi-button data-testid="join-batch" [title]="'artemisApp.quizExercise.join'" [btnType]="ButtonType.SUCCESS" (onClick)="joinBatch()" />
                             </div>
                         }
                         @if (quizExercise().quizMode === QuizMode.INDIVIDUAL && (quizExercise().remainingNumberOfAttempts ?? 1) > 0) {
                             <div jhiTranslate="artemisApp.quizExercise.quizInstructions.startNow"></div>
-                            <jhi-button id="start-batch" [title]="'artemisApp.quizExercise.startBatch'" [btnType]="ButtonType.SUCCESS" (onClick)="joinBatch()" />
+                            <jhi-button data-testid="start-batch" [title]="'artemisApp.quizExercise.startBatch'" [btnType]="ButtonType.SUCCESS" (onClick)="joinBatch()" />
                         }
                         @if (quizExercise().quizMode !== QuizMode.SYNCHRONIZED && quizExercise().remainingNumberOfAttempts === 0) {
                             @if ((quizExercise().allowedNumberOfAttempts ?? 0) > 1) {

--- a/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/visual-question/multiple-choice-visual-question.component.html
+++ b/src/main/webapp/app/quiz/shared/questions/multiple-choice-question/visual-question/multiple-choice-visual-question.component.html
@@ -87,7 +87,7 @@
         </div>
     }
     @if (!reEvaluationInProgress()) {
-        <button id="add-mc-answer-option" class="btn btn-block btn-success mt-2" (click)="addNewAnswer()">
+        <button data-testid="add-mc-answer-option" class="btn btn-block btn-success mt-2" (click)="addNewAnswer()">
             <fa-icon [icon]="faPlus" />
             <span jhiTranslate="artemisApp.multipleChoiceQuestion.visualEditor.newAnswerTitle"></span>
         </button>

--- a/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.html
+++ b/src/main/webapp/app/shared-ui/components/buttons/code-button/code-button.component.html
@@ -17,7 +17,7 @@
     ></button>
     <ng-template #popContent>
         @if (selectedAuthenticationMechanism() === RepositoryAuthenticationMethod.SSH && !doesUserHaveSSHkeys()) {
-            <div class="alert alert-warning" [innerHTML]="sshKeyMissingTip()"></div>
+            <div class="alert alert-warning" data-testid="ssh-key-missing-alert" [innerHTML]="sshKeyMissingTip()"></div>
         }
         @if (selectedAuthenticationMechanism() === RepositoryAuthenticationMethod.SSH && areAnySshKeysExpired()) {
             <div class="alert alert-warning" [innerHTML]="sshKeysExpiredTip()"></div>

--- a/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.html
+++ b/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-button.component.html
@@ -5,7 +5,7 @@
             [overwriteDisabled]="isBeingArchived()"
             type="button"
             [attr.data-mode]="archiveMode()"
-            id="archiveButton"
+            data-testid="archiveButton"
             class="btn btn-sm btn-warning"
             (click)="openArchiveWarningDialog()"
         >

--- a/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-dialog.component.ts
+++ b/src/main/webapp/app/shared-ui/components/buttons/course-exam-archive-button/course-exam-archive-dialog.component.ts
@@ -65,6 +65,7 @@ abstract class CourseExamArchiveDialogBase {
         <div class="modal-footer">
             <button
                 type="button"
+                data-testid="archive-confirm-button"
                 class="btn btn-warning"
                 (click)="close('archive-confirm')"
                 [jhiTranslate]="data.archiveMode === 'Course' ? 'artemisApp.courseExamArchive.archiveCourse' : 'artemisApp.courseExamArchive.archiveExam'"
@@ -91,7 +92,9 @@ export class CourseExamArchiveWarningDialogComponent extends CourseExamArchiveDi
             </p>
         </div>
         <div class="modal-footer">
-            <button type="button" class="btn btn-warning" (click)="close('archive')" [jhiTranslate]="'global.generic.yes'">Yes</button>
+            <button type="button" data-testid="archive-overwrite-confirm-button" class="btn btn-warning" (click)="close('archive')" [jhiTranslate]="'global.generic.yes'">
+                Yes
+            </button>
             <button type="button" class="btn btn-success" [jhiTranslate]="'global.generic.no'" (click)="close()">No</button>
         </div>
     `,

--- a/src/main/webapp/app/shared-ui/components/resizable-panels/resizable-panels.component.html
+++ b/src/main/webapp/app/shared-ui/components/resizable-panels/resizable-panels.component.html
@@ -4,6 +4,7 @@
          its first panel are never destroyed, so the left panel's projected content (e.g. the modeling editor) keeps
          its in-memory state instead of being recreated and reset on collapse. -->
     <p-splitter
+        [pt]="{ gutter: { 'data-testid': 'splitter-gutter' }, panel: { 'data-testid': 'splitter-panel' } }"
         class="resizable-panels-splitter w-100 h-100"
         [class.right-collapsed]="isRightPanelCollapsed()"
         layout="horizontal"
@@ -31,7 +32,7 @@
                         <p-tabs [value]="activeRightIndex()" (valueChange)="setActiveRight($event)" class="right-panel-tabs flex-grow-1">
                             <p-tablist>
                                 @for (panel of rightPanels(); track panel; let i = $index) {
-                                    <p-tab [value]="i">
+                                    <p-tab [value]="i" data-testid="resizable-panel-tab">
                                         @if (panel.iconTemplate()) {
                                             <ng-container [ngTemplateOutlet]="panel.iconTemplate()!" />
                                         } @else if (panel.icon()) {
@@ -63,6 +64,7 @@
                         <button
                             type="button"
                             class="collapsed-right-panel-tab"
+                            data-testid="collapsed-panel-tab"
                             [class.active]="activeRightIndex() === i"
                             (click)="expandRightPanel(i)"
                             [attr.aria-label]="panel.label() | artemisTranslate"
@@ -85,7 +87,7 @@
             <p-tabs [value]="activeSingleIndex()" (valueChange)="setActiveSingle($event)" class="flex-shrink-0">
                 <p-tablist>
                     @for (panel of panels(); track panel; let i = $index) {
-                        <p-tab [value]="i">
+                        <p-tab [value]="i" data-testid="resizable-panel-tab">
                             @if (panel.iconTemplate()) {
                                 <ng-container [ngTemplateOutlet]="panel.iconTemplate()!" />
                             } @else if (panel.icon()) {

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.html
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.html
@@ -14,7 +14,14 @@
         <fa-icon [icon]="faClock" stackItemSize="1x" transform="shrink-6 down-5 right-5" class="text-muted-color" />
     </fa-stack>
 }
-<div class="flex relative" data-testid="date-picker-wrapper" [class.invalid-date-input]="showErrorBorder()" (keydown)="onPickerKeydown($event)" (paste)="onPickerPaste($event)">
+<div
+    class="flex relative"
+    data-testid="date-picker-wrapper"
+    [attr.data-invalid]="showErrorBorder()"
+    [class.invalid-date-input]="showErrorBorder()"
+    (keydown)="onPickerKeydown($event)"
+    (paste)="onPickerPaste($event)"
+>
     @if (lockedToGroup()) {
         <div
             class="date-lock-overlay"
@@ -33,6 +40,7 @@
         #datePicker
         styleClass="w-full"
         panelStyleClass="jhi-date-time-picker-panel"
+        [pt]="passThrough"
         [inputId]="inputId()"
         [fluid]="fluid()"
         [inputStyleClass]="warning() ? 'date-time-picker-warning-border' : ''"

--- a/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
+++ b/src/main/webapp/app/shared-ui/date-time-picker/date-time-picker.component.ts
@@ -49,6 +49,19 @@ export class FormDateTimePickerComponent implements ControlValueAccessor, AfterV
     protected readonly faTriangleExclamation = faTriangleExclamation;
     protected readonly faLock = faLock;
 
+    /**
+     * Names the parts of the PrimeNG picker the end-to-end tests reach for. Declared once rather than as a
+     * template literal so change detection does not hand the picker a fresh object on every cycle.
+     */
+    protected readonly passThrough = {
+        root: { 'data-testid': 'date-picker' },
+        panel: { 'data-testid': 'date-picker-panel' },
+        title: { 'data-testid': 'date-picker-title' },
+        timePicker: { 'data-testid': 'date-picker-time-picker' },
+        weekDay: { 'data-testid': 'date-picker-weekday' },
+        day: { 'data-testid': 'date-picker-day' },
+    };
+
     labelName = input<string>();
     hideLabelName = input<boolean>(false);
     // Suppress the inline "missing/invalid" message. Filters (e.g. the audits from/to range) convey invalid

--- a/src/main/webapp/app/shared-ui/resizeable-container/resizeable-container.component.html
+++ b/src/main/webapp/app/shared-ui/resizeable-container/resizeable-container.component.html
@@ -1,6 +1,6 @@
 <div class="resizable-container" [style.display]="isBeingPrinted() ? 'block' : 'flex'">
     <!--region LEFT SIDE-->
-    <div class="left card" [class.border-0]="isExerciseParticipation()">
+    <div class="left card" data-testid="resizeable-container-left" [class.border-0]="isExerciseParticipation()">
         @if (!isExerciseParticipation()) {
             <div class="card-header bg-primary text-white">
                 <ng-content select="span[left-header]" />
@@ -34,7 +34,7 @@
                 <div class="draggable-left">
                     <fa-icon [icon]="faGripLinesVertical" />
                 </div>
-                <div class="card">
+                <div class="card" data-testid="resizeable-container-right">
                     <div class="card-header text-white bg-primary" (click)="collapsed.set(!collapsed())">
                         <h3 class="card-title">
                             <span class="me-1">

--- a/src/main/webapp/app/text/manage/assess/text-assessment-area/text-assessment-area.component.html
+++ b/src/main/webapp/app/text/manage/assess/text-assessment-area/text-assessment-area.component.html
@@ -23,10 +23,10 @@
     />
 }
 <div>
-    <span class="badge bg-primary mb-2" id="text-assessment-word-count" jhiTranslate="artemisApp.textExercise.wordCount" [translateValues]="{ count: wordCount() }"></span>
+    <span class="badge bg-primary mb-2" data-testid="text-assessment-word-count" jhiTranslate="artemisApp.textExercise.wordCount" [translateValues]="{ count: wordCount() }"></span>
     <span
         class="badge bg-primary mb-2"
-        id="text-assessment-character-count"
+        data-testid="text-assessment-character-count"
         jhiTranslate="artemisApp.textExercise.characterCount"
         [translateValues]="{ count: characterCount() }"
     ></span>

--- a/src/main/webapp/app/text/manage/assess/textblock-feedback-editor/text-block-feedback-editor.component.html
+++ b/src/main/webapp/app/text/manage/assess/textblock-feedback-editor/text-block-feedback-editor.component.html
@@ -83,7 +83,7 @@
                             ? ('artemisApp.assessment.additionalFeedbackCommentPlaceholder' | artemisTranslate)
                             : ('artemisApp.assessment.feedbackCommentPlaceholder' | artemisTranslate)
                     "
-                    id="feedback-editor-text-input"
+                    data-testid="feedback-editor-text-input"
                     [(ngModel)]="feedback().detailText"
                     #detailText
                     (keyup)="textareaAutogrow()"
@@ -100,7 +100,7 @@
                     type="number"
                     step="0.5"
                     [(ngModel)]="feedback().credits"
-                    id="feedback-editor-points-input"
+                    data-testid="feedback-editor-points-input"
                     (keydown.escape)="escKeyup()"
                     (click)="onScoreClick($event)"
                     (focus)="inFocus()"

--- a/src/main/webapp/app/text/manage/example-text-submission/example-text-submission.component.html
+++ b/src/main/webapp/app/text/manage/example-text-submission/example-text-submission.component.html
@@ -117,7 +117,7 @@
     <ng-container left-body>
         @if (state.ui === UIStates.SUBMISSION) {
             <textarea
-                id="example-text-submission-input"
+                data-testid="example-text-submission-input"
                 [(ngModel)]="submission!.text"
                 (ngModelChange)="unsavedSubmissionChanges.set(true)"
                 style="width: 100%; height: 50vh"
@@ -147,7 +147,7 @@
         }
         @if (exercise) {
             <jhi-assessment-instructions
-                id="instructions"
+                data-testid="instructions"
                 [exercise]="exercise"
                 [isAssessmentTraining]="toComplete()"
                 [showAssessmentInstructions]="state.ui === UIStates.ASSESSMENT"

--- a/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.html
+++ b/src/main/webapp/app/text/manage/text-exercise/update/text-exercise-update.component.html
@@ -4,7 +4,7 @@
         @if (!textExercise.id) {
             <h2 id="jhi-text-exercise-heading-create" jhiTranslate="artemisApp.textExercise.home.createLabel"></h2>
         } @else if (!isImport() && textExercise.id) {
-            <h2 id="jhi-text-exercise-heading-edit" jhiTranslate="artemisApp.textExercise.home.editLabel"></h2>
+            <h2 data-testid="jhi-text-exercise-heading-edit" jhiTranslate="artemisApp.textExercise.home.editLabel"></h2>
         } @else if (isImport()) {
             <h2 id="jhi-text-exercise-heading-import" jhiTranslate="artemisApp.textExercise.home.importLabel"></h2>
         }

--- a/src/main/webapp/app/text/overview/text-editor/text-editor.component.html
+++ b/src/main/webapp/app/text/overview/text-editor/text-editor.component.html
@@ -23,7 +23,7 @@
                     <div>
                         <span
                             class="badge bg-primary mb-2"
-                            id="word-count"
+                            data-testid="word-count"
                             [hidden]="submission() && !submission().submitted && isExamSummary()"
                             jhiTranslate="artemisApp.textExercise.wordCount"
                             [translateValues]="{ count: wordCount }"
@@ -31,7 +31,7 @@
                         </span>
                         <span
                             class="badge bg-primary mb-2"
-                            id="character-count"
+                            data-testid="character-count"
                             [hidden]="submission() && !submission().submitted && isExamSummary()"
                             jhiTranslate="artemisApp.textExercise.characterCount"
                             [translateValues]="{ count: characterCount }"

--- a/src/test/playwright/e2e/Passkey.spec.ts
+++ b/src/test/playwright/e2e/Passkey.spec.ts
@@ -131,8 +131,8 @@ test.describe('Passkey', () => {
         await page.goto('/sign-in');
 
         // Wait for the passkey login button to be stable before clicking
-        await page.locator('#passkey-login-button').waitFor({ state: 'visible' });
-        await page.locator('#passkey-login-button').click();
+        await page.locator('[data-testid="passkey-login-button"]').waitFor({ state: 'visible' });
+        await page.locator('[data-testid="passkey-login-button"]').click();
 
         // Verify login succeeded by checking navigation to courses
         await page.waitForURL('**/courses**');
@@ -170,8 +170,8 @@ test.describe('Passkey', () => {
         await page.goto('/sign-in');
 
         // Wait for the passkey login button to be stable before clicking
-        await page.locator('#passkey-login-button').waitFor({ state: 'visible' });
-        await page.locator('#passkey-login-button').click();
+        await page.locator('[data-testid="passkey-login-button"]').waitFor({ state: 'visible' });
+        await page.locator('[data-testid="passkey-login-button"]').click();
 
         // Verify login fails with an error
         const errorAlert = page.locator('.alert-inner').getByText('No passkey was found for Artemis.');

--- a/src/test/playwright/e2e/Passkey.spec.ts
+++ b/src/test/playwright/e2e/Passkey.spec.ts
@@ -75,7 +75,7 @@ test.describe('Passkey', () => {
         // Register passkey via the modal
         await page.getByRole('button', { name: 'Set Up Passkey' }).click();
 
-        const successAlert = page.locator('.alert-inner').getByText('Your passkey has been successfully registered.');
+        const successAlert = page.locator('[data-testid="alert"]').getByText('Your passkey has been successfully registered.');
         await expect(successAlert).toBeVisible();
         await page.waitForURL('**/courses**');
 
@@ -174,7 +174,7 @@ test.describe('Passkey', () => {
         await page.locator('[data-testid="passkey-login-button"]').click();
 
         // Verify login fails with an error
-        const errorAlert = page.locator('.alert-inner').getByText('No passkey was found for Artemis.');
+        const errorAlert = page.locator('[data-testid="alert"]').getByText('No passkey was found for Artemis.');
         await expect(errorAlert).toBeVisible();
 
         // Verify user is still on the sign-in page

--- a/src/test/playwright/e2e/SystemHealth.spec.ts
+++ b/src/test/playwright/e2e/SystemHealth.spec.ts
@@ -31,7 +31,7 @@ test.describe('Check artemis system health', { tag: '@fast' }, () => {
 
     for (const healthCheck of healthChecks) {
         test(`Checks ${healthCheck.name} health`, async () => {
-            const statusLocator = page.locator(`#healthCheck ${healthCheck.selector} [data-testid="status-cell"]`);
+            const statusLocator = page.locator(`[data-testid="healthCheck"] ${healthCheck.selector} [data-testid="status-cell"]`);
             await expect(statusLocator).toHaveText(healthCheck.expectedStatus, { timeout: 5000 });
         });
     }
@@ -39,7 +39,7 @@ test.describe('Check artemis system health', { tag: '@fast' }, () => {
     // WebSocket connection test handled separately with reload mechanism since
     // the client-side WebSocket connection may take longer to establish on CI
     test('Checks websocket connection health', async () => {
-        const statusLocator = page.locator('#healthCheck #websocketConnection [data-testid="status-cell"]');
+        const statusLocator = page.locator('[data-testid="healthCheck"] [data-testid="websocketConnection"] [data-testid="status-cell"]');
         const timeout = 60000;
         const reloadInterval = 5000;
         const startTime = Date.now();

--- a/src/test/playwright/e2e/atlas/CompetencyImport.spec.ts
+++ b/src/test/playwright/e2e/atlas/CompetencyImport.spec.ts
@@ -35,7 +35,7 @@ test.describe('Competency Import', { tag: '@fast' }, () => {
         await competencyManagement.goto(targetCourse.id!);
 
         // Open Import All modal
-        await page.locator('#courseCompetencyImportAllButton').click();
+        await page.locator('[data-testid="courseCompetencyImportAllButton"]').click();
 
         // Wait for the import modal to load
         await expect(page.locator('#import-objects-search')).toBeVisible();

--- a/src/test/playwright/e2e/atlas/CompetencyManagement.spec.ts
+++ b/src/test/playwright/e2e/atlas/CompetencyManagement.spec.ts
@@ -15,10 +15,10 @@ async function selectTaxonomy(page: Page, taxonomy: string) {
         .locator('p-select')
         .filter({ has: page.locator('#taxonomy') })
         .click();
-    const overlay = page.locator('.p-select-overlay');
+    const overlay = page.getByTestId('taxonomy-select-overlay');
     await expect(overlay).toBeVisible();
     await overlay
-        .locator('.p-select-option')
+        .getByTestId('taxonomy-select-option')
         .filter({ hasText: new RegExp(taxonomy.trim(), 'i') })
         .first()
         .click();

--- a/src/test/playwright/e2e/atlas/StudentCompetencyProgressView.spec.ts
+++ b/src/test/playwright/e2e/atlas/StudentCompetencyProgressView.spec.ts
@@ -81,7 +81,7 @@ test.describe('Student Competency Progress View', { tag: '@fast' }, () => {
             await page.waitForLoadState(WAIT_STATE);
 
             // Assert: Initial state - No mastery badge
-            await expect(page.locator('.badge.text-bg-success', { hasText: 'Mastered' })).not.toBeVisible();
+            await expect(page.getByTestId('competency-mastered-badge')).not.toBeVisible();
 
             // Navigate to the lecture unit in the competency detail view and mark it as completed
             const textUnitCard = page.locator('jhi-text-unit');
@@ -91,7 +91,7 @@ test.describe('Student Competency Progress View', { tag: '@fast' }, () => {
             await textUnitCard.locator('#lecture-unit-toggle-button').click();
 
             // Click the completion checkbox
-            const completionCheckbox = textUnitCard.locator('#completed-checkbox');
+            const completionCheckbox = textUnitCard.getByTestId('lecture-unit-completion-icon');
             await expect(completionCheckbox).toBeVisible();
             await completionCheckbox.click();
 
@@ -120,21 +120,21 @@ test.describe('Student Competency Progress View', { tag: '@fast' }, () => {
             await textUnitToggleAfterReload.click();
 
             // Assert: The lecture unit should now show as completed (green check icon)
-            const completedIcon = page.locator('jhi-text-unit #completed-checkbox.text-success');
+            const completedIcon = page.locator('jhi-text-unit [data-testid="lecture-unit-completion-icon"][data-completed="true"]');
             await expect(completedIcon).toBeVisible({ timeout: 10000 });
 
             // Assert: Progress ring should be visible
             await expect(page.locator('jhi-competency-rings')).toBeVisible();
 
             // Assert: "Mastered" badge should now be visible (Test 4.4 requirement)
-            await expect(page.locator('.badge.text-bg-success', { hasText: 'Mastered' })).toBeVisible();
+            await expect(page.getByTestId('competency-mastered-badge')).toBeVisible();
 
             // Navigate to competencies overview to verify global state
             await page.goto(`/courses/${course.id}/competencies`);
             await page.waitForLoadState(WAIT_STATE);
 
             // Assert: Check that the mastered count is visible in the overview
-            const masteredCount = page.locator('.badge.bg-dark');
+            const masteredCount = page.getByTestId('competencies-mastered-count');
             await expect(masteredCount).toBeVisible();
         });
     });

--- a/src/test/playwright/e2e/course/CourseArchive.spec.ts
+++ b/src/test/playwright/e2e/course/CourseArchive.spec.ts
@@ -71,7 +71,7 @@ test.describe('Course archive', { tag: '@slow' }, () => {
         // Archiving lives on the course settings page, not on the course management overview.
         await login(instructor, `/course-management/${course.id}/settings`);
         await page.locator('[data-testid="archiveButton"][data-mode="Course"]').click();
-        await page.locator('.modal-footer .btn-warning').click();
+        await page.getByTestId('archive-confirm-button').click();
 
         await courseManagementAPIRequests.waitForCourseArchive(course.id!);
 

--- a/src/test/playwright/e2e/course/CourseArchive.spec.ts
+++ b/src/test/playwright/e2e/course/CourseArchive.spec.ts
@@ -70,7 +70,7 @@ test.describe('Course archive', { tag: '@slow' }, () => {
 
         // Archiving lives on the course settings page, not on the course management overview.
         await login(instructor, `/course-management/${course.id}/settings`);
-        await page.locator('#archiveButton[data-mode="Course"]').click();
+        await page.locator('[data-testid="archiveButton"][data-mode="Course"]').click();
         await page.locator('.modal-footer .btn-warning').click();
 
         await courseManagementAPIRequests.waitForCourseArchive(course.id!);

--- a/src/test/playwright/e2e/course/CourseMessageInteractions.spec.ts
+++ b/src/test/playwright/e2e/course/CourseMessageInteractions.spec.ts
@@ -295,17 +295,17 @@ test.describe('Message interactions', { tag: '@fast' }, () => {
             for (let attempt = 0; attempt < 3; attempt++) {
                 await postLocator.locator('.message-container').click({ button: 'right' });
                 try {
-                    await page.locator('.dropdown-menu.show').waitFor({ state: 'visible', timeout: 3000 });
+                    await page.getByTestId('posting-context-menu').waitFor({ state: 'visible', timeout: 3000 });
                     break;
                 } catch {
                     if (attempt === 2) throw new Error('Context menu did not appear');
                 }
             }
             // Verify the pin option is NOT in the dropdown
-            await expect(page.locator('.dropdown-menu.show .dropdown-item', { hasText: /pin/i })).toHaveCount(0);
+            await expect(page.getByTestId('posting-menu-pin')).toHaveCount(0);
             // Verify other options ARE present (bookmark, reply, forward)
-            await expect(page.locator('.dropdown-menu.show .dropdown-item', { hasText: /save|bookmark/i })).toBeVisible();
-            await expect(page.locator('.dropdown-menu.show .dropdown-item', { hasText: /reply/i })).toBeVisible();
+            await expect(page.getByTestId('posting-menu-bookmark')).toBeVisible();
+            await expect(page.getByTestId('posting-menu-reply')).toBeVisible();
         });
     });
 

--- a/src/test/playwright/e2e/course/CourseOnboarding.spec.ts
+++ b/src/test/playwright/e2e/course/CourseOnboarding.spec.ts
@@ -38,20 +38,20 @@ test.describe('Course onboarding wizard', { tag: '@fast' }, () => {
         const nextResponse1 = page.waitForResponse((resp) => resp.url().includes(`${COURSE_UPDATE_BASE}/${course.id}`) && resp.request().method() === 'PUT');
         await courseOnboarding.clickNext();
         await nextResponse1;
-        await expect(page.locator('#onboarding_enrollmentEnabled')).toBeVisible();
+        await expect(page.locator('[data-testid="onboarding_enrollmentEnabled"]')).toBeVisible();
         await courseOnboarding.expectPreviousButtonVisible();
 
         // Advance to step 2: Communication
         const nextResponse2 = page.waitForResponse((resp) => resp.url().includes(`${COURSE_UPDATE_BASE}/${course.id}`) && resp.request().method() === 'PUT');
         await courseOnboarding.clickNext();
         await nextResponse2;
-        await expect(page.locator('#onboarding_communicationEnabled')).toBeVisible();
+        await expect(page.locator('[data-testid="onboarding_communicationEnabled"]')).toBeVisible();
 
         // Advance to step 3: Assessment & AI
         const nextResponse3 = page.waitForResponse((resp) => resp.url().includes(`${COURSE_UPDATE_BASE}/${course.id}`) && resp.request().method() === 'PUT');
         await courseOnboarding.clickNext();
         await nextResponse3;
-        await expect(page.locator('#onboarding_complaintsEnabled')).toBeVisible();
+        await expect(page.locator('[data-testid="onboarding_complaintsEnabled"]')).toBeVisible();
         await courseOnboarding.expectFinishButtonVisible();
 
         // Finish setup (saves onboardingDone=true and advances to step 4: Explore)
@@ -74,7 +74,7 @@ test.describe('Course onboarding wizard', { tag: '@fast' }, () => {
         const nextResponse = page.waitForResponse((resp) => resp.url().includes(`${COURSE_UPDATE_BASE}/${course.id}`) && resp.request().method() === 'PUT');
         await courseOnboarding.clickNext();
         await nextResponse;
-        await expect(page.locator('#onboarding_enrollmentEnabled')).toBeVisible();
+        await expect(page.locator('[data-testid="onboarding_enrollmentEnabled"]')).toBeVisible();
 
         // Go back to step 0
         await courseOnboarding.clickPrevious();

--- a/src/test/playwright/e2e/course/CourseTabs.spec.ts
+++ b/src/test/playwright/e2e/course/CourseTabs.spec.ts
@@ -309,13 +309,13 @@ test.describe('Course overview tabs', { tag: '@fast' }, () => {
         // On a student's very first visit the tab asks whether to appear in the leaderboard, behind a modal mask that
         // blocks every other click until it is confirmed. The dialog is appended to the body, not to its host element,
         // and whether it appears depends on whether this student ever answered it, so wait for either outcome.
-        const confirmButton = page.locator('.p-dialog-footer button');
+        const confirmButton = page.getByTestId('quiz-training-confirm-button');
         const leagueBadge = page.locator('jhi-league-badge');
         await expect(confirmButton.or(leagueBadge).first()).toBeVisible({ timeout: 20_000 });
         if (await confirmButton.isVisible()) {
             await confirmButton.click();
         }
-        await expect(page.locator('.p-dialog-mask')).toHaveCount(0);
+        await expect(page.getByTestId('quiz-training-dialog-mask')).toHaveCount(0);
         await expect(leagueBadge).toBeVisible({ timeout: 20_000 });
 
         await expect.poll(() => leaderboardRequests.length, { timeout: 20_000 }).toBeGreaterThan(0);

--- a/src/test/playwright/e2e/exam/ExamArchive.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamArchive.spec.ts
@@ -55,7 +55,7 @@ test.describe('Exam archive', { tag: '@slow' }, () => {
         }
 
         await login(instructor, `/course-management/${course.id}/exams/${exam.id}`);
-        await page.locator('#archiveButton[data-mode="Exam"]').click();
+        await page.locator('[data-testid="archiveButton"][data-mode="Exam"]').click();
         await page.locator('.modal-footer .btn-warning').click();
 
         // Archiving runs asynchronously; the download button only appears once the archive is on disk.

--- a/src/test/playwright/e2e/exam/ExamArchive.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamArchive.spec.ts
@@ -56,7 +56,7 @@ test.describe('Exam archive', { tag: '@slow' }, () => {
 
         await login(instructor, `/course-management/${course.id}/exams/${exam.id}`);
         await page.locator('[data-testid="archiveButton"][data-mode="Exam"]').click();
-        await page.locator('.modal-footer .btn-warning').click();
+        await page.getByTestId('archive-confirm-button').click();
 
         // Archiving runs asynchronously; the download button only appears once the archive is on disk.
         const downloadButton = page.locator('[data-testid="archive-download-button"][data-mode="Exam"]');

--- a/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamAssessment.spec.ts
@@ -45,7 +45,7 @@ test.describe('Exam assessment', () => {
             // template repository, which routinely takes 30-60s under multi-node CI load.
             // The student must finish startParticipation + handInEarly inside this window
             // — at 60s, setup occasionally overran the exam end and the conduction page
-            // redirected, leaving `#hand-in-early` un-clickable. 180s leaves comfortable
+            // redirected, leaving `[data-testid="hand-in-early"]` un-clickable. 180s leaves comfortable
             // headroom; the test still doesn't wait the full window since
             // `waitForExamEnd` returns once the exam ends.
             examEnd = dayjs().add(180, 'seconds');
@@ -373,8 +373,8 @@ test.describe.serial('Exam assessment dashboard and scores across two correction
         await expect(page.getByRole('heading', { name: /Correction Round: 2/ })).toBeVisible();
         await expect(page.getByText('This correction round is not yet enabled.')).toHaveCount(1);
         // Nothing is assessed yet, so the first round has a submission on offer and no assessed row.
-        await expect(page.locator('#start-new-assessment')).toHaveCount(1);
-        await expect(page.locator('#open-assessment')).toHaveCount(0);
+        await expect(page.locator('[data-testid="start-new-assessment"]')).toHaveCount(1);
+        await expect(page.locator('[data-testid="open-assessment"]')).toHaveCount(0);
     });
 
     test('First round assessment shows up on the dashboard and opens the second round', async ({
@@ -394,10 +394,10 @@ test.describe.serial('Exam assessment dashboard and scores across two correction
         // Back on the dashboard the assessed submission is listed for round 1 with the score the tutor gave.
         await examManagement.openAssessmentDashboard(dashboardCourse.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT);
         await courseAssessment.clickExerciseDashboardButton(0, EXAM_DASHBOARD_TIMEOUT);
-        await expect(page.locator('#open-assessment')).toHaveCount(1);
+        await expect(page.locator('[data-testid="open-assessment"]')).toHaveCount(1);
         await expect(page.getByText('60%').first()).toBeVisible();
         // The first round has nothing left to hand out, and the second round is still not enabled.
-        await expect(page.locator('#start-new-assessment')).toHaveCount(0);
+        await expect(page.locator('[data-testid="start-new-assessment"]')).toHaveCount(0);
         await expect(page.getByText('This correction round is not yet enabled.')).toHaveCount(1);
     });
 
@@ -421,7 +421,7 @@ test.describe.serial('Exam assessment dashboard and scores across two correction
         // submission the tutor already assessed.
         await expect(page.getByText('This correction round is not yet enabled.')).toHaveCount(0);
         await expect(page.getByRole('heading', { name: /Correction Round: 2/ })).toBeVisible();
-        await expect(page.locator('#start-new-assessment')).toHaveCount(1);
+        await expect(page.locator('[data-testid="start-new-assessment"]')).toHaveCount(1);
 
         await exerciseAssessment.clickStartNewAssessment();
         await examAssessment.fillFeedback(9, 'Second corrector');
@@ -433,14 +433,14 @@ test.describe.serial('Exam assessment dashboard and scores across two correction
         await examManagement.openAssessmentDashboard(dashboardCourse.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT);
         await courseAssessment.clickExerciseDashboardButton(0, EXAM_DASHBOARD_TIMEOUT);
         await expect(page.getByRole('heading', { name: /Correction Round: 2/ })).toBeVisible();
-        await expect(page.locator('#open-assessment')).toHaveCount(1);
+        await expect(page.locator('[data-testid="open-assessment"]')).toHaveCount(1);
         await expect(page.getByText('90%').first()).toBeVisible();
 
         // The tutor still sees their own first round with the score they gave, so the second round did not overwrite it.
         await login(tutor);
         await examManagement.openAssessmentDashboard(dashboardCourse.id!, exam.id!, EXAM_DASHBOARD_TIMEOUT);
         await courseAssessment.clickExerciseDashboardButton(0, EXAM_DASHBOARD_TIMEOUT);
-        await expect(page.locator('#open-assessment')).toHaveCount(1);
+        await expect(page.locator('[data-testid="open-assessment"]')).toHaveCount(1);
         await expect(page.getByText('60%').first()).toBeVisible();
         // The student is shown the second corrector's result, not the first one.
         await login(studentOne, `/courses/${dashboardCourse.id}/exams/${exam.id}`);
@@ -613,7 +613,7 @@ test.describe.serial('A test run of an exam with two correction rounds', { tag: 
         // A test run is a dry run for the instructor, so a second corrector never enters the picture: the toggle that
         // enables the round is not offered, and no round hands out submissions.
         await expect(page.getByTestId('toggle-second-correction')).toHaveCount(0);
-        await expect(page.locator('#start-new-assessment')).toHaveCount(0);
+        await expect(page.locator('[data-testid="start-new-assessment"]')).toHaveCount(0);
         await expect(page.getByText('This correction round is not yet enabled.')).toHaveCount(0);
         // The regular dashboard of the same exercise does offer the toggle, so the difference is the test run itself.
         await page.goto(`/course-management/${testRunCourse.id}/exams/${exam.id}/assessment-dashboard/${exerciseId}`);

--- a/src/test/playwright/e2e/exam/ExamChecklists.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamChecklists.spec.ts
@@ -307,7 +307,7 @@ async function navigateToExamDetailsPage(page: Page, course: any, exam: Exam) {
     // reload once before giving up so a slow first chunk fetch does not flake the whole test.
     const examUrl = `/course-management/${course.id}/exams/${exam.id}`;
     await page.goto(examUrl);
-    const title = page.locator('#exam-detail-title');
+    const title = page.locator('[data-testid="exam-detail-title"]');
     const visibleWithin = async (timeout: number): Promise<boolean> =>
         title
             .waitFor({ state: 'visible', timeout })

--- a/src/test/playwright/e2e/exam/ExamImportValidation.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamImportValidation.spec.ts
@@ -149,7 +149,7 @@ test.describe('Exam import with a clashing programming exercise', { tag: '@slow'
         expect(importResponse.ok()).toBeTruthy();
 
         // The progress dialog shows the success summary and must be dismissed before navigating on.
-        const dismissButton = page.locator('#exam-import-progress-dismiss');
+        const dismissButton = page.locator('[data-testid="exam-import-progress-dismiss"]');
         await expect(dismissButton).toBeVisible({ timeout: 60000 });
         await expect(page.getByText(/imported successfully/i)).toBeVisible();
         await dismissButton.click();

--- a/src/test/playwright/e2e/exam/ExamParticipation.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamParticipation.spec.ts
@@ -479,7 +479,7 @@ test.describe('Exam participation', () => {
                 await modalDialog.checkDialogMessage(timeChangeMessage);
                 await modalDialog.closeDialog();
                 // After reducing working time by 30min (from 1h2min to 32min), verify timer shows ~25-31min remaining
-                await expect(studentPage.locator('#displayTime')).toContainText(/2[5-9]|3[0-1]/);
+                await expect(studentPage.locator('[data-testid="displayTime"]')).toContainText(/2[5-9]|3[0-1]/);
             }
         });
 

--- a/src/test/playwright/e2e/exam/ExamResults.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamResults.spec.ts
@@ -229,11 +229,11 @@ async function navigateToExerciseAssessment(page: import('@playwright/test').Pag
 
     // Click "I have read the instructions" to register tutor participation (persisted server-side).
     // After this, reloads will show the submissions table directly.
-    const participateButton = page.locator('#participate-in-assessment');
+    const participateButton = page.locator('[data-testid="participate-in-assessment"]');
     await Commands.reloadUntilFound(page, participateButton, 10000, 90000);
     await participateButton.click();
     // Wait for the start-assessment button (reloadUntilFound works because participation is persisted)
-    const startButton = page.locator('#start-new-assessment').first();
+    const startButton = page.locator('[data-testid="start-new-assessment"]').first();
     await Commands.reloadUntilFound(page, startButton, 10000, 90000);
     await startButton.click();
 }

--- a/src/test/playwright/e2e/exam/ExamSummaryPublicationDate.spec.ts
+++ b/src/test/playwright/e2e/exam/ExamSummaryPublicationDate.spec.ts
@@ -95,7 +95,7 @@ test.describe('Exam submission overview publication date', { tag: '@slow' }, () 
         await examParticipation.handInEarly();
 
         // The submission was received, but the overview and PDF export are withheld until the publication date.
-        await expect(page.locator('#examSummaryUnavailableHint')).toBeVisible({ timeout: 20000 });
+        await expect(page.locator('[data-testid="examSummaryUnavailableHint"]')).toBeVisible({ timeout: 20000 });
         await expect(page.locator('#showExamSummaryButton')).toBeHidden();
         await expect(page.locator('#exportToPDFButton')).toBeHidden();
 
@@ -123,7 +123,7 @@ test.describe('Exam submission overview publication date', { tag: '@slow' }, () 
 
         // Default behaviour: the overview is offered as soon as the submission is in, and no release hint is shown.
         await expect(page.locator('#showExamSummaryButton')).toBeVisible({ timeout: 20000 });
-        await expect(page.locator('#examSummaryUnavailableHint')).toBeHidden();
+        await expect(page.locator('[data-testid="examSummaryUnavailableHint"]')).toBeHidden();
 
         // The server serves the summary, so the gate is open on both sides and not just visually.
         const summaryResponse = await page.request.get(`api/exam/courses/${course.id}/exams/${exam.id}/student-exams/${studentExamId}/summary`);

--- a/src/test/playwright/e2e/exercise/ExerciseSplitPanelResize.spec.ts
+++ b/src/test/playwright/e2e/exercise/ExerciseSplitPanelResize.spec.ts
@@ -67,10 +67,8 @@ test.describe('Resizable exercise split panel (p-splitter)', { tag: '@fast' }, (
         await courseOverview.startExercise(textExercise.id!);
 
         const splitter = page.locator('jhi-resizable-panels p-splitter').first();
-        const gutter = splitter.locator('.p-splitter-gutter').first();
-        // The current PrimeNG Splitter renders its panels as `p-splitterpanel`. This class name has
-        // changed across PrimeNG majors, so revisit this selector when upgrading PrimeNG.
-        const leftPanel = splitter.locator('.p-splitterpanel').first();
+        const gutter = splitter.getByTestId('splitter-gutter').first();
+        const leftPanel = splitter.getByTestId('splitter-panel').first();
 
         await expect(gutter).toBeVisible({ timeout: 30_000 });
         await expect(leftPanel).toBeVisible();

--- a/src/test/playwright/e2e/exercise/file-upload/FileUploadExerciseAssessment.spec.ts
+++ b/src/test/playwright/e2e/exercise/file-upload/FileUploadExerciseAssessment.spec.ts
@@ -41,9 +41,11 @@ test.describe('File upload exercise assessment', { tag: '@slow' }, () => {
             await exerciseAssessment.clickHaveReadInstructionsButton();
             await exerciseAssessment.clickStartNewAssessment();
             await expect(fileUploadExerciseAssessment.getInstructionsRootElement().getByText(exercise.title!)).toBeVisible();
-            await expect(fileUploadExerciseAssessment.getInstructionsRootElement().locator('.collapse.show').getByText(exercise.problemStatement!)).toBeVisible();
-            await expect(fileUploadExerciseAssessment.getInstructionsRootElement().locator('.collapse.show').getByText(exercise.exampleSolution!)).toBeVisible();
-            await expect(fileUploadExerciseAssessment.getInstructionsRootElement().locator('.collapse.show').getByText(exercise.gradingInstructions!)).toBeVisible();
+            await expect(fileUploadExerciseAssessment.getInstructionsRootElement().getByTestId('expandable-section-content').getByText(exercise.problemStatement!)).toBeVisible();
+            await expect(fileUploadExerciseAssessment.getInstructionsRootElement().getByTestId('expandable-section-content').getByText(exercise.exampleSolution!)).toBeVisible();
+            await expect(
+                fileUploadExerciseAssessment.getInstructionsRootElement().getByTestId('expandable-section-content').getByText(exercise.gradingInstructions!),
+            ).toBeVisible();
             await fileUploadExerciseAssessment.downloadSubmissionFile();
             await fileUploadExerciseAssessment.addNewFeedback(tutorFeedbackPoints, tutorFeedback);
             await fileUploadExerciseAssessment.submitFeedback();

--- a/src/test/playwright/e2e/exercise/modeling/ModelingEditorResize.spec.ts
+++ b/src/test/playwright/e2e/exercise/modeling/ModelingEditorResize.spec.ts
@@ -41,7 +41,7 @@ test.describe('Responsive modeling editor tile', { tag: '@fast' }, () => {
         const cornerRadius = await frame.evaluate((element) => getComputedStyle(element).borderTopLeftRadius);
         await expect(tile).toHaveCSS('border-top-left-radius', cornerRadius);
         await expect(page.locator('.modeling-editor')).toHaveCSS('border-top-left-radius', cornerRadius);
-        await expect(page.locator('.modeling-submission jhi-resizeable-container .left.card').first()).toHaveCSS('border-top-left-radius', cornerRadius);
+        await expect(page.locator('.modeling-submission').getByTestId('resizeable-container-left').first()).toHaveCSS('border-top-left-radius', cornerRadius);
 
         const statusIsland = page.locator('[data-apollon-region="top-left"] .modeling-editor__status-island');
         const actionIsland = page.locator('[data-apollon-region="top-right"] .modeling-editor__actions');

--- a/src/test/playwright/e2e/exercise/modeling/ModelingExamplePracticeAssessment.spec.ts
+++ b/src/test/playwright/e2e/exercise/modeling/ModelingExamplePracticeAssessment.spec.ts
@@ -78,12 +78,12 @@ test.describe('Modeling example submission practice assessment', { tag: '@slow' 
         await expect(submit).toBeEnabled();
 
         await submit.click();
-        await expect(page.locator('.alert-inner').filter({ hasText: 'mistake' })).toBeVisible();
+        await expect(page.locator('[data-testid="alert"]').filter({ hasText: 'mistake' })).toBeVisible();
         await expect(feedbackCard).toContainText('score');
 
         await score.fill('5');
         await feedbackCard.locator('textarea').fill('Sample solution feedback');
         await submit.click();
-        await expect(page.locator('.alert-inner').filter({ hasText: 'good assessment' })).toBeVisible();
+        await expect(page.locator('[data-testid="alert"]').filter({ hasText: 'good assessment' })).toBeVisible();
     });
 });

--- a/src/test/playwright/e2e/exercise/modeling/ModelingExerciseManagement.spec.ts
+++ b/src/test/playwright/e2e/exercise/modeling/ModelingExerciseManagement.spec.ts
@@ -106,7 +106,7 @@ test.describe('Modeling Exercise Management', { tag: '@fast' }, () => {
             await modelingExerciseEditor.saveExampleSubmission();
             const saveResponse = await savePromise;
             expect(saveResponse.status()).toBe(200);
-            await expect(page.locator('jhi-alert-overlay .alert-inner.danger')).toHaveCount(0);
+            await expect(page.locator('[data-testid="alert"][data-alert-type="danger"]')).toHaveCount(0);
         });
 
         test.afterEach('Delete modeling exercise', async ({ login, exerciseAPIRequests }) => {

--- a/src/test/playwright/e2e/exercise/programming/CodeEditorResize.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/CodeEditorResize.spec.ts
@@ -8,7 +8,7 @@ const course = { id: SEED_COURSES.exerciseParticipation.id } as any;
 /**
  * End-to-end coverage for the interact.js -> jhiResizable migration in the code editor grid.
  * The file-browser sidebar (`.editor-sidebar-left`) is resized by dragging its right-edge handle
- * (`#draggableIconForFileBrowser`, class `.rg-sidebar-left`).
+ * (`[data-testid="draggableIconForFileBrowser"]`, class `.rg-sidebar-left`).
  */
 test.describe('Resizable code editor sidebar', { tag: '@fast' }, () => {
     let programmingExercise: any;
@@ -23,7 +23,7 @@ test.describe('Resizable code editor sidebar', { tag: '@fast' }, () => {
         await courseOverview.startExercise(programmingExercise.id!);
 
         const sidebar = page.locator('.editor-sidebar-left').first();
-        const handle = page.locator('#draggableIconForFileBrowser');
+        const handle = page.locator('[data-testid="draggableIconForFileBrowser"]');
 
         // The editor (and its file-browser handle) appear once the participation + repository are ready.
         await expect(handle).toBeVisible({ timeout: 120_000 });

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseParticipation.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseParticipation.spec.ts
@@ -242,7 +242,7 @@ test.describe('Programming exercise advanced participation', { tag: '@slow' }, (
                     const participationId = await programmingExerciseOverview.startParticipation(course.id!, exercise.id!, studentOne);
                     await programmingExerciseOverview.openCloneMenu(GitCloneMethod.ssh);
                     await expect(programmingExerciseOverview.getCloneUrlButton()).toBeDisabled();
-                    const sshKeyNotFoundAlert = page.locator('.alert', { hasText: 'To use ssh, you need to add an ssh key to your account' });
+                    const sshKeyNotFoundAlert = page.getByTestId('ssh-key-missing-alert');
                     await expect(sshKeyNotFoundAlert).toBeVisible();
                     // SSH-setup happens in a separate page context, then we reload the main
                     // page. Under heavy multi-node CI load the reload-vs-SSH-key-registration

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExercisePracticeMode.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExercisePracticeMode.spec.ts
@@ -78,9 +78,9 @@ test.describe('Programming exercise practice mode', { tag: '@slow' }, () => {
             // touched before that swap: the graded repository is read-only after the due date, so a file action aimed at
             // it is dropped and the editor never sends the request the submission helper waits for. Its create controls
             // being enabled is what says the writable practice repository is the one on screen.
-            await expect(getExercise(page, exercise.id!).locator('#file-browser-folder-create-file').first()).toBeEnabled({ timeout: 30000 });
+            await expect(getExercise(page, exercise.id!).locator('[data-testid="file-browser-folder-create-file"]').first()).toBeEnabled({ timeout: 30000 });
             await programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, javaAllSuccessfulSubmission, async () => {
-                await expect(page.locator('#exercise-headers-information')).toContainText('100%', { timeout: BUILD_RESULT_TIMEOUT });
+                await expect(page.locator('[data-testid="exercise-headers-information"]')).toContainText('100%', { timeout: BUILD_RESULT_TIMEOUT });
             });
         });
     });
@@ -110,7 +110,7 @@ test.describe('Programming exercise practice mode', { tag: '@slow' }, () => {
             // The graded mode stays reachable, so the student can recognize that they missed the due date
             await gradedButton.click();
             await expect(gradedButton).toHaveClass(ACTIVE_MODE_CLASS);
-            await expect(page.locator('#exercise-headers-information')).toContainText('Missed due date');
+            await expect(page.locator('[data-testid="exercise-headers-information"]')).toContainText('Missed due date');
 
             // ... and practice can be selected again
             await practiceButton.click();
@@ -131,11 +131,11 @@ test.describe('Programming exercise practice mode', { tag: '@slow' }, () => {
 
             // The live submission state is shown in practice mode even though the due date has passed
             // (instead of a static "currently participating" text that never updates)
-            await expect(page.locator('#exercise-headers-information')).toContainText('No result');
+            await expect(page.locator('[data-testid="exercise-headers-information"]')).toContainText('No result');
 
             // Submitting in practice mode must process the submission and show its result
             await programmingExerciseEditor.makeSubmissionAndVerifyResults(exercise.id!, javaAllSuccessfulSubmission, async () => {
-                await expect(page.locator('#exercise-headers-information')).toContainText('100%', { timeout: BUILD_RESULT_TIMEOUT });
+                await expect(page.locator('[data-testid="exercise-headers-information"]')).toContainText('100%', { timeout: BUILD_RESULT_TIMEOUT });
             });
         });
     });

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExercisePracticeMode.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExercisePracticeMode.spec.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 
 import { ProgrammingExercise } from 'app/programming/shared/entities/programming-exercise.model';
 
-import { Page, expect } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
 import javaAllSuccessfulSubmission from '../../../fixtures/exercise/programming/java/all_successful/submission.json';
 import { admin, studentOne } from '../../../support/users';
 import { test } from '../../../support/fixtures';
@@ -12,12 +12,13 @@ import { BUILD_RESULT_TIMEOUT } from '../../../support/timeouts';
 
 const course = { id: SEED_COURSES.programmingParticipation.id } as any;
 
-// The graded/practice toggle renders as a PrimeNG select button; each option is a `.p-togglebutton`
-// whose active state is expressed via the `p-togglebutton-checked` class.
-const ACTIVE_MODE_CLASS = /p-togglebutton-checked/;
-
 function modeButton(page: Page, mode: 'practice' | 'graded') {
-    return page.locator(`.p-togglebutton:has(#${mode}-mode-button)`);
+    return page.getByTestId(`${mode}-mode-button`);
+}
+
+/** Asserts that the given mode is the one the toggle currently reports as selected. */
+async function expectModeSelected(button: Locator) {
+    await expect(button).toHaveAttribute('data-selected', 'true');
 }
 
 /**
@@ -56,16 +57,16 @@ test.describe('Programming exercise practice mode', { tag: '@slow' }, () => {
             const gradedButton = modeButton(page, 'graded');
             await expect(practiceButton).toBeVisible();
             await expect(gradedButton).toBeVisible();
-            await expect(practiceButton).toHaveClass(ACTIVE_MODE_CLASS);
+            await expectModeSelected(practiceButton);
 
             // Switching back to graded must not remove the practice option
             await gradedButton.click();
-            await expect(gradedButton).toHaveClass(ACTIVE_MODE_CLASS);
+            await expectModeSelected(gradedButton);
             await expect(practiceButton).toBeVisible();
 
             // ... and practice can be selected again
             await practiceButton.click();
-            await expect(practiceButton).toHaveClass(ACTIVE_MODE_CLASS);
+            await expectModeSelected(practiceButton);
 
             // The toggle also survives a fresh page load, even though no practice submission exists yet
             await page.goto(`/courses/${course.id}/exercises/${exercise.id}`);
@@ -104,17 +105,17 @@ test.describe('Programming exercise practice mode', { tag: '@slow' }, () => {
             const practiceButton = modeButton(page, 'practice');
             const gradedButton = modeButton(page, 'graded');
             await expect(practiceButton).toBeVisible();
-            await expect(practiceButton).toHaveClass(ACTIVE_MODE_CLASS);
+            await expectModeSelected(practiceButton);
             await expect(page.locator('.code-button')).toBeVisible();
 
             // The graded mode stays reachable, so the student can recognize that they missed the due date
             await gradedButton.click();
-            await expect(gradedButton).toHaveClass(ACTIVE_MODE_CLASS);
+            await expectModeSelected(gradedButton);
             await expect(page.locator('[data-testid="exercise-headers-information"]')).toContainText('Missed due date');
 
             // ... and practice can be selected again
             await practiceButton.click();
-            await expect(practiceButton).toHaveClass(ACTIVE_MODE_CLASS);
+            await expectModeSelected(practiceButton);
 
             // The practice mode survives a fresh page load, even though no practice submission exists yet
             await page.goto(`/courses/${course.id}/exercises/${exercise.id}`);
@@ -127,7 +128,7 @@ test.describe('Programming exercise practice mode', { tag: '@slow' }, () => {
             test.slow();
             await login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
             await startPracticeFromExercisePage(page, exercise.id!, 'Practice');
-            await expect(modeButton(page, 'practice')).toHaveClass(ACTIVE_MODE_CLASS);
+            await expectModeSelected(modeButton(page, 'practice'));
 
             // The live submission state is shown in practice mode even though the due date has passed
             // (instead of a static "currently participating" text that never updates)

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseRepositoryExport.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseRepositoryExport.spec.ts
@@ -169,7 +169,9 @@ test.describe('Programming exercise repository export', { tag: '@slow' }, () => 
 
         await programmingExerciseExportDialog.export();
 
-        await expect(page.locator('.alert-inner.danger .message'), 'the dialog has to say what is missing').toContainText(/select at least one participant/i);
+        await expect(page.locator('[data-testid="alert"][data-alert-type="danger"] .message'), 'the dialog has to say what is missing').toContainText(
+            /select at least one participant/i,
+        );
         expect(exportRequests, 'nothing may be requested from the server').toEqual([]);
         await expect(programmingExerciseExportDialog.dialog(), 'the dialog stays open so the selection can be corrected').toBeVisible();
     });

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseRepositoryExport.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseRepositoryExport.spec.ts
@@ -359,12 +359,7 @@ test.describe('Programming exercise example solution export', { tag: '@slow' }, 
     test('Lets a student download the published example solution', async ({ page, login }) => {
         await login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
         // The example solution lives in a panel that starts collapsed, so its download button is not reachable yet.
-        await page
-            .locator('p-panel')
-            .filter({ hasText: /example solution/i })
-            .locator('.p-panel-toggle-button')
-            .first()
-            .click();
+        await page.getByTestId('example-solution-toggle').first().click();
         const downloadButton = page.locator('jhi-programming-exercise-example-solution-repo-download button').first();
         await downloadButton.waitFor({ state: 'visible' });
         const { filePath, suggestedFilename } = await downloadArchive(page, () => downloadButton.click());

--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseStaticCodeAnalysis.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseStaticCodeAnalysis.spec.ts
@@ -44,7 +44,7 @@ test.describe('Static code analysis tests', { tag: '@slow' }, () => {
         // the student build — all of which can take several minutes under CI load.
         test.setTimeout(300000);
         await login(studentOne, `/courses/${course.id}/exercises/${exercise.id}`);
-        const resultScore = page.locator('#exercise-headers-information').locator('#result-score');
+        const resultScore = page.locator('[data-testid="exercise-headers-information"]').locator('#result-score');
         const expectedScore = resultScore.getByText(cScaSubmission.expectedResult);
         // Build is already confirmed complete via API. Use reloadUntilFound as a fallback
         // in case the page needs a moment to render the result.

--- a/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseAIGeneration.spec.ts
+++ b/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseAIGeneration.spec.ts
@@ -274,7 +274,7 @@ test.describe('Quiz Exercise AI Generation', { tag: '@fast' }, () => {
         await modal.locator('.generate-button').click();
 
         // Error alert shown; no question cards appear
-        await expect(page.locator('.alert-inner.danger')).toBeVisible({ timeout: 10000 });
+        await expect(page.locator('[data-testid="alert"][data-alert-type="danger"]')).toBeVisible({ timeout: 10000 });
         await expect(modal.locator('jhi-quiz-ai-generated-question-card')).toHaveCount(0);
     });
 

--- a/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseAIGeneration.spec.ts
+++ b/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseAIGeneration.spec.ts
@@ -61,11 +61,11 @@ test.describe('Quiz Exercise AI Generation', { tag: '@fast' }, () => {
             .filter({ hasText: /AI|Generate/i })
             .click();
 
-        const modal = page.locator('.quiz-ai-generation-modal');
+        const modal = page.getByTestId('quiz-ai-generation-modal');
         await expect(modal).toBeVisible({ timeout: 10000 });
 
         // The modal uses [showHeader]="false" — no PrimeNG default close in header
-        await expect(modal.locator('.p-dialog-header')).toHaveCount(0);
+        await expect(modal.getByTestId('quiz-ai-generation-modal-header')).toHaveCount(0);
 
         // Close button is inside the preview panel
         const previewCloseBtn = modal.locator('.preview-header button[aria-label]');
@@ -95,7 +95,7 @@ test.describe('Quiz Exercise AI Generation', { tag: '@fast' }, () => {
             .locator('.section-header-action')
             .filter({ hasText: /AI|Generate/i })
             .click();
-        const modal = page.locator('.quiz-ai-generation-modal');
+        const modal = page.getByTestId('quiz-ai-generation-modal');
         await expect(modal).toBeVisible({ timeout: 10000 });
 
         // Fill in topic
@@ -123,7 +123,7 @@ test.describe('Quiz Exercise AI Generation', { tag: '@fast' }, () => {
             .locator('.section-header-action')
             .filter({ hasText: /AI|Generate/i })
             .click();
-        const modal = page.locator('.quiz-ai-generation-modal');
+        const modal = page.getByTestId('quiz-ai-generation-modal');
         await expect(modal).toBeVisible({ timeout: 10000 });
 
         await modal.locator('#quiz-ai-topic').fill('Algorithms');
@@ -148,7 +148,7 @@ test.describe('Quiz Exercise AI Generation', { tag: '@fast' }, () => {
             .locator('.section-header-action')
             .filter({ hasText: /AI|Generate/i })
             .click();
-        const modal = page.locator('.quiz-ai-generation-modal');
+        const modal = page.getByTestId('quiz-ai-generation-modal');
         await expect(modal).toBeVisible({ timeout: 10000 });
 
         // Wait for competency mode toggle to appear
@@ -180,7 +180,7 @@ test.describe('Quiz Exercise AI Generation', { tag: '@fast' }, () => {
             .locator('.section-header-action')
             .filter({ hasText: /AI|Generate/i })
             .click();
-        const modal = page.locator('.quiz-ai-generation-modal');
+        const modal = page.getByTestId('quiz-ai-generation-modal');
         await expect(modal).toBeVisible({ timeout: 10000 });
 
         // Switch to competency mode
@@ -191,9 +191,9 @@ test.describe('Quiz Exercise AI Generation', { tag: '@fast' }, () => {
         // competencies, so pick the option by its unique title rather than the first option.
         const multiSelect = modal.locator('p-multiselect');
         await multiSelect.click();
-        const overlay = page.locator('.p-multiselect-overlay').or(page.locator('.p-overlay-open'));
+        const overlay = page.getByTestId('quiz-ai-competency-overlay');
         await expect(overlay.first()).toBeVisible({ timeout: 5000 });
-        await overlay.first().locator('.p-multiselect-option').filter({ hasText: competencyTitle }).click();
+        await overlay.first().getByTestId('quiz-ai-competency-option').filter({ hasText: competencyTitle }).click();
         // Close overlay
         await modal.locator('.section-title').first().click();
 
@@ -223,7 +223,7 @@ test.describe('Quiz Exercise AI Generation', { tag: '@fast' }, () => {
             .locator('.section-header-action')
             .filter({ hasText: /AI|Generate/i })
             .click();
-        const modal = page.locator('.quiz-ai-generation-modal');
+        const modal = page.getByTestId('quiz-ai-generation-modal');
         await expect(modal).toBeVisible({ timeout: 10000 });
 
         await modal.locator('#quiz-ai-topic').fill('Algorithms');
@@ -242,7 +242,7 @@ test.describe('Quiz Exercise AI Generation', { tag: '@fast' }, () => {
             .locator('.section-header-action')
             .filter({ hasText: /AI|Generate/i })
             .click();
-        const modal = page.locator('.quiz-ai-generation-modal');
+        const modal = page.getByTestId('quiz-ai-generation-modal');
         await expect(modal).toBeVisible({ timeout: 10000 });
 
         // Topic field is empty by default — generate button must be disabled
@@ -267,7 +267,7 @@ test.describe('Quiz Exercise AI Generation', { tag: '@fast' }, () => {
             .locator('.section-header-action')
             .filter({ hasText: /AI|Generate/i })
             .click();
-        const modal = page.locator('.quiz-ai-generation-modal');
+        const modal = page.getByTestId('quiz-ai-generation-modal');
         await expect(modal).toBeVisible({ timeout: 10000 });
 
         await modal.locator('#quiz-ai-topic').fill('Algorithms');
@@ -283,7 +283,7 @@ test.describe('Quiz Exercise AI Generation', { tag: '@fast' }, () => {
             .locator('.section-header-action')
             .filter({ hasText: /AI|Generate/i })
             .click();
-        const modal = page.locator('.quiz-ai-generation-modal');
+        const modal = page.getByTestId('quiz-ai-generation-modal');
         await expect(modal).toBeVisible({ timeout: 10000 });
 
         await modal.locator('#quiz-ai-topic').fill('Sorting');
@@ -309,7 +309,7 @@ test.describe('Quiz Exercise AI Generation', { tag: '@fast' }, () => {
             .locator('.section-header-action')
             .filter({ hasText: /AI|Generate/i })
             .click();
-        const modal = page.locator('.quiz-ai-generation-modal');
+        const modal = page.getByTestId('quiz-ai-generation-modal');
         await expect(modal).toBeVisible({ timeout: 10000 });
 
         await modal.locator('#quiz-ai-topic').fill('Sorting');

--- a/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseAIRefinement.spec.ts
+++ b/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseAIRefinement.spec.ts
@@ -141,7 +141,7 @@ test.describe('Quiz Exercise AI Refinement', { tag: '@fast' }, () => {
 
         // No reasoning card shown; error alert appears
         await expect(panel.locator('.refinement-explanation-card')).not.toBeVisible({ timeout: 5000 });
-        await expect(page.locator('.alert-inner.danger')).toBeVisible({ timeout: 10000 });
+        await expect(page.locator('[data-testid="alert"][data-alert-type="danger"]')).toBeVisible({ timeout: 10000 });
     });
 
     test('Global bulk refinement FAB is visible when MC questions exist', async ({ page }) => {

--- a/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseLifecycle.spec.ts
+++ b/src/test/playwright/e2e/exercise/quiz-exercise/QuizExerciseLifecycle.spec.ts
@@ -160,7 +160,7 @@ test.describe('Quiz Exercise Lifecycle', { tag: '@fast' }, () => {
             await login(admin, `/course-management/${course.id}/quiz-exercises/${quizExercise.id}/edit`);
             const titleField = page.locator('#field_title');
             await expect(titleField).toHaveValue(quizExercise.title!, { timeout: 30000 });
-            const mcQuestionTitle = page.locator('#mc-question-title');
+            const mcQuestionTitle = page.locator('[data-testid="mc-question-title"]');
             // The MC question component mounts lazily after the quiz fetch; match the 30s
             // used for the title field above to avoid spurious timeouts under CI load.
             await expect(mcQuestionTitle).toBeVisible({ timeout: 30000 });
@@ -205,7 +205,7 @@ test.describe('Quiz Exercise Lifecycle', { tag: '@fast' }, () => {
             const titleField = page.locator('#field_title');
             await expect(titleField).toHaveValue(quizExercise.title!, { timeout: 30000 });
 
-            const mcQuestionTitle = page.locator('#mc-question-title');
+            const mcQuestionTitle = page.locator('[data-testid="mc-question-title"]');
             await expect(mcQuestionTitle).toBeVisible({ timeout: 30000 });
             await expect(mcQuestionTitle).toHaveValue(multipleChoiceTemplate.title, { timeout: 10000 });
             const scoreField = page.locator('#score').first();

--- a/src/test/playwright/e2e/exercise/text/TextExerciseAssessment.spec.ts
+++ b/src/test/playwright/e2e/exercise/text/TextExerciseAssessment.spec.ts
@@ -117,7 +117,7 @@ test.describe('Text exercise assessment', { tag: '@slow' }, () => {
             const totalPoints = tutorFeedbackPoints + tutorTextFeedbackPoints;
             const percentage = totalPoints * 10;
             await login(instructor, `/course-management/${course.id}/text-exercises/${exercise.id}/example-submissions`);
-            await page.locator('#import-example-submission').click();
+            await page.locator('[data-testid="import-example-submission"]').click();
             const modal = page.locator('jhi-example-submission-import');
             await modal.locator('#searchParticipant').waitFor({ state: 'visible' });
             // The student-name search is exercise-scoped, so the only participant ("Student One") yields one row.

--- a/src/test/playwright/e2e/iris/IrisCourseTab.spec.ts
+++ b/src/test/playwright/e2e/iris/IrisCourseTab.spec.ts
@@ -106,7 +106,7 @@ test.describe('Iris course tab (real Pyris)', { tag: '@slow' }, () => {
         await expect.poll(() => lectureRequests.length, { timeout: 15_000 }).toBe(1);
         await expect.poll(() => exerciseTitleRequests.length, { timeout: 15_000 }).toBe(1);
 
-        const options = page.locator('.p-select-overlay .p-select-option');
+        const options = page.getByTestId('iris-context-overlay').getByTestId('iris-context-option');
         await expect(options.filter({ hasText: lecture.title! })).toBeVisible({ timeout: 15_000 });
         await expect(options.filter({ hasText: exercise.title! })).toBeVisible();
 

--- a/src/test/playwright/e2e/shared/DateTimePicker.spec.ts
+++ b/src/test/playwright/e2e/shared/DateTimePicker.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '../../support/fixtures';
 import { expect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
-import dayjs from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 import { fillDateTimePicker } from '../../support/utils';
 import { SEED_COURSES } from '../../support/seedData';
 import { admin } from '../../support/users';
@@ -22,19 +22,27 @@ function pickerWrapper(page: Page, pickerId: string): Locator {
     return page.locator(`jhi-date-time-picker#${pickerId}`);
 }
 
+/** The input row of the picker, which reports whether the picker currently holds an unparseable value. */
+function pickerInputRow(page: Page, pickerId: string): Locator {
+    return pickerWrapper(page, pickerId).getByTestId('date-picker-wrapper');
+}
+
 /** Clicks the in-input calendar icon and waits for the overlay panel to appear. */
 async function openPanel(page: Page, pickerId: string): Promise<Locator> {
-    await pickerWrapper(page, pickerId).locator('.p-datepicker-input-icon').click();
-    const panel = page.locator('.p-datepicker-panel');
+    // PrimeNG renders the calendar and the clear affordance into the same pass-through section, and tells them
+    // apart by the icon they carry.
+    await pickerWrapper(page, pickerId).locator('[data-p-icon="calendar"]').click();
+    const panel = page.getByTestId('date-picker-panel');
     await expect(panel).toBeVisible();
     return panel;
 }
 
 /** Closes the overlay panel if it is open. */
 async function closePanel(page: Page): Promise<void> {
-    if (await page.locator('.p-datepicker-panel').isVisible()) {
+    const panel = page.getByTestId('date-picker-panel');
+    if (await panel.isVisible()) {
         await page.keyboard.press('Escape');
-        await expect(page.locator('.p-datepicker-panel')).toBeHidden();
+        await expect(panel).toBeHidden();
     }
 }
 
@@ -46,9 +54,23 @@ async function typeRawText(input: Locator, text: string): Promise<void> {
     await input.press('Tab');
 }
 
-/** Clicks a day cell of the current month in the open panel. */
-async function clickDay(panel: Locator, day: number): Promise<void> {
-    await panel.locator(`.p-datepicker-calendar td:not(.p-datepicker-other-month) span.p-datepicker-day:text-is("${day}")`).click();
+/** The cell of one specific date in the open panel. PrimeNG keys every day cell by its own date. */
+function dayCell(panel: Locator, date: Dayjs): Locator {
+    return panel.locator(`[data-testid="date-picker-day"][data-date="${date.year()}-${date.month()}-${date.date()}"]`);
+}
+
+/** Clicks the cell of the given date in the open panel. */
+async function clickDay(panel: Locator, date: Dayjs): Promise<void> {
+    await dayCell(panel, date).click();
+}
+
+/**
+ * Asserts that the panel shows the given date as the selected one. PrimeNG marks the selected day with a class
+ * and offers no attribute or ARIA state for it, so this reads that class deliberately: the cell is found by its
+ * own date, and the class is only the state being asserted.
+ */
+async function expectDaySelected(panel: Locator, date: Dayjs): Promise<void> {
+    await expect(dayCell(panel, date)).toHaveClass(/p-datepicker-day-selected/);
 }
 
 test.describe('Date-time picker', { tag: '@fast' }, () => {
@@ -58,6 +80,7 @@ test.describe('Date-time picker', { tag: '@fast' }, () => {
         const pickerId = 'field_startDate';
         const input = pickerInput(page, pickerId);
         const wrapper = pickerWrapper(page, pickerId);
+        const inputRow = pickerInputRow(page, pickerId);
         await expect(input).toBeVisible();
         // DEFAULT mode shows date + time
         await expect(input).toHaveAttribute('placeholder', 'dd.mm.yyyy hh:mm');
@@ -66,36 +89,36 @@ test.describe('Date-time picker', { tag: '@fast' }, () => {
         const typedDate = dayjs().add(1, 'year').month(11).date(20).hour(8).minute(30); // 20.12.<next year> 08:30
         await fillDateTimePicker(input, typedDate, 'DD.MM.YYYY HH:mm');
         await expect(input).toHaveValue(typedDate.format('DD.MM.YYYY HH:mm'));
-        await expect(wrapper.locator('.p-datepicker')).not.toHaveClass(/p-invalid/);
+        await expect(inputRow).toHaveAttribute('data-invalid', 'false');
 
         // 2) The calendar overlay reflects the typed value: correct month/year, selected day, a time picker, Monday-first week
         const panel = await openPanel(page, pickerId);
-        await expect(panel.locator('.p-datepicker-title')).toContainText(typedDate.format('MMMM'));
-        await expect(panel.locator('.p-datepicker-title')).toContainText(typedDate.format('YYYY'));
-        await expect(panel.locator('.p-datepicker-day-selected')).toHaveText(String(typedDate.date()));
-        await expect(panel.locator('.p-datepicker-time-picker')).toBeVisible();
-        await expect(panel.locator('.p-datepicker-weekday').first()).toHaveText('Mo');
+        await expect(panel.getByTestId('date-picker-title')).toContainText(typedDate.format('MMMM'));
+        await expect(panel.getByTestId('date-picker-title')).toContainText(typedDate.format('YYYY'));
+        await expectDaySelected(panel, typedDate);
+        await expect(panel.getByTestId('date-picker-time-picker')).toBeVisible();
+        await expect(panel.getByTestId('date-picker-weekday').first()).toHaveText('Mo');
 
         // 3) Picking a different day updates the value while preserving the entered time
-        await clickDay(panel, 15);
+        await clickDay(panel, typedDate.date(15));
         await expect(input).toHaveValue(typedDate.date(15).format('DD.MM.YYYY HH:mm'));
         await closePanel(page);
 
         // 4) Unparseable text is flagged invalid, kept verbatim (not silently coerced into a date)
         await typeRawText(input, 'notadate');
         await expect(input).toHaveValue('notadate');
-        await expect(wrapper.locator('.p-datepicker')).toHaveClass(/p-invalid/);
-        await expect(wrapper.locator('[data-testid="date-picker-validation-message"]').first()).toBeVisible();
+        await expect(inputRow).toHaveAttribute('data-invalid', 'true');
+        await expect(wrapper.getByTestId('date-picker-validation-message').first()).toBeVisible();
 
         // 5) Recovery: typing a valid date again clears the invalid state
         const recoveredDate = dayjs().add(1, 'year').month(5).date(1).hour(9).minute(45); // 01.06.<next year> 09:45
         await fillDateTimePicker(input, recoveredDate, 'DD.MM.YYYY HH:mm');
         await expect(input).toHaveValue(recoveredDate.format('DD.MM.YYYY HH:mm'));
-        await expect(wrapper.locator('.p-datepicker')).not.toHaveClass(/p-invalid/);
-        await expect(wrapper.locator('[data-testid="date-picker-validation-message"]')).toHaveCount(0);
+        await expect(inputRow).toHaveAttribute('data-invalid', 'false');
+        await expect(wrapper.getByTestId('date-picker-validation-message')).toHaveCount(0);
 
         // 6) The clear (×) button empties the field
-        await wrapper.locator('.p-datepicker-clear-icon').click();
+        await wrapper.locator('[data-p-icon="times"]').click();
         await expect(input).toHaveValue('');
     });
 
@@ -116,25 +139,25 @@ test.describe('Date-time picker', { tag: '@fast' }, () => {
 
         // 2) The overlay is calendar-only (no time picker) and reflects the typed value
         const panel = await openPanel(page, pickerId);
-        await expect(panel.locator('.p-datepicker-title')).toContainText(typedDate.format('MMMM'));
-        await expect(panel.locator('.p-datepicker-title')).toContainText(typedDate.format('YYYY'));
-        await expect(panel.locator('.p-datepicker-day-selected')).toHaveText(String(typedDate.date()));
-        await expect(panel.locator('.p-datepicker-time-picker')).toHaveCount(0);
+        await expect(panel.getByTestId('date-picker-title')).toContainText(typedDate.format('MMMM'));
+        await expect(panel.getByTestId('date-picker-title')).toContainText(typedDate.format('YYYY'));
+        await expectDaySelected(panel, typedDate);
+        await expect(panel.getByTestId('date-picker-time-picker')).toHaveCount(0);
 
         // 3) Picking a different day updates the value
-        await clickDay(panel, 10);
+        await clickDay(panel, typedDate.date(10));
         await expect(input).toHaveValue(typedDate.date(10).format('DD.MM.YYYY'));
         await closePanel(page);
 
         // 4) Unparseable text is flagged invalid and kept verbatim
         await typeRawText(input, 'xx.yy.zzzz');
         await expect(input).toHaveValue('xx.yy.zzzz');
-        await expect(wrapper.locator('[data-testid="date-picker-validation-message"]').first()).toBeVisible();
+        await expect(wrapper.getByTestId('date-picker-validation-message').first()).toBeVisible();
 
         // 5) Restoring a valid value and clearing it empties the field
         await fillDateTimePicker(input, typedDate, 'DD.MM.YYYY');
         await expect(input).toHaveValue(typedDate.format('DD.MM.YYYY'));
-        await wrapper.locator('.p-datepicker-clear-icon').click();
+        await wrapper.locator('[data-p-icon="times"]').click();
         await expect(input).toHaveValue('');
     });
 });

--- a/src/test/playwright/e2e/shared/DateTimePicker.spec.ts
+++ b/src/test/playwright/e2e/shared/DateTimePicker.spec.ts
@@ -65,9 +65,9 @@ async function clickDay(panel: Locator, date: Dayjs): Promise<void> {
 }
 
 /**
- * Asserts that the panel shows the given date as the selected one. PrimeNG marks the selected day with a class
- * and offers no attribute or ARIA state for it, so this reads that class deliberately: the cell is found by its
- * own date, and the class is only the state being asserted.
+ * Asserts that the panel shows the given date as the selected one. As of PrimeNG 21.1.9 the day cell carries its own
+ * date but marks the selection only with a class, so this reads that class deliberately: the cell is found by its
+ * own date, and the class is only the state being asserted. Re-check this when PrimeNG is upgraded.
  */
 async function expectDaySelected(panel: Locator, date: Dayjs): Promise<void> {
     await expect(dayCell(panel, date)).toHaveClass(/p-datepicker-day-selected/);

--- a/src/test/playwright/support/pageobjects/LoginPage.ts
+++ b/src/test/playwright/support/pageobjects/LoginPage.ts
@@ -87,12 +87,12 @@ export class LoginPage {
     }
 
     async shouldShowReleaseNotesInFooter() {
-        await expect(this.page.locator('#releases')).toBeVisible();
+        await expect(this.page.locator('[data-testid="releases"]')).toBeVisible();
     }
 
     async shouldShowPrivacyStatementInFooter() {
-        await expect(this.page.locator('#privacy')).toBeVisible();
-        await expect(this.page.locator('#privacy')).toHaveAttribute('href', '/privacy');
+        await expect(this.page.locator('[data-testid="privacy"]')).toBeVisible();
+        await expect(this.page.locator('[data-testid="privacy"]')).toHaveAttribute('href', '/privacy');
     }
 
     async shouldShowImprintInFooter() {

--- a/src/test/playwright/support/pageobjects/NavigationBar.ts
+++ b/src/test/playwright/support/pageobjects/NavigationBar.ts
@@ -38,6 +38,6 @@ export class NavigationBar {
      */
     async logout() {
         await this.page.locator('#account-menu').click();
-        await this.page.locator('#logout').click();
+        await this.page.locator('[data-testid="logout"]').click();
     }
 }

--- a/src/test/playwright/support/pageobjects/assessment/AbstractExerciseAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/AbstractExerciseAssessmentPage.ts
@@ -79,20 +79,20 @@ export abstract class AbstractExerciseAssessmentPage {
     }
 
     async nextAssessment() {
-        await this.page.locator('#assessNextButton').click();
-        await this.page.locator('#assessNextButton').waitFor({ state: 'hidden' });
+        await this.page.locator('[data-testid="assessNextButton"]').click();
+        await this.page.locator('[data-testid="assessNextButton"]').waitFor({ state: 'hidden' });
     }
 
     private async handleComplaint(response: string, accept: boolean, exerciseType: ExerciseType, examMode: boolean, complaintExerciseTitle?: string) {
         if (exerciseType !== ExerciseType.MODELING && !examMode) {
             // The course-wide complaints list intermingles complaints from every assessment test that shares the seed
             // course (e.g. file-upload and modeling both use the exerciseAssessment course). Clicking the first
-            // #show-complaint therefore races those other tests and can open an unrelated — possibly different-type —
+            // [data-testid="show-complaint"] therefore races those other tests and can open an unrelated — possibly different-type —
             // complaint whose response editor never enables for this flow (the observed flake). When the caller knows
             // the exercise title, open that exercise's own complaint row instead of the first one.
             const showComplaintButton = complaintExerciseTitle
-                ? this.page.locator('tr', { hasText: complaintExerciseTitle }).locator('#show-complaint')
-                : this.page.locator('#show-complaint').first();
+                ? this.page.locator('tr', { hasText: complaintExerciseTitle }).locator('[data-testid="show-complaint"]')
+                : this.page.locator('[data-testid="show-complaint"]').first();
             await showComplaintButton.click();
         }
         // The response textarea starts as readonly/disabled while the complaint data loads.

--- a/src/test/playwright/support/pageobjects/assessment/CourseAssessmentDashboardPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/CourseAssessmentDashboardPage.ts
@@ -9,26 +9,28 @@ export class CourseAssessmentDashboardPage {
     }
 
     async openComplaints() {
-        await this.page.locator('#open-complaints').click();
+        await this.page.locator('[data-testid="open-complaints"]').click();
     }
 
     /**
      * Opens a complaint from the course-wide complaints list.
      *
      * The list intermingles complaints from every assessment test that shares the seed course, so clicking the
-     * first #show-complaint races those other tests and can open an unrelated (possibly already-handled)
+     * first [data-testid="show-complaint"] races those other tests and can open an unrelated (possibly already-handled)
      * complaint whose response editor never enables for this flow. When the exercise title is known, open that
      * exercise's own complaint row instead of the first one to keep the selection deterministic.
      * @param exerciseTitle - The title of the exercise whose complaint should be opened (optional).
      */
     async showTheComplaint(exerciseTitle?: string) {
-        const showComplaintButton = exerciseTitle ? this.page.locator('tr', { hasText: exerciseTitle }).locator('#show-complaint') : this.page.locator('#show-complaint').first();
+        const showComplaintButton = exerciseTitle
+            ? this.page.locator('tr', { hasText: exerciseTitle }).locator('[data-testid="show-complaint"]')
+            : this.page.locator('[data-testid="show-complaint"]').first();
         await showComplaintButton.click();
     }
 
     async clickExerciseDashboardButton(exerciseIndex: number = 0, timeout?: number) {
         // Sometimes the page does not load properly, so we reload it if the button is not found
-        const openExerciseDashboardLocator = this.page.locator('#open-exercise-dashboard').nth(exerciseIndex);
+        const openExerciseDashboardLocator = this.page.locator('[data-testid="open-exercise-dashboard"]').nth(exerciseIndex);
         await Commands.reloadUntilFound(this.page, openExerciseDashboardLocator, 5000, timeout);
         await openExerciseDashboardLocator.click();
     }

--- a/src/test/playwright/support/pageobjects/assessment/ExerciseAssessmentDashboardPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/ExerciseAssessmentDashboardPage.ts
@@ -10,23 +10,23 @@ export class ExerciseAssessmentDashboardPage {
     }
 
     async clickHaveReadInstructionsButton() {
-        const participateButton = this.page.locator('#participate-in-assessment');
+        const participateButton = this.page.locator('[data-testid="participate-in-assessment"]');
         await Commands.reloadUntilFound(this.page, participateButton);
         await participateButton.click();
     }
 
     async clickStartNewAssessment(assessmentRound: number = 1) {
-        const startAssessingButton = this.page.locator('#start-new-assessment').nth(assessmentRound - 1);
+        const startAssessingButton = this.page.locator('[data-testid="start-new-assessment"]').nth(assessmentRound - 1);
         await Commands.reloadUntilFound(this.page, startAssessingButton);
         await startAssessingButton.click();
     }
 
     async clickOpenAssessment() {
-        await this.page.locator('#open-assessment').click();
+        await this.page.locator('[data-testid="open-assessment"]').click();
     }
 
     async clickEvaluateComplaint() {
-        await this.page.locator('#evaluate-complaint').click();
+        await this.page.locator('[data-testid="evaluate-complaint"]').click();
     }
 
     getComplaintText() {
@@ -34,7 +34,7 @@ export class ExerciseAssessmentDashboardPage {
     }
 
     getLockedMessage() {
-        return this.page.locator('#assessmentLockedCurrentUser');
+        return this.page.locator('[data-testid="assessmentLockedCurrentUser"]');
     }
 
     async checkComplaintText(complaintText: string) {

--- a/src/test/playwright/support/pageobjects/assessment/FileUploadExerciseAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/FileUploadExerciseAssessmentPage.ts
@@ -10,7 +10,7 @@ export class FileUploadExerciseAssessmentPage extends AbstractExerciseAssessment
     }
 
     async downloadSubmissionFile() {
-        await this.page.locator('#e2e-download-file').click();
+        await this.page.locator('[data-testid="e2e-download-file"]').click();
     }
 
     async submitFeedback() {

--- a/src/test/playwright/support/pageobjects/assessment/ProgrammingExerciseAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/ProgrammingExerciseAssessmentPage.ts
@@ -6,7 +6,8 @@ import { AbstractExerciseAssessmentPage } from './AbstractExerciseAssessmentPage
  */
 export class ProgrammingExerciseAssessmentPage extends AbstractExerciseAssessmentPage {
     async provideFeedbackOnCodeLine(lineIndex: number, points: number, feedback: string) {
-        // We can't change elements from the Monaco editor, so we can't use custom ids here
+        // Monaco renders the code lines, and its decoration API takes a class name and nothing else, so the
+        // hover button cannot carry a test id either. These two selectors name Monaco's DOM out of necessity.
         await this.page.locator('.view-line').nth(lineIndex).hover();
         await this.page.locator('.monaco-add-feedback-button').click();
         await this.typeIntoFeedbackEditor(feedback, lineIndex);

--- a/src/test/playwright/support/pageobjects/assessment/ProgrammingExerciseAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/ProgrammingExerciseAssessmentPage.ts
@@ -23,7 +23,7 @@ export class ProgrammingExerciseAssessmentPage extends AbstractExerciseAssessmen
     }
 
     private async saveFeedback(index: number) {
-        await this.getInlineFeedback(index).locator('#feedback-save').click();
+        await this.getInlineFeedback(index).locator('[data-testid="feedback-save"]').click();
     }
 
     private getInlineFeedback(line: number) {

--- a/src/test/playwright/support/pageobjects/assessment/StudentAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/StudentAssessmentPage.ts
@@ -29,7 +29,7 @@ export class StudentAssessmentPage {
     }
 
     getComplaintBadge() {
-        return this.page.locator('jhi-complaint-request .badge');
+        return this.page.getByTestId('complaint-status-badge');
     }
 
     getComplaintResponse() {

--- a/src/test/playwright/support/pageobjects/assessment/StudentAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/StudentAssessmentPage.ts
@@ -33,7 +33,7 @@ export class StudentAssessmentPage {
     }
 
     getComplaintResponse() {
-        return this.page.locator('#complainResponseTextArea');
+        return this.page.locator('[data-testid="complainResponseTextArea"]');
     }
 
     async checkComplaintStatusText(text: string) {

--- a/src/test/playwright/support/pageobjects/assessment/TextExerciseAssessmentPage.ts
+++ b/src/test/playwright/support/pageobjects/assessment/TextExerciseAssessmentPage.ts
@@ -17,11 +17,11 @@ export class TextExerciseAssessmentPage extends AbstractExerciseAssessmentPage {
     }
 
     private async typeIntoFeedbackEditor(sectionIndex: number, feedbackText: string) {
-        await this.getFeedbackSection(sectionIndex).locator('#feedback-editor-text-input').fill(feedbackText);
+        await this.getFeedbackSection(sectionIndex).locator('[data-testid="feedback-editor-text-input"]').fill(feedbackText);
     }
 
     private async typePointsIntoFeedbackEditor(sectionIndex: number, feedbackPoints: number) {
-        const textField = this.getFeedbackSection(sectionIndex).locator('#feedback-editor-points-input');
+        const textField = this.getFeedbackSection(sectionIndex).locator('[data-testid="feedback-editor-points-input"]');
         await textField.clear();
         await textField.fill(feedbackPoints.toString());
     }
@@ -71,10 +71,10 @@ export class TextExerciseAssessmentPage extends AbstractExerciseAssessmentPage {
     }
 
     getWordCountElement() {
-        return this.page.locator('#text-assessment-word-count');
+        return this.page.locator('[data-testid="text-assessment-word-count"]');
     }
 
     getCharacterCountElement() {
-        return this.page.locator('#text-assessment-character-count');
+        return this.page.locator('[data-testid="text-assessment-character-count"]');
     }
 }

--- a/src/test/playwright/support/pageobjects/course/CourseCommunicationPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseCommunicationPage.ts
@@ -200,30 +200,6 @@ export class CourseCommunicationPage {
     }
 
     /**
-     * Deletes the specified post.
-     * @param postID - The ID of the post to delete.
-     */
-    async deletePost(postID: number) {
-        const deleteIcon = this.getSinglePost(postID).locator('.deleteIcon');
-        await deleteIcon.click();
-        await deleteIcon.click();
-    }
-
-    /**
-     * Edits the content of a message in a specified post.
-     * @param postID - The ID of the post containing the message to edit.
-     * @param content - The new content for the message.
-     */
-    async editMessage(postID: number, content: string) {
-        const post = this.getSinglePost(postID);
-        await post.locator('.editIcon').click();
-        await this.setContentInline(content);
-        const responsePromise = this.page.waitForResponse(`api/communication/courses/*/messages/*`);
-        await this.page.locator('#save').click();
-        await responsePromise;
-    }
-
-    /**
      * Shows the replies for a specified post, expanding them if they are not already visible.
      * @param postID - The ID of the post for which to show replies.
      */

--- a/src/test/playwright/support/pageobjects/course/CourseCommunicationPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseCommunicationPage.ts
@@ -25,7 +25,7 @@ export class CourseCommunicationPage {
      * @returns The locator for the context selector.
      */
     getContextSelectorInModal() {
-        return this.page.locator('.p-dialog-content #context');
+        return this.page.getByRole('dialog').locator('#context');
     }
 
     /**
@@ -33,8 +33,9 @@ export class CourseCommunicationPage {
      * @param title - The title to be set.
      */
     async setTitleInModal(title: string) {
-        await this.page.locator('.p-dialog-content').locator('#title').fill('');
-        await this.page.locator('.p-dialog-content').locator('#title').fill(title);
+        const titleInput = this.page.getByRole('dialog').locator('#title');
+        await titleInput.fill('');
+        await titleInput.fill(title);
     }
 
     /**
@@ -42,7 +43,7 @@ export class CourseCommunicationPage {
      * @param content - The content to be set.
      */
     async setContentInModal(content: string) {
-        const contentField = this.page.locator('.p-dialog-content .markdown-editor .monaco-editor');
+        const contentField = this.page.getByRole('dialog').getByTestId('markdown-editor').locator('.monaco-editor');
         await setMonacoEditorContentByLocator(this.page, contentField, content);
     }
 
@@ -51,7 +52,7 @@ export class CourseCommunicationPage {
      * @param content - The content to be set.
      */
     async setContentInline(content: string) {
-        const contentField = this.page.locator('.markdown-editor-wrapper .markdown-editor .monaco-editor');
+        const contentField = this.page.getByTestId('markdown-editor').first().locator('.monaco-editor');
         await setMonacoEditorContentByLocator(this.page, contentField, content);
     }
 
@@ -154,10 +155,10 @@ export class CourseCommunicationPage {
      */
     async reply(postID: number, content: string) {
         const postElement = this.getSinglePost(postID);
-        const postReplyField = postElement.locator('.new-reply-inline-input .markdown-editor .monaco-editor');
+        const postReplyField = postElement.getByTestId('inline-reply-input').getByTestId('markdown-editor').locator('.monaco-editor');
         await setMonacoEditorContentByLocator(this.page, postReplyField, content);
         const responsePromise = this.page.waitForResponse(`api/communication/courses/*/answer-posts`);
-        await postElement.locator('.new-reply-inline-input #save').click();
+        await postElement.getByTestId('inline-reply-input').locator('#save').click();
         await responsePromise;
     }
 
@@ -169,10 +170,10 @@ export class CourseCommunicationPage {
      */
     async replyWithMessage(postID: number, content: string): Promise<Post> {
         const postElement = this.getSinglePost(postID);
-        const postReplyField = postElement.locator('.new-reply-inline-input .markdown-editor .monaco-editor');
+        const postReplyField = postElement.getByTestId('inline-reply-input').getByTestId('markdown-editor').locator('.monaco-editor');
         await setMonacoEditorContentByLocator(this.page, postReplyField, content);
         const responsePromise = this.page.waitForResponse(`api/communication/courses/*/answer-messages`);
-        await this.getSinglePost(postID).locator('.new-reply-inline-input #save').click();
+        await this.getSinglePost(postID).getByTestId('inline-reply-input').locator('#save').click();
         const response = await responsePromise;
         return readResponseJson(response);
     }

--- a/src/test/playwright/support/pageobjects/course/CourseCommunicationPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseCommunicationPage.ts
@@ -43,7 +43,7 @@ export class CourseCommunicationPage {
      * @param content - The content to be set.
      */
     async setContentInModal(content: string) {
-        const contentField = this.page.getByRole('dialog').getByTestId('markdown-editor').locator('.monaco-editor');
+        const contentField = this.page.getByRole('dialog').getByTestId('markdown-editor');
         await setMonacoEditorContentByLocator(this.page, contentField, content);
     }
 
@@ -52,7 +52,7 @@ export class CourseCommunicationPage {
      * @param content - The content to be set.
      */
     async setContentInline(content: string) {
-        const contentField = this.page.getByTestId('markdown-editor').first().locator('.monaco-editor');
+        const contentField = this.page.getByTestId('markdown-editor').first();
         await setMonacoEditorContentByLocator(this.page, contentField, content);
     }
 
@@ -155,7 +155,7 @@ export class CourseCommunicationPage {
      */
     async reply(postID: number, content: string) {
         const postElement = this.getSinglePost(postID);
-        const postReplyField = postElement.getByTestId('inline-reply-input').getByTestId('markdown-editor').locator('.monaco-editor');
+        const postReplyField = postElement.getByTestId('inline-reply-input').getByTestId('markdown-editor');
         await setMonacoEditorContentByLocator(this.page, postReplyField, content);
         const responsePromise = this.page.waitForResponse(`api/communication/courses/*/answer-posts`);
         await postElement.getByTestId('inline-reply-input').locator('#save').click();
@@ -170,7 +170,7 @@ export class CourseCommunicationPage {
      */
     async replyWithMessage(postID: number, content: string): Promise<Post> {
         const postElement = this.getSinglePost(postID);
-        const postReplyField = postElement.getByTestId('inline-reply-input').getByTestId('markdown-editor').locator('.monaco-editor');
+        const postReplyField = postElement.getByTestId('inline-reply-input').getByTestId('markdown-editor');
         await setMonacoEditorContentByLocator(this.page, postReplyField, content);
         const responsePromise = this.page.waitForResponse(`api/communication/courses/*/answer-messages`);
         await this.getSinglePost(postID).getByTestId('inline-reply-input').locator('#save').click();

--- a/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
@@ -50,7 +50,7 @@ export class CourseManagementExercisesPage {
     }
 
     async clickExampleSubmissionsButton() {
-        await this.page.locator('#example-submissions-button').click();
+        await this.page.locator('[data-testid="example-submissions-button"]').click();
     }
 
     getExerciseTitle(exerciseTitle: string) {

--- a/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
@@ -216,15 +216,18 @@ export class CourseManagementExercisesPage {
     }
 
     async openQuizExerciseDetailsPage(exerciseId: number) {
-        await Promise.all([this.page.waitForURL(`/course-management/*/quiz-exercises/${exerciseId}`), this.getExercise(exerciseId).locator('.col-title a').click()]);
+        await Promise.all([
+            this.page.waitForURL(`/course-management/*/quiz-exercises/${exerciseId}`),
+            this.getExercise(exerciseId).getByTestId('exercise-row-title').getByRole('link').click(),
+        ]);
     }
 
     getModelingExerciseTitle(exerciseID: number) {
-        return this.getExercise(exerciseID).locator('.col-title');
+        return this.getExercise(exerciseID).getByTestId('exercise-row-title');
     }
 
     getModelingExerciseMaxPoints(exerciseID: number) {
-        return this.getExercise(exerciseID).locator('.col-points');
+        return this.getExercise(exerciseID).getByTestId('exercise-row-points');
     }
 
     async openExerciseTeams(exerciseId: number) {

--- a/src/test/playwright/support/pageobjects/course/CourseManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementPage.ts
@@ -211,7 +211,10 @@ export class CourseManagementPage {
         await searchInput.fill(credentials.username);
         // Pick the matching suggestion (rendered as "Name (login)"). The closing parenthesis keeps the match
         // unambiguous, e.g. it selects artemis_test_user_1 rather than artemis_test_user_10.
-        await this.page.locator('.p-autocomplete-option', { hasText: `(${credentials.username})` }).click();
+        await this.page
+            .getByTestId('user-autocomplete-option')
+            .filter({ hasText: `(${credentials.username})` })
+            .click();
         await responsePromise;
     }
 

--- a/src/test/playwright/support/pageobjects/course/CourseManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementPage.ts
@@ -203,7 +203,7 @@ export class CourseManagementPage {
     private async addUserToGroup(credentials: UserCredentials, groupType: string, selector: string) {
         const responsePromise = this.page.waitForResponse(`api/course/courses/*/${groupType}/${credentials.username}`);
         // Open the user-management dropdown and the add-<group> action, which navigates to the group page.
-        await this.page.locator('#user-management-dropdown').click();
+        await this.page.locator('[data-testid="user-management-dropdown"]').click();
         await this.page.locator(selector).click();
         // The group page hosts a PrimeNG autocomplete to search for and add users.
         const searchInput = this.page.locator('p-autocomplete input');

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -63,7 +63,7 @@ export class CourseMessagesPage {
      */
     async joinChannel(channelID: number) {
         const responsePromise = this.page.waitForResponse(`api/communication/courses/*/channels/*/register`);
-        await this.page.locator(`#channel-${channelID} #register${channelID}`).click({ force: true });
+        await this.page.locator(`[data-channel-id="${channelID}"]`).locator(`#register${channelID}`).click({ force: true });
         await responsePromise;
     }
 
@@ -73,7 +73,7 @@ export class CourseMessagesPage {
      */
     async leaveChannel(channelID: number) {
         const responsePromise = this.page.waitForResponse(`api/communication/courses/*/channels/*/deregister`);
-        await this.page.locator(`#channel-${channelID} #deregister${channelID}`).click({ force: true });
+        await this.page.locator(`[data-channel-id="${channelID}"]`).locator(`#deregister${channelID}`).click({ force: true });
         await responsePromise;
     }
 

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -180,7 +180,7 @@ export class CourseMessagesPage {
      * @returns The locator for the topic element.
      */
     getTopic() {
-        return this.page.locator('#conversation-topic');
+        return this.page.locator('[data-testid="conversation-topic"]');
     }
 
     /**
@@ -1025,7 +1025,7 @@ export class CourseMessagesPage {
      * If the user has already accepted the code of conduct, the button won't be present.
      */
     async acceptCodeOfConductButton() {
-        const button = this.page.locator('#acceptCodeOfConductButton');
+        const button = this.page.locator('[data-testid="acceptCodeOfConductButton"]');
         // Wait a short time for the page to load and determine if the button should be shown
         await this.page.waitForLoadState('domcontentloaded');
         if (await button.isVisible()) {

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -21,7 +21,7 @@ export class CourseMessagesPage {
      * Clicks the button to initiate channel creation.
      */
     async createChannelButton() {
-        await this.page.locator('.btn-primary.btn-sm.square-button').click();
+        await this.page.getByTestId('sidebar-create-menu-button').click();
         const createBtn = this.page.locator('button', { hasText: 'Create channel' });
         await createBtn.waitFor({ state: 'visible', timeout: 5000 });
         await createBtn.click();
@@ -31,7 +31,7 @@ export class CourseMessagesPage {
      * Navigates to the channel overview section.
      */
     async browseChannelsButton() {
-        await this.page.locator('.btn-primary.btn-sm.square-button').click();
+        await this.page.getByTestId('sidebar-create-menu-button').click();
         const browseBtn = this.page.locator('button', { hasText: 'Browse channels' });
         await browseBtn.waitFor({ state: 'visible', timeout: 5000 });
         await browseBtn.click();
@@ -111,35 +111,35 @@ export class CourseMessagesPage {
      * Sets a channel to be private in the modal dialog (PrimeNG SelectButton).
      */
     async setPrivate() {
-        await this.page.locator('.p-dialog-content p-selectbutton').first().getByText('Private').click();
+        await this.page.getByTestId('channel-visibility-select').getByText('Private').click();
     }
 
     /**
      * Sets a channel to be public in the modal dialog (PrimeNG SelectButton).
      */
     async setPublic() {
-        await this.page.locator('.p-dialog-content p-selectbutton').first().getByText('Public').click();
+        await this.page.getByTestId('channel-visibility-select').getByText('Public').click();
     }
 
     /**
      * Marks a channel as course-wide in the modal dialog (PrimeNG SelectButton).
      */
     async setCourseWideChannel() {
-        await this.page.locator('.p-dialog-content p-selectbutton').nth(1).getByText('Course-wide Channel').click();
+        await this.page.getByTestId('channel-scope-select').getByText('Course-wide Channel').click();
     }
 
     /**
      * Marks a channel as an announcement channel in the modal dialog (PrimeNG SelectButton).
      */
     async setAnnouncementChannel() {
-        await this.page.locator('.p-dialog-content p-selectbutton').nth(2).getByText('Announcement Channel').click();
+        await this.page.getByTestId('channel-type-select').getByText('Announcement Channel').click();
     }
 
     /**
      * Marks a channel as unrestricted in the modal dialog (PrimeNG SelectButton).
      */
     async setUnrestrictedChannel() {
-        await this.page.locator('.p-dialog-content p-selectbutton').nth(2).getByText('Unrestricted Channel').click();
+        await this.page.getByTestId('channel-type-select').getByText('Unrestricted Channel').click();
     }
 
     /**
@@ -471,7 +471,7 @@ export class CourseMessagesPage {
      * Clicks the button to initiate group chat creation.
      */
     async createGroupChatButton() {
-        await this.page.locator('.btn-primary.btn-sm.square-button').click();
+        await this.page.getByTestId('sidebar-create-menu-button').click();
         const createBtn = this.page.locator('button', { hasText: 'Create group chat' });
         await createBtn.waitFor({ state: 'visible', timeout: 5000 });
         await createBtn.click();
@@ -615,7 +615,7 @@ export class CourseMessagesPage {
      * Opens the settings tab within the conversation details.
      */
     async openSettingsTab() {
-        const settingsTab = this.page.locator('.settings-tab .nav-link');
+        const settingsTab = this.page.getByTestId('conversation-settings-tab');
         await settingsTab.waitFor({ state: 'visible', timeout: 10000 });
         await settingsTab.click();
     }
@@ -779,7 +779,7 @@ export class CourseMessagesPage {
      * Clicks the "+" button and selects "Create direct message".
      */
     async createDirectMessageButton() {
-        await this.page.locator('.btn-primary.btn-sm.square-button').click();
+        await this.page.getByTestId('sidebar-create-menu-button').click();
         const createBtn = this.page.locator('button', { hasText: 'Direct message' });
         await createBtn.waitFor({ state: 'visible', timeout: 5000 });
         await createBtn.click();

--- a/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseMessagesPage.ts
@@ -36,7 +36,7 @@ export class CourseMessagesPage {
         await browseBtn.waitFor({ state: 'visible', timeout: 5000 });
         await browseBtn.click();
         // Wait for the channels overview to load
-        await this.page.locator('.channels-overview').waitFor({ state: 'visible', timeout: 10000 });
+        await this.page.getByTestId('channels-overview-dialog').waitFor({ state: 'visible', timeout: 10000 });
     }
 
     /**
@@ -44,7 +44,7 @@ export class CourseMessagesPage {
      * @param name - The name of the channel to check for existence.
      */
     async checkChannelsExists(name: string) {
-        await expect(this.page.locator('.channels-overview .list-group-item').getByText(name, { exact: true })).toBeVisible({ timeout: 15000 });
+        await expect(this.page.getByTestId('channel-overview-item').getByText(name, { exact: true })).toBeVisible({ timeout: 15000 });
     }
 
     /**
@@ -53,9 +53,8 @@ export class CourseMessagesPage {
      * @returns The ID of the channel.
      */
     async getChannelIdByName(name: string) {
-        const channelElement = this.page.locator('.channels-overview .list-group-item', { hasText: name });
-        const id = await channelElement.getAttribute('id');
-        return id?.replace('channel-', '');
+        const channelElement = this.page.getByTestId('channel-overview-item').filter({ hasText: name });
+        return (await channelElement.getAttribute('data-channel-id')) ?? undefined;
     }
 
     /**
@@ -84,7 +83,7 @@ export class CourseMessagesPage {
      * @returns The locator for the badge element.
      */
     getJoinedBadge(channelID: number) {
-        return this.page.locator(`#channel-${channelID} .badge`);
+        return this.page.locator(`[data-channel-id="${channelID}"]`).getByTestId('channel-joined-badge');
     }
 
     /**
@@ -92,7 +91,7 @@ export class CourseMessagesPage {
      * @param name - The name to be set.
      */
     async setName(name: string) {
-        const locator = this.page.locator('.p-dialog-content #name');
+        const locator = this.page.getByRole('dialog').locator('#name');
         await locator.clear();
         await locator.fill(name);
     }
@@ -102,7 +101,7 @@ export class CourseMessagesPage {
      * @param description - The description to be set.
      */
     async setDescription(description: string) {
-        const locator = this.page.locator('.p-dialog-content #description');
+        const locator = this.page.getByRole('dialog').locator('#description');
         await locator.clear();
         await locator.fill(description);
     }
@@ -151,7 +150,7 @@ export class CourseMessagesPage {
         const responsePromise = this.page.waitForResponse(
             (resp) => resp.url().includes('api/communication/courses/') && resp.url().endsWith('/channels') && resp.request().method() === 'POST' && resp.status() === 201,
         );
-        await this.page.locator('.p-dialog-content #submitButton').click();
+        await this.page.getByRole('dialog').locator('#submitButton').click();
         const response = await responsePromise;
         const channel: ChannelDTO = await readResponseJson(response);
         await this.page.waitForURL(`**/communication?conversationId=${channel.id}`);
@@ -164,7 +163,7 @@ export class CourseMessagesPage {
      * @returns The locator for the error message element.
      */
     getError() {
-        return this.page.locator('.modal-body .alert');
+        return this.page.getByTestId('channel-name-error');
     }
 
     /**
@@ -172,7 +171,7 @@ export class CourseMessagesPage {
      * @returns The locator for the name element.
      */
     getName() {
-        return this.page.locator('h4.d-inline-block');
+        return this.page.getByTestId('conversation-name');
     }
 
     /**
@@ -236,7 +235,7 @@ export class CourseMessagesPage {
      * Closes the edit panel in the conversation detail dialog.
      */
     async closeEditPanel() {
-        await this.page.locator('.conversation-detail-dialog .btn-close').click();
+        await this.page.getByTestId('conversation-detail-close-button').click();
     }
 
     /**
@@ -312,6 +311,9 @@ export class CourseMessagesPage {
      * Returns the locator for Monaco's suggest widget (the autocomplete popup shown while typing),
      * scoped to its `visible` state class so a hidden (but still DOM-attached) widget from a
      * previous session does not cause a strict-mode match with the currently open one.
+     *
+     * Monaco builds this overlay itself and offers no way to put attributes on it, so unlike the rest
+     * of the suite this locator has to name Monaco's own classes.
      */
     getSuggestWidget() {
         return this.page.locator('.suggest-widget.visible');
@@ -390,18 +392,18 @@ export class CourseMessagesPage {
         for (let attempt = 0; attempt < 3; attempt++) {
             await postLocator.locator('.message-container').click({ button: 'right' });
             try {
-                await this.page.locator('.dropdown-menu.show').waitFor({ state: 'visible', timeout: 3000 });
+                await this.page.getByTestId('posting-context-menu').waitFor({ state: 'visible', timeout: 3000 });
                 break;
             } catch {
                 if (attempt === 2) throw new Error('Context menu did not appear after 3 right-click attempts');
             }
         }
 
-        const editButton = postLocator.locator('.dropdown-menu.show .editIcon');
+        const editButton = postLocator.getByTestId('posting-menu-edit');
         if (await editButton.isVisible()) {
             await editButton.click();
         } else {
-            await postLocator.locator('.reaction-button.edit').click();
+            await postLocator.getByTestId('posting-reaction-edit').click();
         }
 
         // Use the setMonacoEditorContentByLocator utility to set the content directly
@@ -424,7 +426,7 @@ export class CourseMessagesPage {
         for (let attempt = 0; attempt < 3; attempt++) {
             await postLocator.locator('.message-container').click({ button: 'right' });
             try {
-                await this.page.locator('.dropdown-menu.show').waitFor({ state: 'visible', timeout: 3000 });
+                await this.page.getByTestId('posting-context-menu').waitFor({ state: 'visible', timeout: 3000 });
                 break;
             } catch {
                 if (attempt === 2) throw new Error('Context menu did not appear after 3 right-click attempts');
@@ -432,11 +434,11 @@ export class CourseMessagesPage {
         }
 
         const responsePromise = this.page.waitForResponse(`api/communication/courses/*/messages/*`);
-        const deleteButton = postLocator.locator('.dropdown-menu.show .deleteIcon');
+        const deleteButton = postLocator.getByTestId('posting-menu-delete');
         if (await deleteButton.isVisible()) {
             await deleteButton.click();
         } else {
-            await postLocator.locator('.reaction-button.delete').click();
+            await postLocator.getByTestId('posting-reaction-delete').click();
         }
         await responsePromise;
     }
@@ -526,7 +528,7 @@ export class CourseMessagesPage {
     async addUserToGroupChat(user: string) {
         // Use a flexible selector that matches any users-selector search input (the ID suffix is a global counter)
         const searchInput = this.page.locator('input[id$="-search-input"][id^="users-selector"]');
-        const dropdownItem = this.page.locator('.dropdown-item', { hasText: `(${user})` });
+        const dropdownItem = this.page.getByTestId('user-search-result').filter({ hasText: `(${user})` });
         for (let attempt = 0; attempt < 3; attempt++) {
             await searchInput.clear();
             await searchInput.fill(user);
@@ -608,7 +610,7 @@ export class CourseMessagesPage {
      * This is faster and more reliable than opening the member list dialog.
      */
     async checkConversationHeaderContains(name: string) {
-        await expect(this.page.locator('h4.d-inline-block')).toContainText(name, { timeout: 10000 });
+        await expect(this.page.getByTestId('conversation-name')).toContainText(name, { timeout: 10000 });
     }
 
     /**
@@ -657,7 +659,7 @@ export class CourseMessagesPage {
         for (let attempt = 0; attempt < 3; attempt++) {
             await postLocator.locator('.message-container').click({ button: 'right' });
             try {
-                await this.page.locator('.dropdown-menu.show').waitFor({ state: 'visible', timeout: 3000 });
+                await this.page.getByTestId('posting-context-menu').waitFor({ state: 'visible', timeout: 3000 });
                 break;
             } catch {
                 if (attempt === 2) throw new Error('Context menu did not appear after 3 right-click attempts');
@@ -667,7 +669,7 @@ export class CourseMessagesPage {
         const responsePromise = this.page.waitForResponse(
             (resp) => resp.url().includes('/saved-posts') && (resp.request().method() === 'POST' || resp.request().method() === 'DELETE'),
         );
-        await postLocator.locator('.dropdown-menu.show .dropdown-item', { hasText: /bookmark|save/i }).click();
+        await postLocator.getByTestId('posting-menu-bookmark').click();
         await responsePromise;
     }
 
@@ -698,7 +700,7 @@ export class CourseMessagesPage {
         for (let attempt = 0; attempt < 3; attempt++) {
             await postLocator.locator('.message-container').click({ button: 'right' });
             try {
-                await this.page.locator('.dropdown-menu.show').waitFor({ state: 'visible', timeout: 3000 });
+                await this.page.getByTestId('posting-context-menu').waitFor({ state: 'visible', timeout: 3000 });
                 break;
             } catch {
                 if (attempt === 2) throw new Error('Context menu did not appear after 3 right-click attempts');
@@ -706,7 +708,7 @@ export class CourseMessagesPage {
         }
 
         // Click the "Add reaction" item — this opens the emoji picker at the click location
-        await this.page.locator('.dropdown-menu.show .dropdown-item', { hasText: /reaction/i }).click();
+        await this.page.getByTestId('posting-menu-react').click();
         // Search for the emoji and click it
         await this.page.locator('.emoji-mart').waitFor({ state: 'visible', timeout: 5000 });
         await this.page.locator('.emoji-mart').locator('.emoji-mart-search input').fill(emoji);
@@ -737,14 +739,14 @@ export class CourseMessagesPage {
         for (let attempt = 0; attempt < 3; attempt++) {
             await postLocator.locator('.message-container').click({ button: 'right' });
             try {
-                await this.page.locator('.dropdown-menu.show').waitFor({ state: 'visible', timeout: 3000 });
+                await this.page.getByTestId('posting-context-menu').waitFor({ state: 'visible', timeout: 3000 });
                 break;
             } catch {
                 if (attempt === 2) throw new Error('Context menu did not appear after 3 right-click attempts');
             }
         }
 
-        await postLocator.locator('.dropdown-menu.show .dropdown-item', { hasText: /reply/i }).click();
+        await postLocator.getByTestId('posting-menu-reply').click();
         // Wait for the thread sidebar to become visible
         await this.page.locator('.expanded-thread').waitFor({ state: 'visible', timeout: 10000 });
     }
@@ -797,14 +799,14 @@ export class CourseMessagesPage {
         for (let attempt = 0; attempt < 3; attempt++) {
             await postLocator.locator('.message-container').click({ button: 'right' });
             try {
-                await this.page.locator('.dropdown-menu.show').waitFor({ state: 'visible', timeout: 3000 });
+                await this.page.getByTestId('posting-context-menu').waitFor({ state: 'visible', timeout: 3000 });
                 break;
             } catch {
                 if (attempt === 2) throw new Error('Context menu did not appear after 3 right-click attempts');
             }
         }
 
-        await postLocator.locator('.dropdown-menu.show .forward').click();
+        await postLocator.getByTestId('posting-menu-forward').click();
         // Wait for the forward dialog to appear
         await this.page.locator('jhi-forward-message-dialog').waitFor({ state: 'visible', timeout: 10000 });
     }
@@ -818,7 +820,7 @@ export class CourseMessagesPage {
         const dialog = this.page.locator('jhi-forward-message-dialog');
         const input = dialog.locator('input.tag-input');
         // the dialog selects on (mousedown) so the option is chosen before the input blur closes the dropdown
-        const option = dialog.locator('.autocomplete-dropdown .list-group-item-action', { hasText: destinationName }).first();
+        const option = dialog.getByTestId('forward-destination-option').filter({ hasText: destinationName }).first();
         // The autocomplete dropdown re-renders as the debounced search resolves, so the matched option can detach between
         // becoming visible and the mousedown — an unbounded dispatchEvent then hangs until the test timeout. Re-type and
         // re-select as a unit with a bounded mousedown so a detach retries quickly instead of hanging.
@@ -840,7 +842,7 @@ export class CourseMessagesPage {
         }
         // forwarding first creates the container post, then the forwarded-message link(s)
         const forwardResponse = this.page.waitForResponse((resp) => resp.url().includes('/forwarded-messages') && resp.request().method() === 'POST');
-        await dialog.locator('.modal-footer button.btn-primary').click();
+        await dialog.getByTestId('forward-send-button').click();
         await forwardResponse;
         await dialog.waitFor({ state: 'hidden', timeout: 10000 });
     }
@@ -870,7 +872,7 @@ export class CourseMessagesPage {
         for (let attempt = 0; attempt < 3; attempt++) {
             await replyLocator.locator('.message-container').click({ button: 'right' });
             try {
-                await this.page.locator('.dropdown-menu.show').waitFor({ state: 'visible', timeout: 3000 });
+                await this.page.getByTestId('posting-context-menu').waitFor({ state: 'visible', timeout: 3000 });
                 break;
             } catch {
                 if (attempt === 2) throw new Error('Context menu did not appear after 3 right-click attempts');
@@ -878,7 +880,7 @@ export class CourseMessagesPage {
         }
         // jhi-answer-post renders its context dropdown as a sibling of the #item-<id> div (not inside it),
         // so scope the click to the surrounding jhi-answer-post host instead of the #item-<id> element
-        await this.page.locator(`jhi-answer-post:has(#item-${replyId})`).locator('.dropdown-menu.show .forward').click();
+        await this.page.locator(`jhi-answer-post:has(#item-${replyId})`).getByTestId('posting-menu-forward').click();
         await this.completeForwardDialog(destinationName, extraContent);
     }
 
@@ -936,7 +938,7 @@ export class CourseMessagesPage {
         for (let attempt = 0; attempt < 3; attempt++) {
             await postLocator.locator('.message-container').click({ button: 'right' });
             try {
-                await this.page.locator('.dropdown-menu.show').waitFor({ state: 'visible', timeout: 3000 });
+                await this.page.getByTestId('posting-context-menu').waitFor({ state: 'visible', timeout: 3000 });
                 break;
             } catch {
                 if (attempt === 2) throw new Error('Context menu did not appear after 3 right-click attempts');
@@ -944,7 +946,7 @@ export class CourseMessagesPage {
         }
 
         const responsePromise = this.page.waitForResponse((resp) => resp.url().includes('/messages/') && resp.request().method() === 'PUT');
-        await postLocator.locator('.dropdown-menu.show .dropdown-item', { hasText: /pin/i }).click();
+        await postLocator.getByTestId('posting-menu-pin').click();
         await responsePromise;
     }
 
@@ -975,7 +977,7 @@ export class CourseMessagesPage {
         for (let attempt = 0; attempt < 3; attempt++) {
             await replyLocator.locator('.message-container').click({ button: 'right' });
             try {
-                await this.page.locator('.dropdown-menu.show').waitFor({ state: 'visible', timeout: 3000 });
+                await this.page.getByTestId('posting-context-menu').waitFor({ state: 'visible', timeout: 3000 });
                 break;
             } catch {
                 if (attempt === 2) throw new Error('Context menu did not appear after 3 right-click attempts');
@@ -983,7 +985,7 @@ export class CourseMessagesPage {
         }
 
         // Click "Edit Message" from the dropdown by matching translated text
-        await this.page.locator('.dropdown-menu.show .dropdown-item', { hasText: /edit/i }).click();
+        await this.page.getByTestId('posting-menu-edit').click();
 
         await setMonacoEditorContentByLocator(this.page, replyLocator, newContent);
         const responsePromise = this.page.waitForResponse((resp) => resp.url().includes('/answer-messages/') && resp.request().method() === 'PUT');
@@ -1003,7 +1005,7 @@ export class CourseMessagesPage {
         for (let attempt = 0; attempt < 3; attempt++) {
             await replyLocator.locator('.message-container').click({ button: 'right' });
             try {
-                await this.page.locator('.dropdown-menu.show').waitFor({ state: 'visible', timeout: 3000 });
+                await this.page.getByTestId('posting-context-menu').waitFor({ state: 'visible', timeout: 3000 });
                 break;
             } catch {
                 if (attempt === 2) throw new Error('Context menu did not appear after 3 right-click attempts');
@@ -1012,7 +1014,7 @@ export class CourseMessagesPage {
 
         const responsePromise = this.page.waitForResponse((resp) => resp.url().includes('/answer-messages/') && resp.request().method() === 'DELETE');
         // Click "Delete Message" from the dropdown by matching translated text
-        await this.page.locator('.dropdown-menu.show .dropdown-item', { hasText: /delete/i }).click();
+        await this.page.getByTestId('posting-menu-delete').click();
         await responsePromise;
     }
 

--- a/src/test/playwright/support/pageobjects/course/CourseOnboardingPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseOnboardingPage.ts
@@ -14,28 +14,28 @@ export class CourseOnboardingPage {
      * Verifies that the onboarding wizard is displayed.
      */
     async expectWizardVisible() {
-        await expect(this.page.locator('.onboarding-wizard')).toBeVisible();
+        await expect(this.page.getByTestId('onboarding-wizard')).toBeVisible();
     }
 
     /**
      * @returns A locator for the currently active step indicator element.
      */
     getActiveStepItem() {
-        return this.page.locator('.step-item.active');
+        return this.page.locator('[data-testid="onboarding-step"][data-step-state="active"]');
     }
 
     /**
      * @returns All completed step items.
      */
     getCompletedStepItems() {
-        return this.page.locator('.step-item.completed');
+        return this.page.locator('[data-testid="onboarding-step"][data-step-state="completed"]');
     }
 
     /**
      * @returns The step indicator container.
      */
     getStepIndicator() {
-        return this.page.locator('.step-indicator');
+        return this.page.getByTestId('onboarding-step-indicator');
     }
 
     /**
@@ -98,13 +98,13 @@ export class CourseOnboardingPage {
      * Verifies the explore cards are visible on the Explore step.
      */
     async expectExploreCardsVisible() {
-        await expect(this.page.locator('.explore-card').first()).toBeVisible();
+        await expect(this.page.getByTestId('onboarding-explore-card').first()).toBeVisible();
     }
 
     /**
      * Gets the content area of the wizard.
      */
     getContent() {
-        return this.page.locator('.onboarding-content');
+        return this.page.getByTestId('onboarding-content');
     }
 }

--- a/src/test/playwright/support/pageobjects/course/CourseOnboardingPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseOnboardingPage.ts
@@ -42,56 +42,56 @@ export class CourseOnboardingPage {
      * Clicks the "Next" button to advance to the next step (saves current step).
      */
     async clickNext() {
-        await this.page.locator('.footer-right .btn-primary').click();
+        await this.page.getByTestId('onboarding-next-button').click();
     }
 
     /**
      * Clicks the "Previous" button to go back to the previous step.
      */
     async clickPrevious() {
-        await this.page.locator('.footer-left .btn-secondary').click();
+        await this.page.getByTestId('onboarding-previous-button').click();
     }
 
     /**
      * Clicks the "Finish Setup" button (saves onboardingDone and advances to Explore step).
      */
     async clickFinishSetup() {
-        await this.page.locator('.footer-right .btn-success').click();
+        await this.page.getByTestId('onboarding-finish-button').click();
     }
 
     /**
      * Clicks the "Go to Course" button on the Explore step.
      */
     async clickGoToCourse() {
-        await this.page.locator('.footer-right .btn-primary').click();
+        await this.page.getByTestId('onboarding-go-to-course-button').click();
     }
 
     /**
      * Verifies the "Previous" button is not visible (first step).
      */
     async expectNoPreviousButton() {
-        await expect(this.page.locator('.footer-left .btn-secondary')).toBeHidden();
+        await expect(this.page.getByTestId('onboarding-previous-button')).toBeHidden();
     }
 
     /**
      * Verifies the "Previous" button is visible.
      */
     async expectPreviousButtonVisible() {
-        await expect(this.page.locator('.footer-left .btn-secondary')).toBeVisible();
+        await expect(this.page.getByTestId('onboarding-previous-button')).toBeVisible();
     }
 
     /**
      * Verifies the "Finish Setup" button is visible (Assessment step).
      */
     async expectFinishButtonVisible() {
-        await expect(this.page.locator('.footer-right .btn-success')).toBeVisible();
+        await expect(this.page.getByTestId('onboarding-finish-button')).toBeVisible();
     }
 
     /**
      * Verifies the "Next" button is visible.
      */
     async expectNextButtonVisible() {
-        await expect(this.page.locator('.footer-right .btn-primary')).toBeVisible();
+        await expect(this.page.getByTestId('onboarding-next-button')).toBeVisible();
     }
 
     /**

--- a/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseOverviewPage.ts
@@ -388,7 +388,7 @@ export class CourseOverviewPage {
      */
     async submitExercise(apiPattern: string) {
         const responsePromise = this.page.waitForResponse(apiPattern);
-        await this.page.locator('#submit-exercise, #submit-exercise-popover').first().click();
+        await this.page.locator('#submit-exercise, [data-testid="submit-exercise-popover"]').first().click();
         return await responsePromise;
     }
 }

--- a/src/test/playwright/support/pageobjects/exam/ExamCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamCreationPage.ts
@@ -32,7 +32,7 @@ export class ExamCreationPage {
      * Sets exam to test mode
      */
     async setTestMode() {
-        await this.page.locator('#exam-mode-picker #test-mode').click();
+        await this.page.locator('[data-testid="exam-mode-picker"] [data-testid="test-mode"]').click();
     }
 
     /**

--- a/src/test/playwright/support/pageobjects/exam/ExamDetailsPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamDetailsPage.ts
@@ -45,11 +45,11 @@ export class ExamDetailsPage {
     }
 
     async clickEditExamForPublishDate() {
-        await this.page.locator('#editButton_publish').click();
+        await this.page.locator('[data-testid="editButton_publish"]').click();
     }
 
     async clickEditExamForReviewDate() {
-        await this.page.locator('#editButton_review').click();
+        await this.page.locator('[data-testid="editButton_review"]').click();
     }
 
     async clickEvaluateQuizExercises() {
@@ -70,8 +70,8 @@ export class ExamDetailsPage {
         // Under multi-node load that round-trip can creep past Playwright's default
         // action timeout, eating into the 60s test budget. Wait for the title (same
         // @if block) explicitly with a generous timeout so the subsequent click is fast.
-        await this.page.locator('#exam-detail-title').waitFor({ state: 'visible', timeout: 30_000 });
-        await this.page.locator('#exam-delete').click();
+        await this.page.locator('[data-testid="exam-detail-title"]').waitFor({ state: 'visible', timeout: 30_000 });
+        await this.page.locator('[data-testid="exam-delete"]').click();
         const deleteButton = this.page.getByTestId('delete-dialog-confirm-button');
         await expect(deleteButton).toBeDisabled();
         await this.page.locator('#confirm-entity-name').fill(examTitle);

--- a/src/test/playwright/support/pageobjects/exam/ExamExerciseGroupCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamExerciseGroupCreationPage.ts
@@ -45,14 +45,14 @@ export class ExamExerciseGroupCreationPage {
 
     async clickSave(): Promise<ExerciseGroup> {
         const responsePromise = this.page.waitForResponse(`api/exam/courses/*/exams/*/exercise-groups`);
-        await this.page.locator('#save-group').click();
+        await this.page.locator('[data-testid="save-group"]').click();
         const response = await responsePromise;
         return readResponseJson(response);
     }
 
     async update() {
         const responsePromise = this.page.waitForResponse(`api/exam/courses/*/exams/*/exercise-groups`);
-        await this.page.locator('#save-group').click();
+        await this.page.locator('[data-testid="save-group"]').click();
         await responsePromise;
     }
 

--- a/src/test/playwright/support/pageobjects/exam/ExamExerciseGroupsPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamExerciseGroupsPage.ts
@@ -65,7 +65,7 @@ export class ExamExerciseGroupsPage {
 
     async shouldShowNumberOfExerciseGroups(numberOfGroups: number) {
         // The count is now part of the page's title-bar heading ("Exercise Groups (N)") rather than a separate line.
-        const titleLocator = this.page.locator('#exercise-groups-title');
+        const titleLocator = this.page.locator('[data-testid="exercise-groups-title"]');
         await titleLocator.waitFor({ state: 'visible', timeout: 30000 });
         await expect(titleLocator).toContainText(`(${numberOfGroups})`, { timeout: 30000 });
     }
@@ -97,11 +97,11 @@ export class ExamExerciseGroupsPage {
     }
 
     async visitPageViaUrl(courseId: number, examId: number) {
-        // Reload once if the exercise-groups lazy chunk fails to render `#exercise-groups-title`
+        // Reload once if the exercise-groups lazy chunk fails to render `[data-testid="exercise-groups-title"]`
         // within 30s under multi-node CI load (same pattern as other navigateToXxxPage
         // helpers in this codebase).
         const url = `/course-management/${courseId}/exams/${examId}/exercise-groups`;
-        const marker = this.page.locator('#exercise-groups-title');
+        const marker = this.page.locator('[data-testid="exercise-groups-title"]');
         await this.page.goto(url);
         const visible = await marker
             .waitFor({ state: 'visible', timeout: 30000 })

--- a/src/test/playwright/support/pageobjects/exam/ExamManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamManagementPage.ts
@@ -31,7 +31,7 @@ export class ExamManagementPage {
      * Clicks the create new exam button.
      */
     async createNewExam() {
-        await this.page.locator('#create-exam').click();
+        await this.page.locator('[data-testid="create-exam"]').click();
     }
 
     /**
@@ -140,11 +140,11 @@ export class ExamManagementPage {
         await row.waitFor({ state: 'visible' });
         await row.getByRole('link', { name: 'View exam' }).click();
         await this.page.locator('.summery').click();
-        await expect(this.page.locator('#exercise-result-score')).toHaveText(score, { useInnerText: true });
+        await expect(this.page.locator('[data-testid="exercise-result-score"]')).toHaveText(score, { useInnerText: true });
     }
 
     async openAnnouncementDialog() {
-        await this.page.locator('#announcement-create-button').click();
+        await this.page.locator('[data-testid="announcement-create-button"]').click();
     }
 
     async typeAnnouncementMessage(message: string) {
@@ -169,7 +169,7 @@ export class ExamManagementPage {
     }
 
     async openEditWorkingTimeDialog() {
-        await this.page.locator('#edit-working-time-button').click();
+        await this.page.locator('[data-testid="edit-working-time-button"]').click();
     }
 
     async changeExamWorkingTime(newWorkingTime: any) {

--- a/src/test/playwright/support/pageobjects/exam/ExamManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamManagementPage.ts
@@ -148,18 +148,17 @@ export class ExamManagementPage {
     }
 
     async typeAnnouncementMessage(message: string) {
-        // Match either the legacy NgbModal (.modal-content) or the migrated PrimeNG dialog (.p-dialog-content).
-        const modalContent = this.page.locator('.p-dialog-content, .modal-content').first();
+        const modalContent = this.page.getByRole('dialog').first();
         await setMonacoEditorContentByLocator(this.page, modalContent, message);
     }
 
     async verifyAnnouncementContent(announcementTime: Dayjs, message: string, authorUsername: string) {
-        const announcementDialog = this.page.locator('.p-dialog-content, .modal-content').first();
+        const announcementDialog = this.page.getByRole('dialog').first();
         const timeFormat = 'MMM D, YYYY HH:mm';
         const announcementTimeFormatted = announcementTime.format(timeFormat);
         const announcementTimeAfterMinute = announcementTime.add(1, 'minute').format(timeFormat);
-        await expect(announcementDialog.locator('.date').getByText(new RegExp(`(${announcementTimeFormatted}|${announcementTimeAfterMinute})`))).toBeVisible();
-        await expect(announcementDialog.locator('.content').getByText(message)).toBeVisible();
+        await expect(announcementDialog.getByTestId('live-event-date').getByText(new RegExp(`(${announcementTimeFormatted}|${announcementTimeAfterMinute})`))).toBeVisible();
+        await expect(announcementDialog.getByTestId('live-event-content').getByText(message)).toBeVisible();
     }
 
     async sendAnnouncement() {

--- a/src/test/playwright/support/pageobjects/exam/ExamNavigationBar.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamNavigationBar.ts
@@ -61,6 +61,6 @@ export class ExamNavigationBar {
      * Presses the hand in early button in the navigation bar.
      */
     async handInEarly() {
-        await this.page.locator('#hand-in-early').click({ timeout: 30000 });
+        await this.page.locator('[data-testid="hand-in-early"]').click({ timeout: 30000 });
     }
 }

--- a/src/test/playwright/support/pageobjects/exam/ExamParticipationActions.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamParticipationActions.ts
@@ -25,7 +25,7 @@ export class ExamParticipationActions {
     }
 
     async checkExerciseProblemStatementDifference(differenceSlices: TextDifferenceSlice[]) {
-        const problemStatementCard = this.page.locator('.card', { hasText: 'Problem Statement' });
+        const problemStatementCard = this.page.getByTestId('resizeable-container-right').filter({ hasText: 'Problem Statement' });
         const problemStatementText = problemStatementCard.locator('.markdown-preview').locator('p');
 
         if ((await problemStatementText.locator('.diffmod').count()) > 0) {
@@ -90,15 +90,14 @@ export class ExamParticipationActions {
     }
 
     async checkExamTimeChangeDialog(previousWorkingTime: string, newWorkingTime: string, announcementTime: Dayjs, authorUsername: string, message: string) {
-        // Match either the legacy NgbModal (.modal-content) or the migrated PrimeNG dialog (.p-dialog-content).
-        const timeChangeDialog = this.page.locator('.p-dialog-content, .modal-content').first();
+        const timeChangeDialog = this.page.getByRole('dialog').first();
         await expect(timeChangeDialog.getByTestId('old-time').getByText(previousWorkingTime)).toBeVisible();
         await expect(timeChangeDialog.getByTestId('new-time').getByText(newWorkingTime)).toBeVisible();
         const timeFormat = 'MMM D, YYYY HH:mm';
         const announcementTimeFormatted = announcementTime.format(timeFormat);
         const announcementTimeAfterMinute = announcementTime.add(1, 'minute').format(timeFormat);
-        await expect(timeChangeDialog.locator('.date').getByText(new RegExp(`(${announcementTimeFormatted}|${announcementTimeAfterMinute})`))).toBeVisible();
-        await expect(timeChangeDialog.locator('.content').getByText(message)).toBeVisible();
+        await expect(timeChangeDialog.getByTestId('live-event-date').getByText(new RegExp(`(${announcementTimeFormatted}|${announcementTimeAfterMinute})`))).toBeVisible();
+        await expect(timeChangeDialog.getByTestId('live-event-content').getByText(message)).toBeVisible();
     }
 
     async closeDialog() {

--- a/src/test/playwright/support/pageobjects/exam/ExamParticipationActions.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamParticipationActions.ts
@@ -50,7 +50,7 @@ export class ExamParticipationActions {
     }
 
     async checkExamTitle(title: string) {
-        await expect(this.page.locator('#exam-title')).toContainText(title);
+        await expect(this.page.locator('[data-testid="exam-title"]')).toContainText(title);
     }
 
     async getResultScore(exerciseID?: number) {
@@ -72,7 +72,7 @@ export class ExamParticipationActions {
     }
 
     async checkExamFinishedTitle(title: string) {
-        await expect(this.page.locator('#exam-finished-title')).toContainText(title, { timeout: 40000 });
+        await expect(this.page.locator('[data-testid="exam-finished-title"]')).toContainText(title, { timeout: 40000 });
     }
 
     async checkExamFullnameInputExists() {
@@ -86,7 +86,7 @@ export class ExamParticipationActions {
     }
 
     async checkExamTimeLeft(timeLeft: string) {
-        await expect(this.page.locator('#displayTime').getByText(timeLeft)).toBeVisible();
+        await expect(this.page.locator('[data-testid="displayTime"]').getByText(timeLeft)).toBeVisible();
     }
 
     async checkExamTimeChangeDialog(previousWorkingTime: string, newWorkingTime: string, announcementTime: Dayjs, authorUsername: string, message: string) {

--- a/src/test/playwright/support/pageobjects/exam/ExamResultsPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamResultsPage.ts
@@ -10,7 +10,7 @@ export class ExamResultsPage {
     }
 
     async checkGradeSummary(gradeSummary: any) {
-        const examSummary = this.page.locator('#exam-summary-result-overview .exam-points-summary-container');
+        const examSummary = this.page.locator('[data-testid="exam-summary-result-overview"] .exam-points-summary-container');
         // Wait for the summary container to be visible before checking rows
         await expect(examSummary).toBeVisible({ timeout: 30000 });
         for (const exercise of gradeSummary.studentExam.exercises) {
@@ -100,7 +100,7 @@ export class ExamResultsPage {
     /** Referenced modeling feedback: one row per assessed element, naming the element it belongs to. */
     async checkModellingExerciseAssessment(exerciseId: number, element: string, feedback: string, points: number) {
         const exercise = getExercise(this.page, exerciseId);
-        const componentFeedbacks = exercise.locator('#component-feedback-table');
+        const componentFeedbacks = exercise.locator('[data-testid="component-feedback-table"]');
         const feedbackElement = componentFeedbacks
             .locator('.unified-feedback, .feedback-row')
             .filter({ has: this.page.locator('.unified-feedback-reference-text, .feedback-row__name', { hasText: element }) })

--- a/src/test/playwright/support/pageobjects/exam/ExamStartEndPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamStartEndPage.ts
@@ -49,12 +49,12 @@ export class ExamStartEndPage {
 
     async pressStartWithWait() {
         const responsePromise = this.page.waitForResponse(`api/exam/courses/*/exams/*/student-exams/*/conduction`);
-        await this.page.locator('#start-exam').click();
+        await this.page.locator('[data-testid="start-exam"]').click();
         await responsePromise;
     }
 
     async pressStart() {
-        await this.page.locator('#start-exam').click();
+        await this.page.locator('[data-testid="start-exam"]').click();
     }
 
     async clickContinue() {
@@ -63,7 +63,7 @@ export class ExamStartEndPage {
 
     async pressFinish() {
         const responsePromise = this.page.waitForResponse(`api/exam/courses/*/exams/*/student-exams/submit`);
-        await this.page.locator('#end-exam').click();
+        await this.page.locator('[data-testid="end-exam"]').click();
         return await responsePromise;
     }
 

--- a/src/test/playwright/support/pageobjects/exam/ExamTestRunPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/ExamTestRunPage.ts
@@ -16,8 +16,7 @@ export class ExamTestRunPage {
 
     async confirmTestRun() {
         const responsePromise = this.page.waitForResponse(`api/exam/courses/*/exams/*/test-runs`);
-        // The create-test-run dialog was migrated from NgbModal (.modal-dialog) to PrimeNG (.p-dialog).
-        await this.page.locator('.p-dialog, .modal-dialog').first().locator('#createTestRunButton').click();
+        await this.page.getByRole('dialog').first().locator('#createTestRunButton').click();
         return await responsePromise;
     }
 

--- a/src/test/playwright/support/pageobjects/exam/ModalDialogBox.ts
+++ b/src/test/playwright/support/pageobjects/exam/ModalDialogBox.ts
@@ -41,11 +41,11 @@ export class ModalDialogBox {
     }
 
     async closeDialog() {
-        await this.getModalDialogContent().locator('button').click({ force: true });
+        await this.getModalDialogContent().getByTestId('live-event-action-button').click({ force: true });
     }
 
     async pressModalButton(buttonText: string) {
-        let buttonLocator = this.getModalDialogContent().locator('button');
+        let buttonLocator = this.getModalDialogContent().getByTestId('live-event-action-button');
         if (buttonText) {
             buttonLocator = buttonLocator.filter({ hasText: buttonText });
         }

--- a/src/test/playwright/support/pageobjects/exam/ModalDialogBox.ts
+++ b/src/test/playwright/support/pageobjects/exam/ModalDialogBox.ts
@@ -9,10 +9,7 @@ export class ModalDialogBox {
     }
 
     getModalDialogContent() {
-        // The exam live-events overlay was migrated from NgbModal (.modal-content) to
-        // PrimeNG DynamicDialog (.p-dialog-content). Match either so this page object
-        // works for any modal-style dialog used by the exam tests.
-        return this.page.locator('.p-dialog-content, .modal-content').first();
+        return this.page.getByRole('dialog').first();
     }
 
     async checkDialogTime(dialogTime: Dayjs) {
@@ -21,18 +18,20 @@ export class ModalDialogBox {
         const timeFormat = 'MMM D, YYYY HH:mm';
         const dialogTimeFormatted = dialogTime.format(timeFormat);
         const dialogTimeAfterMinuteFormatted = dialogTime.add(1, 'minute').format(timeFormat);
-        await expect(modalDialog.locator('.date').getByText(new RegExp(`(${dialogTimeFormatted}|${dialogTimeAfterMinuteFormatted})`))).toBeVisible({ timeout: 10000 });
+        await expect(modalDialog.getByTestId('live-event-date').getByText(new RegExp(`(${dialogTimeFormatted}|${dialogTimeAfterMinuteFormatted})`))).toBeVisible({
+            timeout: 10000,
+        });
     }
 
     async checkDialogMessage(message: string) {
-        await expect(this.getModalDialogContent().locator('.content').getByText(message)).toBeVisible({ timeout: 10000 });
+        await expect(this.getModalDialogContent().getByTestId('live-event-content').getByText(message)).toBeVisible({ timeout: 10000 });
     }
 
     async checkDialogType(type: string) {
         const modalContent = this.getModalDialogContent();
         // Wait for modal to be visible first
         await expect(modalContent).toBeVisible({ timeout: 30000 });
-        await expect(modalContent.locator('.type').getByText(type)).toBeVisible({ timeout: 10000 });
+        await expect(modalContent.getByTestId('live-event-type').getByText(type)).toBeVisible({ timeout: 10000 });
     }
 
     async checkExamTimeChangeDialog(previousWorkingTime: string, newWorkingTime: string) {

--- a/src/test/playwright/support/pageobjects/exam/StudentExamManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/StudentExamManagementPage.ts
@@ -35,7 +35,8 @@ export class StudentExamManagementPage {
     }
 
     getGenerateMissingStudentExamsButton() {
-        return this.page.getByTestId('exam-students-menu-item').filter({ hasText: 'Generate missing individual exams' }).last();
+        // The entry's disabled state sits on PrimeNG's list item, which wraps the label this menu projects.
+        return this.page.getByTestId('exam-students-menu-entry').filter({ hasText: 'Generate missing individual exams' }).last();
     }
 
     getStudentExamRows() {

--- a/src/test/playwright/support/pageobjects/exam/StudentExamManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/StudentExamManagementPage.ts
@@ -35,7 +35,7 @@ export class StudentExamManagementPage {
     }
 
     getGenerateMissingStudentExamsButton() {
-        return this.page.locator('.p-menu-item:has([data-testid="exam-students-menu-item"]:has-text("Generate missing individual exams"))').last();
+        return this.page.getByTestId('exam-students-menu-item').filter({ hasText: 'Generate missing individual exams' }).last();
     }
 
     getStudentExamRows() {

--- a/src/test/playwright/support/pageobjects/exam/StudentExamManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/exam/StudentExamManagementPage.ts
@@ -11,7 +11,7 @@ export class StudentExamManagementPage {
     async clickGenerateStudentExams() {
         const responsePromise = this.page.waitForResponse(`api/exam/courses/*/exams/*/generate-student-exams`);
         await this.openManageStudentExamsMenu();
-        await this.page.locator('.p-menu-item-link', { hasText: 'Generate individual exams' }).last().click();
+        await this.page.locator('[data-testid="exam-students-menu-item"]', { hasText: 'Generate individual exams' }).last().click();
         await responsePromise;
         await this.page.keyboard.press('Escape');
     }
@@ -19,13 +19,13 @@ export class StudentExamManagementPage {
     async clickRegisterCourseStudents() {
         const responsePromise = this.page.waitForResponse(`api/exam/courses/*/exams/*/register-course-students`);
         await this.page.getByRole('button', { name: 'Register students' }).click();
-        await this.page.locator('.p-menu-item-link', { hasText: 'Register course students' }).last().click();
+        await this.page.locator('[data-testid="exam-students-menu-item"]', { hasText: 'Register course students' }).last().click();
         return await responsePromise;
     }
 
     async clickPrepareExerciseStart() {
         await this.openManageStudentExamsMenu();
-        await this.page.locator('.p-menu-item-link', { hasText: 'Prepare exercise start' }).last().click();
+        await this.page.locator('[data-testid="exam-students-menu-item"]', { hasText: 'Prepare exercise start' }).last().click();
     }
 
     async openManageStudentExamsMenu() {
@@ -35,7 +35,7 @@ export class StudentExamManagementPage {
     }
 
     getGenerateMissingStudentExamsButton() {
-        return this.page.locator('.p-menu-item:has(.p-menu-item-link:has-text("Generate missing individual exams"))').last();
+        return this.page.locator('.p-menu-item:has([data-testid="exam-students-menu-item"]:has-text("Generate missing individual exams"))').last();
     }
 
     getStudentExamRows() {

--- a/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/ExerciseTeamsPage.ts
@@ -44,8 +44,8 @@ export class ExerciseTeamsPage {
                 }
             }
         }
-        await this.page.locator('#owner-search-input').waitFor({ state: 'visible', timeout: 30_000 });
-        await this.page.locator('#student-search-input').waitFor({ state: 'visible', timeout: 30_000 });
+        await this.page.locator('[data-testid="owner-search-input"]').waitFor({ state: 'visible', timeout: 30_000 });
+        await this.page.locator('[data-testid="student-search-input"]').waitFor({ state: 'visible', timeout: 30_000 });
     }
 
     /**
@@ -300,7 +300,7 @@ export class ExerciseTeamsPage {
      * @param username - the tutor username.
      */
     async setTeamTutor(username: string) {
-        await this.searchTutor(this.page.locator('#owner-search-input'), username);
+        await this.searchTutor(this.page.locator('[data-testid="owner-search-input"]'), username);
     }
 
     /**
@@ -308,7 +308,7 @@ export class ExerciseTeamsPage {
      * @param username - the student username.
      */
     async addStudentToTeam(username: string) {
-        await this.searchStudent(this.page.locator('#student-search-input'), username);
+        await this.searchStudent(this.page.locator('[data-testid="student-search-input"]'), username);
     }
 
     /**

--- a/src/test/playwright/support/pageobjects/exercises/file-upload/FileUploadEditorPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/file-upload/FileUploadEditorPage.ts
@@ -15,7 +15,7 @@ export class FileUploadEditorPage {
 
     async attachFileExam(filePath: string) {
         await this.page.locator('#fileUploadInput').setInputFiles(filePath);
-        await this.page.locator('#file-upload-submit').click();
+        await this.page.locator('[data-testid="file-upload-submit"]').click();
     }
 
     async saveAndContinue() {

--- a/src/test/playwright/support/pageobjects/exercises/modeling/ModelingEditor.ts
+++ b/src/test/playwright/support/pageobjects/exercises/modeling/ModelingEditor.ts
@@ -164,7 +164,7 @@ export class ModelingEditor {
     }
 
     async clickCreateNewExampleSubmission() {
-        await this.page.locator('#new-modeling-example-submission').click();
+        await this.page.locator('[data-testid="new-modeling-example-submission"]').click();
     }
 
     async clickCreateExampleSubmission() {
@@ -172,7 +172,7 @@ export class ModelingEditor {
     }
 
     async showExampleAssessment() {
-        await this.page.locator('#show-modeling-example-assessment').click();
+        await this.page.locator('[data-testid="show-modeling-example-assessment"]').click();
     }
 
     async saveExampleSubmission() {

--- a/src/test/playwright/support/pageobjects/exercises/modeling/ModelingExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/modeling/ModelingExerciseCreationPage.ts
@@ -33,7 +33,7 @@ export class ModelingExerciseCreationPage extends AbstractExerciseCreationPage {
     }
 
     async includeInOverallScore(selection: string = 'No') {
-        await this.page.locator('[data-testid="modeling-includeInScore-picker"]').getByTestId('mode-picker-option').filter({ hasText: selection }).click({ force: true });
+        await this.page.locator('[data-testid="modeling-includeInScore-picker"]').getByTestId('picker-option').filter({ hasText: selection }).click({ force: true });
     }
 
     override async setReleaseDate(date: Dayjs) {
@@ -62,13 +62,13 @@ export class ModelingExerciseCreationPage extends AbstractExerciseCreationPage {
     async pickDifficulty(options: { hard?: boolean; medium?: boolean; easy?: boolean }) {
         const difficultyBar = this.page.locator('[data-testid="modeling-difficulty-picker"]');
         if (options.hard) {
-            await difficultyBar.getByTestId('mode-picker-option').filter({ hasText: 'Hard' }).click();
+            await difficultyBar.getByTestId('picker-option').filter({ hasText: 'Hard' }).click();
         } else if (options.medium) {
-            await difficultyBar.getByTestId('mode-picker-option').filter({ hasText: 'Medium' }).click();
+            await difficultyBar.getByTestId('picker-option').filter({ hasText: 'Medium' }).click();
         } else if (options.easy) {
-            await difficultyBar.getByTestId('mode-picker-option').filter({ hasText: 'Easy' }).click();
+            await difficultyBar.getByTestId('picker-option').filter({ hasText: 'Easy' }).click();
         } else {
-            await difficultyBar.getByTestId('mode-picker-option').filter({ hasText: 'No Level' }).click();
+            await difficultyBar.getByTestId('picker-option').filter({ hasText: 'No Level' }).click();
         }
     }
 }

--- a/src/test/playwright/support/pageobjects/exercises/modeling/ModelingExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/modeling/ModelingExerciseCreationPage.ts
@@ -33,7 +33,7 @@ export class ModelingExerciseCreationPage extends AbstractExerciseCreationPage {
     }
 
     async includeInOverallScore(selection: string = 'No') {
-        await this.page.locator('#modeling-includeInScore-picker').locator('.btn', { hasText: selection }).click({ force: true });
+        await this.page.locator('[data-testid="modeling-includeInScore-picker"]').locator('.btn', { hasText: selection }).click({ force: true });
     }
 
     override async setReleaseDate(date: Dayjs) {
@@ -60,7 +60,7 @@ export class ModelingExerciseCreationPage extends AbstractExerciseCreationPage {
     }
 
     async pickDifficulty(options: { hard?: boolean; medium?: boolean; easy?: boolean }) {
-        const difficultyBar = this.page.locator('#modeling-difficulty-picker');
+        const difficultyBar = this.page.locator('[data-testid="modeling-difficulty-picker"]');
         if (options.hard) {
             await difficultyBar.locator('.btn', { hasText: 'Hard' }).click();
         } else if (options.medium) {

--- a/src/test/playwright/support/pageobjects/exercises/modeling/ModelingExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/modeling/ModelingExerciseCreationPage.ts
@@ -33,7 +33,7 @@ export class ModelingExerciseCreationPage extends AbstractExerciseCreationPage {
     }
 
     async includeInOverallScore(selection: string = 'No') {
-        await this.page.locator('[data-testid="modeling-includeInScore-picker"]').locator('.btn', { hasText: selection }).click({ force: true });
+        await this.page.locator('[data-testid="modeling-includeInScore-picker"]').getByTestId('mode-picker-option').filter({ hasText: selection }).click({ force: true });
     }
 
     override async setReleaseDate(date: Dayjs) {
@@ -62,13 +62,13 @@ export class ModelingExerciseCreationPage extends AbstractExerciseCreationPage {
     async pickDifficulty(options: { hard?: boolean; medium?: boolean; easy?: boolean }) {
         const difficultyBar = this.page.locator('[data-testid="modeling-difficulty-picker"]');
         if (options.hard) {
-            await difficultyBar.locator('.btn', { hasText: 'Hard' }).click();
+            await difficultyBar.getByTestId('mode-picker-option').filter({ hasText: 'Hard' }).click();
         } else if (options.medium) {
-            await difficultyBar.locator('.btn', { hasText: 'Medium' }).click();
+            await difficultyBar.getByTestId('mode-picker-option').filter({ hasText: 'Medium' }).click();
         } else if (options.easy) {
-            await difficultyBar.locator('.btn', { hasText: 'Easy' }).click();
+            await difficultyBar.getByTestId('mode-picker-option').filter({ hasText: 'Easy' }).click();
         } else {
-            await difficultyBar.locator('.btn', { hasText: 'No Level' }).click();
+            await difficultyBar.getByTestId('mode-picker-option').filter({ hasText: 'No Level' }).click();
         }
     }
 }

--- a/src/test/playwright/support/pageobjects/exercises/modeling/ModelingExerciseFeedbackPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/modeling/ModelingExerciseFeedbackPage.ts
@@ -9,7 +9,7 @@ import { expect } from '@playwright/test';
  */
 export class ModelingExerciseFeedbackPage extends AbstractExerciseFeedback {
     async shouldShowComponentFeedback(component: number, points: number, feedback: string) {
-        const row = this.page.locator('#component-feedback-table').locator('.feedback-row').nth(component);
+        const row = this.page.locator('[data-testid="component-feedback-table"]').locator('.feedback-row').nth(component);
         await expect(row.locator('.feedback-row__score', { hasText: points.toString() })).toBeVisible();
         await expect(row.locator('.feedback-row__text', { hasText: feedback })).toBeVisible();
     }

--- a/src/test/playwright/support/pageobjects/exercises/programming/CodeAnalysisGradingPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/CodeAnalysisGradingPage.ts
@@ -29,7 +29,7 @@ export class CodeAnalysisGradingPage {
 
     async saveChanges() {
         const responsePromise = this.page.waitForResponse(`${PROGRAMMING_EXERCISE_BASE}/*/static-code-analysis-categories`);
-        await this.page.locator('#save-table-button').click();
+        await this.page.locator('[data-testid="save-table-button"]').click();
         await responsePromise;
     }
 }

--- a/src/test/playwright/support/pageobjects/exercises/programming/OnlineEditorPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/OnlineEditorPage.ts
@@ -25,7 +25,7 @@ export class OnlineEditorPage {
     }
 
     findFileBrowser(exerciseID: number) {
-        return getExercise(this.page, exerciseID).locator('#cardFiles');
+        return getExercise(this.page, exerciseID).locator('[data-testid="cardFiles"]');
     }
 
     async typeSubmission(exerciseID: number, submission: ProgrammingExerciseSubmission): Promise<WrittenFile[]> {
@@ -55,15 +55,15 @@ export class OnlineEditorPage {
 
     async deleteFile(exerciseID: number, name: string) {
         const responsePromise = this.page.waitForResponse(`${BASE_API}/programming/participations/*/repository/**`);
-        await this.findFile(exerciseID, name).locator('#file-browser-file-delete').click();
-        await this.page.locator('#delete-file').click();
+        await this.findFile(exerciseID, name).locator('[data-testid="file-browser-file-delete"]').click();
+        await this.page.locator('[data-testid="delete-file"]').click();
         const response = await responsePromise;
         expect(response.status()).toBe(200);
         await expect(this.findFile(exerciseID, name)).not.toBeVisible();
     }
 
     private findFile(exerciseID: number, name: string) {
-        return this.findFileBrowser(exerciseID).locator('#file-browser-file', { hasText: name });
+        return this.findFileBrowser(exerciseID).locator('[data-testid="file-browser-file"]', { hasText: name });
     }
 
     async openFileWithName(exerciseID: number, name: string) {
@@ -80,7 +80,7 @@ export class OnlineEditorPage {
      * in the exam without risking that the commit lands too late and an empty repository gets built.
      */
     async submit(exerciseID: number, waitForResult = true) {
-        const submitButton = this.page.locator('#submit-exercise, #submit-exercise-popover, #submit_button').first();
+        const submitButton = this.page.locator('#submit-exercise, [data-testid="submit-exercise-popover"], #submit_button').first();
         if (waitForResult) {
             await submitButton.click();
             await expect(this.page.locator('#exercise-header #result-score, jhi-code-editor-container #result-score').first()).toBeVisible({ timeout: 200000 });
@@ -98,7 +98,7 @@ export class OnlineEditorPage {
     }
 
     async submitPractice(exerciseID: number) {
-        await this.page.locator('#submit-exercise, #submit-exercise-popover, #submit_button').first().click();
+        await this.page.locator('#submit-exercise, [data-testid="submit-exercise-popover"], #submit_button').first().click();
         await expect(this.page.locator('#exercise-header #result-score, jhi-code-editor-container #result-score').first()).toBeVisible({ timeout: 200000 });
     }
 
@@ -106,9 +106,9 @@ export class OnlineEditorPage {
         await getExercise(this.page, exerciseID).locator('[id="create_file_root"]').click();
         await this.page.waitForTimeout(500);
         const responsePromise = this.page.waitForResponse(`${BASE_API}/programming/participations/*/repository/file?file=${fileName}`);
-        await getExercise(this.page, exerciseID).locator('#file-browser-create-node').pressSequentially(fileName);
+        await getExercise(this.page, exerciseID).locator('[data-testid="file-browser-create-node"]').pressSequentially(fileName);
         await this.page.waitForTimeout(500);
-        await getExercise(this.page, exerciseID).locator('#file-browser-create-node').press('Enter');
+        await getExercise(this.page, exerciseID).locator('[data-testid="file-browser-create-node"]').press('Enter');
         const response = await responsePromise;
         expect(response.status()).toBe(200);
         this.rememberParticipationId(response.url());
@@ -120,12 +120,12 @@ export class OnlineEditorPage {
     async createFileInRootPackage(exerciseID: number, fileName: string, packageName: string): Promise<string> {
         const packagePath = packageName.replace(/\./g, '/');
         const filePath = `src/${packagePath}/${fileName}`;
-        await getExercise(this.page, exerciseID).locator('#file-browser-folder-create-file').nth(2).click();
+        await getExercise(this.page, exerciseID).locator('[data-testid="file-browser-folder-create-file"]').nth(2).click();
         await this.page.waitForTimeout(500);
         const responsePromise = this.page.waitForResponse(`${BASE_API}/programming/participations/*/repository/file?file=${filePath}`);
-        await getExercise(this.page, exerciseID).locator('#file-browser-create-node').pressSequentially(fileName);
+        await getExercise(this.page, exerciseID).locator('[data-testid="file-browser-create-node"]').pressSequentially(fileName);
         await this.page.waitForTimeout(500);
-        await getExercise(this.page, exerciseID).locator('#file-browser-create-node').press('Enter');
+        await getExercise(this.page, exerciseID).locator('[data-testid="file-browser-create-node"]').press('Enter');
         const response = await responsePromise;
         expect(response.status()).toBe(200);
         this.rememberParticipationId(response.url());
@@ -149,7 +149,7 @@ export class OnlineEditorPage {
     }
 
     async getBuildOutput() {
-        return this.page.locator('#cardBuildOutput');
+        return this.page.locator('[data-testid="cardBuildOutput"]');
     }
 
     async toggleCompressFileTree(exerciseID: number) {

--- a/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseCreationPage.ts
@@ -8,7 +8,7 @@ const TIMELINE_DATE_FORMAT = 'DD.MM.YYYY HH:mm';
 
 export class ProgrammingExerciseCreationPage extends AbstractExerciseCreationPage {
     async changeEditMode() {
-        await this.page.locator('#switch-edit-mode-button').click();
+        await this.page.locator('[data-testid="switch-edit-mode-button"]').click();
         // Switching from simple to detailed mode adds the difficulty/mode section, so the form status bar grows from
         // four to five section circles. Wait for the fifth circle before continuing: the status-bar section circles
         // bind their scroll target (and indexing) at render time, so acting before the detailed-mode bar has rendered

--- a/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseExportDialog.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseExportDialog.ts
@@ -26,7 +26,7 @@ export class ProgrammingExerciseExportDialog {
     }
 
     dialog() {
-        return this.page.locator('.p-dialog-content');
+        return this.page.getByRole('dialog');
     }
 
     /**

--- a/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseOverviewPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ProgrammingExerciseOverviewPage.ts
@@ -18,7 +18,7 @@ export class ProgrammingExerciseOverviewPage {
     }
 
     async checkResultScore(expectedResult: string) {
-        const resultScore = this.page.locator('#exercise-headers-information').locator('#result-score');
+        const resultScore = this.page.locator('[data-testid="exercise-headers-information"]').locator('#result-score');
         // Use > semantics: accept any non-zero score rather than an exact string match,
         // consistent with verifyResultScore. A '0%' expectation is matched literally.
         const textPattern = ProgrammingExerciseOverviewPage.buildResultScorePattern(expectedResult);
@@ -34,7 +34,7 @@ export class ProgrammingExerciseOverviewPage {
      */
     async checkResultScoreAfterBuild(courseId: number, exerciseId: number, expectedResult: string) {
         const url = `/courses/${courseId}/exercises/${exerciseId}`;
-        const resultScore = this.page.locator('#exercise-headers-information').locator('#result-score');
+        const resultScore = this.page.locator('[data-testid="exercise-headers-information"]').locator('#result-score');
         // Use > semantics: accept any non-zero score rather than an exact string match,
         // consistent with verifyResultScore. A '0%' expectation is matched literally.
         const textPattern = ProgrammingExerciseOverviewPage.buildResultScorePattern(expectedResult);

--- a/src/test/playwright/support/pageobjects/exercises/programming/ScaFeedbackModal.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ScaFeedbackModal.ts
@@ -53,7 +53,7 @@ export class ScaFeedbackModal {
     async closeModal() {
         // After the migration to PrimeNG DialogService, the inline modal header (with .feedback-header__close)
         // is suppressed in dialog mode in favour of PrimeNG's own header X.
-        await this.page.locator('[role="dialog"] [data-pc-section="pcclosebutton"]').first().click();
+        await this.page.locator('[role="dialog"] [data-pc-name="pcclosebutton"]').first().click();
         await expect(this.page.locator('.result-detail-container')).not.toBeAttached();
     }
 }

--- a/src/test/playwright/support/pageobjects/exercises/programming/ScaFeedbackModal.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ScaFeedbackModal.ts
@@ -16,7 +16,7 @@ export class ScaFeedbackModal {
      * and the feedback list rendered at least the expected number of feedback items.
      */
     async shouldRenderFeedbackDetails(minimumFeedbackItems = 1) {
-        await expect(this.page.locator('#result-detail-spinner')).toBeHidden();
+        await expect(this.page.locator('[data-testid="result-detail-spinner"]')).toBeHidden();
         await expect(this.page.locator('.result-detail-container')).toBeVisible();
         // The empty-state fallback ("No result details available.") must not be shown when feedback is present.
         await expect(this.page.getByText('No result details available.')).toBeHidden();
@@ -28,7 +28,7 @@ export class ScaFeedbackModal {
     }
 
     async shouldShowPointChart() {
-        await expect(this.page.locator('#feedback-chart')).toBeVisible();
+        await expect(this.page.locator('[data-testid="feedback-chart"]')).toBeVisible();
     }
 
     /**

--- a/src/test/playwright/support/pageobjects/exercises/programming/ScaFeedbackModal.ts
+++ b/src/test/playwright/support/pageobjects/exercises/programming/ScaFeedbackModal.ts
@@ -53,7 +53,7 @@ export class ScaFeedbackModal {
     async closeModal() {
         // After the migration to PrimeNG DialogService, the inline modal header (with .feedback-header__close)
         // is suppressed in dialog mode in favour of PrimeNG's own header X.
-        await this.page.locator('.p-dialog .p-dialog-close-button, .p-dialog [data-pc-section="closebutton"]').first().click();
+        await this.page.locator('[role="dialog"] [data-pc-section="pcclosebutton"]').first().click();
         await expect(this.page.locator('.result-detail-container')).not.toBeAttached();
     }
 }

--- a/src/test/playwright/support/pageobjects/exercises/quiz/DragAndDropQuiz.ts
+++ b/src/test/playwright/support/pageobjects/exercises/quiz/DragAndDropQuiz.ts
@@ -10,10 +10,10 @@ export class DragAndDropQuiz {
     }
 
     async createDnDQuiz(title: string) {
-        await this.page.locator('#quiz-import-apollon-dnd-question').click();
-        await this.page.locator('#create-apollon-diagram').click();
+        await this.page.locator('[data-testid="quiz-import-apollon-dnd-question"]').click();
+        await this.page.locator('[data-testid="create-apollon-diagram"]').click();
         await this.page.locator('#field_diagram_title').fill(title);
-        await this.page.locator('#save-dnd-quiz').click();
+        await this.page.locator('[data-testid="save-dnd-quiz"]').click();
     }
 
     async dragItemIntoDragArea(itemIndex: number) {
@@ -87,21 +87,21 @@ export class DragAndDropQuiz {
     }
 
     async generateQuizExercise(): Promise<number> {
-        await this.page.locator('#generate-quiz-exercise').click();
-        await this.page.locator('#quiz-save').waitFor({ state: 'visible' });
+        await this.page.locator('[data-testid="generate-quiz-exercise"]').click();
+        await this.page.locator('[data-testid="quiz-save"]').waitFor({ state: 'visible' });
         const responsePromise = this.page.waitForResponse(/api\/quiz\/(courses|exercise-groups)\/\d+\/quiz-exercises$/);
-        await this.page.locator('#quiz-save').click();
+        await this.page.locator('[data-testid="quiz-save"]').click();
         const response = await responsePromise;
         const exercise = await readResponseJson(response);
         return exercise.id;
     }
 
     async waitForQuizExerciseToBeGenerated() {
-        await this.page.locator('#jhi-text-exercise-heading-edit').waitFor({ state: 'visible' });
+        await this.page.locator('[data-testid="jhi-text-exercise-heading-edit"]').waitFor({ state: 'visible' });
     }
 
     async previewQuiz() {
-        await this.page.locator('#preview-quiz').first().click();
+        await this.page.locator('[data-testid="preview-quiz"]').first().click();
     }
 
     async waitForQuizPreviewToLoad() {
@@ -110,7 +110,7 @@ export class DragAndDropQuiz {
 
     async submit() {
         const responsePromise = this.page.waitForResponse(`api/quiz/exercises/*/submissions/live?submit=true`);
-        await this.page.locator('#submit-exercise, #submit-exercise-popover, #submit-quiz').first().click();
+        await this.page.locator('#submit-exercise, [data-testid="submit-exercise-popover"], [data-testid="submit-quiz"]').first().click();
         await responsePromise;
     }
 }

--- a/src/test/playwright/support/pageobjects/exercises/quiz/MultipleChoiceQuiz.ts
+++ b/src/test/playwright/support/pageobjects/exercises/quiz/MultipleChoiceQuiz.ts
@@ -34,7 +34,7 @@ export class MultipleChoiceQuiz {
      * auto-wait stuck against a disabled element until the test timeout fires.
      */
     async submit() {
-        const submitButton = this.page.locator('#submit-exercise, #submit-exercise-popover, #submit-quiz').first();
+        const submitButton = this.page.locator('#submit-exercise, [data-testid="submit-exercise-popover"], [data-testid="submit-quiz"]').first();
         await expect(submitButton).toBeEnabled({ timeout: 30_000 });
         const responsePromise = this.page.waitForResponse(`api/quiz/exercises/*/submissions/live?submit=true`);
         await submitButton.click();

--- a/src/test/playwright/support/pageobjects/exercises/quiz/QuizExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/quiz/QuizExerciseCreationPage.ts
@@ -64,7 +64,7 @@ export class QuizExerciseCreationPage extends AbstractExerciseCreationPage {
         await this.uploadDragAndDropBackground();
 
         // Wait for the click-layer to be enabled (background image loaded)
-        const clickLayer = this.page.locator('.click-layer:not(.disabled)');
+        const clickLayer = this.page.locator('[data-testid="drag-and-drop-click-layer"][data-ready="true"]');
         await clickLayer.waitFor({ state: 'visible', timeout: 20000 });
 
         const element = this.page.locator('.background-area');

--- a/src/test/playwright/support/pageobjects/exercises/quiz/QuizExerciseCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/quiz/QuizExerciseCreationPage.ts
@@ -8,8 +8,8 @@ export class QuizExerciseCreationPage extends AbstractExerciseCreationPage {
     private readonly DEFAULT_MULTIPLE_CHOICE_ANSWER_COUNT = 4;
 
     async addMultipleChoiceQuestion(title: string, points = 1) {
-        await this.page.locator('#quiz-add-mc-question').click();
-        await this.page.locator('#mc-question-title').fill(title);
+        await this.page.locator('[data-testid="quiz-add-mc-question"]').click();
+        await this.page.locator('[data-testid="mc-question-title"]').fill(title);
         await this.page.locator('#score').fill(points.toString());
 
         const fileContent = await Fixtures.get('exercise/quiz/multiple_choice/question.txt');
@@ -30,7 +30,7 @@ export class QuizExerciseCreationPage extends AbstractExerciseCreationPage {
         for (const [index, answerOption] of answerOptions.entries()) {
             let answerOptionLocator = this.page.locator(`#answer-option-${index}`);
             if ((await answerOptionLocator.count()) === 0) {
-                await this.page.locator('#add-mc-answer-option').click();
+                await this.page.locator('[data-testid="add-mc-answer-option"]').click();
                 answerOptionLocator = this.page.locator(`#answer-option-${index}`);
             }
             await answerOptionLocator.locator(`#answer-option-${index}-text`).fill(answerOption);
@@ -43,7 +43,7 @@ export class QuizExerciseCreationPage extends AbstractExerciseCreationPage {
     }
 
     async addShortAnswerQuestion(title: string) {
-        await this.page.locator('#quiz-add-short-answer-question').click();
+        await this.page.locator('[data-testid="quiz-add-short-answer-question"]').click();
         await this.page.locator('#short-answer-question-title').fill(title);
 
         const fileContent = await Fixtures.get('exercise/quiz/short_answer/question.txt');
@@ -51,15 +51,15 @@ export class QuizExerciseCreationPage extends AbstractExerciseCreationPage {
         const textInputField = this.page.locator('.edit-sa-question');
         await setMonacoEditorContentByLocator(this.page, textInputField, fileContent!);
         // Wait for the visual toggle to be ready before clicking
-        const visualToggle = this.page.locator('#short-answer-show-visual');
+        const visualToggle = this.page.locator('[data-testid="short-answer-show-visual"]');
         await visualToggle.waitFor({ state: 'visible' });
         await expect(visualToggle).toBeEnabled();
         await visualToggle.click();
     }
 
     async addDragAndDropQuestion(title: string) {
-        await this.page.locator('#quiz-add-dnd-question').click();
-        await this.page.locator('#drag-and-drop-question-title').fill(title);
+        await this.page.locator('[data-testid="quiz-add-dnd-question"]').click();
+        await this.page.locator('[data-testid="drag-and-drop-question-title"]').fill(title);
 
         await this.uploadDragAndDropBackground();
 
@@ -112,7 +112,7 @@ export class QuizExerciseCreationPage extends AbstractExerciseCreationPage {
     }
 
     async createDragAndDropItem(text: string) {
-        await this.page.locator('#add-text-drag-item').click();
+        await this.page.locator('[data-testid="add-text-drag-item"]').click();
         const dragItem = this.page.locator('#drag-item-0-text');
         await dragItem.clear();
         await dragItem.fill(text);
@@ -120,13 +120,13 @@ export class QuizExerciseCreationPage extends AbstractExerciseCreationPage {
 
     async uploadDragAndDropBackground() {
         const fileChooserPromise = this.page.waitForEvent('filechooser');
-        await this.page.locator('#background-file-input-button').click();
+        await this.page.locator('[data-testid="background-file-input-button"]').click();
         const fileChooser = await fileChooserPromise;
         await fileChooser.setFiles('./fixtures/exercise/quiz/drag_and_drop/background.jpg');
     }
 
     async saveQuiz() {
-        const saveButton = this.page.locator('#quiz-save');
+        const saveButton = this.page.locator('[data-testid="quiz-save"]');
         await saveButton.scrollIntoViewIfNeeded();
         // Wait for the save button to be visible AND enabled.
         // After complex question creation (DnD drag operations, image uploads, Monaco editor),
@@ -140,7 +140,7 @@ export class QuizExerciseCreationPage extends AbstractExerciseCreationPage {
 
     async import() {
         const responsePromise = this.page.waitForResponse(QUIZ_EXERCISE_BASE_CREATION);
-        await this.page.locator('#quiz-save').click();
+        await this.page.locator('[data-testid="quiz-save"]').click();
         return await responsePromise;
     }
 }

--- a/src/test/playwright/support/pageobjects/exercises/quiz/QuizExerciseParticipationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/quiz/QuizExerciseParticipationPage.ts
@@ -13,12 +13,12 @@ export class QuizExerciseParticipationPage {
      * @param batchPassword The password of the batch to join.
      */
     async joinQuizBatch(batchPassword: string) {
-        await this.page.locator('#join-patch-password').fill(batchPassword);
-        await this.page.locator('#join-batch').click();
+        await this.page.locator('[data-testid="join-patch-password"]').fill(batchPassword);
+        await this.page.locator('[data-testid="join-batch"]').click();
     }
 
     async startIndividualQuizBatch() {
-        await this.page.locator('#start-batch').click();
+        await this.page.locator('[data-testid="start-batch"]').click();
     }
 
     /**
@@ -26,7 +26,7 @@ export class QuizExerciseParticipationPage {
      */
     async startQuizBatch() {
         const responsePromise = this.page.waitForResponse(`${BASE_API}/quiz/quiz-exercises/*/join`);
-        await this.page.locator('#start-batch').click();
+        await this.page.locator('[data-testid="start-batch"]').click();
         await responsePromise;
     }
 
@@ -50,7 +50,7 @@ export class QuizExerciseParticipationPage {
      * practice submission endpoint (`/submissions/practice`, not the live one). Returns the practice submit response.
      */
     async submitPractice() {
-        const submitButton = this.page.locator('#submit-exercise, #submit-exercise-popover, #submit-quiz').first();
+        const submitButton = this.page.locator('#submit-exercise, [data-testid="submit-exercise-popover"], [data-testid="submit-quiz"]').first();
         await expect(submitButton).toBeEnabled({ timeout: 30_000 });
         const responsePromise = this.page.waitForResponse(`${BASE_API}/quiz/exercises/*/submissions/practice`);
         await submitButton.click();

--- a/src/test/playwright/support/pageobjects/exercises/quiz/ShortAnswerQuiz.ts
+++ b/src/test/playwright/support/pageobjects/exercises/quiz/ShortAnswerQuiz.ts
@@ -17,7 +17,7 @@ export class ShortAnswerQuiz {
 
     async submit() {
         const responsePromise = this.page.waitForResponse(`api/quiz/exercises/*/submissions/live?submit=true`);
-        await this.page.locator('#submit-exercise, #submit-exercise-popover, #submit-quiz').first().click();
+        await this.page.locator('#submit-exercise, [data-testid="submit-exercise-popover"], [data-testid="submit-quiz"]').first().click();
         return await responsePromise;
     }
 }

--- a/src/test/playwright/support/pageobjects/exercises/text/TextEditorPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/text/TextEditorPage.ts
@@ -32,13 +32,13 @@ export class TextEditorPage {
     }
 
     async shouldShowNumberOfWords(numberOfWords: number): Promise<void> {
-        const wordCountElement = this.page.locator('#word-count');
+        const wordCountElement = this.page.locator('[data-testid="word-count"]');
         await expect(wordCountElement).toContainText(numberOfWords.toString());
         await expect(wordCountElement).toBeVisible();
     }
 
     async shouldShowNumberOfCharacters(numberOfCharacters: number): Promise<void> {
-        const characterCountElement = this.page.locator('#character-count');
+        const characterCountElement = this.page.locator('[data-testid="character-count"]');
         await expect(characterCountElement).toContainText(numberOfCharacters.toString());
         await expect(characterCountElement).toBeVisible();
     }

--- a/src/test/playwright/support/pageobjects/exercises/text/TextExerciseExampleSubmissionCreationPage.ts
+++ b/src/test/playwright/support/pageobjects/exercises/text/TextExerciseExampleSubmissionCreationPage.ts
@@ -12,11 +12,11 @@ export class TextExerciseExampleSubmissionCreationPage {
     }
 
     getInstructionsRootElement() {
-        return this.page.locator('#instructions');
+        return this.page.locator('[data-testid="instructions"]');
     }
 
     async typeExampleSubmission(example: string) {
-        await this.page.locator('#example-text-submission-input').fill(example);
+        await this.page.locator('[data-testid="example-text-submission-input"]').fill(example);
     }
 
     async clickCreateNewExampleSubmission() {

--- a/src/test/playwright/support/pageobjects/iris/IrisChat.ts
+++ b/src/test/playwright/support/pageobjects/iris/IrisChat.ts
@@ -19,12 +19,12 @@ export class IrisChat {
 
     /** The Iris tab of the expanded panel (only present when Iris is enabled for the course). */
     getPanelTab(): Locator {
-        return this.page.locator('.p-tab:has(jhi-iris-logo)');
+        return this.page.getByTestId('resizable-panel-tab').filter({ has: this.page.locator('jhi-iris-logo') });
     }
 
     /** The Iris button of the collapsed icon rail. */
     getCollapsedPanelTab(): Locator {
-        return this.page.locator('.collapsed-right-panel-tab:has(jhi-iris-logo)');
+        return this.page.getByTestId('collapsed-panel-tab').filter({ has: this.page.locator('jhi-iris-logo') });
     }
 
     /** Collapses the panel back to the icon rail. */
@@ -55,11 +55,11 @@ export class IrisChat {
      * wired for, and closes the modal.
      */
     getLlmSelectionModal(): Locator {
-        return this.page.locator('jhi-llm-selection-modal .modal-backdrop');
+        return this.page.getByTestId('llm-selection-modal');
     }
 
     getCloudAiOption(): Locator {
-        return this.page.locator('jhi-llm-selection-modal .option-card.cloud-card');
+        return this.page.getByTestId('llm-selection-cloud-option');
     }
 
     /**

--- a/src/test/playwright/support/pageobjects/lecture/LectureManagementPage.ts
+++ b/src/test/playwright/support/pageobjects/lecture/LectureManagementPage.ts
@@ -31,7 +31,7 @@ export class LectureManagementPage {
     async deleteLecture(lecture: Lecture) {
         const lectureRow = this.getLecture(lecture.id!);
         await lectureRow.waitFor({ state: 'visible', timeout: 30_000 });
-        await lectureRow.locator('#delete-lecture').click();
+        await lectureRow.locator('[data-testid="delete-lecture"]').click();
         const deleteButton = this.page.getByTestId('delete-dialog-confirm-button');
         await expect(deleteButton).toBeDisabled();
         await this.page.fill('#confirm-entity-name', lecture.title!);
@@ -89,7 +89,7 @@ export class LectureManagementPage {
      */
     async openAttachmentsPage(lectureId: number) {
         await this.gotoLectureSubPage(lectureId, 'attachments');
-        await this.page.locator('#add-attachment').waitFor({ state: 'visible', timeout: 30_000 });
+        await this.page.locator('[data-testid="add-attachment"]').waitFor({ state: 'visible', timeout: 30_000 });
     }
 
     /**
@@ -111,7 +111,7 @@ export class LectureManagementPage {
 
     async openAttachmentUnitCreationPage(lectureId: number) {
         await this.openAttachmentsPage(lectureId);
-        await this.page.locator('#add-attachment').click();
+        await this.page.locator('[data-testid="add-attachment"]').click();
     }
 
     /**
@@ -127,7 +127,7 @@ export class LectureManagementPage {
      * @returns A Playwright locator for the unit creation card.
      */
     getUnitCreationCard() {
-        return this.page.locator('#unit-creation');
+        return this.page.locator('[data-testid="unit-creation"]');
     }
 
     /**

--- a/src/test/playwright/support/utils.ts
+++ b/src/test/playwright/support/utils.ts
@@ -567,6 +567,8 @@ export async function setMonacoEditorContent(page: Page, containerSelector: stri
  * @param containerLocator - Locator for the container element that contains the Monaco editor
  * @param text - The text to set in the editor
  */
+// `.monaco-editor` is Monaco's own root element. Monaco renders it itself, so there is no hook to add;
+// scope it through a test id on the surrounding component rather than through further Monaco classes.
 export async function setMonacoEditorContentByLocator(page: Page, containerLocator: Locator, text: string) {
     // Wait for the Monaco editor to be visible
     await containerLocator.waitFor({ state: 'visible' });


### PR DESCRIPTION
### Summary
An end-to-end test should find an element by a hook that exists for it, not by whatever the element happens to look like or by an id that production never asked for. This applies that to the existing suite: the locators bound to styling classes, and the ids that exist only so a test can find something.

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/client).
- [x] I strictly followed the [principle of separation of concerns](https://docs.artemis.tum.de/developer/guidelines/client-design).

### Motivation and Context
The rule itself is #13662, together with the one change that motivated it: both archive tests found the download button as `button.btn-primary`, and when that button became a TUM UI button they waited about eleven minutes each for an element that could no longer exist, with nothing in the diff pointing at the archive tests.

An audit of the 1,796 locators in the suite found that this was not an isolated case:

| Strategy | Count |
|---|---:|
| other CSS | 738 |
| `id` | 557 |
| `getByRole` / `getByText` / … | 349 |
| **styling class** | **118** |
| `data-testid` | 82 |

### Description

**Styling-class locators (118 → 12).** Bootstrap and PrimeNG class names describe how an element looks, so restyling one silently breaks the test. All of them are converted here except the twelve that name Monaco's own DOM.

Two of them were more than a rename:

- `.footer-right .btn-primary` matched **two different buttons**, the next button and the go-to-course button, in branches that happen never to be shown together. They are named separately now.
- The channel form select buttons were told apart by `first()`, `nth(1)` and `nth(2)`. They are `channel-visibility-select`, `channel-scope-select` and `channel-type-select` now, so the positional coupling is gone as well.

Where a test asked a class about *state*, the element now says so itself: `data-alert-type` on the alert overlay, `data-step-state` on an onboarding step, `data-selected` on the graded/practice toggle, `data-invalid` on the date picker, `data-completed` on a lecture unit's completion icon, `data-ready` on the drag-and-drop click layer, and `data-channel-id` on a channel row (which also replaces reading a channel id back out of an `id` attribute).

**Markup the project does not render.** Roughly half the styling-class locators reached into PrimeNG's DOM, which is why the first pass left them alone. PrimeNG answers this with its [pass-through API](https://primeng.org/passthrough): `[pt]` names each internal section, so the date picker, splitter, selects, multi-select, autocomplete, panel and dialogs now carry test ids where the class hunt used to be. Two details are worth knowing and are now written down: a `pc`-prefixed section forwards to a whole component, so the attribute belongs on its `root`, and where one section renders two elements PrimeNG's own `data-p-icon` separates them (the picker's calendar and clear affordances are both `inputIcon`).

The helpers that mean "whichever dialog is open" ask for the dialog role instead of matching both the PrimeNG and the ng-bootstrap class.

Monaco is the one exception left, and the locators now say why: it builds the editor, the code lines and the suggest widget itself, and its decoration API takes a class name and nothing else. Those are scoped through a test id on the hosting component rather than through further Monaco classes.

**Test-only ids.** 102 ids exist for no reason other than letting a test find the element: not a label target, an aria reference, an anchor, a selector in the stylesheets or in the client code, and not used by a client unit test either. Those become test ids. The attribute changes and the value does not, so the diff stays mechanical and each line reads on its own; the kebab-case naming rule applies to hooks added from now on rather than to this rename.

Deliberately **not** converted, out of the 291 ids the suite uses: 76 that production genuinely uses, 60 that a client unit test relies on, 41 built at runtime, and 12 that appear in more than one template.

**Documentation.** The rule from #13662 said what not to do with a styling class but left the case it comes up in most often unanswered. The last commit writes down the answer this conversion used, in the Playwright guide and in `CLAUDE.md`: the pass-through API and its two gotchas, the dialog role, Monaco as the documented exception, and the distinction between finding an element by a class (which the rule forbids) and asserting a rendered state class (which is fine when the library exposes it no other way, and which Artemis-owned markup should replace with an attribute).

### Steps for Testing
No product behaviour changes: every change is an attribute on an element that already existed, plus the locator that reads it.

1. `./run-e2e-tests-local-fast.sh`
2. The suite behaves as it does on `develop`.

### Verification
The whole suite was run locally against a client built from this branch, since a filtered run proves nothing for a change of this size: **396 passed, 10 failed, 6 flaky, 7 skipped**.

Six of those ten failures were mine, and the last commit fixes them. Every one had the same cause: the locator moved to a hook on the wrong node, because I did not check which component actually renders the element. Worth recording that the type checker, Prettier, ESLint and a script that resolves every `getByTestId` in the suite against the templates all passed on all six. Only the suite found them.

| Test | What was wrong |
|---|---|
| join / leave a public channel | the two helpers still scoped by the `id` the channel row had traded for `data-channel-id` |
| Generates student exams | the disabled state is on PrimeNG's list item, not on the label the menu projects into it, so the assertion inverted |
| Edit Existing Modeling Exercise | the form drives `jhi-difficulty-picker` and `jhi-included-in-overall-score-picker`; I had tagged `jhi-mode-picker`, which no test addresses |
| announcement + working time | the dialog role widened the scope from the content region to the whole dialog, so "the button in the dialog" also matched PrimeNG's close button |
| SCA feedback | PrimeNG reports a forwarded section in `data-pc-name`, not `data-pc-section`, so the close button was addressed by an attribute that never exists |

All six pass after the fix, and the ones that had been timing out are quick again (SCA went from a 5.0 minute timeout to 30.7s).

The other four are pre-existing, each checked rather than assumed:

- **`CompetencyImport`** (2 tests) pass on their own (26.1s). The import table lists competencies from every course, id-sorted and paged, so when sibling atlas specs create competencies in parallel their rows push the test's own row off the first page.
- **`QuizExerciseStatistics`** is flaky on `develop` in the same way. Three runs each against the same server and database, only the client differing: `develop` gave fail-then-pass, pass, pass; this branch gave pass, pass, fail-then-pass. Its failure is a submit request that never fires, in a path this branch does not touch.
- The remaining atlas timeouts and both programming-exercise creations passed on re-run; they had run while another build had the machine at load average 80.

Every test id the suite references resolves to an attribute in the application.

### Testserver States
Not needed, this is limited to test hooks.

### Screenshots
None: nothing here is visible to a user. Every application change adds an attribute to an element that already existed, and the one class removal (`editIcon`, `deleteIcon` and `forward` on the posting context menu) took away class names that no stylesheet defines.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Standardized automated UI checks across health, authentication, courses, assessments, exams, exercises, quizzes, communications, and editors.
  - Improved test reliability with stable test identifiers, semantic dialog locators, and clearer UI state assertions.
  - Expanded exam-import coverage for inline validation, live conflict detection, and successful imports.
  - Improved alert verification by distinguishing alert presence and severity.

- **Documentation**
  - Added guidance for reliable locators when testing third-party components and UI state.

- **Reliability**
  - Preserved existing user-facing behavior while improving consistency across automated validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->