### PR TITLE
`Development`: Let a refused git credential stay refused in tests

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalVCLocalCITestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalVCLocalCITestService.java
@@ -22,7 +22,10 @@ import org.eclipse.jgit.api.PushCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.transport.CredentialItem;
+import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.URIish;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -371,11 +374,40 @@ public class LocalVCLocalCITestService {
                 .withMessageContaining(expectedMessage);
     }
 
+    /**
+     * Answers no credential request, so that the credentials in the repository URI are the only ones a git command
+     * here can authenticate with.
+     * <p>
+     * {@code BuildJobGitService.configureSsh} installs a JVM-wide default provider that accepts every request, and the
+     * server shares this JVM with the tests. Without pinning a provider, a command that is correctly refused with 401
+     * answers the challenge from that default and retries instead of failing, so a test asserting that a credential is
+     * rejected watched the fetch succeed. Which class ran first decided whether the default was installed yet, which
+     * is what made those failures come and go.
+     */
+    public static final CredentialsProvider ONLY_THE_CREDENTIALS_IN_THE_URI = new CredentialsProvider() {
+
+        @Override
+        public boolean isInteractive() {
+            return false;
+        }
+
+        @Override
+        public boolean supports(CredentialItem... items) {
+            return false;
+        }
+
+        @Override
+        public boolean get(URIish uri, CredentialItem... items) {
+            return false;
+        }
+    };
+
     private void performFetch(Git repositoryHandle, String username, String password, String projectKey, String repositorySlug) throws GitAPIException, URISyntaxException {
         String repositoryUri = buildLocalVCUri(username, password, projectKey, repositorySlug);
         FetchCommand fetchCommand = repositoryHandle.fetch();
         // Set the remote URL.
         fetchCommand.setRemote(repositoryUri);
+        fetchCommand.setCredentialsProvider(ONLY_THE_CREDENTIALS_IN_THE_URI);
         // Set the refspec to fetch all branches.
         fetchCommand.setRefSpecs(new RefSpec("+refs/heads/*:refs/remotes/origin/*"));
         // Execute the fetch.
@@ -504,6 +536,7 @@ public class LocalVCLocalCITestService {
         PushCommand pushCommand = repositoryHandle.push();
         // Set the remote URL.
         pushCommand.setRemote(repositoryUri);
+        pushCommand.setCredentialsProvider(ONLY_THE_CREDENTIALS_IN_THE_URI);
         // Execute the push.
         pushCommand.call();
     }

--- a/src/test/java/de/tum/cit/aet/artemis/localvc/service/LocalVCFetchAndPushIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localvc/service/LocalVCFetchAndPushIntegrationTest.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.localvc.service;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.LOCAL_CI_DOCKER_CONTAINER_WORKING_DIRECTORY;
 import static de.tum.cit.aet.artemis.core.config.Constants.LOCAL_CI_RESULTS_DIRECTORY;
+import static de.tum.cit.aet.artemis.localci.service.LocalVCLocalCITestService.ONLY_THE_CREDENTIALS_IN_THE_URI;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -209,7 +210,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
         Path clonePath = tempFileUtilService.createTempDirectory(tempPath, "localvc-test-clone-");
         clonedRepoPaths.add(clonePath);
 
-        return Git.cloneRepository().setURI(repoUri).setDirectory(clonePath.toFile()).call();
+        return Git.cloneRepository().setCredentialsProvider(ONLY_THE_CREDENTIALS_IN_THE_URI).setURI(repoUri).setDirectory(clonePath.toFile()).call();
     }
 
     /**
@@ -1475,7 +1476,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             String tokenRepoUri = buildRepositoryUriWithToken(student1.getLogin(), token, projectKey, teamRepoSlug);
             Path clonePath = tempFileUtilService.createTempDirectory(tempPath, "localvc-team-token-clone-");
             clonedRepoPaths.add(clonePath);
-            try (Git git = Git.cloneRepository().setURI(tokenRepoUri).setDirectory(clonePath.toFile()).call()) {
+            try (Git git = Git.cloneRepository().setCredentialsProvider(ONLY_THE_CREDENTIALS_IN_THE_URI).setURI(tokenRepoUri).setDirectory(clonePath.toFile()).call()) {
                 assertThat(git).isNotNull();
 
                 // Verify fetch with the same token also works
@@ -1516,7 +1517,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             String tokenRepoUri = buildRepositoryUriWithToken(student1.getLogin(), token, projectKey, studentRepoSlug);
             Path clonePath = tempFileUtilService.createTempDirectory(tempPath, "localvc-individual-token-clone-");
             clonedRepoPaths.add(clonePath);
-            try (Git git = Git.cloneRepository().setURI(tokenRepoUri).setDirectory(clonePath.toFile()).call()) {
+            try (Git git = Git.cloneRepository().setCredentialsProvider(ONLY_THE_CREDENTIALS_IN_THE_URI).setURI(tokenRepoUri).setDirectory(clonePath.toFile()).call()) {
                 assertThat(git).isNotNull();
                 assertThat(git.getRepository().getBranch()).isNotNull();
 
@@ -1558,7 +1559,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             String templateTokenUri = buildRepositoryUriWithToken(instructor1.getLogin(), token, projectKey, templateRepoSlug);
             Path clonePath = tempFileUtilService.createTempDirectory(tempPath, "localvc-template-token-clone-");
             clonedRepoPaths.add(clonePath);
-            try (Git git = Git.cloneRepository().setURI(templateTokenUri).setDirectory(clonePath.toFile()).call()) {
+            try (Git git = Git.cloneRepository().setCredentialsProvider(ONLY_THE_CREDENTIALS_IN_THE_URI).setURI(templateTokenUri).setDirectory(clonePath.toFile()).call()) {
                 assertThat(git).isNotNull();
                 assertThat(git.getRepository().getBranch()).isNotNull();
 
@@ -1574,8 +1575,8 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             String solutionWithTemplateTokenUri = buildRepositoryUriWithToken(instructor1.getLogin(), token, projectKey, solutionRepoSlug);
             Path solutionClonePath = tempFileUtilService.createTempDirectory(tempPath, "localvc-solution-wrong-token-clone-");
             clonedRepoPaths.add(solutionClonePath);
-            assertThatThrownBy(() -> Git.cloneRepository().setURI(solutionWithTemplateTokenUri).setDirectory(solutionClonePath.toFile()).call())
-                    .isInstanceOf(TransportException.class).hasMessageContaining(NOT_AUTHORIZED);
+            assertThatThrownBy(() -> Git.cloneRepository().setCredentialsProvider(ONLY_THE_CREDENTIALS_IN_THE_URI).setURI(solutionWithTemplateTokenUri)
+                    .setDirectory(solutionClonePath.toFile()).call()).isInstanceOf(TransportException.class).hasMessageContaining(NOT_AUTHORIZED);
         }
 
         @Test
@@ -1597,7 +1598,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             String tutorTokenUri = buildRepositoryUriWithToken(tutor1.getLogin(), tutorToken, projectKey, testsRepoSlug);
             Path clonePath = tempFileUtilService.createTempDirectory(tempPath, "localvc-tests-tutor-token-clone-");
             clonedRepoPaths.add(clonePath);
-            try (Git git = Git.cloneRepository().setURI(tutorTokenUri).setDirectory(clonePath.toFile()).call()) {
+            try (Git git = Git.cloneRepository().setCredentialsProvider(ONLY_THE_CREDENTIALS_IN_THE_URI).setURI(tutorTokenUri).setDirectory(clonePath.toFile()).call()) {
                 // The token authenticates the tutor, and a tutor is allowed to READ the tests repository.
                 assertThat(git).isNotNull();
                 git.fetch().setRemote(tutorTokenUri).setRefSpecs(new RefSpec("+refs/heads/*:refs/remotes/origin/*")).call();
@@ -1626,8 +1627,8 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             String forgedTokenUri = buildRepositoryUriWithToken(instructor1.getLogin(), forgedToken, projectKey, templateRepoSlug);
             Path clonePath = tempFileUtilService.createTempDirectory(tempPath, "localvc-forged-token-clone-");
             clonedRepoPaths.add(clonePath);
-            assertThatThrownBy(() -> Git.cloneRepository().setURI(forgedTokenUri).setDirectory(clonePath.toFile()).call()).isInstanceOf(TransportException.class)
-                    .hasMessageContaining(NOT_AUTHORIZED);
+            assertThatThrownBy(() -> Git.cloneRepository().setCredentialsProvider(ONLY_THE_CREDENTIALS_IN_THE_URI).setURI(forgedTokenUri).setDirectory(clonePath.toFile()).call())
+                    .isInstanceOf(TransportException.class).hasMessageContaining(NOT_AUTHORIZED);
         }
 
         @Test
@@ -1650,8 +1651,8 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             String stolenTokenUri = buildRepositoryUriWithToken(editor1.getLogin(), instructorToken, projectKey, templateRepoSlug);
             Path clonePath = tempFileUtilService.createTempDirectory(tempPath, "localvc-stolen-token-clone-");
             clonedRepoPaths.add(clonePath);
-            assertThatThrownBy(() -> Git.cloneRepository().setURI(stolenTokenUri).setDirectory(clonePath.toFile()).call()).isInstanceOf(TransportException.class)
-                    .hasMessageContaining(NOT_AUTHORIZED);
+            assertThatThrownBy(() -> Git.cloneRepository().setCredentialsProvider(ONLY_THE_CREDENTIALS_IN_THE_URI).setURI(stolenTokenUri).setDirectory(clonePath.toFile()).call())
+                    .isInstanceOf(TransportException.class).hasMessageContaining(NOT_AUTHORIZED);
         }
     }
 }


### PR DESCRIPTION
### Summary

Fifteen local VC tests failed in some CI runs and passed in others, always the same fifteen. They assert that a credential is refused — a deactivated account, a soft-deleted account, an expired token, a token with no expiry, a forged token, a token belonging to someone else — and they failed with `Expecting code to raise a throwable`: the fetch the server had just refused went through.

### Motivation and Context

The server was never wrong. It logged the refusal every time:

```
WARN  LocalVCServletService : Git authentication attempt for user localvcaccountstatestudent1 whose account is deactivated or deleted
WARN  LocalVCFetchFilter    : LocalVC fetch rejected for /git/SHORTAHRTFRMUTSTEXC/... -> HTTP 401
DEBUG LocalVCServletService : Authorizing user artemis_admin for repository .../SHORTAHRTFRMUTSTEXC/...
```

Refused as the student, then authorized as `artemis_admin` on the same repository 55 ms later. The client had answered the 401 challenge and retried.

`BuildJobGitService.configureSsh` installs a JVM-wide JGit credentials provider, so that the build agent can accept SSH host key prompts with nobody there to answer them. It reports success for every credential request, including the username and password it never fills in. The server shares its JVM with the tests, so a git command a test builds inherits it: a refusal becomes a challenge, the challenge is answered, and the retry succeeds.

Whether the provider had been installed yet depended on which class ran first. `localci` sorts before `localvc`, so a full bucket run installed it before these classes; running them alone never did. That is why they failed on CI and passed locally every time anyone looked.

### Description

The git commands the tests build now pin a credentials provider that answers nothing, so the credentials in the repository URI are the only ones they can authenticate with. A credential the server refuses stays refused.

- `LocalVCLocalCITestService` — pinned on the shared `performFetch` and `performPush` helpers, which covers twelve of the fifteen.
- `LocalVCFetchAndPushIntegrationTest` — pinned on the eight `Git.cloneRepository()` calls this class drives itself, which covers the other three.

**No production code changes.** `BuildJobGitService` is untouched and the build agent authenticates exactly as before; the provider it installs is still there and still accepts host key prompts. Only the tests stop leaning on it.

### Steps for Testing

The five classes involved, in the order the bucket runs them so that the provider is installed before the assertions that depend on it:

```bash
./gradlew test -x webapp --tests "LocalVCLocalCIIntegrationTest" --tests "LocalVCAccountStateIntegrationTest" \
  --tests "LocalVCIntegrationTest" --tests "LocalVCSshIntegrationTest" --tests "LocalVCFetchAndPushIntegrationTest"
```

| | failures |
|---|---|
| before | 15 |
| helper pinned | 3 — exactly the class driving JGit itself |
| both pinned | **0** (177 tests, 173 passed, 4 skipped) |

The middle row is the part worth reading: the fix worked precisely where it reached and nowhere else, which is what distinguishes this from the flake passing by luck.

### Review

Left deliberately: this works around the provider rather than correcting it. `CustomCredentialsProvider.supports` answers `true` for every item and `get` returns `true` while leaving the username and password unset, so it tells JGit a credential was supplied when none was. Its purpose is host key prompts, and restricting it to `CredentialItem.YesNoType` would remove the trap for good — but that is production code and this change is deliberately confined to the tests. Worth its own pull request.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development).

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-05 15:09:48 UTC_

