### PR TITLE
`Development`: Read the user deletion end-to-end responses through the body-loss-proof helper

### DIFF
--- a/src/test/playwright/e2e/admin/UserDeletion.spec.ts
+++ b/src/test/playwright/e2e/admin/UserDeletion.spec.ts
@@ -3,7 +3,7 @@ import { Locator, Page, expect } from '@playwright/test';
 import { test } from '../../support/fixtures';
 import { UserManagementAPIRequests } from '../../support/requests/UserManagementAPIRequests';
 import { admin, UserRole } from '../../support/users';
-import { generateUUID } from '../../support/utils';
+import { generateUUID, readResponseJson } from '../../support/utils';
 import { Course } from 'app/course/shared/entities/course.model';
 import { Channel } from 'app/communication/shared/entities/conversation/channel.model';
 import dayjs from 'dayjs';
@@ -16,6 +16,13 @@ interface DeletionImpactUser {
 
 interface DeletionImpact {
     users: DeletionImpactUser[];
+}
+
+interface DeletionResult {
+    userId: number;
+    login: string;
+    status: string;
+    reason: string | null;
 }
 
 test.describe('Retention-aware user deletion', { tag: '@fast' }, () => {
@@ -166,24 +173,23 @@ test.describe('Retention-aware user deletion', { tag: '@fast' }, () => {
         const userLogin = await createUser(userManagementAPIRequests, 'not_enrolled');
         await page.goto('/admin/user-management');
 
-        // Only wait for the two calls the button fires; what they returned is checked separately below.
-        //
-        // Reading each body as its own response arrives (a .then on the waitForResponse) is not enough, though it
-        // looks like it should be: Playwright still fetches the body over CDP afterwards, and the dialog these two
-        // responses open re-renders the page before that lands. That variant failed in CI on this very line with
-        // "No data found for resource with given identifier". Asking the API directly is what makes it reliable,
-        // because an APIRequestContext buffers its body independently of what the page does next.
+        // Both bodies go through readResponseJson rather than response.json(). A plain read asks Chromium for a
+        // buffer it is free to have dropped by then, which is what failed here in CI with "No data found for resource
+        // with given identifier" once the opening dialog put the page to work right behind these two responses.
+        // readResponseJson reads the impact POST from the copy installApiResponseCapture already holds in Node, and
+        // replays the not-enrolled GET if its buffer is gone, so neither read depends on that buffer surviving.
         const notEnrolledResponse = page.waitForResponse(
             (response) => response.url().endsWith('/api/account/admin/users/not-enrolled') && response.request().method() === 'GET' && response.status() === 200,
         );
         const impactResponse = page.waitForResponse((response) => response.url().endsWith('/api/account/admin/users/deletion-impact') && response.status() === 200);
         await page.getByRole('button', { name: 'Delete not enrolled users' }).click();
-        await Promise.all([notEnrolledResponse, impactResponse]);
+        const [notEnrolledLogins, impact] = await Promise.all([
+            notEnrolledResponse.then((response) => readResponseJson<string[]>(response)),
+            impactResponse.then((response) => readResponseJson<DeletionImpact>(response)),
+        ]);
 
-        const notEnrolledLogins = (await request(page, 'get', 'api/account/admin/users/not-enrolled')) as string[];
         expect(notEnrolledLogins).toContain(userLogin);
         expect(notEnrolledLogins).not.toContain('iris_bot');
-        const impact = (await request(page, 'post', 'api/account/admin/users/deletion-impact', { data: { logins: notEnrolledLogins } })) as DeletionImpact;
         expect(impact.users.map((user) => user.login)).toContain(userLogin);
         const dialog = page.getByRole('dialog', { name: 'Permanently delete user data' });
         await expect(dialog).toBeVisible();
@@ -404,11 +410,12 @@ test.describe('Retention-aware user deletion', { tag: '@fast' }, () => {
 
         const dialog = page.getByRole('dialog', { name: 'Permanently delete user data' });
         await dialog.getByRole('textbox').fill('2');
-        // As above: the deletion result is read as its response arrives. The refreshed impact request that this
-        // deletion triggers is enough for Chromium to drop the deletion body before both responses are in hand.
+        // As above, and this one has no read-side fallback at all: a DELETE must not be replayed to fetch its body
+        // again, so the copy installApiResponseCapture holds in Node is the only source once Chromium has dropped the
+        // buffer, and the refreshed impact request this deletion triggers is enough to provoke exactly that.
         const deletionResultsPromise = page
             .waitForResponse((response) => response.url().endsWith('/api/account/admin/users') && response.request().method() === 'DELETE' && response.status() === 200)
-            .then((response) => response.json());
+            .then((response) => readResponseJson<DeletionResult[]>(response));
         const refreshedImpactResponse = page.waitForResponse(
             (response) => response.url().endsWith('/api/account/admin/users/deletion-impact') && response.request().method() === 'POST' && response.status() === 200,
         );


### PR DESCRIPTION
### Summary

Two tests in `UserDeletion.spec.ts` read a response body straight off the page with `response.json()`, which asks Chromium for a network buffer it is free to have dropped by then. Both have failed in CI with `No data found for resource with given identifier`. They now read through `readResponseJson`, the helper this suite already has for exactly this, so neither read depends on that buffer surviving.

### Checklist

- [x] Verified the fix by forcing the buffer loss, not only by a passing run.
- [x] Ran the affected suite repeatedly and under parallel contention.
- [x] Followed the end-to-end testing conventions.

### Motivation and Context

`Retention-aware user deletion › previews not-enrolled users without deleting before confirmation` and `Retention-aware user deletion › re-previews only the surviving user after a partial deletion changes the plan` are the two tests that have been reddening the E2E gate on unrelated pull requests. Both failures have the same cause.

`installApiResponseCapture` fulfils every non-GET `/api` response from a body it already holds in Node, and `baseFixtures` eagerly memoises GET bodies, precisely because Chromium's per-renderer network buffer is bounded and drops small JSON bodies under parallel load. `readResponseJson` is the read side of that arrangement: it prefers the Node-held copy, and replays a GET whose buffer is gone. A plain `response.json()` opts out of all of it and goes straight to the evictable CDP path.

After this change there is no page-`Response` body read left anywhere in the suite outside `readResponseJson`, so the pattern is closed rather than patched twice.

### Description

- `previews not-enrolled users...`: read the not-enrolled GET and the bulk impact POST through `readResponseJson`.
- The same test no longer re-fetches the list and the impact over a second pair of calls. That asked the server again instead of reading what the page received, and posting the whole global not-enrolled list a second time fails outright once another worker deletes any account in it, because `loadDeletionTargets` answers 404 for a login that has gone.
- `re-previews only the surviving user...`: read the bulk DELETE result through `readResponseJson`. This one is the more exposed of the two, because a DELETE must not be replayed to fetch its body again, so the Node-held copy is its only source.
- Gave the deletion result a named type instead of `any`.

No production code is touched.

### Steps for Testing

1. Run `pnpm exec playwright test e2e/admin/UserDeletion.spec.ts --project=fast-tests` against a local stack.
2. To see that the recovery is real rather than merely unexercised, make both CDP reads in `readResponseJson` throw a `getResponseBody` error for `/api/account/admin/users` and run the suite again. It has to stay green.

### Validation

All against a local single-node stack.

- The suite passes: 6 of 6.
- Repeated 5 times over: 30 of 30.
- Under 8 parallel workers alongside `e2e/course/`, so the tests compete for CPU and create accounts concurrently: 12 of 12 UserDeletion runs, 188 passed overall.
- **The recovery was verified by forcing the failure**, since the race does not reproduce locally on its own. With both `response.json()` and `response.body()` made to throw `Network.getResponseBody: No data found for resource` for every `/api/account/admin/users` URL, all 6 tests still passed. Instrumenting which branch served each body showed exactly the intended routing:
    - `POST .../deletion-impact` served from the Node-held copy, never touching CDP.
    - `DELETE .../users` served from the Node-held copy.
    - `GET .../not-enrolled` hit the forced failure on both read paths and recovered by replaying the request.
- An isolated harness confirmed the mechanism independently: with the same loss forced, `readResponseJson` recovered a captured POST and a replayable GET, while a plain deferred `response.json()` could not.
- `pnpm run lint`, `pnpm run typecheck` and Prettier pass for the Playwright project.

The verification shim was removed afterwards and `support/utils.ts` is byte-identical to `develop`.

### Not addressed

The product itself fetches the not-enrolled list and then posts it back for the impact preview. If a concurrent worker deletes one of those accounts between the two calls, the preview request answers 404 and the test would time out waiting for a 200. That window belongs to the feature rather than to the test, it is a few milliseconds wide, and it is not what has been failing. Removing the test's own duplicate pair of calls halves the exposure; the remaining half is left alone deliberately.

### Review Progress

- [x] Code review
- [x] Verified locally, including the forced-loss path

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-05 16:06:56 UTC_

