### PR TITLE
`Tutorial groups`: Display the tutor's full name in the tutorial groups table

### DIFF
--- a/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-table/tutorial-group-row/tutorial-group-row.component.html
+++ b/src/main/webapp/app/tutorialgroup/manage/tutorial-groups-table/tutorial-group-row/tutorial-group-row.component.html
@@ -13,7 +13,7 @@
         <jhi-tutorial-group-utilization-indicator [tutorialGroup]="tutorialGroup()" />
     </td>
     <td>{{ (tutorialGroup().numberOfRegisteredUsers ?? '') + ' / ' + (tutorialGroup().capacity ?? '') }}</td>
-    <td>{{ tutorialGroup().isUserTutor ? ('global.generic.you' | artemisTranslate) : tutorialGroup().teachingAssistantName }}</td>
+    <td>{{ tutorialGroup().teachingAssistantName }}</td>
     <td>
         @let schedule = tutorialGroup().tutorialGroupSchedule;
         @if (schedule) {


### PR DESCRIPTION
### Summary 
<!-- Add a short, but convincing summary (abstract) of the PR changes here. --> 
Fix writing the tutors name instead of You, https://github.com/ls1intum/Artemis/issues/7518

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes an open issue: https://github.com/ls1intum/Artemis/issues/7518

### Description

The tutor column of the tutorial groups table showed `You` instead of the tutor's name whenever the current user was the tutor of that group (`isUserTutor`), while all other rows showed the actual name. This made the column inconsistent and harder to scan.

The row now always renders `teachingAssistantName`, so every row displays the tutor's full name. The `isUserTutor` conditional and the `global.generic.you` translation usage were removed from this template.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tutorial group management now consistently displays the tutor’s name in the tutor column, including for groups taught by the current user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->