### PR TITLE
`Development`: Repair the client tests broken by the new test hooks

### DIFF
--- a/src/main/webapp/app/communication/answer-post/answer-post.component.spec.ts
+++ b/src/main/webapp/app/communication/answer-post/answer-post.component.spec.ts
@@ -302,7 +302,7 @@ describe('AnswerPostComponent', () => {
         component.posting.set(post);
         fixture.changeDetectorRef.detectChanges();
 
-        const forwardButton = debugElement.query(By.css('button.dropdown-item.d-flex.forward'));
+        const forwardButton = debugElement.query(By.css('[data-testid="posting-menu-forward"]'));
         expect(forwardButton).not.toBeNull();
 
         forwardButton.nativeElement.click();

--- a/src/main/webapp/app/communication/post/post.component.spec.ts
+++ b/src/main/webapp/app/communication/post/post.component.spec.ts
@@ -419,7 +419,7 @@ describe('PostComponent', () => {
         component.posting.set(post);
         fixture.changeDetectorRef.detectChanges();
 
-        const forwardButton = debugElement.query(By.css('button.dropdown-item.d-flex.forward'));
+        const forwardButton = debugElement.query(By.css('[data-testid="posting-menu-forward"]'));
         expect(forwardButton).not.toBeNull();
 
         forwardButton.nativeElement.click();

--- a/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.html
+++ b/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.html
@@ -177,6 +177,7 @@
             <!-- Forward button -->
             <button
                 class="reaction-button clickable px-2 fs-small forward"
+                data-testid="posting-reaction-forward"
                 [disabled]="isReadOnlyMode()"
                 (click)="forwardMessage()"
                 [ngbTooltip]="'artemisApp.metis.post.forwardMessage' | artemisTranslate"

--- a/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.spec.ts
+++ b/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.spec.ts
@@ -141,7 +141,7 @@ describe('PostingReactionsBarComponent', () => {
     });
 
     function getEditButton(): DebugElement | null {
-        return debugElement.query(By.css('button.reaction-button.clickable.px-2.fs-small.edit'));
+        return debugElement.query(By.css('[data-testid="posting-reaction-edit"]'));
     }
 
     function getDeleteButton(): DebugElement | null {
@@ -153,7 +153,7 @@ describe('PostingReactionsBarComponent', () => {
     }
 
     function getForwardButton(): DebugElement | null {
-        return debugElement.query(By.css('button.reaction-button.clickable.px-2.fs-small.forward'));
+        return debugElement.query(By.css('[data-testid="posting-reaction-forward"]'));
     }
 
     it('should initialize user authority and reactions correctly', () => {
@@ -507,7 +507,7 @@ describe('PostingReactionsBarComponent', () => {
         const openPostingCreateEditModalEmitSpy = vi.spyOn(component.openPostingCreateEditModal, 'emit');
         metisServiceUserIsAuthorOfPostingStub.mockReturnValue(true);
         fixture.changeDetectorRef.detectChanges();
-        getElement(debugElement, '.edit').click();
+        getElement(debugElement, '[data-testid="posting-reaction-edit"]').click();
         expect(openPostingCreateEditModalEmitSpy).toHaveBeenCalledOnce();
     });
 

--- a/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.component.html
+++ b/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.component.html
@@ -48,7 +48,7 @@
                 (resizeEnd)="onPanelResized(ResizeType.SIDEBAR_RIGHT)"
             >
                 @if (!rightPanelIsCollapsed()) {
-                    <fa-icon [icon]="faGripLinesVertical" id="draggableIconForInstructions" class="rg-sidebar-right">
+                    <fa-icon [icon]="faGripLinesVertical" data-testid="draggableIconForInstructions" class="rg-sidebar-right">
                         <span></span>
                     </fa-icon>
                 }
@@ -74,7 +74,7 @@
         <ng-content select="[editorBottomArea]" class="editor-bottom-resizable" />
         <!-- Required for resizing; don't remove empty span -->
         @if (!buildOutputIsCollapsed()) {
-            <fa-icon [icon]="faGripLines" id="draggableIconForBuildOutput" class="rg-bottom-bottom"><span></span></fa-icon>
+            <fa-icon [icon]="faGripLines" data-testid="draggableIconForBuildOutput" class="rg-bottom-bottom"><span></span></fa-icon>
         }
     </div>
     @if (isTutorAssessment()) {

--- a/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.component.spec.ts
+++ b/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.component.spec.ts
@@ -59,7 +59,7 @@ describe('CodeEditorGridComponent', () => {
         };
 
         const getDebugElement = (windowName: string) => {
-            return fixture.debugElement.query(By.css('#draggableIconFor' + windowName));
+            return fixture.debugElement.query(By.css(`[data-testid="draggableIconFor${windowName}"]`));
         };
 
         const expectAllWindowsToNotBeCollapsed = () => {


### PR DESCRIPTION
### Summary
Eight client tests fail on `develop` and therefore in every open pull request. The recent move from styling-class selectors to `data-testid` hooks updated the templates but not four unit specs, which still look for classes that no longer exist. This restores the specs and finishes the rename so the whole suite is green again.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).

### Motivation and Context
The single required check aggregates the client test job, so these eight failures block every pull request in the repository regardless of what it changes. The failures are not flaky: they reproduce on a plain `develop` checkout.

Class names describe how an element looks, so a restyle silently breaks any test bound to them and nothing in the diff points at it. That is exactly what happened here, and it is why the guidelines ask for a `data-testid` instead.

### Description
Four specs now locate their elements by the test hook the template carries:

- The postings reactions bar looked for the edit button by `button.reaction-button.clickable.px-2.fs-small.edit`. The `edit` class is gone; the button carries `data-testid="posting-reaction-edit"`. Five tests recovered.
- The post and answer-post context menus looked for the forward entry by `button.dropdown-item.d-flex.forward`. That entry carries `data-testid="posting-menu-forward"`. Two tests recovered.
- The code editor grid looked for its grip handles by `#draggableIconFor<window>`. Only the file browser handle had been renamed to a test hook, so that one test failed while the other two still passed on their ids. All three handles now carry `data-testid`, and the spec builds one selector for all of them.

The forward button in the reactions bar also gets a `data-testid` of its own, so it is found the same way as the edit and delete buttons beside it rather than through its styling classes.

No production behaviour changes: the templates only gain test hooks, and two ids that existed solely so a test could find something become test ids.

### Steps for Testing
Prerequisites:
- 1 course with a communication channel containing at least one message with an answer
- 1 programming exercise

1. Open the communication channel as the author of a message.
2. Hover a message and confirm the edit, delete and forward buttons in the reactions bar still appear and work.
3. Right-click a message and an answer, and confirm the context menu still forwards the message.
4. Open the code editor of the programming exercise.
5. Drag each of the three grip handles (file browser, problem statement, build output) and confirm the panels still resize, then collapse each panel and confirm its handle disappears.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-05 17:11:20 UTC_

