### PR TITLE
`Development`: Let a TUM UI select filter its options

### DIFF
--- a/packages/tum-ui/src/lib/i18n/tum-ui-translations.ts
+++ b/packages/tum-ui/src/lib/i18n/tum-ui-translations.ts
@@ -34,6 +34,8 @@ export const TUM_UI_DEFAULT_TRANSLATIONS = {
     'tumUi.paginator.rowsPerPage': 'Rows per page',
     'tumUi.select.clear': 'Clear selection',
     'tumUi.select.empty': 'No available options',
+    'tumUi.select.filter': 'Filter options',
+    'tumUi.select.noResults': 'No matching options',
     'tumUi.table.actions': 'Actions',
     'tumUi.table.noResults': 'No results found',
     'tumUi.table.searchPlaceholder': 'Search',

--- a/packages/tum-ui/src/lib/select/tum-ui-select.component.html
+++ b/packages/tum-ui/src/lib/select/tum-ui-select.component.html
@@ -74,7 +74,7 @@
                 </li>
             } @empty {
                 <li role="option" aria-selected="false" aria-disabled="true" class="tum:px-3 tum:py-2 tum:text-muted">
-                    {{ filterText().trim().length ? ('tumUi.select.noResults' | tumUiTranslate) : (emptyMessage() ?? ('tumUi.select.empty' | tumUiTranslate)) }}
+                    {{ isFiltering() ? ('tumUi.select.noResults' | tumUiTranslate) : (emptyMessage() ?? ('tumUi.select.empty' | tumUiTranslate)) }}
                 </li>
             }
         </ul>

--- a/packages/tum-ui/src/lib/select/tum-ui-select.component.html
+++ b/packages/tum-ui/src/lib/select/tum-ui-select.component.html
@@ -36,13 +36,29 @@
 
 <ng-template #panel>
     <div class="tum-ui-select-panel tum:box-border tum:w-full tum:rounded-md tum:border tum:border-border tum:bg-overlay-background tum:text-text tum:shadow-md">
+        @if (filter()) {
+            <div class="tum:border-b tum:border-border tum:p-1">
+                <input
+                    #filterInput
+                    type="text"
+                    class="tum-ui-select-filter tum:box-border tum:w-full tum:appearance-none tum:rounded-sm tum:border tum:border-control-border tum:bg-control-background tum:px-2 tum:py-1.5 tum:text-sm tum:text-text tum:placeholder:text-muted tum:focus-visible:outline tum:focus-visible:outline-2 tum:focus-visible:outline-focus"
+                    [value]="filterText()"
+                    [attr.placeholder]="filterPlaceholder() ?? ('tumUi.select.filter' | tumUiTranslate)"
+                    [attr.aria-label]="filterAriaLabel() ?? ('tumUi.select.filter' | tumUiTranslate)"
+                    [attr.aria-controls]="listboxId"
+                    [attr.aria-activedescendant]="activeOptionId()"
+                    (input)="onFilterInput($event)"
+                    (keydown)="onFilterKeydown($event)"
+                />
+            </div>
+        }
         <ul
             [id]="listboxId"
             role="listbox"
             [attr.aria-label]="ariaLabel()"
             class="tum:m-0 tum:flex tum:max-h-60 tum:list-none tum:flex-col tum:gap-0.5 tum:overflow-y-auto tum:p-1 tum:outline-none"
         >
-            @for (option of options(); track $index; let i = $index) {
+            @for (option of visibleOptions(); track $index; let i = $index) {
                 <li
                     [id]="optionId(i)"
                     role="option"
@@ -58,7 +74,7 @@
                 </li>
             } @empty {
                 <li role="option" aria-selected="false" aria-disabled="true" class="tum:px-3 tum:py-2 tum:text-muted">
-                    {{ emptyMessage() ?? ('tumUi.select.empty' | tumUiTranslate) }}
+                    {{ filterText().trim().length ? ('tumUi.select.noResults' | tumUiTranslate) : (emptyMessage() ?? ('tumUi.select.empty' | tumUiTranslate)) }}
                 </li>
             }
         </ul>

--- a/packages/tum-ui/src/lib/select/tum-ui-select.component.spec.ts
+++ b/packages/tum-ui/src/lib/select/tum-ui-select.component.spec.ts
@@ -262,6 +262,106 @@ describe('TumUiSelectComponent', () => {
         expect(emptyOption.getAttribute('aria-disabled')).toBe('true');
         expect(emptyOption.getAttribute('aria-selected')).toBe('false');
     });
+    describe('filter', () => {
+        function filterField(): HTMLInputElement {
+            return document.querySelector('.tum-ui-select-filter') as HTMLInputElement;
+        }
+        function type(query: string): void {
+            const field = filterField();
+            field.value = query;
+            field.dispatchEvent(new Event('input'));
+            fixture.detectChanges();
+        }
+
+        beforeEach(() => {
+            fixture.componentRef.setInput('filter', true);
+            fixture.detectChanges();
+        });
+
+        it('shows no search field unless asked for one', () => {
+            fixture.componentRef.setInput('filter', false);
+            fixture.detectChanges();
+            openPanel();
+
+            expect(filterField()).toBeNull();
+        });
+
+        it('narrows the list to the options whose label matches, case-insensitively', () => {
+            openPanel();
+
+            type('ra');
+
+            expect(optionElements().map((option) => option.textContent?.trim())).toEqual(['Bravo']);
+        });
+
+        it('searches the named fields instead of the label when filterBy is given', () => {
+            fixture.componentRef.setInput('filterBy', 'value');
+            fixture.detectChanges();
+            openPanel();
+
+            type('c');
+
+            // 'c' is the value of Charlie; matching on the label would also have kept Bravo, which contains no c
+            // in its value.
+            expect(optionElements().map((option) => option.textContent?.trim())).toEqual(['Charlie']);
+        });
+
+        it('reports that nothing matched rather than that there are no options', () => {
+            openPanel();
+
+            type('zzz');
+
+            expect(optionElements()).toHaveLength(1);
+            expect(optionElements()[0].textContent?.trim()).toBe('No matching options');
+            expect(optionElements()[0].getAttribute('aria-disabled')).toBe('true');
+        });
+
+        it('commits the option at the active index of the narrowed list, not of the full one', () => {
+            openPanel();
+
+            // 'ar' leaves only Charlie, which is index 2 in the full list and index 0 in the narrowed one.
+            type('ar');
+            filterField().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            fixture.detectChanges();
+
+            expect(labelText()).toBe('Charlie');
+        });
+
+        it('walks the narrowed list with the arrow keys from the search field', () => {
+            openPanel();
+
+            // 'a' keeps Alpha, Bravo and Charlie, so there is somewhere to move to.
+            type('a');
+            filterField().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: DOWN_ARROW, bubbles: true }));
+            fixture.detectChanges();
+            filterField().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            fixture.detectChanges();
+
+            expect(labelText()).toBe('Bravo');
+        });
+
+        it('describes the active option on the search field, because focus is there while filtering', () => {
+            openPanel();
+            type('a');
+
+            const activeId = filterField().getAttribute('aria-activedescendant');
+            expect(activeId).toBeTruthy();
+            expect(document.getElementById(activeId!)?.getAttribute('role')).toBe('option');
+        });
+
+        it('forgets the query once the panel closes, so the next open starts from the whole list', () => {
+            openPanel();
+            type('ra');
+            expect(optionElements()).toHaveLength(1);
+
+            filterField().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            fixture.detectChanges();
+            openPanel();
+
+            expect(optionElements()).toHaveLength(OPTIONS.length);
+            expect(filterField().value).toBe('');
+        });
+    });
 });
 
 describe('TumUiSelectComponent with [(ngModel)]', () => {

--- a/packages/tum-ui/src/lib/select/tum-ui-select.component.spec.ts
+++ b/packages/tum-ui/src/lib/select/tum-ui-select.component.spec.ts
@@ -263,11 +263,16 @@ describe('TumUiSelectComponent', () => {
         expect(emptyOption.getAttribute('aria-selected')).toBe('false');
     });
     describe('filter', () => {
-        function filterField(): HTMLInputElement {
-            return document.querySelector('.tum-ui-select-filter') as HTMLInputElement;
+        function filterField(): HTMLInputElement | null {
+            return document.querySelector('.tum-ui-select-filter');
+        }
+        function requireFilterField(): HTMLInputElement {
+            const field = filterField();
+            expect(field).not.toBeNull();
+            return field!;
         }
         function type(query: string): void {
-            const field = filterField();
+            const field = requireFilterField();
             field.value = query;
             field.dispatchEvent(new Event('input'));
             fixture.detectChanges();
@@ -284,6 +289,18 @@ describe('TumUiSelectComponent', () => {
             openPanel();
 
             expect(filterField()).toBeNull();
+        });
+
+        it('still reports an empty option set as empty when filtering is off', () => {
+            // The message follows whether a query is narrowing the list, not merely whether one was typed, so
+            // turning the filter off cannot leave the list claiming that nothing matched.
+            openPanel();
+            type('zzz');
+            fixture.componentRef.setInput('filter', false);
+            fixture.componentRef.setInput('options', []);
+            fixture.detectChanges();
+
+            expect(optionElements()[0].textContent?.trim()).toBe('No available options');
         });
 
         it('narrows the list to the options whose label matches, case-insensitively', () => {
@@ -321,7 +338,7 @@ describe('TumUiSelectComponent', () => {
 
             // 'ar' leaves only Charlie, which is index 2 in the full list and index 0 in the narrowed one.
             type('ar');
-            filterField().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            requireFilterField().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
             fixture.detectChanges();
 
             expect(labelText()).toBe('Charlie');
@@ -332,9 +349,9 @@ describe('TumUiSelectComponent', () => {
 
             // 'a' keeps Alpha, Bravo and Charlie, so there is somewhere to move to.
             type('a');
-            filterField().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: DOWN_ARROW, bubbles: true }));
+            requireFilterField().dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', keyCode: DOWN_ARROW, bubbles: true }));
             fixture.detectChanges();
-            filterField().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+            requireFilterField().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
             fixture.detectChanges();
 
             expect(labelText()).toBe('Bravo');
@@ -344,7 +361,7 @@ describe('TumUiSelectComponent', () => {
             openPanel();
             type('a');
 
-            const activeId = filterField().getAttribute('aria-activedescendant');
+            const activeId = requireFilterField().getAttribute('aria-activedescendant');
             expect(activeId).toBeTruthy();
             expect(document.getElementById(activeId!)?.getAttribute('role')).toBe('option');
         });
@@ -354,12 +371,12 @@ describe('TumUiSelectComponent', () => {
             type('ra');
             expect(optionElements()).toHaveLength(1);
 
-            filterField().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+            requireFilterField().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
             fixture.detectChanges();
             openPanel();
 
             expect(optionElements()).toHaveLength(OPTIONS.length);
-            expect(filterField().value).toBe('');
+            expect(requireFilterField().value).toBe('');
         });
     });
 });

--- a/packages/tum-ui/src/lib/select/tum-ui-select.component.stories.ts
+++ b/packages/tum-ui/src/lib/select/tum-ui-select.component.stories.ts
@@ -1,7 +1,7 @@
 import { FormsModule } from '@angular/forms';
 import { moduleMetadata } from '@storybook/angular-vite';
 import type { Meta, StoryObj } from '@storybook/angular-vite';
-import { expect, fireEvent, fn, screen, waitForElementToBeRemoved } from 'storybook/test';
+import { expect, fireEvent, fn, screen, waitForElementToBeRemoved, within } from 'storybook/test';
 import { formStoryDecorator } from '../../../.storybook/story-decorators';
 import { TumUiSelectComponent } from './tum-ui-select.component';
 
@@ -92,6 +92,50 @@ export const Empty: Story = {
     play: async ({ canvas, userEvent }) => {
         await userEvent.click(canvas.getByRole('combobox', { name: 'Course language' }));
         await expect(await screen.findByText('No languages available')).toBeVisible();
+    },
+};
+
+export const Filterable: Story = {
+    args: {
+        filter: true,
+        options: [
+            { code: 'en', label: 'English' },
+            { code: 'de', label: 'German' },
+            { code: 'es', label: 'Spanish' },
+            { code: 'fr', label: 'French' },
+            { code: 'it', label: 'Italian' },
+            { code: 'pt', label: 'Portuguese' },
+        ],
+        showClear: false,
+    },
+    play: async ({ canvas, userEvent, args }) => {
+        const trigger = canvas.getByRole('combobox', { name: 'Course language' });
+        await userEvent.click(trigger);
+
+        // Focus moves to the search field, so what the user types filters instead of running the typeahead.
+        const search = await screen.findByRole('textbox', { name: 'Filter options' });
+        await expect(search).toHaveFocus();
+
+        await userEvent.type(search, 'ish');
+        const listbox = await screen.findByRole('listbox', { name: 'Course language' });
+        await expect(within(listbox).getAllByRole('option')).toHaveLength(2);
+
+        await userEvent.click(within(listbox).getByText('Spanish'));
+        await expect(trigger).toHaveTextContent('Spanish');
+        await expect(args.selectionChange).toHaveBeenCalledWith('es');
+    },
+};
+
+export const FilterWithoutMatches: Story = {
+    args: {
+        filter: true,
+    },
+    tags: ['!autodocs'],
+    play: async ({ canvas, userEvent }) => {
+        await userEvent.click(canvas.getByRole('combobox', { name: 'Course language' }));
+        await userEvent.type(await screen.findByRole('textbox', { name: 'Filter options' }), 'zzz');
+
+        await expect(await screen.findByText('No matching options')).toBeVisible();
     },
 };
 

--- a/packages/tum-ui/src/lib/select/tum-ui-select.component.ts
+++ b/packages/tum-ui/src/lib/select/tum-ui-select.component.ts
@@ -6,6 +6,7 @@ import {
     Injector,
     TemplateRef,
     ViewContainerRef,
+    afterRenderEffect,
     booleanAttribute,
     computed,
     effect,
@@ -66,6 +67,17 @@ export class TumUiSelectComponent implements ControlValueAccessor {
 
     readonly showClear = input(false, { transform: booleanAttribute });
 
+    /** Adds a search field above the option list, for option sets too long to scan. */
+    readonly filter = input(false, { transform: booleanAttribute });
+
+    /**
+     * Comma-separated property names searched by the filter, for object options whose match should not be
+     * limited to the visible label — `"name,login"`, say. Defaults to the label alone.
+     */
+    readonly filterBy = input<string>();
+
+    readonly filterPlaceholder = input<string>();
+
     readonly size = input<TumUiSelectSize>();
 
     readonly inputId = input(`tum-ui-select-${nextSelectId++}`);
@@ -73,6 +85,7 @@ export class TumUiSelectComponent implements ControlValueAccessor {
     readonly ariaLabel = input<string>();
     readonly clearAriaLabel = input<string>();
     readonly emptyMessage = input<string>();
+    readonly filterAriaLabel = input<string>();
     readonly selectionChange = output<unknown>();
 
     protected readonly faChevronDown = faChevronDown;
@@ -83,10 +96,12 @@ export class TumUiSelectComponent implements ControlValueAccessor {
 
     private readonly trigger = viewChild.required<ElementRef<HTMLElement>>('trigger');
     private readonly panel = viewChild.required('panel', { read: TemplateRef });
+    private readonly filterInput = viewChild<ElementRef<HTMLInputElement>>('filterInput');
     private overlayRef?: OverlayRef;
 
     protected readonly isOpen = signal(false);
     protected readonly activeIndex = signal(-1);
+    protected readonly filterText = signal('');
     private readonly selectedValue = signal<unknown>(undefined);
     private readonly disabledByForm = signal(false);
 
@@ -102,6 +117,19 @@ export class TumUiSelectComponent implements ControlValueAccessor {
         return this.options().find((option) => this.valuesMatch(this.resolveValue(option), current));
     });
 
+    /**
+     * The options the panel shows. Everything index-based - the key manager, `aria-activedescendant`, the
+     * option ids and every keyboard action - runs over this list rather than `options()`, so an index can
+     * never point at an option the user cannot see.
+     */
+    protected readonly visibleOptions = computed(() => {
+        const query = this.filterText().trim().toLocaleLowerCase();
+        if (!this.filter() || query.length === 0) {
+            return this.options();
+        }
+        return this.options().filter((option) => this.filterFields(option).some((field) => field.toLocaleLowerCase().includes(query)));
+    });
+
     protected readonly hasSelection = computed(() => this.selectedOption() !== undefined);
     protected readonly displayLabel = computed(() => {
         const option = this.selectedOption();
@@ -110,9 +138,10 @@ export class TumUiSelectComponent implements ControlValueAccessor {
     protected readonly showClearButton = computed(() => this.showClear() && this.hasSelection() && !this.isDisabled());
     protected readonly triggerClasses = computed(() => `${this.buildTriggerClasses()} ${this.showClearButton() ? 'tum:pe-17' : 'tum:pe-10'}`);
     protected readonly activeOptionId = computed(() => (this.activeIndex() >= 0 ? this.optionId(this.activeIndex()) : undefined));
-    private readonly keyManagerOptions = computed(() => this.options().map((option) => ({ getLabel: () => this.label(option) })));
+    private readonly keyManagerOptions = computed(() => this.visibleOptions().map((option) => ({ getLabel: () => this.label(option) })));
     private readonly keyManager = new ListKeyManager(this.keyManagerOptions, this.injector).withVerticalOrientation().withHomeAndEnd().withTypeAhead(TYPEAHEAD_DEBOUNCE_MS);
     private typeaheadSequence = '';
+    private pendingFilterFocus = false;
     private typeaheadReset?: ReturnType<typeof setTimeout>;
 
     constructor() {
@@ -130,8 +159,17 @@ export class TumUiSelectComponent implements ControlValueAccessor {
                 this.close();
             }
         });
+        // Focus lands on the search field when one is shown, so typing filters the list rather than running
+        // the trigger's typeahead.
+        afterRenderEffect(() => {
+            const field = this.filterInput()?.nativeElement;
+            if (this.pendingFilterFocus && field) {
+                this.pendingFilterFocus = false;
+                field.focus();
+            }
+        });
         effect(() => {
-            const optionCount = this.options().length;
+            const optionCount = this.visibleOptions().length;
             if (optionCount === 0) {
                 this.keyManager.setActiveItem(-1);
             } else if (this.activeIndex() >= optionCount) {
@@ -175,6 +213,18 @@ export class TumUiSelectComponent implements ControlValueAccessor {
                 return '';
         }
     }
+    /** The strings the filter searches for one option: the named `filterBy` fields, or the visible label. */
+    private filterFields(option: unknown): string[] {
+        const keys = this.filterBy()
+            ?.split(',')
+            .map((key) => key.trim())
+            .filter((key) => key.length > 0);
+        if (!keys?.length || option === null || typeof option !== 'object') {
+            return [this.label(option)];
+        }
+        return keys.map((key) => this.toText((option as Record<string, unknown>)[key]));
+    }
+
     private resolveValue(option: unknown): unknown {
         const key = this.optionValue();
         if (key && option !== null && typeof option === 'object') {
@@ -214,8 +264,8 @@ export class TumUiSelectComponent implements ControlValueAccessor {
         if (this.isOpen() || this.isDisabled()) {
             return;
         }
-        const selectedIndex = this.options().findIndex((option) => this.isSelected(option));
-        const initialIndex = selectedIndex >= 0 ? selectedIndex : this.options().length > 0 ? 0 : -1;
+        const selectedIndex = this.visibleOptions().findIndex((option) => this.isSelected(option));
+        const initialIndex = selectedIndex >= 0 ? selectedIndex : this.visibleOptions().length > 0 ? 0 : -1;
         this.keyManager.setActiveItem(initialIndex);
         const origin = this.trigger();
         this.overlayRef = this.overlayService.createConnectedOverlay(origin, 'bottom', { hasBackdrop: true, matchOriginWidth: true });
@@ -228,6 +278,9 @@ export class TumUiSelectComponent implements ControlValueAccessor {
             }
         });
         this.isOpen.set(true);
+        // The portal attaches above, but its input is only in the document once the view has been rendered,
+        // so the focus move is deferred to the render effect in the constructor.
+        this.pendingFilterFocus = this.filter();
     }
 
     private close(restoreFocus = true): void {
@@ -237,6 +290,7 @@ export class TumUiSelectComponent implements ControlValueAccessor {
         this.overlayRef?.dispose();
         this.overlayRef = undefined;
         this.isOpen.set(false);
+        this.filterText.set('');
         this.resetTypeahead();
         this.onTouchedCallback();
         if (restoreFocus && !this.isDisabled()) {
@@ -283,23 +337,26 @@ export class TumUiSelectComponent implements ControlValueAccessor {
             if (event.key === 'Home' || event.key === 'End') {
                 event.preventDefault();
                 this.open();
-                this.setActive(event.key === 'Home' ? 0 : this.options().length - 1);
+                this.setActive(event.key === 'Home' ? 0 : this.visibleOptions().length - 1);
                 return;
             }
             if (event.key.length === 1 && event.key !== ' ' && !event.ctrlKey && !event.metaKey && !event.altKey) {
                 this.open();
-                this.handleTypeahead(event);
+                // With a search field the character belongs in it, and focus is moving there anyway.
+                if (!this.filter()) {
+                    this.handleTypeahead(event);
+                }
             }
             return;
         }
-        const count = this.options().length;
+        const count = this.visibleOptions().length;
         switch (event.key) {
             case 'Enter':
             case ' ':
             case 'Spacebar':
                 event.preventDefault();
                 if (this.activeIndex() >= 0 && this.activeIndex() < count) {
-                    this.selectOption(this.options()[this.activeIndex()]);
+                    this.selectOption(this.visibleOptions()[this.activeIndex()]);
                 }
                 break;
             case 'Escape':
@@ -307,7 +364,7 @@ export class TumUiSelectComponent implements ControlValueAccessor {
                 break;
             case 'Tab':
                 if (this.activeIndex() >= 0 && this.activeIndex() < count) {
-                    this.selectOption(this.options()[this.activeIndex()]);
+                    this.selectOption(this.visibleOptions()[this.activeIndex()]);
                 } else {
                     this.close(false);
                 }
@@ -319,6 +376,28 @@ export class TumUiSelectComponent implements ControlValueAccessor {
                     this.keyManager.onKeydown(event);
                 }
         }
+    }
+
+    protected onFilterInput(event: Event): void {
+        this.filterText.set((event.target as HTMLInputElement).value);
+        // The previous active option may have been filtered away, so start again at the top of what is left.
+        this.keyManager.setActiveItem(this.visibleOptions().length > 0 ? 0 : -1);
+    }
+
+    /**
+     * Keys typed in the search field. Everything that moves or commits the selection is forwarded to the
+     * same handling the trigger uses; the rest is left to the input.
+     */
+    protected onFilterKeydown(event: KeyboardEvent): void {
+        const navigationKeys = ['ArrowDown', 'ArrowUp', 'Home', 'End', 'Enter', 'Escape', 'Tab'];
+        if (!navigationKeys.includes(event.key)) {
+            return;
+        }
+        if (event.key === 'Home' || event.key === 'End') {
+            // Home and End belong to the text field while the user is editing the query.
+            return;
+        }
+        this.onTriggerKeydown(event);
     }
 
     private handleTypeahead(event: KeyboardEvent): void {

--- a/packages/tum-ui/src/lib/select/tum-ui-select.component.ts
+++ b/packages/tum-ui/src/lib/select/tum-ui-select.component.ts
@@ -122,11 +122,14 @@ export class TumUiSelectComponent implements ControlValueAccessor {
      * option ids and every keyboard action - runs over this list rather than `options()`, so an index can
      * never point at an option the user cannot see.
      */
+    /** Whether a query is currently narrowing the list, rather than merely present. */
+    protected readonly isFiltering = computed(() => this.filter() && this.filterText().trim().length > 0);
+
     protected readonly visibleOptions = computed(() => {
-        const query = this.filterText().trim().toLocaleLowerCase();
-        if (!this.filter() || query.length === 0) {
+        if (!this.isFiltering()) {
             return this.options();
         }
+        const query = this.filterText().trim().toLocaleLowerCase();
         return this.options().filter((option) => this.filterFields(option).some((field) => field.toLocaleLowerCase().includes(query)));
     });
 

--- a/src/main/webapp/app/shared-ui/tum-ui-integration/artemis-tum-ui-translator.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui-integration/artemis-tum-ui-translator.ts
@@ -36,6 +36,8 @@ const ARTEMIS_TRANSLATION_KEYS = {
     'tumUi.paginator.rowsPerPage': 'global.paginator.rowsPerPage',
     'tumUi.select.clear': 'entity.action.clear',
     'tumUi.select.empty': 'global.generic.emptyList',
+    'tumUi.select.filter': 'global.generic.filterOptions',
+    'tumUi.select.noResults': 'global.search.noResultsFound',
     'tumUi.table.actions': 'entity.actions',
     'tumUi.table.noResults': 'global.search.noResultsFound',
     'tumUi.table.searchPlaceholder': 'global.search.searchPlaceholder',

--- a/src/main/webapp/app/shared-ui/tum-ui-integration/artemis-tum-ui-translator.ts
+++ b/src/main/webapp/app/shared-ui/tum-ui-integration/artemis-tum-ui-translator.ts
@@ -37,7 +37,7 @@ const ARTEMIS_TRANSLATION_KEYS = {
     'tumUi.select.clear': 'entity.action.clear',
     'tumUi.select.empty': 'global.generic.emptyList',
     'tumUi.select.filter': 'global.generic.filterOptions',
-    'tumUi.select.noResults': 'global.search.noResultsFound',
+    'tumUi.select.noResults': 'global.generic.noMatchingOptions',
     'tumUi.table.actions': 'entity.actions',
     'tumUi.table.noResults': 'global.search.noResultsFound',
     'tumUi.table.searchPlaceholder': 'global.search.searchPlaceholder',

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -8,6 +8,7 @@
             "you": "Du",
             "emptyList": "Keine Elemente verfügbar",
             "filterOptions": "Optionen filtern",
+            "noMatchingOptions": "Keine passenden Optionen",
             "unset": "Nicht gesetzt",
             "create": "Erstellen",
             "start": "Start",

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -7,6 +7,7 @@
             "no": "Nein",
             "you": "Du",
             "emptyList": "Keine Elemente verfügbar",
+            "filterOptions": "Optionen filtern",
             "unset": "Nicht gesetzt",
             "create": "Erstellen",
             "start": "Start",

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -7,6 +7,7 @@
             "no": "No",
             "you": "You",
             "emptyList": "No items available",
+            "filterOptions": "Filter options",
             "unset": "Unset",
             "create": "Create",
             "start": "Start",

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -8,6 +8,7 @@
             "you": "You",
             "emptyList": "No items available",
             "filterOptions": "Filter options",
+            "noMatchingOptions": "No matching options",
             "unset": "Unset",
             "create": "Create",
             "start": "Start",


### PR DESCRIPTION
### Summary

Adds an optional search field to `tum-ui-select`, so a select over a long option set can be narrowed by typing instead of scrolled.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

`tum-ui-select` can only be reached by scrolling or by its typeahead, which jumps to a **prefix** match on the visible label. That is fine for a handful of options and unusable for a few hundred: picking one tutor out of a course's tutor list means scrolling, and typing "mueller" finds nothing if the label starts with the first name.

This is the gap that keeps `p-select` alive in the tutorial group migration (#13667): the tutor picker uses PrimeNG's `[filter]` and `filterBy`. Closing it here lets that PR finish rather than carrying a documented PrimeNG fallback.

### Description

**`filter`** turns on a search field above the option list. **`filterBy`** takes a comma-separated list of property names to search instead of the visible label — `filterBy="name,login"` — so a tutor can be found by login even when the label shows the name. Matching is a case-insensitive substring test, so it finds a match anywhere in the value rather than only at the start. `filterPlaceholder` and `filterAriaLabel` override the defaults.

```html
<tum-ui-select [options]="tutors()" optionLabel="nameAndLogin" optionValue="id" filter filterBy="nameAndLogin" />
```

**The visible list became the single source of truth for anything index-based.** The key manager, `aria-activedescendant`, the option ids and every keyboard action now run over `visibleOptions()` rather than `options()`. That is the substantive part of the change: with two lists in play, an active index taken from the full list would commit an option the user could not see.

**Focus moves to the search field when the panel opens**, so typing filters rather than running the trigger's typeahead, and the trigger's single-character typeahead is skipped while a filter is present. Arrow keys, `Enter`, `Escape` and `Tab` are forwarded from the field to the existing trigger handling; `Home` and `End` stay with the text field, where they belong while editing a query. The query is cleared when the panel closes, so the next open starts from the whole list.

**An empty result now says so.** Previously the panel could only report "No available options", which is wrong when the list is non-empty and simply does not match — it says "No matching options" instead.

Nothing changes for a select without `filter`: the field is not rendered and `visibleOptions()` returns `options()` untouched.

### Steps for Testing

Prerequisites:
- 1 Course with several tutors
- 1 Instructor

1. Open Storybook (`pnpm run tum-ui:storybook`) → *Forms → Select → Filterable*.
2. Open the select and confirm focus lands in the search field. Type a fragment from the **middle** of an option and confirm the list narrows.
3. Walk the narrowed list with `ArrowDown`/`ArrowUp` and commit with `Enter`; confirm the committed option is the highlighted one.
4. Type something that matches nothing and confirm the panel says "No matching options".
5. Press `Escape`, reopen, and confirm the full list is back and the field is empty.
6. Repeat with a screen reader and confirm the active option is announced while typing.
7. Check an existing select **without** `filter` (e.g. *Account settings → Language*) is unchanged.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| artemis-tum-ui-translator.ts | 100.00% | 63 | 3 | 4.8 |

_Last updated: 2026-09-05 19:30:53 UTC_


### Screenshots

<!-- To be added. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional filtering to select menus, including case-insensitive search and configurable searchable fields.
  - Added keyboard navigation and selection support while filtering.
  - Added accessible labels and customizable placeholder text for the filter field.
  - Added localized messages for filtering options and no matching results in English and German.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->