### PR TITLE
`Development`: Point the client specs at the new end-to-end test hooks

### DIFF
--- a/src/main/webapp/app/communication/answer-post/answer-post.component.spec.ts
+++ b/src/main/webapp/app/communication/answer-post/answer-post.component.spec.ts
@@ -302,7 +302,7 @@ describe('AnswerPostComponent', () => {
         component.posting.set(post);
         fixture.changeDetectorRef.detectChanges();
 
-        const forwardButton = debugElement.query(By.css('button.dropdown-item.d-flex.forward'));
+        const forwardButton = debugElement.query(By.css('button[data-testid="posting-menu-forward"]'));
         expect(forwardButton).not.toBeNull();
 
         forwardButton.nativeElement.click();

--- a/src/main/webapp/app/communication/post/post.component.spec.ts
+++ b/src/main/webapp/app/communication/post/post.component.spec.ts
@@ -419,7 +419,7 @@ describe('PostComponent', () => {
         component.posting.set(post);
         fixture.changeDetectorRef.detectChanges();
 
-        const forwardButton = debugElement.query(By.css('button.dropdown-item.d-flex.forward'));
+        const forwardButton = debugElement.query(By.css('button[data-testid="posting-menu-forward"]'));
         expect(forwardButton).not.toBeNull();
 
         forwardButton.nativeElement.click();

--- a/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.spec.ts
+++ b/src/main/webapp/app/communication/posting-reactions-bar/posting-reactions-bar.component.spec.ts
@@ -141,7 +141,7 @@ describe('PostingReactionsBarComponent', () => {
     });
 
     function getEditButton(): DebugElement | null {
-        return debugElement.query(By.css('button.reaction-button.clickable.px-2.fs-small.edit'));
+        return debugElement.query(By.css('button[data-testid="posting-reaction-edit"]'));
     }
 
     function getDeleteButton(): DebugElement | null {
@@ -507,7 +507,7 @@ describe('PostingReactionsBarComponent', () => {
         const openPostingCreateEditModalEmitSpy = vi.spyOn(component.openPostingCreateEditModal, 'emit');
         metisServiceUserIsAuthorOfPostingStub.mockReturnValue(true);
         fixture.changeDetectorRef.detectChanges();
-        getElement(debugElement, '.edit').click();
+        getElement(debugElement, '[data-testid="posting-reaction-edit"]').click();
         expect(openPostingCreateEditModalEmitSpy).toHaveBeenCalledOnce();
     });
 

--- a/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.component.html
+++ b/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.component.html
@@ -48,7 +48,7 @@
                 (resizeEnd)="onPanelResized(ResizeType.SIDEBAR_RIGHT)"
             >
                 @if (!rightPanelIsCollapsed()) {
-                    <fa-icon [icon]="faGripLinesVertical" id="draggableIconForInstructions" class="rg-sidebar-right">
+                    <fa-icon [icon]="faGripLinesVertical" data-testid="draggableIconForInstructions" class="rg-sidebar-right">
                         <span></span>
                     </fa-icon>
                 }
@@ -74,7 +74,7 @@
         <ng-content select="[editorBottomArea]" class="editor-bottom-resizable" />
         <!-- Required for resizing; don't remove empty span -->
         @if (!buildOutputIsCollapsed()) {
-            <fa-icon [icon]="faGripLines" id="draggableIconForBuildOutput" class="rg-bottom-bottom"><span></span></fa-icon>
+            <fa-icon [icon]="faGripLines" data-testid="draggableIconForBuildOutput" class="rg-bottom-bottom"><span></span></fa-icon>
         }
     </div>
     @if (isTutorAssessment()) {

--- a/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.component.spec.ts
+++ b/src/main/webapp/app/programming/shared/code-editor/layout/code-editor-grid/code-editor-grid.component.spec.ts
@@ -59,7 +59,7 @@ describe('CodeEditorGridComponent', () => {
         };
 
         const getDebugElement = (windowName: string) => {
-            return fixture.debugElement.query(By.css('#draggableIconFor' + windowName));
+            return fixture.debugElement.query(By.css(`[data-testid="draggableIconFor${windowName}"]`));
         };
 
         const expectAllWindowsToNotBeCollapsed = () => {


### PR DESCRIPTION
### Summary

Eight client tests have been failing on `develop` since #13663 with `expected null not to be null`, which reds `Test / Client Tests` on every pull request. That change replaced the styling classes and test-only ids these specs query with `data-testid` attributes and updated the Playwright locators, but not the Vitest specs. The specs now query the hooks.

### Checklist

- [x] Ran the full client test suite locally.
- [x] Followed the client coding and locator conventions.

### Motivation and Context

`develop` run [33968793612](https://github.com/ls1intum/Artemis/actions/runs/33968793612) fails with 4 test files and 8 tests down, and every pull request opened since inherits it. The cause is a half-finished rename:

- `posting-reactions-bar.component.html` lost `class="... edit"` in favour of `data-testid="posting-reaction-edit"`.
- `post.component.html` and `answer-post.component.html` lost `class="... forward"` in favour of `data-testid="posting-menu-forward"`.
- `code-editor-grid.component.html` turned `id="draggableIconForFileBrowser"` into a `data-testid`, but left the other two icons on their ids.

Binding a test to a styling class is the thing the locator convention added in that same change forbids, so the specs are moved onto the hooks rather than back onto the classes.

### Description

- `posting-reactions-bar.component.spec.ts`: query `button[data-testid="posting-reaction-edit"]` in `getEditButton()` and in the embedded-view test.
- `post.component.spec.ts` and `answer-post.component.spec.ts`: query `button[data-testid="posting-menu-forward"]`.
- `code-editor-grid.component.spec.ts`: query `[data-testid="draggableIconFor<window>"]`.
- `code-editor-grid.component.html`: give the instructions and build-output icons a `data-testid` too. Both ids were referenced by nothing but this spec, so they were test-only ids, and the template no longer mixes the two conventions.

### Steps for Testing

1. Run the four affected suites, or the whole client suite.
2. Confirm the resize handles still work in the code editor: drag the file browser, instructions and build output dividers.

### Validation

- The four affected suites pass: 134 of 134, up from 126 of 134.
- Full client suite passes: 1298 of 1298 files, 17267 of 17267 tests.
- ESLint and Prettier pass on the changed files.
- Checked that `draggableIconForInstructions` and `draggableIconForBuildOutput` appear nowhere else in `src` or `packages`, so no stylesheet, component or Playwright locator depended on those ids. `draggableIconForFileBrowser` is already used as a `data-testid` by `CodeEditorResize.spec.ts`.

### Review Progress

- [ ] Code review
- [x] Verified locally

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-05 17:25:17 UTC_

