### PR TITLE
`Development`: Update qs and GitPython to their patched releases

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,7 @@ overrides:
   piscina: 5.3.2
   postcss: 8.5.27
   punycode: 2.3.1
+  qs: 6.16.0
   semver: 7.8.5
   serialize-javascript: 7.1.1
   shell-quote: 1.10.0
@@ -7120,8 +7121,8 @@ packages:
     resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
     engines: {node: '>=20'}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -12605,7 +12606,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -13385,7 +13386,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.2
+      qs: 6.16.0
       range-parser: 1.2.1
       router: 2.2.0(supports-color@10.2.2)
       send: 1.2.1(supports-color@10.2.2)
@@ -15047,8 +15048,9 @@ snapshots:
     dependencies:
       hookified: 2.2.0
 
-  qs@6.15.2:
+  qs@6.16.0:
     dependencies:
+      es-define-property: 1.0.1
       side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -169,6 +169,11 @@ overrides:
   piscina: '5.3.2'
   postcss: '8.5.27'
   punycode: '2.3.1'
+  # Reached through express / body-parser, which both already sit on their newest release and
+  # still resolve qs to 6.15.x. 6.16.0 fixed GHSA-4mjr-xmp4-gh2g (uncaught TypeError when a
+  # parsed object with a non-callable constructor.isBuffer is stringified again) and
+  # GHSA-x5fp-wj9c-mxmx (bracket keys bypassing arrayLimit when comma parsing is on).
+  qs: '6.16.0'
   semver: '7.8.5'
   serialize-javascript: '7.1.1'
   shell-quote: '1.10.0'

--- a/supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt
+++ b/supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt
@@ -1,6 +1,10 @@
 requests==2.34.2
 urllib3>=2.7.0
-gitpython==3.1.58
+# Must stay >= 3.1.59, which fixed CVE-2026-78675 (file content disclosure through .gitmodules
+# include directives), CVE-2026-78676 (code execution through multi-line git-config values),
+# CVE-2026-78677 (--separate-git-dir escaping the clone destination) and CVE-2026-78678
+# (arbitrary file reads through --contents/-S in Repo.blame).
+gitpython==3.1.61
 beautifulsoup4==4.15.0
 soupsieve>=2.8.4
 pyperclip==1.11.0


### PR DESCRIPTION
### Summary

[OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/ls1intum/Artemis) rates the project's "Vulnerabilities" check as failing, with six open advisories. They all come from two packages: the npm package `qs` and the Python package `gitpython`. This PR moves both to their patched releases, which takes the reported count to zero.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

The Scorecard "Vulnerabilities" check is a high-weight signal and currently reports:

| Advisory | Package | Fixed in |
|---|---|---|
| [GHSA-4mjr-xmp4-gh2g](https://osv.dev/GHSA-4mjr-xmp4-gh2g) | npm `qs` 6.15.2 | 6.16.0 |
| [GHSA-x5fp-wj9c-mxmx](https://osv.dev/GHSA-x5fp-wj9c-mxmx) | npm `qs` 6.15.2 | 6.16.0 |
| [PYSEC-2026-3785](https://osv.dev/PYSEC-2026-3785) (CVE-2026-78675) | PyPI `gitpython` 3.1.58 | 3.1.59 |
| [PYSEC-2026-3786](https://osv.dev/PYSEC-2026-3786) (CVE-2026-78676) | PyPI `gitpython` 3.1.58 | 3.1.59 |
| [PYSEC-2026-3787](https://osv.dev/PYSEC-2026-3787) (CVE-2026-78677) | PyPI `gitpython` 3.1.58 | 3.1.59 |
| [PYSEC-2026-3788](https://osv.dev/PYSEC-2026-3788) (CVE-2026-78678) | PyPI `gitpython` 3.1.58 | 3.1.59 |

**Neither package is part of the deployed application, so this is housekeeping rather than an incident.** It is worth being explicit about that so the change is reviewed for what it is:

- `qs` is reached only through `express` / `body-parser`, which are pulled in by `webpack-dev-server`. Artemis serves the client with `@angular/build` (esbuild/Vite), so that code path never runs. The `qs` flaws both require an application that parses attacker-controlled query strings.
- `gitpython` is used by `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py`, a local developer tool that is not run in CI and not shipped.

Both are still worth fixing: the advisories are real, the upgrades are cheap, and leaving them open keeps the Scorecard check red, which makes it useless as a signal for the next genuine finding.

### Description

**`qs` 6.15.2 → 6.16.0** (`pnpm-workspace.yaml`, `pnpm-lock.yaml`)

`express` 5.2.1 and `body-parser` 2.3.0 are both already the newest published releases, and both still resolve `qs` to 6.15.x, so there is no parent to upgrade. The fix is a pin in the root `overrides:` block, matching how the other CVE-driven pins in that file are handled. 6.16.0 satisfies both parents' ranges (`^6.14.0` and `^6.15.2`).

The resulting lockfile change is 12 lines and touches nothing but `qs`. The one new dependency edge (`es-define-property`) was already in the tree via `side-channel`, so no package is added.

`documentation/` already resolves `qs` 6.16.0 and `src/test/playwright/` does not depend on `qs` at all, so neither needed a change.

**`gitpython` 3.1.58 → 3.1.61** (`requirements.txt`)

3.1.59 is the release that fixes all four CVEs. I went to 3.1.61 rather than the minimum because 3.1.60 removed `Actor.name_email_regex` and 3.1.61 restored it, so 3.1.61 is the safer landing point.

3.1.60 also introduced "require explicit opt-in for filesystem diffs", and the script does call `.diff()`, so I checked that rather than assuming: the call is commit-to-commit (`branch_head.diff(branch_base)`), not against the working tree, and is unaffected.

Both files gained a short comment recording which advisory the pin is holding back, following the existing convention in `supporting_scripts/lecture-transcription/requirements.txt` and the `overrides:` block.

**Out of scope, deliberately:** a full sweep also surfaces `image-size` 2.0.2 (GHSA-5p2g-fcmc-qvqq, GHSA-w3rx-r6r6-pgpr) in `documentation/`. Scorecard does not report it and no action is needed: it is already fixed in-tree by `patches/image-size@2.0.2.patch` and recorded in `documentation/osv-scanner.toml`, because upstream was archived read-only with the fix PR unmerged. That suppression carries `ignoreUntil = 2027-03-01`, so it resurfaces for review on its own.

### Steps for Testing

This is a dependency-only change with no user-visible behaviour, so testing is verification that nothing regressed and that the advisories are actually cleared.

Prerequisites:
- A local clone of the branch, `corepack enable`

1. Confirm the lockfile is authoritative (what CI runs):
   ```bash
   pnpm install --frozen-lockfile
   ```
2. Confirm the client still builds through the esbuild pipeline:
   ```bash
   pnpm run webapp:prod
   ```
3. Confirm `qs` resolves to the patched release everywhere it appears:
   ```bash
   grep -n "qs@6" pnpm-lock.yaml
   ```
   Expect `qs@6.16.0`, no 6.15.x.
4. Confirm the coverage script's dependency set still resolves:
   ```bash
   python3 -m venv /tmp/gpcheck
   /tmp/gpcheck/bin/pip install -r supporting_scripts/code-coverage/generate_code_cov_table/requirements.txt
   /tmp/gpcheck/bin/pip check
   ```
5. Optionally, run the coverage table script itself against a branch with changes and confirm the file list is unchanged from `develop`.

### Verification performed

- **Advisory coverage.** Queried the OSV API for every pinned package across all three `pnpm-lock.yaml` files and every `requirements*.txt` (2511 packages), on `develop` and on this branch. `develop` reports `gitpython` (4), `qs` (2) and the already-suppressed `image-size` (2). This branch reports only `image-size`. The six Scorecard advisories go to zero.
- **GitPython behavioural equivalence.** Ran the script's exact API path (`Repo`, `active_branch`, `commit`, `merge_base`, `commit.diff(..., R=True)`, `change_type`, `InvalidGitRepositoryError`) under both 3.1.58 and 3.1.61 over a 1366-file diff. Output was byte-identical.
- `pnpm install --frozen-lockfile` passes.
- `pnpm run webapp:prod` completes (bundle generated in 47s).
- `pnpm run check:vite-override` passes.
- `pip check` reports no broken requirements with `gitpython` 3.1.61 alongside the rest of the pin set.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Updated the GitPython dependency to a newer secure version.
  - Documented the minimum supported version required to address four known vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->