### PR TITLE
`Development`: Fix client warning by improving eslint rules

### DIFF
--- a/rules/enforce-cleanup-on-destroy.mjs
+++ b/rules/enforce-cleanup-on-destroy.mjs
@@ -3,14 +3,14 @@ import { ESLintUtils } from '@typescript-eslint/utils';
 const createRule = ESLintUtils.RuleCreator(() => '');
 
 /**
- * ESLint rule that enforces proper cleanup of resources in Angular component ngOnDestroy.
+ * ESLint rule that enforces proper cleanup of resources on Angular component teardown.
  *
  * Detects:
- * - MutationObserver / ResizeObserver / IntersectionObserver created without .disconnect() in ngOnDestroy
- * - addEventListener calls without removeEventListener in ngOnDestroy
- * - interact() calls without .unset() in ngOnDestroy
+ * - MutationObserver / ResizeObserver / IntersectionObserver created without .disconnect() on teardown
+ * - addEventListener calls without removeEventListener on teardown
+ * - interact() calls without .unset() on teardown
  * - Monaco disposable-returning calls (monaco.editor.create / createModel, monaco.languages.register*,
- *   editor.addAction) without a .dispose() in ngOnDestroy. These retain the editor/model — and its whole
+ *   editor.addAction) without a .dispose() on teardown. These retain the editor/model — and its whole
  *   detached DOM subtree — via Monaco's process-global registries until disposed (see PR #12976, where an
  *   undisposed editor.addCommand leaked every Monaco editor on navigation). The companion no-restricted-syntax
  *   rule bans editor.addCommand outright; this rule guards the disposables that are legitimate but must be
@@ -37,7 +37,7 @@ const rule = createRule({
             missingInteractUnset:
                 'interact() handler is created but never unset. Store the return value and call .unset() in ngOnDestroy() or in a DestroyRef.onDestroy() callback to prevent accumulated event handlers.',
             missingMonacoDispose:
-                "{{api}} returns a Monaco disposable that is never disposed. Store it and call .dispose() in ngOnDestroy() — otherwise the editor/model (and its detached DOM) is retained via Monaco's process-global registries (see PR #12976).",
+                "{{api}} returns a Monaco disposable that is never disposed. Store it and call .dispose() in ngOnDestroy() or in a DestroyRef.onDestroy() callback — otherwise the editor/model (and its detached DOM) is retained via Monaco's process-global registries (see PR #12976).",
         },
         schema: [],
     },
@@ -53,11 +53,53 @@ const rule = createRule({
         // callback. The checks below are text heuristics, so one accumulated string is all they need.
         let cleanupBody = '';
 
+        // Names bound to an actual DestroyRef, so that an unrelated object with an onDestroy() method is not
+        // mistaken for Angular's teardown hook. Filled while traversing and read back at Program:exit, because a
+        // field can be declared after the constructor that uses it.
+        const destroyRefBindings = new Set();
+        const onDestroyCalls = []; // { receiverName, callbackText } — resolved once every binding is known
+
         const observers = []; // { type, node }
         const addEventListenerCalls = []; // { eventName, node }
         const interactCalls = []; // { node }
         const monacoDisposables = []; // { api, node, namespaced }
         let referencesMonaco = false; // file uses the `monaco.*` namespace at least once
+
+        /** `inject(DestroyRef)`, the way every component here obtains one. */
+        function isDestroyRefValue(node) {
+            return node?.type === 'CallExpression' && node.callee?.name === 'inject' && node.arguments?.[0]?.name === 'DestroyRef';
+        }
+
+        /** A `: DestroyRef` annotation on a field, local or parameter. */
+        function isDestroyRefTypeAnnotation(node) {
+            return node?.typeAnnotation?.type === 'TSTypeReference' && node.typeAnnotation.typeName?.name === 'DestroyRef';
+        }
+
+        function addBinding(node) {
+            if (node?.type === 'Identifier') {
+                destroyRefBindings.add(node.name);
+            }
+        }
+
+        /**
+         * The name a receiver of `.onDestroy()` refers to: the identifier itself, the property behind `this.`, or
+         * `''` for a `inject(DestroyRef)` called in place. Returns undefined for anything that cannot be a DestroyRef.
+         */
+        function resolveReceiverName(receiver) {
+            if (!receiver) {
+                return undefined;
+            }
+            if (receiver.type === 'Identifier') {
+                return receiver.name;
+            }
+            if (receiver.type === 'MemberExpression' && receiver.object?.type === 'ThisExpression' && !receiver.computed) {
+                return receiver.property?.name;
+            }
+            if (isDestroyRefValue(receiver)) {
+                return '';
+            }
+            return undefined;
+        }
 
         return {
             // Collect ngOnDestroy method body text for checking cleanup calls
@@ -67,21 +109,39 @@ const rule = createRule({
                 }
             },
 
+            // Remember every name that holds a DestroyRef: `inject(DestroyRef)` initialisers and `: DestroyRef`
+            // annotations, whether on a field, a local or a constructor parameter.
+            PropertyDefinition(node) {
+                if (isDestroyRefValue(node.value) || isDestroyRefTypeAnnotation(node.typeAnnotation)) {
+                    addBinding(node.key);
+                }
+            },
+            VariableDeclarator(node) {
+                if (isDestroyRefValue(node.init) || isDestroyRefTypeAnnotation(node.id?.typeAnnotation)) {
+                    addBinding(node.id);
+                }
+            },
+            TSParameterProperty(node) {
+                if (isDestroyRefTypeAnnotation(node.parameter?.typeAnnotation)) {
+                    addBinding(node.parameter);
+                }
+            },
+            'MethodDefinition[kind="constructor"] > FunctionExpression > Identifier'(node) {
+                if (isDestroyRefTypeAnnotation(node.typeAnnotation)) {
+                    addBinding(node);
+                }
+            },
+
             // Collect DestroyRef.onDestroy(() => ...) callbacks, which run on teardown exactly like ngOnDestroy.
-            // Matched on the receiver name so an unrelated `.onDestroy()` on some other object is not mistaken
-            // for cleanup: Angular's own API is only ever reached through a DestroyRef.
+            // Resolved against the bindings above rather than the receiver's name, so that a `customDestroyRef`
+            // that is not a DestroyRef cannot silence the rule with an onDestroy() of its own.
             "CallExpression[callee.property.name='onDestroy']"(node) {
-                const receiver = node.callee.object;
-                if (!receiver) {
+                const receiverName = resolveReceiverName(node.callee.object);
+                if (receiverName === undefined) {
                     return;
                 }
-                const receiverText = context.sourceCode.getText(receiver);
-                if (!/destroyRef$/i.test(receiverText) && !/\bDestroyRef\b/.test(receiverText)) {
-                    return;
-                }
-                for (const argument of node.arguments) {
-                    cleanupBody += context.sourceCode.getText(argument);
-                }
+                const callbackText = node.arguments.map((argument) => context.sourceCode.getText(argument)).join('');
+                onDestroyCalls.push({ receiverName, callbackText });
             },
 
             // Detect new MutationObserver / ResizeObserver / IntersectionObserver
@@ -146,6 +206,14 @@ const rule = createRule({
 
             // At the end of the program, check if cleanup is present
             'Program:exit'() {
+                // Only now is every DestroyRef binding known, so the collected callbacks can be attributed.
+                // `''` is the marker for `inject(DestroyRef).onDestroy(...)`, which needs no binding at all.
+                for (const call of onDestroyCalls) {
+                    if (call.receiverName === '' || destroyRefBindings.has(call.receiverName)) {
+                        cleanupBody += call.callbackText;
+                    }
+                }
+
                 // Check observers
                 for (const obs of observers) {
                     if (!cleanupBody.includes('.disconnect()') && !cleanupBody.includes('disconnect()')) {
@@ -157,7 +225,7 @@ const rule = createRule({
                     }
                 }
 
-                // Check addEventListener — only report if removeEventListener is not in ngOnDestroy
+                // Check addEventListener — only report if removeEventListener is missing from every teardown scope
                 for (const listener of addEventListenerCalls) {
                     // Skip @HostListener-style calls (those on 'document' or 'window' objects managed by Angular)
                     const callee = listener.node.callee;
@@ -186,7 +254,7 @@ const rule = createRule({
                     }
                 }
 
-                // Check Monaco disposables — flag only when there is no .dispose() anywhere in ngOnDestroy (mirrors
+                // Check Monaco disposables — flag only when there is no .dispose() in any teardown scope (mirrors
                 // the .disconnect()/.unset() heuristics above). Editor-instance calls (addAction) are reported only
                 // when the file references the monaco namespace, to avoid matching unrelated .addAction() methods.
                 if (!cleanupBody.includes('.dispose()')) {

--- a/rules/enforce-cleanup-on-destroy.mjs
+++ b/rules/enforce-cleanup-on-destroy.mjs
@@ -16,6 +16,10 @@ const createRule = ESLintUtils.RuleCreator(() => '');
  *   rule bans editor.addCommand outright; this rule guards the disposables that are legitimate but must be
  *   torn down.
  *
+ * Cleanup counts wherever Angular runs it on teardown: the `ngOnDestroy` method, or a callback registered
+ * with `DestroyRef.onDestroy()`. The latter is the idiom the signal-based components here use, and treating
+ * only `ngOnDestroy` as cleanup reported them as leaks even though they tear down correctly.
+ *
  * Only checks Angular component files (.component.ts).
  */
 const rule = createRule({
@@ -23,13 +27,15 @@ const rule = createRule({
     meta: {
         type: 'problem',
         docs: {
-            description: 'Enforce cleanup of observers, event listeners, and interact.js handlers in ngOnDestroy',
+            description: 'Enforce cleanup of observers, event listeners, and interact.js handlers on component teardown',
         },
         messages: {
-            missingObserverDisconnect: '{{observerType}} is created but never disconnected. Store the observer and call .disconnect() in ngOnDestroy() to prevent memory leaks.',
+            missingObserverDisconnect:
+                '{{observerType}} is created but never disconnected. Store the observer and call .disconnect() in ngOnDestroy() or in a DestroyRef.onDestroy() callback to prevent memory leaks.',
             missingRemoveEventListener:
-                "addEventListener('{{eventName}}', ...) is called but the listener is not removed in ngOnDestroy(). Store the listener reference and call removeEventListener() in ngOnDestroy().",
-            missingInteractUnset: 'interact() handler is created but never unset. Store the return value and call .unset() in ngOnDestroy() to prevent accumulated event handlers.',
+                "addEventListener('{{eventName}}', ...) is called but the listener is not removed on teardown. Store the listener reference and call removeEventListener() in ngOnDestroy() or in a DestroyRef.onDestroy() callback.",
+            missingInteractUnset:
+                'interact() handler is created but never unset. Store the return value and call .unset() in ngOnDestroy() or in a DestroyRef.onDestroy() callback to prevent accumulated event handlers.',
             missingMonacoDispose:
                 "{{api}} returns a Monaco disposable that is never disposed. Store it and call .dispose() in ngOnDestroy() — otherwise the editor/model (and its detached DOM) is retained via Monaco's process-global registries (see PR #12976).",
         },
@@ -43,7 +49,9 @@ const rule = createRule({
             return {};
         }
 
-        let ngOnDestroyBody = '';
+        // Text of every teardown scope in the file: the ngOnDestroy body plus each DestroyRef.onDestroy()
+        // callback. The checks below are text heuristics, so one accumulated string is all they need.
+        let cleanupBody = '';
 
         const observers = []; // { type, node }
         const addEventListenerCalls = []; // { eventName, node }
@@ -55,7 +63,24 @@ const rule = createRule({
             // Collect ngOnDestroy method body text for checking cleanup calls
             "MethodDefinition[key.name='ngOnDestroy']"(node) {
                 if (node.value && node.value.body) {
-                    ngOnDestroyBody = context.sourceCode.getText(node.value.body);
+                    cleanupBody += context.sourceCode.getText(node.value.body);
+                }
+            },
+
+            // Collect DestroyRef.onDestroy(() => ...) callbacks, which run on teardown exactly like ngOnDestroy.
+            // Matched on the receiver name so an unrelated `.onDestroy()` on some other object is not mistaken
+            // for cleanup: Angular's own API is only ever reached through a DestroyRef.
+            "CallExpression[callee.property.name='onDestroy']"(node) {
+                const receiver = node.callee.object;
+                if (!receiver) {
+                    return;
+                }
+                const receiverText = context.sourceCode.getText(receiver);
+                if (!/destroyRef$/i.test(receiverText) && !/\bDestroyRef\b/.test(receiverText)) {
+                    return;
+                }
+                for (const argument of node.arguments) {
+                    cleanupBody += context.sourceCode.getText(argument);
                 }
             },
 
@@ -123,7 +148,7 @@ const rule = createRule({
             'Program:exit'() {
                 // Check observers
                 for (const obs of observers) {
-                    if (!ngOnDestroyBody.includes('.disconnect()') && !ngOnDestroyBody.includes('disconnect()')) {
+                    if (!cleanupBody.includes('.disconnect()') && !cleanupBody.includes('disconnect()')) {
                         context.report({
                             node: obs.node,
                             messageId: 'missingObserverDisconnect',
@@ -142,7 +167,7 @@ const rule = createRule({
                             continue;
                         }
                     }
-                    if (!ngOnDestroyBody.includes('removeEventListener')) {
+                    if (!cleanupBody.includes('removeEventListener')) {
                         context.report({
                             node: listener.node,
                             messageId: 'missingRemoveEventListener',
@@ -153,7 +178,7 @@ const rule = createRule({
 
                 // Check interact()
                 for (const call of interactCalls) {
-                    if (!ngOnDestroyBody.includes('.unset()') && !ngOnDestroyBody.includes('unset()')) {
+                    if (!cleanupBody.includes('.unset()') && !cleanupBody.includes('unset()')) {
                         context.report({
                             node: call.node,
                             messageId: 'missingInteractUnset',
@@ -164,7 +189,7 @@ const rule = createRule({
                 // Check Monaco disposables — flag only when there is no .dispose() anywhere in ngOnDestroy (mirrors
                 // the .disconnect()/.unset() heuristics above). Editor-instance calls (addAction) are reported only
                 // when the file references the monaco namespace, to avoid matching unrelated .addAction() methods.
-                if (!ngOnDestroyBody.includes('.dispose()')) {
+                if (!cleanupBody.includes('.dispose()')) {
                     for (const disposable of monacoDisposables) {
                         if (!disposable.namespaced && !referencesMonaco) {
                             continue;

--- a/rules/enforce-cleanup-on-destroy.spec.mjs
+++ b/rules/enforce-cleanup-on-destroy.spec.mjs
@@ -1,0 +1,100 @@
+import { describe, it } from 'vitest';
+import rule from './enforce-cleanup-on-destroy.mjs';
+import { createTypeScriptRuleTester } from './rule-tester.mjs';
+
+const ruleTester = createTypeScriptRuleTester();
+
+// The rule only looks at component files, so every case has to be named like one.
+const filename = 'src/main/webapp/app/example/example.component.ts';
+
+describe('enforce-cleanup-on-destroy', () => {
+    it('accepts cleanup in ngOnDestroy and in a DestroyRef.onDestroy callback alike', () => {
+        ruleTester.run('enforce-cleanup-on-destroy', rule, {
+            valid: [
+                // The classic lifecycle hook.
+                {
+                    filename,
+                    code: `
+                        class ExampleComponent {
+                            private observer = new ResizeObserver(() => {});
+                            ngOnDestroy() {
+                                this.observer.disconnect();
+                            }
+                        }
+                    `,
+                },
+                // DestroyRef.onDestroy runs on teardown exactly like ngOnDestroy, so it counts too. This is what
+                // the signal-based components use, and reporting it was the false positive this case pins down.
+                {
+                    filename,
+                    code: `
+                        class ExampleComponent {
+                            private readonly destroyRef = inject(DestroyRef);
+                            private observer = new ResizeObserver(() => {});
+                            constructor() {
+                                this.destroyRef.onDestroy(() => this.observer.disconnect());
+                            }
+                        }
+                    `,
+                },
+                // Registered on a locally held DestroyRef rather than through \`this\`.
+                {
+                    filename,
+                    code: `
+                        class ExampleComponent {
+                            constructor(destroyRef: DestroyRef) {
+                                const observer = new ResizeObserver(() => {});
+                                destroyRef.onDestroy(() => observer.disconnect());
+                            }
+                        }
+                    `,
+                },
+                // Listeners and interact() handlers torn down the same way.
+                {
+                    filename,
+                    code: `
+                        class ExampleComponent {
+                            private readonly destroyRef = inject(DestroyRef);
+                            constructor() {
+                                const el = document.querySelector('div')!;
+                                el.addEventListener('scroll', this.onScroll);
+                                this.destroyRef.onDestroy(() => el.removeEventListener('scroll', this.onScroll));
+                            }
+                        }
+                    `,
+                },
+                // A non-component file is out of scope entirely.
+                {
+                    filename: 'src/main/webapp/app/example/example.service.ts',
+                    code: `const observer = new ResizeObserver(() => {});`,
+                },
+            ],
+            invalid: [
+                // No teardown at all.
+                {
+                    filename,
+                    code: `
+                        class ExampleComponent {
+                            private observer = new ResizeObserver(() => {});
+                        }
+                    `,
+                    errors: [{ messageId: 'missingObserverDisconnect' }],
+                },
+                // An \`onDestroy\` on something that is not a DestroyRef must not be mistaken for cleanup,
+                // otherwise the rule could be silenced by an unrelated method of the same name.
+                {
+                    filename,
+                    code: `
+                        class ExampleComponent {
+                            private observer = new ResizeObserver(() => {});
+                            constructor(private readonly editor: SomeEditor) {
+                                this.editor.onDestroy(() => this.observer.disconnect());
+                            }
+                        }
+                    `,
+                    errors: [{ messageId: 'missingObserverDisconnect' }],
+                },
+            ],
+        });
+    });
+});

--- a/rules/enforce-cleanup-on-destroy.spec.mjs
+++ b/rules/enforce-cleanup-on-destroy.spec.mjs
@@ -63,6 +63,32 @@ describe('enforce-cleanup-on-destroy', () => {
                         }
                     `,
                 },
+                // A DestroyRef obtained and used in one expression.
+                {
+                    filename,
+                    code: `
+                        class ExampleComponent {
+                            private observer = new ResizeObserver(() => {});
+                            constructor() {
+                                inject(DestroyRef).onDestroy(() => this.observer.disconnect());
+                            }
+                        }
+                    `,
+                },
+                // The field is declared after the constructor that registers on it, so the binding can only be
+                // resolved once the whole file has been walked.
+                {
+                    filename,
+                    code: `
+                        class ExampleComponent {
+                            constructor() {
+                                this.destroyRef.onDestroy(() => this.observer.disconnect());
+                            }
+                            private readonly destroyRef = inject(DestroyRef);
+                            private observer = new ResizeObserver(() => {});
+                        }
+                    `,
+                },
                 // A non-component file is out of scope entirely.
                 {
                     filename: 'src/main/webapp/app/example/example.service.ts',
@@ -89,6 +115,21 @@ describe('enforce-cleanup-on-destroy', () => {
                             private observer = new ResizeObserver(() => {});
                             constructor(private readonly editor: SomeEditor) {
                                 this.editor.onDestroy(() => this.observer.disconnect());
+                            }
+                        }
+                    `,
+                    errors: [{ messageId: 'missingObserverDisconnect' }],
+                },
+                // A name that merely looks like a DestroyRef is not one. Its \`onDestroy\` may store the callback
+                // and never call it, so the observer is still leaked.
+                {
+                    filename,
+                    code: `
+                        class ExampleComponent {
+                            private readonly customDestroyRef = new CustomLifecycle();
+                            private observer = new ResizeObserver(() => {});
+                            constructor() {
+                                this.customDestroyRef.onDestroy(() => this.observer.disconnect());
                             }
                         }
                     `,

--- a/src/main/webapp/app/course/manage/services/course-management.service.spec.ts
+++ b/src/main/webapp/app/course/manage/services/course-management.service.spec.ts
@@ -307,6 +307,8 @@ describe('Course Management Service', () => {
         req.flush(null);
     });
 
+    // `findOneForDashboard` is deprecated for the web client but the endpoint stays for the iOS, Android and
+    // VS Code clients, so these three tests are the only remaining coverage of it and have to keep calling it.
     it('should find one course for dashboard', () => {
         returnedFromService = { ...courseForDashboard };
         courseStorageService
@@ -316,6 +318,7 @@ describe('Course Management Service', () => {
                 expect(updatedCourse).toEqual(course);
             });
         courseManagementService
+            // eslint-disable-next-line @typescript-eslint/no-deprecated -- see the note above this test
             .findOneForDashboard(course.id!)
             .pipe(take(1))
             .subscribe((res) => expect(res.body).toEqual(course));
@@ -323,6 +326,7 @@ describe('Course Management Service', () => {
     });
 
     it('should pass on an empty response body when fetching one course for dashboard and there is no response body sent from the server', () => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- see the note on the test above
         courseManagementService.findOneForDashboard(course.id!).subscribe((res) => expect(res.body).toBeNull());
 
         const req = httpMock.expectOne({ method: 'GET', url: `${resourceUrl}/${course.id}/for-dashboard` });
@@ -335,6 +339,7 @@ describe('Course Management Service', () => {
         const setParticipationResultsSpy = vi.spyOn(scoresStorageService, 'setStoredParticipationResults');
         const setAchievedGroupPointsSpy = vi.spyOn(scoresStorageService, 'setStoredAchievedPointsPerVariantGroup');
         courseManagementService
+            // eslint-disable-next-line @typescript-eslint/no-deprecated -- see the note two tests above
             .findOneForDashboard(course.id!)
             .pipe(take(1))
             .subscribe(() => {


### PR DESCRIPTION
### Summary

Five of the client's 47 ESLint warnings were not defects. Two were false positives of `localRules/enforce-cleanup-on-destroy`, which only recognised an `ngOnDestroy` method and so reported components that tear down in a `DestroyRef.onDestroy()` callback as leaking. Three were specs covering an endpoint that is deliberately kept. The rule now understands both teardown idioms, and the deliberate calls are marked. 47 warnings down to 42.

### Checklist

- [x] Verified the rule change with a new rule spec, in both directions.
- [x] Ran the affected client suites and the rule suite.
- [x] Followed the client coding conventions.

### Motivation and Context

`enforce-cleanup-on-destroy` collects cleanup text from `MethodDefinition[key.name='ngOnDestroy']` only. `ExerciseActionBarComponent` registers its teardown on the injected `DestroyRef`, which is the idiom the signal-based components here use, so both of its `ResizeObserver`s were reported as never disconnected even though both are disconnected on destroy. A rule that pushes new code back to `ngOnDestroy` works against the direction the client is moving in.

The three `findOneForDashboard` warnings are a different case. That method carries `@deprecated The web client no longer uses this ... The endpoint stays for the iOS, Android and VS Code clients. Do not add new callers.` It is intentionally retained, so the specs covering it are correct and are its only remaining coverage. They are marked rather than removed.

### Description

- `rules/enforce-cleanup-on-destroy.mjs`: also collect callbacks passed to `DestroyRef.onDestroy()` as teardown. The receiver has to be a name the file binds to a `DestroyRef`, through `inject(DestroyRef)` or a `DestroyRef` type annotation on a field, a local or a constructor parameter, so an unrelated `onDestroy` method on some other object cannot silence the rule. The calls are attributed at `Program:exit`, once every binding is known, so a field declared after the constructor that registers on it still counts. Messages and the rule description now name both places.
- `rules/enforce-cleanup-on-destroy.spec.mjs`: new. Covers cleanup in `ngOnDestroy`, cleanup through `this.destroyRef`, through a locally held `DestroyRef` and through an `inject(DestroyRef)` called in place, a field declared after its use, an `addEventListener` torn down the same way, no cleanup at all, and the two guards that an `onDestroy` on something which is not a `DestroyRef` is still reported, including one whose name ends in `destroyRef`.
- `course-management.service.spec.ts`: one note explaining why the endpoint is kept, plus a line-level disable at each of the three call sites.

No production code changes.

### Steps for Testing

1. Run `pnpm run test:rules`.
2. Run `pnpm exec eslint src/main/webapp src/test/javascript` and confirm 42 warnings, none of them `enforce-cleanup-on-destroy`.
3. Confirm the action bar still collapses its buttons correctly when the window is resized, and that resizing after leaving the page logs nothing.

### Validation

- `pnpm run test:rules`: 18 files, 98 tests pass (was 17 and 97).
- ESLint on the client: 42 warnings, 0 errors, down from 47. The delta is exactly the five addressed here, so nothing new was introduced and no other rule output changed.
- `course-management.service.spec.ts` and `exercise-action-bar.component.spec.ts`: 60 of 60 pass.
- Prettier passes on the changed files.

Checked both `ResizeObserver`s by hand before changing the rule: the field observer is disconnected in the constructor's `destroyRef.onDestroy`, and the one created in `afterNextRender` is disconnected through its own `destroyRef.onDestroy`. Neither leaks.

### What this PR does not do

The other 42 warnings are one migration in flight, not warnings to fix: `CompetencySelectionComponent` (25), `ExerciseTitleChannelNameComponent` (11) and `TitleChannelNameComponent` (6) each already have a PrimeNG successor, and `findOneForDashboard` is the deliberate case above. Finishing those three migrations clears the list.

### Review Progress

- [x] Code review
- [x] Verified locally

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-05 23:26:24 UTC_

