### PR TITLE
`Development`: Clear the mechanical Java deprecations

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/RedisDiscoveryEnvironmentPostProcessor.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/RedisDiscoveryEnvironmentPostProcessor.java
@@ -4,8 +4,8 @@ import static de.tum.cit.aet.artemis.core.config.Constants.REDIS;
 
 import java.util.Map;
 
+import org.springframework.boot.EnvironmentPostProcessor;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SpringAIConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SpringAIConfiguration.java
@@ -85,8 +85,8 @@ public class SpringAIConfiguration {
         }
 
         for (ChatModel model : chatModels) {
-            if (model.getDefaultOptions() != null) {
-                log.info("Found Chat Model: {} with options: {}", model.getDefaultOptions().getModel(), model.getDefaultOptions());
+            if (model.getOptions() != null) {
+                log.info("Found Chat Model: {} with options: {}", model.getOptions().getModel(), model.getOptions());
             }
             else {
                 log.info("Found Chat Model: {} with no default options", model);

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SpringAIConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SpringAIConfiguration.java
@@ -89,7 +89,7 @@ public class SpringAIConfiguration {
                 log.info("Found Chat Model: {} with options: {}", model.getOptions().getModel(), model.getOptions());
             }
             else {
-                log.info("Found Chat Model: {} with no default options", model);
+                log.info("Found Chat Model: {} with no options", model);
             }
         }
         ChatModel chatModel = chatModels.getFirst(); // Use the first available model

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,7 +1,7 @@
 org.springframework.boot.autoconfigure.AutoConfigurationImportFilter=\
 de.tum.cit.aet.artemis.core.config.SpringAIAutoConfigurationFilter
 
-org.springframework.boot.env.EnvironmentPostProcessor=\
+org.springframework.boot.EnvironmentPostProcessor=\
 de.tum.cit.aet.artemis.core.config.RedisDiscoveryEnvironmentPostProcessor
 
 org.springframework.boot.diagnostics.FailureAnalyzer=\

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/AtlasAgentDelegationServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/AtlasAgentDelegationServiceTest.java
@@ -60,7 +60,6 @@ class AtlasAgentDelegationServiceTest {
     @BeforeEach
     void setUp() {
         // Since Spring AI 2.0.0-M6 the ChatClient merges request options into the model's default options, which must be non-null.
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/service/AtlasAgentServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/service/AtlasAgentServiceTest.java
@@ -89,7 +89,6 @@ class AtlasAgentServiceTest {
     void setUp() {
         // Since Spring AI 2.0.0-M6 the ChatClient merges request options into the model's default
         // options, which must be non-null (lenient: not every nested test exercises the chat path).
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         previewService = new AtlasAgentPreviewService(chatMemory);

--- a/src/test/java/de/tum/cit/aet/artemis/atlas/web/CompetencyOrchestrationResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/atlas/web/CompetencyOrchestrationResourceIntegrationTest.java
@@ -120,7 +120,7 @@ class CompetencyOrchestrationResourceIntegrationTest extends AbstractAtlasIntegr
         ProgrammingExercise examExercise = programmingExerciseUtilService.addEnrolledCourseExamExerciseGroupWithOneProgrammingExercise(TEST_PREFIX);
 
         request.performMvcRequest(post("/api/atlas/orchestrator/exercises/{exerciseId}/run", examExercise.getId()).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isUnprocessableEntity()).andExpect(jsonPath("$.status").value("FAILED")).andExpect(jsonPath("$.failureReason").value("UNSUPPORTED_EXERCISE"));
+                .andExpect(status().isUnprocessableContent()).andExpect(jsonPath("$.status").value("FAILED")).andExpect(jsonPath("$.failureReason").value("UNSUPPORTED_EXERCISE"));
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/communication/MaintenanceEmailIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/MaintenanceEmailIntegrationTest.java
@@ -2,7 +2,7 @@ package de.tum.cit.aet.artemis.communication;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -95,7 +95,7 @@ class MaintenanceEmailIntegrationTest extends AbstractSpringIntegrationIndepende
         mailEnabledProperties.getMail().setFrom("test@greenmail.test");
 
         testMailService = new MailSendingService(mailEnabledProperties, greenMailSender, mainMessageSource, testTemplateEngine);
-        ReflectionTestUtils.setField(testMailService, "artemisServerUrl", new URL("http://localhost:9000"));
+        ReflectionTestUtils.setField(testMailService, "artemisServerUrl", URI.create("http://localhost:9000").toURL());
 
         recipient = new User();
         recipient.setEmail("instructor@greenmail.test");

--- a/src/test/java/de/tum/cit/aet/artemis/core/CourseRequestEmailIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/CourseRequestEmailIntegrationTest.java
@@ -2,7 +2,7 @@ package de.tum.cit.aet.artemis.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Map;
@@ -87,7 +87,7 @@ class CourseRequestEmailIntegrationTest extends AbstractSpringIntegrationIndepen
         mailEnabledProperties.getMail().setFrom("test@greenmail.test");
 
         testMailService = new MailSendingService(mailEnabledProperties, greenMailSender, mainMessageSource, testTemplateEngine);
-        ReflectionTestUtils.setField(testMailService, "artemisServerUrl", new URL("http://localhost:9000"));
+        ReflectionTestUtils.setField(testMailService, "artemisServerUrl", URI.create("http://localhost:9000").toURL());
 
         recipient = new User();
         recipient.setEmail("requester@greenmail.test");

--- a/src/test/java/de/tum/cit/aet/artemis/core/FileIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/FileIntegrationTest.java
@@ -480,7 +480,7 @@ class FileIntegrationTest extends AbstractSpringIntegrationIndependentTest {
         MockMultipartFile file = new MockMultipartFile("file", "image.png", "image/png", largeContent);
 
         request.postWithMultipartFile("/api/core/files/courses/" + course.getId() + "/conversations/" + conversation.getId(), file.getOriginalFilename(), "file", file,
-                JsonNode.class, HttpStatus.PAYLOAD_TOO_LARGE);
+                JsonNode.class, HttpStatus.CONTENT_TOO_LARGE);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/core/config/SpringFactoriesRegistrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/config/SpringFactoriesRegistrationTest.java
@@ -1,0 +1,47 @@
+package de.tum.cit.aet.artemis.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.EnvironmentPostProcessor;
+
+/**
+ * Guards the entry of {@code META-INF/spring.factories} that Spring resolves by interface name.
+ * <p>
+ * A key that no longer matches the interface fails silently: the class is never loaded, and the application starts and
+ * behaves normally until whatever it configured is needed. {@link EnvironmentPostProcessor} moved from
+ * {@code org.springframework.boot.env} to {@code org.springframework.boot} in Spring Boot 4.1, which is exactly the
+ * kind of change that leaves such an entry pointing at nothing. Asserting against the compiled interface name rather
+ * than a literal means the next move is caught here instead of in production.
+ */
+class SpringFactoriesRegistrationTest {
+
+    @Test
+    void shouldRegisterTheRedisDiscoveryEnvironmentPostProcessorUnderTheInterfaceSpringReads() throws IOException {
+        String registeredClass = RedisDiscoveryEnvironmentPostProcessor.class.getName();
+        List<String> keysDeclaringIt = new ArrayList<>();
+
+        for (URL resource : Collections.list(getClass().getClassLoader().getResources("META-INF/spring.factories"))) {
+            Properties factories = new Properties();
+            try (InputStream stream = resource.openStream()) {
+                factories.load(stream);
+            }
+            factories.forEach((key, value) -> {
+                if (value.toString().contains(registeredClass)) {
+                    keysDeclaringIt.add(key.toString());
+                }
+            });
+        }
+
+        assertThat(keysDeclaringIt).as("%s must be declared exactly once, under the interface Spring Boot actually reads", registeredClass)
+                .containsExactly(EnvironmentPostProcessor.class.getName());
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadSubmissionIntegrationTest.java
@@ -626,7 +626,7 @@ class FileUploadSubmissionIntegrationTest extends AbstractFileUploadIntegrationT
         final MockMultipartFile tooLargeFile = new MockMultipartFile("file", "file.png", "application/json", new String(charsTooLarge).getBytes());
         request.postWithMultipartFile("/api/fileupload/exercises/" + releasedFileUploadExercise.getId() + "/file-upload-submissions",
                 submissionInput(submittedFileUploadSubmission, releasedFileUploadExercise.getId()), "submission", tooLargeFile, FileUploadSubmissionDTO.class,
-                HttpStatus.PAYLOAD_TOO_LARGE);
+                HttpStatus.CONTENT_TOO_LARGE);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionChecklistServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionChecklistServiceTest.java
@@ -68,8 +68,7 @@ class HyperionChecklistServiceTest {
 
     @BeforeEach
     void setup() {
-        // Since Spring AI 2.0 the ChatClient merges request options into the model's options (getOptions since RC1, getDefaultOptions before), which must be non-null
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+        // Since Spring AI 2.0 the ChatClient merges request options into the model's options, which must be non-null
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
 

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionCompetencyContextServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionCompetencyContextServiceTest.java
@@ -71,8 +71,7 @@ class HyperionCompetencyContextServiceTest {
     void setup() {
         mocks = MockitoAnnotations.openMocks(this);
         var templateService = new HyperionPromptTemplateService();
-        // Since Spring AI 2.0 the ChatClient merges request options into the model's options (getOptions since RC1, getDefaultOptions before), which must be non-null
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+        // Since Spring AI 2.0 the ChatClient merges request options into the model's options, which must be non-null
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         service = new HyperionCompetencyContextService(Optional.of(courseCompetencyApi), Optional.of(competencyRelationApi), Optional.of(irisLectureSearchApi),

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionConsistencyCheckServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionConsistencyCheckServiceTest.java
@@ -86,8 +86,7 @@ class HyperionConsistencyCheckServiceTest {
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
-        // Since Spring AI 2.0 the ChatClient merges request options into the model's options (getOptions since RC1, getDefaultOptions before), which must be non-null
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+        // Since Spring AI 2.0 the ChatClient merges request options into the model's options, which must be non-null
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         var templateService = new HyperionPromptTemplateService();

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionFaqRewriteServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionFaqRewriteServiceTest.java
@@ -44,8 +44,7 @@ class HyperionFaqRewriteServiceTest {
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
-        // Since Spring AI 2.0 the ChatClient merges request options into the model's options (getOptions since RC1, getDefaultOptions before), which must be non-null
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+        // Since Spring AI 2.0 the ChatClient merges request options into the model's options, which must be non-null
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         var templateService = new HyperionPromptTemplateService();

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionProblemStatementGenerationServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionProblemStatementGenerationServiceTest.java
@@ -48,8 +48,7 @@ class HyperionProblemStatementGenerationServiceTest {
     @BeforeEach
     void setup() {
         mocks = MockitoAnnotations.openMocks(this);
-        // Since Spring AI 2.0 the ChatClient merges request options into the model's options (getOptions since RC1, getDefaultOptions before), which must be non-null
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+        // Since Spring AI 2.0 the ChatClient merges request options into the model's options, which must be non-null
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         var templateService = new HyperionPromptTemplateService();

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionProblemStatementRefinementServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionProblemStatementRefinementServiceTest.java
@@ -49,8 +49,7 @@ class HyperionProblemStatementRefinementServiceTest {
     @BeforeEach
     void setup() {
         mocks = MockitoAnnotations.openMocks(this);
-        // Since Spring AI 2.0 the ChatClient merges request options into the model's options (getOptions since RC1, getDefaultOptions before), which must be non-null
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+        // Since Spring AI 2.0 the ChatClient merges request options into the model's options, which must be non-null
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         var templateService = new HyperionPromptTemplateService();

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionProblemStatementRewriteServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/HyperionProblemStatementRewriteServiceTest.java
@@ -44,8 +44,7 @@ class HyperionProblemStatementRewriteServiceTest {
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
-        // Since Spring AI 2.0 the ChatClient merges request options into the model's options (getOptions since RC1, getDefaultOptions before), which must be non-null
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+        // Since Spring AI 2.0 the ChatClient merges request options into the model's options, which must be non-null
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         var templateService = new HyperionPromptTemplateService();

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionCodeGenerationStrategyTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionCodeGenerationStrategyTest.java
@@ -68,7 +68,7 @@ class HyperionCodeGenerationServiceTest {
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
-        // ChatClient merges request options into the model's options, so the mocked ChatModel must return non-null options from both getters.
+        // ChatClient merges request options into the model's options, so the mocked ChatModel must return non-null options from getOptions().
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.builder(chatModel).defaultAdvisors(ChatModelCallAdvisor.builder().chatModel(chatModel).build()).build();
         this.strategy = new TestCodeGenerationStrategy(chatClient, templates, llmTokenUsageService);

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionCodeGenerationStrategyTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionCodeGenerationStrategyTest.java
@@ -69,7 +69,6 @@ class HyperionCodeGenerationServiceTest {
     void setup() {
         MockitoAnnotations.openMocks(this);
         // ChatClient merges request options into the model's options, so the mocked ChatModel must return non-null options from both getters.
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.builder(chatModel).defaultAdvisors(ChatModelCallAdvisor.builder().chatModel(chatModel).build()).build();
         this.strategy = new TestCodeGenerationStrategy(chatClient, templates, llmTokenUsageService);

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionSolutionRepositoryTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionSolutionRepositoryTest.java
@@ -66,7 +66,6 @@ class HyperionSolutionRepositoryServiceTest {
     void setup() {
         MockitoAnnotations.openMocks(this);
         // ChatClient merges request options into the model's options, so the mocked ChatModel must return non-null options from both getters.
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         this.solutionRepository = new HyperionSolutionRepositoryService(chatClient, templates, gitService, contextRenderer, llmTokenUsageService);

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionSolutionRepositoryTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionSolutionRepositoryTest.java
@@ -65,7 +65,7 @@ class HyperionSolutionRepositoryServiceTest {
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
-        // ChatClient merges request options into the model's options, so the mocked ChatModel must return non-null options from both getters.
+        // ChatClient merges request options into the model's options, so the mocked ChatModel must return non-null options from getOptions().
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         this.solutionRepository = new HyperionSolutionRepositoryService(chatClient, templates, gitService, contextRenderer, llmTokenUsageService);

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionTemplateRepositoryTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionTemplateRepositoryTest.java
@@ -70,7 +70,7 @@ class HyperionTemplateRepositoryServiceTest {
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
-        // ChatClient merges request options into the model's options, so the mocked ChatModel must return non-null options from both getters.
+        // ChatClient merges request options into the model's options, so the mocked ChatModel must return non-null options from getOptions().
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         this.templateRepository = new HyperionTemplateRepositoryService(chatClient, templates, gitService, contextRenderer, llmTokenUsageService);

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionTemplateRepositoryTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionTemplateRepositoryTest.java
@@ -71,7 +71,6 @@ class HyperionTemplateRepositoryServiceTest {
     void setup() {
         MockitoAnnotations.openMocks(this);
         // ChatClient merges request options into the model's options, so the mocked ChatModel must return non-null options from both getters.
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         this.templateRepository = new HyperionTemplateRepositoryService(chatClient, templates, gitService, contextRenderer, llmTokenUsageService);

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionTestRepositoryTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionTestRepositoryTest.java
@@ -67,7 +67,7 @@ class HyperionTestRepositoryServiceTest {
     @BeforeEach
     void setup() {
         MockitoAnnotations.openMocks(this);
-        // ChatClient merges request options into the model's options, so the mocked ChatModel must return non-null options from both getters.
+        // ChatClient merges request options into the model's options, so the mocked ChatModel must return non-null options from getOptions().
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         this.testRepository = new HyperionTestRepositoryService(chatClient, templates, gitService, contextRenderer, llmTokenUsageService);

--- a/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionTestRepositoryTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/hyperion/service/codegeneration/HyperionTestRepositoryTest.java
@@ -68,7 +68,6 @@ class HyperionTestRepositoryServiceTest {
     void setup() {
         MockitoAnnotations.openMocks(this);
         // ChatClient merges request options into the model's options, so the mocked ChatModel must return non-null options from both getters.
-        lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
         lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         ChatClient chatClient = ChatClient.create(chatModel);
         this.testRepository = new HyperionTestRepositoryService(chatClient, templates, gitService, contextRenderer, llmTokenUsageService);

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisDashboardEmailIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisDashboardEmailIntegrationTest.java
@@ -2,7 +2,7 @@ package de.tum.cit.aet.artemis.iris;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
@@ -72,10 +72,10 @@ class IrisDashboardEmailIntegrationTest extends AbstractSpringIntegrationIndepen
         mailEnabledProperties.getMail().setFrom("test@greenmail.test");
 
         var testMailSendingService = new MailSendingService(mailEnabledProperties, greenMailSender, mainMessageSource, testTemplateEngine);
-        ReflectionTestUtils.setField(testMailSendingService, "artemisServerUrl", new URL("http://localhost:9000"));
+        ReflectionTestUtils.setField(testMailSendingService, "artemisServerUrl", URI.create("http://localhost:9000").toURL());
 
         testMailService = new MailService(mainMessageSource, testTemplateEngine, testMailSendingService);
-        ReflectionTestUtils.setField(testMailService, "artemisServerUrl", new URL("http://localhost:9000"));
+        ReflectionTestUtils.setField(testMailService, "artemisServerUrl", URI.create("http://localhost:9000").toURL());
 
         recipient = new MailRecipientDTO("admin@greenmail.test", "en", "iris-dashboard-recipient", "Administrator", null, null, null);
     }

--- a/src/test/java/de/tum/cit/aet/artemis/notification/notifications/service/CourseNotificationEmailIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/notifications/service/CourseNotificationEmailIntegrationTest.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.notification.notifications.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
@@ -50,7 +51,7 @@ class CourseNotificationEmailIntegrationTest extends AbstractSpringIntegrationIn
 
     static {
         try {
-            SERVER_URL = new URL("http://localhost:9000");
+            SERVER_URL = URI.create("http://localhost:9000").toURL();
         }
         catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/test/java/de/tum/cit/aet/artemis/notification/notifications/service/MailServiceEmailIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/notifications/service/MailServiceEmailIntegrationTest.java
@@ -2,7 +2,7 @@ package de.tum.cit.aet.artemis.notification.notifications.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.URL;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -86,10 +86,10 @@ class MailServiceEmailIntegrationTest extends AbstractSpringIntegrationIndepende
         mailEnabledProperties.getMail().setFrom("test@greenmail.test");
 
         testMailSendingService = new MailSendingService(mailEnabledProperties, greenMailSender, mainMessageSource, testTemplateEngine);
-        ReflectionTestUtils.setField(testMailSendingService, "artemisServerUrl", new URL("http://localhost:9000"));
+        ReflectionTestUtils.setField(testMailSendingService, "artemisServerUrl", URI.create("http://localhost:9000").toURL());
 
         testMailService = new MailService(mainMessageSource, testTemplateEngine, testMailSendingService);
-        ReflectionTestUtils.setField(testMailService, "artemisServerUrl", new URL("http://localhost:9000"));
+        ReflectionTestUtils.setField(testMailService, "artemisServerUrl", URI.create("http://localhost:9000").toURL());
 
         recipient = new User();
         recipient.setEmail("user@greenmail.test");

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/MockDelegate.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/MockDelegate.java
@@ -37,12 +37,6 @@ public interface MockDelegate {
     void mockGetRepositorySlugFromRepositoryUri(String repositorySlug, VcsRepositoryUri repositoryUri);
 
     @Deprecated
-    void mockGetProjectKeyFromRepositoryUri(String projectKey, VcsRepositoryUri repositoryUri);
-
-    @Deprecated
-    void mockGetRepositoryPathFromRepositoryUri(String projectPath, VcsRepositoryUri repositoryUri);
-
-    @Deprecated
     void mockGetProjectKeyFromAnyUrl(String projectKey);
 
     void mockCopyBuildPlan(ProgrammingExerciseStudentParticipation participation) throws Exception;

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractArtemisIntegrationTest.java
@@ -252,16 +252,6 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
     }
 
     @Override
-    public void mockGetProjectKeyFromRepositoryUri(String projectKey, VcsRepositoryUri repositoryUri) {
-        doReturn(projectKey).when(uriService).getProjectKeyFromRepositoryUri(repositoryUri);
-    }
-
-    @Override
-    public void mockGetRepositoryPathFromRepositoryUri(String projectPath, VcsRepositoryUri repositoryUri) {
-        doReturn(projectPath).when(uriService).getRepositoryPathFromRepositoryUri(repositoryUri);
-    }
-
-    @Override
     public void mockGetProjectKeyFromAnyUrl(String projectKey) {
         doReturn(projectKey).when(uriService).getProjectKeyFromRepositoryUri(any());
     }

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationIndependentTestBase.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationIndependentTestBase.java
@@ -109,8 +109,7 @@ public abstract class AbstractSpringIntegrationIndependentTestBase extends Abstr
     protected void setupSpringAIMocks() {
         if (chatModel != null) {
             when(chatModel.call(any(Prompt.class))).thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage("Mocked AI response for testing")))));
-            // Since Spring AI 2.0 the ChatClient merges request options into the model's options (getOptions since RC1, getDefaultOptions before), which must be non-null
-            when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+            // Since Spring AI 2.0 the ChatClient merges request options into the model's options, which must be non-null
             when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
         }
         // Mock passkey authentication to always return true for super admin operations in tests

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationLocalCILocalVCTestBase.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationLocalCILocalVCTestBase.java
@@ -209,9 +209,8 @@ public abstract class AbstractSpringIntegrationLocalCILocalVCTestBase extends Ab
     }
 
     @BeforeEach
-    void stubChatModelDefaultOptions() {
-        // Since Spring AI 2.0 the ChatClient merges request options into the model's options (getOptions since RC1, getDefaultOptions before), which must be non-null
-        Mockito.when(azureOpenAiChatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
+    void stubChatModelOptions() {
+        // Since Spring AI 2.0 the ChatClient merges request options into the model's options, which must be non-null
         Mockito.when(azureOpenAiChatModel.getOptions()).thenReturn(ChatOptions.builder().build());
     }
 


### PR DESCRIPTION
### Summary

Clears the Java deprecations whose replacement is unambiguous, and settles the Spring AI question: 2.0.1 is already the current release, so there is nothing to upgrade. The compiler goes from 92 distinct warning sites to 65.

### Checklist

- [x] Checked the actual replacement for each deprecation rather than assuming one.
- [x] Ran the affected server tests.
- [x] Followed the server coding conventions.

### Motivation and Context

`javac` reports 92 distinct deprecation sites on `develop`, 33 of them `[removal]`, which become compile errors on the next major. This PR takes the ones that are a rename or a package move and leaves the ones that need a decision.

**Spring AI is already current.** `spring-ai-bom` is pinned at `2.0.1`, and Maven Central lists `2.0.1` as both `latest` and `release`, so no upgrade is needed. `ChatModel.getDefaultOptions()` was renamed to `getOptions()` in 2.0.0-RC1 and the old name is marked for removal.

The interesting part is that the 15 tests stubbing it were already stubbing both:

```java
lenient().when(chatModel.getDefaultOptions()).thenReturn(ChatOptions.builder().build());
lenient().when(chatModel.getOptions()).thenReturn(ChatOptions.builder().build());
```

`DefaultChatClient` only ever calls `getOptions()`, so the first line was a pre-RC1 leftover that the `lenient()` kept from failing as unused. It is removed rather than renamed, which would have produced a duplicate stub.

### Description

- `SpringAIConfiguration`: read `getOptions()`.
- 15 test classes: drop the redundant `getDefaultOptions()` stub and trim the comment that explained the rename. `AbstractSpringIntegrationLocalCILocalVCTestBase.stubChatModelDefaultOptions` is renamed to `stubChatModelOptions` so the name still describes what it does.
- Seven tests: `new URL(String)` becomes `URI.create(...).toURL()`. Both throw `MalformedURLException`, so no signature changes.
- `HttpStatus.PAYLOAD_TOO_LARGE` becomes `CONTENT_TOO_LARGE` (2 sites) and `status().isUnprocessableEntity()` becomes `isUnprocessableContent()` (1 site), the RFC 9110 names.
- `RedisDiscoveryEnvironmentPostProcessor` implements `org.springframework.boot.EnvironmentPostProcessor`, and the `spring.factories` key moves with it.
- `MockDelegate.mockGetProjectKeyFromRepositoryUri` and `mockGetRepositoryPathFromRepositoryUri`, both deprecated with no callers, are removed along with their implementations.

### Steps for Testing

1. `./gradlew compileJava compileTestJava -x webapp --warning-mode all --rerun-tasks` and count the warnings.
2. Run the Hyperion and Atlas agent suites, which are the Spring AI callers.
3. Start the server with `artemis.distributed-data.provider=Redis` and confirm it still comes up, which is what the moved post-processor guards.

### Validation

- Compiler warnings: **92 distinct sites down to 65**, measured with `--rerun-tasks` on both sides so the two numbers are comparable. Gradle only re-emits warnings for files it recompiles, so an incremental build gives a misleading count.
- `*Hyperion*` and `*AtlasAgent*Test`: pass.
- `*EmailIntegrationTest`, `*FileIntegrationTest`, `*FileUploadSubmissionIntegrationTest`, `*CompetencyOrchestrationResourceIntegrationTest`: 180 of 180 pass.
- `spotlessCheck` and `checkstyleMain` pass.
- The `spring.factories` move was checked against Spring Boot 4.1's own `spring.factories`, which registers its five environment post-processors under exactly `org.springframework.boot.EnvironmentPostProcessor=`. Boot's `SpringFactoriesEnvironmentPostProcessorsFactory` reads both the old and the new key, so the class and the key were moved together rather than one at a time.
- `SpringFactoriesRegistrationTest` is new and guards that key. It is the one change here that can fail silently: a key resolved by name that no longer matches the interface loads nothing, and the application starts normally until the Redis discovery configuration is needed. The test asserts the literal key against the compiled interface name, so the next package move is caught here rather than in a deployment; it fails when the key is set back to the pre-4.1 package, which is how it was verified.

### Deliberately not included

Each of these was looked at and left alone, with a reason:

- **`MappingJackson2*` converters (15 sites, `[removal]`).** The only cluster with a real deadline, and the one that needs care: `WebsocketConfiguration` and the `GzipMessageConverter` subclass carry custom behaviour. Worth its own PR.
- **`Lecture.getAttachments` and friends (21 sites).** A model migration to attachment units, not a rename.
- **`CORE_PREFIX` (8 sites).** The `api/core/` compatibility window for deployed clients, with a `TODO: Remove ... once external clients have migrated`. A product decision.
- **`softDeleteUser` (4 sites).** Called only from three tests after the move to permanent deletion, so it is removable, but that means rewriting those tests and belongs with the deletion work.
- **`Saml2AuthenticatedPrincipal` (8 sites).** Production login path, not testable here without an identity provider.
- **`setRoleHierarchy` (1).** A Spring Security configuration change on the authorization path.
- **`PostgreSQLContainer` (1).** Comes from Zonky's `PostgreSQLContainerCustomizer` signature, not from our code, so it cannot be fixed here.
- **JPlag `getLength()` (1).** Needs a semantic decision about which length the DTO wants.

### Review Progress

- [x] Code review
- [x] Verified locally

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| RedisDiscoveryEnvironmentPostProcessor.java | 100.00% | 22 |
| SpringAIConfiguration.java | 75.00% | 67 |

_Last updated: 2026-09-06 01:14:33 UTC_

