### PR TITLE
`Development`: Let spring security wire the role hierarchy itself

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SecurityConfiguration.java
@@ -18,7 +18,6 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -242,30 +241,16 @@ public class SecurityConfiguration {
     }
 
     /**
-     * Creates and configures a {@link DefaultMethodSecurityExpressionHandler} bean for handling security expressions.
-     * <p>
-     * This method sets up a {@link DefaultMethodSecurityExpressionHandler} with a role hierarchy,
-     * enhancing Spring Security's method security expression handling capabilities. By setting a role hierarchy,
-     * it allows the application to interpret security expressions in a way that respects the hierarchy of roles,
-     * making authorization decisions more flexible and intuitive.
-     * </p>
-     *
-     * @return A fully configured {@link DefaultMethodSecurityExpressionHandler} instance ready for use
-     *         in securing methods based on security expressions.
-     */
-    // Renamed for clarity; Spring Security 7 auto-detects this bean by type, not by name
-    @Bean
-    public DefaultMethodSecurityExpressionHandler methodSecurityExpressionHandler() {
-        DefaultMethodSecurityExpressionHandler expressionHandler = new DefaultMethodSecurityExpressionHandler();
-        expressionHandler.setRoleHierarchy(roleHierarchy());
-        return expressionHandler;
-    }
-
-    /**
      * Defines the hierarchy of roles within the application's security context.
      * <p>
      * Administrator identity and teaching roles are separate. Administrators remain regular users, but only explicit teaching authorities or passkey-backed administrator elevation
      * can satisfy teaching-role authorization.
+     * </p>
+     *
+     * <p>
+     * Nothing else has to be wired up: Spring Security's own method-security configuration picks this bean up by
+     * type and applies it to the expression handler it creates, so an application-supplied
+     * {@code DefaultMethodSecurityExpressionHandler} would only take that handler's place without adding anything.
      * </p>
      *
      * @return A {@link RoleHierarchy} instance with a predefined hierarchy of roles, ready to be used by the

--- a/src/test/java/de/tum/cit/aet/artemis/core/security/RoleHierarchyIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/security/RoleHierarchyIntegrationTest.java
@@ -1,0 +1,48 @@
+package de.tum.cit.aet.artemis.core.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import de.tum.cit.aet.artemis.atlas.AbstractAtlasIntegrationTest;
+import de.tum.cit.aet.artemis.atlas.dto.ScienceSettingDTO;
+
+/**
+ * Covers the role hierarchy declared in {@code SecurityConfiguration}, which is what lets a higher role satisfy the
+ * {@code hasRole('USER')} expression behind {@code @EnforceAtLeastStudent}.
+ * <p>
+ * Spring Security applies the hierarchy by picking the {@code RoleHierarchy} bean up by type, without the application
+ * configuring an expression handler of its own. Nothing else asserts that this still happens, and when it stops the
+ * failure is silent at startup and only shows up as every teaching role losing access to student endpoints.
+ * <p>
+ * {@code GET api/atlas/science-settings} is the subject because it is a plain {@code @EnforceAtLeastStudent} endpoint
+ * that needs no course, exercise or other precondition, so a 403 here can only come from the hierarchy.
+ */
+class RoleHierarchyIntegrationTest extends AbstractAtlasIntegrationTest {
+
+    private static final String TEST_PREFIX = "rolehierarchy";
+
+    @BeforeEach
+    void initTestCase() {
+        userUtilService.addUsers(TEST_PREFIX, 0, 1, 0, 1);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
+    void tutorReachesAStudentLevelEndpoint() throws Exception {
+        List<ScienceSettingDTO> settings = request.getList("/api/atlas/science-settings", HttpStatus.OK, ScienceSettingDTO.class);
+        assertThat(settings).isNotNull();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void instructorReachesAStudentLevelEndpoint() throws Exception {
+        List<ScienceSettingDTO> settings = request.getList("/api/atlas/science-settings", HttpStatus.OK, ScienceSettingDTO.class);
+        assertThat(settings).isNotNull();
+    }
+}


### PR DESCRIPTION
### Summary

`SecurityConfiguration` declared a `DefaultMethodSecurityExpressionHandler` bean only so it could call the deprecated `setRoleHierarchy` on it. Spring Security 7 does that itself from the `RoleHierarchy` bean, so the handler bean is removed and the deprecation goes with it. The invariant it guarded now has a test, which it did not have before.

### Checklist

- [x] Confirmed the replacement in the Spring Security bytecode rather than assuming it.
- [x] Added a regression test and verified it fails without the hierarchy.
- [x] Followed the server coding conventions.

### Motivation and Context

`AbstractSecurityExpressionHandler.setRoleHierarchy` is deprecated in Spring Security 7. Checking what replaces it showed the bean was redundant: `PrePostMethodSecurityConfiguration` holds its own `DefaultMethodSecurityExpressionHandler` and has setter injection that calls `setRoleHierarchy` with the application's `RoleHierarchy` bean, alongside `setDefaultRolePrefix` from `GrantedAuthorityDefaults` and `setApplicationContext`. Supplying our own handler only replaced that one, and ours received the hierarchy and nothing else.

This matters more than the warning count suggests. The hierarchy is what makes `ROLE_INSTRUCTOR > ROLE_EDITOR > ROLE_TA > ROLE_USER` work, and `@EnforceAtLeastStudent` is `@PreAuthorize("hasRole('USER')")`. If the hierarchy ever stops reaching method security, startup succeeds and every teaching role silently loses access to student endpoints.

### Description

- Remove the `methodSecurityExpressionHandler` bean and its now-unused import. The `RoleHierarchy` bean is unchanged; its javadoc now records that Spring Security picks it up by type.
- Add `RoleHierarchyIntegrationTest`, which calls a plain `@EnforceAtLeastStudent` endpoint as a tutor and as an instructor.

`GET api/atlas/science-settings` is the subject because it is `@EnforceAtLeastStudent` with no course, exercise or other precondition, so a 403 there can only come from the hierarchy.

### Steps for Testing

1. Run `RoleHierarchyIntegrationTest`.
2. To see that it is sensitive, drop `@Bean` from `roleHierarchy()` and run it again. Both cases must fail with 403.
3. Sign in as a tutor and open a course; the student-level endpoints must still answer.

### Validation

- `RoleHierarchyIntegrationTest`: 2 of 2 pass with the handler bean removed.
- **Negative control**: with `@Bean` removed from `roleHierarchy()`, the same call is rejected with `403 Access Denied` on `/api/atlas/science-settings`. So the test observes the hierarchy rather than passing for an unrelated reason, and the hierarchy really does still reach method security after this change.
- `spotlessCheck` and `checkstyleMain` pass.
- Checked that nothing injects `MethodSecurityExpressionHandler` or `DefaultMethodSecurityExpressionHandler`; the bean had no consumers. After the change there is no such bean in the context at all, which is the normal Spring Security arrangement.

### Review Progress

- [x] Code review
- [x] Verified locally, including the negative control

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| SecurityConfiguration.java | 100.00% | 162 |

_Last updated: 2026-09-05 22:38:53 UTC_

