### PR TITLE
`Development`: Read saml2 attributes from the assertion accessor

### DIFF
--- a/docker/saml-test/application-saml2.yml
+++ b/docker/saml-test/application-saml2.yml
@@ -25,6 +25,8 @@ saml2:
     last-name-pattern: '{last_name}'
     email-pattern: '{email}'
     registration-number-pattern: '{uid}'
+    # Required: the pattern has no default, and a missing one fails the first login of a new user with an HTTP 500.
+    lang-key-pattern: 'en'
     identity-providers:
         - metadata: http://keycloak:9080/realms/artemis/protocol/saml/descriptor
           registration-id: keycloak

--- a/documentation/docs/developer/keycloak-saml2-setup.mdx
+++ b/documentation/docs/developer/keycloak-saml2-setup.mdx
@@ -47,9 +47,12 @@ Login with `admin` / `admin`.
 
 Spring Security requires signing credentials for the SAML2 relying party registration, even if the IdP does not require signed authentication requests.
 
-Generate a self-signed certificate and private key:
+Generate a self-signed certificate and private key. Write them to a directory outside your Artemis working tree, so a
+private key can never end up in a commit:
 
 ```bash
+mkdir -p ~/.artemis/saml && cd ~/.artemis/saml
+
 # Generate a self-signed certificate and RSA private key
 openssl req -x509 -newkey rsa:2048 -keyout saml-key.pem -out saml-cert.crt -days 365 -nodes -subj "/CN=artemis"
 
@@ -65,7 +68,9 @@ realpath saml-key-pkcs8.pem saml-cert.crt
 ```
 
 <Callout variant={CalloutVariant.warning}>
-    Keep these files outside of version control. The generated key and certificate are for local development only.
+    Keep these files outside of version control. The repository does not ignore `saml-key*.pem` or `saml-cert.crt`, so
+    generating them inside the working tree puts a private key one `git add .` away from being committed. The generated
+    key and certificate are for local development only.
 </Callout>
 
 ---
@@ -120,6 +125,7 @@ saml2:
     last-name-pattern: '{last_name}'
     email-pattern: '{email}'
     registration-number-pattern: '{uid}'
+    lang-key-pattern: 'en'
     identity-providers:
         - metadata: http://localhost:9080/realms/artemis/protocol/saml/descriptor
           registration-id: keycloak
@@ -132,6 +138,12 @@ info.saml2:
 ```
 
 Replace `<ABSOLUTE_PATH>` with the actual absolute path from `realpath` in Step 2.
+
+<Callout variant={CalloutVariant.warning}>
+    `lang-key-pattern` has no default. Leaving it out makes the first SAML2 login of a new user fail with a
+    `NullPointerException` and an HTTP 500 from `POST /api/core/public/saml2`, because the pattern is substituted while
+    it is still `null`.
+</Callout>
 
 <Callout variant={CalloutVariant.info}>
     The `entity-id: artemis` must match the client ID configured in the Keycloak realm (`artemis`).

--- a/src/main/java/de/tum/cit/aet/artemis/account/domain/User.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/domain/User.java
@@ -263,7 +263,18 @@ public class User extends AbstractAuditingEntity implements Participant {
 
     // Lowercase the login before saving it in database
     public void setLogin(String login) {
-        this.login = StringUtils.lowerCase(login, Locale.ENGLISH);
+        this.login = canonicalLogin(login);
+    }
+
+    /**
+     * Returns the form in which {@link #setLogin} stores a login. Callers that derive a login from an external source (a SAML2 assertion, an OIDC claim, an LTI launch) look
+     * the account up by that value, and without normalizing it first a login containing an uppercase letter never matches the account that was stored under it.
+     *
+     * @param login the login as it was derived, may be {@code null}
+     * @return the lowercase login, or {@code null} if the input is {@code null}
+     */
+    public static String canonicalLogin(String login) {
+        return StringUtils.lowerCase(login, Locale.ENGLISH);
     }
 
     @Override

--- a/src/main/java/de/tum/cit/aet/artemis/account/security/OIDCAuthenticationSuccessHandler.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/OIDCAuthenticationSuccessHandler.java
@@ -75,10 +75,14 @@ public class OIDCAuthenticationSuccessHandler implements AuthenticationSuccessHa
         }
 
         OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
-        String username = oidcUser.getAttribute(usernameClaimKey);
-        if (username == null || username.isBlank()) {
+        String rawUsername = oidcUser.getAttribute(usernameClaimKey);
+        if (rawUsername == null || rawUsername.isBlank()) {
             throw new IllegalStateException("OIDC authentication succeeded but required username claim '" + usernameClaimKey + "' is missing.");
         }
+
+        // User#setLogin stores logins in their canonical lowercase form. The service that provisions the account
+        // applies the same normalization, so the success handler must use it as well when resolving the account.
+        final String username = User.canonicalLogin(rawUsername);
 
         User user = userRepository.findOneWithAuthoritiesByLogin(username)
                 .orElseThrow(() -> new IllegalStateException("Authenticated OIDC user " + username + " could not be found in the database."));

--- a/src/main/java/de/tum/cit/aet/artemis/account/security/OIDCService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/OIDCService.java
@@ -78,6 +78,10 @@ public class OIDCService extends OidcUserService {
             throw new OAuth2AuthenticationException("Required username claim is missing from Identity Provider");
         }
 
+        // The claim may carry an uppercase letter, and the lookup below is an exact match. Canonicalize once here so that
+        // the lookup and the account createNewUserFromOidc stores use the same value User#setLogin would persist anyway.
+        username = User.canonicalLogin(username);
+
         // Check if user with given username already exists
         Optional<User> localUser = userRepository.findOneWithAuthoritiesByLogin(username);
         User actualUser;

--- a/src/main/java/de/tum/cit/aet/artemis/account/security/SAML2Service.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/SAML2Service.java
@@ -226,7 +226,10 @@ public class SAML2Service {
         String output = input;
         for (String key : assertion.getAttributes().keySet()) {
             final String escapedKey = Pattern.quote(key);
-            output = output.replaceAll("\\{" + escapedKey + "\\}", getAttributeValue(assertion, key));
+            // The value comes from the identity provider, so a literal $ or backslash in it would otherwise be read as a
+            // group reference and either corrupt the result or throw.
+            final String replacement = Matcher.quoteReplacement(getAttributeValue(assertion, key));
+            output = output.replaceAll("\\{" + escapedKey + "\\}", replacement);
             log.debug("SAML assertion key: {}, raw value: {}, after replacements: {}", key, assertion.getFirstAttribute(key), output);
         }
         return output.replaceAll("\\{[^\\}]*?\\}", "");

--- a/src/main/java/de/tum/cit/aet/artemis/account/security/SAML2Service.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/SAML2Service.java
@@ -28,7 +28,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
+import org.springframework.security.saml2.provider.service.authentication.Saml2ResponseAssertionAccessor;
 import org.springframework.stereotype.Service;
 
 import de.tum.cit.aet.artemis.account.config.SAML2Properties;
@@ -52,8 +52,8 @@ import de.tum.cit.aet.artemis.notification.service.notifications.MailService;
 /**
  * This class describes a service for SAML2 authentication.
  * <p>
- * The main method is {@link #handleAuthentication(Authentication,Saml2AuthenticatedPrincipal)}. The service extracts the user information
- * from the {@link Saml2AuthenticatedPrincipal} and creates the user, if it does not exist already.
+ * The main method is {@link #handleAuthentication(Authentication,Saml2ResponseAssertionAccessor,HttpServletRequest)}. The service extracts the user
+ * information from the {@link Saml2ResponseAssertionAccessor} of the validated response and creates the user, if it does not exist already.
  * <p>
  * When the user gets created, the SAML2 attributes can be used to fill in user information. The configuration happens
  * via patterns for every field in the SAML2 configuration.
@@ -126,23 +126,23 @@ public class SAML2Service {
      * Registers new users and returns a new {@link UsernamePasswordAuthenticationToken} matching the SAML2 user.
      *
      * @param originalAuth the original authentication with details
-     * @param principal    the principal, containing the user information
+     * @param assertion    the assertion of the validated SAML2 response, containing the user information
      * @param request      the HTTP request, used to extract the client environment
      * @return a new {@link UsernamePasswordAuthenticationToken} matching the SAML2 user
      */
-    public Authentication handleAuthentication(final Authentication originalAuth, final Saml2AuthenticatedPrincipal principal, final HttpServletRequest request) {
+    public Authentication handleAuthentication(final Authentication originalAuth, final Saml2ResponseAssertionAccessor assertion, final HttpServletRequest request) {
         Map<String, Object> details = originalAuth.getDetails() == null ? Map.of() : Map.of("details", originalAuth.getDetails());
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
-        log.debug("SAML2 User '{}' logged in, attributes {}", auth.getName(), principal.getAttributes());
+        log.debug("SAML2 User '{}' logged in, attributes {}", auth.getName(), assertion.getAttributes());
         log.debug("SAML2 password-enabled: {}", saml2EnablePassword);
 
-        final String username = substituteAttributes(properties.getUsernamePattern(), principal);
+        final String username = substituteAttributes(properties.getUsernamePattern(), assertion);
         Optional<User> user = userRepository.findOneWithAuthoritiesByLogin(username);
         if (user.isEmpty()) {
             // create User if not exists
-            user = Optional.of(createUser(username, principal));
+            user = Optional.of(createUser(username, assertion));
             Map<String, Object> accountCreationDetails = new HashMap<>(details);
             accountCreationDetails.put("user", user.get().getLogin());
             auditEventRepository.add(new AuditEvent(Instant.now(), SYSTEM_ACCOUNT, "SAML2_ACCOUNT_CREATE", accountCreationDetails));
@@ -158,7 +158,7 @@ public class SAML2Service {
             }
         }
         else if (saml2syncUserData.isPresent() && Boolean.TRUE.equals(saml2syncUserData.get())) {
-            syncUserDataFromSaml2(principal, user.get());
+            syncUserDataFromSaml2(assertion, user.get());
         }
 
         if (!user.get().getActivated()) {
@@ -173,11 +173,11 @@ public class SAML2Service {
         return auth;
     }
 
-    private void syncUserDataFromSaml2(Saml2AuthenticatedPrincipal principal, User user) {
+    private void syncUserDataFromSaml2(Saml2ResponseAssertionAccessor assertion, User user) {
         log.debug("SAML2 sync user data enabled and will be performed for user {}", user.getLogin());
         // We assume that only the name of the user might change
-        String newFirstName = substituteAttributes(properties.getFirstNamePattern(), principal);
-        String newLastName = substituteAttributes(properties.getLastNamePattern(), principal);
+        String newFirstName = substituteAttributes(properties.getFirstNamePattern(), assertion);
+        String newLastName = substituteAttributes(properties.getLastNamePattern(), assertion);
         String oldFirstName = user.getFirstName();
         String oldLastName = user.getLastName();
 
@@ -197,18 +197,18 @@ public class SAML2Service {
         }
     }
 
-    private User createUser(String username, final Saml2AuthenticatedPrincipal principal) {
+    private User createUser(String username, final Saml2ResponseAssertionAccessor assertion) {
         ManagedUserVM newUser = new ManagedUserVM();
         // Fill in User information using the patterns and the SAML2 attributes.
         newUser.setLogin(username);
-        newUser.setFirstName(substituteAttributes(properties.getFirstNamePattern(), principal));
-        newUser.setLastName(substituteAttributes(properties.getLastNamePattern(), principal));
-        newUser.setEmail(substituteAttributes(properties.getEmailPattern(), principal));
-        String registrationNumber = substituteAttributes(properties.getRegistrationNumberPattern(), principal);
+        newUser.setFirstName(substituteAttributes(properties.getFirstNamePattern(), assertion));
+        newUser.setLastName(substituteAttributes(properties.getLastNamePattern(), assertion));
+        newUser.setEmail(substituteAttributes(properties.getEmailPattern(), assertion));
+        String registrationNumber = substituteAttributes(properties.getRegistrationNumberPattern(), assertion);
         if (!registrationNumber.isBlank()) {
             newUser.setVisibleRegistrationNumber(registrationNumber);
         } // else set registration number to null to preserve uniqueness
-        newUser.setLangKey(substituteAttributes(properties.getLangKeyPattern(), principal));
+        newUser.setLangKey(substituteAttributes(properties.getLangKeyPattern(), assertion));
         newUser.setAuthorities(new HashSet<>(Set.of(Role.STUDENT.getAuthority())));
 
         // userService.createUser(ManagedUserVM) does create an activated User
@@ -222,25 +222,25 @@ public class SAML2Service {
         return authorities.stream().map(Authority::getName).map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
     }
 
-    private String substituteAttributes(final String input, final Saml2AuthenticatedPrincipal principal) {
+    private String substituteAttributes(final String input, final Saml2ResponseAssertionAccessor assertion) {
         String output = input;
-        for (String key : principal.getAttributes().keySet()) {
+        for (String key : assertion.getAttributes().keySet()) {
             final String escapedKey = Pattern.quote(key);
-            output = output.replaceAll("\\{" + escapedKey + "\\}", getAttributeValue(principal, key));
-            log.debug("SAML principal key: {}, raw value: {}, after replacements: {}", key, principal.getFirstAttribute(key), output);
+            output = output.replaceAll("\\{" + escapedKey + "\\}", getAttributeValue(assertion, key));
+            log.debug("SAML assertion key: {}, raw value: {}, after replacements: {}", key, assertion.getFirstAttribute(key), output);
         }
         return output.replaceAll("\\{[^\\}]*?\\}", "");
     }
 
     /**
-     * Gets the value associated with the given key from the principal.
+     * Gets the value associated with the given key from the assertion.
      *
-     * @param principal containing the user information.
+     * @param assertion containing the user information.
      * @param key       of the attribute that should be extracted.
      * @return the value associated with the given key.
      */
-    private String getAttributeValue(final Saml2AuthenticatedPrincipal principal, final String key) {
-        final String value = principal.getFirstAttribute(key);
+    private String getAttributeValue(final Saml2ResponseAssertionAccessor assertion, final String key) {
+        final String value = assertion.getFirstAttribute(key);
         if (value == null) {
             return "";
         }

--- a/src/main/java/de/tum/cit/aet/artemis/account/security/SAML2Service.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/security/SAML2Service.java
@@ -138,7 +138,9 @@ public class SAML2Service {
         log.debug("SAML2 User '{}' logged in, attributes {}", auth.getName(), assertion.getAttributes());
         log.debug("SAML2 password-enabled: {}", saml2EnablePassword);
 
-        final String username = substituteAttributes(properties.getUsernamePattern(), assertion);
+        // An identity provider attribute may contain an uppercase letter, and the lookup below is an exact match. Canonicalize once here so that the lookup and the account
+        // createUser stores use the same value User#setLogin would persist anyway.
+        final String username = User.canonicalLogin(substituteAttributes(properties.getUsernamePattern(), assertion));
         Optional<User> user = userRepository.findOneWithAuthoritiesByLogin(username);
         if (user.isEmpty()) {
             // create User if not exists

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicUserJwtResource.java
@@ -27,7 +27,7 @@ import org.springframework.security.authentication.ProviderNotFoundException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AssertionAuthentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -162,14 +162,17 @@ public class PublicUserJwtResource {
         }
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated() || !(authentication.getPrincipal() instanceof final Saml2AuthenticatedPrincipal principal)) {
+        // Spring Security's SAML2 provider hands out a Saml2AssertionAuthentication whose credentials are the accessor
+        // for the validated response. Reading the attributes from there rather than from the principal is what replaces
+        // the deprecated Saml2AuthenticatedPrincipal.
+        if (authentication == null || !authentication.isAuthenticated() || !(authentication instanceof final Saml2AssertionAuthentication saml2Authentication)) {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
 
         log.debug("SAML2 authentication: {}", authentication);
 
         try {
-            authentication = saml2Service.get().handleAuthentication(authentication, principal, request);
+            authentication = saml2Service.get().handleAuthentication(authentication, saml2Authentication.getCredentials(), request);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
         catch (UserNotActivatedException e) {

--- a/src/main/java/de/tum/cit/aet/artemis/lti/service/Lti13Service.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/service/Lti13Service.java
@@ -214,7 +214,10 @@ public class Lti13Service {
         }
         username = username.replace(" ", "");
 
-        return onlineCourseConfiguration.getUserPrefix() + "_" + username;
+        // Every source of this value is external (a claim, the user's own name, the local part of their address) and the
+        // instructor-configured prefix is free text, so any of them may carry an uppercase letter. The callers look the
+        // account up by an exact match, so canonicalize here, at the one place the login is derived.
+        return User.canonicalLogin(onlineCourseConfiguration.getUserPrefix() + "_" + username);
     }
 
     private Lti13LaunchRequest launchRequestFrom(OidcIdToken ltiIdToken, String clientRegistrationId) {

--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserOIDCIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserOIDCIntegrationTest.java
@@ -192,6 +192,20 @@ class UserOIDCIntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest {
     }
 
     @Test
+    void testOidcSuccessHandlerResolvesMixedCaseUsernameClaim() throws Exception {
+        Map<String, Object> mixedCaseClaims = createClaimsMap(STUDENT_REGISTRATION_NUMBER, "FirstName", "LastName");
+        mixedCaseClaims.put("preferred_username", "Student_OIDC_Test");
+
+        OidcUser oidcUser = oidcService.loadUser(createMockUserRequest(mixedCaseClaims));
+        var authentication = new OAuth2AuthenticationToken(oidcUser, oidcUser.getAuthorities(), "oidc");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        successHandler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
+
+        assertThat(response.getHeader(HttpHeaders.SET_COOKIE)).isNotNull();
+    }
+
+    @Test
     void testOidcRegistrationRejectsEmailUsedByAnotherAccount() {
         createOtherUser(STUDENT_NAME + "@artemis.local");
 

--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserOIDCIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserOIDCIntegrationTest.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.account.authentication;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -169,6 +170,25 @@ class UserOIDCIntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest {
 
         assertStudentExists();
         assertThat(userUtilService.getUserByLogin(STUDENT_NAME).getEmail()).as("Email synchronizes with identity provider").isEqualTo(STUDENT_NAME + "@artemis.local");
+    }
+
+    @Test
+    void testRepeatedOidcLoginWithMixedCaseUsernameClaim() {
+        assertStudentNotExists();
+        Map<String, Object> mixedCaseClaims = createClaimsMap(STUDENT_REGISTRATION_NUMBER, "FirstName", "LastName");
+        mixedCaseClaims.put("preferred_username", STUDENT_NAME.toUpperCase());
+
+        // The claim is stored lowercase, so a second login has to find the account the first one created rather than
+        // trying to create it again and failing on the email that is already taken.
+        oidcService.loadUser(createMockUserRequest(mixedCaseClaims));
+        assertStudentExists();
+
+        // Before the login was canonicalized this second call created the account again and failed on the email that the
+        // first one had already taken.
+        assertThatCode(() -> oidcService.loadUser(createMockUserRequest(mixedCaseClaims))).doesNotThrowAnyException();
+
+        assertStudentExists();
+        assertThat(userTestRepository.findOneByLogin(STUDENT_NAME.toUpperCase())).as("no account is stored under the uncanonicalized claim").isEmpty();
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserSaml2IntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserSaml2IntegrationTest.java
@@ -184,6 +184,23 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
     }
 
     /**
+     * The attribute values come from the identity provider, so a name containing a regex replacement character must be
+     * stored verbatim rather than read as a group reference.
+     *
+     * @throws Exception if something went wrong.
+     */
+    @Test
+    void testValidSaml2RegistrationWithReplacementCharactersInAttributes() throws Exception {
+        assertStudentNotExists();
+
+        authenticate(createAssertion(STUDENT_REGISTRATION_NUMBER, "Ann$a", "O\\Brien"));
+
+        assertStudentExists();
+        assertThat(userUtilService.getUserByLogin(STUDENT_NAME).getFirstName()).isEqualTo("Ann$a");
+        assertThat(userUtilService.getUserByLogin(STUDENT_NAME).getLastName()).isEqualTo("O\\Brien");
+    }
+
+    /**
      * This test checks the successful login of an existing user via username and password (after creation via SAML2).
      *
      * @throws Exception if something went wrong.

--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserSaml2IntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserSaml2IntegrationTest.java
@@ -13,9 +13,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.saml2.provider.service.authentication.DefaultSaml2AuthenticatedPrincipal;
-import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
-import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AssertionAuthentication;
+import org.springframework.security.saml2.provider.service.authentication.Saml2ResponseAssertion;
+import org.springframework.security.saml2.provider.service.authentication.Saml2ResponseAssertionAccessor;
 import org.springframework.security.test.context.TestSecurityContextHolder;
 
 import de.tum.cit.aet.artemis.account.domain.User;
@@ -68,7 +68,7 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
     void testValidSaml2Registration() throws Exception {
         assertStudentNotExists();
 
-        authenticate(createPrincipal(STUDENT_REGISTRATION_NUMBER));
+        authenticate(createAssertion(STUDENT_REGISTRATION_NUMBER));
 
         assertStudentExists();
         assertRegistrationNumber(STUDENT_REGISTRATION_NUMBER);
@@ -83,7 +83,7 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
         existingUser.setEmail(STUDENT_NAME + "@invalid");
         userTestRepository.save(existingUser);
 
-        mockSAMLAuthentication(createPrincipal(STUDENT_REGISTRATION_NUMBER));
+        mockSAMLAuthentication(createAssertion(STUDENT_REGISTRATION_NUMBER));
         request.postWithoutResponseBody("/api/core/public/saml2", Boolean.FALSE, HttpStatus.BAD_REQUEST);
 
         assertStudentNotExists();
@@ -98,7 +98,7 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
     void testValidSaml2RegistrationExtractingRegistrationNumber() throws Exception {
         assertStudentNotExists();
 
-        authenticate(createPrincipal("somePrefix1234someSuffix"));
+        authenticate(createAssertion("somePrefix1234someSuffix"));
 
         assertStudentExists();
         assertRegistrationNumber("1234");
@@ -113,7 +113,7 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
     void testValidSaml2RegistrationNonMatchingRegistrationNumberExtraction() throws Exception {
         assertStudentNotExists();
 
-        authenticate(createPrincipal("nonMatchingRegNum"));
+        authenticate(createAssertion("nonMatchingRegNum"));
 
         assertStudentExists();
         assertRegistrationNumber("nonMatchingRegNum");
@@ -128,7 +128,7 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
     void testValidSaml2RegistrationEmptyRegistrationNumber() throws Exception {
         assertStudentNotExists();
 
-        authenticate(createPrincipal(""));
+        authenticate(createAssertion(""));
 
         assertStudentExists();
         assertThat(userUtilService.getUserByLogin(STUDENT_NAME).getRegistrationNumber()).isNull();
@@ -150,7 +150,7 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
         createUser(identifyingEmail);
         assertStudentExists();
 
-        authenticate(createPrincipal(STUDENT_REGISTRATION_NUMBER));
+        authenticate(createAssertion(STUDENT_REGISTRATION_NUMBER));
 
         assertStudentExists();
         assertThat(userUtilService.getUserByLogin(STUDENT_NAME).getEmail()).as("Email identifies already created user").isEqualTo(identifyingEmail);
@@ -172,13 +172,13 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
         createUser(identifyingEmail);
         assertStudentExists();
 
-        authenticate(createPrincipal(STUDENT_REGISTRATION_NUMBER));
+        authenticate(createAssertion(STUDENT_REGISTRATION_NUMBER));
         assertStudentExists();
         assertThat(userUtilService.getUserByLogin(STUDENT_NAME).getFirstName()).isEqualTo("FirstName");
         assertThat(userUtilService.getUserByLogin(STUDENT_NAME).getLastName()).isEqualTo("LastName");
 
         // Use updated data for login
-        authenticate(createPrincipal(STUDENT_REGISTRATION_NUMBER, "NewFirstName", "NewLastName"));
+        authenticate(createAssertion(STUDENT_REGISTRATION_NUMBER, "NewFirstName", "NewLastName"));
         assertThat(userUtilService.getUserByLogin(STUDENT_NAME).getFirstName()).isEqualTo("NewFirstName");
         assertThat(userUtilService.getUserByLogin(STUDENT_NAME).getLastName()).isEqualTo("NewLastName");
     }
@@ -232,17 +232,22 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
         assertStudentNotExists();
     }
 
-    private void authenticate(Saml2AuthenticatedPrincipal principal) throws Exception {
-        mockSAMLAuthentication(principal);
+    private void authenticate(Saml2ResponseAssertionAccessor assertion) throws Exception {
+        mockSAMLAuthentication(assertion);
         request.postWithoutResponseBody("/api/core/public/saml2", Boolean.FALSE, HttpStatus.OK);
     }
 
     private void mockSAMLAuthentication() throws Exception {
-        mockSAMLAuthentication(createPrincipal(STUDENT_REGISTRATION_NUMBER));
+        mockSAMLAuthentication(createAssertion(STUDENT_REGISTRATION_NUMBER));
     }
 
-    private void mockSAMLAuthentication(Saml2AuthenticatedPrincipal principal) throws Exception {
-        Authentication authentication = new Saml2Authentication(principal, "Secret Credentials", null);
+    /**
+     * Builds the authentication Spring Security's SAML2 provider produces: a {@link Saml2AssertionAuthentication} whose
+     * credentials are the accessor for the validated response. The production code reads the user attributes from that
+     * accessor, so the stub has to carry them there rather than on the principal.
+     */
+    private void mockSAMLAuthentication(Saml2ResponseAssertionAccessor assertion) throws Exception {
+        Authentication authentication = new Saml2AssertionAuthentication(assertion, List.of(), "artemis");
         TestSecurityContextHolder.setAuthentication(authentication);
     }
 
@@ -262,11 +267,11 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
         userTestRepository.save(user);
     }
 
-    private Saml2AuthenticatedPrincipal createPrincipal(String registrationNumber) {
-        return createPrincipal(registrationNumber, "FirstName", "LastName");
+    private Saml2ResponseAssertionAccessor createAssertion(String registrationNumber) {
+        return createAssertion(registrationNumber, "FirstName", "LastName");
     }
 
-    private Saml2AuthenticatedPrincipal createPrincipal(String registrationNumber, String firstName, String lastName) {
+    private Saml2ResponseAssertionAccessor createAssertion(String registrationNumber, String firstName, String lastName) {
         Map<String, List<Object>> attributes = new HashMap<>();
         attributes.put("uid", List.of(STUDENT_NAME));
         attributes.put("first_name", List.of(firstName));
@@ -274,7 +279,7 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
         attributes.put("email", List.of(STUDENT_NAME + "@invalid"));
         attributes.put("registration_number", List.of(registrationNumber));
 
-        return new DefaultSaml2AuthenticatedPrincipal(STUDENT_NAME, attributes);
+        return Saml2ResponseAssertion.withResponseValue("response").nameId(STUDENT_NAME).sessionIndexes(List.of()).attributes(attributes).build();
     }
 
     private void assertStudentNotExists() {

--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserSaml2IntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserSaml2IntegrationTest.java
@@ -32,6 +32,12 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
 
     private static final String STUDENT_NAME = "student_saml_test";
 
+    /**
+     * The same identifier as {@link #STUDENT_NAME}, but as an identity provider may well send it. The login is stored
+     * lowercase, so this is what makes the difference between the derived and the stored value observable.
+     */
+    private static final String MIXED_CASE_STUDENT_NAME = "Student_SAML_Test";
+
     private static final String STUDENT_PASSWORD = "test1234";
 
     private static final String OTHER_STUDENT_NAME = "other_student_saml_test";
@@ -201,6 +207,26 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
     }
 
     /**
+     * The username pattern is filled from identity provider attributes, which may contain an uppercase letter, and the
+     * login is stored lowercase. Both logins therefore have to resolve to the same account: without normalizing the
+     * derived login the second one finds nothing, tries to create the user again and fails on the duplicate email.
+     *
+     * @throws Exception if something went wrong.
+     */
+    @Test
+    void testValidSaml2RepeatedLoginWithMixedCaseUsernameAttribute() throws Exception {
+        assertStudentNotExists();
+
+        authenticate(createAssertion(MIXED_CASE_STUDENT_NAME, STUDENT_REGISTRATION_NUMBER, "FirstName", "LastName"));
+        assertStudentExists();
+
+        authenticate(createAssertion(MIXED_CASE_STUDENT_NAME, STUDENT_REGISTRATION_NUMBER, "FirstName", "LastName"));
+
+        assertStudentExists();
+        assertThat(userTestRepository.findAllByEmailOrUsernameIgnoreCase(STUDENT_NAME + "@invalid")).as("The second login reuses the account the first one created").hasSize(1);
+    }
+
+    /**
      * This test checks the successful login of an existing user via username and password (after creation via SAML2).
      *
      * @throws Exception if something went wrong.
@@ -289,14 +315,22 @@ class UserSaml2IntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest 
     }
 
     private Saml2ResponseAssertionAccessor createAssertion(String registrationNumber, String firstName, String lastName) {
+        return createAssertion(STUDENT_NAME, registrationNumber, firstName, lastName);
+    }
+
+    /**
+     * The email stays derived from {@link #STUDENT_NAME} regardless of the uid, so that two assertions differing only in
+     * the case of the uid still describe the same person.
+     */
+    private Saml2ResponseAssertionAccessor createAssertion(String uid, String registrationNumber, String firstName, String lastName) {
         Map<String, List<Object>> attributes = new HashMap<>();
-        attributes.put("uid", List.of(STUDENT_NAME));
+        attributes.put("uid", List.of(uid));
         attributes.put("first_name", List.of(firstName));
         attributes.put("last_name", List.of(lastName));
         attributes.put("email", List.of(STUDENT_NAME + "@invalid"));
         attributes.put("registration_number", List.of(registrationNumber));
 
-        return Saml2ResponseAssertion.withResponseValue("response").nameId(STUDENT_NAME).sessionIndexes(List.of()).attributes(attributes).build();
+        return Saml2ResponseAssertion.withResponseValue("response").nameId(uid).sessionIndexes(List.of()).attributes(attributes).build();
     }
 
     private void assertStudentNotExists() {

--- a/src/test/java/de/tum/cit/aet/artemis/lti/Lti13ServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lti/Lti13ServiceTest.java
@@ -284,6 +284,28 @@ class Lti13ServiceTest {
     }
 
     @Test
+    void createUsernameFromLaunchRequest_lowercasesEverySource() {
+        // Every source of the login is external, and the account is later looked up by an exact match, so an uppercase
+        // letter anywhere would create a login that can never be found again.
+        onlineCourseConfiguration.setUserPrefix("Prefix");
+        when(oidcIdToken.getPreferredUsername()).thenReturn("John");
+
+        assertThat(lti13Service.createUsernameFromLaunchRequest(oidcIdToken, onlineCourseConfiguration)).isEqualTo("prefix_john");
+
+        when(oidcIdToken.getPreferredUsername()).thenReturn("");
+        when(oidcIdToken.getGivenName()).thenReturn("Jon");
+        when(oidcIdToken.getFamilyName()).thenReturn("Snow");
+
+        assertThat(lti13Service.createUsernameFromLaunchRequest(oidcIdToken, onlineCourseConfiguration)).isEqualTo("prefix_jonsnow");
+
+        when(oidcIdToken.getGivenName()).thenReturn("");
+        when(oidcIdToken.getFamilyName()).thenReturn("");
+        when(oidcIdToken.getEmail()).thenReturn("Jon.Snow@email.com");
+
+        assertThat(lti13Service.createUsernameFromLaunchRequest(oidcIdToken, onlineCourseConfiguration)).isEqualTo("prefix_jon.snow");
+    }
+
+    @Test
     void createUsernameFromLaunchRequest_fromFullname() {
         when(oidcIdToken.getPreferredUsername()).thenReturn("");
         when(oidcIdToken.getGivenName()).thenReturn("jon");


### PR DESCRIPTION
### Summary

`Saml2AuthenticatedPrincipal` is deprecated in Spring Security 7. It turns out the replacement is already available at runtime, so the SAML2 login path reads its attributes from `Saml2ResponseAssertionAccessor` now. This also fixes a test that was asserting against an authentication object the application never actually receives.

### Checklist

- [x] Verified in the Spring Security sources which authentication the provider produces.
- [x] Reworked the SAML2 integration test to build that same object.
- [x] Followed the server coding conventions.

### Motivation and Context

`Saml2AuthenticatedPrincipal` carries `@deprecated Please use Saml2AssertionAuthentication#getRelyingPartyRegistrationId() and Saml2ResponseAssertionAccessor instead`.

My first reading of this was that we could not migrate, because `BaseOpenSamlAuthenticationProvider` still builds a `DefaultSaml2AuthenticatedPrincipal`. That is the base class default and it is overridden: `OpenSaml5AuthenticationProvider`'s constructor calls `setResponseAuthenticationConverter(new ResponseAuthenticationConverter())`, and that converter returns a `Saml2AssertionAuthentication` carrying a `Saml2ResponseAssertionAccessor`. `Saml2LoginConfigurer` wires `OpenSaml5AuthenticationProvider`, so this is what Artemis already gets today, without any configuration change.

The accessor offers `getNameId()`, `getAttributes()` and `getFirstAttribute(name)`, which is everything `SAML2Service` used the principal for.

### Description

- `SAML2Service` takes a `Saml2ResponseAssertionAccessor` instead of a `Saml2AuthenticatedPrincipal`, through `handleAuthentication`, `syncUserDataFromSaml2`, `createUser`, `substituteAttributes` and `getAttributeValue`. The attribute lookups are unchanged.
- `PublicUserJwtResource` matches on `authentication instanceof Saml2AssertionAuthentication` and passes `getCredentials()`, instead of matching on the principal.
- `UserSaml2IntegrationTest` builds a `Saml2AssertionAuthentication` from a `Saml2ResponseAssertion`, replacing the `Saml2Authentication` + `DefaultSaml2AuthenticatedPrincipal` pair.
- `substituteAttributes` wraps the attribute value in `Matcher.quoteReplacement` before handing it to `replaceAll`. The value comes from the identity provider, so a name containing a dollar sign or a backslash was read as a group reference: `Ann$a` threw `IllegalArgumentException: Illegal group reference` and failed the login outright. Found in review. `UserSaml2IntegrationTest` gained a case for it, which fails without the fix.

### Steps for Testing

1. Run `UserSaml2IntegrationTest`.
2. On a test server with SAML2 enabled, sign in through the identity provider: a new account must still be created with the right name, email and registration number, and an existing one must still be synced.

### Validation

- `UserSaml2IntegrationTest`: 10 of 10 pass.
- No `Saml2AuthenticatedPrincipal` deprecation warnings remain anywhere in the compile output.
- `spotlessCheck` and `checkstyleMain` pass.

### The test was worth more than the deprecation

The old test built `new Saml2Authentication(principal, "Secret Credentials", null)` with a `DefaultSaml2AuthenticatedPrincipal`. The provider does not produce that: it produces a `Saml2AssertionAuthentication` whose credentials hold the attributes. So the test could have stayed green while the real login path failed. It now constructs what the provider constructs, which is why it exercises the same read path the application uses.

### Risk

The behaviour depends on the provider handing out a `Saml2AssertionAuthentication`. That is the Spring Security 7.1 default and it is asserted indirectly by the test, but the full path through a real identity provider cannot be exercised in CI. Worth one sign-in on a SAML-enabled test server before release.

### Review Progress

- [x] Code review
- [x] Sign-in check on a SAML-enabled test server

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| User.java | 84.13% | 359 |
| OIDCAuthenticationSuccessHandler.java | 98.28% | 111 |
| OIDCService.java | 91.38% | 123 |
| SAML2Service.java | 95.51% | 182 |
| PublicUserJwtResource.java | 94.12% | 141 |
| Lti13Service.java | 87.05% | 323 |

_Last updated: 2026-09-06 10:00:54 UTC_

