### PR TITLE
`Plagiarism checks`: Highlight a match to the end JPlag reports

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/domain/PlagiarismSubmissionElement.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/domain/PlagiarismSubmissionElement.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
+import org.jspecify.annotations.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.jplag.Token;
@@ -29,7 +31,23 @@ public class PlagiarismSubmissionElement extends DomainObject {
 
     private String file;
 
+    /**
+     * @deprecated JPlag reports this without counting line breaks, so it must not be used to derive the end position of
+     *             a token. Kept because results computed before {@link #endLine} and {@link #endColumn} existed only
+     *             have this value. Use the explicit end position for anything new.
+     */
+    @Deprecated
     private int length;
+
+    /**
+     * Where the token ends, as reported by JPlag. Null for results computed before these columns existed: the token
+     * stream is not stored, so those rows cannot be backfilled and the client falls back to {@link #length}.
+     */
+    @Column(name = "end_line")
+    private Integer endLine;
+
+    @Column(name = "end_column")
+    private Integer endColumn;
 
     /**
      * Create a new PlagiarismSubmissionElement instance from an existing JPlag Token
@@ -51,7 +69,13 @@ public class PlagiarismSubmissionElement extends DomainObject {
             final var fileStringWithinRepository = PlagiarismSubmissionElement.getString(token, submissionDirectory);
             textSubmissionElement.setFile(fileStringWithinRepository);
         }
-        textSubmissionElement.setLength(token.getLength());
+        // getLength() is deprecated for removal, but it is still the only value results computed before the explicit
+        // end position have, so it keeps being written until those results have aged out.
+        @SuppressWarnings("removal")
+        int tokenLength = token.getLength();
+        textSubmissionElement.setLength(tokenLength);
+        textSubmissionElement.setEndLine(token.getEndLine());
+        textSubmissionElement.setEndColumn(token.getEndColumn());
         textSubmissionElement.setPlagiarismSubmission(plagiarismSubmission);
 
         return textSubmissionElement;
@@ -101,8 +125,30 @@ public class PlagiarismSubmissionElement extends DomainObject {
         this.file = file;
     }
 
+    /**
+     * @deprecated see the field: only correct for a token that stays on one line. Use {@link #getEndLine()} and
+     *             {@link #getEndColumn()} instead, falling back to this for results that predate them.
+     * @return the token length in characters, not counting line breaks
+     */
+    @Deprecated
     public int getLength() {
         return length;
+    }
+
+    public @Nullable Integer getEndLine() {
+        return endLine;
+    }
+
+    public void setEndLine(@Nullable Integer endLine) {
+        this.endLine = endLine;
+    }
+
+    public @Nullable Integer getEndColumn() {
+        return endColumn;
+    }
+
+    public void setEndColumn(@Nullable Integer endColumn) {
+        this.endColumn = endColumn;
     }
 
     public void setLength(int length) {

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionElementDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionElementDTO.java
@@ -7,12 +7,25 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmissionElement;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record PlagiarismSubmissionElementDTO(Long id, int column, int line, @Nullable String file, int length) {
+/**
+ * @param length    where the token ends, counted in characters from its start and without line breaks. Only correct
+ *                      for a token that stays on one line, which is why {@code endLine} and {@code endColumn} exist;
+ *                      it is still sent because results computed before those have nothing else.
+ * @param endLine   where the token ends, as reported by JPlag, or null for a result computed before this was recorded
+ * @param endColumn the column the token ends at, or null for such a result
+ */
+public record PlagiarismSubmissionElementDTO(Long id, int column, int line, @Nullable String file, int length, @Nullable Integer endLine, @Nullable Integer endColumn) {
 
+    /**
+     * @param element the element to convert, may be null
+     * @return the DTO for the given element, or null if there is none
+     */
+    @SuppressWarnings("deprecation")
     public static @Nullable PlagiarismSubmissionElementDTO fromElement(@Nullable PlagiarismSubmissionElement element) {
         if (element == null) {
             return null;
         }
-        return new PlagiarismSubmissionElementDTO(element.getId(), element.getColumn(), element.getLine(), element.getFile(), element.getLength());
+        return new PlagiarismSubmissionElementDTO(element.getId(), element.getColumn(), element.getLine(), element.getFile(), element.getLength(), element.getEndLine(),
+                element.getEndColumn());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionElementDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismSubmissionElementDTO.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmissionElement;
 
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
 /**
  * @param length    where the token ends, counted in characters from its start and without line breaks. Only correct
  *                      for a token that stays on one line, which is why {@code endLine} and {@code endColumn} exist;
@@ -14,6 +13,7 @@ import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismSubmissionElement;
  * @param endLine   where the token ends, as reported by JPlag, or null for a result computed before this was recorded
  * @param endColumn the column the token ends at, or null for such a result
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record PlagiarismSubmissionElementDTO(Long id, int column, int line, @Nullable String file, int length, @Nullable Integer endLine, @Nullable Integer endColumn) {
 
     /**

--- a/src/main/resources/config/liquibase/changelog/20260905190000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260905190000_changelog.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+        Record where a plagiarism match token ends.
+
+        JPlag deprecated Token.getLength() for removal, because "the length does not include line breaks and should not
+        be used to calculate the end position of a token". The plagiarism view did exactly that: it derived the end
+        column of the last token of a match by adding the length to its start column, so a match whose last token spans
+        a line break was highlighted with the wrong end.
+
+        The two columns are added rather than replacing `length`, and they are nullable on purpose. The token stream a
+        result was computed from is not stored, so results that already exist cannot be backfilled; for those rows the
+        columns stay null and the client falls back to the old computation. New results carry the explicit end position
+        that JPlag reports.
+    -->
+    <changeSet id="20260905190000-1" author="artemis">
+        <addColumn tableName="plagiarism_submission_element">
+            <column name="end_line" type="INT"/>
+            <column name="end_column" type="INT"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -62,6 +62,7 @@
     <include file="classpath:config/liquibase/changelog/20260826080000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260827090000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260828100000_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20260905190000_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command "date '+%Y%m%d%H%M%S'" to get the current date and time in the correct format -->

--- a/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.spec.ts
+++ b/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.spec.ts
@@ -237,6 +237,46 @@ describe('Text Submission Viewer Component', () => {
         expect(updatedFileContent).toEqual(expectedFileContent);
     });
 
+    it('uses the reported end position when the last token of a match spans a line break', () => {
+        // `length` counts characters without line breaks, so column + length would put the end on the first line and
+        // stop the highlight early. JPlag reports the real end, and the highlight has to follow that instead.
+        // endColumn is exclusive, the same convention column + length already had, so the trailing space is included.
+        const mockMatches = [
+            {
+                from: { column: 1, line: 1, length: 5 } as PlagiarismSubmissionElement,
+                to: { column: 19, line: 1, length: 14, endLine: 2, endColumn: 11 } as PlagiarismSubmissionElement,
+            },
+        ];
+        vi.spyOn(comp, 'getMatchesForCurrentFile').mockReturnValue(mockMatches);
+
+        const fileContent = `Lorem ipsum dolor sit amet.\nConsetetur sadipscing elitr.`;
+        const expectedFileContent = `<span class="plagiarism-match">Lorem ipsum dolor sit amet.\nConsetetur </span>sadipscing elitr.`;
+        fixture.componentRef.setInput('exercise', { type: ExerciseType.TEXT } as Exercise);
+
+        const updatedFileContent = comp.insertMatchTokens(fileContent);
+
+        expect(updatedFileContent).toEqual(expectedFileContent);
+    });
+
+    it('falls back to the token length when a result carries no end position', () => {
+        // Results computed before the end position was recorded cannot be backfilled, so they keep the old derivation.
+        const mockMatches = [
+            {
+                from: { column: 1, line: 1, length: 5 } as PlagiarismSubmissionElement,
+                to: { column: 13, line: 1, length: 5 } as PlagiarismSubmissionElement,
+            },
+        ];
+        vi.spyOn(comp, 'getMatchesForCurrentFile').mockReturnValue(mockMatches);
+
+        const fileContent = `Lorem ipsum dolor sit amet.`;
+        const expectedFileContent = `<span class="plagiarism-match">Lorem ipsum dolor </span>sit amet.`;
+        fixture.componentRef.setInput('exercise', { type: ExerciseType.TEXT } as Exercise);
+
+        const updatedFileContent = comp.insertMatchTokens(fileContent);
+
+        expect(updatedFileContent).toEqual(expectedFileContent);
+    });
+
     it('should insert full line match tokens', () => {
         const mockMatches = [
             {

--- a/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
+++ b/src/main/webapp/app/plagiarism/manage/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
@@ -264,7 +264,9 @@ export class TextSubmissionViewerComponent {
 
         const linesWithMatches = new Set<number>();
         for (const match of matches) {
-            for (let i = match.from.line - 1; i < match.to.line; i++) {
+            // As below: the last token of a match can end on a later line than it starts on, so the whole-line
+            // highlighting has to run to the reported end line rather than to the line the token begins on.
+            for (let i = match.from.line - 1; i < (match.to.endLine ?? match.to.line); i++) {
                 linesWithMatches.add(i);
             }
         }
@@ -321,10 +323,15 @@ export class TextSubmissionViewerComponent {
     private buildFileContentPartForMatch(matches: FromToElement[], match_index: number, fileLines: string[]): string {
         const match = matches[match_index];
         const idxLineFrom = match.from.line - 1;
-        const idxLineTo = match.to.line - 1;
+        // Where the last token of the match ends. JPlag reports this explicitly; `length` excludes line breaks, so
+        // deriving the end from it only holds while the token stays on one line. Results computed before the end
+        // position was recorded have no value here, and for those the old derivation is still the best available: it
+        // is what JPlag itself used to compute (`endColumn = column + length`).
+        const lineTo = match.to.endLine ?? match.to.line;
+        const idxLineTo = lineTo - 1;
 
         const idxColumnFrom = match.from.column > 0 ? match.from.column - 1 : 0;
-        const idxColumnTo = match.to.column + match.to.length;
+        const idxColumnTo = match.to.endColumn ?? match.to.column + match.to.length;
 
         let result = this.tokenStart;
 
@@ -354,7 +361,7 @@ export class TextSubmissionViewerComponent {
             for (let j = idxLineTo + 1; j < fileLines.length; j++) {
                 result += '\n' + escape(fileLines[j]);
             }
-        } else if (matches[match_index + 1].from.line === match.to.line) {
+        } else if (matches[match_index + 1].from.line === lineTo) {
             result += escape(fileLines[idxLineTo].slice(idxColumnTo, matches[match_index + 1].from.column - 1));
         } else {
             result += escape(fileLines[idxLineTo].slice(idxColumnTo)) + '\n';

--- a/src/main/webapp/app/plagiarism/shared/entities/PlagiarismSubmissionElement.ts
+++ b/src/main/webapp/app/plagiarism/shared/entities/PlagiarismSubmissionElement.ts
@@ -4,7 +4,15 @@ export class PlagiarismSubmissionElement {
     column!: number;
     line!: number;
     file!: string;
+    /**
+     * Where the token ends, counted in characters from its start and without line breaks, so it only gives the end
+     * column for a token that stays on one line. Superseded by `endLine` / `endColumn`; still sent because results
+     * computed before those were recorded have nothing else.
+     */
     length!: number;
+    /** Where the token ends, as reported by JPlag. Undefined for a result computed before this was recorded. */
+    endLine?: number;
+    endColumn?: number;
 }
 
 /** Instantiated via its constructor; fields are populated at construction time. */


### PR DESCRIPTION
### Summary

A plagiarism match whose last token spans a line break was highlighted with the wrong end, because the view derived the end position from a token length that does not count line breaks. JPlag reports the real end position, so the comparison view uses that now. This also removes the last `[removal]` deprecation from the JPlag API.

### Checklist

- [x] Added tests for both the corrected and the fallback path.
- [x] Ran the plagiarism suites on both sides.
- [x] Followed the server and client coding conventions.

### Motivation and Context

`de.jplag.Token.getLength()` carries `@Deprecated(since = "6.2.0", forRemoval = true)` with the reason:

> The length does not include line breaks and should not be used to calculate the end position of a token

`text-submission-viewer.component.ts` did precisely that:

```ts
const idxColumnTo = match.to.column + match.to.length;
```

So for a match whose last token crosses a line break, the highlight ended at a column on the wrong line. The whole-line variant had the same problem: it ran to `match.to.line`, the line the last token *starts* on.

JPlag's own deprecated constructor computes `endColumn = column + length`, so the explicit end position it now reports is the same value for a single-line token and the correct one otherwise. That makes this a drop-in with no change to existing behaviour except where it was wrong.

### Description

- `PlagiarismSubmissionElement` gains `endLine` and `endColumn`, filled from `token.getEndLine()` / `token.getEndColumn()`.
- One additive Liquibase changelog adds the two nullable columns.
- `PlagiarismSubmissionElementDTO` and the client model carry them through.
- The text comparison view highlights to the reported end, in both the exact-match and the whole-line path, and falls back to the old derivation when a result has no end position.
- `length` is kept and marked deprecated rather than removed, because results computed before this change have nothing else.

### Why nothing is backfilled

The token stream a result was computed from is not stored, so an existing `plagiarism_submission_element` row cannot be given an end position after the fact. Those rows keep `null` and the client keeps the old derivation for them, which is exactly the behaviour they have today. New results carry the explicit end. That is why the columns are nullable and why this needs no data migration.

### Steps for Testing

1. Run a plagiarism check on a text exercise and open a comparison.
2. Find a match whose last token wraps across a line break; the highlight must now cover it to its real end rather than stopping short.
3. Open a comparison from a plagiarism result computed before this change; the highlighting must be unchanged.

### Validation

- Client: 241 of 241 plagiarism specs pass, including two new ones covering a match that spans a line break and a result without an end position.
- Server: 212 of 212 tests in `de.tum.cit.aet.artemis.plagiarism` pass.
- `spotlessCheck` and `checkstyleMain` pass.
- The `[removal] getLength() in Token` warning is gone; the one remaining call is the deliberate write of the legacy value, suppressed at that line.

While writing the test I got the expected string wrong by one character, which was a useful check on the convention: `endColumn` is exclusive, the same as `column + length` was, and the existing tests already encode that.

### Review Progress

- [x] Code review
- [x] Visual check on a real comparison

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| text-submission-viewer.component.ts | 95.34% | 236 | 31 | 13.1 |
| PlagiarismSubmissionElement.ts | 100.00% | 17 | ? | ? |

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| PlagiarismSubmissionElement.java | 97.62% | 102 |
| PlagiarismSubmissionElementDTO.java | 80.00% | 15 |

_Last updated: 2026-09-05 23:11:08 UTC_

