### PR TITLE
`Assessment`: Fix a duplicate correction round after deleting an earlier assessment

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/Submission.java
@@ -315,16 +315,18 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
      * <p>
      * This is where the round used to come from implicitly: the results were an ordered list and the position carried
      * the round, so adding a result to the list decided which round it belonged to. The round now lives on the result,
-     * and this is the same moment, so the behaviour is unchanged for every caller that does not set it itself.
-     * {@code SubmissionService.lockSubmission} does set it, from the round the tutor asked for, and that takes
-     * precedence. Automatic and Athena results are not correction rounds and keep no round.
+     * and this is the same moment. {@code SubmissionService.lockSubmission} does set it, from the round the tutor asked
+     * for, and that takes precedence. Automatic and Athena results are not correction rounds and keep no round.
+     * <p>
+     * The next round is the one after the highest existing round, not the number of existing results: after a result
+     * of an earlier round is deleted the two differ, and counting would hand the new result a round that is still taken.
      *
      * @param result the result to add
      */
     public void addResult(Result result) {
         if (result != null) {
             if (result.getCorrectionRound() == null && !result.isAutomatic() && !result.isAthenaBased()) {
-                result.setCorrectionRound(countCorrectionRoundResults(result));
+                result.setCorrectionRound(nextCorrectionRound(result));
             }
             // Keep both ends of the association in sync. The results are mapped on the inverse side and cascade, so
             // without this Hibernate inserts the cascaded result with an empty submission_id and only fills it in with
@@ -335,11 +337,12 @@ public abstract class Submission extends DomainObject implements Comparable<Subm
     }
 
     /**
-     * @param resultToAdd the result that is about to be added, which must not count itself
-     * @return how many correction-round results this submission already holds
+     * @param resultToAdd the result that is about to be added, which must not be considered itself
+     * @return the round after the highest one a correction-round result of this submission holds, or 0 if there is none
      */
-    private int countCorrectionRoundResults(Result resultToAdd) {
-        return (int) results.stream().filter(other -> other != null && other != resultToAdd && !other.isAutomatic() && !other.isAthenaBased()).count();
+    private int nextCorrectionRound(Result resultToAdd) {
+        return results.stream().filter(other -> other != null && other != resultToAdd && !other.isAutomatic() && !other.isAthenaBased()).map(Result::getCorrectionRound)
+                .filter(Objects::nonNull).mapToInt(round -> round + 1).max().orElse(0);
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/AssessmentComplaintIntegrationTest.java
@@ -31,6 +31,7 @@ import de.tum.cit.aet.artemis.assessment.dto.ComplaintDTO;
 import de.tum.cit.aet.artemis.assessment.dto.ComplaintRequestDTO;
 import de.tum.cit.aet.artemis.assessment.dto.ComplaintResponseUpdateDTO;
 import de.tum.cit.aet.artemis.assessment.repository.ComplaintRepository;
+import de.tum.cit.aet.artemis.assessment.service.AssessmentService;
 import de.tum.cit.aet.artemis.assessment.test_repository.ComplaintResponseTestRepository;
 import de.tum.cit.aet.artemis.assessment.util.ComplaintUtilService;
 import de.tum.cit.aet.artemis.core.domain.Language;
@@ -64,6 +65,9 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
 
     @Autowired
     private ComplaintRepository complaintRepo;
+
+    @Autowired
+    private AssessmentService assessmentService;
 
     @Autowired
     private SubmissionTestRepository submissionRepository;
@@ -349,6 +353,42 @@ class AssessmentComplaintIntegrationTest extends AbstractSpringIntegrationIndepe
                 .isEqualTo(resultAfterComplaint.getId());
         // The student is shown the newest result, which is the one the complaint produced.
         assertThat(storedSubmission.getLatestResult()).isNotNull().extracting(Result::getId).isEqualTo(resultAfterComplaint.getId());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor2", roles = "TA")
+    void submitComplaintResponse_afterDeletingTheFirstRound_doesNotReuseTheRemainingRound() throws Exception {
+        // Two correction rounds, then an instructor deletes the result of the first one, so only round 1 is left.
+        Result secondRoundAssessment = participationUtilService.addResultToSubmission(AssessmentType.MANUAL, ZonedDateTime.now(), modelingSubmission, TEST_PREFIX + "instructor1",
+                List.of());
+        assertThat(secondRoundAssessment.getCorrectionRound()).isEqualTo(1);
+        Submission submissionWithResults = submissionRepository.findByIdWithResultsElseThrow(modelingSubmission.getId());
+        assessmentService.deleteAssessment(submissionWithResults, submissionWithResults.getResultForCorrectionRound(0));
+
+        Complaint complaintAboutSecondRound = complaintRepo
+                .save(new Complaint().result(secondRoundAssessment).complaintText("The second corrector was unfair").complaintType(ComplaintType.COMPLAINT));
+        ComplaintResponse complaintResponse = complaintUtilService.createInitialEmptyResponse(TEST_PREFIX + "tutor2", complaintAboutSecondRound);
+        complaintResponse.getComplaint().setAccepted(true);
+        complaintResponse.setResponseText("Accepted");
+
+        List<Feedback> feedbacks = participationUtilService.loadAssessmentFomResources("test-data/model-assessment/assessment.54727.json");
+        feedbacks.forEach(feedback -> feedback.setType(FeedbackType.MANUAL));
+        Result resultAfterComplaint = request.putWithResponseBody("/api/modeling/modeling-submissions/" + modelingSubmission.getId() + "/assessment-after-complaint",
+                new AssessmentUpdateDTO(feedbacks, complaintResponse, null), Result.class, HttpStatus.OK);
+
+        // The complaint result takes the round after the highest remaining one. Counting the remaining results would
+        // give it round 1, which the complained-about result still holds, and one of the two would then be unreachable.
+        assertThat(resultAfterComplaint).isNotNull();
+        assertThat(resultAfterComplaint.getCorrectionRound()).as("the result of an accepted complaint follows the highest remaining round").isEqualTo(2);
+
+        Submission storedSubmission = submissionRepository.findByIdWithResultsElseThrow(modelingSubmission.getId());
+        assertThat(storedSubmission.getResults()).as("the remaining round and the complaint result are kept").hasSize(2);
+        assertThat(storedSubmission.getResults()).extracting(Result::getCorrectionRound).as("each result has its own round").doesNotHaveDuplicates();
+        assertThat(storedSubmission.getResultForCorrectionRound(0)).as("the deleted round stays empty").isNull();
+        assertThat(storedSubmission.getResultForCorrectionRound(1)).as("the complained-about result still resolves to its round").isNotNull().extracting(Result::getId)
+                .isEqualTo(secondRoundAssessment.getId());
+        assertThat(storedSubmission.getResultForCorrectionRound(2)).as("the complaint result is the one of the following round").isNotNull().extracting(Result::getId)
+                .isEqualTo(resultAfterComplaint.getId());
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/domain/SubmissionResultAccessorTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/domain/SubmissionResultAccessorTest.java
@@ -71,6 +71,57 @@ class SubmissionResultAccessorTest {
     }
 
     @Test
+    void addResultAssignsTheRoundAfterTheHighestExistingOne() {
+        // The result of the first round was deleted, so the submission holds only the second round. A new result must
+        // not be handed round 1 again, which counting the results would do.
+        Result secondRound = result(2L, AssessmentType.MANUAL);
+        secondRound.setCorrectionRound(1);
+        Submission submission = submissionWith(secondRound);
+
+        Result added = result(3L, AssessmentType.MANUAL);
+        submission.addResult(added);
+
+        assertThat(added.getCorrectionRound()).isEqualTo(2);
+        assertThat(submission.getResultForCorrectionRound(1)).isEqualTo(secondRound);
+        assertThat(submission.getResultForCorrectionRound(2)).isEqualTo(added);
+    }
+
+    @Test
+    void addResultAssignsRoundZeroWhenNoCorrectionRoundResultExists() {
+        Submission submission = submissionWith(result(1L, AssessmentType.AUTOMATIC), result(2L, AssessmentType.AUTOMATIC_ATHENA));
+
+        Result added = result(3L, AssessmentType.MANUAL);
+        submission.addResult(added);
+
+        assertThat(added.getCorrectionRound()).isZero();
+    }
+
+    @Test
+    void addResultKeepsTheRoundTheCallerSet() {
+        Result firstRound = result(1L, AssessmentType.MANUAL);
+        firstRound.setCorrectionRound(0);
+        Submission submission = submissionWith(firstRound);
+
+        Result added = result(2L, AssessmentType.MANUAL);
+        added.setCorrectionRound(5);
+        submission.addResult(added);
+
+        assertThat(added.getCorrectionRound()).isEqualTo(5);
+    }
+
+    @Test
+    void addResultLeavesAutomaticResultsWithoutARound() {
+        Result firstRound = result(1L, AssessmentType.MANUAL);
+        firstRound.setCorrectionRound(0);
+        Submission submission = submissionWith(firstRound);
+
+        Result automatic = result(2L, AssessmentType.AUTOMATIC);
+        submission.addResult(automatic);
+
+        assertThat(automatic.getCorrectionRound()).isNull();
+    }
+
+    @Test
     void manualResultAccessorsToleratePlaceholdersLeftByDeletedResults() {
         Result manual = result(2L, AssessmentType.MANUAL);
         Submission submission = new TextSubmission();

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
@@ -1168,10 +1168,12 @@ public class ParticipationUtilService {
         }
         // Excluded by reference and by id: a result that is not saved yet has no id to match on, and a caller can also
         // hand in a persisted result, which the query above returns as a different object for the same row.
-        long manualResults = existing.filter(
+        // The round after the highest existing one, as in Submission.addResult: counting would reuse a round after a
+        // result of an earlier round was deleted.
+        int nextRound = existing.filter(
                 other -> other != null && other != result && !isSameRow(other, result) && other.getAssessmentType() != null && !other.isAutomatic() && !other.isAthenaBased())
-                .count();
-        result.setCorrectionRound((int) manualResults);
+                .map(Result::getCorrectionRound).filter(Objects::nonNull).mapToInt(round -> round + 1).max().orElse(0);
+        result.setCorrectionRound(nextRound);
         return result;
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
@@ -1126,20 +1126,19 @@ public class ParticipationUtilService {
     }
 
     /**
-     * Assigns the correction round the way production does, so that fixtures behave like the assessment lock: the n-th
-     * manual result of a submission belongs to round n. Automatic and Athena results are not correction rounds and keep
-     * a null round.
-     * <p>
-     * The count comes from the submission's results in memory, which is where the position of the result used to come
-     * from as well when Hibernate maintained the order column.
-     *
-     * @param result the result about to be saved
-     * @return the same result, with its correction round set when it is a manual one
+     * @param one   a result
+     * @param other another result
+     * @return whether both are persisted and refer to the same database row
      */
+    private static boolean isSameRow(Result one, Result other) {
+        return one.getId() != null && one.getId().equals(other.getId());
+    }
+
     /**
      * Assigns the correction round a manual result would get if it were added through {@link Submission#addResult}, so
      * that results created directly through the repository carry the same value as results created through the
-     * production code path.
+     * production code path: the round after the highest one the submission's manual results already hold, or 0 if
+     * there is none. Automatic and Athena results are not correction rounds and keep a null round.
      * <p>
      * The already existing results are read from the database rather than from {@code submission.getResults()}, because
      * the submissions handed to these helpers usually come straight out of a repository and are detached, which makes
@@ -1148,10 +1147,6 @@ public class ParticipationUtilService {
      * @param result the result about to be saved
      * @return the same result, with the correction round set when it is a manual one
      */
-    private static boolean isSameRow(Result one, Result other) {
-        return one.getId() != null && one.getId().equals(other.getId());
-    }
-
     private Result withCorrectionRound(Result result) {
         boolean manual = result.getAssessmentType() != null && !result.isAutomatic() && !result.isAthenaBased();
         Submission submission = result.getSubmission();


### PR DESCRIPTION
### Summary

After an instructor deletes the result of an earlier correction round, a later assessment that does not set its own round (for example the result of an accepted complaint) received a round that another result still holds. `Submission.addResult` now assigns the round after the highest existing one instead of counting the results.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server. (Tested locally with the server tests below; not yet confirmed on a test server.)
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

Fixes #13618.

Since #13570 the correction round lives on the result. `Submission.addResult` gave a manual result without a round the number of manual results the submission already held. That equals the next free round only while no earlier round has been deleted. With rounds 0 and 1 assessed and round 0 deleted, the count is 1, so the result of an accepted complaint also got round 1. `getResultForCorrectionRound(1)` then returned only the lower id of the two, so one of the results was unreachable by round.

### Description

- `Submission.addResult` assigns `max(existing correction round) + 1`, or 0 if no manual result carries a round. A round the caller sets (as `SubmissionService.lockSubmission` does) still takes precedence, and automatic and Athena results still get no round.
- `ParticipationUtilService.withCorrectionRound`, the test helper that mirrors this rule for fixtures written through the result repository, follows the same rule.
- Unit tests for `addResult` (gap, no manual result, caller-set round, automatic result) and an integration test that runs the reported scenario: two rounds, delete round 0, accept a complaint about round 1, and check the complaint result gets round 2 while round 1 still resolves to its own result.

Both new tests fail on `develop` (`expected: 2 but was: 1`) and pass with this change.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Student
- 1 Exam with a modeling (or text) exercise, 2 correction rounds, and complaints enabled

1. As the student, take the exam and submit the modeling exercise.
2. As the instructor, assess the submission in correction round 1 and again in correction round 2.
3. Open Course Management > Exam > Exercise > Participations > Submissions for that participation and delete the result of correction round 1. The round-2 result stays.
4. Publish the results, and as the student open the result and file a complaint.
5. As the instructor, accept the complaint and update the assessment.
6. Open the submission's results again (Participations > Submissions, or `GET /api/exercise/participations/{participationId}/submissions`). The complaint result has correction round 3 (`correctionRound: 2` in the payload), the remaining earlier result still has `correctionRound: 1`, and no two results share a round.

#### Exam Mode Testing

The steps above run in exam mode. Also check that the two-round flow without deletion is unchanged: assess round 1, assess round 2, accept a complaint, and the complaint result gets `correctionRound: 2`.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| Submission.java | 89.16% | 254 |

_Last updated: 2026-09-05 23:14:32 UTC_

