### PR TITLE
`Modeling exercises`: Fix historical assessment results disappearing after response conversion

### DIFF
--- a/src/main/webapp/app/exercise/shared/entities/submission/submission.model.spec.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission.model.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { Result } from 'app/exercise/shared/entities/result/result.model';
-import { Submission, getLatestSubmissionResult, getNewestResult, getSubmissionResultByCorrectionRound } from 'app/exercise/shared/entities/submission/submission.model';
+import {
+    Submission,
+    getLatestSubmissionResult,
+    getNewestResult,
+    getSubmissionResultByCorrectionRound,
+    setLatestSubmissionResult,
+} from 'app/exercise/shared/entities/submission/submission.model';
 import { AssessmentType } from 'app/assessment/shared/entities/assessment-type.model';
 import { ProgrammingSubmission } from 'app/programming/shared/entities/programming-submission.model';
 
@@ -50,6 +56,54 @@ describe('Submission model', () => {
             // The server holds the results in a set, so both orders are possible for the same data.
             expect(getLatestSubmissionResult(submissionWith([resultWith(4), newest]))).toBe(newest);
             expect(getLatestSubmissionResult(submissionWith([newest, resultWith(4)]))).toBe(newest);
+        });
+    });
+
+    describe('setLatestSubmissionResult', () => {
+        it('should keep the other results when the newest one is not the last element', () => {
+            const newest = resultWith(25);
+            const older = resultWith(24);
+            const submission = submissionWith([newest, older]);
+
+            setLatestSubmissionResult(submission, getLatestSubmissionResult(submission));
+
+            expect(submission.results).toEqual([newest, older]);
+            expect(submission.latestResult).toBe(newest);
+            expect(newest.submission).toBe(submission);
+        });
+
+        it('should replace the result that has the same id', () => {
+            const submission = submissionWith([resultWith(24), resultWith(25)]);
+            const updated = resultWith(25);
+
+            setLatestSubmissionResult(submission, updated);
+
+            expect(submission.results).toHaveLength(2);
+            expect(submission.results![1]).toBe(updated);
+            expect(submission.latestResult).toBe(updated);
+        });
+
+        it('should let a draft without an id replace the last entry', () => {
+            // A cloned draft, as the example-submission editors send it, must not sit next to the result it was cloned from.
+            const persisted = resultWith(24);
+            const draft = resultWith(undefined);
+            const submission = submissionWith([persisted, draft]);
+            const clone = resultWith(undefined);
+
+            setLatestSubmissionResult(submission, clone);
+
+            expect(submission.results).toEqual([persisted, clone]);
+            expect(submission.latestResult).toBe(clone);
+        });
+
+        it('should create the results list when there is none', () => {
+            const submission = submissionWith(undefined as unknown as Result[]);
+            const result = resultWith(1);
+
+            setLatestSubmissionResult(submission, result);
+
+            expect(submission.results).toEqual([result]);
+            expect(submission.latestResult).toBe(result);
         });
     });
 

--- a/src/main/webapp/app/exercise/shared/entities/submission/submission.model.spec.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission.model.spec.ts
@@ -73,13 +73,16 @@ describe('Submission model', () => {
         });
 
         it('should replace the result that has the same id', () => {
-            const submission = submissionWith([resultWith(24), resultWith(25)]);
+            // The matching entry is not the last one, so overwriting the last entry would fail this test.
+            const older = resultWith(24);
+            const submission = submissionWith([resultWith(25), older]);
             const updated = resultWith(25);
 
             setLatestSubmissionResult(submission, updated);
 
             expect(submission.results).toHaveLength(2);
-            expect(submission.results![1]).toBe(updated);
+            expect(submission.results![0]).toBe(updated);
+            expect(submission.results![1]).toBe(older);
             expect(submission.latestResult).toBe(updated);
         });
 

--- a/src/main/webapp/app/exercise/shared/entities/submission/submission.model.ts
+++ b/src/main/webapp/app/exercise/shared/entities/submission/submission.model.ts
@@ -109,8 +109,13 @@ export function getSubmissionResultById(submission: Submission | undefined, resu
 }
 
 /**
- * Used to set / override the latest result in the results list, and set / override the
- * var latestResult
+ * Sets the given result as the submission's latest result and makes sure it is part of the results list.
+ *
+ * A result that is already in the list (same object or same id) is updated in place, so the other results stay where
+ * they are. The server does not order results by id, so the last element is not necessarily the newest one, and
+ * overwriting it would drop an older result from the history. A result that is not in the list yet is a draft the
+ * client just created; it replaces the last entry, as it always did, so a draft never sits next to the result it
+ * stands in for.
  *
  * @param submission
  * @param result
@@ -120,11 +125,16 @@ export function setLatestSubmissionResult(submission: Submission | undefined, re
         return;
     }
 
-    if (submission.results?.length) {
-        submission.results[submission.results.length - 1] = result;
+    const results = submission.results ?? [];
+    const index = results.findIndex((existing) => existing === result || (existing?.id !== undefined && existing.id === result.id));
+    if (index >= 0) {
+        results[index] = result;
+    } else if (results.length) {
+        results[results.length - 1] = result;
     } else {
-        submission.results = [result];
+        results.push(result);
     }
+    submission.results = results;
     // make sure relationship is correct
     result.submission = submission;
     submission.latestResult = result;

--- a/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.component.spec.ts
+++ b/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.component.spec.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, input, output } from '@angular/core';
 import { MarkdownDirective } from 'app/foundation/directives/markdown.directive';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HttpResponse, provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ChangeDetectorRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Params, RouterModule } from '@angular/router';
@@ -171,8 +171,8 @@ describe('ModelingSubmissionComponent', () => {
                 { provide: ParticipationWebsocketService, useClass: MockParticipationWebsocketService },
                 { provide: WebsocketService, useClass: MockWebsocketService },
                 ResultService,
-                provideHttpClientTesting(),
                 provideHttpClient(),
+                provideHttpClientTesting(),
                 {
                     provide: AccountService,
                     useClass: MockAccountService,
@@ -315,6 +315,39 @@ describe('ModelingSubmissionComponent', () => {
         expect(comp.submission()?.results).toHaveLength(2);
         expect(comp.result()?.id).toBe(99);
         expect(comp.result()?.assessmentType).toBe(AssessmentType.MANUAL);
+    });
+
+    it('should show an older result by id after the real service conversion of a newest-first response', () => {
+        const route = {
+            params: of({ courseId: 5, exerciseId: 22, participationId: 1, submissionId: 20, resultId: 24 }),
+        } as any as ActivatedRoute;
+
+        createModelingSubmissionComponent(route);
+
+        const modelingExercise = new ModelingExercise(UMLDiagramType.ClassDiagram, undefined, undefined);
+        modelingExercise.dueDate = dayjs().subtract(2, 'days');
+        modelingExercise.assessmentDueDate = dayjs().subtract(1, 'days');
+        modelingExercise.maxPoints = 20;
+        modelingExercise.teamMode = false;
+        const participation = new StudentParticipation();
+        participation.exercise = modelingExercise;
+        participation.id = 1;
+
+        // The history endpoint lists results newest first, so the older result is the last element.
+        const olderFeedback = { id: 2, text: 'older', credits: 5, type: FeedbackType.MANUAL } as Feedback;
+        const newerResult = { id: 25, completionDate: dayjs().subtract(1, 'hour'), assessmentType: AssessmentType.MANUAL, score: 90, feedbacks: [] } as Result;
+        const olderResult = { id: 24, completionDate: dayjs().subtract(2, 'hours'), assessmentType: AssessmentType.MANUAL, score: 50, feedbacks: [olderFeedback] } as Result;
+        const serverSubmission = { id: 20, submitted: true, participation, results: [newerResult, olderResult] } as ModelingSubmission;
+
+        // Answer the HTTP requests, not the service, so the real ModelingSubmissionService conversion runs on the server payload.
+        const httpMock = TestBed.inject(HttpTestingController);
+        comp.ngOnInit();
+        httpMock.expectOne({ method: 'GET', url: 'api/modeling/participations/1/submissions-with-results' }).flush([serverSubmission]);
+        httpMock.expectOne({ method: 'GET', url: 'api/modeling/participations/1/latest-modeling-submission' }).flush(serverSubmission);
+
+        expect(comp.submission()?.results?.map((result) => result.id)).toEqual([25, 24]);
+        expect(comp.result()?.id).toBe(24);
+        expect(comp.assessmentResult()?.feedbacks).toEqual([olderFeedback]);
     });
 
     it('should get inactive as soon as the due date passes the current date', async () => {

--- a/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.service.spec.ts
+++ b/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.service.spec.ts
@@ -7,6 +7,8 @@ import { take } from 'rxjs/operators';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from 'test/helpers/mocks/service/mock-account.service';
 import { provideHttpClient } from '@angular/common/http';
+import { deepClone } from 'app/foundation/util/deep-clone.util';
+import { Result } from 'app/exercise/shared/entities/result/result.model';
 
 describe('ModelingSubmission Service', () => {
     let service: ModelingSubmissionService;
@@ -141,7 +143,8 @@ describe('ModelingSubmission Service', () => {
         // The history endpoint sorts results by completion date, newest first, so the older result sits behind the newer one.
         const newerResult = { id: 25, completionDate: '2026-08-30T10:00:00Z', feedbacks: [{ id: 3, text: 'newer' }] };
         const olderResult = { id: 24, completionDate: '2026-08-29T10:00:00Z', feedbacks: [{ id: 2, text: 'older' }] };
-        const submissionFromServer = { ...elemDefault, results: [newerResult, olderResult] };
+        const submissionFromServer = deepClone(elemDefault);
+        submissionFromServer.results = [newerResult, olderResult] as Result[];
 
         let converted: ModelingSubmission[] = [];
         service

--- a/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.service.spec.ts
+++ b/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.service.spec.ts
@@ -8,7 +8,6 @@ import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from 'test/helpers/mocks/service/mock-account.service';
 import { provideHttpClient } from '@angular/common/http';
 import { deepClone } from 'app/foundation/util/deep-clone.util';
-import { Result } from 'app/exercise/shared/entities/result/result.model';
 
 describe('ModelingSubmission Service', () => {
     let service: ModelingSubmissionService;
@@ -143,8 +142,7 @@ describe('ModelingSubmission Service', () => {
         // The history endpoint sorts results by completion date, newest first, so the older result sits behind the newer one.
         const newerResult = { id: 25, completionDate: '2026-08-30T10:00:00Z', feedbacks: [{ id: 3, text: 'newer' }] };
         const olderResult = { id: 24, completionDate: '2026-08-29T10:00:00Z', feedbacks: [{ id: 2, text: 'older' }] };
-        const submissionFromServer = deepClone(elemDefault);
-        submissionFromServer.results = [newerResult, olderResult] as Result[];
+        const submissionFromServer = { ...deepClone(elemDefault), results: [newerResult, olderResult] };
 
         let converted: ModelingSubmission[] = [];
         service

--- a/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.service.spec.ts
+++ b/src/main/webapp/app/modeling/overview/modeling-submission/modeling-submission.service.spec.ts
@@ -137,6 +137,25 @@ describe('ModelingSubmission Service', () => {
         req.flush(submissions);
     });
 
+    it('should keep every result of a submission when the server lists the newest result first', () => {
+        // The history endpoint sorts results by completion date, newest first, so the older result sits behind the newer one.
+        const newerResult = { id: 25, completionDate: '2026-08-30T10:00:00Z', feedbacks: [{ id: 3, text: 'newer' }] };
+        const olderResult = { id: 24, completionDate: '2026-08-29T10:00:00Z', feedbacks: [{ id: 2, text: 'older' }] };
+        const submissionFromServer = { ...elemDefault, results: [newerResult, olderResult] };
+
+        let converted: ModelingSubmission[] = [];
+        service
+            .getSubmissionsWithResultsForParticipation(4)
+            .pipe(take(1))
+            .subscribe((resp) => (converted = resp));
+        httpMock.expectOne({ method: 'GET', url: 'api/modeling/participations/4/submissions-with-results' }).flush([submissionFromServer]);
+
+        const results = converted[0].results!;
+        expect(results.map((result) => result.id)).toEqual([25, 24]);
+        expect(converted[0].latestResult?.id).toBe(25);
+        expect(results.find((result) => result.id === 24)?.feedbacks?.[0]?.text).toBe('older');
+    });
+
     it('should get submission without lock', () => {
         const { returnedFromService } = getDefaultValues();
 


### PR DESCRIPTION
### Summary

`setLatestSubmissionResult` overwrote the last element of `submission.results` with the newest result. The modeling history endpoint lists results newest first, so a response with results `[25, 24]` became `[25, 25]` on the client, and the direct URL for result 24 showed no assessment. The function now updates a result that is already in the list in place, so the other results stay where they are.

### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server. (Tested locally in the browser with the steps below and with the client tests; not yet confirmed on a test server.)
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context

Fixes #13619.

`getLatestSubmissionResult` picks the result with the highest id, and `setLatestSubmissionResult` then wrote that result over the last element of `submission.results`. That was fine while the last element was the newest one. `GET /api/modeling/participations/{id}/submissions-with-results` sorts results by completion date, newest first, so the last element is the oldest result and gets replaced. `SubmissionService.convertSubmissionFromServer` runs this on every response, so the client never saw the older result. The direct history view (`.../submission/{submissionId}/result/{resultId}`, added in #12147) looks the result up by id and found nothing.

### Description

- `setLatestSubmissionResult` finds the entry with the same id (or the same object) and replaces it in place. Nothing else in the list is touched. A result that is not in the list yet is a draft the client just created (the example-submission editors clone one before sending it); it replaces the last entry as before, so a draft never sits next to the result it was cloned from. Every caller keeps its wire payload; only the conversion path that passes a result already in the list changes.
- Regression tests:
  - `submission.model.spec.ts`: the newest result not being the last element, replacing by id, a draft replacing the last entry, and creating the list.
  - `modeling-submission.service.spec.ts`: a server-shaped two-result response, newest first, comes out of `getSubmissionsWithResultsForParticipation` with both results and the older result's feedback intact.
  - `modeling-submission.component.spec.ts`: the same payload is flushed through `HttpTestingController`, so the real `ModelingSubmissionService` conversion runs; the component opens result 24 by route and shows its feedback. The spec's `provideHttpClient()` / `provideHttpClientTesting()` order is swapped to the documented one so the testing backend is the one in use.

The three history tests fail on `develop` (`expected [ 25, 25 ] to deeply equal [ 25, 24 ]`) and pass with this change.

Verified locally in the browser with the steps below: on `develop` the older result's URL renders an empty assessment panel; with this change it shows the older feedback and points, after a reload and when reached through the result-history popover. The newer result still renders.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Student
- 1 Modeling exercise with manual assessment, complaints enabled, and a due date in the past

1. As the student, submit the modeling exercise.
2. As the instructor, assess the submission and submit the assessment.
3. As the student, open the result and file a complaint.
4. As the instructor, accept the complaint and update the assessment with different points. The submission now has two results, and the newer one has the larger id.
5. As the student, open the exercise, click the score in the exercise header to open the result history, and click the older result. The URL ends in `/submission/{submissionId}/result/{olderResultId}` and the older assessment and its feedback show.
6. Reload the page. The older assessment and its feedback still show. On `develop` the assessment panel is empty.
7. Open the newer result from the history and reload. It still shows.

#### Exam Mode Testing

The changed function is shared by all exercise types. Also check that assessing a modeling exercise in an exam (two correction rounds) and viewing the results in the exam summary still shows the assessment.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| submission.model.ts | not found (modified) | 141 | 24 | 17.0 |

_Last updated: 2026-09-06 11:15:20 UTC_

