### PR TITLE
`Development`: Document instance-wide open edx LTI registration

### DIFF
--- a/documentation/docs/instructor/integrations/lti-configuration.mdx
+++ b/documentation/docs/instructor/integrations/lti-configuration.mdx
@@ -290,9 +290,9 @@ On the Artemis side (as an Artemis admin), add one platform under *Server Admini
 Instructors then use the configuration in every course that the Open edX admin enabled for the store, without further admin steps:
 
 1. In Artemis, enable *Online Course* and select the platform in the course's LTI configuration (see <a href="#sharing-access-to-a-course">Sharing access to a course</a>). Deep linking refuses courses without this configuration.
-2. In Studio, add an *LTI Consumer* component and set *Configuration Type* to *Existing* (older versions: *External*).
-3. Enter the *Filter Key* in *LTI Reusability ID* (older versions: *External Config ID*). The component takes the LTI version from the store and hides the *LTI Version* field; releases before 11.3.0 still show it, so set it to *LTI 1.3* there.
-4. Set *Scored* to True with *Weight* 100, and set *Request user's username*, *Request user's full name* and *Request user's email* to True. Artemis matches launches to users by email, and edX only sends it when sharing is enabled. If these fields are missing, the Open edX admin has to allow PII sharing for the course.
+2. In Studio, add an *LTI Consumer* component and set *Configuration Type* to *Existing* (older versions: *Reusable Configuration*).
+3. Enter the *Filter Key* in *LTI Reusability ID* (older versions: *LTI Reusable Configuration ID*). The component takes the LTI version from the store and hides the *LTI Version* field; releases before 11.3.0 still show it, so set it to *LTI 1.3* there.
+4. Set *This activity is graded* (older versions: *Scored*) to True and *Grade Weight* (*Weight*) to the points the exercise is worth in the Open edX gradebook. Artemis sends scores as a percentage, so any weight works. Set *Share Username*, *Share Full name* and *Share Email* (*Request user's username*, *Request user's full name*, *Request user's email*) to True. Artemis matches launches to users by email, and edX only sends it when sharing is enabled. If these fields are missing, the Open edX admin has to allow PII sharing for the course.
 5. Publish the component, then follow <a href="#deep-linking-for-edx">Deep Linking for edX</a> to select the Artemis exercise or lecture for it before students open the unit.
 
 One platform serves all Artemis courses linked to that Open edX instance.

--- a/documentation/docs/instructor/integrations/lti-configuration.mdx
+++ b/documentation/docs/instructor/integrations/lti-configuration.mdx
@@ -248,6 +248,52 @@ The registration process is now complete.
 EdX course admins must enable the LTI tool in Studio before an instructor can add LTI components to their course. To allow the LTI tool in Studio, add *lti_consumer* to the Advanced Module List on the Advanced Settings page.
 For more information, please see the official <a href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html">edX documentation</a>.
 
+There are two ways to register Artemis with Open edX:
+
+1. **Once per Open edX instance** with the <a href="https://github.com/open-craft/openedx-ltistore">LTI Store</a> plugin (recommended). An Open edX admin creates one *External LTI Configuration*, an Artemis admin creates one matching platform, and from then on instructors link content themselves via deep linking. No admin is involved per course or per exercise.
+2. **Once per LTI component**. Every LTI Consumer component in Studio is its own consumer with its own client ID and URLs, so every component needs its own Artemis platform. Use this only if the LTI Store is not installed.
+
+##### Register once per Open edX instance (LTI Store)
+
+> **Note**
+> Do **not** paste an exercise launch URL into the *LTI 1.3 Launch URL* of the External LTI Configuration. That ties the configuration, and therefore the Artemis platform, to a single exercise. Use the Artemis *Tool URL* instead and select the exercise per component via deep linking.
+
+On the Open edX side (as an Open edX admin):
+
+1. Open the Django admin and add an *External LTI Configuration* under *LTI_STORE*.
+2. Set *LTI Version* to *LTI 1.3*.
+3. Copy the following values from the Artemis *Server Administration > LTI Configuration > Service URLs* tab:
+   * *Tool URL* into *LTI 1.3 Launch URL*.
+   * *Initiate Login URL* into *LTI 1.3 OIDC URL*. Append the Artemis *Registration ID* once the platform exists in Artemis (see below).
+   * *Keyset URL* into *LTI 1.3 Tool Keyset URL*.
+   * *Redirect URI* into *LTI 1.3 Redirect URIs*.
+   * *Deep linking URL* into *LTI Advantage Deep Linking launch URL* and enable *LTI Advantage Deep Linking*.
+4. Keep *LTI Advantage Assignment and Grade Services Mode* at *declarative* so Artemis can send scores.
+5. Save. Note down the *Filter Key* (for example `lti_store:1`) and the generated *Client ID*.
+6. Enable the `enable_external_config_filter` waffle flag for the courses that should use the store.
+
+On the Artemis side (as an Artemis admin), add one platform under *Server Administration > LTI Configuration > Add new platform configuration*:
+
+| Artemis field     | Value                                                                                        |
+|-------------------|----------------------------------------------------------------------------------------------|
+| Tool URL          | The Open edX LMS base URL, for example `https://lms.example.edu`                             |
+| Client ID         | The *Client ID* of the External LTI Configuration                                            |
+| Authorization URI | `https://lms.example.edu/api/lti_consumer/v1/launch/`                                        |
+| Token URI         | `https://lms.example.edu/api/lti_consumer/v1/token/lti_store/<id>`                           |
+| JWKSet URI        | `https://lms.example.edu/api/lti_consumer/v1/public_keysets/lti_store/<id>`                  |
+
+`<id>` is the part of the *Filter Key* after `lti_store:`. Save, copy the *Registration ID* from the platforms list and append it to the *LTI 1.3 OIDC URL* in the External LTI Configuration.
+
+Instructors then use the configuration in every course and component without further admin steps:
+
+1. In Studio, add an *LTI Consumer* component, set *LTI Version* to *LTI 1.3* and *Configuration Type* to *External*.
+2. Enter the *Filter Key* in *External Config ID*.
+3. Follow <a href="#deep-linking-for-edx">Deep Linking for edX</a> to select the Artemis exercise or lecture for this component.
+
+In Artemis, the instructor selects the same platform in the course's LTI configuration (see <a href="#sharing-access-to-a-course">Sharing access to a course</a>). One platform serves all Artemis courses linked to that Open edX instance.
+
+##### Register once per LTI component
+
 Please follow the below steps to add the LTI 1.3 component to the edX course unit and configure Artemis:
 
 1. As an instructor, edit the course unit where you want to add Artemis and select *Advanced* from the *Add New Component* section. Select *LTI Consumer*.
@@ -258,6 +304,7 @@ Please follow the below steps to add the LTI 1.3 component to the edX course uni
 
 > **Note**
 > Each LTI Consumer component in edX acts as an independent LTI consumer, meaning each LTI consumer must be defined to Artemis manually.
+> To avoid this, register once per instance with the LTI Store as described above.
 
 Now we are back on the Artemis. Please follow the below steps to manually configure the edX component into Artemis:
 
@@ -383,7 +430,7 @@ This video describes how you can use the LTI Deep Linking Service to integrate c
 #### Deep Linking for edX
 
 1. As an instructor, in other words, a staff user for the edX course, navigate to Studio for your course.
-2. Locate the unit and the corresponding LTI component in Studio.
+2. Locate the unit and the corresponding LTI component in Studio. With the LTI Store, the component only needs *LTI Version* *LTI 1.3*, *Configuration Type* *External* and the *Filter Key* in *External Config ID*.
 3. In the LTI component page in Studio, locate the *Deep Linking Launch - Configure tool* link at the bottom and navigate.
 4. Artemis will redirect you to the login page to login using your instructor account.
 5. Select the Artemis course to which you have access.
@@ -470,6 +517,10 @@ This video describes how to use manually link exercises from an Artemis course i
 
 As a Moodle administrator, verifying your permissions is essential if you initiate the dynamic registration process with Artemis and find that no configuration card appears.
 Please get in touch with your Artemis administrator to ensure you have the privileges to successfully conduct dynamic registration.
+
+### Issue: A Separate Artemis Platform per Exercise in edX
+
+If every exercise needs its own External LTI Configuration and Artemis platform, the *LTI 1.3 Launch URL* of the External LTI Configuration points at an exercise. Set it to the Artemis *Tool URL* and select the exercise per component via deep linking instead. See <a href="#register-once-per-open-edx-instance-lti-store">Register once per Open edX instance</a>.
 
 ### Issue: Blank Page on Exercise Launch in edX
 

--- a/documentation/docs/instructor/integrations/lti-configuration.mdx
+++ b/documentation/docs/instructor/integrations/lti-configuration.mdx
@@ -256,21 +256,22 @@ There are two ways to register Artemis with Open edX:
 ##### Register once per Open edX instance (LTI Store)
 
 > **Note**
-> Do **not** paste an exercise launch URL into the *LTI 1.3 Launch URL* of the External LTI Configuration. That ties the configuration, and therefore the Artemis platform, to a single exercise. Use the Artemis *Tool URL* instead and select the exercise per component via deep linking.
+> The *LTI 1.3 Launch URL* of the External LTI Configuration is only the default launch target. Pasting an exercise launch URL there and skipping deep linking is what makes the configuration, and the Artemis platform, exercise-specific. Use the Artemis *Tool URL* as the default, enable deep linking, and select the exercise per component. A component that students launch before deep linking is configured gets an HTTP 400 (course not found) from Artemis, so configure the component before publishing it.
 
 On the Open edX side (as an Open edX admin):
 
 1. Open the Django admin and add an *External LTI Configuration* under *LTI_STORE*.
 2. Set *LTI Version* to *LTI 1.3*.
-3. Copy the following values from the Artemis *Server Administration > LTI Configuration > Service URLs* tab:
+3. Generate an RSA private key (for example `openssl genrsa 2048`) and paste it into *LTI 1.3 Private Key*. The store does not generate it and rejects the configuration without it.
+4. Copy the following values from the Artemis *Server Administration > LTI Configuration > Service URLs* tab:
    * *Tool URL* into *LTI 1.3 Launch URL*.
    * *Initiate Login URL* into *LTI 1.3 OIDC URL*. Append the Artemis *Registration ID* once the platform exists in Artemis (see below).
    * *Keyset URL* into *LTI 1.3 Tool Keyset URL*.
-   * *Redirect URI* into *LTI 1.3 Redirect URIs*.
+   * *Redirect URI* into *LTI 1.3 Redirect URIs* as a JSON list, for example `["https://artemis.example.edu/api/lti/public/lti13/auth-callback"]`.
    * *Deep linking URL* into *LTI Advantage Deep Linking launch URL* and enable *LTI Advantage Deep Linking*.
-4. Keep *LTI Advantage Assignment and Grade Services Mode* at *declarative* so Artemis can send scores.
-5. Save. Note down the *Filter Key* (for example `lti_store:1`) and the generated *Client ID*.
-6. Enable the `enable_external_config_filter` waffle flag for the courses that should use the store.
+5. Keep *LTI Advantage Assignment and Grade Services Mode* at *declarative* so Artemis can send scores.
+6. Save. Note down the *Filter Key* (`lti_store:<slug>`) and the generated *Client ID*.
+7. Enable the `enable_external_config_filter` waffle flag for the courses that should use the store. The LTI Store README also requires its filter pipeline in the LMS and Studio settings.
 
 On the Artemis side (as an Artemis admin), add one platform under *Server Administration > LTI Configuration > Add new platform configuration*:
 
@@ -279,16 +280,17 @@ On the Artemis side (as an Artemis admin), add one platform under *Server Admini
 | Tool URL          | The Open edX LMS base URL, for example `https://lms.example.edu`                             |
 | Client ID         | The *Client ID* of the External LTI Configuration                                            |
 | Authorization URI | `https://lms.example.edu/api/lti_consumer/v1/launch/`                                        |
-| Token URI         | `https://lms.example.edu/api/lti_consumer/v1/token/lti_store/<id>`                           |
-| JWKSet URI        | `https://lms.example.edu/api/lti_consumer/v1/public_keysets/lti_store/<id>`                  |
+| Token URI         | `https://lms.example.edu/api/lti_consumer/v1/token/lti_store/<slug>`                         |
+| JWKSet URI        | `https://lms.example.edu/api/lti_consumer/v1/public_keysets/lti_store/<slug>`                |
 
-`<id>` is the part of the *Filter Key* after `lti_store:`. Save, copy the *Registration ID* from the platforms list and append it to the *LTI 1.3 OIDC URL* in the External LTI Configuration.
+`<slug>` is the part of the *Filter Key* after `lti_store:`. Save, copy the *Registration ID* from the platforms list and append it to the *LTI 1.3 OIDC URL* in the External LTI Configuration.
 
 Instructors then use the configuration in every course and component without further admin steps:
 
 1. In Studio, add an *LTI Consumer* component, set *LTI Version* to *LTI 1.3* and *Configuration Type* to *External*.
 2. Enter the *Filter Key* in *External Config ID*.
-3. Follow <a href="#deep-linking-for-edx">Deep Linking for edX</a> to select the Artemis exercise or lecture for this component.
+3. Set *Scored* to True with *Weight* 100, and set *Request user's username*, *Request user's full name* and *Request user's email* to True. Artemis matches launches to users by email, and edX only sends it when sharing is enabled.
+4. Follow <a href="#deep-linking-for-edx">Deep Linking for edX</a> to select the Artemis exercise or lecture for this component, then publish.
 
 In Artemis, the instructor selects the same platform in the course's LTI configuration (see <a href="#sharing-access-to-a-course">Sharing access to a course</a>). One platform serves all Artemis courses linked to that Open edX instance.
 
@@ -430,7 +432,7 @@ This video describes how you can use the LTI Deep Linking Service to integrate c
 #### Deep Linking for edX
 
 1. As an instructor, in other words, a staff user for the edX course, navigate to Studio for your course.
-2. Locate the unit and the corresponding LTI component in Studio. With the LTI Store, the component only needs *LTI Version* *LTI 1.3*, *Configuration Type* *External* and the *Filter Key* in *External Config ID*.
+2. Locate the unit and the corresponding LTI component in Studio. With the LTI Store, the component needs *LTI Version* *LTI 1.3*, *Configuration Type* *External*, the *Filter Key* in *External Config ID*, and the scored and user-sharing settings from the registration section.
 3. In the LTI component page in Studio, locate the *Deep Linking Launch - Configure tool* link at the bottom and navigate.
 4. Artemis will redirect you to the login page to login using your instructor account.
 5. Select the Artemis course to which you have access.
@@ -520,7 +522,7 @@ Please get in touch with your Artemis administrator to ensure you have the privi
 
 ### Issue: A Separate Artemis Platform per Exercise in edX
 
-If every exercise needs its own External LTI Configuration and Artemis platform, the *LTI 1.3 Launch URL* of the External LTI Configuration points at an exercise. Set it to the Artemis *Tool URL* and select the exercise per component via deep linking instead. See <a href="#register-once-per-open-edx-instance-lti-store">Register once per Open edX instance</a>.
+If every exercise needs its own External LTI Configuration and Artemis platform, the components use the configuration's *LTI 1.3 Launch URL* directly instead of deep linking. Enable deep linking in the configuration, set the launch URL to the Artemis *Tool URL*, and select the exercise per component via *Deep Linking Launch - Configure tool*. See <a href="#register-once-per-open-edx-instance-lti-store">Register once per Open edX instance</a>.
 
 ### Issue: Blank Page on Exercise Launch in edX
 

--- a/documentation/docs/instructor/integrations/lti-configuration.mdx
+++ b/documentation/docs/instructor/integrations/lti-configuration.mdx
@@ -290,8 +290,8 @@ On the Artemis side (as an Artemis admin), add one platform under *Server Admini
 Instructors then use the configuration in every course that the Open edX admin enabled for the store, without further admin steps:
 
 1. In Artemis, enable *Online Course* and select the platform in the course's LTI configuration (see <a href="#sharing-access-to-a-course">Sharing access to a course</a>). Deep linking refuses courses without this configuration.
-2. In Studio, add an *LTI Consumer* component, set *LTI Version* to *LTI 1.3* and *Configuration Type* to *External*.
-3. Enter the *Filter Key* in *External Config ID*.
+2. In Studio, add an *LTI Consumer* component, set *LTI Version* to *LTI 1.3* and *Configuration Type* to *Existing* (older versions: *External*).
+3. Enter the *Filter Key* in *LTI Reusability ID* (older versions: *External Config ID*).
 4. Set *Scored* to True with *Weight* 100, and set *Request user's username*, *Request user's full name* and *Request user's email* to True. Artemis matches launches to users by email, and edX only sends it when sharing is enabled. If these fields are missing, the Open edX admin has to allow PII sharing for the course.
 5. Publish the component, then follow <a href="#deep-linking-for-edx">Deep Linking for edX</a> to select the Artemis exercise or lecture for it before students open the unit.
 
@@ -435,7 +435,7 @@ This video describes how you can use the LTI Deep Linking Service to integrate c
 #### Deep Linking for edX
 
 1. As an instructor, in other words, a staff user for the edX course, navigate to Studio for your course.
-2. Locate the unit and the corresponding LTI component in Studio. With the LTI Store, the component needs *LTI Version* *LTI 1.3*, *Configuration Type* *External*, the *Filter Key* in *External Config ID*, and the scored and user-sharing settings from the registration section.
+2. Locate the unit and the corresponding LTI component in Studio. With the LTI Store, the component needs *LTI Version* *LTI 1.3*, *Configuration Type* *Existing*, the *Filter Key* in *LTI Reusability ID*, and the scored and user-sharing settings from the registration section.
 3. In the LTI component page in Studio, locate the *Deep Linking Launch - Configure tool* link at the bottom and navigate.
 4. Artemis will redirect you to the login page to login using your instructor account.
 5. Select the Artemis course to which you have access.

--- a/documentation/docs/instructor/integrations/lti-configuration.mdx
+++ b/documentation/docs/instructor/integrations/lti-configuration.mdx
@@ -250,7 +250,7 @@ For more information, please see the official <a href="https://edx.readthedocs.i
 
 There are two ways to register Artemis with Open edX:
 
-1. **Once per Open edX instance** with the <a href="https://github.com/open-craft/openedx-ltistore">LTI Store</a> plugin (recommended). An Open edX admin creates one *External LTI Configuration*, an Artemis admin creates one matching platform, and from then on instructors link content themselves via deep linking. No admin is involved per course or per exercise.
+1. **Once per Open edX instance** with the <a href="https://github.com/open-craft/openedx-ltistore">LTI Store</a> plugin (recommended). An Open edX admin creates one *External LTI Configuration*, an Artemis admin creates one matching platform, and from then on instructors link content themselves via deep linking. No platform registration is needed per component; the Open edX admin only enables the store's waffle flag per course, unless it is set for the whole instance or organization.
 2. **Once per LTI component**. Every LTI Consumer component in Studio is its own consumer with its own client ID and URLs, so every component needs its own Artemis platform. Use this only if the LTI Store is not installed.
 
 ##### Register once per Open edX instance (LTI Store)
@@ -258,7 +258,7 @@ There are two ways to register Artemis with Open edX:
 > **Note**
 > The *LTI 1.3 Launch URL* of the External LTI Configuration is only the default launch target. If every component launches that default and it points at one exercise, the configuration, and the Artemis platform, become exercise-specific. Use the Artemis *Tool URL* as the default and pick the exercise per component, either via deep linking (below) or, on xblock-lti-consumer 9.14.1 or newer, by enabling the course flag `lti_consumer.enable_external_multiple_launch_urls` and pasting the exercise's LTI 1.3 Launch URL into the component. A component that students launch with the default target gets an HTTP 400 (course not found) from Artemis, so select the content before releasing the unit to students.
 >
-> Studio field labels differ between xblock-lti-consumer versions. The names below follow the current release.
+> Studio field labels differ between xblock-lti-consumer versions. The names below follow release 11.2.0 or newer; older labels are given in brackets.
 
 On the Open edX side (as an Open edX admin):
 
@@ -273,7 +273,7 @@ On the Open edX side (as an Open edX admin):
    * *Deep linking URL* into *LTI Advantage Deep Linking launch URL* and enable *LTI Advantage Deep Linking*.
 5. Keep *LTI Advantage Assignment and Grade Services Mode* at *declarative* so Artemis can send scores. Open edX only records scores for graded components and ignores a score of 0, so a later zero result does not replace an earlier grade.
 6. Save. Note down the *Filter Key* (`lti_store:<slug>`) and the generated *Client ID*.
-7. Enable the `enable_external_config_filter` waffle flag for the courses that should use the store. The LTI Store README also requires its filter pipeline in the LMS and Studio settings.
+7. Enable the `lti_consumer.enable_external_config_filter` waffle flag for the courses that should use the store, or once for the whole instance or organization. The LTI Store README also requires its filter pipeline in the LMS and Studio settings.
 
 On the Artemis side (as an Artemis admin), add one platform under *Server Administration > LTI Configuration > Add new platform configuration*:
 
@@ -290,8 +290,8 @@ On the Artemis side (as an Artemis admin), add one platform under *Server Admini
 Instructors then use the configuration in every course that the Open edX admin enabled for the store, without further admin steps:
 
 1. In Artemis, enable *Online Course* and select the platform in the course's LTI configuration (see <a href="#sharing-access-to-a-course">Sharing access to a course</a>). Deep linking refuses courses without this configuration.
-2. In Studio, add an *LTI Consumer* component, set *LTI Version* to *LTI 1.3* and *Configuration Type* to *Existing* (older versions: *External*).
-3. Enter the *Filter Key* in *LTI Reusability ID* (older versions: *External Config ID*).
+2. In Studio, add an *LTI Consumer* component and set *Configuration Type* to *Existing* (older versions: *External*).
+3. Enter the *Filter Key* in *LTI Reusability ID* (older versions: *External Config ID*). The component takes the LTI version from the store and hides the *LTI Version* field; releases before 11.3.0 still show it, so set it to *LTI 1.3* there.
 4. Set *Scored* to True with *Weight* 100, and set *Request user's username*, *Request user's full name* and *Request user's email* to True. Artemis matches launches to users by email, and edX only sends it when sharing is enabled. If these fields are missing, the Open edX admin has to allow PII sharing for the course.
 5. Publish the component, then follow <a href="#deep-linking-for-edx">Deep Linking for edX</a> to select the Artemis exercise or lecture for it before students open the unit.
 
@@ -435,7 +435,7 @@ This video describes how you can use the LTI Deep Linking Service to integrate c
 #### Deep Linking for edX
 
 1. As an instructor, in other words, a staff user for the edX course, navigate to Studio for your course.
-2. Locate the unit and the corresponding LTI component in Studio. With the LTI Store, the component needs *LTI Version* *LTI 1.3*, *Configuration Type* *Existing*, the *Filter Key* in *LTI Reusability ID*, and the scored and user-sharing settings from the registration section.
+2. Locate the unit and the corresponding LTI component in Studio. With the LTI Store, the component needs *Configuration Type* *Existing*, the *Filter Key* in *LTI Reusability ID*, and the scored and user-sharing settings from the registration section.
 3. In the LTI component page in Studio, locate the *Deep Linking Launch - Configure tool* link at the bottom and navigate.
 4. Artemis will redirect you to the login page to login using your instructor account.
 5. Select the Artemis course to which you have access.

--- a/documentation/docs/instructor/integrations/lti-configuration.mdx
+++ b/documentation/docs/instructor/integrations/lti-configuration.mdx
@@ -256,7 +256,9 @@ There are two ways to register Artemis with Open edX:
 ##### Register once per Open edX instance (LTI Store)
 
 > **Note**
-> The *LTI 1.3 Launch URL* of the External LTI Configuration is only the default launch target. Pasting an exercise launch URL there and skipping deep linking is what makes the configuration, and the Artemis platform, exercise-specific. Use the Artemis *Tool URL* as the default, enable deep linking, and select the exercise per component. A component that students launch before deep linking is configured gets an HTTP 400 (course not found) from Artemis, so configure the component before publishing it.
+> The *LTI 1.3 Launch URL* of the External LTI Configuration is only the default launch target. If every component launches that default and it points at one exercise, the configuration, and the Artemis platform, become exercise-specific. Use the Artemis *Tool URL* as the default and pick the exercise per component, either via deep linking (below) or, on xblock-lti-consumer 9.14.1 or newer, by enabling the course flag `lti_consumer.enable_external_multiple_launch_urls` and pasting the exercise's LTI 1.3 Launch URL into the component. A component that students launch with the default target gets an HTTP 400 (course not found) from Artemis, so select the content before releasing the unit to students.
+>
+> Studio field labels differ between xblock-lti-consumer versions. The names below follow the current release.
 
 On the Open edX side (as an Open edX admin):
 
@@ -265,11 +267,11 @@ On the Open edX side (as an Open edX admin):
 3. Generate an RSA private key (for example `openssl genrsa 2048`) and paste it into *LTI 1.3 Private Key*. The store does not generate it and rejects the configuration without it.
 4. Copy the following values from the Artemis *Server Administration > LTI Configuration > Service URLs* tab:
    * *Tool URL* into *LTI 1.3 Launch URL*.
-   * *Initiate Login URL* into *LTI 1.3 OIDC URL*. Append the Artemis *Registration ID* once the platform exists in Artemis (see below).
+   * *Initiate Login URL* into *LTI 1.3 OIDC URL*. Once the platform exists in Artemis (see below), append its *Registration ID* so the value reads `https://artemis.example.edu/api/lti/public/lti13/initiate-login/<registration id>`.
    * *Keyset URL* into *LTI 1.3 Tool Keyset URL*.
    * *Redirect URI* into *LTI 1.3 Redirect URIs* as a JSON list, for example `["https://artemis.example.edu/api/lti/public/lti13/auth-callback"]`.
    * *Deep linking URL* into *LTI Advantage Deep Linking launch URL* and enable *LTI Advantage Deep Linking*.
-5. Keep *LTI Advantage Assignment and Grade Services Mode* at *declarative* so Artemis can send scores.
+5. Keep *LTI Advantage Assignment and Grade Services Mode* at *declarative* so Artemis can send scores. Open edX only records scores for graded components and ignores a score of 0, so a later zero result does not replace an earlier grade.
 6. Save. Note down the *Filter Key* (`lti_store:<slug>`) and the generated *Client ID*.
 7. Enable the `enable_external_config_filter` waffle flag for the courses that should use the store. The LTI Store README also requires its filter pipeline in the LMS and Studio settings.
 
@@ -283,16 +285,17 @@ On the Artemis side (as an Artemis admin), add one platform under *Server Admini
 | Token URI         | `https://lms.example.edu/api/lti_consumer/v1/token/lti_store/<slug>`                         |
 | JWKSet URI        | `https://lms.example.edu/api/lti_consumer/v1/public_keysets/lti_store/<slug>`                |
 
-`<slug>` is the part of the *Filter Key* after `lti_store:`. Save, copy the *Registration ID* from the platforms list and append it to the *LTI 1.3 OIDC URL* in the External LTI Configuration.
+`<slug>` is the part of the *Filter Key* after `lti_store:`. Save, copy the *Registration ID* from the platforms list and complete the *LTI 1.3 OIDC URL* in the External LTI Configuration as shown above.
 
-Instructors then use the configuration in every course and component without further admin steps:
+Instructors then use the configuration in every course that the Open edX admin enabled for the store, without further admin steps:
 
-1. In Studio, add an *LTI Consumer* component, set *LTI Version* to *LTI 1.3* and *Configuration Type* to *External*.
-2. Enter the *Filter Key* in *External Config ID*.
-3. Set *Scored* to True with *Weight* 100, and set *Request user's username*, *Request user's full name* and *Request user's email* to True. Artemis matches launches to users by email, and edX only sends it when sharing is enabled.
-4. Follow <a href="#deep-linking-for-edx">Deep Linking for edX</a> to select the Artemis exercise or lecture for this component, then publish.
+1. In Artemis, enable *Online Course* and select the platform in the course's LTI configuration (see <a href="#sharing-access-to-a-course">Sharing access to a course</a>). Deep linking refuses courses without this configuration.
+2. In Studio, add an *LTI Consumer* component, set *LTI Version* to *LTI 1.3* and *Configuration Type* to *External*.
+3. Enter the *Filter Key* in *External Config ID*.
+4. Set *Scored* to True with *Weight* 100, and set *Request user's username*, *Request user's full name* and *Request user's email* to True. Artemis matches launches to users by email, and edX only sends it when sharing is enabled. If these fields are missing, the Open edX admin has to allow PII sharing for the course.
+5. Publish the component, then follow <a href="#deep-linking-for-edx">Deep Linking for edX</a> to select the Artemis exercise or lecture for it before students open the unit.
 
-In Artemis, the instructor selects the same platform in the course's LTI configuration (see <a href="#sharing-access-to-a-course">Sharing access to a course</a>). One platform serves all Artemis courses linked to that Open edX instance.
+One platform serves all Artemis courses linked to that Open edX instance.
 
 ##### Register once per LTI component
 
@@ -522,7 +525,7 @@ Please get in touch with your Artemis administrator to ensure you have the privi
 
 ### Issue: A Separate Artemis Platform per Exercise in edX
 
-If every exercise needs its own External LTI Configuration and Artemis platform, the components use the configuration's *LTI 1.3 Launch URL* directly instead of deep linking. Enable deep linking in the configuration, set the launch URL to the Artemis *Tool URL*, and select the exercise per component via *Deep Linking Launch - Configure tool*. See <a href="#register-once-per-open-edx-instance-lti-store">Register once per Open edX instance</a>.
+If every exercise needs its own External LTI Configuration and Artemis platform, every component launches the configuration's default *LTI 1.3 Launch URL*. Set that default to the Artemis *Tool URL* and select the exercise per component, via *Deep Linking Launch - Configure tool* or the per-component launch URL flag. See <a href="#register-once-per-open-edx-instance-lti-store">Register once per Open edX instance</a>.
 
 ### Issue: Blank Page on Exercise Launch in edX
 


### PR DESCRIPTION
### Summary
Documents how to register Artemis with Open edX once per instance via the LTI Store plugin, so instructors link exercises themselves via deep linking instead of an admin creating one External LTI Configuration and one Artemis platform per exercise.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

Clarify the LTI integration with Open edX to avoid own External LTI Configuration in the LTI store per programming exercise.

### Description
Changes to `documentation/docs/instructor/integrations/lti-configuration.mdx`:

- New subsection "Register once per Open edX instance (LTI Store)" with the Open edX side (private key, launch URL = Artemis tool URL, full OIDC URL, keyset URL, redirect URIs as JSON list, deep linking, AGS mode, store enablement) and a field mapping table for the Artemis platform (token, keyset and authorization URIs for `lti_store/<slug>` external configs).
- Instructor steps in the right order: Artemis online course and platform selection first, since the deep-linking endpoint rejects unconfigured courses, then the Studio component, publish, deep link, release.
- The deep-linking-free alternative on xblock-lti-consumer 9.14.1 or newer: the course flag `lti_consumer.enable_external_multiple_launch_urls` lets each component keep its own launch URL with shared credentials.
- Caveats: HTTP 400 for launches that still hit the default target, Open edX only records scores for graded components and ignores a score of 0, Studio labels differ between versions.
- The per-component registration stays as the fallback. New Common Issues entry for the per-exercise-platform symptom.

Routes and model fields were checked against openedx/xblock-lti-consumer (`lti_consumer/plugin/urls.py`, `views.py`, `lti_1p3/consumer.py`, `signals/signals.py`, README, CHANGELOG) and open-craft/openedx-ltistore (`lti_store/models.py`, `admin.py`, README). No Artemis code changes.

### Steps for Testing
1. `cd documentation && pnpm install --frozen-lockfile && pnpm build` succeeds.
2. Open Instructor > Integrations > LTI Configuration in the built site and check the sections "Register once per Open edX instance (LTI Store)" and "Issue: A Separate Artemis Platform per Exercise in edX" render with working anchors.
3. Optional, needs an Open edX with the LTI Store: follow the new subsection and confirm one platform serves two Artemis courses and two exercises. This has not been run end to end yet.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified instance-wide and per-course enablement options in the Open edX LTI Store.
  - Added guidance for registering integrations once per instance or once per LTI component.
  - Updated guidance for external LTI configuration, platform mapping, scoring, and user-data sharing.
  - Clarified version-dependent Studio field labels and legacy labels.
  - Documented that existing configurations derive their LTI version from the store.
  - Simplified deep-linking instructions for current releases.
  - Added troubleshooting guidance for platforms configured separately per exercise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->