### PR TITLE
`Development`: Make case conversion locale-explicit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,7 @@ Organized by feature module:
 - Use DTOs (Java records) for REST endpoints
 - Prefer constructor injection for Spring beans
 - Use Java 25 features (records, sealed classes, pattern matching)
+- **Never call `String.toLowerCase()` or `String.toUpperCase()` without a locale.** Both fold case with the JVM default locale, so the same input gives a different answer depending on where the server runs: under a Turkish locale `I` lowercases to the dotless `ı`, which is enough to break a check on `os.name`, a file extension, a MIME type, a header value or a login without any error. Pass `Locale.ROOT` for machine-facing values, `Locale.ENGLISH` only where the surrounding code already does for the same kind of value (`User.setLogin` for logins). Where only the comparison matters, `equalsIgnoreCase`, `String.CASE_INSENSITIVE_ORDER` and `Pattern.CASE_INSENSITIVE` need no locale at all. An ArchUnit rule (`ArchitectureTest.testNoLocaleLessCaseConversion`) enforces this over production and test code
 
 ### Caching
 

--- a/documentation/docs/developer/guidelines/server-development.mdx
+++ b/documentation/docs/developer/guidelines/server-development.mdx
@@ -16,6 +16,7 @@ import {CalloutVariant} from "../../../src/components/Callout/Callout.types";
 * Prefer primitive types to classes (e.g. `long` instead of `Long`).
 * Use `./gradlew spotlessCheck` and `./gradlew spotlessApply` to check and fix Java code style.
 * Don't use `.collect(Collectors.toList())`. Use `.toList()` for an unmodifiable list or `.collect(Collectors.toCollection(ArrayList::new))` for a new ArrayList.
+* Never call `String.toLowerCase()` or `String.toUpperCase()` without a locale. Both fold case with the JVM default locale, so the same input gives a different answer depending on where the server runs: under a Turkish locale the ASCII letter `I` lowercases to the dotless `ı`, which is enough to make a check on `os.name`, a file extension, a MIME type, a header value or a login stop matching without any error. Pass `Locale.ROOT` for machine-facing values, which is almost all of them, and `Locale.ENGLISH` only where the surrounding code already does for the same kind of value, as `User.setLogin` does for logins. Where only the comparison matters, `equalsIgnoreCase`, `String.CASE_INSENSITIVE_ORDER` and `Pattern.CASE_INSENSITIVE` need no locale at all. An ArchUnit rule (`ArchitectureTest.testNoLocaleLessCaseConversion`) enforces this for production and test code.
 
 
 ## Project structure & Naming

--- a/skills/server-arch-gates/SKILL.md
+++ b/skills/server-arch-gates/SKILL.md
@@ -38,6 +38,7 @@ A single class while iterating:
 | Anything holding state across requests | Caching, distributed data                           |
 | An entity or an association            | Caching, entity conventions                         |
 | Anything at all in a large file        | Counted gates                                       |
+| Anything that lowercases or uppercases | Case conversion                                     |
 
 The detail for each, with the reason and the failing rule name, is in `reference/gates.md`. Read
 it rather than guessing; several of these rules forbid something that looks completely reasonable.
@@ -74,6 +75,12 @@ caching use Spring `@Cacheable`, always paired with explicit eviction.
 
 **Reach optional modules through their API.** Use `Optional<*Api>`, never another module's
 repository directly.
+
+**Never fold case without a locale.** `String.toLowerCase()` and `String.toUpperCase()` use the JVM
+default locale, so the same input gives a different answer depending on where the server runs. Pass
+`Locale.ROOT` for machine-facing values and `Locale.ENGLISH` only where the surrounding code already
+does for that kind of value. Enforced by `testNoLocaleLessCaseConversion` in `ArchitectureTest.java`,
+over production and test classes both.
 
 ## Before adding a cache
 

--- a/skills/server-arch-gates/reference/gates.md
+++ b/skills/server-arch-gates/reference/gates.md
@@ -128,6 +128,31 @@ subclass exists. Some modules have no subclass for some rule families, so the ab
 does not prove compliance. There is also an ignore list that can hide an optional-module repository
 leak.
 
+## Case conversion
+
+**Rule.** `String.toLowerCase()` and `String.toUpperCase()` may not be called without a locale, in
+production or in test code. `Locale.ROOT` is the default choice, because it folds case the same way
+everywhere, which is what a machine-facing value needs: identifiers, logins, emails, file names and
+extensions, MIME types, header values, enum names, protocol tokens, URL segments, search
+normalization. `Locale.ENGLISH` is for the places where the surrounding code already uses it for the
+same kind of value, so that the two agree byte for byte, as `User.setLogin` and the two
+authentication providers do for logins.
+
+**Enforced by.** `testNoLocaleLessCaseConversion` in `ArchitectureTest.java`. It has two halves,
+because ArchUnit models a method reference as a `JavaMethodReference` and not as a `JavaMethodCall`:
+`callMethod` catches `value.toLowerCase()`, and a separate condition catches
+`String::toLowerCase`. Naming no parameter types is what restricts the first half to the
+locale-less overloads, so `toLowerCase(Locale.ROOT)` is not matched.
+
+**Why it matters.** Under a Turkish locale the ASCII letter `I` lowercases to the dotless `ı`
+rather than to `i`. That turned `System.getProperty("os.name").toLowerCase()` into `wındows` and
+made the Windows branch in `WebConfigurer` stop matching, with nothing in the logs to say so.
+
+**No exemptions.** Nothing in the codebase needs the default locale, so the rule has no exception
+list. If you find a call that genuinely formats text for a user in their own language, keep the
+default locale, say why in a comment, and add the class to a narrowly scoped exemption rather than
+widening the rule.
+
 ## Counted gates
 
 These compare a repository-wide count against a recorded limit that develop already sits at, so an

--- a/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserCreationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserCreationService.java
@@ -5,6 +5,7 @@ import static de.tum.cit.aet.artemis.core.security.Role.STUDENT;
 
 import java.time.Instant;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -267,7 +268,7 @@ public class UserCreationService {
     @NonNull
     public User updateUser(@NonNull User user, ManagedUserVM updatedUserDTO) {
         updateEmailIfChanged(user, updatedUserDTO.getEmail());
-        user.setLogin(updatedUserDTO.getLogin().toLowerCase());
+        user.setLogin(updatedUserDTO.getLogin().toLowerCase(Locale.ENGLISH));
         user.setFirstName(updatedUserDTO.getFirstName());
         user.setLastName(updatedUserDTO.getLastName());
 

--- a/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/service/user/UserService.java
@@ -390,7 +390,7 @@ public class UserService {
         // Prepare the new user object.
         final var newUser = new User();
         String passwordHash = passwordService.hashPassword(password);
-        newUser.setLogin(userDTO.getLogin().toLowerCase());
+        newUser.setLogin(userDTO.getLogin().toLowerCase(Locale.ENGLISH));
         if (IRIS_BOT_LOGIN.equals(newUser.getLogin())) {
             throw new UsernameAlreadyUsedException();
         }
@@ -412,7 +412,7 @@ public class UserService {
         newUser.setAuthorities(authorities);
 
         // Find user that has the same login
-        Optional<User> optionalExistingUser = userRepository.findOneByLogin(userDTO.getLogin().toLowerCase());
+        Optional<User> optionalExistingUser = userRepository.findOneByLogin(userDTO.getLogin().toLowerCase(Locale.ENGLISH));
         if (optionalExistingUser.isPresent()) {
             User existingUser = optionalExistingUser.get();
             return handleRegisterUserWithSameLoginAsExistingUser(newUser, existingUser);

--- a/src/main/java/de/tum/cit/aet/artemis/account/web/admin/AdminUserResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/web/admin/AdminUserResource.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -158,10 +159,10 @@ public class AdminUserResource {
             throw new BadRequestAlertException("A new user cannot already have an ID", "userManagement", "idExists");
             // Lowercase the user login before comparing with database
         }
-        else if (IRIS_BOT_LOGIN.equals(userToBeCreated.getLogin().toLowerCase())) {
+        else if (IRIS_BOT_LOGIN.equalsIgnoreCase(userToBeCreated.getLogin())) {
             throw new BadRequestAlertException("The login '" + IRIS_BOT_LOGIN + "' is reserved and cannot be used.", "userManagement", "loginReserved");
         }
-        else if (userRepository.findOneByLogin(userToBeCreated.getLogin().toLowerCase()).isPresent()) {
+        else if (userRepository.findOneByLogin(userToBeCreated.getLogin().toLowerCase(Locale.ENGLISH)).isPresent()) {
             throw new LoginAlreadyUsedException();
         }
         else {
@@ -227,11 +228,11 @@ public class AdminUserResource {
         this.userService.checkUsernameAndPasswordValidityElseThrow(managedUserVM.getLogin(), managedUserVM.getPassword());
         log.debug("REST request to update User : {}", managedUserVM);
 
-        if (IRIS_BOT_LOGIN.equals(managedUserVM.getLogin().toLowerCase())) {
+        if (IRIS_BOT_LOGIN.equalsIgnoreCase(managedUserVM.getLogin())) {
             throw new BadRequestAlertException("The login '" + IRIS_BOT_LOGIN + "' is reserved and cannot be used.", "userManagement", "loginReserved");
         }
 
-        var existingUserByLogin = userRepository.findOneByLogin(managedUserVM.getLogin().toLowerCase());
+        var existingUserByLogin = userRepository.findOneByLogin(managedUserVM.getLogin().toLowerCase(Locale.ENGLISH));
         if (existingUserByLogin.isPresent() && (!existingUserByLogin.get().getId().equals(managedUserVM.getId()))) {
             throw new LoginAlreadyUsedException();
         }

--- a/src/main/java/de/tum/cit/aet/artemis/admin/service/VulnerabilityService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/admin/service/VulnerabilityService.java
@@ -5,6 +5,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -678,7 +679,7 @@ public class VulnerabilityService {
     private String determineSeverityFromOsvVulnerability(OsvVulnerabilityDTO vulnerability) {
         // Priority 1: Check database-specific severity (most reliable for GHSA advisories)
         if (vulnerability.databaseSpecific() != null && vulnerability.databaseSpecific().severity() != null) {
-            String dbSeverity = vulnerability.databaseSpecific().severity().toUpperCase();
+            String dbSeverity = vulnerability.databaseSpecific().severity().toUpperCase(Locale.ROOT);
             log.debug("Found database_specific severity for {}: {}", vulnerability.id(), dbSeverity);
             if (isValidSeverity(dbSeverity)) {
                 return normalizeSeverity(dbSeverity);

--- a/src/main/java/de/tum/cit/aet/artemis/admin/web/AdminWebsocketResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/admin/web/AdminWebsocketResource.java
@@ -2,6 +2,8 @@ package de.tum.cit.aet.artemis.admin.web;
 
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
+import java.util.Locale;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
@@ -93,7 +95,7 @@ public class AdminWebsocketResource {
 
         WebsocketBrokerReconnectionService.ControlAction controlAction;
         try {
-            controlAction = WebsocketBrokerReconnectionService.ControlAction.valueOf(action.toUpperCase());
+            controlAction = WebsocketBrokerReconnectionService.ControlAction.valueOf(action.toUpperCase(Locale.ROOT));
         }
         catch (IllegalArgumentException ex) {
             return ResponseEntity.badRequest().build();

--- a/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/assessment/service/ResultService.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -738,7 +739,7 @@ public class ResultService {
 
         // 9. Query the database based on groupFeedback attribute to retrieve paginated and filtered feedback
         final Page<FeedbackDetailDTO> feedbackDetailPage = studentParticipationRepository.findFilteredFeedbackByExerciseId(exerciseId,
-                StringUtils.isBlank(data.getSearchTerm()) ? "" : data.getSearchTerm().toLowerCase(), data.getFilterTestCases(), includeNotAssignedToTask, minOccurrence,
+                StringUtils.isBlank(data.getSearchTerm()) ? "" : data.getSearchTerm().toLowerCase(Locale.ROOT), data.getFilterTestCases(), includeNotAssignedToTask, minOccurrence,
                 maxOccurrence, filterErrorCategories, pageable);
 
         List<FeedbackDetailDTO> processedDetails;

--- a/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaRepositoryExportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaRepositoryExportService.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.athena.service;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -142,9 +143,9 @@ public class AthenaRepositoryExportService {
 
         LocalVCRepositoryUri repoUri = programmingExercise.getRepositoryURI(repositoryType);
         if (repoUri == null) {
-            String errorKey = "invalid." + repositoryType.name().toLowerCase() + ".repository.url";
+            String errorKey = "invalid." + repositoryType.name().toLowerCase(Locale.ROOT) + ".repository.url";
             throw new BadRequestAlertException("Repository URI is null for exercise " + exerciseId + " and repository type " + repositoryType + ". This may indicate that the "
-                    + repositoryType.name().toLowerCase() + " repository has not been set up yet.", ENTITY_NAME, errorKey);
+                    + repositoryType.name().toLowerCase(Locale.ROOT) + " repository has not been set up yet.", ENTITY_NAME, errorKey);
         }
         return repositoryService.getFilesContentFromBareRepositoryForLastCommit(repoUri);
     }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/AtlasAgentService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/AtlasAgentService.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.atlas.service;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -518,7 +519,7 @@ public class AtlasAgentService {
      * @return true if the message is a cancel command
      */
     private boolean isCancelCommand(String message) {
-        String lowerMessage = message.toLowerCase().trim();
+        String lowerMessage = message.toLowerCase(Locale.ROOT).trim();
         return lowerMessage.equals("cancel") || lowerMessage.equals("stop") || lowerMessage.equals("abort") || lowerMessage.equals("cancel plan")
                 || lowerMessage.equals("stop plan") || lowerMessage.equals("cancel workflow") || lowerMessage.equals("stop workflow");
     }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/ExecutionPlanStateManagerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/ExecutionPlanStateManagerService.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import org.jspecify.annotations.Nullable;
@@ -509,7 +510,7 @@ public class ExecutionPlanStateManagerService {
         }
 
         try {
-            return PlanTemplate.valueOf(marker.trim().toUpperCase());
+            return PlanTemplate.valueOf(marker.trim().toUpperCase(Locale.ROOT));
         }
         catch (IllegalArgumentException e) {
             log.warn("Unknown plan template: {}", marker);

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/service/atlasml/AtlasMLService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/service/atlasml/AtlasMLService.java
@@ -412,7 +412,7 @@ public class AtlasMLService {
             return true;
         }
         catch (Exception e) {
-            final String opStr = operationType != null ? operationType.value().toLowerCase() : "update";
+            final String opStr = operationType != null ? operationType.value().toLowerCase(Locale.ROOT) : "update";
             log.error("Failed to {} {} competencies", opStr, competencies.size(), e);
             return false;
         }
@@ -440,7 +440,7 @@ public class AtlasMLService {
             return true;
         }
         catch (Exception e) {
-            final String opStr = operationType != null ? operationType.value().toLowerCase() : "update";
+            final String opStr = operationType != null ? operationType.value().toLowerCase(Locale.ROOT) : "update";
             log.error("Failed to {} exercise with id {}", opStr, exerciseId, e);
             return false;
         }
@@ -491,7 +491,7 @@ public class AtlasMLService {
             return saveExercise(exercise.getId(), exercise.getTitle(), description, competencyIds, courseId, operationType);
         }
         catch (Exception e) {
-            log.error("Failed to {} exercise with competencies for exercise id {}", operationType.value().toLowerCase(), exercise.getId(), e);
+            log.error("Failed to {} exercise with competencies for exercise id {}", operationType.value().toLowerCase(Locale.ROOT), exercise.getId(), e);
             return false;
         }
     }
@@ -533,7 +533,7 @@ public class AtlasMLService {
             return saveExercise(exerciseId, exercise.getTitle(), description, competencyIds, courseId, operationType);
         }
         catch (Exception e) {
-            log.error("Failed to {} exercise with competencies for exercise id {}", operationType.value().toLowerCase(), exerciseId, e);
+            log.error("Failed to {} exercise with competencies for exercise id {}", operationType.value().toLowerCase(Locale.ROOT), exerciseId, e);
             return false;
         }
     }

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/web/CourseLearnerProfileResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/web/CourseLearnerProfileResource.java
@@ -4,6 +4,7 @@ import static de.tum.cit.aet.artemis.atlas.domain.profile.CourseLearnerProfile.M
 import static de.tum.cit.aet.artemis.atlas.domain.profile.CourseLearnerProfile.MIN_PROFILE_VALUE;
 
 import java.time.ZonedDateTime;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -99,7 +100,7 @@ public class CourseLearnerProfileResource {
     private void validateProfileField(int value, String fieldName) {
         if (value < MIN_PROFILE_VALUE || value > MAX_PROFILE_VALUE) {
             String message = "%s (%d) is outside valid bounds [%d, %d]".formatted(fieldName, value, MIN_PROFILE_VALUE, MAX_PROFILE_VALUE);
-            throw new BadRequestAlertException(message, CourseLearnerProfile.ENTITY_NAME, fieldName.toLowerCase() + "OutOfBounds", true);
+            throw new BadRequestAlertException(message, CourseLearnerProfile.ENTITY_NAME, fieldName.toLowerCase(Locale.ROOT) + "OutOfBounds", true);
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/atlas/web/LearnerProfileResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/atlas/web/LearnerProfileResource.java
@@ -4,6 +4,7 @@ import static de.tum.cit.aet.artemis.atlas.domain.profile.LearnerProfile.DEFAULT
 import static de.tum.cit.aet.artemis.atlas.domain.profile.LearnerProfile.MAX_PROFILE_VALUE;
 import static de.tum.cit.aet.artemis.atlas.domain.profile.LearnerProfile.MIN_PROFILE_VALUE;
 
+import java.util.Locale;
 import java.util.Optional;
 
 import jakarta.validation.Valid;
@@ -56,7 +57,7 @@ public class LearnerProfileResource {
     private void validateProfileField(int value, String fieldName) {
         if (value < MIN_PROFILE_VALUE || value > MAX_PROFILE_VALUE) {
             String message = "%s (%d) is outside valid bounds [%d, %d]".formatted(fieldName, value, MIN_PROFILE_VALUE, MAX_PROFILE_VALUE);
-            throw new BadRequestAlertException(message, LearnerProfile.ENTITY_NAME, fieldName.toLowerCase() + "OutOfBounds", true);
+            throw new BadRequestAlertException(message, LearnerProfile.ENTITY_NAME, fieldName.toLowerCase(Locale.ROOT) + "OutOfBounds", true);
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerService.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -796,7 +797,7 @@ public class BuildAgentDockerService {
      */
     private boolean isMacOS() {
         String osName = System.getProperty("os.name");
-        return osName != null && osName.toLowerCase().contains("mac");
+        return osName != null && osName.toLowerCase(Locale.ROOT).contains("mac");
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/calendar/service/CalendarSubscriptionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/calendar/service/CalendarSubscriptionService.java
@@ -5,6 +5,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -125,7 +126,7 @@ public class CalendarSubscriptionService {
      */
     public String getICSFileAsString(String courseShortName, Language language, Set<CalendarEventDTO> calendarEventDTOs) {
         Calendar calendar = new Calendar();
-        calendar.add(new ProdId("-//TUM//Artemis//" + language.getShortName().toUpperCase()));
+        calendar.add(new ProdId("-//TUM//Artemis//" + language.getShortName().toUpperCase(Locale.ROOT)));
         calendar.add(ImmutableVersion.VERSION_2_0);
         calendar.add(ImmutableCalScale.GREGORIAN);
         calendar.add(ImmutableMethod.PUBLISH);

--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/PostingType.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/PostingType.java
@@ -1,10 +1,12 @@
 package de.tum.cit.aet.artemis.communication.domain;
 
+import java.util.Locale;
+
 public enum PostingType {
 
     POST, ANSWER;
 
     public static PostingType fromString(String value) {
-        return PostingType.valueOf(value.toUpperCase());
+        return PostingType.valueOf(value.toUpperCase(Locale.ROOT));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/communication/domain/SavedPostStatus.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/domain/SavedPostStatus.java
@@ -1,10 +1,12 @@
 package de.tum.cit.aet.artemis.communication.domain;
 
+import java.util.Locale;
+
 public enum SavedPostStatus {
 
     IN_PROGRESS, COMPLETED, ARCHIVED;
 
     public static SavedPostStatus fromString(String value) {
-        return SavedPostStatus.valueOf(value.toUpperCase());
+        return SavedPostStatus.valueOf(value.toUpperCase(Locale.ROOT));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/communication/repository/MessageSpecs.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/repository/MessageSpecs.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.communication.repository;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Join;
@@ -59,7 +60,7 @@ public class MessageSpecs {
             }
 
             List<Long> authorIdList = Arrays.stream(authorIds).boxed().toList();
-            Expression<String> searchTextLiteral = criteriaBuilder.literal("%" + searchText.toLowerCase() + "%");
+            Expression<String> searchTextLiteral = criteriaBuilder.literal("%" + searchText.toLowerCase(Locale.ROOT) + "%");
             Predicate baseTextPredicate = criteriaBuilder.like(criteriaBuilder.lower(root.get(Post_.CONTENT)), searchTextLiteral);
             Predicate baseAuthorPredicate = root.get(Post_.AUTHOR).get(User_.ID).in(authorIdList);
             Predicate baseCombined = criteriaBuilder.and(baseTextPredicate, baseAuthorPredicate);
@@ -93,7 +94,7 @@ public class MessageSpecs {
             }
             else {
                 // regular search on content
-                Expression<String> searchTextLiteral = criteriaBuilder.literal("%" + searchText.toLowerCase() + "%");
+                Expression<String> searchTextLiteral = criteriaBuilder.literal("%" + searchText.toLowerCase(Locale.ROOT) + "%");
 
                 Predicate searchInMessageContent = criteriaBuilder.like(criteriaBuilder.lower(root.get(Post_.CONTENT)), searchTextLiteral);
                 Join<Post, AnswerPost> answersJoin = root.join(Post_.ANSWERS, JoinType.LEFT);

--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/conversation/ChannelService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/conversation/ChannelService.java
@@ -5,6 +5,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -165,7 +166,7 @@ public class ChannelService {
      */
     public Channel createChannel(Course course, Channel channel, Optional<User> creator) {
         if (StringUtils.hasText(channel.getName())) {
-            channel.setName(StringUtils.trimAllWhitespace(channel.getName().toLowerCase()));
+            channel.setName(StringUtils.trimAllWhitespace(channel.getName().toLowerCase(Locale.ROOT)));
         }
 
         channel.setCreator(creator.orElse(null));
@@ -495,7 +496,7 @@ public class ChannelService {
         String specialCharacters = "[^a-z0-9]+";
         // -+$ matches a trailing hyphen at the end of a string
         String leadingTrailingHyphens = "-$";
-        channelName = channelName.toLowerCase().replaceAll(specialCharacters, "-").replaceFirst(leadingTrailingHyphens, "");
+        channelName = channelName.toLowerCase(Locale.ROOT).replaceAll(specialCharacters, "-").replaceFirst(leadingTrailingHyphens, "");
         if (channelName.length() > 30) {
             channelName = channelName.substring(0, 30);
         }

--- a/src/main/java/de/tum/cit/aet/artemis/communication/web/conversation/ConversationResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/web/conversation/ConversationResource.java
@@ -4,6 +4,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -314,7 +315,7 @@ public class ConversationResource extends ConversationManagementResource {
                 throw new AccessForbiddenException("Only members of a conversation or instructors can search the members of a conversation.");
             }
         }
-        var searchTerm = loginOrName != null ? loginOrName.toLowerCase().trim() : "";
+        var searchTerm = loginOrName != null ? loginOrName.toLowerCase(Locale.ROOT).trim() : "";
         var originalPage = conversationService.searchMembersOfConversation(course, conversationFromDatabase, pageable, searchTerm, Optional.ofNullable(filter));
 
         var resultDTO = new ArrayList<ConversationUserDTO>();

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/BinaryFileExtensionConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/BinaryFileExtensionConfiguration.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.artemis.core.config;
 
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -70,7 +71,7 @@ public class BinaryFileExtensionConfiguration {
      * @return true if the file is considered a binary file based on the above extensions, false otherwise
      */
     public static boolean isBinaryFile(String filePath) {
-        String lowerCasePath = filePath.toLowerCase();
+        String lowerCasePath = filePath.toLowerCase(Locale.ROOT);
         return binaryFileExtensions.stream().anyMatch(lowerCasePath::endsWith);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/MetricsBean.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/MetricsBean.java
@@ -10,6 +10,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -299,7 +300,7 @@ public class MetricsBean {
             // The health status gets mapped to a double value, as only doubles can be returned by a Gauge.
             if (healthContributor instanceof HealthIndicator healthIndicator) {
                 Gauge.builder(ARTEMIS_HEALTH_NAME, healthIndicator, h -> mapHealthToDouble(h.health())).strongReference(true).description(ARTEMIS_HEALTH_DESCRIPTION)
-                        .tag(ARTEMIS_HEALTH_TAG, healthIndicator.getClass().getSimpleName().toLowerCase()).register(meterRegistry);
+                        .tag(ARTEMIS_HEALTH_TAG, healthIndicator.getClass().getSimpleName().toLowerCase(Locale.ROOT)).register(meterRegistry);
             }
 
             // The DiscoveryCompositeHealthContributor can consist of several HealthIndicators, so they must all be published
@@ -307,7 +308,7 @@ public class MetricsBean {
                 for (HealthContributors.Entry discoveryHealthContributor : discoveryCompositeHealthContributor) {
                     if (discoveryHealthContributor.contributor() instanceof HealthIndicator healthIndicator) {
                         Gauge.builder(ARTEMIS_HEALTH_NAME, healthIndicator, h -> mapHealthToDouble(h.health())).strongReference(true).description(ARTEMIS_HEALTH_DESCRIPTION)
-                                .tag(ARTEMIS_HEALTH_TAG, discoveryHealthContributor.name().toLowerCase()).register(meterRegistry);
+                                .tag(ARTEMIS_HEALTH_TAG, discoveryHealthContributor.name().toLowerCase(Locale.ROOT)).register(meterRegistry);
                     }
                 }
             }

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SentryConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SentryConfiguration.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.core.config;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -211,7 +212,7 @@ public class SentryConfiguration {
             }
 
             if (request.getHeaders() != null) {
-                request.setHeaders(request.getHeaders().entrySet().stream().filter((entry) -> !entry.getKey().toLowerCase().startsWith("x-artemis-client-"))
+                request.setHeaders(request.getHeaders().entrySet().stream().filter((entry) -> !entry.getKey().toLowerCase(Locale.ROOT).startsWith("x-artemis-client-"))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
             }
         }
@@ -221,7 +222,7 @@ public class SentryConfiguration {
 
     private String getEnvironment() {
         if (environment.isPresent() && !environment.get().isBlank()) {
-            return environment.get().trim().toLowerCase();
+            return environment.get().trim().toLowerCase(Locale.ROOT);
         }
         if (isTestServer.isPresent()) {
             if (isTestServer.get()) {

--- a/src/main/java/de/tum/cit/aet/artemis/core/config/WebConfigurer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/WebConfigurer.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.FilterRegistration;
@@ -98,9 +99,9 @@ public class WebConfigurer implements ServletContextInitializer, WebServerFactor
         if (server instanceof ConfigurableServletWebServerFactory servletWebServer) {
             MimeMappings mappings = new MimeMappings(MimeMappings.DEFAULT);
             // IE issue, see https://github.com/jhipster/generator-jhipster/pull/711
-            mappings.add("html", MediaType.TEXT_HTML_VALUE + ";charset=" + StandardCharsets.UTF_8.name().toLowerCase());
+            mappings.add("html", MediaType.TEXT_HTML_VALUE + ";charset=" + StandardCharsets.UTF_8.name().toLowerCase(Locale.ROOT));
             // CloudFoundry issue, see https://github.com/cloudfoundry/gorouter/issues/64
-            mappings.add("json", MediaType.TEXT_HTML_VALUE + ";charset=" + StandardCharsets.UTF_8.name().toLowerCase());
+            mappings.add("json", MediaType.TEXT_HTML_VALUE + ";charset=" + StandardCharsets.UTF_8.name().toLowerCase(Locale.ROOT));
             servletWebServer.setMimeMappings(mappings);
         }
     }
@@ -108,7 +109,7 @@ public class WebConfigurer implements ServletContextInitializer, WebServerFactor
     private void setLocationForStaticAssets(WebServerFactory server) {
         if (server instanceof ConfigurableServletWebServerFactory servletWebServer) {
             String prefixPath = resolvePathPrefix();
-            boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+            boolean isWindows = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win");
             String INVALID_PREFIX_ON_WINDOWS = "/";
             boolean isInvalidPrefixOnWindows = prefixPath.startsWith(INVALID_PREFIX_ON_WINDOWS);
             if (isWindows && isInvalidPrefixOnWindows) {

--- a/src/main/java/de/tum/cit/aet/artemis/core/exception/failureAnalyzer/InsecureDefaultCredentialFailureAnalyzer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/exception/failureAnalyzer/InsecureDefaultCredentialFailureAnalyzer.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.core.exception.failureAnalyzer;
 
+import java.util.Locale;
+
 import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
 import org.springframework.boot.diagnostics.FailureAnalysis;
 
@@ -49,6 +51,6 @@ public class InsecureDefaultCredentialFailureAnalyzer extends AbstractFailureAna
      * @return the corresponding environment variable name
      */
     private static String toEnvironmentVariableName(String propertyPath) {
-        return propertyPath.replace("-", "").replace(".", "_").toUpperCase();
+        return propertyPath.replace("-", "").replace(".", "_").toUpperCase(Locale.ROOT);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/core/exception/failureAnalyzer/InvalidAdminConfigurationFailureAnalyzer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/exception/failureAnalyzer/InvalidAdminConfigurationFailureAnalyzer.java
@@ -5,6 +5,8 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PASSWORD_MIN_LENGTH;
 import static de.tum.cit.aet.artemis.core.config.Constants.USERNAME_MAX_LENGTH;
 import static de.tum.cit.aet.artemis.core.config.Constants.USERNAME_MIN_LENGTH;
 
+import java.util.Locale;
+
 import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
 import org.springframework.boot.diagnostics.FailureAnalysis;
 
@@ -37,7 +39,7 @@ public class InvalidAdminConfigurationFailureAnalyzer extends AbstractFailureAna
                 + "artemis:%n" + "  user-management:%n" + "    internal-admin:%n" + "      username: <choose-a-username>  # %s%n"
                 + "      password: <choose-a-strong-password>  # %s%n%n"
                 + "Do not reuse the example values from the Artemis repository: under the 'prod' profile they are rejected at startup.")
-                .formatted(cause.getPropertyPath().replace("artemis.user-management.", "").replace(".", "_").replace("-", "_").toUpperCase(),
+                .formatted(cause.getPropertyPath().replace("artemis.user-management.", "").replace(".", "_").replace("-", "_").toUpperCase(Locale.ROOT),
                         cause.getPropertyPath().replace("artemis.user-management.", ""), cause.getPropertyPath().replace("artemis.user-management.", ""), cause.getConstraint(),
                         getConstraintForProperty("username"), getConstraintForProperty("password"));
     }

--- a/src/main/java/de/tum/cit/aet/artemis/core/security/Role.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/security/Role.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.core.security;
 
+import java.util.Locale;
+
 /**
  * Constants for Spring Security authorities.
  */
@@ -36,7 +38,7 @@ public enum Role {
      * @return the corresponding role
      */
     public static Role fromString(String courseGroup) {
-        return switch (courseGroup.toLowerCase()) {
+        return switch (courseGroup.toLowerCase(Locale.ROOT)) {
             case "students" -> STUDENT;
             case "tutors" -> TEACHING_ASSISTANT;
             case "instructors" -> INSTRUCTOR;

--- a/src/main/java/de/tum/cit/aet/artemis/core/service/file/FileDownloadService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/service/file/FileDownloadService.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -71,7 +72,7 @@ public class FileDownloadService {
      */
     public FileDownloadPayload prepareAttachmentDownload(Path path, String filename, Optional<String> replaceFilename, List<HttpRange> ranges, int maxPdfRangeBytes) {
         Path actualPath = path.resolve(filename);
-        if (!filename.toLowerCase().endsWith(".pdf")) {
+        if (!filename.toLowerCase(Locale.ROOT).endsWith(".pdf")) {
             return buildFullFilePayload(actualPath, filename, replaceFilename);
         }
         if (!Files.exists(actualPath)) {
@@ -133,8 +134,10 @@ public class FileDownloadService {
     public HttpHeaders createFileHeaders(String filename, Optional<String> replaceFilename) {
         HttpHeaders headers = new HttpHeaders();
 
-        String contentType = filename.toLowerCase().endsWith("htm") || filename.toLowerCase().endsWith("html") || filename.toLowerCase().endsWith("svg")
-                || filename.toLowerCase().endsWith("svgz") ? "attachment" : "inline";
+        String lowerCaseFilename = filename.toLowerCase(Locale.ROOT);
+        String contentType = lowerCaseFilename.endsWith("htm") || lowerCaseFilename.endsWith("html") || lowerCaseFilename.endsWith("svg") || lowerCaseFilename.endsWith("svgz")
+                ? "attachment"
+                : "inline";
         String headerFilename = FileUtil.sanitizeFilename(replaceFilename.orElse(filename));
         headers.setContentDisposition(ContentDisposition.builder(contentType).filename(headerFilename).build());
         headers.set("Filename", headerFilename);

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/FileResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/FileResource.java
@@ -10,6 +10,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -274,8 +275,8 @@ public class FileResource {
     public ResponseEntity<byte[]> getTemplateFile(@PathVariable ProgrammingLanguage language, @PathVariable Optional<ProjectType> projectType) {
         log.debug("REST request to get readme file for programming language {} and project type {}", language, projectType);
 
-        String languagePrefix = language.name().toLowerCase();
-        String projectTypePrefix = projectType.map(type -> type.name().toLowerCase()).orElse("");
+        String languagePrefix = language.name().toLowerCase(Locale.ROOT);
+        String projectTypePrefix = projectType.map(type -> type.name().toLowerCase(Locale.ROOT)).orElse("");
 
         return getTemplateFileContentWithResponse(languagePrefix, projectTypePrefix);
     }

--- a/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicAccountResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/web/open/PublicAccountResource.java
@@ -6,6 +6,7 @@ import static de.tum.cit.aet.artemis.core.security.jwt.JWTFilter.extractValidJwt
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -300,7 +301,7 @@ public class PublicAccountResource {
     @EnforceNothing
     public ResponseEntity<Void> changeLanguageKey(@RequestBody String languageKey) {
         User user = userRepository.getUser();
-        String langKey = languageKey.replaceAll("\"", "").toLowerCase().trim();
+        String langKey = languageKey.replaceAll("\"", "").toLowerCase(Locale.ROOT).trim();
         if (!"en".equals(langKey) && !"de".equals(langKey)) {
             throw new BadRequestAlertException("Language key %s not supported!".formatted(languageKey), "Account", "invalidLanguageKey");
         }

--- a/src/main/java/de/tum/cit/aet/artemis/course/web/CourseAccessResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/course/web/CourseAccessResource.java
@@ -5,6 +5,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -352,7 +353,7 @@ public class CourseAccessResource {
         var course = courseRepository.findByIdElseThrow(courseId);
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.STUDENT, course, null);
 
-        var searchTerm = loginOrName != null ? loginOrName.toLowerCase().trim() : "";
+        var searchTerm = loginOrName != null ? loginOrName.toLowerCase(Locale.ROOT).trim() : "";
         List<UserNameAndLoginDTO> searchResults = userRepository.searchAllWithCourseRolesByLoginOrNameInCourseAndReturnPage(Pageable.ofSize(10), searchTerm, course.getId())
                 .getContent().stream().map(UserNameAndLoginDTO::of).toList();
 

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/ExerciseType.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/ExerciseType.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.exercise.domain;
 
+import java.util.Locale;
+
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import de.tum.cit.aet.artemis.fileupload.domain.FileUploadExercise;
@@ -35,7 +37,7 @@ public enum ExerciseType {
      * @return the exercise type as a lower case String without any special characters (e.g. FILE_UPLOAD -> "file upload")
      */
     public String getExerciseTypeAsReadableString() {
-        return this.toString().toLowerCase().replace('_', ' ');
+        return this.toString().toLowerCase(Locale.ROOT).replace('_', ' ');
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/repository/StudentParticipationSpecs.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/repository/StudentParticipationSpecs.java
@@ -4,6 +4,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Expression;
@@ -160,7 +161,7 @@ public class StudentParticipationSpecs {
      * The escape character is {@code \}.
      */
     private static String likePattern(String token) {
-        return "%" + token.toLowerCase().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_") + "%";
+        return "%" + token.toLowerCase(Locale.ROOT).replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_") + "%";
     }
 
     // --------------------------------------------------

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/ParticipationService.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -710,9 +711,9 @@ public class ParticipationService {
             final var exercise = participation.getProgrammingExercise();
             final var planName = BuildPlanType.TEMPLATE.getName();
             final var username = participation.getParticipantIdentifier();
-            final var buildProjectName = participation.getExercise().getCourseViaExerciseGroupOrCourseMember().getShortName().toUpperCase() + " "
+            final var buildProjectName = participation.getExercise().getCourseViaExerciseGroupOrCourseMember().getShortName().toUpperCase(Locale.ROOT) + " "
                     + participation.getExercise().getTitle();
-            final var targetPlanName = participation.addPracticePrefixIfTestRun(username.toUpperCase());
+            final var targetPlanName = participation.addPracticePrefixIfTestRun(username.toUpperCase(Locale.ROOT));
             // the next action includes recovery, which means if the build plan has already been copied, we simply retrieve the build plan id and do not copy it again
             final var buildPlanId = continuousIntegrationService.orElseThrow().copyBuildPlan(exercise, planName, exercise, buildProjectName, targetPlanName, true);
             participation.setBuildPlanId(buildPlanId);

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/web/TeamResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/web/TeamResource.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -150,7 +151,7 @@ public class TeamResource {
             throw new BadRequestAlertException("A team with this short name already exists in the course.", ENTITY_NAME, "teamShortNameAlreadyExistsInCourse");
         }
         // Remove all special characters and check if the resulting shortname is valid
-        var shortName = dto.shortName().replaceAll("[^0-9a-z]", "").toLowerCase();
+        var shortName = dto.shortName().replaceAll("[^0-9a-z]", "").toLowerCase(Locale.ROOT);
         Matcher shortNameMatcher = SHORT_NAME_PATTERN.matcher(shortName);
         if (!shortNameMatcher.matches()) {
             throw new BadRequestAlertException("The team name must start with a letter.", ENTITY_NAME, "teamShortNameInvalid");

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/web/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/web/FileUploadExerciseResource.java
@@ -7,6 +7,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -313,7 +314,7 @@ public class FileUploadExerciseResource {
         if (exercise.getFilePattern() == null) {
             return false;
         }
-        var filePattern = exercise.getFilePattern().toLowerCase().replaceAll("\\s+", "");
+        var filePattern = exercise.getFilePattern().toLowerCase(Locale.ROOT).replaceAll("\\s+", "");
         var allowedFileEndings = filePattern.split(",");
         var isValid = true;
         for (var allowedFileEnding : allowedFileEndings) {

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/web/FileUploadSubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/web/FileUploadSubmissionResource.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.fileupload.web;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -188,8 +189,8 @@ public class FileUploadSubmissionResource extends AbstractSubmissionResource {
     private static void checkFilePattern(MultipartFile file, FileUploadExercise exercise) {
         // Check the pattern
         final String[] splittedFileName = file.getOriginalFilename().split("\\.");
-        final String fileSuffix = splittedFileName[splittedFileName.length - 1].toLowerCase();
-        final String filePattern = String.join("|", exercise.getFilePattern().toLowerCase().replaceAll("\\s", "").split(","));
+        final String fileSuffix = splittedFileName[splittedFileName.length - 1].toLowerCase(Locale.ROOT);
+        final String filePattern = String.join("|", exercise.getFilePattern().toLowerCase(Locale.ROOT).replaceAll("\\s", "").split(","));
         if (!fileSuffix.matches(filePattern)) {
             throw new BadRequestAlertException("The uploaded file has the wrong type!", ENTITY_NAME, "fileUploadSubmissionIllegalFileType");
         }

--- a/src/main/java/de/tum/cit/aet/artemis/hyperion/service/HyperionConsistencyCheckService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/hyperion/service/HyperionConsistencyCheckService.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -350,7 +351,7 @@ public class HyperionConsistencyCheckService {
      * @return DTO for API responses
      */
     private ConsistencyIssueDTO mapConsistencyIssueToDto(ConsistencyIssue issue) {
-        Severity severity = switch (issue.severity() == null ? "MEDIUM" : issue.severity().toUpperCase()) {
+        Severity severity = switch (issue.severity() == null ? "MEDIUM" : issue.severity().toUpperCase(Locale.ROOT)) {
             case "LOW" -> Severity.LOW;
             case "HIGH" -> Severity.HIGH;
             default -> Severity.MEDIUM;

--- a/src/main/java/de/tum/cit/aet/artemis/hyperion/service/HyperionProgrammingExerciseContextRendererService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/hyperion/service/HyperionProgrammingExerciseContextRendererService.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -162,7 +163,7 @@ public class HyperionProgrammingExerciseContextRendererService {
 
     private static String renderRepository(Map<String, String> files, String repoName) {
         final boolean isProblemStatement = Objects.equals(repoName, "Problem Statement");
-        final String root = isProblemStatement ? null : (repoName == null ? "repository" : repoName.replace(" ", "_").toLowerCase());
+        final String root = isProblemStatement ? null : (repoName == null ? "repository" : repoName.replace(" ", "_").toLowerCase(Locale.ROOT));
         String treePart = "";
         if (!isProblemStatement) {
             treePart = renderFileStructure(root, files.keySet());

--- a/src/main/java/de/tum/cit/aet/artemis/iris/domain/settings/IrisPipelineVariant.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/domain/settings/IrisPipelineVariant.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.iris.domain.settings;
 
+import java.util.Locale;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -32,7 +34,7 @@ public enum IrisPipelineVariant {
         if (raw == null) {
             return DEFAULT;
         }
-        return switch (raw.toLowerCase()) {
+        return switch (raw.toLowerCase(Locale.ROOT)) {
             case "advanced" -> ADVANCED;
             case "default" -> DEFAULT;
             default -> DEFAULT;

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/IrisAdminDashboardService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/IrisAdminDashboardService.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -332,7 +333,7 @@ public class IrisAdminDashboardService {
 
         while (current.isBefore(endExclusive)) {
             buckets.add(current.atStartOfDay(ZoneOffset.UTC).toInstant());
-            current = switch (span.toUpperCase()) {
+            current = switch (span.toUpperCase(Locale.ROOT)) {
                 case "DAY" -> current.plusDays(1);
                 case "WEEK" -> current.plusWeeks(1);
                 case "MONTH" -> current.plusMonths(1);

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/session/IrisChatSessionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/session/IrisChatSessionService.java
@@ -6,6 +6,7 @@ import static de.tum.cit.aet.artemis.iris.domain.session.IrisChatMode.PROGRAMMIN
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -279,8 +280,8 @@ public class IrisChatSessionService extends AbstractIrisChatSessionService<IrisC
         }
         rateLimitService.checkRateLimitElseThrow(session, user);
         log.info("Build failed for user {}", user.getName());
-        CompletableFuture.runAsync(() -> chatPipelineExecutionService.execute(session, Optional.of(IrisEventType.BUILD_FAILED.name().toLowerCase()), Optional.of(settings),
-                Optional.of(submission), Map.of(), List.of())).exceptionally(e -> {
+        CompletableFuture.runAsync(() -> chatPipelineExecutionService.execute(session, Optional.of(IrisEventType.BUILD_FAILED.name().toLowerCase(Locale.ROOT)),
+                Optional.of(settings), Optional.of(submission), Map.of(), List.of())).exceptionally(e -> {
                     log.error("Error while sending build failed message to Iris for session {}", session.getId(), e);
                     return null;
                 });
@@ -313,7 +314,7 @@ public class IrisChatSessionService extends AbstractIrisChatSessionService<IrisC
                     applyContextChange(session, PROGRAMMING_EXERCISE_CHAT, studentParticipation.getProgrammingExercise().getId(), user);
                 }
                 rateLimitService.checkRateLimitElseThrow(session, user);
-                CompletableFuture.runAsync(() -> chatPipelineExecutionService.execute(session, Optional.of(IrisEventType.PROGRESS_STALLED.name().toLowerCase()),
+                CompletableFuture.runAsync(() -> chatPipelineExecutionService.execute(session, Optional.of(IrisEventType.PROGRESS_STALLED.name().toLowerCase(Locale.ROOT)),
                         Optional.of(settings), Optional.of(latestSubmission), Map.of(), List.of())).exceptionally(e -> {
                             log.error("Error while sending progress stalled message to Iris for user {}", studentParticipation.getParticipant().getName(), e);
                             return null;

--- a/src/main/java/de/tum/cit/aet/artemis/jenkins/service/build_plan/JenkinsBuildPlanService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/jenkins/service/build_plan/JenkinsBuildPlanService.java
@@ -4,6 +4,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_JENKINS;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Locale;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -265,7 +266,7 @@ public class JenkinsBuildPlanService {
     }
 
     private String getCleanPlanName(String name) {
-        return name.toUpperCase().replaceAll("[^A-Z0-9]", "");
+        return name.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]", "");
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/jenkins/service/build_plan/JenkinsPipelineScriptCreator.java
+++ b/src/main/java/de/tum/cit/aet/artemis/jenkins/service/build_plan/JenkinsPipelineScriptCreator.java
@@ -101,7 +101,7 @@ public class JenkinsPipelineScriptCreator extends AbstractBuildPlanCreator {
 
         final var pipelineScriptFilename = "pipeline.groovy";
         final var regularOrSequentialDir = isSequentialRuns ? "sequentialRuns" : "regularRuns";
-        final var programmingLanguageName = programmingLanguage.name().toLowerCase();
+        final var programmingLanguageName = programmingLanguage.name().toLowerCase(Locale.ROOT);
         final Optional<String> projectTypeName = getProjectTypeName(programmingLanguage, projectType);
 
         Path resourcePath = Path.of("templates", "jenkins", programmingLanguageName);

--- a/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureUnitProcessingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lecture/service/LectureUnitProcessingService.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -203,8 +204,8 @@ public class LectureUnitProcessingService {
     }
 
     private boolean slideContainsKeyphrase(String slideText, List<String> keyphrasesList) {
-        String lowerCaseSlideText = slideText.toLowerCase();
-        return keyphrasesList.stream().anyMatch(keyphrase -> lowerCaseSlideText.contains(keyphrase.strip().toLowerCase()));
+        String lowerCaseSlideText = slideText.toLowerCase(Locale.ROOT);
+        return keyphrasesList.stream().anyMatch(keyphrase -> lowerCaseSlideText.contains(keyphrase.strip().toLowerCase(Locale.ROOT)));
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/localci/service/BuildPhasesTemplateService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localci/service/BuildPhasesTemplateService.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -119,14 +120,14 @@ public class BuildPhasesTemplateService {
             projectType = Optional.of(ProjectType.PLAIN_MAVEN);
         }
         String templateFileName = buildScriptProviderService.buildTemplateName(projectType, staticAnalysis, sequentialRuns, "yaml");
-        String uniqueKey = programmingLanguage.name().toLowerCase() + "_" + templateFileName;
+        String uniqueKey = programmingLanguage.name().toLowerCase(Locale.ROOT) + "_" + templateFileName;
         if (templateCache.containsKey(uniqueKey)) {
             return templateCache.get(uniqueKey);
         }
 
         String yamlString = null;
         try {
-            Path resourcePath = Path.of("templates", "phases", programmingLanguage.name().toLowerCase(), templateFileName);
+            Path resourcePath = Path.of("templates", "phases", programmingLanguage.name().toLowerCase(Locale.ROOT), templateFileName);
             var resource = this.resourceLoaderService.getResource(resourcePath);
             if (resource != null && resource.exists()) {
                 yamlString = readResourceAsString(resource);

--- a/src/main/java/de/tum/cit/aet/artemis/localci/service/BuildScriptProviderService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localci/service/BuildScriptProviderService.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.localci.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
@@ -35,10 +36,10 @@ public class BuildScriptProviderService {
         List<String> fileNameComponents = new ArrayList<>();
 
         if (ProjectType.MAVEN_BLACKBOX.equals(projectType.orElse(null))) {
-            fileNameComponents.add("plain_" + projectType.get().name().toLowerCase());
+            fileNameComponents.add("plain_" + projectType.get().name().toLowerCase(Locale.ROOT));
         }
         else {
-            fileNameComponents.add(projectType.map(Enum::name).orElse("default").toLowerCase());
+            fileNameComponents.add(projectType.map(Enum::name).orElse("default").toLowerCase(Locale.ROOT));
         }
 
         if (staticAnalysis) {

--- a/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIService.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.localci.service;
 import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_LOCALCI;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -193,6 +194,6 @@ public class LocalCIService implements ContinuousIntegrationService {
     }
 
     private String getCleanPlanName(String name) {
-        return name.toUpperCase().replaceAll("[^A-Z0-9]", "");
+        return name.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]", "");
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/localci/service/scaparser/strategy/sarif/ClippyCategorizer.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localci/service/scaparser/strategy/sarif/ClippyCategorizer.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import de.tum.cit.aet.artemis.localci.service.scaparser.format.sarif.ReportingDescriptor;
@@ -20,15 +21,15 @@ public class ClippyCategorizer implements RuleCategorizer {
         NONSTANDARD_STYLE, UNSAFE_CODE, UNUSED, RUST_OTHER, CARGO, COMPLEXITY, CORRECTNESS, NURSERY, PEDANTIC, PERF, RESTRICTION, STYLE, SUSPICIOUS, CLIPPY_OTHER,
     }
 
-    public static final List<String> CATEGORY_NAMES = Arrays.stream(Category.values()).map(Enum::name).map(String::toLowerCase).toList();
+    public static final List<String> CATEGORY_NAMES = Arrays.stream(Category.values()).map(Enum::name).map(name -> name.toLowerCase(Locale.ROOT)).toList();
 
     @Override
     public String categorizeRule(ReportingDescriptor rule) {
         if (rule.id().startsWith("clippy::")) {
-            return CLIPPY_CATEGORY_BY_NAME.getOrDefault(rule.id(), Category.CLIPPY_OTHER).name().toLowerCase();
+            return CLIPPY_CATEGORY_BY_NAME.getOrDefault(rule.id(), Category.CLIPPY_OTHER).name().toLowerCase(Locale.ROOT);
         }
 
-        return RUST_CATEGORY_BY_NAME.getOrDefault(rule.id(), Category.RUST_OTHER).name().toLowerCase();
+        return RUST_CATEGORY_BY_NAME.getOrDefault(rule.id(), Category.RUST_OTHER).name().toLowerCase(Locale.ROOT);
     }
 
     // @formatter:off

--- a/src/main/java/de/tum/cit/aet/artemis/localvc/service/LocalVCRepositoryUri.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localvc/service/LocalVCRepositoryUri.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.localvc.service;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 import org.springframework.web.util.UriComponentsBuilder;
@@ -66,7 +67,7 @@ public class LocalVCRepositoryUri extends VcsRepositoryUri {
         if (!repositoryName.matches("[a-zA-Z0-9]+-[a-zA-Z0-9-]+")) {
             throw new IllegalArgumentException("Repository name must be in the format <projectKey>-<repoType>");
         }
-        return repositoryName.split("-")[0].toUpperCase();
+        return repositoryName.split("-")[0].toUpperCase(Locale.ROOT);
     }
 
     /**
@@ -218,8 +219,8 @@ public class LocalVCRepositoryUri extends VcsRepositoryUri {
      * @return The normalized repository type or username, free of the project key prefix and "practice-" designation.
      */
     private String getRepositoryTypeOrUserName(String repositorySlug, String projectKey) {
-        String pattern = Pattern.quote(projectKey.toLowerCase()) + "\\d*-";
-        String repositoryTypeOrUserNameWithPracticePrefix = repositorySlug.toLowerCase().replaceAll(pattern, "");
+        String pattern = Pattern.quote(projectKey.toLowerCase(Locale.ROOT)) + "\\d*-";
+        String repositoryTypeOrUserNameWithPracticePrefix = repositorySlug.toLowerCase(Locale.ROOT).replaceAll(pattern, "");
         return repositoryTypeOrUserNameWithPracticePrefix.replace("practice-", "");
     }
 
@@ -232,7 +233,7 @@ public class LocalVCRepositoryUri extends VcsRepositoryUri {
      * @return true if the repository is a practice repository, false otherwise.
      */
     private boolean isPracticeRepository(String repositorySlug, String projectKey) {
-        return repositorySlug.toLowerCase().startsWith(projectKey.toLowerCase() + "-practice-");
+        return repositorySlug.toLowerCase(Locale.ROOT).startsWith(projectKey.toLowerCase(Locale.ROOT) + "-practice-");
     }
 
     /**
@@ -244,7 +245,7 @@ public class LocalVCRepositoryUri extends VcsRepositoryUri {
      * @throws LocalVCInternalException If the repository slug does not start with the project key, indicating an incorrect or malformed slug.
      */
     private void validateProjectKeyAndRepositorySlug(String projectKey, String repositorySlug) {
-        if (!repositorySlug.toLowerCase().startsWith(projectKey.toLowerCase())) {
+        if (!repositorySlug.toLowerCase(Locale.ROOT).startsWith(projectKey.toLowerCase(Locale.ROOT))) {
             throw new LocalVCInternalException("Invalid project key and repository slug: " + projectKey + ", " + repositorySlug);
         }
     }

--- a/src/main/java/de/tum/cit/aet/artemis/localvc/service/vcs/AbstractVersionControlService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localvc/service/vcs/AbstractVersionControlService.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.localvc.service.vcs;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Objects;
 
 import org.eclipse.jgit.api.errors.TransportException;
@@ -62,9 +63,9 @@ public abstract class AbstractVersionControlService implements VersionControlSer
 
     private LocalVCRepositoryUri copyRepository(String sourceProjectKey, String sourceRepositoryName, String sourceBranch, String targetProjectKey, String targetRepositoryName,
             Integer attempt, boolean withHistory) throws VersionControlException {
-        sourceRepositoryName = sourceRepositoryName.toLowerCase();
-        targetRepositoryName = targetRepositoryName.toLowerCase();
-        String targetProjectKeyLowerCase = targetProjectKey.toLowerCase();
+        sourceRepositoryName = sourceRepositoryName.toLowerCase(Locale.ROOT);
+        targetRepositoryName = targetRepositoryName.toLowerCase(Locale.ROOT);
+        String targetProjectKeyLowerCase = targetProjectKey.toLowerCase(Locale.ROOT);
         if (attempt != null && attempt > 0 && !targetRepositoryName.contains("practice-")) {
             targetProjectKeyLowerCase = targetProjectKeyLowerCase + attempt;
         }

--- a/src/main/java/de/tum/cit/aet/artemis/lti/service/DeepLinkingType.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/service/DeepLinkingType.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.lti.service;
 
+import java.util.Locale;
+
 public enum DeepLinkingType {
 
     EXERCISE, GROUPED_EXERCISE, LECTURE, GROUPED_LECTURE, COMPETENCY, LEARNING_PATH, IRIS;
@@ -12,6 +14,6 @@ public enum DeepLinkingType {
      * @throws IllegalArgumentException if the type does not match any enum value.
      */
     public static DeepLinkingType fromString(String type) {
-        return DeepLinkingType.valueOf(type.toUpperCase());
+        return DeepLinkingType.valueOf(type.toUpperCase(Locale.ROOT));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/lti/service/Lti13Service.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/service/Lti13Service.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.lti.service;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -356,7 +357,7 @@ public class Lti13Service {
         }
 
         Map<String, String> pathVariables = matcher.extractUriTemplateVariables(pathPattern, targetLinkPath);
-        String entityId = pathVariables.get(entityName.toLowerCase() + "Id");
+        String entityId = pathVariables.get(entityName.toLowerCase(Locale.ROOT) + "Id");
 
         try {
             return repositoryFinder.apply(entityId);

--- a/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiDeepLinkingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiDeepLinkingService.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.lti.service;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -268,7 +269,7 @@ public class LtiDeepLinkingService {
      */
     private void validateUnitIds(Set<Long> unitIds, DeepLinkingType type) {
         if (unitIds == null || unitIds.isEmpty()) {
-            throw new BadRequestAlertException("No " + type.name().toLowerCase() + " IDs provided for deep linking", "LTI", "no" + type.name() + "Ids");
+            throw new BadRequestAlertException("No " + type.name().toLowerCase(Locale.ROOT) + " IDs provided for deep linking", "LTI", "no" + type.name() + "Ids");
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiDynamicRegistrationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/lti/service/LtiDynamicRegistrationService.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.lti.service;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.util.Locale;
 import java.util.UUID;
 
 import org.slf4j.Logger;
@@ -197,7 +198,7 @@ public class LtiDynamicRegistrationService {
     }
 
     private boolean isLocalDevelopmentHost(String host) {
-        String normalizedHost = host.toLowerCase();
+        String normalizedHost = host.toLowerCase(Locale.ROOT);
         return "localhost".equals(normalizedHost) || normalizedHost.endsWith(".localhost");
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/ProgrammingPlagiarismDetectionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/service/ProgrammingPlagiarismDetectionService.java
@@ -9,6 +9,7 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -479,7 +480,7 @@ public class ProgrammingPlagiarismDetectionService {
             try (Stream<Path> paths = Files.walk(repoPath)) {
                 List<Path> relevantFiles = paths.filter(Files::isRegularFile).filter(path -> {
                     // Only consider files with the correct file extension
-                    String fileName = path.getFileName().toString().toLowerCase();
+                    String fileName = path.getFileName().toString().toLowerCase(Locale.ROOT);
                     return fileExtensions.stream().anyMatch(fileName::endsWith);
                 }).toList();
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingExercise.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/ProgrammingExercise.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -322,7 +323,7 @@ public class ProgrammingExercise extends Exercise {
      */
     public String generateRepositoryName(String repositoryName) {
         generateAndSetProjectKey();
-        return this.projectKey.toLowerCase() + "-" + repositoryName;
+        return this.projectKey.toLowerCase(Locale.ROOT) + "-" + repositoryName;
     }
 
     /**
@@ -356,7 +357,7 @@ public class ProgrammingExercise extends Exercise {
 
     public void forceNewProjectKey() {
         Course course = getCourseViaExerciseGroupOrCourseMember();
-        this.projectKey = (course.getShortName() + this.getShortName()).toUpperCase().replaceAll("\\s+", "");
+        this.projectKey = (course.getShortName() + this.getShortName()).toUpperCase(Locale.ROOT).replaceAll("\\s+", "");
     }
 
     @Override

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/RepositoryType.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/RepositoryType.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.artemis.programming.domain;
 
+import java.util.Locale;
+
 public enum RepositoryType {
 
     TEMPLATE("exercise"), SOLUTION("solution"), TESTS("tests"), AUXILIARY("auxiliary"), USER("user");
@@ -29,6 +31,6 @@ public enum RepositoryType {
      * @throws IllegalArgumentException if the name does not match any enum constant
      */
     public static RepositoryType fromString(String name) {
-        return RepositoryType.valueOf(name.toUpperCase());
+        return RepositoryType.valueOf(name.toUpperCase(Locale.ROOT));
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/VcsRepositoryUri.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/VcsRepositoryUri.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.programming.domain;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -140,7 +141,7 @@ public class VcsRepositoryUri {
      * @return The repository name without the project key and the practice prefix, in lowercase.
      */
     public String repositoryNameWithoutProjectKey() {
-        return repositorySlug().toLowerCase().replace(projectKey().toLowerCase() + "-", "").replace("practice-", "");
+        return repositorySlug().toLowerCase(Locale.ROOT).replace(projectKey().toLowerCase(Locale.ROOT) + "-", "").replace("practice-", "");
     }
 
     /**
@@ -175,6 +176,7 @@ public class VcsRepositoryUri {
      * @return The project key in lowercase, as found in the URI's path.
      */
     private String projectKey() {
-        return this.uri.getPath().substring(this.uri.getPath().lastIndexOf('/', this.uri.getPath().lastIndexOf('/') - 1) + 1, this.uri.getPath().lastIndexOf('/')).toLowerCase();
+        return this.uri.getPath().substring(this.uri.getPath().lastIndexOf('/', this.uri.getPath().lastIndexOf('/') - 1) + 1, this.uri.getPath().lastIndexOf('/'))
+                .toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/AuxiliaryRepositoryService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/AuxiliaryRepositoryService.java
@@ -5,6 +5,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.PROFILE_CORE;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -105,7 +106,7 @@ public class AuxiliaryRepositoryService {
             throw new BadRequestAlertException("Cannot set empty name for auxiliary repositories!", AUX_REPO_ENTITY_NAME,
                     ProgrammingExerciseErrorKeys.INVALID_AUXILIARY_REPOSITORY_NAME);
         }
-        auxiliaryRepository.setName(auxiliaryRepository.getName().toLowerCase());
+        auxiliaryRepository.setName(auxiliaryRepository.getName().toLowerCase(Locale.ROOT));
     }
 
     private void validateAuxiliaryRepositoryNameLength(AuxiliaryRepository auxiliaryRepository) {

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseExportService.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -869,7 +870,7 @@ public class ProgrammingExerciseExportService extends ExerciseWithSubmissionsExp
                 nameNode.setTextContent(nameNode.getTextContent() + " " + participantIdentifier);
             }
             if (artifactIdNode != null) {
-                String artifactId = (artifactIdNode.getTextContent() + "-" + participantIdentifier).replaceAll(" ", "-").toLowerCase();
+                String artifactId = (artifactIdNode.getTextContent() + "-" + participantIdentifier).replaceAll(" ", "-").toLowerCase(Locale.ROOT);
                 artifactIdNode.setTextContent(artifactId);
             }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseImportService.java
@@ -7,6 +7,7 @@ import static de.tum.cit.aet.artemis.core.config.Constants.TEST_REPO_NAME;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -138,7 +139,7 @@ public class ProgrammingExerciseImportService {
         final var targetExerciseProjectKey = newExercise.getProjectKey();
         final var templatePlanName = BuildPlanType.TEMPLATE.getName();
         final var solutionPlanName = BuildPlanType.SOLUTION.getName();
-        final var targetName = newExercise.getCourseViaExerciseGroupOrCourseMember().getShortName().toUpperCase() + " " + newExercise.getTitle();
+        final var targetName = newExercise.getCourseViaExerciseGroupOrCourseMember().getShortName().toUpperCase(Locale.ROOT) + " " + newExercise.getTitle();
         ContinuousIntegrationService continuousIntegration = continuousIntegrationService.orElseThrow();
         continuousIntegration.createProjectForExercise(newExercise);
         continuousIntegration.copyBuildPlan(sourceExercise, templatePlanName, newExercise, targetName, templatePlanName, false);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseRepositoryService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseRepositoryService.java
@@ -224,7 +224,7 @@ public class ProgrammingExerciseRepositoryService {
             // Get path, files and prefix for the project-type dependent files. They are copied last and can overwrite the resources from the programming language.
             final Path programmingLanguageProjectTypePath = ProgrammingExerciseService.getProgrammingLanguageProjectTypePath(programmingExercise.getProgrammingLanguage(),
                     projectType);
-            final String projectTypePath = projectType.name().toLowerCase();
+            final String projectTypePath = projectType.name().toLowerCase(Locale.ROOT);
             final Path generalProjectTypePrefix = Path.of(programmingLanguage, projectTypePath);
             final Path projectTypeSpecificPrefix = generalProjectTypePrefix.resolve(repositoryTypeTemplateDir);
             final Path projectTypeTemplatePath = programmingLanguageProjectTypePath.resolve(repositoryTypeTemplateDir);

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseService.java
@@ -9,6 +9,7 @@ import static de.tum.cit.aet.artemis.programming.repository.TemplateProgrammingE
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -80,11 +81,11 @@ public class ProgrammingExerciseService {
     }
 
     public static Path getProgrammingLanguageProjectTypePath(ProgrammingLanguage programmingLanguage, ProjectType projectType) {
-        return getProgrammingLanguageTemplatePath(programmingLanguage).resolve(projectType.name().toLowerCase());
+        return getProgrammingLanguageTemplatePath(programmingLanguage).resolve(projectType.name().toLowerCase(Locale.ROOT));
     }
 
     public static Path getProgrammingLanguageTemplatePath(ProgrammingLanguage programmingLanguage) {
-        return Path.of("templates", programmingLanguage.name().toLowerCase());
+        return Path.of("templates", programmingLanguage.name().toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseValidationService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingExerciseValidationService.java
@@ -406,7 +406,7 @@ public class ProgrammingExerciseValidationService {
      * @return true if a project with the same ProjectKey or ProjectName already exists, otherwise false
      */
     public boolean preCheckProjectExistsOnVCSOrCI(ProgrammingExercise programmingExercise, String courseShortName) {
-        String projectKey = (courseShortName + programmingExercise.getShortName().replaceAll("\\s+", "")).toUpperCase();
+        String projectKey = (courseShortName + programmingExercise.getShortName().replaceAll("\\s+", "")).toUpperCase(Locale.ROOT);
         String projectName = courseShortName + " " + programmingExercise.getTitle();
         log.debug("Project Key: {}", projectKey);
         log.debug("Project Name: {}", projectName);

--- a/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerSubmittedText.java
+++ b/src/main/java/de/tum/cit/aet/artemis/quiz/domain/ShortAnswerSubmittedText.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.artemis.quiz.domain;
 
+import java.util.Locale;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -109,7 +110,7 @@ public class ShortAnswerSubmittedText extends DomainObject {
             return FuzzySearch.ratio(submittedText.trim(), solution.trim()) >= similarityValue;
         }
         // also use lowercase to allow different cases in the submitted text
-        return FuzzySearch.ratio(submittedText.toLowerCase().trim(), solution.toLowerCase().trim()) >= similarityValue;
+        return FuzzySearch.ratio(submittedText.toLowerCase(Locale.ROOT).trim(), solution.toLowerCase(Locale.ROOT).trim()) >= similarityValue;
     }
 
     @Override

--- a/src/main/java/de/tum/cit/aet/artemis/tutorialgroup/service/TutorialGroupChannelManagementService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/tutorialgroup/service/TutorialGroupChannelManagementService.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.artemis.tutorialgroup.service;
 
 import static jakarta.persistence.Persistence.getPersistenceUtil;
 
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -249,7 +250,7 @@ public class TutorialGroupChannelManagementService {
      */
     private String determineUniqueTutorialGroupChannelName(TutorialGroup tutorialGroup) {
         Course course = tutorialGroup.getCourse();
-        String cleanedGroupTitle = tutorialGroup.getTitle().replaceAll("\\s", "-").toLowerCase();
+        String cleanedGroupTitle = tutorialGroup.getTitle().replaceAll("\\s", "-").toLowerCase(Locale.ROOT);
         String channelName = "tutorgroup-" + cleanedGroupTitle.substring(0, Math.min(cleanedGroupTitle.length(), 18));
 
         if (!channelRepository.existsChannelByNameAndCourseId(channelName, course.getId())) {

--- a/src/test/java/de/tum/cit/aet/artemis/account/util/UserUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/util/UserUtilService.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -664,7 +665,7 @@ public class UserUtilService {
      */
     public User getUserByLogin(String login) {
         // we convert to lowercase for convenience, because logins have to be lower case
-        return userTestRepository.findOneWithAuthoritiesByLogin(login.toLowerCase())
+        return userTestRepository.findOneWithAuthoritiesByLogin(login.toLowerCase(Locale.ENGLISH))
                 .orElseThrow(() -> new IllegalArgumentException("Provided login " + login + " does not exist in database"));
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/communication/AnswerMessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/AnswerMessageIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -871,7 +872,7 @@ class AnswerMessageIntegrationTest extends AbstractSpringIntegrationIndependentT
 
         var params = new LinkedMultiValueMap<String, String>();
         params.add("courseId", courseId.toString());
-        params.add("status", SavedPostStatus.IN_PROGRESS.toString().toLowerCase());
+        params.add("status", SavedPostStatus.IN_PROGRESS.toString().toLowerCase(Locale.ROOT));
 
         List<PostingDTO> saved = request.getList("/api/communication/saved-posts", HttpStatus.OK, PostingDTO.class, params);
 
@@ -892,7 +893,7 @@ class AnswerMessageIntegrationTest extends AbstractSpringIntegrationIndependentT
 
         var params = new LinkedMultiValueMap<String, String>();
         params.add("courseId", courseId.toString());
-        params.add("status", SavedPostStatus.IN_PROGRESS.toString().toLowerCase());
+        params.add("status", SavedPostStatus.IN_PROGRESS.toString().toLowerCase(Locale.ROOT));
 
         List<PostingDTO> saved = request.getList("/api/communication/saved-posts", HttpStatus.OK, PostingDTO.class, params);
 

--- a/src/test/java/de/tum/cit/aet/artemis/communication/SavedPostResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/SavedPostResourceIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,8 +53,8 @@ class SavedPostResourceIntegrationTest extends AbstractConversationTest {
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void shouldReturnPostsWhenGetSavedPostIsCalled() throws Exception {
-        request.performMvcRequest(
-                MockMvcRequestBuilders.get("/api/communication/saved-posts?courseId=" + exampleCourseId + "&status=" + SavedPostStatus.IN_PROGRESS.toString().toLowerCase()))
+        request.performMvcRequest(MockMvcRequestBuilders
+                .get("/api/communication/saved-posts?courseId=" + exampleCourseId + "&status=" + SavedPostStatus.IN_PROGRESS.toString().toLowerCase(Locale.ROOT)))
                 .andExpect(MockMvcResultMatchers.status().isOk()).andExpect(jsonPath("$", hasSize(1))).andExpect(jsonPath("$[0].id").value(testPost.getId()));
     }
 
@@ -65,7 +66,7 @@ class SavedPostResourceIntegrationTest extends AbstractConversationTest {
         conversationMessageRepository.save(newTestPost);
 
         request.performMvcRequest(
-                MockMvcRequestBuilders.post("/api/communication/saved-posts/{postId}?type={type}", newTestPost.getId(), PostingType.POST.toString().toLowerCase()))
+                MockMvcRequestBuilders.post("/api/communication/saved-posts/{postId}?type={type}", newTestPost.getId(), PostingType.POST.toString().toLowerCase(Locale.ROOT)))
                 .andExpect(MockMvcResultMatchers.status().isCreated());
 
         conversationMessageRepository.delete(newTestPost);
@@ -86,7 +87,8 @@ class SavedPostResourceIntegrationTest extends AbstractConversationTest {
             savedPosts.add(savedPost);
         }
 
-        request.performMvcRequest(MockMvcRequestBuilders.post("/api/communication/saved-posts/{postId}?type={type}", testPost.getId(), PostingType.POST.toString().toLowerCase()))
+        request.performMvcRequest(
+                MockMvcRequestBuilders.post("/api/communication/saved-posts/{postId}?type={type}", testPost.getId(), PostingType.POST.toString().toLowerCase(Locale.ROOT)))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest()).andExpect(jsonPath("$.message").value("error.savedPostMaxReached"));
 
         // Cleanup
@@ -97,13 +99,15 @@ class SavedPostResourceIntegrationTest extends AbstractConversationTest {
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void shouldReturnOkWhenUpdatingProperStatus() throws Exception {
         request.performMvcRequest(MockMvcRequestBuilders.put("/api/communication/saved-posts/{postId}?status={status}&type={type}", testPost.getId(),
-                SavedPostStatus.COMPLETED.toString().toLowerCase(), PostingType.POST.toString().toLowerCase())).andExpect(MockMvcResultMatchers.status().isOk());
+                SavedPostStatus.COMPLETED.toString().toLowerCase(Locale.ROOT), PostingType.POST.toString().toLowerCase(Locale.ROOT)))
+                .andExpect(MockMvcResultMatchers.status().isOk());
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
     void shouldReturnNoContentWhenDeletingSavedPost() throws Exception {
-        request.performMvcRequest(MockMvcRequestBuilders.delete("/api/communication/saved-posts/{postId}?type={type}", testPost.getId(), PostingType.POST.toString().toLowerCase()))
+        request.performMvcRequest(
+                MockMvcRequestBuilders.delete("/api/communication/saved-posts/{postId}?type={type}", testPost.getId(), PostingType.POST.toString().toLowerCase(Locale.ROOT)))
                 .andExpect(MockMvcResultMatchers.status().isNoContent());
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/core/config/ProgrammingLanguageConfigurationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/config/ProgrammingLanguageConfigurationTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -150,7 +151,7 @@ class ProgrammingLanguageConfigurationTest {
         for (ProgrammingLanguage language : ProgrammingLanguage.getEnabledLanguages()) {
             final Map<String, String> languageImages = new HashMap<>();
             languageImages.put("default", language.name());
-            images.put(language.toString().toLowerCase(), languageImages);
+            images.put(language.toString().toLowerCase(Locale.ROOT), languageImages);
         }
 
         return images;

--- a/src/test/java/de/tum/cit/aet/artemis/core/connector/JenkinsRequestMockProvider.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/connector/JenkinsRequestMockProvider.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.mockito.MockitoAnnotations;
@@ -248,13 +249,13 @@ public class JenkinsRequestMockProvider {
 
     public void mockConfigureBuildPlan(ProgrammingExercise exercise, String username) throws IOException {
         final var projectKey = exercise.getProjectKey();
-        final var planKey = projectKey + "-" + getCleanPlanName(username.toUpperCase());
+        final var planKey = projectKey + "-" + getCleanPlanName(username.toUpperCase(Locale.ROOT));
         mockUpdatePlanRepository(projectKey, planKey, true);
         mockEnablePlan(projectKey, planKey, true, false);
     }
 
     private String getCleanPlanName(String planName) {
-        return planName.toUpperCase().replaceAll("[^A-Z0-9]", "");
+        return planName.toUpperCase(Locale.ROOT).replaceAll("[^A-Z0-9]", "");
     }
 
     public void mockUpdatePlanRepository(String projectKey, String planName, boolean useLegacyXml) throws IOException {
@@ -306,7 +307,7 @@ public class JenkinsRequestMockProvider {
 
     public void mockCopyBuildPlanForParticipation(ProgrammingExercise exercise, String username) throws IOException {
         final var projectKey = exercise.getProjectKey();
-        final var planKey = projectKey + "-" + getCleanPlanName(username.toUpperCase());
+        final var planKey = projectKey + "-" + getCleanPlanName(username.toUpperCase(Locale.ROOT));
         mockCopyBuildPlanFromTemplateIntoExistingTargetFolder(projectKey, projectKey, planKey);
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/CookieParserTestUtil.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/CookieParserTestUtil.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.core.util;
 
 import java.time.Duration;
+import java.util.Locale;
 
 import org.springframework.http.ResponseCookie;
 
@@ -20,7 +21,7 @@ public class CookieParserTestUtil {
 
         for (int i = 1; i < parts.length; i++) {
             String[] attr = parts[i].trim().split("=", 2);
-            String key = attr[0].trim().toLowerCase();
+            String key = attr[0].trim().toLowerCase(Locale.ROOT);
             String val = attr.length > 1 ? attr[1].trim() : "";
 
             switch (key) {

--- a/src/test/java/de/tum/cit/aet/artemis/core/util/CourseTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/util/CourseTestService.java
@@ -30,6 +30,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -2828,7 +2829,7 @@ public class CourseTestService {
 
         final String repoSuffix = "-" + userPrefix + "student1";
 
-        var buildPlanId = (programmingExercise.getProjectKey() + repoSuffix).toUpperCase();
+        var buildPlanId = (programmingExercise.getProjectKey() + repoSuffix).toUpperCase(Locale.ROOT);
         mockDelegate.mockDeleteBuildPlan(programmingExercise.getProjectKey(), buildPlanId, false);
         request.delete("/api/course/courses/" + course.getId() + "/cleanup", HttpStatus.OK);
 

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationFactory.java
@@ -6,6 +6,7 @@ import static java.time.ZonedDateTime.now;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.jspecify.annotations.NonNull;
 
@@ -420,7 +421,7 @@ public class ParticipationFactory {
      */
     public static ProgrammingExerciseStudentParticipation generateIndividualProgrammingExerciseStudentParticipation(ProgrammingExercise exercise, User user) {
         var participation = new ProgrammingExerciseStudentParticipation();
-        final var buildPlanId = exercise.getProjectKey() + "-" + user.getLogin().toUpperCase();
+        final var buildPlanId = exercise.getProjectKey() + "-" + user.getLogin().toUpperCase(Locale.ROOT);
         participation.setInitializationDate(ZonedDateTime.now());
         participation.setParticipant(user);
         participation.setBuildPlanId(buildPlanId);
@@ -440,7 +441,7 @@ public class ParticipationFactory {
      */
     public static ProgrammingExerciseStudentParticipation generateTeamProgrammingExerciseStudentParticipation(ProgrammingExercise exercise, Team team) {
         var participation = new ProgrammingExerciseStudentParticipation();
-        final var buildPlanId = exercise.getProjectKey().toUpperCase() + "-" + team.getShortName().toUpperCase();
+        final var buildPlanId = exercise.getProjectKey().toUpperCase(Locale.ROOT) + "-" + team.getShortName().toUpperCase(Locale.ROOT);
         participation.setInitializationDate(ZonedDateTime.now());
         participation.setParticipant(team);
         participation.setBuildPlanId(buildPlanId);

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/participation/util/ParticipationUtilService.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -189,8 +190,8 @@ public class ParticipationUtilService {
         if (storedParticipation.isEmpty()) {
             final var user = userUtilService.getUserByLogin(login);
             final var participation = new ProgrammingExerciseStudentParticipation();
-            final var buildPlanId = exercise.getProjectKey().toUpperCase() + "-" + login.toUpperCase();
-            final var repoName = (exercise.getProjectKey() + "-" + login).toLowerCase();
+            final var buildPlanId = exercise.getProjectKey().toUpperCase(Locale.ROOT) + "-" + login.toUpperCase(Locale.ROOT);
+            final var repoName = (exercise.getProjectKey() + "-" + login).toLowerCase(Locale.ROOT);
             participation.setInitializationDate(ZonedDateTime.now());
             participation.setParticipant(user);
             participation.setBuildPlanId(buildPlanId);
@@ -355,7 +356,7 @@ public class ParticipationUtilService {
         }
         ProgrammingExerciseStudentParticipation participation = ParticipationFactory.generateIndividualProgrammingExerciseStudentParticipation(exercise,
                 userUtilService.getUserByLogin(login));
-        final var repoName = (exercise.getProjectKey() + "-" + login).toLowerCase();
+        final var repoName = (exercise.getProjectKey() + "-" + login).toLowerCase(Locale.ROOT);
         var localVcRepoUri = new LocalVCRepositoryUri(localVCBaseUri, exercise.getProjectKey(), repoName);
         participation.setRepositoryUri(localVcRepoUri.toString());
         participation = programmingExerciseStudentParticipationRepo.save(participation);
@@ -379,7 +380,7 @@ public class ParticipationUtilService {
             return existingParticipation.get();
         }
         ProgrammingExerciseStudentParticipation participation = ParticipationFactory.generateTeamProgrammingExerciseStudentParticipation(exercise, team);
-        final var repoName = (exercise.getProjectKey() + "-" + team.getShortName()).toLowerCase();
+        final var repoName = (exercise.getProjectKey() + "-" + team.getShortName()).toLowerCase(Locale.ROOT);
         var localVcRepoUri = new LocalVCRepositoryUri(localVCBaseUri, exercise.getProjectKey(), repoName);
         participation.setRepositoryUri(localVcRepoUri.toString());
         ensureLocalVcRepositoryExists(localVcRepoUri);
@@ -405,7 +406,7 @@ public class ParticipationUtilService {
         }
         ProgrammingExerciseStudentParticipation participation = ParticipationFactory.generateIndividualProgrammingExerciseStudentParticipation(exercise,
                 userUtilService.getUserByLogin(login));
-        final var repoName = (exercise.getProjectKey() + "-" + login).toLowerCase();
+        final var repoName = (exercise.getProjectKey() + "-" + login).toLowerCase(Locale.ROOT);
         participation.setRepositoryUri(localRepoPath.toString());
         ensureLocalVcRepositoryExists(localRepoPath);
         participation = programmingExerciseStudentParticipationRepo.save(participation);

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/programming/AuxiliaryRepositoryResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/programming/AuxiliaryRepositoryResourceIntegrationTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
@@ -76,7 +77,7 @@ class AuxiliaryRepositoryResourceIntegrationTest extends AbstractProgrammingInte
 
         // Create a LocalVC auxiliary repository under the expected LocalVC structure
         var projectKey = programmingExercise.getProjectKey();
-        String auxSlug = projectKey.toLowerCase() + "-auxiliary";
+        String auxSlug = projectKey.toLowerCase(Locale.ROOT) + "-auxiliary";
         localAuxiliaryRepo = localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, auxSlug);
 
         // add file to the repository folder

--- a/src/test/java/de/tum/cit/aet/artemis/exercise/service/review/ExerciseReviewServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exercise/service/review/ExerciseReviewServiceTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -1390,7 +1391,7 @@ class ExerciseReviewServiceTest extends AbstractProgrammingIntegrationLocalCILoc
     }
 
     private LocalRepoWithGit createLocalRepositoryWithGit(String suffix) throws Exception {
-        String repositorySlug = programmingExercise.getProjectKey().toLowerCase() + "-" + suffix;
+        String repositorySlug = programmingExercise.getProjectKey().toLowerCase(Locale.ROOT) + "-" + suffix;
         localVCService.createProjectForExercise(programmingExercise);
         localVCService.createRepository(programmingExercise.getProjectKey(), repositorySlug);
         LocalVCRepositoryUri repositoryUri = new LocalVCRepositoryUri(localVCBaseUri, programmingExercise.getProjectKey(), repositorySlug);

--- a/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/fileupload/FileUploadExerciseIntegrationTest.java
@@ -16,6 +16,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -206,7 +207,7 @@ class FileUploadExerciseIntegrationTest extends AbstractFileUploadIntegrationTes
 
         assertThat(receivedFileUploadExercise).isNotNull();
         assertThat(receivedFileUploadExercise.id()).isNotNull();
-        assertThat(receivedFileUploadExercise.filePattern()).isEqualTo(creationFilePattern.toLowerCase().replaceAll("\\s+", ""));
+        assertThat(receivedFileUploadExercise.filePattern()).isEqualTo(creationFilePattern.toLowerCase(Locale.ROOT).replaceAll("\\s+", ""));
         assertThat(receivedFileUploadExercise.course()).as("course was set for normal exercise").isNotNull();
         assertThat(receivedFileUploadExercise.exerciseGroup()).as("exerciseGroup was not set for normal exercise").isNull();
         assertThat(receivedFileUploadExercise.course().id()).as("courseId was set correctly").isEqualTo(course.getId());
@@ -275,7 +276,7 @@ class FileUploadExerciseIntegrationTest extends AbstractFileUploadIntegrationTes
 
         assertThat(createdFileUploadExercise).isNotNull();
         assertThat(createdFileUploadExercise.id()).isNotNull();
-        assertThat(createdFileUploadExercise.filePattern()).isEqualTo(creationFilePattern.toLowerCase().replaceAll("\\s+", ""));
+        assertThat(createdFileUploadExercise.filePattern()).isEqualTo(creationFilePattern.toLowerCase(Locale.ROOT).replaceAll("\\s+", ""));
         assertThat(createdFileUploadExercise.course()).as("course was not set for exam exercise").isNull();
         assertThat(createdFileUploadExercise.exerciseGroup()).as("exerciseGroup was set for exam exercise").isNotNull();
         assertThat(createdFileUploadExercise.exerciseGroup().id()).as("exerciseGroupId was set correctly").isEqualTo(exerciseGroup.getId());

--- a/src/test/java/de/tum/cit/aet/artemis/globalsearch/config/schema/WeaviateDataTypeTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/globalsearch/config/schema/WeaviateDataTypeTest.java
@@ -3,6 +3,8 @@ package de.tum.cit.aet.artemis.globalsearch.config.schema;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Locale;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -13,7 +15,7 @@ class WeaviateDataTypeTest {
     @EnumSource(WeaviateDataType.class)
     void getWeaviateName_returnsLowercaseString(WeaviateDataType type) {
         assertThat(type.getWeaviateName()).isNotBlank();
-        assertThat(type.getWeaviateName()).isEqualTo(type.getWeaviateName().toLowerCase());
+        assertThat(type.getWeaviateName()).isEqualTo(type.getWeaviateName().toLowerCase(Locale.ROOT));
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatMessageIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatMessageIntegrationTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -665,22 +666,22 @@ class IrisChatMessageIntegrationTest extends AbstractIrisChatSessionTest {
         private ProgrammingExerciseStudentParticipation provisionProgrammingRepositories(ProgrammingExercise exercise) throws GitAPIException, IOException, URISyntaxException {
             String projectKey = exercise.getProjectKey();
             exercise.setProjectType(ProjectType.PLAIN_GRADLE);
-            exercise.setTestRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + projectKey.toLowerCase() + "-tests.git");
+            exercise.setTestRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + projectKey.toLowerCase(Locale.ROOT) + "-tests.git");
             programmingExerciseBuildConfigRepository.save(exercise.getBuildConfig());
             programmingExerciseRepository.save(exercise);
             ProgrammingExercise reloaded = programmingExerciseRepository.findWithAllParticipationsAndBuildConfigById(exercise.getId()).orElseThrow();
 
-            String templateSlug = projectKey.toLowerCase() + "-exercise";
+            String templateSlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
             TemplateProgrammingExerciseParticipation templateParticipation = reloaded.getTemplateParticipation();
             templateParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + templateSlug + ".git");
             templateProgrammingExerciseParticipationRepository.save(templateParticipation);
 
-            String solutionSlug = projectKey.toLowerCase() + "-solution";
+            String solutionSlug = projectKey.toLowerCase(Locale.ROOT) + "-solution";
             SolutionProgrammingExerciseParticipation solutionParticipation = reloaded.getSolutionParticipation();
             solutionParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + solutionSlug + ".git");
             solutionProgrammingExerciseParticipationRepository.save(solutionParticipation);
 
-            String assignmentSlug = projectKey.toLowerCase() + "-" + TEST_PREFIX + "student1";
+            String assignmentSlug = projectKey.toLowerCase(Locale.ROOT) + "-" + TEST_PREFIX + "student1";
             ProgrammingExerciseStudentParticipation studentParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(reloaded,
                     TEST_PREFIX + "student1");
             participationUtilService.addSubmission(studentParticipation, ParticipationFactory.generateProgrammingSubmission(true));
@@ -689,7 +690,7 @@ class IrisChatMessageIntegrationTest extends AbstractIrisChatSessionTest {
             programmingExerciseStudentParticipationRepository.save(studentParticipation);
 
             localVCLocalCITestService.createRepository(projectKey, templateSlug);
-            localVCLocalCITestService.createRepository(projectKey, projectKey.toLowerCase() + "-tests");
+            localVCLocalCITestService.createRepository(projectKey, projectKey.toLowerCase(Locale.ROOT) + "-tests");
             localVCLocalCITestService.createRepository(projectKey, solutionSlug);
             localVCLocalCITestService.createRepository(projectKey, assignmentSlug);
             localVCLocalCITestService.verifyRepositoryFoldersExist(reloaded, localVCBasePath);
@@ -701,22 +702,22 @@ class IrisChatMessageIntegrationTest extends AbstractIrisChatSessionTest {
                 throws GitAPIException, IOException, URISyntaxException {
             String projectKey = exercise.getProjectKey();
             exercise.setProjectType(ProjectType.PLAIN_GRADLE);
-            exercise.setTestRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + projectKey.toLowerCase() + "-tests.git");
+            exercise.setTestRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + projectKey.toLowerCase(Locale.ROOT) + "-tests.git");
             programmingExerciseBuildConfigRepository.save(exercise.getBuildConfig());
             programmingExerciseRepository.save(exercise);
             ProgrammingExercise reloaded = programmingExerciseRepository.findWithAllParticipationsAndBuildConfigById(exercise.getId()).orElseThrow();
 
-            String templateSlug = projectKey.toLowerCase() + "-exercise";
+            String templateSlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
             TemplateProgrammingExerciseParticipation templateParticipation = reloaded.getTemplateParticipation();
             templateParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + templateSlug + ".git");
             templateProgrammingExerciseParticipationRepository.save(templateParticipation);
 
-            String solutionSlug = projectKey.toLowerCase() + "-solution";
+            String solutionSlug = projectKey.toLowerCase(Locale.ROOT) + "-solution";
             SolutionProgrammingExerciseParticipation solutionParticipation = reloaded.getSolutionParticipation();
             solutionParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + solutionSlug + ".git");
             solutionProgrammingExerciseParticipationRepository.save(solutionParticipation);
 
-            String assignmentSlug = projectKey.toLowerCase() + "-" + TEST_PREFIX + "team1";
+            String assignmentSlug = projectKey.toLowerCase(Locale.ROOT) + "-" + TEST_PREFIX + "team1";
             ProgrammingExerciseStudentParticipation studentParticipation = participationUtilService.addTeamParticipationForProgrammingExercise(reloaded, team);
             participationUtilService.addSubmission(studentParticipation, ParticipationFactory.generateProgrammingSubmission(true));
             studentParticipation.setRepositoryUri((localVCBaseUri + "/git/%s/%s.git").formatted(projectKey, assignmentSlug));
@@ -724,7 +725,7 @@ class IrisChatMessageIntegrationTest extends AbstractIrisChatSessionTest {
             programmingExerciseStudentParticipationRepository.save(studentParticipation);
 
             localVCLocalCITestService.createRepository(projectKey, templateSlug);
-            localVCLocalCITestService.createRepository(projectKey, projectKey.toLowerCase() + "-tests");
+            localVCLocalCITestService.createRepository(projectKey, projectKey.toLowerCase(Locale.ROOT) + "-tests");
             localVCLocalCITestService.createRepository(projectKey, solutionSlug);
             localVCLocalCITestService.createRepository(projectKey, assignmentSlug);
             localVCLocalCITestService.verifyRepositoryFoldersExist(reloaded, localVCBasePath);

--- a/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatTokenTrackingIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/IrisChatTokenTrackingIntegrationTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -94,20 +95,20 @@ class IrisChatTokenTrackingIntegrationTest extends AbstractIrisIntegrationTest {
         exercise = ExerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
         String projectKey = exercise.getProjectKey();
         exercise.setProjectType(ProjectType.PLAIN_GRADLE);
-        exercise.setTestRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + projectKey.toLowerCase() + "-tests.git");
+        exercise.setTestRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + projectKey.toLowerCase(Locale.ROOT) + "-tests.git");
         programmingExerciseBuildConfigRepository.save(exercise.getBuildConfig());
         programmingExerciseRepository.save(exercise);
         exercise = programmingExerciseRepository.findWithAllParticipationsAndBuildConfigById(exercise.getId()).orElseThrow();
         // Set the correct repository URIs for the template and the solution participation.
-        String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
+        String templateRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
         TemplateProgrammingExerciseParticipation templateParticipation = exercise.getTemplateParticipation();
         templateParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + templateRepositorySlug + ".git");
         templateProgrammingExerciseParticipationRepository.save(templateParticipation);
-        String solutionRepositorySlug = projectKey.toLowerCase() + "-solution";
+        String solutionRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-solution";
         SolutionProgrammingExerciseParticipation solutionParticipation = exercise.getSolutionParticipation();
         solutionParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + solutionRepositorySlug + ".git");
         solutionProgrammingExerciseParticipationRepository.save(solutionParticipation);
-        String assignmentRepositorySlug = projectKey.toLowerCase() + "-" + TEST_PREFIX + "student1";
+        String assignmentRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-" + TEST_PREFIX + "student1";
         // Add a participation for student1.
         ProgrammingExerciseStudentParticipation studentParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
         studentParticipation.setRepositoryUri((localVCBaseUri + "/git/%s/%s.git").formatted(projectKey, assignmentRepositorySlug));
@@ -115,7 +116,7 @@ class IrisChatTokenTrackingIntegrationTest extends AbstractIrisIntegrationTest {
         programmingExerciseStudentParticipationRepository.save(studentParticipation);
         // Prepare the repositories.
         localVCLocalCITestService.createRepository(projectKey, templateRepositorySlug);
-        localVCLocalCITestService.createRepository(projectKey, projectKey.toLowerCase() + "-tests");
+        localVCLocalCITestService.createRepository(projectKey, projectKey.toLowerCase(Locale.ROOT) + "-tests");
         localVCLocalCITestService.createRepository(projectKey, solutionRepositorySlug);
         localVCLocalCITestService.createRepository(projectKey, assignmentRepositorySlug);
         // Check that the repository folders were created in the file system for all base repositories.

--- a/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/iris/PyrisEventSystemIntegrationTest.java
@@ -14,6 +14,7 @@ import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -106,21 +107,21 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
         exercise = ExerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
         String projectKey = exercise.getProjectKey();
         exercise.setProjectType(ProjectType.PLAIN_GRADLE);
-        exercise.setTestRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + projectKey.toLowerCase() + "-tests.git");
+        exercise.setTestRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + projectKey.toLowerCase(Locale.ROOT) + "-tests.git");
         programmingExerciseRepository.save(exercise);
         exercise = programmingExerciseRepository.findWithAllParticipationsAndBuildConfigById(exercise.getId()).orElseThrow();
 
         // Set the correct repository URIs for the template and the solution participation.
-        String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
+        String templateRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
         TemplateProgrammingExerciseParticipation templateParticipation = exercise.getTemplateParticipation();
         templateParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + templateRepositorySlug + ".git");
         templateProgrammingExerciseParticipationRepository.save(templateParticipation);
-        String solutionRepositorySlug = projectKey.toLowerCase() + "-solution";
+        String solutionRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-solution";
         SolutionProgrammingExerciseParticipation solutionParticipation = exercise.getSolutionParticipation();
         solutionParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + solutionRepositorySlug + ".git");
         solutionProgrammingExerciseParticipationRepository.save(solutionParticipation);
 
-        String assignmentRepositorySlug = projectKey.toLowerCase() + "-" + TEST_PREFIX + "student1";
+        String assignmentRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-" + TEST_PREFIX + "student1";
 
         // Add a participation for student1.
         studentParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(exercise, TEST_PREFIX + "student1");
@@ -131,7 +132,7 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
 
         // Prepare the repositories.
         localVCLocalCITestService.createRepository(projectKey, templateRepositorySlug);
-        localVCLocalCITestService.createRepository(projectKey, projectKey.toLowerCase() + "-tests");
+        localVCLocalCITestService.createRepository(projectKey, projectKey.toLowerCase(Locale.ROOT) + "-tests");
         localVCLocalCITestService.createRepository(projectKey, solutionRepositorySlug);
         localVCLocalCITestService.createRepository(projectKey, assignmentRepositorySlug);
 
@@ -209,7 +210,8 @@ class PyrisEventSystemIntegrationTest extends AbstractIrisIntegrationTest {
     private ProgrammingExerciseStudentParticipation createTeamParticipation(User owner) {
         var team = teamUtilService.addTeamForExercise(exercise, owner);
         var teamParticipation = participationUtilService.addTeamParticipationForProgrammingExercise(exercise, team);
-        teamParticipation.setRepositoryUri((localVCBaseUri + "/git/%s/%s-%s.git").formatted(exercise.getProjectKey(), exercise.getProjectKey().toLowerCase(), team.getShortName()));
+        teamParticipation.setRepositoryUri(
+                (localVCBaseUri + "/git/%s/%s-%s.git").formatted(exercise.getProjectKey(), exercise.getProjectKey().toLowerCase(Locale.ROOT), team.getShortName()));
         return programmingExerciseStudentParticipationRepository.save(teamParticipation);
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/lecture/LectureIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/lecture/LectureIntegrationTest.java
@@ -10,6 +10,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -640,7 +641,8 @@ class LectureIntegrationTest extends AbstractSpringIntegrationIndependentBatchTe
         assertThat(importedLectureDto.startDate()).isEqualTo(this.lecture1.getStartDate());
         assertThat(importedLectureDto.endDate()).isEqualTo(this.lecture1.getEndDate());
         assertThat(importedLectureDto.id()).isNotEqualTo(this.lecture1.getId());
-        assertThat(channel.getName()).isEqualTo("lecture-" + importedLectureDto.title().toLowerCase().replaceAll("[-\\s]+", "-")); // default name of imported lecture channel
+        // default name of imported lecture channel
+        assertThat(channel.getName()).isEqualTo("lecture-" + importedLectureDto.title().toLowerCase(Locale.ROOT).replaceAll("[-\\s]+", "-"));
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIIntegrationTest.java
@@ -26,6 +26,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -516,7 +517,7 @@ class LocalCIIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
         programmingExercise.setMode(ExerciseMode.TEAM);
         programmingExerciseRepository.save(programmingExercise);
         String teamShortName = "team1";
-        String teamRepositorySlug = projectKey1.toLowerCase() + "-" + teamShortName;
+        String teamRepositorySlug = projectKey1.toLowerCase(Locale.ROOT) + "-" + teamShortName;
         LocalVCTestRepository teamLocalRepository = localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey1, teamRepositorySlug);
         Team team = new Team();
         team.setName("Team 1");

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalVCLocalCIParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalVCLocalCIParticipationIntegrationTest.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.artemis.localci.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.ZonedDateTime;
+import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -53,7 +54,7 @@ class LocalVCLocalCIParticipationIntegrationTest extends AbstractProgrammingInte
         programmingExercise = programmingExerciseRepository.findWithAllParticipationsAndBuildConfigById(programmingExercise.getId()).orElseThrow();
 
         // Prepare the template repository to copy the student assignment repository from.
-        String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
+        String templateRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
         TemplateProgrammingExerciseParticipation templateParticipation = programmingExercise.getTemplateParticipation();
         templateParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + templateRepositorySlug + ".git");
         templateProgrammingExerciseParticipationRepository.save(templateParticipation);
@@ -66,7 +67,8 @@ class LocalVCLocalCIParticipationIntegrationTest extends AbstractProgrammingInte
         assertThat(participation).isNotNull();
         assertThat(participation.isPracticeMode()).isFalse();
         assertThat(participation.getStudent()).contains(user);
-        LocalVCRepositoryUri studentAssignmentRepositoryUri = new LocalVCRepositoryUri(localVCBaseUri, projectKey, projectKey.toLowerCase() + "-" + TEST_PREFIX + "student1");
+        LocalVCRepositoryUri studentAssignmentRepositoryUri = new LocalVCRepositoryUri(localVCBaseUri, projectKey,
+                projectKey.toLowerCase(Locale.ROOT) + "-" + TEST_PREFIX + "student1");
         assertThat(studentAssignmentRepositoryUri.getLocalRepositoryPath(localVCBasePath)).exists();
 
         var vcsAccessToken = request.get("/api/account/participation-vcs-access-token?participationId=" + participation.getId(), HttpStatus.OK, String.class);
@@ -85,7 +87,7 @@ class LocalVCLocalCIParticipationIntegrationTest extends AbstractProgrammingInte
         programmingExercise = programmingExerciseRepository.findWithAllParticipationsAndBuildConfigById(programmingExercise.getId()).orElseThrow();
 
         // Prepare the template repository to copy the student assignment repository from.
-        String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
+        String templateRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
         TemplateProgrammingExerciseParticipation templateParticipation = programmingExercise.getTemplateParticipation();
         // Store the template repository URI in a legacy format (pre-LocalVC, no "git" path segment) that LocalVCRepositoryUri cannot parse.
         // Starting the exercise must repair the URI instead of failing with an internal server error (see issue #12840).
@@ -113,11 +115,11 @@ class LocalVCLocalCIParticipationIntegrationTest extends AbstractProgrammingInte
         programmingExercise = programmingExerciseRepository.findWithAllParticipationsAndBuildConfigById(programmingExercise.getId()).orElseThrow();
 
         // Prepare the template repository (with the conventional slug) to copy the student assignment repository from.
-        String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
+        String templateRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
         TemplateProgrammingExerciseParticipation templateParticipation = programmingExercise.getTemplateParticipation();
         // Store a syntactically valid local VC URI that points to a repository which does not exist on disk.
         // Starting the exercise must fall back to the repository derived from the naming convention and repair the URI.
-        templateParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + projectKey.toLowerCase() + "-doesnotexist.git");
+        templateParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + projectKey.toLowerCase(Locale.ROOT) + "-doesnotexist.git");
         templateProgrammingExerciseParticipationRepository.save(templateParticipation);
         LocalVCTestRepository templateRepository = localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, templateRepositorySlug);
 
@@ -143,10 +145,10 @@ class LocalVCLocalCIParticipationIntegrationTest extends AbstractProgrammingInte
         // The stored URI points to a repository that really exists, but in a different project. The copy always reads from the project key of this exercise, so
         // accepting the stored URI would make the copy look for a repository that does not exist and skip the repair entirely (see issue #12840).
         String foreignProjectKey = projectKey + "OTHER";
-        String foreignRepositorySlug = foreignProjectKey.toLowerCase() + "-exercise";
+        String foreignRepositorySlug = foreignProjectKey.toLowerCase(Locale.ROOT) + "-exercise";
         LocalVCTestRepository foreignRepository = localVCLocalCITestService.createRepositoryWithWorkingCopy(foreignProjectKey, foreignRepositorySlug);
 
-        String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
+        String templateRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
         LocalVCTestRepository templateRepository = localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, templateRepositorySlug);
 
         TemplateProgrammingExerciseParticipation templateParticipation = programmingExercise.getTemplateParticipation();

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalVCLocalCITestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalVCLocalCITestService.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.Git;
@@ -124,7 +125,7 @@ public class LocalVCLocalCITestService {
     }
 
     public String getRepositorySlug(String projectKey, String repositoryTypeOrUserName) {
-        return (projectKey + "-" + repositoryTypeOrUserName).toLowerCase();
+        return (projectKey + "-" + repositoryTypeOrUserName).toLowerCase(Locale.ROOT);
     }
 
     /**
@@ -265,8 +266,8 @@ public class LocalVCLocalCITestService {
                 userInfo += ":" + password;
             }
         }
-        return UriComponentsBuilder.fromUri(localVCBaseUri).port(port).userInfo(userInfo).pathSegment("git", projectKey.toUpperCase(), repositorySlug + ".git").build().toUri()
-                .toString();
+        return UriComponentsBuilder.fromUri(localVCBaseUri).port(port).userInfo(userInfo).pathSegment("git", projectKey.toUpperCase(Locale.ROOT), repositorySlug + ".git").build()
+                .toUri().toString();
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/ProgrammingExerciseLocalVCLocalCIIntegrationTest.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -159,21 +160,21 @@ class ProgrammingExerciseLocalVCLocalCIIntegrationTest extends AbstractProgrammi
         programmingExercise = ExerciseUtilService.getFirstExerciseWithType(course, ProgrammingExercise.class);
         String projectKey = programmingExercise.getProjectKey();
         programmingExercise.setProjectType(ProjectType.PLAIN_GRADLE);
-        programmingExercise.setTestRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + projectKey.toLowerCase() + "-tests.git");
+        programmingExercise.setTestRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + projectKey.toLowerCase(Locale.ROOT) + "-tests.git");
         programmingExerciseRepository.save(programmingExercise);
         programmingExercise = programmingExerciseRepository.findWithAllParticipationsAndBuildConfigById(programmingExercise.getId()).orElseThrow();
 
         // Set the correct repository URIs for the template and the solution participation.
-        String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
+        String templateRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
         TemplateProgrammingExerciseParticipation templateParticipation = programmingExercise.getTemplateParticipation();
         templateParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + templateRepositorySlug + ".git");
         templateProgrammingExerciseParticipationRepository.save(templateParticipation);
-        String solutionRepositorySlug = projectKey.toLowerCase() + "-solution";
+        String solutionRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-solution";
         SolutionProgrammingExerciseParticipation solutionParticipation = programmingExercise.getSolutionParticipation();
         solutionParticipation.setRepositoryUri(localVCBaseUri + "/git/" + projectKey + "/" + solutionRepositorySlug + ".git");
         solutionProgrammingExerciseParticipationRepository.save(solutionParticipation);
 
-        String assignmentRepositorySlug = projectKey.toLowerCase() + "-" + TEST_PREFIX + "student1";
+        String assignmentRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-" + TEST_PREFIX + "student1";
 
         // Add a participation for student1.
         ProgrammingExerciseStudentParticipation studentParticipation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise,
@@ -184,7 +185,7 @@ class ProgrammingExerciseLocalVCLocalCIIntegrationTest extends AbstractProgrammi
 
         // Prepare the repositories.
         templateRepository = localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, templateRepositorySlug);
-        testsRepository = localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, projectKey.toLowerCase() + "-tests");
+        testsRepository = localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, projectKey.toLowerCase(Locale.ROOT) + "-tests");
         solutionRepository = localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, solutionRepositorySlug);
         assignmentRepository = localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, assignmentRepositorySlug);
 
@@ -727,7 +728,7 @@ class ProgrammingExerciseLocalVCLocalCIIntegrationTest extends AbstractProgrammi
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void importFromFile_validImportZip_changeTitle_success() throws Exception {
 
-        String uniqueSuffix = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 20).toUpperCase();
+        String uniqueSuffix = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 20).toUpperCase(Locale.ROOT);
         String newTitle = "TITLE" + uniqueSuffix;
         String newShortName = "SHORT" + uniqueSuffix;
 

--- a/src/test/java/de/tum/cit/aet/artemis/localvc/service/LocalVCFetchAndPushIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localvc/service/LocalVCFetchAndPushIntegrationTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -218,8 +219,8 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
      */
     private String buildRepositoryUri(String username, String projectKey, String repositorySlug) {
         String userInfo = username + ":" + UserFactory.USER_PASSWORD;
-        return UriComponentsBuilder.fromUri(localVCBaseUri).port(port).userInfo(userInfo).pathSegment("git", projectKey.toUpperCase(), repositorySlug + ".git").build().toUri()
-                .toString();
+        return UriComponentsBuilder.fromUri(localVCBaseUri).port(port).userInfo(userInfo).pathSegment("git", projectKey.toUpperCase(Locale.ROOT), repositorySlug + ".git").build()
+                .toUri().toString();
     }
 
     /**
@@ -227,8 +228,8 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
      */
     private String buildRepositoryUriWithToken(String username, String token, String projectKey, String repositorySlug) {
         String userInfo = username + ":" + token;
-        return UriComponentsBuilder.fromUri(localVCBaseUri).port(port).userInfo(userInfo).pathSegment("git", projectKey.toUpperCase(), repositorySlug + ".git").build().toUri()
-                .toString();
+        return UriComponentsBuilder.fromUri(localVCBaseUri).port(port).userInfo(userInfo).pathSegment("git", projectKey.toUpperCase(Locale.ROOT), repositorySlug + ".git").build()
+                .toUri().toString();
     }
 
     /**
@@ -344,7 +345,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             // Create exercise via REST API - this creates template, solution, and tests repos
             ProgrammingExercise exercise = createProgrammingExerciseViaApi("test-template-repo");
             String projectKey = exercise.getProjectKey();
-            String templateRepoSlug = projectKey.toLowerCase() + "-exercise";
+            String templateRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
 
             // Students should NOT be able to fetch or push
             try (Git studentGit = cloneRepository(instructor1.getLogin(), projectKey, templateRepoSlug)) {
@@ -379,7 +380,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             // Create exercise via REST API
             ProgrammingExercise exercise = createProgrammingExerciseViaApi("test-solution-repo");
             String projectKey = exercise.getProjectKey();
-            String solutionRepoSlug = projectKey.toLowerCase() + "-solution";
+            String solutionRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-solution";
 
             // Students should NOT be able to fetch or push
             try (Git git = cloneRepository(instructor1.getLogin(), projectKey, solutionRepoSlug)) {
@@ -414,7 +415,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             // Create exercise via REST API
             ProgrammingExercise exercise = createProgrammingExerciseViaApi("test-tests-repo");
             String projectKey = exercise.getProjectKey();
-            String testsRepoSlug = projectKey.toLowerCase() + "-tests";
+            String testsRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-tests";
 
             // Students should NOT be able to fetch or push
             try (Git git = cloneRepository(instructor1.getLogin(), projectKey, testsRepoSlug)) {
@@ -453,7 +454,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             // Get the auxiliary repository slug from the created exercise
             assertThat(exercise.getAuxiliaryRepositories()).hasSize(1);
             AuxiliaryRepository auxRepo = exercise.getAuxiliaryRepositories().getFirst();
-            String auxRepoSlug = projectKey.toLowerCase() + "-" + auxRepo.getName().toLowerCase();
+            String auxRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-" + auxRepo.getName().toLowerCase(Locale.ROOT);
 
             // First, push an initial commit as instructor to populate the aux repo (empty repos cause DetachedHeadException on push)
             try (Git git = cloneRepository(instructor1.getLogin(), projectKey, auxRepoSlug)) {
@@ -506,7 +507,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             assertThat(participation).isNotNull();
             assertThat(participation.getStudent()).contains(student1);
 
-            String student1RepoSlug = projectKey.toLowerCase() + "-" + student1.getLogin();
+            String student1RepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-" + student1.getLogin();
 
             // Student1 should be able to fetch and push to their own repository
             try (Git git = cloneRepository(student1.getLogin(), projectKey, student1RepoSlug)) {
@@ -560,7 +561,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             exercise.setDueDate(ZonedDateTime.now().minusMinutes(1));
             programmingExerciseRepository.save(exercise);
 
-            String student1RepoSlug = projectKey.toLowerCase() + "-" + student1.getLogin();
+            String student1RepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-" + student1.getLogin();
 
             // Student1 should be able to fetch but NOT push after due date
             try (Git git = cloneRepository(student1.getLogin(), projectKey, student1RepoSlug)) {
@@ -607,8 +608,8 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             assertThat(participation2).isNotNull();
             assertThat(participation2.getStudent()).contains(student2);
 
-            String student1RepoSlug = projectKey.toLowerCase() + "-" + student1.getLogin();
-            String student2RepoSlug = projectKey.toLowerCase() + "-" + student2.getLogin();
+            String student1RepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-" + student1.getLogin();
+            String student2RepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-" + student2.getLogin();
 
             // Student1 can access their own repo
             try (Git git = cloneRepository(student1.getLogin(), projectKey, student1RepoSlug)) {
@@ -649,7 +650,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
 
             // Create participation for student1 via utility (not REST API since start date is in future)
             participationUtilService.addStudentParticipationForProgrammingExercise(exercise, student1.getLogin());
-            String student1RepoSlug = projectKey.toLowerCase() + "-" + student1.getLogin();
+            String student1RepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-" + student1.getLogin();
 
             // Student1 should NOT be able to fetch or push before start date
             try (Git git = cloneRepository(instructor1.getLogin(), projectKey, student1RepoSlug)) {
@@ -697,7 +698,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             team.setStudents(Set.of(student1));
             teamRepository.save(team);
 
-            String teamRepoSlug = projectKey.toLowerCase() + "-team1";
+            String teamRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-team1";
 
             // Team member (student1) starts the exercise via REST API (creates repo)
             userUtilService.changeUser(TEST_PREFIX + "student1");
@@ -756,7 +757,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             // Add team participation
             participationUtilService.addTeamParticipationForProgrammingExercise(exercise, team);
 
-            String teamRepoSlug = projectKey.toLowerCase() + "-team2";
+            String teamRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-team2";
 
             // Team member should NOT be able to access before start date
             try (Git git = cloneRepository(instructor1.getLogin(), projectKey, teamRepoSlug)) {
@@ -800,7 +801,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             team.setStudents(Set.of(student1));
             teamRepository.save(team);
 
-            String teamRepoSlug = projectKey.toLowerCase() + "-team3";
+            String teamRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-team3";
 
             // Team member (student1) starts the exercise via REST API (creates repo)
             userUtilService.changeUser(TEST_PREFIX + "student1");
@@ -849,7 +850,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             mockDockerClientForStudentBuild();
             request.postWithResponseBody("/api/exercise/exercises/" + exercise.getId() + "/participations", null, StudentParticipation.class, HttpStatus.CREATED);
 
-            String taRepoSlug = projectKey.toLowerCase() + "-" + tutor1.getLogin();
+            String taRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-" + tutor1.getLogin();
 
             // Students should NOT be able to access TA's assignment repository
             try (Git git = cloneRepository(tutor1.getLogin(), projectKey, taRepoSlug)) {
@@ -883,7 +884,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             mockDockerClientForStudentBuild();
             request.postWithResponseBody("/api/exercise/exercises/" + exercise.getId() + "/participations", null, StudentParticipation.class, HttpStatus.CREATED);
 
-            String instructorRepoSlug = projectKey.toLowerCase() + "-" + instructor1.getLogin();
+            String instructorRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-" + instructor1.getLogin();
 
             // Students should NOT be able to access instructor's assignment repository
             try (Git git = cloneRepository(instructor1.getLogin(), projectKey, instructorRepoSlug)) {
@@ -926,7 +927,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
                     StudentParticipation.class, HttpStatus.CREATED);
             assertThat(practiceParticipation.isPracticeMode()).isTrue();
 
-            String practiceRepoSlug = projectKey.toLowerCase() + "-practice-" + student1.getLogin();
+            String practiceRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-practice-" + student1.getLogin();
 
             // Mock Docker for additional builds
             mockDockerClientForStudentBuild();
@@ -975,7 +976,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
                     StudentParticipation.class, HttpStatus.CREATED);
             assertThat(practiceParticipation.isPracticeMode()).isTrue();
 
-            String practiceRepoSlug = projectKey.toLowerCase() + "-practice-" + tutor1.getLogin();
+            String practiceRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-practice-" + tutor1.getLogin();
 
             // Mock Docker for additional builds
             mockDockerClientForStudentBuild();
@@ -1018,7 +1019,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
                     StudentParticipation.class, HttpStatus.CREATED);
             assertThat(practiceParticipation.isPracticeMode()).isTrue();
 
-            String practiceRepoSlug = projectKey.toLowerCase() + "-practice-" + instructor1.getLogin();
+            String practiceRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-practice-" + instructor1.getLogin();
 
             // Mock Docker for additional builds
             mockDockerClientForStudentBuild();
@@ -1117,7 +1118,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
         @Test
         @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
         void testFetchPush_examTemplateRepository() throws Exception {
-            String templateRepoSlug = examProjectKey.toLowerCase() + "-exercise";
+            String templateRepoSlug = examProjectKey.toLowerCase(Locale.ROOT) + "-exercise";
 
             // Students should NOT be able to fetch or push
             try (Git git = cloneRepository(instructor1.getLogin(), examProjectKey, templateRepoSlug)) {
@@ -1150,7 +1151,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
         @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
         void testFetchPush_examStudentRepository_duringWorkingTime() throws Exception {
             // Participation was created in setup by start-exercises
-            String student1RepoSlug = examProjectKey.toLowerCase() + "-" + student1.getLogin();
+            String student1RepoSlug = examProjectKey.toLowerCase(Locale.ROOT) + "-" + student1.getLogin();
 
             // Mock Docker for CI execution
             mockDockerClientForStudentBuild();
@@ -1186,8 +1187,8 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
         @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
         void testFetchPush_examStudentRepository_twoStudents() throws Exception {
             // Participations were created in setup by start-exercises
-            String student1RepoSlug = examProjectKey.toLowerCase() + "-" + student1.getLogin();
-            String student2RepoSlug = examProjectKey.toLowerCase() + "-" + student2.getLogin();
+            String student1RepoSlug = examProjectKey.toLowerCase(Locale.ROOT) + "-" + student1.getLogin();
+            String student2RepoSlug = examProjectKey.toLowerCase(Locale.ROOT) + "-" + student2.getLogin();
 
             // Mock Docker for CI execution
             mockDockerClientForStudentBuild();
@@ -1232,7 +1233,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             studentExamRepository.save(studentExam1);
 
             // Participation was created in setup by start-exercises
-            String student1RepoSlug = examProjectKey.toLowerCase() + "-" + student1.getLogin();
+            String student1RepoSlug = examProjectKey.toLowerCase(Locale.ROOT) + "-" + student1.getLogin();
 
             // Student1 should be able to fetch but NOT push after exam end
             try (Git git = cloneRepository(student1.getLogin(), examProjectKey, student1RepoSlug)) {
@@ -1268,7 +1269,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             studentExamRepository.save(studentExam1);
 
             // Participation was created in setup by start-exercises
-            String student1RepoSlug = examProjectKey.toLowerCase() + "-" + student1.getLogin();
+            String student1RepoSlug = examProjectKey.toLowerCase(Locale.ROOT) + "-" + student1.getLogin();
 
             // Student1 should NOT be able to fetch or push before exam starts
             try (Git git = cloneRepository(instructor1.getLogin(), examProjectKey, student1RepoSlug)) {
@@ -1317,7 +1318,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             studentExamRepository.save(studentExam1);
 
             // Participation was created in setup by start-exercises
-            String student1RepoSlug = examProjectKey.toLowerCase() + "-" + student1.getLogin();
+            String student1RepoSlug = examProjectKey.toLowerCase(Locale.ROOT) + "-" + student1.getLogin();
 
             // Mock Docker for CI execution
             mockDockerClientForStudentBuild();
@@ -1359,7 +1360,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             studentExamRepository.save(studentExam1);
 
             // Participation was created in setup by start-exercises
-            String student1RepoSlug = examProjectKey.toLowerCase() + "-" + student1.getLogin();
+            String student1RepoSlug = examProjectKey.toLowerCase(Locale.ROOT) + "-" + student1.getLogin();
 
             // Student1 should be able to fetch but NOT push after grace period ends
             try (Git git = cloneRepository(student1.getLogin(), examProjectKey, student1RepoSlug)) {
@@ -1405,7 +1406,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             await().until(
                     () -> programmingExerciseStudentParticipationRepository.findByExerciseIdAndStudentLogin(examProgrammingExercise.getId(), instructor1.getLogin()).isPresent());
 
-            String instructorRepoSlug = examProjectKey.toLowerCase() + "-" + instructor1.getLogin();
+            String instructorRepoSlug = examProjectKey.toLowerCase(Locale.ROOT) + "-" + instructor1.getLogin();
 
             // Mock Docker for build execution
             mockDockerClientForStudentBuild();
@@ -1456,7 +1457,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             team.setStudents(Set.of(student1));
             teamRepository.save(team);
 
-            String teamRepoSlug = projectKey.toLowerCase() + "-tokenteam";
+            String teamRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-tokenteam";
 
             // Team member (student1) starts the exercise via REST API
             userUtilService.changeUser(TEST_PREFIX + "student1");
@@ -1498,7 +1499,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
             ProgrammingExercise exercise = createProgrammingExerciseViaApi("test-individual-token");
 
             String projectKey = exercise.getProjectKey();
-            String studentRepoSlug = projectKey.toLowerCase() + "-" + TEST_PREFIX + "student1";
+            String studentRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-" + TEST_PREFIX + "student1";
 
             // Student1 starts participation
             userUtilService.changeUser(TEST_PREFIX + "student1");
@@ -1542,8 +1543,8 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
         void testCloneFetchPush_templateRepository_withRepositoryVcsAccessToken() throws Exception {
             ProgrammingExercise exercise = createProgrammingExerciseViaApi("test-template-repo-token");
             String projectKey = exercise.getProjectKey();
-            String templateRepoSlug = projectKey.toLowerCase() + "-exercise";
-            String solutionRepoSlug = projectKey.toLowerCase() + "-solution";
+            String templateRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
+            String solutionRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-solution";
 
             // The instructor obtains a repository-scoped token for the template repository via the REST endpoint (the clone-dialog flow).
             String tokenUrl = "/api/programming/repository-vcs-access-token?exerciseId=" + exercise.getId() + "&repositoryType=TEMPLATE";
@@ -1584,7 +1585,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
         void testRepositoryVcsAccessToken_authenticatesButStillEnforcesAuthorization() throws Exception {
             ProgrammingExercise exercise = createProgrammingExerciseViaApi("test-tests-repo-token");
             String projectKey = exercise.getProjectKey();
-            String testsRepoSlug = projectKey.toLowerCase() + "-tests";
+            String testsRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-tests";
 
             // A tutor obtains a repository-scoped token for the tests repository via the REST endpoint (allowed for at least a tutor).
             userUtilService.changeUser(TEST_PREFIX + "tutor1");
@@ -1616,7 +1617,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
         void testRepositoryVcsAccessToken_forgedTokenIsRejected() throws Exception {
             ProgrammingExercise exercise = createProgrammingExerciseViaApi("test-forged-token");
             String projectKey = exercise.getProjectKey();
-            String templateRepoSlug = projectKey.toLowerCase() + "-exercise";
+            String templateRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
 
             // A syntactically valid but never-issued token (correct prefix and length) must not authenticate anyone.
             String forgedToken = "vcpat-" + "x".repeat(44);
@@ -1636,7 +1637,7 @@ class LocalVCFetchAndPushIntegrationTest extends AbstractProgrammingIntegrationL
         void testRepositoryVcsAccessToken_isBoundToOwningUser() throws Exception {
             ProgrammingExercise exercise = createProgrammingExerciseViaApi("test-token-owner-binding");
             String projectKey = exercise.getProjectKey();
-            String templateRepoSlug = projectKey.toLowerCase() + "-exercise";
+            String templateRepoSlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
 
             // The instructor obtains their own repository-scoped token for the template repository.
             String tokenUrl = "/api/programming/repository-vcs-access-token?exerciseId=" + exercise.getId() + "&repositoryType=TEMPLATE";

--- a/src/test/java/de/tum/cit/aet/artemis/localvc/service/LocalVCIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localvc/service/LocalVCIntegrationTest.java
@@ -15,6 +15,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.Base64;
+import java.util.Locale;
 import java.util.Optional;
 
 import javax.naming.InvalidNameException;
@@ -311,7 +312,7 @@ class LocalVCIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
     @Test
     void testFetchPush_assignmentRepository_student_noParticipation() throws GitAPIException, IOException, URISyntaxException {
         // Create a new repository, but don't create a participation for student2.
-        String repositorySlug = projectKey1.toLowerCase() + "-" + student2Login;
+        String repositorySlug = projectKey1.toLowerCase(Locale.ROOT) + "-" + student2Login;
         LocalVCTestRepository student2Repository = localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey1, repositorySlug);
 
         localVCLocalCITestService.testFetchReturnsError(student2Repository.workingCopy(), student2Login, projectKey1, repositorySlug, INTERNAL_SERVER_ERROR);
@@ -499,16 +500,18 @@ class LocalVCIntegrationTest extends AbstractProgrammingIntegrationLocalCILocalV
         String login1 = "ab123git";
         String login2 = "git123ab";
 
-        LocalVCRepositoryUri studentAssignmentRepositoryUri1 = new LocalVCRepositoryUri(localVCBaseUri, projectKey1, projectKey1.toLowerCase() + "-" + login1);
-        LocalVCRepositoryUri studentAssignmentRepositoryUri2 = new LocalVCRepositoryUri(localVCBaseUri, projectKey1, projectKey1.toLowerCase() + "-" + login2);
+        LocalVCRepositoryUri studentAssignmentRepositoryUri1 = new LocalVCRepositoryUri(localVCBaseUri, projectKey1, projectKey1.toLowerCase(Locale.ROOT) + "-" + login1);
+        LocalVCRepositoryUri studentAssignmentRepositoryUri2 = new LocalVCRepositoryUri(localVCBaseUri, projectKey1, projectKey1.toLowerCase(Locale.ROOT) + "-" + login2);
 
         // assert that the URIs are correct
-        assertThat(studentAssignmentRepositoryUri1.getURI().toString()).isEqualTo(localVCBaseUri + "/git/" + projectKey1 + "/" + projectKey1.toLowerCase() + "-" + login1 + ".git");
-        assertThat(studentAssignmentRepositoryUri2.getURI().toString()).isEqualTo(localVCBaseUri + "/git/" + projectKey1 + "/" + projectKey1.toLowerCase() + "-" + login2 + ".git");
+        assertThat(studentAssignmentRepositoryUri1.getURI().toString())
+                .isEqualTo(localVCBaseUri + "/git/" + projectKey1 + "/" + projectKey1.toLowerCase(Locale.ROOT) + "-" + login1 + ".git");
+        assertThat(studentAssignmentRepositoryUri2.getURI().toString())
+                .isEqualTo(localVCBaseUri + "/git/" + projectKey1 + "/" + projectKey1.toLowerCase(Locale.ROOT) + "-" + login2 + ".git");
 
         // assert that the folder names are correct
-        assertThat(studentAssignmentRepositoryUri1.folderNameForRepositoryUri()).isEqualTo(projectKey1 + "/" + projectKey1.toLowerCase() + "-" + login1);
-        assertThat(studentAssignmentRepositoryUri2.folderNameForRepositoryUri()).isEqualTo(projectKey1 + "/" + projectKey1.toLowerCase() + "-" + login2);
+        assertThat(studentAssignmentRepositoryUri1.folderNameForRepositoryUri()).isEqualTo(projectKey1 + "/" + projectKey1.toLowerCase(Locale.ROOT) + "-" + login1);
+        assertThat(studentAssignmentRepositoryUri2.folderNameForRepositoryUri()).isEqualTo(projectKey1 + "/" + projectKey1.toLowerCase(Locale.ROOT) + "-" + login2);
     }
 
     // --- Security tests: authentication and authorization for git operations ---

--- a/src/test/java/de/tum/cit/aet/artemis/programming/AbstractProgrammingIntegrationLocalCILocalVCTestBase.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/AbstractProgrammingIntegrationLocalCILocalVCTestBase.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.lenient;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.sshd.server.SshServer;
 import org.junit.jupiter.api.AfterEach;
@@ -197,7 +198,7 @@ public abstract class AbstractProgrammingIntegrationLocalCILocalVCTestBase exten
         programmingExercise.setReleaseDate(ZonedDateTime.now().minusDays(1));
         programmingExercise.setProjectType(ProjectType.PLAIN_GRADLE);
         programmingExercise.setAllowOfflineIde(true);
-        programmingExercise.setTestRepositoryUri(localVCBaseUri + "/git/" + projectKey1 + "/" + projectKey1.toLowerCase() + "-tests.git");
+        programmingExercise.setTestRepositoryUri(localVCBaseUri + "/git/" + projectKey1 + "/" + projectKey1.toLowerCase(Locale.ROOT) + "-tests.git");
         var defaultPhases = buildPhasesTemplateService.getDefaultBuildPlanPhasesFor(programmingExercise);
         var defaultDockerImage = buildPhasesTemplateService.getDefaultDockerImageFor(programmingExercise);
         var buildPlanPhasesDTO = new BuildPlanPhasesDTO(defaultPhases, defaultDockerImage);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseGitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseGitIntegrationTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.io.FileUtils;
@@ -127,7 +128,7 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractProgrammingIntegrati
     void testGitOperationsWithLocalVC() throws Exception {
         // Create a LocalVC repository (acts as remote) and seed with an initial commit
         var projectKey = "PROGEXGIT";
-        var repoSlug = projectKey.toLowerCase() + "-tests";
+        var repoSlug = projectKey.toLowerCase(Locale.ROOT) + "-tests";
 
         LocalVCTestRepository remoteRepo = RepositoryExportTestUtil.trackRepository(localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, repoSlug));
 
@@ -180,7 +181,7 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractProgrammingIntegrati
     @WithMockUser(username = TEST_PREFIX + "student1", roles = { "USER", "STUDENT" })
     void testFailedPullClosesRepositoryBeforeCleanupAndRecovers() throws Exception {
         var projectKey = "PROGEXGITPULL";
-        var repoSlug = projectKey.toLowerCase() + "-tests";
+        var repoSlug = projectKey.toLowerCase(Locale.ROOT) + "-tests";
 
         LocalVCTestRepository remoteRepo = RepositoryExportTestUtil.trackRepository(localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, repoSlug));
 
@@ -244,7 +245,7 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractProgrammingIntegrati
     @WithMockUser(username = TEST_PREFIX + "student1", roles = { "USER", "STUDENT" })
     void testFailedCloneOfMissingRepositoryDoesNotLogSpuriousDeletionError() {
         var projectKey = "PROGEXGITCLONE";
-        var repoSlug = projectKey.toLowerCase() + "-doesnotexist";
+        var repoSlug = projectKey.toLowerCase(Locale.ROOT) + "-doesnotexist";
 
         LocalVCRepositoryUri repoUri = new LocalVCRepositoryUri(localVCLocalCITestService.buildLocalVCUri(null, null, projectKey, repoSlug));
         Path targetPath = tempPath.resolve("lcvc-failed-clone").resolve("missing-checkout");

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationJenkinsLocalVCTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationJenkinsLocalVCTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
@@ -149,7 +150,7 @@ class ProgrammingExerciseIntegrationJenkinsLocalVCTest extends AbstractProgrammi
         params.add("deleteBaseReposBuildPlans", "true");
 
         for (final var planName : List.of(TEST_PREFIX + "student1", TEST_PREFIX + "student2", TEMPLATE.getName(), SOLUTION.getName())) {
-            jenkinsRequestMockProvider.mockDeleteBuildPlanNotFound(projectKey, projectKey + "-" + planName.toUpperCase());
+            jenkinsRequestMockProvider.mockDeleteBuildPlanNotFound(projectKey, projectKey + "-" + planName.toUpperCase(Locale.ROOT));
         }
 
         jenkinsRequestMockProvider.mockDeleteBuildPlanProject(projectKey, false);
@@ -169,7 +170,7 @@ class ProgrammingExerciseIntegrationJenkinsLocalVCTest extends AbstractProgrammi
         params.add("deleteBaseReposBuildPlans", "true");
 
         for (final var planName : List.of("student1", "student2", TEMPLATE.getName(), SOLUTION.getName())) {
-            jenkinsRequestMockProvider.mockDeleteBuildPlanFailWithException(projectKey, projectKey + "-" + planName.toUpperCase());
+            jenkinsRequestMockProvider.mockDeleteBuildPlanFailWithException(projectKey, projectKey + "-" + planName.toUpperCase(Locale.ROOT));
         }
 
         request.delete(path, HttpStatus.INTERNAL_SERVER_ERROR, params);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseIntegrationTestService.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -425,7 +426,7 @@ public class ProgrammingExerciseIntegrationTestService {
         String modifiedEclipseProjectFile = Files.readString(repoRoot.resolve(".project"));
         assertThat(modifiedEclipseProjectFile).contains(userPrefix + "student1");
         String modifiedPom = Files.readString(repoRoot.resolve("pom.xml"));
-        assertThat(modifiedPom).contains((userPrefix + "student1").toLowerCase());
+        assertThat(modifiedPom).contains((userPrefix + "student1").toLowerCase(Locale.ROOT));
         Files.deleteIfExists(projectFilePath);
         Files.deleteIfExists(pomPath);
     }
@@ -589,7 +590,7 @@ public class ProgrammingExerciseIntegrationTestService {
         params.add("deleteBaseReposBuildPlans", "true");
 
         for (final var planName : List.of(userPrefix + "student1", userPrefix + "student2", TEMPLATE.getName(), SOLUTION.getName())) {
-            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(), false);
+            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(Locale.ROOT), false);
         }
         mockDelegate.mockDeleteBuildPlanProject(projectKey, false);
         request.delete(path, HttpStatus.OK, params);
@@ -603,7 +604,7 @@ public class ProgrammingExerciseIntegrationTestService {
         params.add("deleteBaseReposBuildPlans", "true");
 
         for (final var planName : List.of(userPrefix + "student1", userPrefix + "student2", TEMPLATE.getName(), SOLUTION.getName())) {
-            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(), true);
+            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(Locale.ROOT), true);
         }
         mockDelegate.mockDeleteBuildPlanProject(projectKey, false);
 
@@ -618,7 +619,7 @@ public class ProgrammingExerciseIntegrationTestService {
         params.add("deleteBaseReposBuildPlans", "true");
 
         for (final var planName : List.of(userPrefix + "student1", userPrefix + "student2", TEMPLATE.getName(), SOLUTION.getName())) {
-            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(), false);
+            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(Locale.ROOT), false);
         }
         mockDelegate.mockDeleteBuildPlanProject(projectKey, false);
 
@@ -633,7 +634,7 @@ public class ProgrammingExerciseIntegrationTestService {
         params.add("deleteBaseReposBuildPlans", "true");
 
         for (final var planName : List.of(userPrefix + "student1", userPrefix + "student2", TEMPLATE.getName(), SOLUTION.getName())) {
-            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(), false);
+            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(Locale.ROOT), false);
         }
         mockDelegate.mockDeleteBuildPlanProject(projectKey, true);
 
@@ -650,7 +651,7 @@ public class ProgrammingExerciseIntegrationTestService {
         params.add("deleteBaseReposBuildPlans", "true");
 
         for (final var planName : List.of(userPrefix + "student1", userPrefix + "student2", TEMPLATE.getName(), SOLUTION.getName())) {
-            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(), false);
+            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(Locale.ROOT), false);
         }
         mockDelegate.mockDeleteBuildPlanProject(projectKey, false);
 
@@ -667,7 +668,7 @@ public class ProgrammingExerciseIntegrationTestService {
         params.add("deleteBaseReposBuildPlans", "true");
 
         for (final var planName : List.of(userPrefix + "student1", userPrefix + "student2", TEMPLATE.getName(), SOLUTION.getName())) {
-            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(), false);
+            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(Locale.ROOT), false);
         }
         mockDelegate.mockDeleteBuildPlanProject(projectKey, false);
 
@@ -1974,7 +1975,7 @@ public class ProgrammingExerciseIntegrationTestService {
     void testResetOnlyDeleteStudentParticipationsSubmissionsAndResultsSuccess() throws Exception {
         final var projectKey = programmingExercise.getProjectKey();
         for (final var planName : List.of(userPrefix + "student1", userPrefix + "student2")) {
-            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(), false);
+            mockDelegate.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(Locale.ROOT), false);
         }
 
         // Two participations exist before reset

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseResultJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseResultJenkinsIntegrationTest.java
@@ -5,6 +5,7 @@ import static de.tum.cit.aet.artemis.programming.util.ProgrammingExerciseFactory
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.jupiter.api.AfterEach;
@@ -36,7 +37,7 @@ class ProgrammingExerciseResultJenkinsIntegrationTest extends AbstractProgrammin
     }
 
     private String getRepoName(ProgrammingExercise exercise, String userLogin) {
-        return (exercise.getProjectKey() + "-" + userLogin).toUpperCase();
+        return (exercise.getProjectKey() + "-" + userLogin).toUpperCase(Locale.ROOT);
     }
 
     private String getFolderName(ProgrammingExercise exercise, String repoName) {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseTemplateIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseTemplateIntegrationTest.java
@@ -19,6 +19,7 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -116,7 +117,7 @@ class ProgrammingExerciseTemplateIntegrationTest extends AbstractProgrammingInte
             String mvnExecutable = Os.isFamily(Os.FAMILY_WINDOWS) ? "mvn.cmd" : "mvn";
             var lines = runProcess(new ProcessBuilder(mvnExecutable, "-version"));
             String prefix = "maven home:";
-            Optional<String> home = lines.stream().filter(line -> line.toLowerCase().startsWith(prefix)).findFirst();
+            Optional<String> home = lines.stream().filter(line -> line.toLowerCase(Locale.ROOT).startsWith(prefix)).findFirst();
             home.ifPresent(homeLocation -> System.setProperty("maven.home", homeLocation.substring(prefix.length()).strip()));
         }
         catch (Exception e) {

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseVersionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseVersionIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -195,7 +196,7 @@ class ProgrammingExerciseVersionIntegrationTest extends AbstractProgrammingInteg
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
     void testImportExerciseFromFile_createsExerciseVersion() throws Exception {
 
-        String uniqueSuffix = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 20).toUpperCase();
+        String uniqueSuffix = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 20).toUpperCase(Locale.ROOT);
         String newTitle = "TITLE" + uniqueSuffix;
         String newShortName = "SHORT" + uniqueSuffix;
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionAndResultLocalVCJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionAndResultLocalVCJenkinsIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -228,7 +229,7 @@ class ProgrammingSubmissionAndResultLocalVCJenkinsIntegrationTest extends Abstra
 
     private TestResultsDTO createJenkinsNewResultNotification(String projectKey, String loginName, ProgrammingLanguage programmingLanguage, List<String> successfulTests,
             List<String> failedTests, List<String> logs, List<CommitDTO> commits) {
-        var repoName = (projectKey + "-" + loginName).toUpperCase();
+        var repoName = (projectKey + "-" + loginName).toUpperCase(Locale.ROOT);
         // The full name is specified as <FOLDER NAME> » <JOB NAME> <Build Number>
         var fullName = exercise.getProjectKey() + " » " + repoName + " #3";
         return ProgrammingExerciseFactory.generateTestResultDTO(fullName, repoName, null, programmingLanguage, false, successfulTests, failedTests, logs, commits, null);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/RepositoryIntegrationTest.java
@@ -18,6 +18,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -155,7 +156,7 @@ class RepositoryIntegrationTest extends AbstractProgrammingIntegrationLocalCILoc
         programmingExercise.setReleaseDate(ZonedDateTime.now().minusHours(1));
         programmingExerciseRepository.save(programmingExercise);
 
-        projectKey = programmingExercise.getProjectKey().toUpperCase();
+        projectKey = programmingExercise.getProjectKey().toUpperCase(Locale.ROOT);
         deleteExistingProject(projectKey);
         studentLogin = TEST_PREFIX + "student1";
 
@@ -300,7 +301,7 @@ class RepositoryIntegrationTest extends AbstractProgrammingIntegrationLocalCILoc
 
             assertThat(files).isNotEmpty();
             // case-insensitive, because the extension classifier and the decoding both are
-            assertThat(files.keySet()).noneMatch(file -> file.toLowerCase().endsWith(".jar"));
+            assertThat(files.keySet()).noneMatch(file -> file.toLowerCase(Locale.ROOT).endsWith(".jar"));
             assertThat(files).containsEntry(currentLocalFileName, currentLocalFileContent);
             assertThat(appender.list).as("skipping content that is not valid UTF-8 must not be logged as a problem")
                     .noneMatch(event -> event.getLevel().isGreaterOrEqual(Level.WARN) && event.getFormattedMessage().contains("could not be read"));
@@ -1253,7 +1254,7 @@ class RepositoryIntegrationTest extends AbstractProgrammingIntegrationLocalCILoc
     }
 
     private void initializeStudentParticipation() throws Exception {
-        var studentSlug = (programmingExercise.getProjectKey() + "-" + studentLogin).toLowerCase();
+        var studentSlug = (programmingExercise.getProjectKey() + "-" + studentLogin).toLowerCase(Locale.ROOT);
         studentRepository = createRepositoryForSlug(studentSlug);
         studentFilePath = studentRepository.workingCopyPath().resolve(currentLocalFileName);
         participation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise, studentLogin);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/SubmissionPolicyIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/SubmissionPolicyIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.commons.lang3.Strings;
 import org.junit.jupiter.api.BeforeEach;
@@ -379,7 +380,7 @@ class SubmissionPolicyIntegrationTest extends AbstractProgrammingIntegrationLoca
         }
         ProgrammingExerciseStudentParticipation participation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise,
                 TEST_PREFIX + "student1");
-        String repositoryName = programmingExercise.getProjectKey().toLowerCase() + "-" + TEST_PREFIX + "student1";
+        String repositoryName = programmingExercise.getProjectKey().toLowerCase(Locale.ROOT) + "-" + TEST_PREFIX + "student1";
         var resultNotification = ProgrammingExerciseFactory.generateTestResultDTO(null, repositoryName, null, programmingExercise.getProgrammingLanguage(), false, List.of("test1"),
                 List.of("test2", "test3"), null, List.of(new CommitDTO("commit0", "slug", defaultBranch)), null);
         final var resultRequestBody = convertBuildResultToJsonObject(resultNotification);
@@ -411,7 +412,7 @@ class SubmissionPolicyIntegrationTest extends AbstractProgrammingIntegrationLoca
         }
         ProgrammingExerciseStudentParticipation participation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise,
                 TEST_PREFIX + "student1");
-        String repositoryName = programmingExercise.getProjectKey().toLowerCase() + "-" + TEST_PREFIX + "student1";
+        String repositoryName = programmingExercise.getProjectKey().toLowerCase(Locale.ROOT) + "-" + TEST_PREFIX + "student1";
         var resultNotification = ProgrammingExerciseFactory.generateTestResultDTO(null, repositoryName, null, programmingExercise.getProgrammingLanguage(), false,
                 List.of("test1", "test2", "test3"), List.of(), null, List.of(new CommitDTO("commit0", "slug", defaultBranch)), null);
         participationUtilService.addSubmission(participation, new ProgrammingSubmission().commitHash("commit0").type(SubmissionType.MANUAL).submissionDate(ZonedDateTime.now()));
@@ -443,7 +444,7 @@ class SubmissionPolicyIntegrationTest extends AbstractProgrammingIntegrationLoca
     void test_getSameScoreForSameCommitHash() {
         ProgrammingExerciseStudentParticipation participation = participationUtilService.addStudentParticipationForProgrammingExercise(programmingExercise,
                 TEST_PREFIX + "student1");
-        String repositoryName = programmingExercise.getProjectKey().toLowerCase() + "-" + TEST_PREFIX + "student1";
+        String repositoryName = programmingExercise.getProjectKey().toLowerCase(Locale.ROOT) + "-" + TEST_PREFIX + "student1";
         var resultNotification1 = ProgrammingExerciseFactory.generateTestResultDTO(null, repositoryName, null, programmingExercise.getProgrammingLanguage(), false,
                 List.of("test1"), List.of("test2", "test3"), null, List.of(new CommitDTO("commit1", "slug", defaultBranch)), null);
         var resultNotification2 = ProgrammingExerciseFactory.generateTestResultDTO(null, repositoryName, null, programmingExercise.getProgrammingLanguage(), false,

--- a/src/test/java/de/tum/cit/aet/artemis/programming/TestRepositoryResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/TestRepositoryResourceIntegrationTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.ListBranchCommand;
@@ -58,7 +59,7 @@ class TestRepositoryResourceIntegrationTest extends AbstractProgrammingIntegrati
         programmingExercise.setBuildConfig(programmingExerciseBuildConfigRepository.save(programmingExercise.getBuildConfig()));
 
         // Seed a LocalVC-compatible repository for the TESTS repo
-        var testsSlug = programmingExercise.getProjectKey().toLowerCase() + "-" + RepositoryType.TESTS.getName();
+        var testsSlug = programmingExercise.getProjectKey().toLowerCase(Locale.ROOT) + "-" + RepositoryType.TESTS.getName();
         testRepo = RepositoryExportTestUtil.seedBareRepository(localVCLocalCITestService, programmingExercise.getProjectKey(), testsSlug, null);
 
         // add file to the repository folder

--- a/src/test/java/de/tum/cit/aet/artemis/programming/service/RepositoryServiceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/service/RepositoryServiceIntegrationTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -51,7 +52,7 @@ class RepositoryServiceIntegrationTest extends AbstractProgrammingIntegrationLoc
 
     @BeforeEach
     void setUp() throws Exception {
-        projectKey = ("RSV" + UUID.randomUUID().toString().replace("-", "").substring(0, 8)).toUpperCase();
+        projectKey = ("RSV" + UUID.randomUUID().toString().replace("-", "").substring(0, 8)).toUpperCase(Locale.ROOT);
         String repositorySlug = localVCLocalCITestService.getRepositorySlug(projectKey, "student1");
 
         localRepository = localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, repositorySlug);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/service/sharing/ExerciseSharingServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/service/sharing/ExerciseSharingServiceTest.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -221,7 +222,7 @@ class ExerciseSharingServiceTest extends AbstractSpringIntegrationLocalCILocalVC
         userUtilService.addInstructor(INSTRUCTOR1);
         mockSampleBasketZipForToken(SAMPLE_BASKET_TOKEN);
 
-        SecurityContextHolder.getContext().setAuthentication(AuthenticationFactory.createUsernamePasswordAuthentication(INSTRUCTOR1.toLowerCase()));
+        SecurityContextHolder.getContext().setAuthentication(AuthenticationFactory.createUsernamePasswordAuthentication(INSTRUCTOR1.toLowerCase(Locale.ENGLISH)));
 
         ProgrammingExercise exercise = getExerciseInfoFromBasket();
         Course course1 = programmingExerciseUtilService.addEnrolledCourseWithOneProgrammingExerciseAndTestCases(TEST_PREFIX);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/ProgrammingExerciseTestService.java
@@ -34,6 +34,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -405,7 +406,7 @@ public class ProgrammingExerciseTestService {
      * exercise under the same project key starts from a clean repository.
      */
     private LocalVCTestRepository configureRepositoryForSlug(String projectKey, String repositorySlug) throws Exception {
-        var normalizedProjectKey = projectKey.toUpperCase();
+        var normalizedProjectKey = projectKey.toUpperCase(Locale.ROOT);
         Path projectFolder = localVCBasePath.resolve(normalizedProjectKey);
         Files.createDirectories(projectFolder);
         RepositoryExportTestUtil.safeDeleteDirectory(projectFolder.resolve(repositorySlug + ".git"));
@@ -438,7 +439,7 @@ public class ProgrammingExerciseTestService {
      */
     public LocalVCTestRepository setupParticipantRepository(ProgrammingExercise exercise, String participantName, boolean practiceMode) throws Exception {
         final var projectKey = exercise.getProjectKey();
-        String participantRepoName = projectKey.toLowerCase() + "-" + (practiceMode ? "practice-" : "") + participantName;
+        String participantRepoName = projectKey.toLowerCase(Locale.ROOT) + "-" + (practiceMode ? "practice-" : "") + participantName;
         return configureRepositoryForSlug(projectKey, participantRepoName);
     }
 
@@ -504,9 +505,9 @@ public class ProgrammingExerciseTestService {
         programmingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationById(programmingExercise.getId()).orElseThrow();
 
         String projectKey = programmingExercise.getProjectKey();
-        String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
-        String solutionRepositorySlug = projectKey.toLowerCase() + "-solution";
-        String testsRepositorySlug = projectKey.toLowerCase() + "-tests";
+        String templateRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
+        String solutionRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-solution";
+        String testsRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-tests";
 
         var templateParticipation = programmingExercise.getTemplateParticipation();
         templateParticipation.setRepositoryUri(localVCLocalCITestService.buildLocalVCUri(null, null, projectKey, templateRepositorySlug));
@@ -757,7 +758,7 @@ public class ProgrammingExerciseTestService {
 
     // TEST
     public void createProgrammingExerciseForExam_withoutBuildPlanConfiguration_setsAfterDueDateForResultPhases() throws Exception {
-        String uniqueSuffix = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+        String uniqueSuffix = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase(Locale.ROOT);
         examExercise.setShortName("SHORT" + uniqueSuffix);
         examExercise.setTitle("Title " + uniqueSuffix);
         examExercise.getBuildConfig().setBuildPlanConfiguration(null);
@@ -1317,7 +1318,7 @@ public class ProgrammingExerciseTestService {
 
         assertThat(participation.getInitializationState()).as("Participation should be initialized").isEqualTo(InitializationState.INITIALIZED);
         assertThat(participation.getBuildPlanId()).as("Build Plan Id should be set")
-                .isEqualTo(exercise.getProjectKey().toUpperCase() + "-" + participant.getParticipantIdentifier().toUpperCase());
+                .isEqualTo(exercise.getProjectKey().toUpperCase(Locale.ROOT) + "-" + participant.getParticipantIdentifier().toUpperCase(Locale.ROOT));
     }
 
     // TEST TODO Enable
@@ -1340,7 +1341,7 @@ public class ProgrammingExerciseTestService {
         ProgrammingExerciseStudentParticipation updatedParticipation = (ProgrammingExerciseStudentParticipation) participationRepository.findByIdElseThrow(participation.getId());
         assertThat(updatedParticipation.getInitializationState()).as("Participation should be initialized").isEqualTo(InitializationState.INITIALIZED);
         assertThat(updatedParticipation.getBuildPlanId()).as("Build Plan Id should be set")
-                .isEqualTo(exercise.getProjectKey().toUpperCase() + "-" + participant.getParticipantIdentifier().toUpperCase());
+                .isEqualTo(exercise.getProjectKey().toUpperCase(Locale.ROOT) + "-" + participant.getParticipantIdentifier().toUpperCase(Locale.ROOT));
     }
 
     // TEST
@@ -1366,7 +1367,7 @@ public class ProgrammingExerciseTestService {
         ProgrammingExerciseStudentParticipation updatedParticipation = (ProgrammingExerciseStudentParticipation) participationRepository.findByIdElseThrow(participation.getId());
         assertThat(updatedParticipation.getInitializationState()).as("Participation should be initialized").isEqualTo(InitializationState.INITIALIZED);
         assertThat(updatedParticipation.getBuildPlanId()).as("Build Plan Id should be set")
-                .isEqualTo(exercise.getProjectKey().toUpperCase() + "-" + participant.getParticipantIdentifier().toUpperCase());
+                .isEqualTo(exercise.getProjectKey().toUpperCase(Locale.ROOT) + "-" + participant.getParticipantIdentifier().toUpperCase(Locale.ROOT));
 
         // Trigger the build again and make sure no new submission is created
         request.postWithoutLocation(url, null, HttpStatus.OK, new HttpHeaders());
@@ -1402,7 +1403,7 @@ public class ProgrammingExerciseTestService {
         ProgrammingExerciseStudentParticipation updatedParticipation = (ProgrammingExerciseStudentParticipation) participationRepository.findByIdElseThrow(participation.getId());
         assertThat(updatedParticipation.getInitializationState()).as("Participation should be initialized").isEqualTo(InitializationState.INITIALIZED);
         assertThat(updatedParticipation.getBuildPlanId()).as("Build Plan Id should be set")
-                .isEqualTo(exercise.getProjectKey().toUpperCase() + "-" + participant.getParticipantIdentifier().toUpperCase());
+                .isEqualTo(exercise.getProjectKey().toUpperCase(Locale.ROOT) + "-" + participant.getParticipantIdentifier().toUpperCase(Locale.ROOT));
 
         // Trigger the build again and make sure no new submission is created
         request.postWithoutLocation(url, null, HttpStatus.OK, new HttpHeaders());
@@ -1434,7 +1435,7 @@ public class ProgrammingExerciseTestService {
         ProgrammingExerciseStudentParticipation updatedParticipation = (ProgrammingExerciseStudentParticipation) participationRepository.findByIdElseThrow(participation.getId());
         assertThat(updatedParticipation.getInitializationState()).as("Participation should be initialized").isEqualTo(InitializationState.INITIALIZED);
         assertThat(updatedParticipation.getBuildPlanId()).as("Build Plan Id should be set")
-                .isEqualTo(exercise.getProjectKey().toUpperCase() + "-" + participant.getParticipantIdentifier().toUpperCase());
+                .isEqualTo(exercise.getProjectKey().toUpperCase(Locale.ROOT) + "-" + participant.getParticipantIdentifier().toUpperCase(Locale.ROOT));
 
         // Trigger the build again and make sure no new submission is created
         request.postWithoutLocation(url, null, HttpStatus.OK, new HttpHeaders());
@@ -1875,9 +1876,9 @@ public class ProgrammingExerciseTestService {
         // Explicitly set the repository URIs to match where setupRepositories created the bare repos.
         // This ensures consistency between the participation URIs and the actual repo locations.
         String projectKey = exercise.getProjectKey();
-        String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
-        String solutionRepositorySlug = projectKey.toLowerCase() + "-solution";
-        String testsRepositorySlug = projectKey.toLowerCase() + "-tests";
+        String templateRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
+        String solutionRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-solution";
+        String testsRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-tests";
 
         var templateParticipation = exercise.getTemplateParticipation();
         templateParticipation.setRepositoryUri(localVCLocalCITestService.buildLocalVCUri(null, null, projectKey, templateRepositorySlug));
@@ -1922,9 +1923,9 @@ public class ProgrammingExerciseTestService {
         // Explicitly set the repository URIs to match where setupRepositories created the bare repos.
         // This ensures consistency between the participation URIs and the actual repo locations.
         String projectKey = exercise.getProjectKey();
-        String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
-        String solutionRepositorySlug = projectKey.toLowerCase() + "-solution";
-        String testsRepositorySlug = projectKey.toLowerCase() + "-tests";
+        String templateRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
+        String solutionRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-solution";
+        String testsRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-tests";
 
         var templateParticipation = exercise.getTemplateParticipation();
         templateParticipation.setRepositoryUri(localVCLocalCITestService.buildLocalVCUri(null, null, projectKey, templateRepositorySlug));
@@ -2303,7 +2304,7 @@ public class ProgrammingExerciseTestService {
         // models a NEW participation whose repository is created for the first time and whose creation (copy) fails,
         // so the target repository must not exist beforehand. Otherwise copyRepository treats it as a re-copy into an
         // existing repository, which (since #12777) is intentionally preserved on failure instead of cleaned up.
-        String teamRepoSlug = exercise.getProjectKey().toLowerCase() + "-" + (userPrefix + TEAM_SHORT_NAME).toLowerCase();
+        String teamRepoSlug = exercise.getProjectKey().toLowerCase(Locale.ROOT) + "-" + (userPrefix + TEAM_SHORT_NAME).toLowerCase(Locale.ROOT);
         versionControlService.deleteRepository(versionControlService.getCloneRepositoryUri(exercise.getProjectKey(), teamRepoSlug));
 
         // Start participation
@@ -2316,7 +2317,7 @@ public class ProgrammingExerciseTestService {
         Team team = setupTeamForBadRequestForStartExercise();
 
         // Replace the healthy team repository created by the shared setup with a broken one
-        String teamRepoSlug = exercise.getProjectKey().toLowerCase() + "-" + (userPrefix + TEAM_SHORT_NAME).toLowerCase();
+        String teamRepoSlug = exercise.getProjectKey().toLowerCase(Locale.ROOT) + "-" + (userPrefix + TEAM_SHORT_NAME).toLowerCase(Locale.ROOT);
         LocalVCRepositoryUri targetRepoUri = versionControlService.getCloneRepositoryUri(exercise.getProjectKey(), teamRepoSlug);
         versionControlService.deleteRepository(targetRepoUri);
         Path targetPath = targetRepoUri.getLocalRepositoryPath(localVCBasePath);
@@ -2347,7 +2348,7 @@ public class ProgrammingExerciseTestService {
         Team team = setupTeamForBadRequestForStartExercise();
 
         // The shared setup pre-creates a healthy team repository (with an initial commit); a failed copy must not delete it (see #12777)
-        String teamRepoSlug = exercise.getProjectKey().toLowerCase() + "-" + (userPrefix + TEAM_SHORT_NAME).toLowerCase();
+        String teamRepoSlug = exercise.getProjectKey().toLowerCase(Locale.ROOT) + "-" + (userPrefix + TEAM_SHORT_NAME).toLowerCase(Locale.ROOT);
         LocalVCRepositoryUri targetRepoUri = versionControlService.getCloneRepositoryUri(exercise.getProjectKey(), teamRepoSlug);
         Path targetPath = targetRepoUri.getLocalRepositoryPath(localVCBasePath);
         assertThat(targetPath).as("precondition: the target repository exists before the copy").exists();
@@ -2451,11 +2452,11 @@ public class ProgrammingExerciseTestService {
                 () -> assertThat(programmingExerciseStudentParticipationRepository.findAllWithBuildPlanIdWithResults()).containsExactlyInAnyOrderElementsOf(List.of(participation1a,
                         participation1b, participation2a, participation2b, participation3a, participation3b, participation4b, participation7a, participation7b, participation8a)));
 
-        mockDelegate.mockDeleteBuildPlan(exercise.getProjectKey(), exercise.getProjectKey() + "-" + participation1a.getParticipantIdentifier().toUpperCase(), false);
-        mockDelegate.mockDeleteBuildPlan(exercise.getProjectKey(), exercise.getProjectKey() + "-" + participation2a.getParticipantIdentifier().toUpperCase(), false);
-        mockDelegate.mockDeleteBuildPlan(exercise.getProjectKey(), exercise.getProjectKey() + "-" + participation3a.getParticipantIdentifier().toUpperCase(), false);
-        mockDelegate.mockDeleteBuildPlan(exercise3.getProjectKey(), exercise3.getProjectKey() + "-" + participation7a.getParticipantIdentifier().toUpperCase(), false);
-        mockDelegate.mockDeleteBuildPlan(exercise4.getProjectKey(), exercise4.getProjectKey() + "-" + participation8a.getParticipantIdentifier().toUpperCase(), false);
+        mockDelegate.mockDeleteBuildPlan(exercise.getProjectKey(), exercise.getProjectKey() + "-" + participation1a.getParticipantIdentifier().toUpperCase(Locale.ROOT), false);
+        mockDelegate.mockDeleteBuildPlan(exercise.getProjectKey(), exercise.getProjectKey() + "-" + participation2a.getParticipantIdentifier().toUpperCase(Locale.ROOT), false);
+        mockDelegate.mockDeleteBuildPlan(exercise.getProjectKey(), exercise.getProjectKey() + "-" + participation3a.getParticipantIdentifier().toUpperCase(Locale.ROOT), false);
+        mockDelegate.mockDeleteBuildPlan(exercise3.getProjectKey(), exercise3.getProjectKey() + "-" + participation7a.getParticipantIdentifier().toUpperCase(Locale.ROOT), false);
+        mockDelegate.mockDeleteBuildPlan(exercise4.getProjectKey(), exercise4.getProjectKey() + "-" + participation8a.getParticipantIdentifier().toUpperCase(Locale.ROOT), false);
 
         automaticProgrammingExerciseCleanupService.cleanup(); // this call won't do it, because of the missing profile, we execute it anyway to cover at least some code
         automaticProgrammingExerciseCleanupService.cleanupBuildPlansOnContinuousIntegrationServer();

--- a/src/test/java/de/tum/cit/aet/artemis/programming/util/RepositoryExportTestUtil.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/util/RepositoryExportTestUtil.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -286,9 +287,9 @@ public final class RepositoryExportTestUtil {
      */
     public static BaseRepositories createAndWireBaseRepositoriesWithHandles(LocalVCLocalCITestService localVCLocalCITestService, ProgrammingExercise exercise) throws Exception {
         String projectKey = exercise.getProjectKey();
-        String templateRepositorySlug = projectKey.toLowerCase() + "-exercise";
-        String solutionRepositorySlug = projectKey.toLowerCase() + "-solution";
-        String testsRepositorySlug = projectKey.toLowerCase() + "-" + RepositoryType.TESTS.getName();
+        String templateRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-exercise";
+        String solutionRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-solution";
+        String testsRepositorySlug = projectKey.toLowerCase(Locale.ROOT) + "-" + RepositoryType.TESTS.getName();
 
         wireRepositoryToExercise(localVCLocalCITestService, exercise, RepositoryType.TEMPLATE, templateRepositorySlug);
         wireRepositoryToExercise(localVCLocalCITestService, exercise, RepositoryType.SOLUTION, solutionRepositorySlug);
@@ -466,8 +467,8 @@ public final class RepositoryExportTestUtil {
      * @throws IOException if deletion fails
      */
     public static void deleteStudentBareRepo(ProgrammingExercise exercise, String username, Path localVCBasePath) throws IOException {
-        String projectKey = exercise.getProjectKey().toUpperCase();
-        String slug = (exercise.getProjectKey() + "-" + username).toLowerCase();
+        String projectKey = exercise.getProjectKey().toUpperCase(Locale.ROOT);
+        String slug = (exercise.getProjectKey() + "-" + username).toLowerCase(Locale.ROOT);
         Path bareRepoPath = localVCBasePath.resolve(projectKey).resolve(slug + ".git");
         if (Files.exists(bareRepoPath)) {
             FileUtils.deleteDirectory(bareRepoPath.toFile());
@@ -502,7 +503,7 @@ public final class RepositoryExportTestUtil {
      * @throws IOException if deletion fails
      */
     public static void deleteLocalVcProjectIfPresent(Path localVCBasePath, String projectKey) throws IOException {
-        String normalizedProjectKey = projectKey == null ? null : projectKey.toUpperCase();
+        String normalizedProjectKey = projectKey == null ? null : projectKey.toUpperCase(Locale.ROOT);
         Path projectPath = localVCBasePath.resolve(normalizedProjectKey);
         if (Files.exists(projectPath)) {
             FileUtils.deleteDirectory(projectPath.toFile());

--- a/src/test/java/de/tum/cit/aet/artemis/quiz/util/QuizExerciseFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/quiz/util/QuizExerciseFactory.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
+import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
 
@@ -352,7 +353,7 @@ public class QuizExerciseFactory {
                     submittedText.setText(correctText);
                 }
                 else {
-                    submittedText.setText(correctText.toUpperCase());
+                    submittedText.setText(correctText.toUpperCase(Locale.ROOT));
                 }
                 submittedAnswer.addSubmittedTexts(submittedText);
                 // also invoke remove once

--- a/src/test/java/de/tum/cit/aet/artemis/shared/architecture/ArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/architecture/ArchitectureTest.java
@@ -98,6 +98,7 @@ import com.tngtech.archunit.core.domain.JavaEnumConstant;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.JavaMethodReference;
 import com.tngtech.archunit.core.domain.properties.HasAnnotations;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
@@ -200,6 +201,52 @@ class ArchitectureTest extends AbstractArchitectureTest {
         ArchRule toListUsage = noClasses().should().callMethod(Collectors.class, "toList")
                 .because("You should use .toList() or .collect(Collectors.toCollection(ArrayList::new)) instead");
         toListUsage.check(allClasses);
+    }
+
+    @Test
+    void testNoLocaleLessCaseConversion() {
+        String reason = "String.toLowerCase() and String.toUpperCase() fold case with the JVM default locale, so the same input gives a different answer depending on where the "
+                + "server happens to run. Under a Turkish locale the ASCII letter I lowercases to the dotless \u0131, which turns System.getProperty(\"os.name\").toLowerCase() "
+                + "into \"w\u0131ndows\" and makes the Windows branch in WebConfigurer stop matching without any error; every case-insensitive comparison of an identifier, a "
+                + "file extension, a MIME type, a header value or a login is unreliable in the same way. Pass the locale explicitly. Locale.ROOT is the default choice, because "
+                + "it folds case the same way everywhere, which is what a machine-facing value needs (identifiers, logins, emails, file names and extensions, MIME types, header "
+                + "values, enum names, protocol tokens, URL segments, search normalization). Use Locale.ENGLISH only where the surrounding code already does for the same kind of "
+                + "value, as User.setLogin does for logins, so that the two agree byte for byte. Where only the comparison matters, equalsIgnoreCase, "
+                + "String.CASE_INSENSITIVE_ORDER and Pattern.CASE_INSENSITIVE need no locale at all.";
+
+        // ArchUnit matches a call by its signature, so naming no parameter types addresses the no-argument overloads
+        // only: the toLowerCase(Locale) and toUpperCase(Locale) calls that this rule asks for are not matched.
+        ArchRule noLocaleLessCalls = noClasses().should().callMethod(String.class, "toLowerCase").orShould().callMethod(String.class, "toUpperCase").because(reason);
+        ArchRule noLocaleLessMethodReferences = classes().should(notReferenceLocaleLessCaseConversion()).because(reason);
+
+        // Test classes are checked as well: the sweep that made these calls explicit covered them too, and a test that
+        // compares a repository slug or a build plan name is exactly as locale-sensitive as the production code it asserts on.
+        noLocaleLessCalls.check(allClasses);
+        noLocaleLessMethodReferences.check(allClasses);
+    }
+
+    /**
+     * Complements {@code callMethod} in {@link #testNoLocaleLessCaseConversion()} for {@code String::toLowerCase} and
+     * {@code String::toUpperCase}. A method reference compiles to an invokedynamic rather than to an invocation, so
+     * ArchUnit models it as a {@link JavaMethodReference} and not as a {@code JavaMethodCall}, which is what
+     * {@code callMethod} looks at. Without this condition a method reference is a hole in the rule.
+     *
+     * @return the condition
+     */
+    private ArchCondition<JavaClass> notReferenceLocaleLessCaseConversion() {
+        return new ArchCondition<>("not reference String.toLowerCase() or String.toUpperCase() without a locale") {
+
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                for (JavaMethodReference reference : item.getMethodReferencesFromSelf()) {
+                    var target = reference.getTarget();
+                    boolean isCaseConversion = "toLowerCase".equals(target.getName()) || "toUpperCase".equals(target.getName());
+                    if (isCaseConversion && target.getOwner().isEquivalentTo(String.class) && target.getRawParameterTypes().isEmpty()) {
+                        events.add(violated(reference, reference.getDescription()));
+                    }
+                }
+            }
+        };
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/shared/architecture/module/AbstractModuleRepositoryArchitectureTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/architecture/module/AbstractModuleRepositoryArchitectureTest.java
@@ -7,6 +7,7 @@ import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predica
 import static com.tngtech.archunit.core.domain.properties.HasType.Predicates.rawType;
 import static com.tngtech.archunit.lang.SimpleConditionEvent.violated;
 
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -91,7 +92,7 @@ public abstract class AbstractModuleRepositoryArchitectureTest extends AbstractA
             String[] queryWords = query.split("[\\r\\n ]+");
 
             for (var word : queryWords) {
-                if (SQL_KEYWORDS.contains(word.toUpperCase()) && !StringUtils.isAllUpperCase(word)) {
+                if (SQL_KEYWORDS.contains(word.toUpperCase(Locale.ROOT)) && !StringUtils.isAllUpperCase(word)) {
                     events.add(violated(item, "In the Query of %s the keyword \"%s\" should be written in upper case.".formatted(item.getFullName(), word)));
                 }
             }

--- a/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationJenkinsLocalVCTestBase.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/base/AbstractSpringIntegrationJenkinsLocalVCTestBase.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
@@ -216,7 +217,7 @@ public abstract class AbstractSpringIntegrationJenkinsLocalVCTestBase extends Ab
     @Override
     public void mockUpdatePlanRepositoryForParticipation(ProgrammingExercise exercise, String username) throws IOException {
         final var projectKey = exercise.getProjectKey();
-        final var repoName = projectKey.toLowerCase() + "-" + username;
+        final var repoName = projectKey.toLowerCase(Locale.ROOT) + "-" + username;
         mockUpdatePlanRepository(exercise, username, ASSIGNMENT_REPO_NAME, repoName);
     }
 
@@ -340,7 +341,7 @@ public abstract class AbstractSpringIntegrationJenkinsLocalVCTestBase extends Ab
         planNames.add(TEMPLATE.getName());
         planNames.add(SOLUTION.getName());
         for (final String planName : planNames) {
-            jenkinsRequestMockProvider.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(), false);
+            jenkinsRequestMockProvider.mockDeleteBuildPlan(projectKey, projectKey + "-" + planName.toUpperCase(Locale.ROOT), false);
         }
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/shared/config/TestDataSourcePoolConfig.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/config/TestDataSourcePoolConfig.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.shared.config;
 
 import java.sql.SQLException;
+import java.util.Locale;
 
 import javax.sql.DataSource;
 
@@ -55,7 +56,7 @@ public class TestDataSourcePoolConfig {
      */
     private static String getDatabaseProductName(DataSource ds) {
         try (var conn = ds.getConnection()) {
-            return conn.getMetaData().getDatabaseProductName().toLowerCase();
+            return conn.getMetaData().getDatabaseProductName().toLowerCase(Locale.ROOT);
         }
         catch (SQLException e) {
             log.warn("Could not determine database type", e);

--- a/src/test/java/de/tum/cit/aet/artemis/tutorialgroup/AbstractTutorialGroupIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/tutorialgroup/AbstractTutorialGroupIntegrationTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -463,7 +464,7 @@ public abstract class AbstractTutorialGroupIntegrationTest extends AbstractSprin
         var configuration = courseRepository.findByIdWithEagerTutorialGroupConfigurationElseThrow(tutorialGroup.getCourse().getId()).getTutorialGroupsConfiguration();
 
         Function<TutorialGroup, String> expectedTutorialGroupName = (TutorialGroup tg) -> {
-            var cleanedTitle = tg.getTitle().replaceAll("\\s", "-").toLowerCase();
+            var cleanedTitle = tg.getTitle().replaceAll("\\s", "-").toLowerCase(Locale.ROOT);
             return "tutorgroup-" + cleanedTitle.substring(0, Math.min(cleanedTitle.length(), 18));
         };
         var tutorialGroupFromDb = tutorialGroupTestRepository.findByIdWithTeachingAssistantAndRegistrationsElseThrow(tutorialGroup.getId());

--- a/src/test/java/de/tum/cit/aet/artemis/tutorialgroup/TutorialGroupIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/tutorialgroup/TutorialGroupIntegrationTest.java
@@ -9,6 +9,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -703,7 +704,7 @@ class TutorialGroupIntegrationTest extends AbstractTutorialGroupIntegrationTest 
     }
 
     private void assertTutorialGroupChannelHasExpectedProperties(Channel channel, TutorialGroup tutorialGroup, User currentTutor) {
-        var cleanedTitle = tutorialGroup.getTitle().replaceAll("\\s", "-").toLowerCase();
+        var cleanedTitle = tutorialGroup.getTitle().replaceAll("\\s", "-").toLowerCase(Locale.ROOT);
         var expectedChannelName = "tutorgroup-" + cleanedTitle.substring(0, Math.min(cleanedTitle.length(), 18));
         assertThat(channel).isNotNull();
         assertThat(channel.getName()).isEqualTo(expectedChannelName);


### PR DESCRIPTION
### Summary

`String.toLowerCase()` and `String.toUpperCase()` fold case with the JVM default locale, so the same input can give a different answer depending on where the server runs. `WebConfigurer` decided whether it was running on Windows with `System.getProperty("os.name").toLowerCase().contains("win")`. Under a Turkish locale the ASCII letter `I` lowercases to the dotless `ı`, so that expression evaluates `"wındows".contains("win")`, which is false, and the Windows branch silently stops matching. Nothing logs it and nothing fails; the setting simply does not apply. Every other case-insensitive comparison of an identifier, a login, a file extension, a MIME type, a header value or a search term in the codebase was unreliable in the same way.

This pull request makes every case conversion in the Java sources locale-explicit and adds an ArchUnit rule so the locale-less overloads cannot come back.

### Motivation and Context

Artemis already had the right pattern in three places. `User.canonicalEmail` normalises an address with `Locale.ROOT`, `User.setLogin` stores a login with `Locale.ENGLISH`, and `RedisClientListResolver` carries a comment explaining precisely this hazard for a client-name prefix check. The other 289 call sites did not, which means the behaviour of an Artemis node depended on the locale of the machine and the JVM it happened to start on. In a multi-node cluster that is worse than a single wrong answer, because two nodes can disagree.

### Description

**The sweep.** 106 sites in `src/main/java` across 66 files, and 183 sites in `src/test/java` across 44 files.

**The locale chosen.** `Locale.ROOT` is the default, on 96 of the main sites and 181 of the test sites. It folds case the same way everywhere, which is what a machine-facing value needs, and it is what `canonicalEmail` already uses. The categories it covers: identifiers and project keys, repository slugs and names, emails, file names and extensions, MIME types and content types, header names, enum names, protocol and query tokens, URL and path segments, build plan and channel names, and search-term normalisation.

**Where the sweep deviated from `Locale.ROOT`.**

* Login normalisation uses `Locale.ENGLISH` on five main sites (`UserService` twice, `UserCreationService`, `AdminUserResource` twice) and two test sites (`UserUtilService`, `ExerciseSharingServiceTest`). `User.setLogin` stores a login as `StringUtils.lowerCase(login, Locale.ENGLISH)`, and `LdapAuthenticationProvider` and `ArtemisInternalAuthenticationProvider` already normalise an incoming login the same way. A value that has to equal a stored login byte for byte is produced the way the stored one was.
* `AdminUserResource` checked the reserved `iris_bot` login with `IRIS_BOT_LOGIN.equals(login.toLowerCase())`. That is now `IRIS_BOT_LOGIN.equalsIgnoreCase(login)`, which needs no locale at all. `IRIS_BOT_LOGIN` is `"iris_bot"`, and the login field carries `@Pattern(regexp = LOGIN_REGEX)` with an ASCII-only character class on a `@Valid` request body, so the two forms accept and reject exactly the same inputs.
* `FileDownloadService.createFileHeaders` lowercased the same filename four times in one expression. It now lowercases once into a local variable and tests the four suffixes against that.
* `ClippyCategorizer` used the method reference `String::toLowerCase`, which cannot carry an argument, so it is now a lambda that passes `Locale.ROOT`.

**No site keeps the default locale.** Every call the sweep touched normalises a value for a comparison, a lookup, a path or a wire format, so none of them formats text for a user in their own language. `ExerciseType.getExerciseTypeAsReadableString` is the closest call: its Javadoc says human-readable, but what it lowercases is an ASCII enum constant name and its callers are a log statement, an error message and an Athena module lookup, so `Locale.ROOT` is the correct answer there rather than a display-formatting exception.

**The ArchUnit rule.** `ArchitectureTest.testNoLocaleLessCaseConversion`, next to `testNoCollectorsToList`, which is the closest existing rule in shape. It checks `allClasses`, production and test together, the same set `testNoCollectorsToList` uses. Test classes are in scope deliberately: the sweep covered them, and a test that builds a repository slug or a build plan name is exactly as locale-sensitive as the production code it asserts against.

The rule has two halves. `noClasses().should().callMethod(String.class, "toLowerCase").orShould().callMethod(String.class, "toUpperCase")` covers ordinary calls; naming no parameter types is what restricts it to the locale-less overloads, so `toLowerCase(Locale.ROOT)` is not matched. A method reference is not covered by that, because ArchUnit models `String::toLowerCase` as a `JavaMethodReference` and not as a `JavaMethodCall`, so a second half checks method references through a small `ArchCondition`. Without it, `.map(String::toLowerCase)` is a hole in the rule, and the codebase contained one.

The rule has no exemption list, because no site needs the default locale. The `because(...)` message names the Turkish-locale failure and the `os.name` check concretely, gives `Locale.ROOT` as the default choice with the categories it applies to, says when `Locale.ENGLISH` is right instead, and points at the three locale-free comparison APIs.

**Documentation.** A bullet in the server development guidelines, an entry in the `server-arch-gates` skill and its gate reference, and a bullet in `CLAUDE.md`.

### Steps for Testing

This is a refactoring with no behaviour change on any locale that Artemis is deployed on, so it is covered by the test suite rather than by manual steps.

```bash
./gradlew spotlessApply checkstyleMain compileJava compileTestJava -x webapp
./gradlew test -x webapp --tests 'de.tum.cit.aet.artemis.shared.architecture.ArchitectureTest'
```

Behaviour of the touched production code was checked with the test classes covering the comparisons that could have changed meaning: `FileDownloadServiceTest`, `BinaryFileExtensionConfigurationTest`, `FileUploadExerciseIntegrationTest`, `FileUploadSubmissionIntegrationTest`, `CourseAccessServiceTest` (which is what exercises `Role.fromString`), `ShortAnswerSubmittedTextTest`, `ExerciseTypeTest`, plus `LocalVCIntegrationTest`, `ChannelIntegrationTest`, `ConversationIntegrationTest`, `TutorialGroupIntegrationTest`, `WeaviateDataTypeTest`, `ProgrammingLanguageConfigurationTest`, `AthenaRepositoryExportServiceUnitTest` and `JenkinsInternalUriServiceTest`.

That the new rule actually bites was verified by violating it on purpose. A probe class with `value.toLowerCase()`, `value.toUpperCase()` and `.map(String::toLowerCase)` in it made the test fail and report all three, while `value.toLowerCase(Locale.ROOT)` and `value.toUpperCase(Locale.ENGLISH)` in the same class were not reported. The probe was then removed.

The javac warning count did not move: 281 main and 59 test, the same as `develop`.

### Checklist

#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
