### PR TITLE
`Assessment`: Reject negative correction rounds when locking a submission

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
@@ -665,12 +665,29 @@ public class SubmissionService {
     }
 
     /**
+     * The correction round is a request parameter, so a caller can send any int. A negative round would otherwise be
+     * stored on a new manual result that no lookup can ever return again.
+     *
+     * @param correctionRound the correction round to check
+     * @throws BadRequestAlertException if the correction round is negative
+     */
+    protected static void checkCorrectionRoundIsNotNegativeElseThrow(int correctionRound) {
+        if (correctionRound < 0) {
+            throw new BadRequestAlertException("The correction round must not be negative", "submission", "negativeCorrectionRound");
+        }
+    }
+
+    /**
      * Soft locks the submission to prevent other tutors from receiving and assessing it. We set the assessor and save the result to soft lock the assessment in the client, i.e.
      * the client will not allow tutors to assess a submission when an assessor is already assigned. If no result exists for this submission we create one first.
      *
-     * @param submission the submission to lock
+     * @param submission      the submission to lock
+     * @param correctionRound the correction round to lock the submission for, must not be negative
+     * @return the locked result
+     * @throws BadRequestAlertException if the correction round is negative
      */
     protected Result lockSubmission(Submission submission, int correctionRound) {
+        checkCorrectionRoundIsNotNegativeElseThrow(correctionRound);
         Result result = submission.getResultForCorrectionRound(correctionRound);
         if (result == null && correctionRound > 0) {
             // copy the result of the previous correction round

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/service/SubmissionService.java
@@ -665,15 +665,17 @@ public class SubmissionService {
     }
 
     /**
-     * The correction round is a request parameter, so a caller can send any int. A negative round would otherwise be
-     * stored on a new manual result that no lookup can ever return again.
+     * Defence in depth for {@link #checkCorrectionRoundIsValidElseThrow(Exercise, int)}: the endpoints validate the round against
+     * the exercise before they lock, this only makes sure that no path which skips that validation can persist a result for a
+     * negative round. The upper bound is not checked here because the exercise reachable from a submission does not
+     * necessarily have its exam loaded.
      *
      * @param correctionRound the correction round to check
      * @throws BadRequestAlertException if the correction round is negative
      */
     protected static void checkCorrectionRoundIsNotNegativeElseThrow(int correctionRound) {
         if (correctionRound < 0) {
-            throw new BadRequestAlertException("The correction round must not be negative", "submission", "negativeCorrectionRound");
+            throw new BadRequestAlertException("The correction round must not be negative", ENTITY_NAME, "invalidCorrectionRound");
         }
     }
 
@@ -787,6 +789,22 @@ public class SubmissionService {
                 log.debug("The due date of exercise '{}' has not been reached yet.", exercise.getTitle());
                 throw new AccessForbiddenException("The due date of exercise '" + exercise.getTitle() + "' has not been reached yet.");
             }
+        }
+    }
+
+    /**
+     * The correction round is a request parameter, so a caller can send any int. A round outside {@code [0, numberOfCorrectionRounds)}
+     * would otherwise be stored on a new manual result that no dashboard, lookup or score calculation ever reaches again.
+     * Call this before locking a submission, at a point where the exercise (and its exam, for exam exercises) is loaded.
+     *
+     * @param exercise        the exercise the submission belongs to
+     * @param correctionRound the requested correction round
+     * @throws BadRequestAlertException if the round is negative or not below the exercise's number of correction rounds
+     */
+    public void checkCorrectionRoundIsValidElseThrow(Exercise exercise, int correctionRound) {
+        if (correctionRound < 0 || correctionRound >= exercise.getNumberOfCorrectionRounds()) {
+            throw new BadRequestAlertException("The correction round " + correctionRound + " does not exist for exercise " + exercise.getId(), ENTITY_NAME,
+                    "invalidCorrectionRound");
         }
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/fileupload/web/FileUploadSubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/fileupload/web/FileUploadSubmissionResource.java
@@ -217,6 +217,7 @@ public class FileUploadSubmissionResource extends AbstractSubmissionResource {
         User user = userRepository.getUserWithAuthorities();
         authCheckService.checkIsAllowedToAssessExerciseElseThrow(fileUploadExercise, user, resultId);
         fileUploadSubmissionService.checkThatAssessmentIsPossibleElseThrow(fileUploadExercise, studentParticipation);
+        fileUploadSubmissionService.checkCorrectionRoundIsValidElseThrow(fileUploadExercise, correctionRound);
 
         // load submission with results either by resultId or by correctionRound
         if (resultId != null) {
@@ -294,6 +295,7 @@ public class FileUploadSubmissionResource extends AbstractSubmissionResource {
 
         // Check if tutors can start assessing the students submission
         fileUploadSubmissionService.checkIfExerciseDueDateIsReached(fileUploadExercise);
+        fileUploadSubmissionService.checkCorrectionRoundIsValidElseThrow(fileUploadExercise, correctionRound);
 
         // Check if the limit of simultaneously locked submissions has been reached
         fileUploadSubmissionService.checkSubmissionLockLimit(fileUploadExercise.getCourseViaExerciseGroupOrCourseMember().getId());

--- a/src/main/java/de/tum/cit/aet/artemis/modeling/web/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/modeling/web/ModelingSubmissionResource.java
@@ -267,6 +267,7 @@ public class ModelingSubmissionResource extends AbstractSubmissionResource {
         }
 
         modelingSubmissionService.checkThatAssessmentIsPossibleElseThrow(modelingExercise, studentParticipation);
+        modelingSubmissionService.checkCorrectionRoundIsValidElseThrow(modelingExercise, correctionRound);
 
         // now we can assume the user is at least a tutor for the underlying exercise
         var gradingCriteria = gradingCriterionRepository.findByExerciseIdWithEagerGradingCriteria(modelingExercise.getId());
@@ -333,6 +334,7 @@ public class ModelingSubmissionResource extends AbstractSubmissionResource {
 
         // Check if tutors can start assessing the students submission
         this.modelingSubmissionService.checkIfExerciseDueDateIsReached(exercise);
+        this.modelingSubmissionService.checkCorrectionRoundIsValidElseThrow(exercise, correctionRound);
 
         // Check if the limit of simultaneously locked submissions has been reached
         modelingSubmissionService.checkSubmissionLockLimit(exercise.getCourseViaExerciseGroupOrCourseMember().getId());

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingSubmissionService.java
@@ -488,6 +488,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
     @Override
     // TODO: why do we override this method and why do we not try to reuse the method in the super class?
     public Result lockSubmission(Submission submission, int correctionRound) {
+        checkCorrectionRoundIsNotNegativeElseThrow(correctionRound);
         Optional<Result> optionalExistingResult;
         if (correctionRound == 0 && submission.getLatestResult() != null && AssessmentType.AUTOMATIC == submission.getLatestResult().getAssessmentType()) {
             optionalExistingResult = Optional.of(submission.getLatestResult());

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingSubmissionService.java
@@ -488,7 +488,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
     @Override
     // TODO: why do we override this method and why do we not try to reuse the method in the super class?
     public Result lockSubmission(Submission submission, int correctionRound) {
-        checkCorrectionRoundIsNotNegativeElseThrow(correctionRound);
+        SubmissionService.checkCorrectionRoundIsNotNegativeElseThrow(correctionRound);
         Optional<Result> optionalExistingResult;
         if (correctionRound == 0 && submission.getLatestResult() != null && AssessmentType.AUTOMATIC == submission.getLatestResult().getAssessmentType()) {
             optionalExistingResult = Optional.of(submission.getLatestResult());

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingSubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingSubmissionResource.java
@@ -328,6 +328,7 @@ public class ProgrammingSubmissionResource {
         }
 
         programmingSubmissionService.checkThatAssessmentIsPossibleElseThrow(programmingExercise, participation);
+        programmingSubmissionService.checkCorrectionRoundIsValidElseThrow(programmingExercise, correctionRound);
         if (!programmingExercise.areManualResultsAllowed()) {
             throw new AccessForbiddenException("Creating manual results is disabled for this exercise!");
         }
@@ -414,6 +415,7 @@ public class ProgrammingSubmissionResource {
 
         if (submission != null) {
             if (lockSubmission) {
+                programmingSubmissionService.checkCorrectionRoundIsValidElseThrow(programmingExercise, correctionRound);
                 // NOTE: we explicitly load the feedback for the submission eagerly to avoid org.hibernate.LazyInitializationException
                 submission = programmingSubmissionService.lockAndGetProgrammingSubmission(submission.getId(), correctionRound);
             }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingSubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/web/ProgrammingSubmissionResource.java
@@ -398,6 +398,7 @@ public class ProgrammingSubmissionResource {
 
         // Check if the limit of simultaneously locked submissions has been reached
         programmingSubmissionService.checkSubmissionLockLimit(programmingExercise.getCourseViaExerciseGroupOrCourseMember().getId());
+        programmingSubmissionService.checkCorrectionRoundIsValidElseThrow(programmingExercise, correctionRound);
 
         // TODO Check if submission has newly created manual result for this and endpoint and endpoint above
         ProgrammingSubmission submission;
@@ -415,7 +416,6 @@ public class ProgrammingSubmissionResource {
 
         if (submission != null) {
             if (lockSubmission) {
-                programmingSubmissionService.checkCorrectionRoundIsValidElseThrow(programmingExercise, correctionRound);
                 // NOTE: we explicitly load the feedback for the submission eagerly to avoid org.hibernate.LazyInitializationException
                 submission = programmingSubmissionService.lockAndGetProgrammingSubmission(submission.getId(), correctionRound);
             }

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextAssessmentResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextAssessmentResource.java
@@ -405,6 +405,7 @@ public class TextAssessmentResource extends AssessmentResource {
         // return forbidden if caller is not allowed to assess
         authCheckService.checkIsAllowedToAssessExerciseElseThrow(exercise, user, resultId);
         textSubmissionService.checkThatAssessmentIsPossibleElseThrow(exercise, participation);
+        textSubmissionService.checkCorrectionRoundIsValidElseThrow(exercise, correctionRound);
 
         Result result;
         if (resultId != null) {

--- a/src/main/java/de/tum/cit/aet/artemis/text/web/TextSubmissionResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/text/web/TextSubmissionResource.java
@@ -319,6 +319,7 @@ public class TextSubmissionResource extends AbstractSubmissionResource {
 
         // Check if tutors can start assessing the students submission
         textSubmissionService.checkIfExerciseDueDateIsReached(exercise);
+        textSubmissionService.checkCorrectionRoundIsValidElseThrow(exercise, correctionRound);
 
         // Check if the limit of simultaneously locked submissions has been reached
         textSubmissionService.checkSubmissionLockLimit(exercise.getCourseViaExerciseGroupOrCourseMember().getId());

--- a/src/main/webapp/i18n/de/error.json
+++ b/src/main/webapp/i18n/de/error.json
@@ -12,6 +12,7 @@
         },
         "assessmentNotPossibleExamRunning": "Die Bewertung ist noch nicht möglich: Du kannst beginnen, sobald die Klausur für alle Studierenden am {{ date }} beendet ist.",
         "assessmentNotPossibleTestsPending": "Die Bewertung ist noch nicht möglich: Die Tests müssen noch einmal auf den endgültigen Abgaben ausgeführt werden. Du kannst ab {{ date }} bewerten.",
+        "negativeCorrectionRound": "Die Korrekturrunde darf nicht negativ sein.",
         "cannotDeleteYourself": "Du kannst nicht deinen eigenen Account löschen!",
         "examExerciseNotIncludedInScore": "Eine Klausuraufgabe muss im Ergebnis enthalten sein!",
         "fileUploadSavingError": "Fehler! Der Upload schlug fehl. Stelle sicher, dass eine Internetverbindung besteht!",

--- a/src/main/webapp/i18n/de/error.json
+++ b/src/main/webapp/i18n/de/error.json
@@ -12,7 +12,7 @@
         },
         "assessmentNotPossibleExamRunning": "Die Bewertung ist noch nicht möglich: Du kannst beginnen, sobald die Klausur für alle Studierenden am {{ date }} beendet ist.",
         "assessmentNotPossibleTestsPending": "Die Bewertung ist noch nicht möglich: Die Tests müssen noch einmal auf den endgültigen Abgaben ausgeführt werden. Du kannst ab {{ date }} bewerten.",
-        "negativeCorrectionRound": "Die Korrekturrunde darf nicht negativ sein.",
+        "invalidCorrectionRound": "Diese Korrekturrunde gibt es für die Aufgabe nicht.",
         "cannotDeleteYourself": "Du kannst nicht deinen eigenen Account löschen!",
         "examExerciseNotIncludedInScore": "Eine Klausuraufgabe muss im Ergebnis enthalten sein!",
         "fileUploadSavingError": "Fehler! Der Upload schlug fehl. Stelle sicher, dass eine Internetverbindung besteht!",

--- a/src/main/webapp/i18n/en/error.json
+++ b/src/main/webapp/i18n/en/error.json
@@ -12,6 +12,7 @@
         },
         "assessmentNotPossibleExamRunning": "Assessment is not possible yet: you can start once the exam has ended for all students on {{ date }}.",
         "assessmentNotPossibleTestsPending": "Assessment is not possible yet: the tests still have to run once more on the final submissions. You can start assessing on {{ date }}.",
+        "negativeCorrectionRound": "The correction round must not be negative.",
         "cannotDeleteYourself": "You cannot delete your own account!",
         "fileUploadSavingError": "Error! The upload failed. Make sure you are connected to the Internet!",
         "isNull": "No {{ entityName }} was provided.",

--- a/src/main/webapp/i18n/en/error.json
+++ b/src/main/webapp/i18n/en/error.json
@@ -12,7 +12,7 @@
         },
         "assessmentNotPossibleExamRunning": "Assessment is not possible yet: you can start once the exam has ended for all students on {{ date }}.",
         "assessmentNotPossibleTestsPending": "Assessment is not possible yet: the tests still have to run once more on the final submissions. You can start assessing on {{ date }}.",
-        "negativeCorrectionRound": "The correction round must not be negative.",
+        "invalidCorrectionRound": "This correction round does not exist for the exercise.",
         "cannotDeleteYourself": "You cannot delete your own account!",
         "fileUploadSavingError": "Error! The upload failed. Make sure you are connected to the Internet!",
         "isNull": "No {{ entityName }} was provided.",

--- a/src/test/java/de/tum/cit/aet/artemis/assessment/test_repository/ResultTestRepository.java
+++ b/src/test/java/de/tum/cit/aet/artemis/assessment/test_repository/ResultTestRepository.java
@@ -29,6 +29,8 @@ public interface ResultTestRepository extends ResultRepository {
 
     Optional<Result> findDistinctBySubmissionId(long submissionId);
 
+    long countBySubmissionId(long submissionId);
+
     @EntityGraph(type = LOAD, attributePaths = "feedbacks")
     Optional<Result> findDistinctWithFeedbackBySubmissionId(long submissionId);
 

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionIntegrationTest.java
@@ -646,12 +646,12 @@ class ProgrammingSubmissionIntegrationTest extends AbstractProgrammingIntegratio
         final var submission = programmingExerciseUtilService.createProgrammingSubmission(programmingExerciseStudentParticipation, false, "1");
         participationUtilService.addResultToSubmission(submission, AssessmentType.AUTOMATIC, null);
         exerciseUtilService.updateExerciseDueDate(exercise.getId(), ZonedDateTime.now().minusHours(1));
-        long resultsBefore = resultRepository.count();
+        long resultsBefore = resultRepository.countBySubmissionId(submission.getId());
 
         String url = "/api/programming/exercises/" + exercise.getId() + "/programming-submission-without-assessment?lock=true&correction-round=-1";
         request.get(url, HttpStatus.BAD_REQUEST, ProgrammingSubmission.class);
 
-        assertThat(resultRepository.count()).as("no result is created for a negative correction round").isEqualTo(resultsBefore);
+        assertThat(resultRepository.countBySubmissionId(submission.getId())).as("no result is created for a negative correction round").isEqualTo(resultsBefore);
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionIntegrationTest.java
@@ -642,6 +642,20 @@ class ProgrammingSubmissionIntegrationTest extends AbstractProgrammingIntegratio
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
+    void testGetProgrammingSubmissionWithoutAssessmentAndLock_negativeCorrectionRound_badRequest() throws Exception {
+        final var submission = programmingExerciseUtilService.createProgrammingSubmission(programmingExerciseStudentParticipation, false, "1");
+        participationUtilService.addResultToSubmission(submission, AssessmentType.AUTOMATIC, null);
+        exerciseUtilService.updateExerciseDueDate(exercise.getId(), ZonedDateTime.now().minusHours(1));
+        long resultsBefore = resultRepository.count();
+
+        String url = "/api/programming/exercises/" + exercise.getId() + "/programming-submission-without-assessment?lock=true&correction-round=-1";
+        request.get(url, HttpStatus.BAD_REQUEST, ProgrammingSubmission.class);
+
+        assertThat(resultRepository.count()).as("no result is created for a negative correction round").isEqualTo(resultsBefore);
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void testLockAndGetProgrammingSubmissionWithoutManualResult() throws Exception {
         final var submission = programmingExerciseUtilService.createProgrammingSubmission(programmingExerciseStudentParticipation, true, "1");
         participationUtilService.addResultToSubmission(submission, AssessmentType.AUTOMATIC, null);

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingSubmissionIntegrationTest.java
@@ -646,12 +646,17 @@ class ProgrammingSubmissionIntegrationTest extends AbstractProgrammingIntegratio
         final var submission = programmingExerciseUtilService.createProgrammingSubmission(programmingExerciseStudentParticipation, false, "1");
         participationUtilService.addResultToSubmission(submission, AssessmentType.AUTOMATIC, null);
         exerciseUtilService.updateExerciseDueDate(exercise.getId(), ZonedDateTime.now().minusHours(1));
-        long resultsBefore = resultRepository.countBySubmissionId(submission.getId());
+        final Result resultBefore = resultRepository.findDistinctBySubmissionId(submission.getId()).orElseThrow();
 
         String url = "/api/programming/exercises/" + exercise.getId() + "/programming-submission-without-assessment?lock=true&correction-round=-1";
         request.get(url, HttpStatus.BAD_REQUEST, ProgrammingSubmission.class);
 
-        assertThat(resultRepository.countBySubmissionId(submission.getId())).as("no result is created for a negative correction round").isEqualTo(resultsBefore);
+        assertThat(resultRepository.countBySubmissionId(submission.getId())).as("no result is created for a negative correction round").isOne();
+        final Result resultAfter = resultRepository.findDistinctBySubmissionId(submission.getId()).orElseThrow();
+        assertThat(resultAfter.getId()).isEqualTo(resultBefore.getId());
+        assertThat(resultAfter.getAssessmentType()).isEqualTo(AssessmentType.AUTOMATIC);
+        assertThat(resultAfter.getAssessor()).as("the existing result is not claimed").isNull();
+        assertThat(resultAfter.getCorrectionRound()).isEqualTo(resultBefore.getCorrectionRound());
     }
 
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
@@ -293,6 +293,19 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
+    void retrieveParticipationForSubmission_negativeCorrectionRound_badRequest() throws Exception {
+        TextSubmission textSubmission = ParticipationFactory.generateTextSubmission("Some text", Language.ENGLISH, true);
+        textSubmission = textExerciseUtilService.saveTextSubmission(textExercise, textSubmission, TEST_PREFIX + "student1");
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("correction-round", "-1");
+
+        request.get("/api/text/text-submissions/" + textSubmission.getId() + "/for-assessment", HttpStatus.BAD_REQUEST, TextParticipationDTO.class, params);
+
+        assertThat(resultRepository.existsBySubmissionId(textSubmission.getId())).as("no result is created for a negative correction round").isFalse();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void retrieveParticipationForNonExistingSubmission() throws Exception {
         TextParticipationDTO participation = request.get("/api/text/text-submissions/345395769256365/for-assessment", HttpStatus.NOT_FOUND, TextParticipationDTO.class);
         assertThat(participation).as("participation should not be found").isNull();

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
@@ -320,6 +320,22 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
+    void getTextSubmissionWithoutAssessmentAndLock_correctionRoundBeyondExercise_badRequest() throws Exception {
+        TextSubmission textSubmission = ParticipationFactory.generateTextSubmission("Some text", Language.ENGLISH, true);
+        textSubmission = textExerciseUtilService.saveTextSubmission(textExercise, textSubmission, TEST_PREFIX + "student1");
+        exerciseDueDatePassed();
+        var params = new LinkedMultiValueMap<String, String>();
+        params.add("lock", "true");
+        params.add("correction-round", "1");
+
+        request.get("/api/text/exercises/" + textExercise.getId() + "/text-submission-without-assessment", HttpStatus.BAD_REQUEST, TextSubmissionWithoutAssessmentDTO.class,
+                params);
+
+        assertThat(resultRepository.existsBySubmissionId(textSubmission.getId())).as("no result is created for a correction round the exercise does not have").isFalse();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void retrieveParticipationForNonExistingSubmission() throws Exception {
         TextParticipationDTO participation = request.get("/api/text/text-submissions/345395769256365/for-assessment", HttpStatus.NOT_FOUND, TextParticipationDTO.class);
         assertThat(participation).as("participation should not be found").isNull();

--- a/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/text/TextAssessmentIntegrationTest.java
@@ -306,6 +306,20 @@ class TextAssessmentIntegrationTest extends AbstractSpringIntegrationIndependent
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
+    void retrieveParticipationForSubmission_correctionRoundBeyondExercise_badRequest() throws Exception {
+        TextSubmission textSubmission = ParticipationFactory.generateTextSubmission("Some text", Language.ENGLISH, true);
+        textSubmission = textExerciseUtilService.saveTextSubmission(textExercise, textSubmission, TEST_PREFIX + "student1");
+        var params = new LinkedMultiValueMap<String, String>();
+        // a course exercise has exactly one correction round, so round 1 is the first round that does not exist
+        params.add("correction-round", "1");
+
+        request.get("/api/text/text-submissions/" + textSubmission.getId() + "/for-assessment", HttpStatus.BAD_REQUEST, TextParticipationDTO.class, params);
+
+        assertThat(resultRepository.existsBySubmissionId(textSubmission.getId())).as("no result is created for a correction round the exercise does not have").isFalse();
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TA")
     void retrieveParticipationForNonExistingSubmission() throws Exception {
         TextParticipationDTO participation = request.get("/api/text/text-submissions/345395769256365/for-assessment", HttpStatus.NOT_FOUND, TextParticipationDTO.class);
         assertThat(participation).as("participation should not be found").isNull();


### PR DESCRIPTION
### Summary

A tutor could request a submission for assessment with a correction round the exercise does not have (negative, or at or above the exercise's number of correction rounds). The lock entry points now reject such a round with HTTP 400 before a result is created or claimed.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another round of reviews.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context

Fixes #13620.

The `correction-round` request parameter is an unrestricted `int`. `Submission.getResultForCorrectionRound` returns `null` for a negative round, so `SubmissionService.lockSubmission` treated the request as a first assessment: it created an empty manual result, stamped the negative round on it and saved it. That result is unreachable by round afterwards. On `develop`, `GET /api/text/text-submissions/{id}/for-assessment?correction-round=-1` returns 200 and leaves results behind on a submission that had none.

### Description

- `SubmissionService.checkCorrectionRoundIsValidElseThrow(exercise, correctionRound)` rejects a round outside `[0, exercise.getNumberOfCorrectionRounds())` with a `BadRequestAlertException` (error key `invalidCorrectionRound`). It sits next to `checkThatAssessmentIsPossibleElseThrow` and is called at the eight lock entry points: the four per-submission endpoints (text `for-assessment`, modeling and file upload submission retrieval, programming `lock`) right after that gate, and the four `*-submission-without-assessment` endpoints before a candidate is selected (right after `checkIfExerciseDueDateIsReached`, or after the lock-limit check for programming). At both points the exam of an exam exercise is already loaded, so the round count can be read safely.
- `SubmissionService.lockSubmission` and the `ProgrammingSubmissionService` override (which does not call `super`) keep a sign check as defence in depth, with the same error key; the Javadoc says why the upper bound is not checked there.
- English and German `error.json` get the `invalidCorrectionRound` message.
- Integration tests: `TextAssessmentIntegrationTest.retrieveParticipationForSubmission_negativeCorrectionRound_badRequest` (the endpoint from the report), `TextAssessmentIntegrationTest.retrieveParticipationForSubmission_correctionRoundBeyondExercise_badRequest` (round 1 on a course exercise, the value a client off-by-one produces), `TextAssessmentIntegrationTest.getTextSubmissionWithoutAssessmentAndLock_correctionRoundBeyondExercise_badRequest` (the same on the without-assessment endpoint with `lock=true`) and `ProgrammingSubmissionIntegrationTest.testGetProgrammingSubmissionWithoutAssessmentAndLock_negativeCorrectionRound_badRequest` (the only programming endpoint that reaches the override with a caller-supplied round). Both expect 400 and check that no result was persisted.

All four tests fail on `develop` (`Response status expected:<400> but was:<200>`) and pass with this change. `programming-submissions/{id}/lock?correction-round=-1` never reached the lock path on `develop` either (it returns 200 with no results and persists nothing), so that endpoint is unchanged.

Local runs at 2a00d172e4: `TextAssessmentIntegrationTest`, `TextSubmissionIntegrationTest`, `ProgrammingSubmissionIntegrationTest`, `ProgrammingAssessmentIntegrationTest`, `ModelingAssessmentIntegrationTest`, `FileUploadAssessmentIntegrationTest`, `ExamAssessmentAvailabilityIntegrationTest` (296 tests, 0 failures), `spotlessCheck`, `checkstyleMain`.

### Steps for Testing

Prerequisites:
- 1 Tutor
- 1 Student
- 1 Text exercise whose due date has passed

1. As the student, submit the text exercise.
2. As the tutor, open the assessment dashboard for the exercise and note the submission id (or take it from `GET /api/text/exercises/{exerciseId}/text-submissions`).
3. Request `GET /api/text/text-submissions/{submissionId}/for-assessment?correction-round=-1` with the tutor's session.
4. The response is 400 with the message "The correction round must not be negative."
5. Open `GET /api/exercise/participations/{participationId}/submissions` (or the submission in Course Management > Exercise > Participations > Submissions): the submission still has no result.
6. Open the submission normally through the assessment dashboard: it locks for the tutor with `correctionRound: 0` as before.

#### Exam Mode Testing

Prerequisites:
- 1 Instructor
- 1 Student
- 1 Exam with a text exercise and 2 correction rounds

1. As the student, take the exam and submit the text exercise.
2. As the instructor, assess the submission in correction round 1 and again in correction round 2 from the exam assessment dashboard. Both rounds still lock and save as before.
3. Request `GET /api/text/text-submissions/{submissionId}/for-assessment?correction-round=-1`: 400, and the submission still has exactly the two results.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| SubmissionService.java | 95.82% | 532 |
| FileUploadSubmissionResource.java | 95.62% | 275 |
| ModelingSubmissionResource.java | 96.88% | 313 |
| ProgrammingSubmissionService.java | 89.94% | 325 |
| ProgrammingSubmissionResource.java | 95.24% | 274 |
| TextAssessmentResource.java | 94.76% | 472 |
| TextSubmissionResource.java | 95.31% | 257 |

_Last updated: 2026-09-07 11:10:53 UTC_

