### PR TITLE
`Programming exercises`: Fall back to the login as git committer name for users without a name

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/account/domain/User.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/domain/User.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -296,16 +298,16 @@ public class User extends AbstractAuditingEntity implements Participant {
     }
 
     /**
-     * @return name as a concatenation of first name and last name
+     * The display name: first and last name joined by a space, skipping whichever is blank. Falls back to the login when neither is
+     * set, which happens for accounts an LTI platform provisions without name claims (Open edX sends none by default). The result is
+     * also used as the git committer identity, and JGit rejects a null name there.
+     *
+     * @return the display name, never null for a persisted user
      */
     @Override
     public String getName() {
-        if (lastName != null && !lastName.isEmpty()) {
-            return firstName + " " + lastName;
-        }
-        else {
-            return firstName;
-        }
+        String name = Stream.of(firstName, lastName).filter(StringUtils::isNotBlank).collect(Collectors.joining(" "));
+        return name.isEmpty() ? login : name;
     }
 
     public String getEmail() {

--- a/src/main/java/de/tum/cit/aet/artemis/account/domain/User.java
+++ b/src/main/java/de/tum/cit/aet/artemis/account/domain/User.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.BatchSize;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.web.webauthn.api.Bytes;
 
@@ -306,6 +307,19 @@ public class User extends AbstractAuditingEntity implements Participant {
      */
     @Override
     public String getName() {
+        return displayName(firstName, lastName, login);
+    }
+
+    /**
+     * The single owner of the display-name rule, shared with the DTOs that carry a user's name fields without the entity (mail
+     * recipients, student lists, plagiarism cases). Keep every copy on this method so the fallback cannot drift.
+     *
+     * @param firstName the first name, may be null or blank
+     * @param lastName  the last name, may be null or blank
+     * @param login     the login to fall back to when both names are blank
+     * @return the non-blank name parts joined by a space, or the login when there are none
+     */
+    public static @Nullable String displayName(@Nullable String firstName, @Nullable String lastName, @Nullable String login) {
         String name = Stream.of(firstName, lastName).filter(StringUtils::isNotBlank).collect(Collectors.joining(" "));
         return name.isEmpty() ? login : name;
     }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/dto/StudentDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/dto/StudentDTO.java
@@ -1,32 +1,14 @@
 package de.tum.cit.aet.artemis.exercise.dto;
 
-import org.jspecify.annotations.Nullable;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.cit.aet.artemis.account.domain.User;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public record StudentDTO(long id, String login, String firstName, String lastName, String name, String registrationNumber,   // null if not provided
         String email) {
 
     public StudentDTO(long id, String login, String firstName, String lastName, String registrationNumber, String email) {
-        this(id, login, firstName, lastName, createName(firstName, lastName), registrationNumber, email);
-    }
-
-    private static String createName(@Nullable String firstName, @Nullable String lastName) {
-        boolean hasFirst = firstName != null && !firstName.isEmpty();
-        boolean hasLast = lastName != null && !lastName.isEmpty();
-
-        if (hasFirst && hasLast) {
-            return firstName + " " + lastName;
-        }
-        else if (hasFirst) {
-            return firstName;
-        }
-        else if (hasLast) {
-            return lastName;
-        }
-        else {
-            return "";
-        }
+        this(id, login, firstName, lastName, User.displayName(firstName, lastName, login), registrationNumber, email);
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/notification/dto/CourseNotificationRecipientDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/dto/CourseNotificationRecipientDTO.java
@@ -16,13 +16,11 @@ import de.tum.cit.aet.artemis.account.domain.User;
 public record CourseNotificationRecipientDTO(Long id, String login, String email, String langKey, String firstName, String lastName) {
 
     /**
-     * Returns the recipient's full name in the format used by the mail templates.
+     * Returns the recipient's display name in the format used by the mail templates, falling back to the login when the account
+     * has no name (see {@link User#displayName}).
      */
     public String getName() {
-        if (lastName != null && !lastName.isEmpty()) {
-            return firstName + " " + lastName;
-        }
-        return firstName;
+        return User.displayName(firstName, lastName, login);
     }
 
     public static CourseNotificationRecipientDTO from(User user) {

--- a/src/main/java/de/tum/cit/aet/artemis/notification/dto/MailRecipientDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/notification/dto/MailRecipientDTO.java
@@ -16,13 +16,11 @@ import de.tum.cit.aet.artemis.account.domain.User;
 public record MailRecipientDTO(String email, String langKey, String login, String firstName, String lastName, String activationKey, String resetKey) {
 
     /**
-     * Returns the user's full name in the format used by the mail templates.
+     * Returns the user's display name in the format used by the mail templates, falling back to the login when the account has no
+     * name (see {@link User#displayName}).
      */
     public String getName() {
-        if (lastName != null && !lastName.isEmpty()) {
-            return firstName + " " + lastName;
-        }
-        return firstName;
+        return User.displayName(firstName, lastName, login);
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/plagiarism/dto/PlagiarismCaseOverviewDTO.java
@@ -6,6 +6,7 @@ import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.plagiarism.domain.PlagiarismVerdict;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -38,9 +39,9 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
             @Nullable String studentLastName, @Nullable Long postId, @Nullable ZonedDateTime postCreationDate, boolean hasStudentAnswer, @Nullable PlagiarismVerdict verdict,
             @Nullable ZonedDateTime verdictDate, @Nullable Long verdictById, @Nullable String verdictByLogin, @Nullable String verdictByFirstName,
             @Nullable String verdictByLastName, long plagiarismSubmissionCount, boolean createdByContinuousPlagiarismControl) {
-        this(id, exercise, userOrNull(studentId, studentLogin, fullName(studentFirstName, studentLastName), null), postOrNull(postId, postCreationDate), verdict, verdictDate,
-                userOrNull(verdictById, verdictByLogin, fullName(verdictByFirstName, verdictByLastName), null), toBoundedInt(plagiarismSubmissionCount),
-                createdByContinuousPlagiarismControl, hasStudentAnswer);
+        this(id, exercise, userOrNull(studentId, studentLogin, User.displayName(studentFirstName, studentLastName, studentLogin), null), postOrNull(postId, postCreationDate),
+                verdict, verdictDate, userOrNull(verdictById, verdictByLogin, User.displayName(verdictByFirstName, verdictByLastName, verdictByLogin), null),
+                toBoundedInt(plagiarismSubmissionCount), createdByContinuousPlagiarismControl, hasStudentAnswer);
     }
 
     private static @Nullable PlagiarismCaseUserDTO userOrNull(@Nullable Long id, @Nullable String login, @Nullable String name, @Nullable String visibleRegistrationNumber) {
@@ -48,21 +49,6 @@ public record PlagiarismCaseOverviewDTO(Long id, PlagiarismCaseExerciseDTO exerc
             return null;
         }
         return new PlagiarismCaseUserDTO(id, login, name, visibleRegistrationNumber);
-    }
-
-    private static @Nullable String fullName(@Nullable String firstName, @Nullable String lastName) {
-        boolean hasFirstName = firstName != null && !firstName.isEmpty();
-        boolean hasLastName = lastName != null && !lastName.isEmpty();
-        if (hasFirstName && hasLastName) {
-            return firstName + " " + lastName;
-        }
-        if (hasFirstName) {
-            return firstName;
-        }
-        if (hasLastName) {
-            return lastName;
-        }
-        return null;
     }
 
     private static int toBoundedInt(long value) {

--- a/src/test/java/de/tum/cit/aet/artemis/account/domain/UserTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/domain/UserTest.java
@@ -4,6 +4,8 @@ import static de.tum.cit.aet.artemis.account.domain.User.IRIS_BOT_LOGIN;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class UserTest {
 
@@ -60,5 +62,22 @@ class UserTest {
         User user = new User(1L, "student", "Student", "Test", "en", "Student@Example.COM");
 
         assertThat(user.getEmail()).isEqualTo("student@example.com");
+    }
+
+    /**
+     * An LTI platform such as Open edX may omit the given_name and family_name claims, so an account can carry no name at all. The
+     * display name must then fall back to the login: it is written into git commit identities, where JGit rejects null, and shown
+     * wherever Artemis names a user.
+     */
+    @ParameterizedTest
+    @CsvSource(nullValues = "null", value = { "Jane, Doe, Jane Doe", "Jane, null, Jane", "Jane, '', Jane", "null, Doe, Doe", "null, null, edx_jane", "'  ', '  ', edx_jane",
+            "'', '', edx_jane" })
+    void getName_fallsBackToLoginWhenNoNameIsSet(String firstName, String lastName, String expected) {
+        User user = new User();
+        user.setLogin("edx_jane");
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+
+        assertThat(user.getName()).isEqualTo(expected);
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/notification/RecipientDTONameTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/RecipientDTONameTest.java
@@ -1,4 +1,4 @@
-package de.tum.cit.aet.artemis.notification.dto;
+package de.tum.cit.aet.artemis.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -6,6 +6,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import de.tum.cit.aet.artemis.account.domain.User;
+import de.tum.cit.aet.artemis.notification.dto.CourseNotificationRecipientDTO;
+import de.tum.cit.aet.artemis.notification.dto.MailRecipientDTO;
 
 /**
  * The mail templates render {@code getName()} of both recipient DTOs. An account without name claims (see #13537) must show its

--- a/src/test/java/de/tum/cit/aet/artemis/notification/RecipientDTONameTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/RecipientDTONameTest.java
@@ -16,7 +16,7 @@ import de.tum.cit.aet.artemis.notification.dto.MailRecipientDTO;
 class RecipientDTONameTest {
 
     @ParameterizedTest
-    @CsvSource(nullValues = "null", value = { "Jane, Doe, Jane Doe", "null, Doe, Doe", "Jane, null, Jane", "null, null, edx_jane", "'', '', edx_jane" })
+    @CsvSource(nullValues = "null", value = { "Jane, Doe, Jane Doe", "null, Doe, Doe", "Jane, null, Jane", "null, null, edx_jane", "'', '', edx_jane", "'   ', '   ', edx_jane" })
     void recipientNamesFallBackToLogin(String firstName, String lastName, String expected) {
         User user = new User();
         user.setLogin("edx_jane");

--- a/src/test/java/de/tum/cit/aet/artemis/notification/dto/RecipientDTONameTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/notification/dto/RecipientDTONameTest.java
@@ -1,0 +1,29 @@
+package de.tum.cit.aet.artemis.notification.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import de.tum.cit.aet.artemis.account.domain.User;
+
+/**
+ * The mail templates render {@code getName()} of both recipient DTOs. An account without name claims (see #13537) must show its
+ * login there, not "null Doe" or nothing.
+ */
+class RecipientDTONameTest {
+
+    @ParameterizedTest
+    @CsvSource(nullValues = "null", value = { "Jane, Doe, Jane Doe", "null, Doe, Doe", "Jane, null, Jane", "null, null, edx_jane", "'', '', edx_jane" })
+    void recipientNamesFallBackToLogin(String firstName, String lastName, String expected) {
+        User user = new User();
+        user.setLogin("edx_jane");
+        user.setEmail("edx_jane@example.com");
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+
+        assertThat(MailRecipientDTO.from(user).getName()).isEqualTo(expected);
+        assertThat(MailRecipientDTO.withRecoveryKey(user, "activation", null).getName()).isEqualTo(expected);
+        assertThat(CourseNotificationRecipientDTO.from(user).getName()).isEqualTo(expected);
+    }
+}

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseGitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseGitIntegrationTest.java
@@ -28,6 +28,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
 import de.tum.cit.aet.artemis.core.service.TempFileUtilService;
 import de.tum.cit.aet.artemis.exercise.util.ExerciseUtilService;
@@ -169,6 +170,50 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractProgrammingIntegrati
         }
         finally {
             // Ensure repository handle is closed and the local clone is deleted even on failures
+            if (checkedOut != null) {
+                checkedOut.close();
+            }
+            RepositoryExportTestUtil.safeDeleteDirectory(targetPath);
+        }
+    }
+
+    /**
+     * Regression test for #13537: an LTI-provisioned account whose platform sent no given_name/family_name has null names. Committing from
+     * the online editor stamps that user as the git committer, and JGit rejects a null committer name with "Name of PersonIdent must not be
+     * null". The commit has to succeed with the login as the committer name instead.
+     */
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = { "USER", "STUDENT" })
+    void testCommitAndPushWithUserWithoutName() throws Exception {
+        var projectKey = "PROGEXGITNONAME";
+        var repoSlug = projectKey.toLowerCase() + "-student";
+        LocalVCTestRepository remoteRepo = RepositoryExportTestUtil.trackRepository(localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, repoSlug));
+        FileUtils.writeStringToFile(remoteRepo.workingCopyPath().resolve("README.md").toFile(), "Initial commit", StandardCharsets.UTF_8);
+        remoteRepo.workingCopy().add().addFilepattern(".").call();
+        GitService.commit(remoteRepo.workingCopy()).setMessage("Initial commit").call();
+        remoteRepo.workingCopy().push().setRemote("origin").call();
+
+        User student = userUtilService.getUserByLogin(TEST_PREFIX + "student1");
+        student.setFirstName(null);
+        student.setLastName(null);
+
+        LocalVCRepositoryUri repoUri = new LocalVCRepositoryUri(localVCLocalCITestService.buildLocalVCUri(null, null, projectKey, repoSlug));
+        Path targetPath = tempPath.resolve("lcvc-checkout").resolve("no-name-checkout");
+        var checkedOut = gitService.getOrCheckoutRepositoryWithTargetPath(repoUri, targetPath, true, true);
+        try {
+            FileUtils.writeStringToFile(targetPath.resolve("hello.txt").toFile(), "hello world", StandardCharsets.UTF_8);
+            gitService.stageAllChanges(checkedOut);
+
+            String commitHash = gitService.commitAndPush(checkedOut, "Submit from online editor", true, student);
+
+            try (var revWalk = new org.eclipse.jgit.revwalk.RevWalk(checkedOut)) {
+                var committer = revWalk.parseCommit(checkedOut.resolve(commitHash)).getCommitterIdent();
+                assertThat(committer.getName()).isEqualTo(student.getLogin());
+                assertThat(committer.getEmailAddress()).isEqualTo(student.getEmail());
+            }
+            assertThat(gitService.getLastCommitHash(repoUri)).isEqualTo(commitHash);
+        }
+        finally {
             if (checkedOut != null) {
                 checkedOut.close();
             }

--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseGitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseGitIntegrationTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.revwalk.RevWalk;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -206,7 +207,7 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractProgrammingIntegrati
 
             String commitHash = gitService.commitAndPush(checkedOut, "Submit from online editor", true, student);
 
-            try (var revWalk = new org.eclipse.jgit.revwalk.RevWalk(checkedOut)) {
+            try (var revWalk = new RevWalk(checkedOut)) {
                 var committer = revWalk.parseCommit(checkedOut.resolve(commitHash)).getCommitterIdent();
                 assertThat(committer.getName()).isEqualTo(student.getLogin());
                 assertThat(committer.getEmailAddress()).isEqualTo(student.getEmail());


### PR DESCRIPTION
### Summary
An LTI platform can provision an Artemis account without `given_name` and `family_name` (Open edX sends neither by default). Such a user cannot submit from the online editor: `User.getName()` returns null, `GitService.commitAndPush` passes it to JGit as the committer, and JGit rejects it with `Name of PersonIdent must not be null`. The display name now falls back to the login when both name parts are blank, so the commit succeeds and the user is shown as their login everywhere `getName()` is used.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).

### Motivation and Context
Fixes #13537. Open edX launches create users with null first and last name. Every later online-editor submission of that user fails with "Illegal argument during operation or file already exists" (HTTP 400), and the server logs `IllegalArgumentException: Name of PersonIdent must not be null` at `GitService.commitAndPush`.

#13538 addressed this at account creation only, so users that already exist with null names keep failing, and that branch is stale and conflicting. This change fixes it where every caller goes through.

### Description
- `User.getName()` builds the display name from whichever of first and last name is non-blank and falls back to the login when both are missing. Before, a null first name produced `null Doe` or a null name.
- `UserTest`: parameterized cases for full, partial, blank, and missing names.
- `ProgrammingExerciseGitIntegrationTest.testCommitAndPushWithUserWithoutName`: commits through `GitService.commitAndPush` as a user with null names and asserts the committer identity is `login <email>`. On develop this test fails with the exact exception from the issue.

No client change. Accounts created with null names keep null first and last name in the database; only the derived display name changes.

### Steps for Testing
Prerequisites:
- 1 Student whose first and last name are both empty. Either launch via an LTI platform that sends no name claims, or clear both columns for a test student directly in the database:
  `UPDATE jhi_user SET first_name = NULL, last_name = NULL WHERE login = '<student>';`
- 1 Programming Exercise with the online editor enabled (LocalVC and LocalCI)

1. Log in to Artemis as the student
2. Open the programming exercise and start the participation
3. Open the online editor, change a file, and click Submit
4. Verify the submission is accepted ("Submitted.", build starts) and no "Illegal argument during operation or file already exists" alert appears
5. Verify the header shows the student's login as their name
6. Optional: inspect the student repository. The commit author and committer read `<login> <email>`

#### Exam Mode Testing
The exam online editor commits through the same `GitService.commitAndPush` path with the same user object, so the fix applies unchanged. Repeat steps 3 and 4 inside a running exam with the same student if a name-less exam participant is available.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Verification done locally
- `./gradlew test --tests UserTest --tests ProgrammingExerciseGitIntegrationTest.testCommitAndPushWithUserWithoutName -x webapp`: fails on develop with `Name of PersonIdent must not be null`, passes on this branch.
- `./gradlew spotlessCheck checkstyleMain`: clean.
- Local LocalVC/LocalCI stack: student with null names submitted from the online editor, commit endpoint returned 200, repository commit identity is `edx_jane <edx_jane@example.com>`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved user name display so non-blank first and last names appear together.
  - When no name is available, the user’s login is displayed instead of an incomplete or blank name across relevant views and notifications.
  - Git commits now succeed for users without first or last names, using their login and email for identification.

- **Tests**
  - Added coverage for blank, empty, whitespace-only, and missing name values.
  - Added regression coverage for commits made by users without names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
