### PR TITLE
`Development`: Pass the locale in the OIDC login test

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserOIDCIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/account/authentication/UserOIDCIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -176,7 +177,7 @@ class UserOIDCIntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest {
     void testRepeatedOidcLoginWithMixedCaseUsernameClaim() {
         assertStudentNotExists();
         Map<String, Object> mixedCaseClaims = createClaimsMap(STUDENT_REGISTRATION_NUMBER, "FirstName", "LastName");
-        mixedCaseClaims.put("preferred_username", STUDENT_NAME.toUpperCase());
+        mixedCaseClaims.put("preferred_username", STUDENT_NAME.toUpperCase(Locale.ENGLISH));
 
         // The claim is stored lowercase, so a second login has to find the account the first one created rather than
         // trying to create it again and failing on the email that is already taken.
@@ -188,7 +189,7 @@ class UserOIDCIntegrationTest extends AbstractSpringIntegrationLocalVCSamlTest {
         assertThatCode(() -> oidcService.loadUser(createMockUserRequest(mixedCaseClaims))).doesNotThrowAnyException();
 
         assertStudentExists();
-        assertThat(userTestRepository.findOneByLogin(STUDENT_NAME.toUpperCase())).as("no account is stored under the uncanonicalized claim").isEmpty();
+        assertThat(userTestRepository.findOneByLogin(STUDENT_NAME.toUpperCase(Locale.ENGLISH))).as("no account is stored under the uncanonicalized claim").isEmpty();
     }
 
     @Test


### PR DESCRIPTION
### Summary

`develop` is red, and it fails its own architecture rule. Two calls of the no-argument `String.toUpperCase` now pass `Locale.ENGLISH`.

### Motivation and Context

#13692 added `ArchitectureTest.testNoLocaleLessCaseConversion`, which bans the no-argument `String.toLowerCase` and `String.toUpperCase`. #13682 added two `String.toUpperCase()` calls in `UserOIDCIntegrationTest`. Each pull request was validated against a merge base that predated the other, so neither run could see the conflict, and the combination only appeared once both had merged.

The effect is not limited to one branch. Every open pull request that merges current `develop` inherits the failure, and it reds four jobs at once: `Quality / Server Code Style`, `Test / Server Tests (Remaining)`, `Test / Server Tests Report` and `All required CI Passed`. The report job fails because `dorny/test-reporter` runs with `fail-on-error`, so it inherits the single test failure rather than having a problem of its own.

### Description

`STUDENT_NAME.toUpperCase()` becomes `STUDENT_NAME.toUpperCase(Locale.ENGLISH)` at both call sites.

`Locale.ENGLISH` rather than `Locale.ROOT`, even though `ROOT` is the default choice for machine-facing values. The test feeds a mixed-case `preferred_username` claim and then asserts that no account was stored under the uncanonicalized form. That assertion only means something if the test folds case the way the production path does, and `User.canonicalLogin` folds with `Locale.ENGLISH`. Using `ROOT` here would pass today but would compare different bytes than the code under test.

### Steps for Testing

No functional change. The rule is what verifies this:

1. `./gradlew test --tests de.tum.cit.aet.artemis.shared.architecture.ArchitectureTest -x webapp`
2. `./gradlew test --tests UserOIDCIntegrationTest -x webapp`

### Validation

- `ArchitectureTest`: 37 tests, 37 passed, 0 failures.
- `spotlessCheck` passes.
- Verified that these are the only two violations in the tree: the remaining matches for a no-argument case conversion are the rule's own reason string and a comment in `RedisClientListResolver`.

### Review Progress

- [x] Code review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved OIDC integration test consistency by using a fixed English locale for mixed-case username handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->