### PR TITLE
`General`: Fix links being underlined twice on hover

### DIFF
--- a/src/main/webapp/app/core/navbar/navbar.scss
+++ b/src/main/webapp/app/core/navbar/navbar.scss
@@ -15,13 +15,12 @@ Navbar
 ========================================================================== */
 
 /*
- * Don't underline the menu items on hover. `global.scss` underlines every hovered anchor with an `!important`
- * rule that carries three `:not()` clauses, so this override has to match that clause count before Angular's
- * `[_ngcontent]` attribute tips the specificity in its favour — with fewer clauses the global rule wins and the
- * underline reappears. On the account menu that is especially visible: the avatar covers the stretch of the
- * underline behind it, so all that surfaces is a short blue dash next to the image.
+ * Don't underline the menu items on hover, overriding the rule that does so for every anchor in `global.scss` — see
+ * the comment there for why the exclusions belong in one `:not()` argument list rather than a chain of clauses. On
+ * the account menu the stray underline is especially visible: the avatar covers the stretch behind it, so all that
+ * surfaces is a short blue dash next to the image.
  */
-a:not(.btn):not(.tum-ui-btn):not(.tab-link):hover {
+a:not(.btn, .tum-ui-btn, .tab-link):hover {
     text-decoration: none !important;
 }
 

--- a/src/main/webapp/app/course/overview/course-exercises/group-detail/course-exercise-group-detail.component.scss
+++ b/src/main/webapp/app/course/overview/course-exercises/group-detail/course-exercise-group-detail.component.scss
@@ -74,7 +74,8 @@
         }
     }
 
-    // Beats the global `a:not(.btn):not(.tab-link):hover` rule.
+    // Beats the hover underline from `global.scss` — see the comment there rather than restating its selector, which
+    // has already gone stale twice.
     a.variant-card__link:hover,
     a.variant-card__link:focus,
     a.variant-card__link:active {

--- a/src/main/webapp/app/course/shared/course-base-container/course-base-container.component.scss
+++ b/src/main/webapp/app/course/shared/course-base-container/course-base-container.component.scss
@@ -92,7 +92,11 @@
     }
 }
 
-a:not(.btn):not(.tab-link):hover {
+/*
+ * Opts the shell's links (breadcrumbs, sidebar) out of the hover underline from `global.scss` — see the comment there
+ * for why the exclusions belong in one `:not()` argument list.
+ */
+a:not(.btn, .tab-link):hover {
     text-decoration: none !important;
 }
 

--- a/src/main/webapp/app/course/shared/course-sidebar/course-sidebar.component.scss
+++ b/src/main/webapp/app/course/shared/course-sidebar/course-sidebar.component.scss
@@ -130,8 +130,10 @@ $transition-color-length: 0.2s;
     color: var(--link-item-color);
 }
 
-// We have to override this style from globals.scss here as we only want to target the span with the text inside
-a:not(.btn):not(.tab-link):hover {
+// Overrides the hover underline from `global.scss`, because only the label span below should be underlined — the
+// anchor also holds the icon, so an underline on it draws a second line under the label and a dash beside the icon.
+// See the comment in `global.scss` for why the exclusions belong in one `:not()` argument list.
+a:not(.btn, .tab-link):hover {
     text-decoration: none !important;
 }
 

--- a/src/main/webapp/app/text/manage/assess/textblock-feedback-editor/dropdown/textblock-feedback-dropdown.component.scss
+++ b/src/main/webapp/app/text/manage/assess/textblock-feedback-editor/dropdown/textblock-feedback-dropdown.component.scss
@@ -2,7 +2,8 @@
     padding: 0;
 }
 
-a:hover {
+/* Opts out of the hover underline from `global.scss`; see the sibling editor stylesheet for why the `:not()` matters. */
+a:not(.btn):hover {
     text-decoration: none !important;
     color: var(--bs-body-color);
 }

--- a/src/main/webapp/app/text/manage/assess/textblock-feedback-editor/text-block-feedback-editor.component.scss
+++ b/src/main/webapp/app/text/manage/assess/textblock-feedback-editor/text-block-feedback-editor.component.scss
@@ -72,7 +72,12 @@ label {
     }
 }
 
-a:hover {
+/*
+ * Opts out of the hover underline from `global.scss`. The `:not()` is what carries the override past that rule:
+ * without it both selectors weigh one class and only their order in `<head>` decides, which the critical-CSS
+ * inlining and the theme stylesheet swap both reshuffle.
+ */
+a:not(.btn):hover {
     text-decoration: none !important;
     color: var(--bs-body-color);
 }

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -100,7 +100,15 @@ a {
     cursor: default !important;
 }
 
-a:not(.btn):not(.tum-ui-btn):not(.tum-ui-list-item-action):not(.tum-ui-menu-item):not(.tab-link):hover {
+/*
+ * Restores the hover underline that the rule above removes. Keep every exclusion inside the one `:not()` argument
+ * list: a `:not()` counts as its most specific argument, so the whole selector stays at one class no matter how many
+ * classes are listed. Component stylesheets opt individual links out of this underline (navbar, course sidebar, admin
+ * sidebar) and rely on Angular's `[_ngcontent]` attribute to keep them one class above it. Chaining the exclusions as
+ * separate `:not()` clauses raises this rule past those overrides, and the anchor underline comes back on top of the
+ * one they draw themselves — a double underline under the label plus a stray dash beside the icon.
+ */
+a:not(.btn, .tum-ui-btn, .tum-ui-list-item-action, .tum-ui-menu-item, .tab-link):hover {
     text-decoration: underline !important;
 }
 


### PR DESCRIPTION
### Summary

Hovering a navigation link underlined its label twice and drew a small stray dash next to the link's icon. This restores the single, intended underline everywhere a link opts out of the global hover underline: the top navbar, the course sidebar, the course shell (breadcrumbs) and the admin sidebar.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

`global.scss` underlines every hovered anchor with an `!important` rule. Components that want only their own label underlined opt the whole link out of that rule locally, and such an override outranks the global rule only by the single class of specificity that Angular's emulated-encapsulation `[_ngcontent]` attribute adds. That made every override depend on mirroring the global rule's chain of `:not()` clauses.

The chain then grew twice without the overrides following: from three clauses to four in #13291, and to five in #13660. At five clauses the global rule outranks all four overrides, so a hovered link got the anchor-level underline back on top of the label underline the sidebar draws itself at `text-underline-offset: 3px` — the double underline — and that anchor-level underline also ran through the inline gap next to the `fa-icon`, which is the stray dash.

The failure mode was already described in a comment in `navbar.scss`: on the account menu the avatar covers the stretch of the underline behind it, "so all that surfaces is a short blue dash next to the image".

### Description

Per CSS Selectors 4, a `:not()` takes the specificity of its most specific argument. Listing the exclusions in one argument list — `:not(.btn, .tum-ui-btn, ...)` instead of `:not(.btn):not(.tum-ui-btn)...` — therefore matches exactly the same elements while pinning the selector at one class, however many classes are excluded.

Applying that form to the global rule drops it from six classes to two, so every component override keeps its one-class lead permanently, and adding another exclusion to `global.scss` can no longer take that lead away. The same form is applied to the three overrides that mirrored the chain, so none of them depends on the global clause count any more, and their comments now explain the constraint instead of restating a clause count that goes stale. `global.scss` already used this list form for the sibling link-colour rule directly above.

**The visual surface is wider than the four files suggest.** Lowering the global rule also revives component overrides that were silently losing to it. Every one of them declares `text-decoration: none !important`, so each change is in the direction its author intended, but reviewers should look at these surfaces too:

| Stylesheet | Selector | Was | Now |
|---|---|---|---|
| `admin-sidebar.component.scss` | `.sidebar-container a.nav-link-sidebar:hover` | lost | **wins** |
| `course-exercise-group-detail.component.scss` | `a.variant-card__link:hover` | lost | **wins** |
| `global-search-lecture-results.component.scss` | `.lecture-result-card:hover` | lost | **wins** |
| `global-search-iris-answer.component.scss` | `.iris-chip:hover` | lost | **wins** |
| `global.scss` | `.session-switcher-menu a.p-menu-item-link:hover` | lost | **wins** |
| `global.scss` | `.iris-inline-answer a.iris-chip:hover` | lost | **wins** |
| `text-block-feedback-editor.component.scss` + its dropdown | `a:hover` | lost | **tie → fixed here** |

The admin sidebar is notable: it carried the same double-underline bug and is fixed without being touched, because it already scoped its override by class (`.sidebar-container a.nav-link-sidebar:hover`) instead of mirroring the chain.

The last row was a genuine problem rather than a free win. Those two `a:hover` selectors weigh exactly one class, the same as the global rule after this change, so nothing but their position in the document head would decide which applies — and both the production critical-CSS inlining and the runtime theme stylesheet swap reshuffle that order. They now carry a `:not(.btn)` clause so they win outright.

Verified against the compiled output rather than by reasoning alone. In the running application, with the hover state forced on a course-sidebar link:

| element | `text-decoration-line` before | after |
|---|---|---|
| the `<a>` nav link | `underline` | `none` |
| the label `<span>` | `underline` (offset 3px) | `underline` (offset 3px, thickness 1px) |

Every rule in the built `styles.css` that sets `text-decoration` on an anchor was enumerated to confirm nothing else competes, and the built component styles were checked to confirm they emit `a[_ngcontent-%COMP%]:not(.btn, .tab-link):hover`, i.e. that the one-class lead is real. Both the light and the dark theme were checked.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Course

1. Log in to Artemis.
2. Hover the entries of the course sidebar (for example Communication). The label is underlined exactly once and there is no small dash between the icon and the label.
3. Hover the entries of the course management sidebar and of the admin sidebar (Server Administration). Same result.
4. Hover the account menu in the top right of the navbar. No short dash appears next to the avatar.
5. Hover the breadcrumb links above a course. They are not underlined.
6. Hover an ordinary link in page content, for example in a lecture description. It is still underlined on hover.
7. Hover a button-styled link and a TUM UI menu entry. Neither is underlined.
8. Check the surfaces in the table above that are newly covered by their own override: an exercise group variant card, a global-search lecture result card, an Iris source chip, the Iris session-switcher menu, and a text-assessment feedback block link. None of them should be underlined on hover.
9. Repeat in the dark theme.

#### Exam Mode Testing

Prerequisites:
- 1 Instructor
- 1 Student
- 1 Exam with any exercise

1. Participate in the exam as a student.
2. Hover the entries of the exam navigation sidebar and confirm the hover styling is unchanged. That sidebar never opted out of the global underline, so it keeps underlining on hover.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Course sidebar, course management sidebar, admin sidebar, navbar account menu, breadcrumbs
- [ ] The surfaces newly covered by their own override (step 8)
#### Exam Mode Test
- [x] Exam navigation sidebar unchanged

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-06 17:15:58 UTC_


### Screenshots

Screenshots of the hovered course sidebar in both the light and the dark theme are attached to this PR. In the reported bug the label carried two underlines and a small dash sat between the icon and the label; after the fix there is one underline and no dash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized link hover behavior across navigation, course, and assessment interfaces.
  * Refined hover underline exclusions so buttons, tabs, menu items, and action controls retain their intended styling.
  * Preserved hover underlines for standard links while limiting underline behavior to appropriate clickable labels and links.
  * Improved consistency in hover and focus states across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->