### PR TITLE
`Adaptive learning`: Fix the learner profile settings failing when its modules are disabled

### DIFF
--- a/documentation/docs/student/progress-analytics/adaptive-learning.mdx
+++ b/documentation/docs/student/progress-analytics/adaptive-learning.mdx
@@ -3,8 +3,8 @@ title: Adaptive Learning
 sidebar_label: Adaptive Learning
 ---
 
-import Image, {ImageSize} from "../../../src/components/Image/Image";
-import TumLiveVideo from "../../../src/components/TumLiveVideo/TumLiveVideo";
+import Image, { ImageSize } from '../../../src/components/Image/Image';
+import TumLiveVideo from '../../../src/components/TumLiveVideo/TumLiveVideo';
 
 import studentsLearningGoalsStatisticsImg from '../assets/adaptive-learning/students-learning-goals-statistics.png';
 import studentsLearningGoalsStatisticsDetailImg from '../assets/adaptive-learning/students-learning-goals-statistics-detail.png';
@@ -39,7 +39,7 @@ The page lists all competencies with their title, description, and <a href="http
 
 Expanding the prerequisites section shows the student all competencies the instructor has selected as a prerequisite for this course.
 
-<Image src={studentsLearningGoalsStatisticsImg} alt={"students-learning-goals-statistics"} size={ImageSize.large}/>
+<Image src={studentsLearningGoalsStatisticsImg} alt={'students-learning-goals-statistics'} size={ImageSize.large} />
 
 When clicking on a competency, a page displays detailed statistics about the competency and all linked lecture units and exercises.
 The two rings show the student's advancement:
@@ -48,7 +48,7 @@ The **red ring indicates the mastery**, which shows the overall advancement towa
 
 If the mastery diverges from the progress, the student can see the main reason for this divergence as a tooltip next to the mastery value.
 
-<Image src={studentsLearningGoalsStatisticsDetailImg} alt={"students-learning-goals-statistics-detail"} size={ImageSize.large}/>
+<Image src={studentsLearningGoalsStatisticsDetailImg} alt={'students-learning-goals-statistics-detail'} size={ImageSize.large} />
 
 ---
 
@@ -58,13 +58,13 @@ Students can access their learning path in the learning path tab. Here, they can
 Recommendations are generated via an intelligent agent that accounts for multiple metrics, e.g., prior performance, confidence, relations, and due dates, to support students in selecting learning resources.
 Students can use the "Previous" and "Next" buttons to navigate to the previous or next recommendation, respectively.
 
-<Image src={studentsLearningPathParticipationImg} alt={"students-learning-path-participation"} size={ImageSize.large}/>
+<Image src={studentsLearningPathParticipationImg} alt={'students-learning-path-participation'} size={ImageSize.large} />
 
 Students can access all scheduled competencies and prerequisites by clicking on the title of the learning object they are currently viewing. Expanding a competency or prerequisite in the list reveals its associated learning objects, each indicating whether it has been completed.
 To navigate to a specific learning object, students can click on its title.
 Students can open the course competency graph for a broader view of how competencies and prerequisites are interconnected. This graph starts with competencies that have no prerequisites and progresses to those that build upon earlier knowledge. To aid navigation, a mini-map is available in the top-right corner.
 
-<Image src={studentsLearningPathGraphImg} alt={"students-learning-path-graph"} size={ImageSize.large}/>
+<Image src={studentsLearningPathGraphImg} alt={'students-learning-path-graph'} size={ImageSize.large} />
 
 ---
 
@@ -73,27 +73,30 @@ Students can open the course competency graph for a broader view of how competen
 **Learner Profiles** allow students to configure their personal learning preferences and motivations, making their experience in Artemis more tailored to their individual needs.
 Currently, there are three types of learner profiles available: **Feedback Learner Profile**, **Course Learner Profile**, and **Insights Learner Profile**.
 
+Each profile depends on the Artemis module that stores it, so students only see the profiles their instance supports. The Feedback and Course Learner Profiles require the Adaptive Learning module, and the Insights Learner Profile requires the Iris AI memory feature. When none of them is available, the **Learner Profile** entry does not appear in the user settings at all.
+
 ### Feedback Learner Profile
 
 The Feedback Learner Profile contains the student's feedback preferences. Students can adjust how they would like to receive feedback along predetermined dimensions. The automatically generated feedback from Athena will respect these preferences whenever a student selects "request AI feedback" after submitting a solution to an exercise.
 Currently, the available dimensions are:
-* Detail of the feedback
-* Formality of the feedback
+
+- Detail of the feedback
+- Formality of the feedback
 
 Students can choose between binary options for each dimension or leave the setting as neutral.
 When setting up the feedback preferences for the first time, students are guided by an onboarding wizard. This wizard presents examples from both ends of the spectrum for each dimension, helping students understand the impact of their choices.
 
 The setup screen welcomes students with a button that directs them to an onboarding wizard.
 
-<Image src={studentsFeedbackLearnerProfileInitialImg} alt={"students-feedback-learner-profile-initial-screen"} size={ImageSize.large}/>
+<Image src={studentsFeedbackLearnerProfileInitialImg} alt={'students-feedback-learner-profile-initial-screen'} size={ImageSize.large} />
 
 The onboarding wizard displays example feedback for each dimension and aligns students' expectations with what the system actually generates.
 
-<Image src={studentsFeedbackLearnerProfileOnboardingImg} alt={"students-feedback-learner-profile-onboarding"} size={ImageSize.large}/>
+<Image src={studentsFeedbackLearnerProfileOnboardingImg} alt={'students-feedback-learner-profile-onboarding'} size={ImageSize.large} />
 
 Once students have completed the onboarding wizard, they can see their feedback preferences in the setup screen and change them anytime. Students can redo the onboarding at any time as well.
 
-<Image src={studentsFeedbackLearnerProfileSetupImg} alt={"students-feedback-learner-profile-setup"} size={ImageSize.large}/>
+<Image src={studentsFeedbackLearnerProfileSetupImg} alt={'students-feedback-learner-profile-setup'} size={ImageSize.large} />
 
 ---
 
@@ -104,7 +107,7 @@ By indicating their goals and motivations, students enable Artemis to provide a 
 
 Students can modify their course learner profile at the bottom of the Learner Profile settings page.
 
-<Image src={studentsCourseLearnerProfileImg} alt={"students-course-learner-profile"} size={ImageSize.large}/>
+<Image src={studentsCourseLearnerProfileImg} alt={'students-course-learner-profile'} size={ImageSize.large} />
 
 ---
 

--- a/src/main/webapp/app/account/user/settings/learner-profile/learner-profile-availability.ts
+++ b/src/main/webapp/app/account/user/settings/learner-profile/learner-profile-availability.ts
@@ -1,0 +1,61 @@
+import { MODULE_FEATURE_ATLAS, MODULE_FEATURE_IRIS } from 'app/app.constants';
+import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
+
+/**
+ * The learner profile page composes sections served by two different modules, either of which may be disabled. These
+ * helpers are the single definition of when each section can load, so the tab, the route guard and the page itself
+ * cannot drift apart.
+ *
+ * The module lookups are deliberately separate from the predicates: a `computed()` may only read signals, so a
+ * component reads the module state once into a signal rather than calling the profile service from inside a computed,
+ * which would cache whatever the service happened to answer on the first evaluation.
+ */
+
+/**
+ * Whether the atlas module — which serves the feedback and the course section, through the server-side
+ * {@code LearnerProfileResource} and {@code CourseLearnerProfileResource} annotated with
+ * {@code @Conditional(AtlasEnabled.class)} — is active. With atlas disabled those requests answer 404.
+ *
+ * @param profileService the profile service holding the active module features
+ * @returns true if the atlas module is active
+ */
+export function isAtlasModuleActive(profileService: ProfileService): boolean {
+    return profileService.isModuleFeatureActive(MODULE_FEATURE_ATLAS);
+}
+
+/**
+ * Whether the iris module — which serves the insights section, through the server-side {@code IrisMemoryResource} —
+ * is active.
+ *
+ * @param profileService the profile service holding the active module features
+ * @returns true if the iris module is active
+ */
+export function isIrisModuleActive(profileService: ProfileService): boolean {
+    return profileService.isModuleFeatureActive(MODULE_FEATURE_IRIS);
+}
+
+/**
+ * Whether the insights section can load. {@code IrisMemoryResource} is annotated with both
+ * {@code @Conditional(IrisEnabled.class)} and {@code @FeatureToggle(Feature.Memiris)}, and
+ * {@code FeatureToggleService} seeds the Memiris toggle independently of the module, so an admin can switch the toggle
+ * on while iris is disabled. Both therefore have to hold.
+ *
+ * @param irisModuleActive whether the iris module is active
+ * @param memirisEnabled whether the Memiris feature toggle is active
+ * @returns true if the insights section can load
+ */
+export function insightsSectionAvailable(irisModuleActive: boolean, memirisEnabled: boolean): boolean {
+    return irisModuleActive && memirisEnabled;
+}
+
+/**
+ * Whether any section of the learner profile can load. When this is false the page would render empty, so the tab is
+ * hidden and the route redirects instead.
+ *
+ * @param profileService the profile service holding the active module features
+ * @param memirisEnabled whether the Memiris feature toggle is active
+ * @returns true if at least one section can load
+ */
+export function learnerProfileAvailable(profileService: ProfileService, memirisEnabled: boolean): boolean {
+    return isAtlasModuleActive(profileService) || insightsSectionAvailable(isIrisModuleActive(profileService), memirisEnabled);
+}

--- a/src/main/webapp/app/account/user/settings/learner-profile/learner-profile.component.html
+++ b/src/main/webapp/app/account/user/settings/learner-profile/learner-profile.component.html
@@ -1,9 +1,13 @@
-<jhi-feedback-learner-profile />
-<hr />
-@if (coursePanelEnabled()) {
-    <jhi-course-learner-profile />
+@if (atlasEnabled()) {
+    <jhi-feedback-learner-profile />
+    @if (coursePanelEnabled()) {
+        <hr />
+        <jhi-course-learner-profile />
+    }
 }
-<hr />
-@if (memirisEnabled()) {
+@if (insightsEnabled()) {
+    @if (atlasEnabled()) {
+        <hr />
+    }
     <jhi-insights-learner-profile />
 }

--- a/src/main/webapp/app/account/user/settings/learner-profile/learner-profile.component.spec.ts
+++ b/src/main/webapp/app/account/user/settings/learner-profile/learner-profile.component.spec.ts
@@ -6,15 +6,24 @@ import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.
 import { TranslateService } from '@ngx-translate/core';
 import { AlertService } from 'app/foundation/service/alert.service';
 import { MockAlertService } from 'test/helpers/mocks/service/mock-alert.service';
-import { provideHttpClient } from '@angular/common/http';
+import { HttpErrorResponse, provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { MockProvider } from 'ng-mocks';
 import { LearnerProfileApiService } from './learner-profile-api.service';
 import { CourseManagementService } from 'app/course/manage/services/course-management.service';
+import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
+import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
+import { FeatureToggle, FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
+import { MockFeatureToggleService } from 'test/helpers/mocks/service/mock-feature-toggle.service';
+import { MODULE_FEATURE_ATLAS, MODULE_FEATURE_IRIS } from 'app/app.constants';
+import { LearnerProfileDTO } from './dto/learner-profile-dto.model';
 
 describe('LearnerProfileComponent', () => {
     let component: LearnerProfileComponent;
     let fixture: ComponentFixture<LearnerProfileComponent>;
+    let profileService: ProfileService;
+    let featureToggleService: FeatureToggleService;
+    let learnerProfileApiService: LearnerProfileApiService;
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
@@ -23,6 +32,8 @@ describe('LearnerProfileComponent', () => {
                 SessionStorageService,
                 { provide: AlertService, useClass: MockAlertService },
                 { provide: TranslateService, useClass: MockTranslateService },
+                { provide: ProfileService, useClass: MockProfileService },
+                { provide: FeatureToggleService, useClass: MockFeatureToggleService },
                 MockProvider(LearnerProfileApiService),
                 MockProvider(CourseManagementService),
                 provideHttpClient(),
@@ -32,6 +43,9 @@ describe('LearnerProfileComponent', () => {
 
         fixture = TestBed.createComponent(LearnerProfileComponent);
         component = fixture.componentInstance;
+        profileService = TestBed.inject(ProfileService);
+        featureToggleService = TestBed.inject(FeatureToggleService);
+        learnerProfileApiService = TestBed.inject(LearnerProfileApiService);
         fixture.detectChanges();
     });
 
@@ -46,5 +60,99 @@ describe('LearnerProfileComponent', () => {
     it('should render the component', () => {
         const compiled = fixture.nativeElement;
         expect(compiled).toBeTruthy();
+    });
+
+    describe('module gating', () => {
+        /** Marks exactly the given module features active, so a test states the whole module configuration it means. */
+        const setActiveModules = (features: string[]) => vi.spyOn(profileService, 'isModuleFeatureActive').mockImplementation((feature) => features.includes(feature));
+
+        const render = async () => {
+            await component.ngOnInit();
+            fixture.detectChanges();
+        };
+
+        const query = (selector: string) => fixture.nativeElement.querySelector(selector);
+
+        /**
+         * Counts only the separators this template emits between its own sections. The section components render
+         * separators of their own, so a plain `hr` query would count those too.
+         */
+        const separatorCount = () => [...fixture.nativeElement.children].filter((element: Element) => element.tagName === 'HR').length;
+
+        it('should not request the learner profile nor render the atlas sections when the atlas module is inactive', async () => {
+            const getLearnerProfile = vi.spyOn(learnerProfileApiService, 'getLearnerProfileForCurrentUser');
+            setActiveModules([MODULE_FEATURE_IRIS]);
+
+            await render();
+
+            expect(component.atlasEnabled()).toBe(false);
+            // Both endpoints are @Conditional(AtlasEnabled) on the server, so any request would answer 404
+            expect(getLearnerProfile).not.toHaveBeenCalled();
+            expect(query('jhi-feedback-learner-profile')).toBeFalsy();
+            expect(query('jhi-course-learner-profile')).toBeFalsy();
+            // The iris-backed section still loads, which is what keeps the tab worth showing without atlas
+            expect(component.insightsEnabled()).toBe(true);
+            expect(query('jhi-insights-learner-profile')).toBeTruthy();
+            expect(separatorCount()).toBe(0);
+        });
+
+        it('should hide the insights section when the iris module is inactive despite the Memiris toggle being on', async () => {
+            setActiveModules([MODULE_FEATURE_ATLAS]);
+            vi.spyOn(learnerProfileApiService, 'getLearnerProfileForCurrentUser').mockResolvedValue(new LearnerProfileDTO({ id: 1 }));
+            vi.spyOn(learnerProfileApiService, 'getCourseLearnerProfilesForCurrentUser').mockResolvedValue([]);
+
+            await render();
+
+            // IrisMemoryResource needs @Conditional(IrisEnabled) as well as the toggle, and the toggle is seeded
+            // independently of the module, so the toggle alone must not open the section
+            expect(component.insightsEnabled()).toBe(false);
+            expect(query('jhi-insights-learner-profile')).toBeFalsy();
+            // feedback, separator, course
+            expect(separatorCount()).toBe(1);
+        });
+
+        it('should render no section at all when neither module backs one', async () => {
+            setActiveModules([]);
+            featureToggleService.setFeatureToggleState(FeatureToggle.Memiris, false);
+
+            await render();
+
+            expect(component.atlasEnabled()).toBe(false);
+            expect(component.insightsEnabled()).toBe(false);
+            expect(query('jhi-feedback-learner-profile')).toBeFalsy();
+            expect(query('jhi-course-learner-profile')).toBeFalsy();
+            expect(query('jhi-insights-learner-profile')).toBeFalsy();
+            expect(separatorCount()).toBe(0);
+        });
+
+        it('should request the learner profile and render every section when both modules are active', async () => {
+            const getLearnerProfile = vi.spyOn(learnerProfileApiService, 'getLearnerProfileForCurrentUser').mockResolvedValue(new LearnerProfileDTO({ id: 1 }));
+            vi.spyOn(learnerProfileApiService, 'getCourseLearnerProfilesForCurrentUser').mockResolvedValue([]);
+            setActiveModules([MODULE_FEATURE_ATLAS, MODULE_FEATURE_IRIS]);
+
+            await render();
+
+            expect(component.atlasEnabled()).toBe(true);
+            expect(component.coursePanelEnabled()).toBe(true);
+            expect(getLearnerProfile).toHaveBeenCalled();
+            expect(query('jhi-feedback-learner-profile')).toBeTruthy();
+            expect(query('jhi-course-learner-profile')).toBeTruthy();
+            expect(query('jhi-insights-learner-profile')).toBeTruthy();
+            // feedback, separator, course, separator, insights
+            expect(separatorCount()).toBe(2);
+        });
+
+        it('should report a failing atlas request as information and still open the course panel', async () => {
+            vi.spyOn(learnerProfileApiService, 'getLearnerProfileForCurrentUser').mockRejectedValue(new HttpErrorResponse({ status: 500, statusText: 'Internal Server Error' }));
+            vi.spyOn(learnerProfileApiService, 'getCourseLearnerProfilesForCurrentUser').mockResolvedValue([]);
+            setActiveModules([MODULE_FEATURE_ATLAS]);
+            const info = vi.spyOn(TestBed.inject(AlertService), 'info');
+
+            await render();
+
+            expect(info).toHaveBeenCalledWith('artemisApp.learnerProfile.loadFailed');
+            // A failed base request must not keep the course section from loading on its own
+            expect(component.coursePanelEnabled()).toBe(true);
+        });
     });
 });

--- a/src/main/webapp/app/account/user/settings/learner-profile/learner-profile.component.ts
+++ b/src/main/webapp/app/account/user/settings/learner-profile/learner-profile.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { CourseLearnerProfileComponent } from 'app/account/user/settings/learner-profile/course-learner-profile/course-learner-profile.component';
 import { FeedbackLearnerProfileComponent } from 'app/account/user/settings/learner-profile/feedback-learner-profile/feedback-learner-profile.component';
@@ -7,6 +7,8 @@ import { AlertService } from 'app/foundation/service/alert.service';
 import { captureException } from '@sentry/angular';
 import { FeatureToggle, FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
 import { InsightsLearnerProfileComponent } from 'app/account/user/settings/learner-profile/insights-learner-profile/insights-learner-profile.component';
+import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
+import { insightsSectionAvailable, isAtlasModuleActive, isIrisModuleActive } from 'app/account/user/settings/learner-profile/learner-profile-availability';
 
 @Component({
     selector: 'jhi-learner-profile',
@@ -18,12 +20,25 @@ export class LearnerProfileComponent implements OnInit {
     private readonly learnerProfileAPIService = inject(LearnerProfileApiService);
     private readonly alertService = inject(AlertService);
     private readonly featureToggleService = inject(FeatureToggleService);
+    private readonly profileService = inject(ProfileService);
+
+    // Each section is only rendered — and the atlas request only made — while the module behind it is active.
+    // Otherwise the requests answer 404 and the page reports the failures as errors. LearnerProfileGuard keeps the
+    // route reachable only while at least one section can render.
+    public readonly atlasEnabled = signal(false);
+    private readonly irisEnabled = signal(false);
+    private readonly memirisEnabled = toSignal(this.featureToggleService.getFeatureToggleActive(FeatureToggle.Memiris), { requireSync: true });
+    public readonly insightsEnabled = computed(() => insightsSectionAvailable(this.irisEnabled(), this.memirisEnabled()));
 
     // Gate rendering of course learner profiles until the base learner profile request has completed
     public readonly coursePanelEnabled = signal(false);
-    memirisEnabled = toSignal(this.featureToggleService.getFeatureToggleActive(FeatureToggle.Memiris), { requireSync: true });
 
     async ngOnInit(): Promise<void> {
+        this.atlasEnabled.set(isAtlasModuleActive(this.profileService));
+        this.irisEnabled.set(isIrisModuleActive(this.profileService));
+        if (!this.atlasEnabled()) {
+            return;
+        }
         try {
             await this.learnerProfileAPIService.getLearnerProfileForCurrentUser();
         } catch (error) {

--- a/src/main/webapp/app/account/user/settings/learner-profile/learner-profile.guard.spec.ts
+++ b/src/main/webapp/app/account/user/settings/learner-profile/learner-profile.guard.spec.ts
@@ -1,0 +1,107 @@
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
+import { Observable, firstValueFrom, isObservable, of } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MockRouter } from 'test/helpers/mocks/mock-router';
+import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
+import { MockProfileService } from 'test/helpers/mocks/service/mock-profile.service';
+import { MockFeatureToggleService } from 'test/helpers/mocks/service/mock-feature-toggle.service';
+import { MODULE_FEATURE_ATLAS, MODULE_FEATURE_IRIS } from 'app/app.constants';
+import { FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
+import { learnerProfileGuard } from 'app/account/user/settings/learner-profile/learner-profile.guard';
+
+describe('learnerProfileGuard', () => {
+    let profileService: ProfileService;
+    let featureToggleService: FeatureToggleService;
+    let router: MockRouter;
+
+    // The guard ignores its arguments, so empty snapshots are sufficient.
+    const route = {} as ActivatedRouteSnapshot;
+    const state = {} as RouterStateSnapshot;
+
+    beforeEach(() => {
+        router = new MockRouter();
+        TestBed.configureTestingModule({
+            providers: [
+                { provide: ProfileService, useClass: MockProfileService },
+                { provide: FeatureToggleService, useClass: MockFeatureToggleService },
+                { provide: Router, useValue: router },
+            ],
+        });
+        profileService = TestBed.inject(ProfileService);
+        featureToggleService = TestBed.inject(FeatureToggleService);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    /**
+     * Runs the guard and resolves its verdict, asserting on the way that it stays a single-value observable — the
+     * router only ever reads the first emission.
+     */
+    async function runGuard(): Promise<boolean | UrlTree> {
+        const result = TestBed.runInInjectionContext(() => learnerProfileGuard(route, state));
+        expect(isObservable(result)).toBe(true);
+        return await firstValueFrom(result as Observable<boolean | UrlTree>);
+    }
+
+    /** Marks exactly the given module features active, so a test states the whole module configuration it means. */
+    function setActiveModules(features: string[]): void {
+        vi.spyOn(profileService, 'isModuleFeatureActive').mockImplementation((feature) => features.includes(feature));
+    }
+
+    function setMemirisActive(active: boolean): void {
+        vi.spyOn(featureToggleService, 'getFeatureToggleActive').mockReturnValue(of(active));
+    }
+
+    function expectRedirectToUserSettings(result: boolean | UrlTree, redirect: UrlTree): void {
+        expect(router.createUrlTree).toHaveBeenCalledWith(['/user-settings']);
+        expect(result).toBe(redirect);
+    }
+
+    it('should allow activation when the atlas module is active', async () => {
+        setActiveModules([MODULE_FEATURE_ATLAS]);
+        setMemirisActive(false);
+
+        await expect(runGuard()).resolves.toBe(true);
+        expect(router.createUrlTree).not.toHaveBeenCalled();
+    });
+
+    it('should allow activation for the insights section when the iris module and Memiris are active', async () => {
+        setActiveModules([MODULE_FEATURE_IRIS]);
+        setMemirisActive(true);
+
+        await expect(runGuard()).resolves.toBe(true);
+        expect(router.createUrlTree).not.toHaveBeenCalled();
+    });
+
+    it('should redirect when Memiris is active but the iris module serving it is not', async () => {
+        // IrisMemoryResource is @Conditional(IrisEnabled) as well as @FeatureToggle(Memiris), and the toggle is
+        // seeded independently of the module, so the toggle alone must not open a page that would answer 404
+        setActiveModules([]);
+        setMemirisActive(true);
+        const redirect = new UrlTree();
+        router.createUrlTree.mockReturnValue(redirect);
+
+        expectRedirectToUserSettings(await runGuard(), redirect);
+    });
+
+    it('should redirect when the iris module is active but Memiris is off', async () => {
+        setActiveModules([MODULE_FEATURE_IRIS]);
+        setMemirisActive(false);
+        const redirect = new UrlTree();
+        router.createUrlTree.mockReturnValue(redirect);
+
+        expectRedirectToUserSettings(await runGuard(), redirect);
+    });
+
+    it('should redirect when no module backs any section of the page', async () => {
+        setActiveModules([]);
+        setMemirisActive(false);
+        const redirect = new UrlTree();
+        router.createUrlTree.mockReturnValue(redirect);
+
+        expectRedirectToUserSettings(await runGuard(), redirect);
+    });
+});

--- a/src/main/webapp/app/account/user/settings/learner-profile/learner-profile.guard.ts
+++ b/src/main/webapp/app/account/user/settings/learner-profile/learner-profile.guard.ts
@@ -1,0 +1,26 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+import { Observable, map, take } from 'rxjs';
+import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
+import { FeatureToggle, FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
+import { learnerProfileAvailable } from 'app/account/user/settings/learner-profile/learner-profile-availability';
+
+/**
+ * Guards the "/user-settings/profile" route. Every section of the learner profile is served by a module that can be
+ * disabled, and a disabled module means the section's requests answer 404 and the page reports the failures as errors.
+ * See {@link learnerProfileAvailable} for which module backs which section.
+ *
+ * The sidebar already hides the tab when no section can load; this guard additionally prevents direct navigation (e.g.
+ * via a bookmark or URL) from opening the empty page by redirecting back to the user-settings root.
+ *
+ * @returns true if at least one section of the learner profile can load, otherwise a redirect to the user-settings root
+ */
+export const learnerProfileGuard: CanActivateFn = (): Observable<boolean | UrlTree> => {
+    const profileService = inject(ProfileService);
+    const featureToggleService = inject(FeatureToggleService);
+    const router = inject(Router);
+    return featureToggleService.getFeatureToggleActive(FeatureToggle.Memiris).pipe(
+        take(1),
+        map((memirisEnabled) => (learnerProfileAvailable(profileService, memirisEnabled) ? true : router.createUrlTree(['/user-settings']))),
+    );
+};

--- a/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.html
+++ b/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.html
@@ -43,17 +43,19 @@
                         ></a>
                     </li>
                 }
-                <li tumUiListItem>
-                    <a
-                        tumUiListItemAction
-                        routerLink="profile"
-                        routerLinkActive
-                        #profileLink="routerLinkActive"
-                        [active]="profileLink.isActive"
-                        jhiTranslate="artemisApp.userSettings.learnerProfile"
-                    ></a>
-                </li>
-                @if (isScienceEnabled()) {
+                @if (isLearnerProfileEnabled()) {
+                    <li tumUiListItem>
+                        <a
+                            tumUiListItemAction
+                            routerLink="profile"
+                            routerLinkActive
+                            #profileLink="routerLinkActive"
+                            [active]="profileLink.isActive"
+                            jhiTranslate="artemisApp.userSettings.learnerProfile"
+                        ></a>
+                    </li>
+                }
+                @if (isAtlasEnabled()) {
                     <li tumUiListItem>
                         <a
                             tumUiListItemAction

--- a/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.spec.ts
+++ b/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.spec.ts
@@ -11,12 +11,15 @@ import { MockAccountService } from 'test/helpers/mocks/service/mock-account.serv
 import { MockActivatedRoute } from 'test/helpers/mocks/activated-route/mock-activated-route';
 import { UserSettingsContainerComponent } from 'app/account/user/settings/user-settings-container/user-settings-container.component';
 import { MODULE_FEATURE_ATHENA, MODULE_FEATURE_ATLAS, MODULE_FEATURE_IRIS } from 'app/app.constants';
+import { FeatureToggle, FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
+import { MockFeatureToggleService } from 'test/helpers/mocks/service/mock-feature-toggle.service';
 
 describe('UserSettingsContainerComponent', () => {
     let fixture: ComponentFixture<UserSettingsContainerComponent>;
     let component: UserSettingsContainerComponent;
 
     let translateService: TranslateService;
+    let featureToggleService: FeatureToggleService;
 
     const router = new MockRouter();
     router.setUrl('');
@@ -30,12 +33,14 @@ describe('UserSettingsContainerComponent', () => {
                 { provide: ActivatedRoute, useValue: new MockActivatedRoute() },
                 { provide: AccountService, useClass: MockAccountService },
                 { provide: ProfileService, useClass: MockProfileService },
+                { provide: FeatureToggleService, useClass: MockFeatureToggleService },
             ],
         }).compileComponents();
         fixture = TestBed.createComponent(UserSettingsContainerComponent);
         component = fixture.componentInstance;
         translateService = TestBed.inject(TranslateService);
         translateService.use('en');
+        featureToggleService = TestBed.inject(FeatureToggleService);
     });
 
     afterEach(() => {
@@ -63,17 +68,70 @@ describe('UserSettingsContainerComponent', () => {
         it('should hide the science tab when the atlas module is inactive (issue #13173)', () => {
             vi.spyOn(component['profileService'], 'isModuleFeatureActive').mockImplementation((feature) => feature !== MODULE_FEATURE_ATLAS);
             component.ngOnInit();
-            expect(component.isScienceEnabled()).toBe(false);
+            expect(component.isAtlasEnabled()).toBe(false);
             expect(queryScienceLink()).toBeFalsy();
         });
 
         it('should show the science tab when the atlas module is active', () => {
             vi.spyOn(component['profileService'], 'isModuleFeatureActive').mockImplementation((feature) => feature === MODULE_FEATURE_ATLAS);
             component.ngOnInit();
-            expect(component.isScienceEnabled()).toBe(true);
+            expect(component.isAtlasEnabled()).toBe(true);
             const scienceLink = queryScienceLink();
             expect(scienceLink).toBeTruthy();
             expect(scienceLink?.getAttribute('jhiTranslate')).toBe('artemisApp.userSettings.scienceSettings');
+        });
+    });
+
+    describe('learner profile tab visibility', () => {
+        const queryLearnerProfileLink = (): HTMLElement | null => {
+            fixture.detectChanges();
+            return fixture.nativeElement.querySelector('a[routerLink="profile"]');
+        };
+
+        /** Marks exactly the given module features active, so a test states the whole module configuration it means. */
+        const setActiveModules = (features: string[]) => {
+            vi.spyOn(component['profileService'], 'isModuleFeatureActive').mockImplementation((feature) => features.includes(feature));
+        };
+
+        it('should hide the learner profile tab when no module backs any of its sections', () => {
+            setActiveModules([]);
+            featureToggleService.setFeatureToggleState(FeatureToggle.Memiris, false);
+            component.ngOnInit();
+            expect(component.isLearnerProfileEnabled()).toBe(false);
+            expect(queryLearnerProfileLink()).toBeFalsy();
+        });
+
+        it('should show the learner profile tab when the atlas module is active', () => {
+            setActiveModules([MODULE_FEATURE_ATLAS]);
+            featureToggleService.setFeatureToggleState(FeatureToggle.Memiris, false);
+            component.ngOnInit();
+            expect(component.isLearnerProfileEnabled()).toBe(true);
+            const learnerProfileLink = queryLearnerProfileLink();
+            expect(learnerProfileLink).toBeTruthy();
+            expect(learnerProfileLink?.getAttribute('jhiTranslate')).toBe('artemisApp.userSettings.learnerProfile');
+        });
+
+        it('should show the learner profile tab for the insights section once Memiris is switched on', () => {
+            setActiveModules([MODULE_FEATURE_IRIS]);
+            featureToggleService.setFeatureToggleState(FeatureToggle.Memiris, false);
+            component.ngOnInit();
+            expect(component.isLearnerProfileEnabled()).toBe(false);
+            expect(queryLearnerProfileLink()).toBeFalsy();
+
+            featureToggleService.setFeatureToggleState(FeatureToggle.Memiris, true);
+
+            expect(component.isLearnerProfileEnabled()).toBe(true);
+            expect(queryLearnerProfileLink()).toBeTruthy();
+        });
+
+        it('should hide the learner profile tab when Memiris is on but the iris module serving it is not', () => {
+            // IrisMemoryResource is @Conditional(IrisEnabled) as well as @FeatureToggle(Memiris), and the toggle is
+            // seeded independently of the module, so the toggle alone must not show a tab that would answer 404
+            setActiveModules([]);
+            featureToggleService.setFeatureToggleState(FeatureToggle.Memiris, true);
+            component.ngOnInit();
+            expect(component.isLearnerProfileEnabled()).toBe(false);
+            expect(queryLearnerProfileLink()).toBeFalsy();
         });
     });
 

--- a/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.ts
+++ b/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { faUser } from '@fortawesome/free-solid-svg-icons';
-import { MODULE_FEATURE_ATLAS, MODULE_FEATURE_PASSKEY, addPublicFilePrefix } from 'app/app.constants';
+import { MODULE_FEATURE_PASSKEY, addPublicFilePrefix } from 'app/app.constants';
 import { User } from 'app/account/user/user.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
@@ -9,6 +10,8 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { tap } from 'rxjs';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { DataGuard } from 'app/account/user/settings/data-guard.service';
+import { FeatureToggle, FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
+import { insightsSectionAvailable, isAtlasModuleActive, isIrisModuleActive } from 'app/account/user/settings/learner-profile/learner-profile-availability';
 import { TumUiListComponent, TumUiListItemActionDirective, TumUiListItemDirective } from '@tumaet/ui-angular';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
 
@@ -27,6 +30,7 @@ export class UserSettingsContainerComponent implements OnInit {
     private readonly profileService = inject(ProfileService);
     private readonly accountService = inject(AccountService);
     private readonly dataGuard = inject(DataGuard);
+    private readonly featureToggleService = inject(FeatureToggleService);
 
     readonly currentUser = signal<User | undefined>(undefined);
 
@@ -36,11 +40,18 @@ export class UserSettingsContainerComponent implements OnInit {
     // The science settings live in the atlas module (server-side ScienceSettingsResource is @Conditional(AtlasEnabled)).
     // When atlas is disabled the science-settings endpoint does not exist, so the tab must be hidden instead of opening
     // an empty page (issue #13173).
-    readonly isScienceEnabled = signal(false);
+    readonly isAtlasEnabled = signal(false);
+    // The learner profile composes sections from the atlas and the iris module, so its tab needs at least one of them.
+    // The module state is read into signals in ngOnInit rather than from inside the computed, which may only read
+    // signals; insightsSectionAvailable is shared with the page and its route guard.
+    private readonly isIrisEnabled = signal(false);
+    private readonly isMemirisEnabled = toSignal(this.featureToggleService.getFeatureToggleActive(FeatureToggle.Memiris), { requireSync: true });
+    readonly isLearnerProfileEnabled = computed(() => this.isAtlasEnabled() || insightsSectionAvailable(this.isIrisEnabled(), this.isMemirisEnabled()));
 
     ngOnInit() {
         this.isPasskeyEnabled.set(this.profileService.isModuleFeatureActive(MODULE_FEATURE_PASSKEY));
-        this.isScienceEnabled.set(this.profileService.isModuleFeatureActive(MODULE_FEATURE_ATLAS));
+        this.isAtlasEnabled.set(isAtlasModuleActive(this.profileService));
+        this.isIrisEnabled.set(isIrisModuleActive(this.profileService));
 
         this.isAiEnabled.set(this.dataGuard.isUsingLLM());
         this.accountService

--- a/src/main/webapp/app/account/user/settings/user-settings.route.ts
+++ b/src/main/webapp/app/account/user/settings/user-settings.route.ts
@@ -3,6 +3,7 @@ import { Routes } from '@angular/router';
 import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
 import { IS_AT_LEAST_STUDENT, IS_AT_LEAST_TUTOR } from 'app/foundation/constants/authority.constants';
 import { DataGuard } from 'app/account/user/settings/data-guard.service';
+import { learnerProfileGuard } from 'app/account/user/settings/learner-profile/learner-profile.guard';
 import { scienceSettingsGuard } from 'app/account/user/settings/science-settings/science-settings.guard';
 
 export const routes: Routes = [
@@ -39,6 +40,7 @@ export const routes: Routes = [
                 data: {
                     pageTitle: 'artemisApp.userSettings.learnerProfile',
                 },
+                canActivate: [learnerProfileGuard],
             },
             {
                 path: 'science',


### PR DESCRIPTION
### Summary

On an Artemis instance without the Adaptive Learning (atlas) module, opening **User Settings → Learner Profile** raised a "Not Found" error and a "Learner profile could not be loaded" notice, and pressing "Set your feedback preferences" failed with a raw HTTP error. Every section of that page is now shown only when the module serving it is active, and the tab and its route disappear when no section is left — so the page can no longer report failures for endpoints the instance does not have.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

The learner profile page is a composite of three sections, and each one is served by a module an operator can switch off:

| Section | Server resource | Condition |
|---|---|---|
| Feedback Learner Profile | `LearnerProfileResource` | `@Conditional(AtlasEnabled.class)` |
| Course Learner Profile | `CourseLearnerProfileResource` | `@Conditional(AtlasEnabled.class)` |
| Insights Learner Profile | `IrisMemoryResource` | `@Conditional(IrisEnabled.class)` **and** `@FeatureToggle(Feature.Memiris)` |

The tab, the route and all three sections rendered unconditionally, so on an instance with atlas disabled the two atlas requests answered 404 and the page surfaced every failure: the global HTTP error alert ("Not Found"), its own informational alert ("Learner profile could not be loaded"), a `captureException` to Sentry, and — when the onboarding modal saved — the raw `Http failure response for http://localhost:9000/api/atlas/learner-profile: 404 Not Found`.

This is the same class of bug as #13173, which hid the science settings tab because `ScienceSettingsResource` is `@Conditional(AtlasEnabled.class)` too. The learner profile was never covered by that fix.

### Description

Each section is now gated on the module that serves it, and the tab and the route on whether any section is left:

- `LearnerProfileComponent` requests the base learner profile and renders the feedback and course sections only while atlas is active, so no atlas request is made otherwise.
- The insights section checks the **iris module as well as** the Memiris toggle. `FeatureToggleService.initFeatures()` seeds `Memiris` independently of the module, so an admin can switch the toggle on for an instance where `artemis.iris.enabled` is false — checking only the toggle would leave exactly the same 404 page reachable, one module over.
- `learnerProfileGuard` redirects `/user-settings/profile` to the user-settings root when nothing can load, so a bookmark or a typed URL cannot open an empty page. It mirrors `scienceSettingsGuard`.
- `learner-profile-availability.ts` holds the single definition of which module backs which section, shared by the page, the tab and the guard, so the three cannot drift apart.
- The separators between the sections were unconditional, so they dangled whenever a section was missing. They now belong to the section that follows them.

The module lookups are read into signals in `ngOnInit` rather than called from inside the `computed()` signals. A `computed()` may only read signals: calling `ProfileService` from inside one caches whatever it answered on the first evaluation, which made the rendered result depend on when the signal happened to be read first.

Verified on a locally running Artemis started with the atlas module disabled, which reproduces the reported configuration (`/management/info` returned `activeModuleFeatures: [exam, plagiarism, text, modeling, fileupload, lecture, tutorialgroup, passkey]` — no `atlas`):

- **User Settings** shows no "Learner Profile" entry and raises no alert.
- Navigating straight to `/user-settings/profile` lands on Account Information with zero alerts.
- Not a single request to `/api/atlas/*` was made during the whole session, so the 404s are gone rather than merely suppressed.

### Steps for Testing

Prerequisites:
- 1 Student
- An Artemis instance you can restart with the atlas module disabled (`artemis.atlas.enabled: false`)

1. Start Artemis with the atlas module disabled and log in as a student.
2. Open **User Settings**. There is no "Learner Profile" entry, and no error notification appears.
3. Navigate directly to `/user-settings/profile`. You are redirected to Account Information, again with no error notification.
4. Open the browser network tab and confirm that no request to `/api/atlas/learner-profile` or `/api/atlas/course-learner-profiles` is made.
5. As an admin, enable the **Memiris** feature toggle under Server Administration → Feature Toggles while iris is still disabled. The "Learner Profile" entry stays hidden, because the section behind it needs the iris module too.
6. Restart with both the atlas module and iris enabled, and enable Memiris. **User Settings → Learner Profile** shows the Feedback, Course and Insights sections with one separator between each, and setting feedback preferences works as before.
7. Restart with the atlas module enabled and Memiris off. The page shows only the Feedback and Course sections, with no separator dangling after them.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [x] Test with the atlas module disabled
- [x] Test with the atlas module enabled

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| learner-profile-availability.ts | 100.00% | 14 | ? | ? |
| learner-profile.component.ts | 100.00% | 43 | 27 | 62.8 |
| learner-profile.guard.ts | 100.00% | 15 | 7 | 46.7 |
| user-settings-container.component.ts | 100.00% | 53 | 26 | 49.1 |

_Last updated: 2026-09-06 13:58:15 UTC_


### Screenshots

Screenshots of User Settings with the atlas module disabled are attached to this PR. The "Learner Profile" entry is gone and no alert is raised; before the fix the same page opened with a red "Not Found" alert and a "Learner profile could not be loaded" notice next to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Learner Profile availability now adapts to enabled learning modules and Insights settings.
  - Added access protection that redirects users when no supported profile is available.
  - Learner Profile navigation and sections are shown only when applicable.
  - Updated documentation with learner-profile availability guidance and learning-path visuals.

- **Bug Fixes**
  - Prevented unnecessary profile requests when the required module is unavailable.
  - Improved handling of unavailable or failed profile requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->