### PR TITLE
`General`: Refresh the settings sidebar picture without a reload

### DIFF
--- a/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.spec.ts
+++ b/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.spec.ts
@@ -13,6 +13,8 @@ import { UserSettingsContainerComponent } from 'app/account/user/settings/user-s
 import { MODULE_FEATURE_ATHENA, MODULE_FEATURE_ATLAS, MODULE_FEATURE_IRIS } from 'app/app.constants';
 import { FeatureToggle, FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
 import { MockFeatureToggleService } from 'test/helpers/mocks/service/mock-feature-toggle.service';
+import { User } from 'app/account/user/user.model';
+import { deepClone } from 'app/foundation/util/deep-clone.util';
 
 describe('UserSettingsContainerComponent', () => {
     let fixture: ComponentFixture<UserSettingsContainerComponent>;
@@ -20,6 +22,7 @@ describe('UserSettingsContainerComponent', () => {
 
     let translateService: TranslateService;
     let featureToggleService: FeatureToggleService;
+    let accountService: AccountService;
 
     const router = new MockRouter();
     router.setUrl('');
@@ -41,6 +44,9 @@ describe('UserSettingsContainerComponent', () => {
         translateService = TestBed.inject(TranslateService);
         translateService.use('en');
         featureToggleService = TestBed.inject(FeatureToggleService);
+        accountService = TestBed.inject(AccountService);
+        // The sidebar reads the identity signal, so the logged-in user has to be on it.
+        accountService.userIdentity.set({ id: 99, login: 'admin', imageUrl: 'profile-pictures/first.png' } as User);
     });
 
     afterEach(() => {
@@ -51,6 +57,37 @@ describe('UserSettingsContainerComponent', () => {
         component.ngOnInit();
         expect(component.currentUser()).toBeDefined();
         expect(component.isAtLeastTutor()).toBe(true);
+    });
+
+    it('follows the profile picture when it changes while the user stays logged in', () => {
+        component.ngOnInit();
+        expect(component.currentUser()?.imageUrl).toBe('profile-pictures/first.png');
+
+        // What AccountService.setImageUrl does: replace the identity, without a log-in or log-out. The
+        // sidebar used to snapshot the authentication state observable, which does not emit here, so the
+        // old picture stayed on screen until the next full page load.
+        accountService.userIdentity.update((user) => {
+            const updated = deepClone(user!);
+            updated.imageUrl = 'profile-pictures/second.png';
+            return updated;
+        });
+
+        expect(component.currentUser()?.imageUrl).toBe('profile-pictures/second.png');
+    });
+
+    it('follows the profile picture being removed', () => {
+        component.ngOnInit();
+        // Asserting the picture is there first is what makes this a guard: without it the expectation
+        // below also holds for an identity that never had one.
+        expect(component.currentUser()?.imageUrl).toBe('profile-pictures/first.png');
+
+        accountService.userIdentity.update((user) => {
+            const updated = deepClone(user!);
+            updated.imageUrl = undefined;
+            return updated;
+        });
+
+        expect(component.currentUser()?.imageUrl).toBeUndefined();
     });
 
     it('should set isPasskeyEnabled to false when the module feature is inactive', () => {

--- a/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.ts
+++ b/src/main/webapp/app/account/user/settings/user-settings-container/user-settings-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { Component, OnInit, Signal, computed, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { faUser } from '@fortawesome/free-solid-svg-icons';
 import { MODULE_FEATURE_PASSKEY, addPublicFilePrefix } from 'app/app.constants';
@@ -7,7 +7,6 @@ import { AccountService } from 'app/core/auth/account.service';
 import { TranslateDirective } from 'app/foundation/language/translate.directive';
 import { RouterModule } from '@angular/router';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { tap } from 'rxjs';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import { DataGuard } from 'app/account/user/settings/data-guard.service';
 import { FeatureToggle, FeatureToggleService } from 'app/foundation/feature-toggle/feature-toggle.service';
@@ -32,10 +31,17 @@ export class UserSettingsContainerComponent implements OnInit {
     private readonly dataGuard = inject(DataGuard);
     private readonly featureToggleService = inject(FeatureToggleService);
 
-    readonly currentUser = signal<User | undefined>(undefined);
+    // Read straight from the account service's signal instead of taking a snapshot from the
+    // authentication state observable: that is a BehaviorSubject driven by the log-in / log-out effect, so
+    // it does not emit when the identity changes while the user stays logged in. Uploading or deleting a
+    // profile picture goes through AccountService.setImageUrl, which replaces userIdentity, so a snapshot
+    // taken here went stale and the sidebar kept the previous picture until the next full page load.
+    readonly currentUser: Signal<User | undefined> = this.accountService.userIdentity;
 
     readonly isPasskeyEnabled = signal(false);
-    readonly isAtLeastTutor = signal(false);
+    // Derived for the same reason: isAtLeastTutor reads userIdentity, so the computed re-evaluates
+    // whenever the identity changes.
+    readonly isAtLeastTutor = computed(() => this.accountService.isAtLeastTutor());
     readonly isAiEnabled = signal(false);
     // The science settings live in the atlas module (server-side ScienceSettingsResource is @Conditional(AtlasEnabled)).
     // When atlas is disabled the science-settings endpoint does not exist, so the tab must be hidden instead of opening
@@ -54,15 +60,6 @@ export class UserSettingsContainerComponent implements OnInit {
         this.isIrisEnabled.set(isIrisModuleActive(this.profileService));
 
         this.isAiEnabled.set(this.dataGuard.isUsingLLM());
-        this.accountService
-            .getAuthenticationState()
-            .pipe(
-                tap((user: User | undefined) => {
-                    this.currentUser.set(user);
-                    this.isAtLeastTutor.set(this.accountService.isAtLeastTutor());
-                }),
-            )
-            .subscribe();
     }
 
     protected readonly addPublicFilePrefix = addPublicFilePrefix;


### PR DESCRIPTION
### Summary

The profile picture in the user settings sidebar did not follow a change made on the account page right next to it. After uploading, replacing or deleting a picture, the sidebar kept showing the previous one — or the placeholder icon — until the next full page load, while the account page and the navbar updated immediately.

`UserSettingsContainerComponent` took a one-time snapshot of the user from `AccountService.getAuthenticationState()`. That observable is a `BehaviorSubject` fed by the log-in / log-out effect, so it does not emit while the user stays logged in. Changing a picture goes through `AccountService.setImageUrl`, which replaces the `userIdentity` signal without touching the logged-in state, so the snapshot went stale.

The sidebar now reads the identity signal directly and derives the tutor flag from it, so it follows every identity change. The subscription is gone with it.

The observable is still the right tool where the point is to react to a log-in or log-out; it is only wrong for rendering identity fields that change during a session.

### Motivation and Context

Found while manually testing #13699 on a local stack. It is not caused by that PR — the container is untouched by it — so it is fixed separately here.

### Steps for Testing

Prerequisites:
- 1 User (any role)

1. Log in to Artemis
2. Navigate to *User Settings → Account Information*
3. Note the placeholder icon at the top left of the sidebar
4. Add a profile picture and crop it
5. The sidebar picture updates immediately, **without reloading the page**
6. Delete the picture again — the sidebar falls back to the placeholder immediately
7. Reload the page and confirm the picture state is unchanged

### Testserver States

Tested locally against a full stack (Postgres, server, client).

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [x] Test 1
- [x] Test 2

### Client

- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| user-settings-container.component.ts | 100.00% | 43 | 30 | 69.8 |

_Last updated: 2026-09-06 22:47:02 UTC_

