### PR TITLE
`Development`: Flush feature usage every ten seconds in multi-node e2e

### DIFF
--- a/run-e2e-tests-local-multinode-fast.sh
+++ b/run-e2e-tests-local-multinode-fast.sh
@@ -551,6 +551,11 @@ launch_node() {
         export ARTEMIS_SUBMISSIONEXPORTPATH="$ARTEMIS_DATA_DIR/exports"
         export ARTEMIS_LEGALPATH="$ARTEMIS_DATA_DIR/legal"
         export ARTEMIS_BUILDLOGSPATH="$ARTEMIS_DATA_DIR/build-logs"
+        # Feature usage flushes every five minutes in production, and FeatureUsage.spec.ts and
+        # FeatureUsageGit.spec.ts assert that a counter reaches the database within the test window.
+        # Matches run-e2e-tests-local-fast.sh and docker/artemis/config/playwright.env, which the
+        # containerised stacks read instead. Without it both specs fail here and pass everywhere else.
+        export ARTEMIS_FEATURE_USAGE_FLUSH_INTERVAL="10s"
         export ARTEMIS_VERSIONCONTROL_LOCALVCSREPOPATH="$ARTEMIS_DATA_DIR/local-vcs-repos"
 
         # Run the JVM in UTC to match production servers (which run UTC) and the app's own

--- a/run-e2e-tests-local-multinode-fast.sh
+++ b/run-e2e-tests-local-multinode-fast.sh
@@ -288,6 +288,11 @@ fi
 
 if [ "$REUSE_RUNNING_NODES" = true ]; then
     echo -e "${GREEN}All three nodes answer /management/health/readiness — keeping the running stack (--skip-up).${NC}"
+    # A running JVM keeps the configuration it started with, so the flush interval set in launch_node
+    # cannot reach a node that is being reused. A node this script started already has it; one left
+    # over from before this setting existed, or started another way, still flushes every five minutes
+    # and will fail the two feature usage specs. Relaunch (--stop, or drop --skip-up) if they fail here.
+    echo -e "${YELLOW}Reused nodes keep their original feature usage flush interval; relaunch if FeatureUsage specs fail.${NC}"
 else
     for port in "${ALL_PORTS[@]}"; do
         check_port_available "$port" "Artemis host JVM"


### PR DESCRIPTION
### Summary

Two feature usage end-to-end tests fail for everyone who runs the fast multi-node script, and pass on every other stack. The script never shortens the feature usage flush interval, so its nodes keep the production default of five minutes. One line brings it in line with the two runners that already do this.

### Checklist
#### General
<!-- Items that do not apply to this pull request have been removed. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

### Motivation and Context

`FeatureUsage.spec.ts` and `FeatureUsageGit.spec.ts` assert that a usage counter actually reaches the database while the test is watching. That is the point of those tests: a counter that only lives in memory would let the analysis page look healthy while recording nothing.

`FeatureUsageFlushService` writes each node's accumulated counters on a schedule:

```java
@Scheduled(fixedRateString = "${artemis.feature-usage.flush-interval:5m}",
           initialDelayString = "${artemis.feature-usage.flush-interval:5m}")
```

Five minutes, after an initial five minute delay. The other two ways of running these tests already override it to ten seconds — `run-e2e-tests-local-fast.sh` for the single-node stack, and `docker/artemis/config/playwright.env` for the containerised stacks and CI. Only `run-e2e-tests-local-multinode-fast.sh` was missing it, so its nodes ran with the production interval and the counter could not arrive inside the test window.

This is why the two specs are green in CI and red on a developer machine running the fast multi-node script. Anyone using that script to check a change hits two failures that have nothing to do with what they changed, which is the kind of noise that teaches people to ignore the runner.

### Description

One `export` in `launch_node`, next to the other `ARTEMIS_*` values each node JVM receives, with a comment naming the two files it mirrors so the three stay together.

`FeatureUsageFlushService` is `@Profile(PROFILE_CORE)`, so only core-profile nodes run the flush; setting the variable for every node is harmless and matches how the other two runners set it globally rather than per node.

### Steps for Testing

Prerequisites:
- Docker running
- No Artemis stack currently up

1. Check out `develop` and run `./run-e2e-tests-local-multinode-fast.sh --specs "e2e/admin/FeatureUsage.spec.ts e2e/admin/FeatureUsageGit.spec.ts"`. Both `Records the calls of a request that just happened` and `Counts a clone and a push of an assignment repository` fail, twice each, one on `expect(received).toBeGreaterThan(expected)` with `Received: 0` and the other on `toBeTruthy()` with `Received: false`.
2. Check out this branch and run the same command. Both pass.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] The two specs fail on develop and pass on this branch, using the fast multi-node runner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved local multi-node end-to-end test reliability by ensuring feature-usage data is flushed during the test window.
  - Aligned local test behavior with containerized test environments for more consistent results.
  - Added a warning when reusing running nodes, since their existing flush settings may cause FeatureUsage tests to fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->