### PR TITLE
`Plagiarism checks`: Fix the cut-off label in the continuous plagiarism control settings

### DIFF
--- a/src/main/webapp/app/plagiarism/manage/exercise-update-plagiarism/exercise-update-plagiarism.component.scss
+++ b/src/main/webapp/app/plagiarism/manage/exercise-update-plagiarism/exercise-update-plagiarism.component.scss
@@ -1,9 +1,7 @@
 .label-row {
     display: inline-flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 0.4rem;
-    white-space: nowrap;
-    overflow: hidden;
     margin-bottom: 0.5rem;
     min-width: 0;
 }
@@ -11,9 +9,6 @@
 .label-row .form-control-label {
     flex: 1 1 0;
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     line-height: 1.1;
 }
 
@@ -32,6 +27,7 @@
 
 .form-group.d-flex .form-control {
     min-height: 42px;
+    margin-top: auto;
 }
 
 .form-control.mt-auto {


### PR DESCRIPTION
### Summary

The "Significant similarity response period in days" label in the Continuous Plagiarism Control settings was cut off with an ellipsis and could not be read in full. Labels in that panel now wrap onto a second line instead of being truncated, while the four input fields stay aligned on one baseline.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes #12453.

The labels in the Continuous Plagiarism Control panel were forced onto a single line and clipped with an ellipsis:

```scss
.label-row .form-control-label {
    overflow: hidden;
    text-overflow: ellipsis;
    white-space: nowrap;
}
```

Three of the four labels are short enough to fit, so only the longest one visibly broke. In the narrow `col-xl-3` column it needs 294px but has 227px available, so instructors saw "Significant similarity response p…" and could not tell which unit the field expects. The German translations are longer still, so there the truncation is worse.

The truncation was presumably there to keep the four inputs on one baseline: without it, a wrapped label makes its column taller and its input drops below the others.

### Description

Only `exercise-update-plagiarism.component.scss` changed. No HTML and no TypeScript.

- Removed `white-space: nowrap`, `overflow: hidden` and `text-overflow: ellipsis` from `.label-row` and `.label-row .form-control-label`, so long labels wrap instead of being cut off.
- Changed `.label-row` from `align-items: center` to `align-items: flex-start`, so the tooltip icon lines up with the first line of a wrapped label.
- Added `margin-top: auto` to `.form-group.d-flex .form-control`. The container is already `d-flex flex-column h-100`, so this pushes every input to the bottom of its column and keeps the four inputs aligned once a label wraps.

No colors, strings or translations were touched.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Course

1. Log in as the instructor and switch to the management view.
2. Navigate to a course > Exercises > Create a new **text exercise** (the component is also embedded in the programming exercise form; both are worth checking).
3. Scroll to the **Continuous Plagiarism Control** panel and click "Show Continuous Plagiarism Control".
4. Confirm that all four labels are fully readable, in particular "Significant similarity response period in days", which previously ended in an ellipsis.
5. Confirm that the four input fields are still aligned on the same baseline, even though the last label now wraps onto two lines.
6. Resize the browser window and confirm nothing is cut off at any width.
7. Switch the language to German and repeat steps 4 and 5. The German labels are longer and were previously truncated as well.
8. Switch between the light and the dark theme and confirm the panel looks unchanged apart from the wrapping.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-07 14:32:02 UTC_


### Screenshots
<img width="1114" height="632" alt="image" src="https://github.com/user-attachments/assets/e9e42518-f11c-4f89-b0a7-2a774d094d02" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved plagiarism exercise form layout by allowing labels to wrap naturally and aligning them to the top.
  * Adjusted form controls for improved vertical alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->