### PR TITLE
`Programming exercises`: Reject scientific notation in the points input fields  

### DIFF
--- a/src/main/webapp/app/foundation/validators/custom-no-scientific-notation-validator.directive.spec.ts
+++ b/src/main/webapp/app/foundation/validators/custom-no-scientific-notation-validator.directive.spec.ts
@@ -1,0 +1,66 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { CustomNoScientificNotationValidatorDirective } from './custom-no-scientific-notation-validator.directive';
+
+@Component({
+    standalone: true,
+    template:
+        '<form name="editForm" #editForm="ngForm">' +
+        '<input type="number" name="bonusPoints" noScientificNotation #bonusPointsModel="ngModel" [(ngModel)]="bonusPoints"/>' +
+        '</form>',
+    imports: [FormsModule, CustomNoScientificNotationValidatorDirective],
+})
+class NoScientificNotationComponent {
+    bonusPoints?: number;
+}
+
+describe('CustomNoScientificNotationValidatorDirective', () => {
+    let fixture: ComponentFixture<NoScientificNotationComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [CommonModule, FormsModule],
+        }).compileComponents();
+        fixture = TestBed.createComponent(NoScientificNotationComponent);
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+    });
+
+    const typeIntoInput = async (value: string) => {
+        const input = fixture.debugElement.query(By.css('input[name=bonusPoints]'));
+        input.nativeElement.value = value;
+        input.nativeElement.dispatchEvent(new Event('input'));
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        return input.references['bonusPointsModel'];
+    };
+
+    it.each(['0', '0.1', '0.111', '0.001', '10.5', '9999'])('should accept the decimal value %s', async (value) => {
+        const model = await typeIntoInput(value);
+
+        expect(model.errors).toBeNull();
+    });
+
+    it.each(['1e-3', '1e-30', '1e3', '1E3'])('should set an error for the scientific notation value %s', async (value) => {
+        const model = await typeIntoInput(value);
+
+        expect(model.errors.scientificNotation).toBe(true);
+    });
+
+    it('should clear the error once the value is rewritten without scientific notation', async () => {
+        expect((await typeIntoInput('1e-3')).errors.scientificNotation).toBe(true);
+
+        const model = await typeIntoInput('0.001');
+
+        expect(model.errors).toBeNull();
+    });
+});

--- a/src/main/webapp/app/foundation/validators/custom-no-scientific-notation-validator.directive.ts
+++ b/src/main/webapp/app/foundation/validators/custom-no-scientific-notation-validator.directive.ts
@@ -1,0 +1,24 @@
+import { Directive, ElementRef, inject } from '@angular/core';
+import { NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+
+/**
+ * Custom validator that rejects numbers written in scientific notation, e.g. 1e-3
+ *
+ * Adds the 'scientificNotation' error key (= true) to the control. The raw text of the input element is checked instead of the
+ * control value, because a number input has already parsed 1e-3 into 0.001 by the time the control value is set.
+ */
+@Directive({
+    selector: 'input[type=number][noScientificNotation][ngModel],input[type=number][noScientificNotation][formControl]',
+    providers: [{ provide: NG_VALIDATORS, useExisting: CustomNoScientificNotationValidatorDirective, multi: true }],
+})
+export class CustomNoScientificNotationValidatorDirective implements Validator {
+    private readonly elementRef = inject<ElementRef<HTMLInputElement>>(ElementRef);
+
+    validate(): ValidationErrors | null {
+        if (/e/i.test(this.elementRef.nativeElement.value)) {
+            return { scientificNotation: true };
+        }
+
+        return null;
+    }
+}

--- a/src/main/webapp/app/programming/manage/update/update-components/grading/programming-exercise-grading.component.html
+++ b/src/main/webapp/app/programming/manage/update/update-components/grading/programming-exercise-grading.component.html
@@ -24,6 +24,7 @@
                         class="form-control"
                         [min]="programmingExercise().includedInOverallScore === IncludedInOverallScore.NOT_INCLUDED ? 0 : 1"
                         max="9999"
+                        noScientificNotation
                         name="points"
                         id="field_points"
                         [(ngModel)]="programmingExercise().maxPoints"
@@ -45,6 +46,7 @@
                         class="form-control"
                         min="0"
                         max="9999"
+                        noScientificNotation
                         name="bonusPoints"
                         id="field_bonusPoints"
                         [(ngModel)]="programmingExercise().bonusPoints"

--- a/src/main/webapp/app/programming/manage/update/update-components/grading/programming-exercise-grading.component.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/grading/programming-exercise-grading.component.ts
@@ -21,6 +21,7 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { KeyValuePipe } from '@angular/common';
 import { ArtemisTranslatePipe } from 'app/foundation/pipes/artemis-translate.pipe';
 import { Message } from 'primeng/message';
+import { CustomNoScientificNotationValidatorDirective } from 'app/foundation/validators/custom-no-scientific-notation-validator.directive';
 
 @Component({
     selector: 'jhi-programming-exercise-grading',
@@ -39,6 +40,7 @@ import { Message } from 'primeng/message';
         KeyValuePipe,
         ArtemisTranslatePipe,
         Message,
+        CustomNoScientificNotationValidatorDirective,
     ],
 })
 export class ProgrammingExerciseGradingComponent implements AfterViewInit, OnDestroy {


### PR DESCRIPTION
### Summary

The points and bonus points fields of the programming exercise form accepted values written in scientific notation, so `1e-3` was silently stored as `0.001` bonus points. Both fields now reject scientific notation, while plain decimal values such as `0.111` and `10.5` and the existing value ranges stay exactly as they are.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Closes #12451.

Typing `1e-3` into **Bonus Points** produced no validation error at all, and the exercise was saved with `0.001` bonus points. The two fields differ only in their lower bound:

| | min | max |
|---|---|---|
| Points | `1` (`0` when not included in the score) | `9999` |
| Bonus Points | `0` | `9999` |

`1e-3` parses to `0.001`. That is below the points minimum of `1`, so **Points** rejected it, but it is above the bonus points minimum of `0`, so **Bonus Points** accepted it. Points was therefore never really validating the notation; it only happened to catch this value through its range. Entering `1e3` into Points produced `1000` and was accepted without complaint.

The browser does flag both cases (`stepMismatch` is `true` for a fractional value against the default step of `1`), but Angular has no step validator, so nothing surfaced it.

This cannot be fixed with the `pattern` attribute the way `maxPenalty` uses it in the same template. Angular's pattern validator runs against the parsed control value, and by then `1e-3` is already the number `0.001`, which stringifies to `"0.001"` and passes any decimal pattern. The notation only survives in the raw text of the input element.

For the same reason the rule cannot be enforced on the server: JSON does not distinguish `1e-3` from `0.001`, both are the same number token, and Jackson parses both to `Double` `0.001`.

### Description

- **New** `custom-no-scientific-notation-validator.directive.ts` in `app/foundation/validators/`, following the conventions of the existing validators in that folder (attribute selector, `NG_VALIDATORS` provider, JSDoc). It injects `ElementRef` and inspects the raw text of the input element, adding a `scientificNotation` error when it contains `e` or `E`.
- **New** `custom-no-scientific-notation-validator.directive.spec.ts` with 11 tests.
- Applied the `noScientificNotation` attribute to both the points and the bonus points input in `programming-exercise-grading.component.html`.
- Registered the directive in the `imports` array of the standalone `ProgrammingExerciseGradingComponent`.

The `min`, `max` and `required` bindings and both error messages are unchanged, so the accepted value ranges are exactly as before. Decimal precision is unaffected: `1.11111` and `0.111` remain valid.

Behaviour after the change, verified in the running client:

| entered | Points | Bonus Points |
|---|---|---|
| `0` | invalid (below its minimum of 1) | valid |
| `0.1`, `0.111`, `0.001`, `0.5` | invalid (below its minimum of 1) | valid |
| `1`, `1.1`, `1.11111`, `10.5`, `9999` | valid | valid |
| `1e-3`, `1e-30`, `1e3`, `1E3` | **invalid** | **invalid** |
| `10000` | invalid | invalid |

Note that `1e3` and `1E3` were accepted by Points before this change and are now rejected, which is the intended tightening.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Course

1. Log in as the instructor and switch to the management view.
2. Navigate to a course > Exercises > Create a new programming exercise and scroll to the **Grading** section.
3. In **Bonus Points**, enter `1e-3`. Confirm the field is marked invalid and shows "Must be a number between 0 and 9999." Before this change it was silently accepted.
4. Repeat with `1e-30`, `1e3` and `1E3` and confirm each is rejected.
5. Enter `0`, then `0.5`, then `0.111`, then `10.5`. Confirm each is accepted, so ordinary decimal values still work.
6. In **Points**, enter `1e3`. Confirm it is now rejected. Then enter `1.11111` and `9999` and confirm both are accepted.
7. Retype a rejected value in plain notation, for example replace `1e-3` with `0.001` in Bonus Points, and confirm the error disappears. Both are the same number, so this checks that the validation follows what was typed.
8. Save the exercise with valid values and confirm it is created correctly.
9. Edit an existing programming exercise and repeat steps 3 to 6 to confirm the edit form behaves the same.

#### Exam Mode Testing

Prerequisites:
- 1 Instructor
- 1 Exam

1. Log in as the instructor and navigate to a course > Exams > an exam > Exercise Groups.
2. Create or edit a programming exercise inside an exercise group. The same grading component is used there.
3. Repeat steps 3 to 6 above and confirm the validation behaves identically.
4. Confirm that saving an exam programming exercise with valid points and bonus points still works.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| custom-no-scientific-notation-validator.directive.ts | 100.00% | 15 | 4 | 26.7 |
| programming-exercise-grading.component.ts | 97.56% | 177 | 25 | 14.1 |

_Last updated: 2026-09-07 14:48:05 UTC_


### Screenshots
Before 

<img width="1118" height="572" alt="image" src="https://github.com/user-attachments/assets/72da7cf8-3a55-43af-a8fc-554b2bf554ca" />

After
<img width="1094" height="606" alt="image" src="https://github.com/user-attachments/assets/87dec5ed-ebfe-49d9-8d53-eef0e8ee2cd8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Number fields for exercise points and bonus points now reject values entered in scientific notation.
  * Clear validation feedback is provided when scientific notation is used.

* **Bug Fixes**
  * Prevented scientific-notation input from being silently converted into decimal values, ensuring entered values are validated as displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->