### PR TITLE
`Development`: Pass locale in the git integration test

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseGitIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/ProgrammingExerciseGitIntegrationTest.java
@@ -188,7 +188,7 @@ class ProgrammingExerciseGitIntegrationTest extends AbstractProgrammingIntegrati
     @WithMockUser(username = TEST_PREFIX + "student1", roles = { "USER", "STUDENT" })
     void testCommitAndPushWithUserWithoutName() throws Exception {
         var projectKey = "PROGEXGITNONAME";
-        var repoSlug = projectKey.toLowerCase() + "-student";
+        var repoSlug = projectKey.toLowerCase(Locale.ROOT) + "-student";
         LocalVCTestRepository remoteRepo = RepositoryExportTestUtil.trackRepository(localVCLocalCITestService.createRepositoryWithWorkingCopy(projectKey, repoSlug));
         FileUtils.writeStringToFile(remoteRepo.workingCopyPath().resolve("README.md").toFile(), "Initial commit", StandardCharsets.UTF_8);
         remoteRepo.workingCopy().add().addFilepattern(".").call();


### PR DESCRIPTION
### Summary
develop is red since #13697 merged: `ArchitectureTest.testNoLocaleLessCaseConversion` fails in `Quality / Server Code Style` and `Test / Server Tests (Remaining)`. This PR replaces the one remaining bare `toLowerCase()` in test code with `toLowerCase(Locale.ROOT)`.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).

#### Client
Not applicable, no client changes.

#### Changes affecting Programming Exercises
Not applicable, only a test constant changes.

### Motivation and Context
#13692 added an ArchUnit rule that forbids locale-less `String.toLowerCase()` / `toUpperCase()`. #13697 was reviewed before that rule existed and merged shortly after it without a rebase. Its regression test `ProgrammingExerciseGitIntegrationTest.testCommitAndPushWithUserWithoutName` calls `projectKey.toLowerCase()`, which is now the only violation in the codebase, so every develop CI run fails on that one test.

### Description
Pass `Locale.ROOT`, as the sibling tests in the same class already do. One line, test code only.

### Steps for Testing
No user-facing change. Verify that the architecture tests pass:

```
./gradlew test -DincludeTags="ArchitectureTest"
```

Passes locally on this branch; fails on develop at e49602ffe2.

#### Exam Mode Testing
Not applicable, no production code changes.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-07 16:29:25 UTC_


### Screenshots
Not applicable, no UI changes.
