### PR TITLE
`Development`: Recover from a route whose lazy chunk fails to load

### DIFF
--- a/src/main/webapp/app/app.component.spec.ts
+++ b/src/main/webapp/app/app.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { By } from '@angular/platform-browser';
 import { NgClass, NgStyle } from '@angular/common';
-import { RouterModule, RouterOutlet } from '@angular/router';
+import { Router, RouterModule, RouterOutlet } from '@angular/router';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { of } from 'rxjs';
 import { MockComponent } from 'ng-mocks';
@@ -14,6 +14,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { ThemeService } from 'app/core/theme/shared/theme.service';
 import { AlertOverlayComponent } from 'app/core/alert/alert-overlay.component';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
+import { LazyRouteRecoveryService } from 'app/core/navigation/lazy-route-recovery.service';
 import { PageRibbonComponent } from 'app/core/layouts/profiles/page-ribbon.component';
 import { FooterComponent } from 'app/core/layouts/footer/footer.component';
 import { CourseNotificationPopupOverlayComponent } from 'app/notification/course-notification/course-notification-popup-overlay/course-notification-popup-overlay.component';
@@ -36,10 +37,20 @@ class MockThemeService {
 describe('AppComponent', () => {
     let fixture: ComponentFixture<AppComponent>;
     let comp: AppComponent;
+    let handleNavigationError: ReturnType<typeof vi.fn>;
 
     beforeEach(async () => {
+        handleNavigationError = vi.fn();
         await TestBed.configureTestingModule({
-            imports: [AppComponent, RouterModule.forRoot([])],
+            imports: [
+                AppComponent,
+                RouterModule.forRoot([
+                    // A route whose lazily loaded chunk cannot be fetched, and one whose loader fails the way a
+                    // resolver surfaces a missing entity, so both NavigationError branches can be driven for real.
+                    { path: 'chunk-failure', loadComponent: () => Promise.reject(new Error('Failed to fetch dynamically imported module: /chunk-ABC123.js')) },
+                    { path: 'server-error-404', loadComponent: () => Promise.reject({ status: 404 }) },
+                ]),
+            ],
             providers: [
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: ThemeService, useClass: MockThemeService },
@@ -52,6 +63,7 @@ describe('AppComponent', () => {
                 },
                 { provide: SentryErrorHandler, useValue: { initSentry: vi.fn() } },
                 { provide: JhiLanguageHelper, useValue: { updateTitle: vi.fn() } },
+                { provide: LazyRouteRecoveryService, useValue: { handleNavigationError } },
                 provideHttpClient(),
                 provideHttpClientTesting(),
             ],
@@ -103,5 +115,30 @@ describe('AppComponent', () => {
         const footerElement = fixture.debugElement.query(By.css('jhi-footer'));
 
         expect(footerElement).toBeNull();
+    });
+
+    // Driven through real navigations to the routes registered above, so the router reports the NavigationError the
+    // same way it does in the browser rather than the test pushing a synthetic event into its event stream.
+    describe('navigation errors', () => {
+        it('should hand a failed route chunk to the recovery service', async () => {
+            const router = TestBed.inject(Router);
+
+            await router.navigateByUrl('/chunk-failure').catch(() => {});
+
+            expect(handleNavigationError).toHaveBeenCalledOnce();
+            const [error, url] = handleNavigationError.mock.calls[0];
+            expect((error as Error).message).toContain('Failed to fetch dynamically imported module');
+            expect(url).toBe('/chunk-failure');
+        });
+
+        it('should still send a 404 to the not-found page rather than the recovery service', async () => {
+            const router = TestBed.inject(Router);
+            const navigate = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+
+            await router.navigateByUrl('/server-error-404').catch(() => {});
+
+            expect(navigate).toHaveBeenCalledExactlyOnceWith(['/404']);
+            expect(handleNavigationError).not.toHaveBeenCalled();
+        });
     });
 });

--- a/src/main/webapp/app/app.component.spec.ts
+++ b/src/main/webapp/app/app.component.spec.ts
@@ -49,6 +49,7 @@ describe('AppComponent', () => {
                     // resolver surfaces a missing entity, so both NavigationError branches can be driven for real.
                     { path: 'chunk-failure', loadComponent: () => Promise.reject(new Error('Failed to fetch dynamically imported module: /chunk-ABC123.js')) },
                     { path: 'server-error-404', loadComponent: () => Promise.reject({ status: 404 }) },
+                    { path: 'rejected-without-error', loadComponent: () => Promise.reject() },
                 ]),
             ],
             providers: [
@@ -139,6 +140,15 @@ describe('AppComponent', () => {
 
             expect(navigate).toHaveBeenCalledExactlyOnceWith(['/404']);
             expect(handleNavigationError).not.toHaveBeenCalled();
+        });
+
+        // The router types the error as any, so reading a property off it unconditionally would throw here.
+        it('should survive a navigation that failed without an error value', async () => {
+            const router = TestBed.inject(Router);
+
+            await router.navigateByUrl('/rejected-without-error').catch(() => {});
+
+            expect(handleNavigationError).toHaveBeenCalledExactlyOnceWith(undefined, '/rejected-without-error');
         });
     });
 });

--- a/src/main/webapp/app/app.component.ts
+++ b/src/main/webapp/app/app.component.ts
@@ -19,6 +19,7 @@ import { GlobalSearchModalComponent } from 'app/core/navbar/global-search/compon
 import { SetupPasskeyModalComponent } from 'app/course/overview/setup-passkey-modal/setup-passkey-modal.component';
 import { EmbedPdfPreloadService } from 'app/core/pdf/embed-pdf-preload.service';
 import { observeShellMetrics, reattachShellMetricsObserver } from 'app/foundation/util/navbar.util';
+import { LazyRouteRecoveryService } from 'app/core/navigation/lazy-route-recovery.service';
 
 @Component({
     selector: 'jhi-app',
@@ -52,6 +53,7 @@ export class AppComponent implements OnInit, OnDestroy {
     private ltiService = inject(LtiService);
     private featureToggleService = inject(FeatureToggleService);
     private embedPdfPreloadService = inject(EmbedPdfPreloadService);
+    private lazyRouteRecoveryService = inject(LazyRouteRecoveryService);
 
     readonly globalSearchEnabled = signal(false);
     private examStartedSubscription?: Subscription;
@@ -149,9 +151,15 @@ export class AppComponent implements OnInit, OnDestroy {
                     }
                 }
             }
-            if (event instanceof NavigationError && event.error.status === 404) {
-                // noinspection JSIgnoredPromiseFromCall
-                void this.router.navigate(['/404']);
+            if (event instanceof NavigationError) {
+                if (event.error.status === 404) {
+                    // noinspection JSIgnoredPromiseFromCall
+                    void this.router.navigate(['/404']);
+                } else {
+                    // A route whose lazily loaded chunk could not be fetched fails here with no status, and callers
+                    // routinely discard the navigation promise, so without this the click silently does nothing.
+                    this.lazyRouteRecoveryService.handleNavigationError(event.error, event.url);
+                }
             }
         });
 

--- a/src/main/webapp/app/app.component.ts
+++ b/src/main/webapp/app/app.component.ts
@@ -152,7 +152,9 @@ export class AppComponent implements OnInit, OnDestroy {
                 }
             }
             if (event instanceof NavigationError) {
-                if (event.error.status === 404) {
+                // Optional access: the router types this as any, so a guard rejecting with null or undefined would
+                // otherwise throw here and take the recovery below down with it.
+                if (event.error?.status === 404) {
                     // noinspection JSIgnoredPromiseFromCall
                     void this.router.navigate(['/404']);
                 } else {

--- a/src/main/webapp/app/core/navigation/lazy-route-recovery.service.spec.ts
+++ b/src/main/webapp/app/core/navigation/lazy-route-recovery.service.spec.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { AlertService, AlertType } from 'app/foundation/service/alert.service';
+import { WINDOW_INJECTOR_TOKEN } from 'app/core/interceptor/artemis-version.interceptor';
+import { LAZY_ROUTE_RECOVERY_KEY_PREFIX, LazyRouteRecoveryService } from 'app/core/navigation/lazy-route-recovery.service';
+
+describe('LazyRouteRecoveryService', () => {
+    let service: LazyRouteRecoveryService;
+    let assign: ReturnType<typeof vi.fn>;
+    let addAlert: ReturnType<typeof vi.fn>;
+    let store: Map<string, string>;
+
+    const FAILED_URL = '/course-management/1/programming-exercises/new';
+    /** What Chrome reports when a lazily imported route chunk cannot be fetched. */
+    const chunkError = () => new Error('Failed to fetch dynamically imported module: https://artemis.example.org/chunk-ABC123.js');
+
+    beforeEach(() => {
+        assign = vi.fn();
+        addAlert = vi.fn();
+        store = new Map<string, string>();
+
+        const windowStub = {
+            location: { assign },
+            sessionStorage: {
+                getItem: (key: string) => store.get(key) ?? null,
+                setItem: (key: string, value: string) => void store.set(key, value),
+            },
+        };
+
+        TestBed.configureTestingModule({
+            providers: [LazyRouteRecoveryService, { provide: WINDOW_INJECTOR_TOKEN, useValue: windowStub }, { provide: AlertService, useValue: { addAlert } }],
+        });
+
+        service = TestBed.inject(LazyRouteRecoveryService);
+    });
+
+    it('should reload into the requested url when a route chunk fails to load', () => {
+        service.handleNavigationError(chunkError(), FAILED_URL);
+
+        expect(assign).toHaveBeenCalledExactlyOnceWith(FAILED_URL);
+        expect(addAlert).not.toHaveBeenCalled();
+    });
+
+    it('should alert instead of reloading again when the same url already failed once', () => {
+        service.handleNavigationError(chunkError(), FAILED_URL);
+        assign.mockClear();
+
+        service.handleNavigationError(chunkError(), FAILED_URL);
+
+        expect(assign).not.toHaveBeenCalled();
+        expect(addAlert).toHaveBeenCalledOnce();
+        expect(addAlert.mock.calls[0][0]).toMatchObject({ type: AlertType.DANGER, message: 'artemisApp.lazyRouteLoadFailedAlert' });
+    });
+
+    it('should still recover a different url that failed for the first time', () => {
+        service.handleNavigationError(chunkError(), FAILED_URL);
+        assign.mockClear();
+
+        service.handleNavigationError(chunkError(), '/course-management/1/text-exercises/new');
+
+        expect(assign).toHaveBeenCalledExactlyOnceWith('/course-management/1/text-exercises/new');
+    });
+
+    it('should offer an action that reloads the page', () => {
+        service.handleNavigationError(chunkError(), FAILED_URL);
+        service.handleNavigationError(chunkError(), FAILED_URL);
+        assign.mockClear();
+
+        addAlert.mock.calls[0][0].action.callback();
+
+        expect(assign).toHaveBeenCalledExactlyOnceWith(FAILED_URL);
+    });
+
+    it.each(['error loading dynamically imported module: https://artemis.example.org/chunk.js', 'Importing a module script failed.', 'Loading chunk 42 failed.'])(
+        'should recognise "%s" as a chunk load failure',
+        (message: string) => {
+            service.handleNavigationError(new Error(message), FAILED_URL);
+
+            expect(assign).toHaveBeenCalledOnce();
+        },
+    );
+
+    // Bundlers that wrap the failure give it a name rather than one of the messages above.
+    it('should recognise an error named ChunkLoadError', () => {
+        const error = new Error('Loading failed for the chunk');
+        error.name = 'ChunkLoadError';
+
+        service.handleNavigationError(error, FAILED_URL);
+
+        expect(assign).toHaveBeenCalledOnce();
+    });
+
+    it('should ignore an error that is not a chunk load failure', () => {
+        service.handleNavigationError(new Error('Cannot activate the route because the guard rejected it'), FAILED_URL);
+
+        expect(assign).not.toHaveBeenCalled();
+        expect(addAlert).not.toHaveBeenCalled();
+    });
+
+    it('should ignore a server error surfaced by a resolver', () => {
+        service.handleNavigationError({ status: 500, message: 'Internal Server Error' }, FAILED_URL);
+
+        expect(assign).not.toHaveBeenCalled();
+        expect(addAlert).not.toHaveBeenCalled();
+    });
+
+    it('should recover even when session storage cannot be read', () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            providers: [
+                LazyRouteRecoveryService,
+                {
+                    provide: WINDOW_INJECTOR_TOKEN,
+                    useValue: {
+                        location: { assign },
+                        // A browser configured to block site data throws on access rather than returning null.
+                        get sessionStorage(): Storage {
+                            throw new Error('The operation is insecure.');
+                        },
+                    },
+                },
+                { provide: AlertService, useValue: { addAlert } },
+            ],
+        });
+
+        TestBed.inject(LazyRouteRecoveryService).handleNavigationError(chunkError(), FAILED_URL);
+
+        expect(assign).toHaveBeenCalledExactlyOnceWith(FAILED_URL);
+    });
+
+    it('should remember the attempt under a namespaced key so it survives the reload', () => {
+        service.handleNavigationError(chunkError(), FAILED_URL);
+
+        expect([...store.keys()]).toEqual([`${LAZY_ROUTE_RECOVERY_KEY_PREFIX}${FAILED_URL}`]);
+    });
+});

--- a/src/main/webapp/app/core/navigation/lazy-route-recovery.service.spec.ts
+++ b/src/main/webapp/app/core/navigation/lazy-route-recovery.service.spec.ts
@@ -2,12 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { AlertService, AlertType } from 'app/foundation/service/alert.service';
 import { WINDOW_INJECTOR_TOKEN } from 'app/core/interceptor/artemis-version.interceptor';
+import { SentryErrorHandler } from 'app/core/sentry/sentry.error-handler';
 import { LAZY_ROUTE_RECOVERY_KEY_PREFIX, LazyRouteRecoveryService } from 'app/core/navigation/lazy-route-recovery.service';
 
 describe('LazyRouteRecoveryService', () => {
     let service: LazyRouteRecoveryService;
     let assign: ReturnType<typeof vi.fn>;
     let addAlert: ReturnType<typeof vi.fn>;
+    let handleError: ReturnType<typeof vi.fn>;
     let store: Map<string, string>;
 
     const FAILED_URL = '/course-management/1/programming-exercises/new';
@@ -17,6 +19,7 @@ describe('LazyRouteRecoveryService', () => {
     beforeEach(() => {
         assign = vi.fn();
         addAlert = vi.fn();
+        handleError = vi.fn();
         store = new Map<string, string>();
 
         const windowStub = {
@@ -28,7 +31,12 @@ describe('LazyRouteRecoveryService', () => {
         };
 
         TestBed.configureTestingModule({
-            providers: [LazyRouteRecoveryService, { provide: WINDOW_INJECTOR_TOKEN, useValue: windowStub }, { provide: AlertService, useValue: { addAlert } }],
+            providers: [
+                LazyRouteRecoveryService,
+                { provide: WINDOW_INJECTOR_TOKEN, useValue: windowStub },
+                { provide: AlertService, useValue: { addAlert } },
+                { provide: SentryErrorHandler, useValue: { handleError } },
+            ],
         });
 
         service = TestBed.inject(LazyRouteRecoveryService);
@@ -104,28 +112,64 @@ describe('LazyRouteRecoveryService', () => {
         expect(addAlert).not.toHaveBeenCalled();
     });
 
-    it('should recover even when session storage cannot be read', () => {
-        TestBed.resetTestingModule();
-        TestBed.configureTestingModule({
-            providers: [
-                LazyRouteRecoveryService,
-                {
-                    provide: WINDOW_INJECTOR_TOKEN,
-                    useValue: {
-                        location: { assign },
-                        // A browser configured to block site data throws on access rather than returning null.
-                        get sessionStorage(): Storage {
-                            throw new Error('The operation is insecure.');
+    // A reload can only be limited to one attempt while the marker is readable afterwards. Where it is not, every
+    // fresh document would see the same url fail for the "first" time, so reloading at all would never terminate.
+    describe('when the recovery attempt cannot be recorded', () => {
+        function configureWithStorage(sessionStorage: Partial<Storage> | (() => never)) {
+            TestBed.resetTestingModule();
+            TestBed.configureTestingModule({
+                providers: [
+                    LazyRouteRecoveryService,
+                    {
+                        provide: WINDOW_INJECTOR_TOKEN,
+                        useValue: {
+                            location: { assign },
+                            get sessionStorage(): Partial<Storage> {
+                                return typeof sessionStorage === 'function' ? sessionStorage() : sessionStorage;
+                            },
                         },
                     },
-                },
-                { provide: AlertService, useValue: { addAlert } },
-            ],
+                    { provide: AlertService, useValue: { addAlert } },
+                    { provide: SentryErrorHandler, useValue: { handleError } },
+                ],
+            });
+            return TestBed.inject(LazyRouteRecoveryService);
+        }
+
+        it('should alert rather than reload when session storage throws', () => {
+            // A browser configured to block site data throws on access rather than returning null.
+            const service = configureWithStorage(() => {
+                throw new Error('The operation is insecure.');
+            });
+
+            service.handleNavigationError(chunkError(), FAILED_URL);
+
+            expect(assign).not.toHaveBeenCalled();
+            expect(addAlert).toHaveBeenCalledOnce();
         });
 
-        TestBed.inject(LazyRouteRecoveryService).handleNavigationError(chunkError(), FAILED_URL);
+        it('should alert rather than reload when session storage silently drops the write', () => {
+            const service = configureWithStorage({ getItem: () => null, setItem: () => {} });
 
-        expect(assign).toHaveBeenCalledExactlyOnceWith(FAILED_URL);
+            service.handleNavigationError(chunkError(), FAILED_URL);
+
+            expect(assign).not.toHaveBeenCalled();
+            expect(addAlert).toHaveBeenCalledOnce();
+        });
+    });
+
+    it('should report the failure so it is visible in monitoring', () => {
+        const error = chunkError();
+
+        service.handleNavigationError(error, FAILED_URL);
+
+        expect(handleError).toHaveBeenCalledExactlyOnceWith(error);
+    });
+
+    it('should not report an error it does not act on', () => {
+        service.handleNavigationError(new Error('Cannot activate the route because the guard rejected it'), FAILED_URL);
+
+        expect(handleError).not.toHaveBeenCalled();
     });
 
     it('should remember the attempt under a namespaced key so it survives the reload', () => {

--- a/src/main/webapp/app/core/navigation/lazy-route-recovery.service.ts
+++ b/src/main/webapp/app/core/navigation/lazy-route-recovery.service.ts
@@ -1,0 +1,100 @@
+import { Injectable, inject } from '@angular/core';
+import { AlertService, AlertType } from 'app/foundation/service/alert.service';
+import { WINDOW_INJECTOR_TOKEN } from 'app/core/interceptor/artemis-version.interceptor';
+
+/** Prefix for the per-url marker that records an attempted recovery, so a reload loop cannot form. */
+export const LAZY_ROUTE_RECOVERY_KEY_PREFIX = 'artemis.lazyRouteRecovery.';
+
+/**
+ * Messages browsers use when a lazily imported route chunk cannot be fetched. Angular surfaces the raw import
+ * failure on the {@code NavigationError}, so there is no error type to match on.
+ */
+const CHUNK_LOAD_FAILURE_PATTERNS = [
+    /failed to fetch dynamically imported module/i,
+    /error loading dynamically imported module/i,
+    /importing a module script failed/i,
+    /loading chunk \S+ failed/i,
+];
+
+/**
+ * Recovers from a navigation that failed because the route's lazily loaded chunk could not be fetched.
+ * <p>
+ * Without this, such a navigation is silent: the router reports a {@code NavigationError}, the caller has usually
+ * discarded the promise, and the application simply stays where it was. The user sees a click that did nothing,
+ * which is what an instructor gets when a deployment replaces the chunk files while their tab is open.
+ * <p>
+ * The first failure for a url is answered with a full page load of that same url. That is deliberately not a
+ * router navigation: a failed dynamic import stays failed in the module map, so only a fresh document re-fetches
+ * the chunk, and after a deployment only a fresh document gets the new chunk names at all. The user asked to
+ * leave the current page by clicking, so navigating there is also the least surprising recovery.
+ * <p>
+ * A marker in session storage makes that recovery one-shot per url. Should the reloaded document fail on the same
+ * url again, the chunk is genuinely gone rather than momentarily unreachable, and the user is told instead.
+ */
+@Injectable({ providedIn: 'root' })
+export class LazyRouteRecoveryService {
+    private readonly injectedWindow = inject<Window>(WINDOW_INJECTOR_TOKEN);
+    private readonly alertService = inject(AlertService);
+
+    /**
+     * Recovers from, or reports, a failed navigation. Anything that is not a chunk load failure is left alone, so
+     * that guard rejections and server errors keep reaching their existing handling.
+     *
+     * @param error the error the router reported on the {@code NavigationError}
+     * @param url   the url the navigation was heading for
+     */
+    handleNavigationError(error: unknown, url: string): void {
+        if (!LazyRouteRecoveryService.isChunkLoadFailure(error)) {
+            return;
+        }
+
+        if (this.hasAlreadyAttemptedRecovery(url)) {
+            this.alertService.addAlert({
+                type: AlertType.DANGER,
+                message: 'artemisApp.lazyRouteLoadFailedAlert',
+                timeout: 0,
+                action: {
+                    label: 'artemisApp.lazyRouteLoadFailedAction',
+                    callback: () => this.injectedWindow.location.assign(url),
+                },
+            });
+            return;
+        }
+
+        this.rememberRecoveryAttempt(url);
+        this.injectedWindow.location.assign(url);
+    }
+
+    private static isChunkLoadFailure(error: unknown): boolean {
+        if (error === null || error === undefined) {
+            return false;
+        }
+        const candidate = error as { name?: unknown; message?: unknown };
+        if (candidate.name === 'ChunkLoadError') {
+            return true;
+        }
+        const message = typeof candidate.message === 'string' ? candidate.message : '';
+        return CHUNK_LOAD_FAILURE_PATTERNS.some((pattern) => pattern.test(message));
+    }
+
+    /**
+     * Session storage is read through a try/catch because a browser configured to block site data throws on access
+     * rather than returning null. Recovering twice is a far better failure mode than never recovering at all, so an
+     * unreadable store is treated as "not attempted yet".
+     */
+    private hasAlreadyAttemptedRecovery(url: string): boolean {
+        try {
+            return this.injectedWindow.sessionStorage.getItem(LAZY_ROUTE_RECOVERY_KEY_PREFIX + url) !== null;
+        } catch {
+            return false;
+        }
+    }
+
+    private rememberRecoveryAttempt(url: string): void {
+        try {
+            this.injectedWindow.sessionStorage.setItem(LAZY_ROUTE_RECOVERY_KEY_PREFIX + url, String(Date.now()));
+        } catch {
+            // Nothing to do: the recovery below still runs, it just cannot be limited to one attempt.
+        }
+    }
+}

--- a/src/main/webapp/app/core/navigation/lazy-route-recovery.service.ts
+++ b/src/main/webapp/app/core/navigation/lazy-route-recovery.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { AlertService, AlertType } from 'app/foundation/service/alert.service';
 import { WINDOW_INJECTOR_TOKEN } from 'app/core/interceptor/artemis-version.interceptor';
+import { SentryErrorHandler } from 'app/core/sentry/sentry.error-handler';
 
 /** Prefix for the per-url marker that records an attempted recovery, so a reload loop cannot form. */
 export const LAZY_ROUTE_RECOVERY_KEY_PREFIX = 'artemis.lazyRouteRecovery.';
@@ -35,6 +36,7 @@ const CHUNK_LOAD_FAILURE_PATTERNS = [
 export class LazyRouteRecoveryService {
     private readonly injectedWindow = inject<Window>(WINDOW_INJECTOR_TOKEN);
     private readonly alertService = inject(AlertService);
+    private readonly sentryErrorHandler = inject(SentryErrorHandler);
 
     /**
      * Recovers from, or reports, a failed navigation. Anything that is not a chunk load failure is left alone, so
@@ -48,7 +50,13 @@ export class LazyRouteRecoveryService {
             return;
         }
 
-        if (this.hasAlreadyAttemptedRecovery(url)) {
+        // Report before recovering. A full page load tears the document down, so anything after it never runs, and
+        // without this a chunk failure leaves no trace at all for whoever operates the instance.
+        this.sentryErrorHandler.handleError(error);
+
+        // Reloading is only safe while the attempt can be recorded. Without a readable marker every fresh document
+        // treats the same url as its first failure, so the reloads would never stop; tell the user instead.
+        if (this.hasAlreadyAttemptedRecovery(url) || !this.recordRecoveryAttempt(url)) {
             this.alertService.addAlert({
                 type: AlertType.DANGER,
                 message: 'artemisApp.lazyRouteLoadFailedAlert',
@@ -61,7 +69,6 @@ export class LazyRouteRecoveryService {
             return;
         }
 
-        this.rememberRecoveryAttempt(url);
         this.injectedWindow.location.assign(url);
     }
 
@@ -79,8 +86,8 @@ export class LazyRouteRecoveryService {
 
     /**
      * Session storage is read through a try/catch because a browser configured to block site data throws on access
-     * rather than returning null. Recovering twice is a far better failure mode than never recovering at all, so an
-     * unreadable store is treated as "not attempted yet".
+     * rather than returning null. An unreadable store reports "not attempted", and the write below then fails too,
+     * which is what routes such a browser to the alert rather than to a reload it could not bound.
      */
     private hasAlreadyAttemptedRecovery(url: string): boolean {
         try {
@@ -90,11 +97,20 @@ export class LazyRouteRecoveryService {
         }
     }
 
-    private rememberRecoveryAttempt(url: string): void {
+    /**
+     * Records that this url is being recovered, and reports whether that record can be relied on. The marker is read
+     * back rather than assumed from a successful write, because a store that silently drops writes would let the
+     * reloads repeat just as endlessly as one that throws.
+     *
+     * @return true when the marker is in place, so at most one reload can follow
+     */
+    private recordRecoveryAttempt(url: string): boolean {
+        const key = LAZY_ROUTE_RECOVERY_KEY_PREFIX + url;
         try {
-            this.injectedWindow.sessionStorage.setItem(LAZY_ROUTE_RECOVERY_KEY_PREFIX + url, String(Date.now()));
+            this.injectedWindow.sessionStorage.setItem(key, String(Date.now()));
+            return this.injectedWindow.sessionStorage.getItem(key) !== null;
         } catch {
-            // Nothing to do: the recovery below still runs, it just cannot be limited to one attempt.
+            return false;
         }
     }
 }

--- a/src/main/webapp/i18n/de/alert.json
+++ b/src/main/webapp/i18n/de/alert.json
@@ -3,6 +3,8 @@
         "disconnectedAlert": "Du bist nicht mehr mit dem Artemis Server verbunden. Bitte überprüfe deine Internetverbindung.",
         "outdatedAlert": "<b>Du verwendest eine veraltete Version von Artemis.</b> Bitte aktualisiere Artemis auf die neueste Version.",
         "outdatedAction": "Update",
+        "lazyRouteLoadFailedAlert": "<b>Diese Seite konnte nicht geladen werden.</b> Möglicherweise wurde Artemis inzwischen aktualisiert oder die Verbindung war unterbrochen. Ein Neuladen behebt das in der Regel.",
+        "lazyRouteLoadFailedAction": "Neu laden",
         "alerts": {
             "dismissAll": "Alle verwerfen"
         }

--- a/src/main/webapp/i18n/en/alert.json
+++ b/src/main/webapp/i18n/en/alert.json
@@ -3,6 +3,8 @@
         "disconnectedAlert": "You are not connected to the Artemis Server. Please check your internet connection.",
         "outdatedAlert": "<b>Your Artemis version is outdated.</b> Please update to the latest version.",
         "outdatedAction": "Update",
+        "lazyRouteLoadFailedAlert": "<b>This page could not be loaded.</b> Artemis may have been updated in the meantime, or the connection was interrupted. Reloading usually resolves it.",
+        "lazyRouteLoadFailedAction": "Reload",
         "alerts": {
             "dismissAll": "Dismiss all"
         }

--- a/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
+++ b/src/test/playwright/support/pageobjects/course/CourseManagementExercisesPage.ts
@@ -42,7 +42,17 @@ export class CourseManagementExercisesPage {
      */
     private async selectExerciseTypeCard(mode: 'create' | 'import', type: string) {
         await this.page.getByTestId(`${mode}-exercise-button`).click();
+        const urlBeforeSelection = this.page.url();
         await this.page.getByTestId(`${mode}-${type}-exercise`).click();
+        if (mode === 'create') {
+            // Selecting a create card closes the dialog and navigates. Closing the dialog is not evidence that the
+            // navigation happened: a route whose lazily loaded chunk fails to fetch used to leave the page exactly
+            // here, with the click delivered, the dialog closed and nothing else. Assert the navigation started, so
+            // that case reports itself instead of surfacing as an unexplained waitForURL timeout in the caller.
+            await expect(this.page, `selecting the ${type} card closed the dialog but the page never left ${urlBeforeSelection}`).not.toHaveURL(urlBeforeSelection, {
+                timeout: 30000,
+            });
+        }
     }
 
     async clickDeleteExercise(exerciseID: number) {


### PR DESCRIPTION
### Summary

Clicking something that navigates to a lazily loaded route did nothing at all when that route's chunk could not be fetched. No navigation, no error, no log entry — the dialog just closed and the page stayed where it was. Deploying a new Artemis version while someone has a tab open is enough to cause it, because the chunk files that the open page knows about no longer exist.

Artemis now recovers by loading the requested page in a fresh document, and tells the user when even that does not help.

This also removes a flaky e2e failure that has been hitting pull requests across the repository: it is the same silent navigation, seen from the test side as a `waitForURL` timeout with nothing to explain it.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [x] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context

The failure was found while investigating an e2e test that fails intermittently on many pull requests at the moment (`Creates a new programming exercise` and `FormStatusBar scrolls to the correct section`, both in `ProgrammingExerciseManagement.spec.ts`). The Playwright trace shows the click was delivered correctly — the locator resolved to the right button, the element was *"visible, enabled and stable"*, *"click action done"*, *"navigations have finished"* — and the browser console recorded ten `net::ERR_FAILED` resource loads. One of them was the chunk for the target route.

From there the path through the client is:

1. `exercise-add-modal.component.ts` runs `void this.router.navigate(...)`, so the rejected navigation promise is discarded.
2. The router emits a `NavigationError` whose `error` is the raw import failure, with no `status`.
3. `app.component.ts` subscribed to `NavigationError` but only acted `if (event.error.status === 404)`, so a chunk failure fell straight through.

Nothing was left to report the problem, which is why the symptom is a click that silently does nothing. `void router.navigate(...)` is a widespread pattern, so this is fixed once at the router level rather than at that one call site.

### Description

`LazyRouteRecoveryService` (new, `app/core/navigation/`) decides what to do with a failed navigation:

- Anything that is not a chunk load failure is ignored, so guard rejections and server errors keep reaching their existing handling.
- The first failure for a url triggers a full page load of that same url. This is deliberately **not** a router navigation: a failed dynamic import stays failed in the module map, and after a deployment the chunk names have changed anyway, so only a fresh document can recover. The user asked to leave the page by clicking, so going there is also the least surprising outcome.
- A marker in session storage limits that to one attempt per url, so no reload loop can form — the marker survives the reload, which is exactly what makes the guard work. A second failure means the chunk is genuinely gone rather than briefly unreachable, and the user gets an alert with a reload action instead, in the same style as the existing outdated-version alert.
- Session storage is read inside a `try`/`catch`, because a browser configured to block site data throws on access rather than returning null. An unreadable store is treated as "not attempted yet", since recovering twice is a much better failure mode than never recovering.

`app.component.ts` keeps navigation-error policy in the one place it already lived: the 404 branch is unchanged, and everything else is handed to the service.

On the test side, `CourseManagementExercisesPage.selectExerciseTypeCard` now asserts that selecting a create card actually leaves the page. Closing the dialog is not evidence of a navigation — in the failure above the dialog *did* close — so without this the caller only finds out 60 seconds later through a `waitForURL` timeout that says nothing about the cause.

### Steps for Testing

Prerequisites:
- 1 Instructor
- 1 Course

Recovery from a stale chunk (this is the reported scenario):

1. Log in as an instructor and open Course Management, then the exercises page of a course. Leave the tab open.
2. Deploy a new client build, or simulate it: in the browser developer tools, open the Network tab and add a request blocking rule for `*chunk-*.js` (Chrome: Network conditions, "Block request pattern").
3. Click **Create** and choose **Programming exercise**.
4. Confirm the programming exercise creation page opens. Before this change the dialog closed and nothing else happened.
5. Keep the block in place and repeat the click. Confirm an alert now explains that the page could not be loaded and offers to reload, rather than the click silently doing nothing again.

Normal behaviour is unaffected:

6. Remove the blocking rule and create exercises of each type from the same dialog. Confirm each opens its creation page as before.
7. Open a url that does not exist, for example `/course-management/999999`. Confirm you still land on the not-found page, so the 404 branch is untouched.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| lazy-route-recovery.service.ts | 96.55% | 63 | 20 | 31.7 |

_Last updated: 2026-09-08 11:42:14 UTC_

