### PR TITLE
`Development`: Pin Valkey 9.1.2 as the distributed data image

### DIFF
--- a/.env
+++ b/.env
@@ -18,7 +18,7 @@ MARIADB_VERSION=12.0.2-debian-12-r0
 POSTGRES_IMAGE_VARIANT=-alpine
 
 # Caching and middleware
-# Valkey is the distributed data backend Artemis ships and tests. It speaks the Redis protocol, so
+# Valkey is the distributed data store Artemis ships and tests. It speaks the Redis protocol, so
 # `artemis.distributed-data.provider: Redis` and every Redisson code path stay unchanged, and a
 # deployment may run Redis 8 instead. Valkey (BSD-3-Clause) replaces the redis-stack-server image
 # used before, which was Redis 7.4 under RSALv2/SSPL only, so it carried no OSI-approved license

--- a/.env
+++ b/.env
@@ -18,9 +18,12 @@ MARIADB_VERSION=12.0.2-debian-12-r0
 POSTGRES_IMAGE_VARIANT=-alpine
 
 # Caching and middleware
-# Note: This is redis-stack-server, not standard Redis. Uses different version tags.
-REDIS_STACK_VERSION=7.4.0-v8
-VALKEY_VERSION=8.1.9
+# Valkey is the distributed data backend Artemis ships and tests. It speaks the Redis protocol, so
+# `artemis.distributed-data.provider: Redis` and every Redisson code path stay unchanged, and a
+# deployment may run Redis 8 instead. Valkey (BSD-3-Clause) replaces the redis-stack-server image
+# used before, which was Redis 7.4 under RSALv2/SSPL only, so it carried no OSI-approved license
+# and it loaded search, JSON and time series modules Artemis never calls.
+VALKEY_VERSION=9.1.2
 
 # Search
 # Weaviate must be compatible with the Java client: https://docs.weaviate.io/weaviate/release-notes

--- a/docker/redis.yml
+++ b/docker/redis.yml
@@ -1,9 +1,14 @@
 # ----------------------------------------------------------------------------------------------------------------------
-# Redis base service
+# Redis-protocol base service, running Valkey
 #
 # Alternative distributed data backend to the embedded Hazelcast cluster. Artemis reaches it through the
 # DistributedDataProvider abstraction, selected with `artemis.distributed-data.provider: Redis`, so nothing else about a
 # deployment changes when this container is used instead of Hazelcast.
+#
+# The image is Valkey, which implements the Redis protocol: the provider, the Redisson client and the `redis` service
+# name here all stay as they are, and a deployment is free to point them at Redis 8 instead. Valkey is what this repo
+# pins and tests because it is BSD-3-Clause, where redis-stack-server was RSALv2/SSPL only. The healthcheck therefore
+# deliberately calls `redis-cli`, which both images provide, rather than `valkey-cli`, which only Valkey provides.
 #
 # Only started by the multi-node E2E runners when `--middleware redis` is passed; the default stays Hazelcast.
 # ----------------------------------------------------------------------------------------------------------------------
@@ -11,7 +16,7 @@
 services:
     redis:
         container_name: artemis-redis
-        image: "redis/redis-stack-server:${REDIS_STACK_VERSION}"
+        image: "valkey/valkey:${VALKEY_VERSION}"
         pull_policy: missing
         # Bound to the loopback interface, like Postgres: the host JVMs of the fast runner connect through it, and it must
         # not be reachable from outside the machine.

--- a/docker/redis/redis.yml
+++ b/docker/redis/redis.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis/redis-stack-server:${REDIS_STACK_VERSION}
+    image: valkey/valkey:${VALKEY_VERSION}
     restart: always
     ports:
       - "6379:6379"
@@ -13,7 +13,7 @@ services:
       "--requirepass ${REDIS_PASSWORD:-artemis}",
       "--user artemis on >${REDIS_PASSWORD:-artemis} +@all &* ~*",
       "--user default off nopass nocommands",
-      "--protected-mode no" # Needed, as redis does not detect that the default user has a password if it is disabled
+      "--protected-mode no" # Needed, as the server does not detect that the default user has a password if it is disabled
     ]
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-artemis}", "ping"]

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/distributed/RedissonDistributedDataTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/distributed/RedissonDistributedDataTest.java
@@ -49,7 +49,11 @@ class RedissonDistributedDataTest extends AbstractDistributedDataTest {
 
     @AfterAll
     static void afterAll() {
-        valkey.stop();
+        // JUnit runs @AfterAll even when @BeforeAll threw, and create() throws when the version property is missing.
+        // Without the guard that failure would surface as a NullPointerException here instead.
+        if (valkey != null) {
+            valkey.stop();
+        }
     }
 
     @Override

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/distributed/RedissonDistributedDataTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/distributed/RedissonDistributedDataTest.java
@@ -12,10 +12,11 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.DockerClientFactory;
 
-import com.redis.testcontainers.RedisStackContainer;
+import com.redis.testcontainers.RedisContainer;
 
 import de.tum.cit.aet.artemis.core.service.distributed.api.DistributedDataProvider;
 import de.tum.cit.aet.artemis.core.service.distributed.redisson.RedissonDistributedDataProviderService;
+import de.tum.cit.aet.artemis.shared.ValkeyTestContainerFactory;
 
 @SpringBootTest
 @ActiveProfiles({ PROFILE_BUILDAGENT, PROFILE_TEST_BUILDAGENT })
@@ -27,7 +28,7 @@ class RedissonDistributedDataTest extends AbstractDistributedDataTest {
     @Autowired
     protected RedissonDistributedDataProviderService redissonDistributedDataProvider;
 
-    private static RedisStackContainer redis;
+    private static RedisContainer valkey;
 
     static boolean isDockerAvailable() {
         try {
@@ -40,15 +41,15 @@ class RedissonDistributedDataTest extends AbstractDistributedDataTest {
 
     @BeforeAll
     static void beforeAll() {
-        redis = new RedisStackContainer(RedisStackContainer.DEFAULT_IMAGE_NAME.withTag("7.4.0-v8"));
-        redis.start();
-        System.setProperty("spring.data.redis.host", redis.getHost());
-        System.setProperty("spring.data.redis.port", redis.getMappedPort(6379).toString());
+        valkey = ValkeyTestContainerFactory.create();
+        valkey.start();
+        System.setProperty("spring.data.redis.host", valkey.getHost());
+        System.setProperty("spring.data.redis.port", valkey.getMappedPort(6379).toString());
     }
 
     @AfterAll
     static void afterAll() {
-        redis.stop();
+        valkey.stop();
     }
 
     @Override

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/distributed/RedissonPriorityQueueBenchmarkTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/distributed/RedissonPriorityQueueBenchmarkTest.java
@@ -18,7 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.DockerClientFactory;
 
-import com.redis.testcontainers.RedisStackContainer;
+import com.redis.testcontainers.RedisContainer;
 
 import de.tum.cit.aet.artemis.buildagent.dto.BuildConfig;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildJobQueueItem;
@@ -29,6 +29,7 @@ import de.tum.cit.aet.artemis.core.service.distributed.redisson.RedissonDistribu
 import de.tum.cit.aet.artemis.programming.domain.ProgrammingLanguage;
 import de.tum.cit.aet.artemis.programming.domain.ProjectType;
 import de.tum.cit.aet.artemis.programming.domain.RepositoryType;
+import de.tum.cit.aet.artemis.shared.ValkeyTestContainerFactory;
 
 /**
  * Measures how the cost of enqueueing a build job into a Redis-backed queue scales with the queue depth.
@@ -66,7 +67,7 @@ class RedissonPriorityQueueBenchmarkTest {
      */
     private static final int[] DEPTHS = { 100, 1000, 5000 };
 
-    private static RedisStackContainer redis;
+    private static RedisContainer valkey;
 
     private static RedissonClient redissonClient;
 
@@ -81,12 +82,12 @@ class RedissonPriorityQueueBenchmarkTest {
 
     @BeforeAll
     static void beforeAll() {
-        assertThat(isDockerAvailable()).as("this benchmark requires Docker for the Redis testcontainer").isTrue();
-        redis = new RedisStackContainer(RedisStackContainer.DEFAULT_IMAGE_NAME.withTag(RedisStackContainer.DEFAULT_TAG));
-        redis.start();
+        assertThat(isDockerAvailable()).as("this benchmark requires Docker for the Valkey testcontainer").isTrue();
+        valkey = ValkeyTestContainerFactory.create();
+        valkey.start();
 
         Config config = new Config();
-        config.useSingleServer().setAddress("redis://" + redis.getHost() + ":" + redis.getMappedPort(6379));
+        config.useSingleServer().setAddress("redis://" + valkey.getHost() + ":" + valkey.getMappedPort(6379));
         redissonClient = Redisson.create(config);
     }
 
@@ -95,8 +96,8 @@ class RedissonPriorityQueueBenchmarkTest {
         if (redissonClient != null) {
             redissonClient.shutdown();
         }
-        if (redis != null) {
-            redis.stop();
+        if (valkey != null) {
+            valkey.stop();
         }
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/core/service/distributed/redisson/RedissonDistributedDataMigratorTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/service/distributed/redisson/RedissonDistributedDataMigratorTest.java
@@ -27,7 +27,9 @@ import org.redisson.config.Config;
 import org.redisson.connection.CRC16;
 import org.testcontainers.DockerClientFactory;
 
-import com.redis.testcontainers.RedisStackContainer;
+import com.redis.testcontainers.RedisContainer;
+
+import de.tum.cit.aet.artemis.shared.ValkeyTestContainerFactory;
 
 /**
  * Covers the namespace migration against a real Redis, which is the only way to exercise the drain: the semantics that
@@ -37,7 +39,7 @@ import com.redis.testcontainers.RedisStackContainer;
 @EnabledIf("isDockerAvailable")
 class RedissonDistributedDataMigratorTest {
 
-    private static RedisStackContainer redis;
+    private static RedisContainer valkey;
 
     private static RedissonClient redissonClient;
 
@@ -52,12 +54,12 @@ class RedissonDistributedDataMigratorTest {
 
     @BeforeAll
     static void beforeAll() {
-        redis = new RedisStackContainer(RedisStackContainer.DEFAULT_IMAGE_NAME.withTag("7.4.0-v8"));
-        redis.start();
+        valkey = ValkeyTestContainerFactory.create();
+        valkey.start();
         Config config = new Config();
         // The same codec the provider installs, so values written here round-trip exactly as production ones do.
         config.setCodec(new BackwardCompatibleSerializationCodec());
-        config.useSingleServer().setAddress("redis://" + redis.getHost() + ":" + redis.getMappedPort(6379));
+        config.useSingleServer().setAddress("redis://" + valkey.getHost() + ":" + valkey.getMappedPort(6379));
         redissonClient = Redisson.create(config);
     }
 
@@ -66,8 +68,8 @@ class RedissonDistributedDataMigratorTest {
         if (redissonClient != null) {
             redissonClient.shutdown();
         }
-        if (redis != null) {
-            redis.stop();
+        if (valkey != null) {
+            valkey.stop();
         }
     }
 

--- a/src/test/java/de/tum/cit/aet/artemis/shared/ValkeyTestContainerFactory.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/ValkeyTestContainerFactory.java
@@ -1,0 +1,53 @@
+package de.tum.cit.aet.artemis.shared;
+
+import org.testcontainers.utility.DockerImageName;
+
+import com.redis.testcontainers.RedisContainer;
+
+/**
+ * Builds the Valkey container the Redis-backed distributed data tests run against.
+ *
+ * <p>
+ * Artemis reaches the store through {@code DistributedDataProvider} with
+ * {@code artemis.distributed-data.provider: Redis}, and Valkey implements the Redis protocol, so these tests exercise
+ * exactly the production code path. Valkey is what the repository pins and tests because it is BSD-3-Clause; a
+ * deployment may run Redis 8 instead, which is protocol-compatible.
+ *
+ * <p>
+ * The version comes from {@code VALKEY_VERSION} in {@code .env}, which {@code gradle/test.gradle} hands to the test
+ * JVM as the {@code valkey.version} system property. Keeping the single source of truth there is what stops the test
+ * pin from drifting away from the pin the E2E stacks use - the drift that left these tests on
+ * {@code redis-stack-server:7.4.0-v8} while the rest of the world moved on.
+ *
+ * @see de.tum.cit.aet.artemis.core.service.distributed.RedissonDistributedDataTest
+ * @see de.tum.cit.aet.artemis.core.service.distributed.redisson.RedissonDistributedDataMigratorTest
+ * @see de.tum.cit.aet.artemis.core.service.distributed.RedissonPriorityQueueBenchmarkTest
+ */
+public final class ValkeyTestContainerFactory {
+
+    private static final String VERSION_PROPERTY = "valkey.version";
+
+    private ValkeyTestContainerFactory() {
+    }
+
+    /**
+     * Creates an unstarted container on the pinned Valkey image. Each caller owns its own lifecycle, because these
+     * tests deliberately start from an empty store.
+     *
+     * @return the container, still to be started by the caller
+     * @throws IllegalStateException if the {@code valkey.version} system property is missing, which means the test is
+     *                                   running outside Gradle; failing loudly beats falling back to a hardcoded
+     *                                   version that can drift away from the pin the compose files use
+     */
+    public static RedisContainer create() {
+        String version = System.getProperty(VERSION_PROPERTY);
+        if (version == null || version.isBlank()) {
+            throw new IllegalStateException("The '" + VERSION_PROPERTY + "' system property is not set. It is derived from VALKEY_VERSION in .env by gradle/test.gradle, "
+                    + "so run this test through Gradle, or pass -D" + VERSION_PROPERTY + "=<version> explicitly.");
+        }
+        // A no-op today: RedisContainer asserts nothing about the image name, it only exposes 6379 and waits for the
+        // "Ready to accept connections" log line, which Valkey emits too. Declared anyway so the intent survives if
+        // the library ever does start checking.
+        return new RedisContainer(DockerImageName.parse("valkey/valkey:" + version).asCompatibleSubstituteFor("redis"));
+    }
+}


### PR DESCRIPTION
### Summary

Artemis can run its cross-node state (build job queue, feature toggles, build agent registrations, `@Cacheable` caches) on a Redis-protocol store instead of Hazelcast. The image the repository pinned for that was `redis/redis-stack-server:7.4.0-v8`: Redis 7.4 under RSALv2/SSPL, so it carried no OSI-approved license, it predates the Redis 8 AGPL relicensing entirely, and it loads search, JSON and time series modules Artemis never calls. This switches the shipped and tested image to Valkey, pinned exactly at `9.1.2`, and makes the test containers read that same pin instead of each carrying its own.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server. <!-- Tested locally (see Test Coverage below); the test-server confirmation by a second developer is still outstanding. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

Three problems, one root cause — the image pin was never revisited:

1. **Licensing.** `redis-stack-server:7.4.0-v8` is available only under RSALv2 and SSPLv1, neither of which is OSI-approved. Artemis is MIT and is deployed by institutions beyond TUM, some of which screen dependencies for exactly this. Valkey is BSD-3-Clause. Redis 8 is a legitimate alternative too — it added AGPLv3, which *is* OSI-approved — but it is copyleft, and the pinned image was not Redis 8 in any case.
2. **Staleness.** The pin was two majors behind, and it is what the multi-node E2E runners exercise with `--middleware redis`, so CI was validating a build nobody would deploy.
3. **Drift between the compose pin and the test pin.** Three server tests hardcoded their own image. Two sat on `7.4.0-v8`; `RedissonPriorityQueueBenchmarkTest` used `RedisStackContainer.DEFAULT_TAG`, which resolves to a floating `latest`. Pinning that one is arguably worth the change on its own.

`VALKEY_VERSION` also moves from `8.1.9` to `9.1.2` here. That is deliberate, not a byproduct: `8.1.9` was only ever read by two unreferenced compose files, so nothing was running it, and `9.1.2` is the current release. If any deployment does run Valkey 8.x, this means the tested version is ahead of it — worth a reviewer's attention.

### Description

**Nothing about the abstraction changes.** Valkey implements the Redis protocol, so `artemis.distributed-data.provider: Redis`, the Redisson client, the `DistributedDataProvider` implementation, the compose service name `redis` and the container name `artemis-redis` all stay exactly as they are. A deployment remains free to point them at Redis 8 instead. Renaming any of that would have spread the change across both runner scripts for no benefit.

- **`.env`** — `VALKEY_VERSION` `8.1.9` → `9.1.2`. `REDIS_STACK_VERSION` is removed, since nothing references it any more.
- **`docker/redis.yml`** — image → `valkey/valkey:${VALKEY_VERSION}`. This is the file both multi-node runners start. **The healthcheck deliberately stays on `redis-cli`, not `valkey-cli`**: the Valkey image ships `redis-cli` and `redis-server` as compatibility binaries, but a `redis:8` image has no `valkey-cli`. Using the Valkey-only name would have quietly broken the "point it at Redis 8" escape hatch the file's own comment advertises — the container would never reach `healthy`.
- **`docker/redis/redis.yml`** — image pin only. This file is **not referenced anywhere** in the repo and it mounts a `redis.conf` that does not exist, so it is already unrunnable. It is edited here only because removing `REDIS_STACK_VERSION` from `.env` would otherwise leave it interpolating an undefined variable, which `.env` documents as a deliberate fail-fast. **The edit is not an endorsement that the file works.** It and `docker/valkey/valkey.yml` are dead near-duplicates of `docker/redis.yml`; deleting both is the right cleanup but is left out to keep this diff to its purpose. Happy to fold it in if a reviewer prefers.
- **`ValkeyTestContainerFactory`** (new, in `shared/`, following the existing `WeaviateTestContainerFactory` convention) — resolves the image from the `valkey.version` system property, which `gradle/test.gradle` already derives from `VALKEY_VERSION` in `.env` for every key in that file, so no new Gradle wiring is needed. It throws rather than falling back to a hardcoded version that could drift from the compose pin. It intentionally diverges from `WeaviateTestContainerFactory`'s `null`-to-skip contract: Weaviate's callers are `@EnabledIf`-guarded on the container, whereas these three classes gate only on Docker availability, so a `null` would either NPE in `beforeAll` or silently green-skip the only tests that exercise the Redis-protocol store.
- **`RedissonDistributedDataTest`, `RedissonDistributedDataMigratorTest`, `RedissonPriorityQueueBenchmarkTest`** — use the factory instead of `RedisStackContainer`. **The compose pin and the test pin are now the same line in `.env`**, which is what stops the drift that produced this state.

One thing a reviewer will reasonably ask about: **Valkey reports `redis_version:7.2.4`** alongside `valkey_version:9.1.2` as its compatibility level, which is below the 7.4 threshold Redisson uses to gate native hash-field expiry. That is not a problem here, because `RedissonDistributedDataProviderService.getExpiringMap` uses `redissonClient.getMapCache(...)` — `RMapCache`, whose expiry is Redisson-side — and not `getMapCacheNative`. So nothing is silently downgraded. It is worth knowing for any future code that gates on the reported version.

### Steps for Testing

No user-visible behaviour changes, so this is verified through the test suite and the local multi-node stack.

Prerequisites:
- Docker running

1. Run the two Redis-protocol store server tests. Both start a Valkey 9.1.2 container through the new factory and must pass:
   ```
   ./gradlew test --tests RedissonDistributedDataTest --tests RedissonDistributedDataMigratorTest -x webapp
   ```
   `RedissonDistributedDataTest` is the shared cross-provider contract suite (48 tests); `RedissonDistributedDataMigratorTest` (13 tests) covers the schema-version migration, including the server-side `RPOPLPUSH` slot move and preservation of an expiring entry's remaining lifetime.
2. Confirm the compose service the runners use resolves and becomes healthy:
   ```
   docker compose --env-file .env -f docker/redis.yml up -d redis
   docker inspect -f '{{.State.Health.Status}}' artemis-redis                 # healthy
   docker exec artemis-redis redis-cli INFO server | grep valkey_version      # 9.1.2
   docker compose --env-file .env -f docker/redis.yml down -v
   ```
3. Run the multi-node E2E suite against the new image and confirm the nodes actually reach it (the script reports the key count, and prints an error if no keys arrive):
   ```
   ./run-e2e-tests-local-multinode-fast.sh --middleware redis --filter "Quiz"
   ```
4. Optional — the opt-in benchmark that previously ran on a floating tag:
   ```
   ./gradlew test --tests RedissonPriorityQueueBenchmarkTest -Dartemis.benchmark=true -x webapp
   ```

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Multi-node E2E with `--middleware redis` passes against Valkey 9.1.2
- [ ] `docker/redis.yml` service starts and reports healthy

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-08 12:39:29 UTC_

