### PR TITLE
`Development`: Drop the dead passkey modal CSS from the e2e suppression

### DIFF
--- a/src/test/playwright/e2e/Passkey.spec.ts
+++ b/src/test/playwright/e2e/Passkey.spec.ts
@@ -52,20 +52,10 @@ test.describe('Passkey', () => {
     test('registers a passkey via the setup modal and displays it in user settings', async ({ page, loginPage, virtualAuthenticator }) => {
         const user = passkeyTestUser(test.info().title);
         // Ensure the passkey setup modal is shown on every navigation, including the post-login redirect.
-        // The autoTestFixture init script suppresses the modal globally via localStorage AND CSS;
-        // this overrides both by removing the suppression key and re-enabling the dialog.
+        // The shared init script suppresses it by storing a far-future reminder date, and the component
+        // reads that date in ngOnInit, so removing the key is all it takes to get the modal back.
         await page.addInitScript(() => {
             localStorage.removeItem('earliestSetupPasskeyReminderDate');
-            const injectOverride = () => {
-                const style = document.createElement('style');
-                style.textContent = '.p-dialog-mask:has(.passkey-setup-dialog) { display: flex !important; }';
-                document.head.appendChild(style);
-            };
-            if (document.head) {
-                injectOverride();
-            }
-            // Also register for DOMContentLoaded to override any deferred CSS from the context init script
-            document.addEventListener('DOMContentLoaded', injectOverride);
         });
         // Clear the admin session from beforeEach so we land on the sign-in page
         await page.context().clearCookies();

--- a/src/test/playwright/e2e/PasskeyReminderPersistence.spec.ts
+++ b/src/test/playwright/e2e/PasskeyReminderPersistence.spec.ts
@@ -33,22 +33,12 @@ test.afterEach(async ({ page }) => {
 
 test('Passkey reminder modal is not displayed on re-login after remind me in 30 days was chosen', async ({ page, loginPage, navigationBar }) => {
     // Ensure the passkey setup modal is shown on every page load.
-    // The autoTestFixture init script suppresses the modal globally via localStorage AND CSS;
-    // this overrides both by removing the suppression key and re-enabling the dialog.
+    // The shared init script suppresses the modal by storing a far-future reminder date, so removing
+    // that key is all it takes to get the modal back.
     // Logout in Artemis is SPA navigation (no page reload), so this init script fires only once
     // during page.goto('/sign-in'), and the key set by "Remind me in 30 days" persists afterward.
     await page.addInitScript(() => {
         localStorage.removeItem('earliestSetupPasskeyReminderDate');
-        const injectOverride = () => {
-            const style = document.createElement('style');
-            style.textContent = '.p-dialog-mask:has(.passkey-setup-dialog) { display: flex !important; }';
-            document.head.appendChild(style);
-        };
-        if (document.head) {
-            injectOverride();
-        }
-        // Also register for DOMContentLoaded to override any deferred CSS from the context init script
-        document.addEventListener('DOMContentLoaded', injectOverride);
     });
 
     // First login — clear the admin session from beforeEach

--- a/src/test/playwright/support/utils.ts
+++ b/src/test/playwright/support/utils.ts
@@ -720,12 +720,13 @@ export async function addE2EInitScript(page: Page) {
         // Hide the notification popup overlay
         const injectStyle = () => {
             const style = document.createElement('style');
-            style.textContent = [
-                'jhi-course-notification-popup-overlay { display: none !important; }',
-                // Hide the passkey setup modal overlay (PrimeNG appends it to <body>).
-                // CSS backup for the localStorage suppression below.
-                '.p-dialog-mask:has(.passkey-setup-dialog) { display: none !important; }',
-            ].join('\n');
+            // The passkey setup modal is not hidden here. It used to have a CSS backup, but that rule
+            // named PrimeNG classes and stopped matching anything when the modal moved to tum-ui-dialog,
+            // so it sat here as dead code while reading like a safety net. It cannot be reinstated as
+            // written either: the replacement renders through the CDK, whose backdrop carries the same
+            // cdk-overlay-dark-backdrop class as every other dialog, so hiding it would also hide the
+            // dialogs tests legitimately drive. The localStorage suppression below is the mechanism.
+            style.textContent = ['jhi-course-notification-popup-overlay { display: none !important; }'].join('\n');
             document.head.appendChild(style);
         };
         if (document.head) {


### PR DESCRIPTION
### Summary

The end-to-end suite hides the passkey setup modal so it cannot swallow clicks. It does this two ways: by storing a far-future reminder date in local storage, and by a CSS rule described as a backup for it. The CSS rule names PrimeNG classes and has matched nothing since the modal moved to `tum-ui-dialog`, so it has been dead code that reads like a safety net. This removes it and says plainly which mechanism works.

### Checklist
#### General
<!-- Items that do not apply to this pull request have been removed. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

### Motivation and Context

`addE2EInitScript` injects this:

```css
.p-dialog-mask:has(.passkey-setup-dialog) { display: none !important; }
```

Neither half matches any more. `setup-passkey-modal.component.html` renders a `<tum-ui-dialog>`, `p-dialog-mask` is produced nowhere in the client or the component kit, and the string `passkey-setup-dialog` appears in no template at all. Two specs carry the mirror image of the same rule to force the modal back on, and they pass only because removing the stored reminder date is by itself enough.

Dead test scaffolding is worse than no scaffolding, because it gets believed. When the `FormStatusBar` test began timing out, the reasonable reading was that the overlay had slipped past a guard that was still holding elsewhere. It was not holding anywhere.

### Description

The rule cannot be rewritten to do what it claimed. The replacement dialog opens through `@angular/cdk/dialog` with `backdropClass: 'cdk-overlay-dark-backdrop'`, and the backdrop is a sibling of the panel rather than its parent, so a selector cannot reach from the passkey dialog's content back to its own backdrop. That class is shared by every TUM UI dialog, so hiding it would also hide the dialogs tests drive on purpose.

What remains is the mechanism the component actually reads. `SetupPasskeyModalComponent.ngOnInit` retrieves `earliestSetupPasskeyReminderDate` and returns early when it lies in the future, and `LocalStorageService.clear()` names that key in `KEYS_TO_PRESERVE`, so it survives the storage clear on login. Three comments claiming suppression happens "via localStorage AND CSS" now say what is true.

### Steps for Testing

Prerequisites:
- Docker running

1. Run `./run-e2e-tests-local-fast.sh --specs "e2e/Passkey.spec.ts e2e/PasskeyReminderPersistence.spec.ts e2e/exercise/programming/ProgrammingExerciseManagement.spec.ts e2e/exercise/modeling/ModelingAssessmentWorkspace.spec.ts"` on a fresh stack.
2. All twelve pass. This covers both directions: the passkey specs need the modal to appear, and the programming and modeling specs need it suppressed.

Use a fresh stack rather than `--skip-db`. `Passkey.spec.ts` names its user after the test title, so on a reused database that user already holds a passkey, `askToSetupPasskey` is false, and the modal correctly does not appear.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] The four specs above pass on a fresh stack