### PR TITLE
`Development`: Update PostgreSQL to 18.6

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@ COMPOSE_PROJECT_NAME=artemis
 MYSQL_VERSION=9.7.2
 # Full Docker image reference for MySQL. Override for custom registries or images (e.g. database-migration tester).
 MYSQL_IMAGE=docker.io/library/mysql:${MYSQL_VERSION}
-POSTGRES_VERSION=18.4
+POSTGRES_VERSION=18.6
 MARIADB_VERSION=12.0.2-debian-12-r0
 POSTGRES_IMAGE_VARIANT=-alpine
 

--- a/build.gradle
+++ b/build.gradle
@@ -701,7 +701,7 @@ dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${spring_cloud_version}"
         // BOM uses 3-part versions (e.g. 18.1.0); POSTGRES_VERSION from .env may be 2-part (e.g. 18.1)
-        def pgVersion = findProperty('postgres_version') ?: '18.4'
+        def pgVersion = findProperty('postgres_version') ?: '18.6'
         def bomVersion = pgVersion.count('.') < 2 ? "${pgVersion}.0" : pgVersion
         mavenBom "io.zonky.test.postgres:embedded-postgres-binaries-bom:${bomVersion}"
         mavenBom "org.testcontainers:testcontainers-bom:${testcontainers_version}"

--- a/documentation/docs/admin/database-tips.mdx
+++ b/documentation/docs/admin/database-tips.mdx
@@ -77,7 +77,7 @@ and run the following commands to convert the `Artemis.sql` dump into `Artemis.p
                - db-migration
 
        postgres:
-           image: docker.io/library/postgres:18.4-alpine
+           image: docker.io/library/postgres:18.6-alpine
            environment:
                - POSTGRES_USER=root
                - POSTGRES_DB=Artemis


### PR DESCRIPTION
### Summary

PostgreSQL 18.6 is the current release of the 18 series. This moves the three places that name an exact version, and explains the two that deliberately keep a different one.

### Checklist
#### General
<!-- Items that do not apply to this pull request have been removed. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

### Motivation and Context

The repository was on 18.4. There is no 18.5: it was never published, and the Zonky binaries confirm it, publishing `18.4.0` and `18.6.0` with nothing in between.

### Description

Three files name an exact version, and they are not one setting read from one place:

| File | What it feeds |
|---|---|
| `.env` | the image tag in `docker/postgres.yml`, and, via the `.env`-to-system-property mapping in `gradle/test.gradle`, the Testcontainers image the server tests run against |
| `build.gradle` | the `embedded-postgres-binaries-bom` version for the Zonky embedded database |
| `documentation/docs/admin/database-tips.mdx` | a compose snippet shown to administrators |

The `build.gradle` one is worth knowing about: it reads `findProperty('postgres_version')`, a Gradle property, and falls back to a literal. Nothing in the repository or in CI passes that property, so the literal is the effective value and it can drift from `.env` silently. Both were on 18.4 and both move to 18.6 here.

Three further mentions are deliberately left as they are:

- `src/main/resources/config/liquibase/consolidate-changelogs.sh` starts throwaway containers from `postgres:18`. A floating major already resolves to 18.6, and it matches the `mysql:9` beside it, so pinning a patch here would only go stale.
- `NightlyLtiMoodleInteropTest` pins `bitnamilegacy/postgresql:17`. That is Moodle's own database, matching the Bitnami Moodle image the same test uses, and the `bitnamilegacy` namespace is a frozen archive: `bitnamilegacy/postgresql:18` returns 404. The existing comment on the sibling constant already records that this namespace receives no new versions.
- The JDBC driver `org.postgresql:postgresql:42.7.13` is already the latest release.

### Steps for Testing

1. Run any server integration test, for example `./gradlew test -x webapp --tests "de.tum.cit.aet.artemis.core.ContentVersionIntegrationTest"`. It passes, and `docker images` then lists `postgres:18.6-alpine`, which is the tag the test container resolved from `.env`.
2. Start a compose stack with `--env-file .env` and confirm the `artemis-postgres` container reports 18.6.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] A server integration test passes and resolves the 18.6 image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the PostgreSQL version used by the application’s database containers and test environments to 18.6.
- **Documentation**
  - Updated the PostgreSQL version shown in the database migration example to 18.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->