### PR TITLE
`Lectures`: Give the student lecture page a compact title bar

### DIFF
--- a/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.html
+++ b/src/main/webapp/app/lecture/overview/course-lectures/details/course-lecture-details.component.html
@@ -8,30 +8,18 @@
 @if (lecture(); as lecture) {
     <div class="d-flex flex-column h-100 overflow-hidden">
         <!--
-            Header card, laid out exactly like the exercise header: the title on its own line with the start and end
-            date beneath it, then the grey divider to the content card.
+            The page's own title bar. `page-top-bar` holds it to the same height as the shell's title bars, so the
+            lecture page reads like the other student pages; the start and end dates sit with the description instead.
+            `px-*` rather than `p-*`, so Bootstrap's !important spacing does not overrule the class's vertical padding.
         -->
-        <div class="lecture-header detail-header-card module-bg rounded-3 p-2 shell-divider-b">
-            <div class="detail-header-title-row gap-3">
-                @if (isSidebarCollapsed()) {
-                    <jhi-course-sidebar-toggle-button [isCollapsed]="isSidebarCollapsed()" (toggleSidebar)="toggleSidebar()" />
-                }
-                <h5 class="mb-0 text-truncate">
-                    <fa-icon class="me-2" [icon]="faChalkboardTeacher" />
-                    {{ lecture.title }}
-                </h5>
-            </div>
-            <div class="d-flex flex-row gap-2">
-                @for (informationBoxData of informationBoxData(); track informationBoxData.title) {
-                    <jhi-information-box [informationBoxData]="informationBoxData">
-                        <ng-container contentComponent>
-                            @if (informationBoxData.content.type === 'dateTime') {
-                                <span contentComponent>{{ informationBoxData.content.value | artemisDate }}</span>
-                            }
-                        </ng-container>
-                    </jhi-information-box>
-                }
-            </div>
+        <div class="page-top-bar module-bg rounded-3 px-3 shell-divider-b d-flex align-items-center gap-3">
+            @if (isSidebarCollapsed()) {
+                <jhi-course-sidebar-toggle-button [isCollapsed]="isSidebarCollapsed()" (toggleSidebar)="toggleSidebar()" />
+            }
+            <h5 class="mb-0 text-truncate">
+                <fa-icon class="me-2" [icon]="faChalkboardTeacher" />
+                {{ lecture.title }}
+            </h5>
         </div>
 
         <!--
@@ -41,6 +29,18 @@
         -->
         <jhi-resizable-panels class="flex-fill overflow-hidden" [useViewportWidthForCollapse]="true" storageKey="lecture-details-split">
             <ng-template jhiPanel [label]="'artemisApp.courseOverview.lectureDetails.lectureContent'" [icon]="faChalkboardTeacher">
+                <!-- Above the description rather than inside it, so the dates still show for a lecture without one. -->
+                <div class="d-flex flex-row flex-wrap gap-2 mb-2">
+                    @for (informationBoxData of informationBoxData(); track informationBoxData.title) {
+                        <jhi-information-box [informationBoxData]="informationBoxData">
+                            <ng-container contentComponent>
+                                @if (informationBoxData.content.type === 'dateTime') {
+                                    <span contentComponent>{{ informationBoxData.content.value | artemisDate }}</span>
+                                }
+                            </ng-container>
+                        </jhi-information-box>
+                    }
+                </div>
                 @if (lecture.description) {
                     <div class="row mb-2 mt-2 align-items-baseline">
                         <div class="col-auto">


### PR DESCRIPTION
### Summary

The student lecture page gave its title a full header card, roughly 110px tall for a row holding nothing but the title. This replaces it with the compact bar the other student pages use and moves the start and end dates down to the description.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [x] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

The lecture header used `detail-header-card`, which it shares with the exercise page. That card is two rows: the title, then the start and end dates, with padding around both. The exercise page earns the height because it packs its action buttons into the title row, but the lecture page has no actions, so the same card spends about 110px on a title and two dates.

### Description

- The header becomes a single `page-top-bar` row. That class already exists for a page that renders a bar in place of the shell's, so the lecture header now sits at the same height as the bars on Statistics, Calendar and FAQ. Horizontal padding goes through `px-3`, since Bootstrap's `!important` spacing utilities would otherwise overrule the vertical padding the class sets.
- The start and end information boxes move into the content panel, above the description heading rather than below it, so they still render for a lecture without a description.
- Removes the `lecture-header` class, which nothing styles.

One template file changed; no TypeScript or server changes.

### Steps for Testing

Prerequisites:
- 1 Student
- 1 Course with a lecture that has a start date, an end date and a description

1. Log in to Artemis as the student.
2. Open the course and go to **Lectures**.
3. Select the lecture. The title bar is a single compact row, the same height as the bar on the Statistics, Calendar and FAQ pages.
4. Confirm the start and end dates now sit at the top of the content panel, above **Description**.
5. Collapse the lecture sidebar and confirm the toggle button still appears in the title bar and reopens it.
6. Switch between the light and the dark theme and confirm the header still reads correctly.
7. Open a lecture **without** a description and confirm the start and end dates still show.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress

#### Code Review
- [x] Code Review 1

#### Manual Tests
- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

**No code changes detected** - test coverage not required for this PR.

_Last updated: 2026-09-08 16:15:22 UTC_


### Screenshots

Before:
<img width="1279" height="313" alt="image" src="https://github.com/user-attachments/assets/deef4af0-8fba-48ec-a5b7-2b5ac4919f83" />

After:
<img width="1515" height="319" alt="image" src="https://github.com/user-attachments/assets/5c63908b-51b8-40f1-8e12-519094f72b14" />
