### PR TITLE
`Athena`: Show AI feedback checkboxes in course settings regardless of module activation

### DIFF
--- a/src/main/webapp/app/course/manage/update/course-update.component.html
+++ b/src/main/webapp/app/course/manage/update/course-update.component.html
@@ -461,7 +461,7 @@
                         </div>
                     }
                 </jhi-feature-overlay>
-                @if (isAtLeastInstructor() && isAthenaEnabled()) {
+                @if (isAtLeastInstructor()) {
                     <div class="nested-form-group-head flex items-center gap-2">
                         <tum-ui-checkbox
                             inputId="field_athenaFeedbackEnabled"

--- a/src/main/webapp/app/course/manage/update/course-update.component.ts
+++ b/src/main/webapp/app/course/manage/update/course-update.component.ts
@@ -10,7 +10,7 @@ import { integerValidator } from 'app/shared-ui/form/integer-validator.directive
 import { Course, CourseInformationSharingConfiguration, isCommunicationEnabled, isMessagingEnabled, unsetCourseIcon } from 'app/course/shared/entities/course.model';
 import { CourseManagementService } from '../services/course-management.service';
 import { ColorSelectorComponent } from 'app/shared-ui/color-selector/color-selector.component';
-import { ARTEMIS_DEFAULT_COLOR, MODULE_FEATURE_ATHENA, MODULE_FEATURE_ATLAS, MODULE_FEATURE_LTI } from 'app/app.constants';
+import { ARTEMIS_DEFAULT_COLOR, MODULE_FEATURE_ATLAS, MODULE_FEATURE_LTI } from 'app/app.constants';
 import { ImageComponent } from 'app/shared-ui/image/image.component';
 import { ProfileService } from 'app/core/layouts/profiles/shared/profile.service';
 import dayjs from 'dayjs/esm';
@@ -160,7 +160,6 @@ export class CourseUpdateComponent implements OnInit {
     readonly athenaFeedbackEnabled = signal(false);
     readonly atlasEnabled = signal(false);
     readonly ltiEnabled = signal(false);
-    readonly isAthenaEnabled = signal(false);
     // Global auto-orchestration defaults, fetched when Atlas is active, shown as the override-field
     // placeholders so instructors see what an empty override resolves to. `undefined` until loaded
     // (or if the fetch fails) — the template falls back to a plain "Use default" label.
@@ -215,7 +214,6 @@ export class CourseUpdateComponent implements OnInit {
 
         this.atlasEnabled.set(this.profileService.isModuleFeatureActive(MODULE_FEATURE_ATLAS));
         this.ltiEnabled.set(this.profileService.isModuleFeatureActive(MODULE_FEATURE_LTI));
-        this.isAthenaEnabled.set(this.profileService.isModuleFeatureActive(MODULE_FEATURE_ATHENA));
         // Load the global auto-orchestration defaults to display as override placeholders. Best-effort:
         // if the feature toggle is off or the request fails, the placeholders stay on the plain
         // "Use default" label.


### PR DESCRIPTION
### Summary
The Athena AI feedback activation checkboxes in course settings were hidden whenever the Athena module was not active on the server. They are now shown as soon as the user is at least an instructor, independent of Athena's server-side activation state.

### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Client
- [x] I **strictly** followed the client coding guidelines.

### Motivation and Context
Instructors were unable to see or configure the Athena feedback settings (AI feedback, formative feedback, grading feedback) in the course settings UI unless the Athena module happened to be active on the server, even though these settings are part of the course configuration itself.

### Description
Removed the `isAthenaEnabled()` guard from the `@if` block wrapping the Athena feedback checkboxes in `course-update.component.html`, so only `isAtLeastInstructor()` gates visibility. Removed the now-unused `isAthenaEnabled` signal, its assignment, and the `MODULE_FEATURE_ATHENA` import from `course-update.component.ts`.

Not yet manually verified on a running instance — needs testing on a test server before merge.

### Steps for Testing
1. Log in to Artemis as an instructor (on a server where the Athena module is **not** active).
2. Navigate to Course Administration > Edit Course.
3. Confirm the "AI feedback" checkbox (and, once enabled, the formative/grading feedback checkboxes) are visible in the course settings form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Instructors can now view and manage Athena feedback settings in course configuration even when the Athena module is disabled.
  - Feedback options remain governed by the course’s existing formative and grading feedback settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->