### PR TITLE
`Development`: Add a documentation writing guideline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,10 @@ Organized by feature module:
 - **Do not commit design documents, specs, plans, or scratch notes.** Working notes belong in the pull request
   description or the issue, not in the repository. What is worth keeping goes into `documentation/docs/` as a proper
   page for its audience.
+- Full conventions — heading and anchor rules, naming controls in bold rather than backticks, screenshot and
+  screencast practice, when to split a page — live in
+  [`documentation/docs/developer/guidelines/documentation.mdx`](./documentation/docs/developer/guidelines/documentation.mdx).
+  Read it before writing or restructuring a page.
 
 ### API Specification
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,8 @@ Organized by feature module:
   `instructor/`, `student/`, `developer/`, `about/`. There is no top-level `docs/` folder; that was the old Sphinx
   location and anything written there is invisible on the documentation site. A `README.md` next to the tool it
   explains (a script directory, a docker setup) stays where it is and does not move into the site tree.
-- Pages are Docusaurus `.mdx` files with `id`, `title` and `sidebar_label` frontmatter. A new page is only reachable
+- Pages are Docusaurus `.mdx` files with `id`, `title` and `sidebar_label` frontmatter, and no H1 in the body —
+  Docusaurus renders the heading from `title`, so writing both makes the title drift. A new page is only reachable
   once it is listed in the matching `documentation/sidebar-*.ts`, so add it there and link it from the related pages.
 - Write for the audience of the folder, in the present tense, describing what the reader sees and does in Artemis. Do
   not reference pull requests, issues, or commits, and do not describe the change relative to a previous release.

--- a/documentation/docs/developer/guidelines/documentation.mdx
+++ b/documentation/docs/developer/guidelines/documentation.mdx
@@ -1,0 +1,280 @@
+---
+id: documentation
+title: Writing Documentation
+sidebar_label: Documentation
+---
+
+import Callout from "../../../src/components/Callout/Callout";
+import {CalloutVariant} from "../../../src/components/Callout/Callout.types";
+
+# Writing Documentation
+
+This page is about the documentation site itself: where a page belongs, how to structure it, how to name what the
+reader sees on screen, and how to keep screenshots and screencasts from going stale. It applies to every page under
+`documentation/docs/`, whichever audience it is written for.
+
+Each rule below states why it exists. Most of them exist because the opposite was tried first and broke something.
+
+<Callout variant={CalloutVariant.info}>
+
+  Two neighbouring guidelines cover the words rather than the page, and both apply here:
+  [Terminology](/developer/guidelines/terminology) for naming components precisely, and
+  [Language](/developer/guidelines/language) for inclusive, diversity-sensitive and appreciative language.
+
+</Callout>
+
+## Where a page belongs
+
+Documentation lives under `documentation/docs/`, split by audience: `admin/`, `instructor/`, `student/`,
+`developer/`, `about/`. Write for the audience of the folder. An instructor page explains what an instructor
+configures; a student page explains what a student sees and does. When both need to know about the same feature,
+write two pages and link them, rather than one page that describes the other side's screens.
+
+A new page is only reachable once it is listed in the matching `documentation/sidebar-*.ts`. Add it there and link
+it from the related pages in the same change.
+
+Screenshots and diagrams go into the nearest `assets/` directory, in a subdirectory named after the page or the
+feature. Do not copy an asset into a second audience's tree so that a second page can use it — either the two pages
+should link to each other, or one of them should not be showing that screen at all.
+
+<Callout variant={CalloutVariant.warning}>
+
+  Do not commit design documents, specifications, plans or scratch notes. Working notes belong in the pull request
+  description or the issue. What is worth keeping becomes a proper page here, for a named audience.
+
+</Callout>
+
+## Frontmatter and the page title
+
+Every page carries three frontmatter keys:
+
+```yaml
+---
+id: exam-timeline
+title: Timeline of an Artemis Online Exam
+sidebar_label: Exam Timeline
+---
+```
+
+- **`id`** is what the sidebar file and other pages refer to. Keep it equal to the filename without its extension.
+- **`title`** is the browser tab title, the search result heading, and the name the page is known by.
+- **`sidebar_label`** is the entry in the navigation tree. It is usually shorter than the title, because the sidebar
+  is narrow and the surrounding category already supplies context.
+
+The body then opens with exactly **one** H1, whose text matches `title`.
+
+This is not a duplicate. Docusaurus renders a synthetic H1 from the frontmatter title *only* when the body has no
+top-level heading of its own (`DocItemContent` in `@docusaurus/theme-classic` checks `contentTitle`), so a page with
+a body H1 shows that one and nothing else. Writing both keeps the title visible while editing the file and lets the
+tab title, the sidebar entry and the on-page heading be chosen independently — but if they drift apart the reader
+sees one thing in the tab and another on the page, which is why they have to match.
+
+Never write a second H1. Two `<h1>` elements on one page break the document outline that screen readers and search
+engines rely on. A second top-level section is an H2.
+
+## Headings and anchors
+
+**A heading's anchor is derived from its text.** `## Configure Grading` becomes `#configure-grading`. Two
+consequences follow.
+
+**Do not number headings manually.** `## 1. Creation and Configuration` produces the anchor
+`#1-creation-and-configuration`, and `### 1.6 Manage Student Exams` produces `#16-manage-student-exams`. Every link
+to that section then encodes a section number, so inserting one section silently redirects a dozen links to the
+wrong place — silently, because the anchors stay syntactically valid and the build cannot tell that the meaning
+moved. Let the heading say what the section is about and let the sidebar supply the ordering. Numbered *steps*
+belong in an ordered list, not in headings.
+
+**The `{#custom-id}` syntax does not work here.** MDX parses the braces as a JSX expression and the build fails with
+`Could not parse expression with acorn`. When you need a specific anchor — to keep an inbound link alive after a
+rewrite, for instance — choose heading text whose natural slug is the anchor you need.
+
+Two further rules:
+
+- Do not skip heading levels. An H4 under an H2 leaves a hole in the outline.
+- Keep heading text unique within a page. Repeated text produces `#the-heading` and `#the-heading-1`, and neither
+  link tells the reader which one it goes to. Nesting a heading inside an identically named parent is the common
+  version of this mistake.
+
+## Naming what the reader sees
+
+**Write the name of a control in bold, exactly as the interface spells it.**
+
+> Check **Enable manual assessment**, then set the **Release Date of Results**.
+
+Do not put control names in backticks. Backticks mean code, so `` `Generate individual exams` `` reads as an
+identifier rather than a button, and a reader looking for that string in the interface does not know whether the
+capitalisation is real.
+
+Backticks are for what actually is code: file and directory paths, class and method names, configuration keys,
+commands, and literal values a reader types or a build produces.
+
+**The translation file is the authority for a label, not your memory of the screen.** Before naming a control, check
+it in `src/main/webapp/i18n/en/*.json`. Labels get reworded, and documentation that names a control the interface no
+longer has costs a reader more time than no documentation at all. The same check applies to whether a control exists
+at all: several fields are hidden depending on configuration — anything gated on `isLocalCIEnabled`, for example,
+does not appear on an instance running Integrated Code Lifecycle — so say which setup a control belongs to.
+
+Do not leak internal vocabulary into instructor and student pages. Students have no concept named "VC server" or
+"build plan"; they have repositories and builds. Naming a component precisely is a separate obligation that applies
+to every page — see [Terminology](/developer/guidelines/terminology).
+
+## Screenshots
+
+Use the `Image` component rather than a raw `<img>` tag, so that every figure gets the same frame, sizing and
+caption treatment:
+
+```mdx
+import Image, {ImageSize} from "../../../src/components/Image/Image";
+import configureGrading from './assets/exams/configure-grading.png';
+
+<Image src={configureGrading} alt="Configure Grading page" size={ImageSize.large}
+       caption="Test case configuration on the Configure Grading page" />
+```
+
+The number of `../` segments depends on how deep the page sits, so copy the import from a neighbouring page in the
+same directory rather than from here.
+
+**Crop to the subject.** A figure about one panel should show that panel, not the whole browser window with the
+navigation bar and the course sidebar around it. The chrome adds pixels, dates the screenshot faster than its
+content does, and pushes the thing being explained down to a corner. Capture the element rather than cropping by
+pixel coordinates where you can — pixel crops cut off text as soon as anything reflows.
+
+**Do not photograph a button.** A cropped picture of a labelled control, embedded inline in a sentence, has to be
+recaptured on every restyle, is invisible to the site's search index, carries a light background into dark mode, and
+tells a reader less than the label written in bold does. Write the label instead.
+
+The `inline` prop on `Image` exists for the genuine case: an icon that carries no text of its own, such as the hint
+icon next to a form field. A control that has a name is named.
+
+**Capture with realistic data.** A screenshot of an empty table, a course called `test`, or a student named
+`student1` teaches the reader nothing about what they will see. Populate the local instance with plausible course,
+exercise and participant data first. An older screenshot with real content in it is worth more than a fresh one that
+is empty — if a recapture would come out emptier than what is already there, leave the old one and note why.
+
+**Retire what you replace.** When a screenshot stops being referenced, delete the file. Unreferenced assets
+accumulate invisibly; they are never noticed until someone measures.
+
+## Screencasts
+
+Embed TUM-Live recordings with the `TumLiveVideo` component, passing the **bare recording id**:
+
+```mdx
+import TumLiveVideo from "../../../src/components/TumLiveVideo/TumLiveVideo";
+
+<TumLiveVideo src="67223" title="Quiz Training Mode Tutorial" height={400} />
+```
+
+The component expands a bare id to the presentation stream. A full URL is passed through unchanged, so it plays the
+default stream instead — which means two embeds of the same recording behave differently depending on which form the
+author happened to use. Use the bare id.
+
+**A stale screencast is worse than none.** A reader who follows a video through an interface that no longer looks
+like that loses the time twice: once watching, once working out which parts still apply. When a recording no longer
+matches the product, re-record it or remove the embed. Do not leave it in place next to screenshots that contradict
+it.
+
+## Callouts, tables and separators
+
+Use the `Callout` component for anything set apart from the flow, with the variant that matches the message —
+`info`, `tip`, `success`, `warning` or `danger`:
+
+```mdx
+<Callout variant={CalloutVariant.warning}>
+
+  Checkout paths can only be changed while the exercise is being created.
+
+</Callout>
+```
+
+Reserve `warning` and `danger` for consequences a reader cannot undo. A page where every third paragraph is a
+warning has no warnings.
+
+Use a table when the reader is comparing values across a fixed set of things — languages against supported
+features, settings against their effects. Markdown tables are enough for that. Reach for raw `<table>` markup only
+when you need `rowSpan` or `colSpan`, which Markdown cannot express.
+
+Do not separate sections with `---` horizontal rules. Headings already separate sections, and the rules add a second
+inconsistent visual rhythm on top of them.
+
+## Prose over bullet lists
+
+A bullet list is for things that genuinely are a list: options, steps, requirements, alternatives. It is not a way
+to avoid writing sentences. Three bullets that are three sentences of one argument read worse than the paragraph,
+because the reader has to reconstruct the connection between them that the bullets threw away.
+
+Write in the present tense, describing what the reader sees and does. Do not reference pull requests, issues or
+commits, and do not describe a feature relative to a previous release — the reader is looking at the version that is
+deployed, not at a changelog.
+
+## Links
+
+**Link across sections and audiences with an absolute site path:**
+
+```mdx
+See [Integrated Code Lifecycle](/instructor/integrations/integrated-code-lifecycle).
+```
+
+Relative links resolve against the page's own directory, so they break the moment a page moves into a
+subdirectory — `../assessment-grading/plagiarism-check` starts pointing one level too deep and the build fails.
+Relative links between two pages in the same directory are fine and are the exception.
+
+`onBrokenLinks`, `onBrokenAnchors` and `onBrokenMarkdownLinks` are all set to `throw`, so the build catches a link
+to a page or an anchor that does not exist. It cannot catch two things: a link whose target moved but whose anchor
+still resolves somewhere (see the numbering rule above), and a placeholder `](#)`, which is syntactically a valid
+link to the top of the page. Do not leave placeholders behind.
+
+When a feature has both an instructor and a student page, link each from the other. An instructor deciding how to
+configure something needs to see what the student will get, and a student reading about a limit needs to know who
+sets it.
+
+## Page size and landing pages
+
+Once a page passes roughly 300 lines, check whether it is still about one thing. A long reference page — a table of
+supported languages, a catalogue of analysis rules — is fine at any length, because a reader arrives looking up one
+row. A long *task* page is not, because a reader arrives with one task and has to scroll past five others.
+
+Split the second kind into a category: a landing page at the original URL, and focused pages beneath it. Splitting
+later is more expensive than it looks, because every inbound link and in-product help URL has to keep resolving —
+so check the anchors before moving text, not after.
+
+A category landing page opens with one or two sentences saying what the area is for, followed by a table of the
+pages beneath it:
+
+```markdown
+| Page | Description |
+|------|-------------|
+| [Create an Exercise](/instructor/exercises/programming-exercise/create-an-exercise) | The creation form field by field, simple and advanced mode, and import |
+| [Write Code and Tests](/instructor/exercises/programming-exercise/write-code-and-tests) | Repositories, the problem statement, and the supported test frameworks |
+```
+
+The description says what the reader will find, not what the page is called again.
+
+## Checking your work
+
+Build the site before opening a pull request:
+
+```bash
+cd documentation
+pnpm install --frozen-lockfile
+pnpm run build
+```
+
+The build is the only check for broken links and anchors, and it is strict: a single bad link fails it. Run
+`pnpm run start` while writing to preview a page, but run the full build before pushing — `start` tolerates things
+`build` rejects.
+
+The terminology check runs over documentation too, and it only sees tracked files, so stage a new page before
+running it:
+
+```bash
+git add documentation/docs/<audience>/<your-page>.mdx
+python3 supporting_scripts/check_terminology.py
+```
+
+## Related
+
+* [Terminology](/developer/guidelines/terminology) — naming components instead of layers, and the check that
+  enforces it.
+* [Language](/developer/guidelines/language) — inclusive, diversity-sensitive and appreciative language.
+* [Work with AI](/developer/work-with-ai) — how the agent skills in `skills/` relate to these guidelines, and which
+  ones to update when a convention changes.

--- a/documentation/docs/developer/guidelines/documentation.mdx
+++ b/documentation/docs/developer/guidelines/documentation.mdx
@@ -7,8 +7,6 @@ sidebar_label: Documentation
 import Callout from "../../../src/components/Callout/Callout";
 import {CalloutVariant} from "../../../src/components/Callout/Callout.types";
 
-# Writing Documentation
-
 This page is about the documentation site itself: where a page belongs, how to structure it, how to name what the
 reader sees on screen, and how to keep screenshots and screencasts from going stale. It applies to every page under
 `documentation/docs/`, whichever audience it is written for.
@@ -46,7 +44,7 @@ should link to each other, or one of them should not be showing that screen at a
 
 ## Frontmatter and the page title
 
-Every page carries three frontmatter keys:
+Every page carries three frontmatter keys, and **no H1 of its own**:
 
 ```yaml
 ---
@@ -57,20 +55,19 @@ sidebar_label: Exam Timeline
 ```
 
 - **`id`** is what the sidebar file and other pages refer to. Keep it equal to the filename without its extension.
-- **`title`** is the browser tab title, the search result heading, and the name the page is known by.
+- **`title`** is the browser tab title, the on-page heading, the search result heading, and the name the page is
+  known by.
 - **`sidebar_label`** is the entry in the navigation tree. It is usually shorter than the title, because the sidebar
   is narrow and the surrounding category already supplies context.
 
-The body then opens with exactly **one** H1, whose text matches `title`.
+**Do not write an H1 in the body.** Docusaurus renders one from `title` whenever the body has no top-level heading
+of its own: `DocItemContent` in `@docusaurus/theme-classic` synthesises the heading when `contentTitle` is
+undefined. Writing the title once means it cannot drift out of sync with the tab, the sidebar entry and the search
+result — which is exactly what happens when the same page states it twice.
 
-This is not a duplicate. Docusaurus renders a synthetic H1 from the frontmatter title *only* when the body has no
-top-level heading of its own (`DocItemContent` in `@docusaurus/theme-classic` checks `contentTitle`), so a page with
-a body H1 shows that one and nothing else. Writing both keeps the title visible while editing the file and lets the
-tab title, the sidebar entry and the on-page heading be chosen independently — but if they drift apart the reader
-sees one thing in the tab and another on the page, which is why they have to match.
-
-Never write a second H1. Two `<h1>` elements on one page break the document outline that screen readers and search
-engines rely on. A second top-level section is an H2.
+The body therefore opens with its first paragraph, below any component imports. Every heading you write in the body
+is an H2 or deeper. Two `<h1>` elements on one page break the document outline that screen readers and search
+engines rely on, and a body H1 next to a frontmatter title is the way that happens by accident.
 
 ## Headings and anchors
 
@@ -90,7 +87,7 @@ rewrite, for instance — choose heading text whose natural slug is the anchor y
 
 Two further rules:
 
-- Do not skip heading levels. An H4 under an H2 leaves a hole in the outline.
+- Do not skip heading levels. The body starts at H2, so an H4 directly under an H2 leaves a hole in the outline.
 - Keep heading text unique within a page. Repeated text produces `#the-heading` and `#the-heading-1`, and neither
   link tells the reader which one it goes to. Nesting a heading inside an identically named parent is the common
   version of this mistake.

--- a/documentation/docs/developer/guidelines/index.mdx
+++ b/documentation/docs/developer/guidelines/index.mdx
@@ -38,5 +38,6 @@ Guidelines for Spring Boot and Java server development:
 
 ## General Guidelines
 
+- **[Documentation](/developer/guidelines/documentation)** - Structuring a documentation page, naming what the reader sees on screen, and keeping screenshots and screencasts current
 - **[Language](/developer/guidelines/language)** - Inclusive, diversity-sensitive, and appreciative language guidelines
 - **[Terminology](/developer/guidelines/terminology)** - Naming components precisely, and the two vague layer words Artemis does not use

--- a/documentation/sidebar-developer.ts
+++ b/documentation/sidebar-developer.ts
@@ -48,7 +48,7 @@ const sidebars: SidebarsConfig = {
                 {
                     type: 'category',
                     label: 'General Guidelines',
-                    items: ['guidelines/language', 'guidelines/terminology'],
+                    items: ['guidelines/documentation', 'guidelines/language', 'guidelines/terminology'],
                 },
             ],
         },


### PR DESCRIPTION
### Summary

Adds a guideline page describing how to write for the documentation site: where a page belongs, how to structure it,
how to name what the reader sees on screen, and how to keep screenshots and screencasts current. Each rule states its
reason.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context

`CLAUDE.md` carries four bullets about documentation — the audience folders, the three frontmatter keys, present
tense, and no design notes in the repository. Everything beyond that has been decided per page, so conventions that
should be uniform across the site currently differ from one page to the next: whether a UI control is written in bold
or in backticks, whether frontmatter is present, whether sections are separated by headings alone or also by
horizontal rules, whether headings are numbered by hand.

Some of those choices have consequences that are not obvious when making them. Manually numbered headings, for
instance, put the section number into the anchor, so inserting a section silently redirects every link that pointed
past it — and the build cannot detect this, because the anchors stay syntactically valid.

Writing the conventions down once, with the reasoning attached, means a page author does not have to rediscover
them and a reviewer does not have to re-argue them.

### Description

Adds `documentation/docs/developer/guidelines/documentation.mdx`, registered in `sidebar-developer.ts` and in the
guidelines index under **General Guidelines**, alongside Language and Terminology. `CLAUDE.md` gains one bullet
pointing at it, so its short summary now has a full reference behind it. No existing documentation page is changed.

The page covers:

- **Where a page belongs** — audience folders, sidebar registration, where assets go, and why an asset should not be
  copied into a second audience's tree so that a second page can use it.
- **Frontmatter and the page title** — what each of `id`, `title` and `sidebar_label` controls, and why the
  frontmatter title is the only place a page states its title: `DocItemContent` in `@docusaurus/theme-classic`
  synthesises the H1 from `title` whenever the body has no top-level heading, so writing both states the title twice
  and lets it drift out of sync with the tab and the sidebar entry. This page carries no body H1 itself, so it
  demonstrates the rule it states.
- **Headings and anchors** — the anchor derives from the heading text, which is what makes manual numbering risky.
  Also records that the `{#custom-id}` escape hatch does not work in this MDX setup — it fails with
  `Could not parse expression with acorn` — and what to do instead when a specific anchor has to be preserved.
- **Naming what the reader sees** — bold for controls, backticks for code, and `src/main/webapp/i18n/en/*.json` as
  the authority for a label, including the case where a control is hidden depending on configuration.
- **Screenshots** — the `Image` component, cropping to the subject, capturing with realistic data, and why a
  labelled button is better written in bold than photographed. Notes that `Image`'s `inline` prop is meant for an
  icon that carries no text of its own, which is the legitimate inline-image case.
- **Screencasts** — pass `TumLiveVideo` a bare recording id, since a full URL skips the `/PRES` expansion and plays
  a different stream; and replace or remove a recording that no longer matches the product rather than leaving it
  beside screenshots that contradict it.
- **Callouts, tables and separators**, **prose over bullet lists**, **links** — absolute site paths, and the two
  cases `onBrokenLinks: 'throw'` cannot catch — **page size and landing pages**, and **how to verify a change**: the
  documentation build plus the terminology check, which only sees tracked files.

### Steps for Testing

Documentation only; no product behaviour changes.

1. `cd documentation && pnpm install --frozen-lockfile && pnpm run build`. This is the real link check:
   `onBrokenLinks`, `onBrokenAnchors` and `onBrokenMarkdownLinks` are all set to `throw`.
2. `pnpm run start`, then open **Developer → Coding and Design Guidelines → General Guidelines → Documentation**.
   The sidebar entry reads *Documentation*, the browser tab reads *Writing Documentation*, and the page renders
   exactly one H1 — synthesised from the frontmatter title, since the body has none.
3. `python3 supporting_scripts/check_terminology.py` passes.

### Related

Follows [#13731](https://github.com/ls1intum/Artemis/pull/13731), which restructured the programming exercise guide
and is the worked example most of these rules are drawn from. Further documentation improvements are planned
separately; this page is a prerequisite for them, so that each one does not settle the same questions again.
