### PR TITLE
`Development`: Serve the client bundle from the nginx cache

### DIFF
--- a/docker/nginx/artemis-nginx.conf
+++ b/docker/nginx/artemis-nginx.conf
@@ -69,6 +69,30 @@ limit_req_zone $git_credential_attempt_key zone=gitauthlimit:10m rate=60r/m;
 # Rate limit for git data transfer, at most 5 requests per second
 limit_req_zone $rate_limit_key zone=gitlimit:10m rate=5r/s;
 
+# ----------------------------------------------------------------------------------------------------
+# Cache for the client bundle. The location that uses it lives in artemis-server.conf.
+#
+# Without it every request for a chunk reaches a core node, which reads the file out of the WAR and
+# gzips it, because server.compression is on. A cohort opening the page at once turns that into a very
+# large number of application requests for a few hundred distinct files: measured against 2000
+# simulated students, roughly 1.2 million of them in a few minutes, which is what limits how fast a
+# lecture hall can load Artemis.
+#
+# Sizing: a build's bundle is tens of megabytes, so max_size is generous rather than tight and exists
+# only to bound the disk. Old builds evict themselves, because their file names vanish with them;
+# inactive=30d then removes what nothing has asked for since. 20m of keys is far more than the few
+# hundred entries a build needs.
+proxy_cache_path /var/cache/nginx/artemis-assets levels=1:2 keys_zone=artemis_assets:20m
+                 max_size=2g inactive=30d use_temp_path=off;
+
+# Collapses the many Accept-Encoding strings browsers send ("gzip, deflate, br, zstd" and friends) into
+# the two representations Artemis can actually return. Both the upstream request and the cache key use
+# this, so the cache holds two entries per file rather than one per browser variant.
+map $http_accept_encoding $artemis_asset_encoding {
+    default   "identity";
+    "~*gzip"  "gzip";
+}
+
 server {
     listen 80 default_server;
     listen [::]:80 default_server;

--- a/docker/nginx/artemis-nginx.conf
+++ b/docker/nginx/artemis-nginx.conf
@@ -88,9 +88,14 @@ proxy_cache_path /var/cache/nginx/artemis-assets levels=1:2 keys_zone=artemis_as
 # Collapses the many Accept-Encoding strings browsers send ("gzip, deflate, br, zstd" and friends) into
 # the two representations Artemis can actually return. Both the upstream request and the cache key use
 # this, so the cache holds two entries per file rather than one per browser variant.
+# The zero-quality form is matched first because nginx takes the first regex that matches: a client
+# sending "gzip;q=0" is explicitly refusing gzip, and the generic rule below would otherwise hand it a
+# gzipped body it said it could not accept. q=0.5 and friends are not affected - the pattern requires the
+# zero to end the value.
 map $http_accept_encoding $artemis_asset_encoding {
-    default   "identity";
-    "~*gzip"  "gzip";
+    default                                 "identity";
+    "~*gzip\s*;\s*q=0(\.0+)?(\s|,|$)"      "identity";
+    "~*gzip"                                "gzip";
 }
 
 server {

--- a/docker/nginx/artemis-server.conf
+++ b/docker/nginx/artemis-server.conf
@@ -44,6 +44,59 @@ location / {
     add_header alt-svc 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000';
  }
 
+# The client bundle, answered from nginx's own cache instead of from a core node.
+#
+# Everything matched here is versioned in its URL: Angular emits content-hashed names for JavaScript,
+# CSS and the media they reference, and the translation loader appends the build's I18N_HASH as a query
+# parameter, which is part of the cache key. A cached copy therefore cannot go stale - a new build is a
+# new URL - and the entries the old build left behind are never asked for again.
+#
+# The regex deliberately anchors the file name to the first path segment. It must not grow into
+# something that also matches /api/..., because a regex location beats a prefix location: it would take
+# the rate-limited endpoints below out of their zones without any other sign that it had happened.
+location ~* ^/(?:[^/]+\.(?:js|css)|media/|i18n/) {
+    proxy_pass http://artemis;
+
+    # Declaring any proxy_set_header in a location drops every one inherited from the server level, so
+    # the three forwarding headers have to be restated here - see the comment at the top of this file.
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # Normalised, so a core node returns one of two representations rather than one per browser.
+    proxy_set_header Accept-Encoding $artemis_asset_encoding;
+
+    proxy_cache artemis_assets;
+    # The encoding is in the key because Vary is ignored below.
+    proxy_cache_key "$scheme$request_method$host$request_uri$artemis_asset_encoding";
+    # Artemis answers these with Vary: Accept-Encoding, and nginx would then key the entry on the
+    # client's raw Accept-Encoding rather than on the normalised one set above, which is what the
+    # normalisation is there to avoid. Safe to ignore only because encoding is the sole dimension these
+    # responses vary on, and the key already covers it.
+    proxy_ignore_headers Vary;
+
+    # One request fills an entry and the rest wait for it. This is the line that matters at the start of
+    # a lecture: without it a cold cache still sends the whole cohort upstream simultaneously, which is
+    # exactly the moment the cache exists to protect.
+    proxy_cache_lock on;
+    proxy_cache_lock_timeout 30s;
+    # Serve what we have rather than pile onto a node that is already struggling.
+    proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+    proxy_cache_background_update on;
+    proxy_cache_revalidate on;
+
+    # Only used for responses that carry no caching directives of their own. Artemis sends Cache-Control
+    # on these paths and stays authoritative; this is the floor, not the policy.
+    proxy_cache_valid 200 30d;
+    # A 404 here means a build no longer ships that file. Cache it briefly so a stale client asking
+    # repeatedly cannot turn into load, but not so long that a deploy race is remembered.
+    proxy_cache_valid 404 1m;
+
+    # add_header does not accumulate across levels: naming one here drops those set in `location /`,
+    # so alt-svc is repeated to keep advertising HTTP/3 on these responses.
+    add_header alt-svc 'h3=":443"; ma=2592000,h3-29=":443"; ma=2592000';
+    add_header X-Cache-Status $upstream_cache_status always;
+}
+
 # Login. NOTE: this must match the real endpoint served by PublicUserJwtResource
 # (@RequestMapping("api/core/public/") + @PostMapping("authenticate")). The former
 # /api/authenticate path is not served by any controller, so a block pointing at it

--- a/docker/nginx/artemis-server.conf
+++ b/docker/nginx/artemis-server.conf
@@ -66,8 +66,12 @@ location ~* ^/(?:[^/]+\.(?:js|css)|media/) {
     proxy_set_header Accept-Encoding $artemis_asset_encoding;
 
     proxy_cache artemis_assets;
+    # $uri, not $request_uri: the path already identifies the content, because everything reaching this
+    # location has its build hash in the file name. Keying on the query string as well would let anyone
+    # mint unlimited distinct entries with /chunk-abc.js?1, ?2, ?3 - each one a cache miss forwarded
+    # upstream, each one a separate proxy_cache_lock scope, and each one evicting something real.
     # The encoding is in the key because Vary is ignored below.
-    proxy_cache_key "$scheme$request_method$host$request_uri$artemis_asset_encoding";
+    proxy_cache_key "$scheme$request_method$host$uri$artemis_asset_encoding";
     # Vary: Artemis answers these with Vary: Accept-Encoding, and nginx would then key the entry on the
     # client's raw Accept-Encoding rather than on the normalised one set above, which is what the
     # normalisation is there to avoid. Safe to ignore only because encoding is the sole dimension these

--- a/docker/nginx/artemis-server.conf
+++ b/docker/nginx/artemis-server.conf
@@ -54,7 +54,7 @@ location / {
 # The regex deliberately anchors the file name to the first path segment. It must not grow into
 # something that also matches /api/..., because a regex location beats a prefix location: it would take
 # the rate-limited endpoints below out of their zones without any other sign that it had happened.
-location ~* ^/(?:[^/]+\.(?:js|css)|media/|i18n/) {
+location ~* ^/(?:[^/]+\.(?:js|css)|media/) {
     proxy_pass http://artemis;
 
     # Declaring any proxy_set_header in a location drops every one inherited from the server level, so
@@ -68,11 +68,17 @@ location ~* ^/(?:[^/]+\.(?:js|css)|media/|i18n/) {
     proxy_cache artemis_assets;
     # The encoding is in the key because Vary is ignored below.
     proxy_cache_key "$scheme$request_method$host$request_uri$artemis_asset_encoding";
-    # Artemis answers these with Vary: Accept-Encoding, and nginx would then key the entry on the
+    # Vary: Artemis answers these with Vary: Accept-Encoding, and nginx would then key the entry on the
     # client's raw Accept-Encoding rather than on the normalised one set above, which is what the
     # normalisation is there to avoid. Safe to ignore only because encoding is the sole dimension these
     # responses vary on, and the key already covers it.
-    proxy_ignore_headers Vary;
+    #
+    # Cache-Control and Expires: CachingHttpHeadersFilter stamps a 30 day lifetime on everything matching
+    # *.js and *.css before the request is handled, so a 404 for a chunk an old node does not have yet
+    # carries it too. Honouring that would let a single mid-rollout miss stick in the shared cache for a
+    # month and hide the chunk from every healthy node. Ignoring both leaves proxy_cache_valid below as
+    # the only thing that decides what is cacheable, and it names 200 alone.
+    proxy_ignore_headers Vary Cache-Control Expires;
 
     # One request fills an entry and the rest wait for it. This is the line that matters at the start of
     # a lecture: without it a cold cache still sends the whole cohort upstream simultaneously, which is
@@ -84,12 +90,10 @@ location ~* ^/(?:[^/]+\.(?:js|css)|media/|i18n/) {
     proxy_cache_background_update on;
     proxy_cache_revalidate on;
 
-    # Only used for responses that carry no caching directives of their own. Artemis sends Cache-Control
-    # on these paths and stays authoritative; this is the floor, not the policy.
+    # 200 and nothing else. Every other status - a 404 from a node that has not been upgraded yet, a 502
+    # from one being restarted - has to reach the client and be asked again, because during a rolling
+    # deployment the same URL is genuinely absent on one node and present on the next.
     proxy_cache_valid 200 30d;
-    # A 404 here means a build no longer ships that file. Cache it briefly so a stale client asking
-    # repeatedly cannot turn into load, but not so long that a deploy race is remembered.
-    proxy_cache_valid 404 1m;
 
     # add_header does not accumulate across levels: naming one here drops those set in `location /`,
     # so alt-svc is repeated to keep advertising HTTP/3 on these responses.


### PR DESCRIPTION
### Summary

Artemis serves its own static content, and nothing in front of it caches: there is no `proxy_cache_path` anywhere in `docker/nginx/`, and `location /` proxies everything. Every request for a chunk therefore reaches a core node, which reads the file out of the WAR and gzips it, because `server.compression` is on.

nginx now answers the client bundle from its own cache instead.

### Motivation and Context

Found while benchmarking exam start-up load. A cohort of 2000 simulated students produces roughly **1.2 million application requests in a few minutes** for a few hundred distinct files, and that is what limits how fast a lecture hall can open Artemis — the static phase plateaus at ~4,000 req/s no matter how much concurrency is thrown at it, and those are Java threads, not nginx workers.

### Description

Everything matched is versioned in its URL — content hashes for JavaScript, CSS and the media they reference, and the build's `I18N_HASH` as a query parameter for translations (`split-translate-loader.ts:49`). A cached copy therefore *cannot* go stale: a new build is a new URL, and the entries an old build left behind are simply never asked for again. `inactive=30d` and `max_size` handle eviction.

Three details worth knowing:

**`proxy_cache_lock` is the point.** Without it a cold cache still sends the whole cohort upstream simultaneously, which is exactly the moment the cache exists for.

**Accept-Encoding is normalised** into the two representations Artemis can return, put in the cache key, and `Vary` is ignored. Without that, nginx keys on the client's raw `Accept-Encoding` and a cache entry exists per browser variant (`gzip`, `gzip, deflate`, `gzip, deflate, br`, `gzip, deflate, br, zstd`, …). Ignoring `Vary` is safe *only* because encoding is the sole dimension these responses vary on and the key covers it.

**The regex anchors the file name to the first path segment**, and must stay that way. A regex location beats a prefix location, so widening it to also match `/api/...` would silently take the rate-limited endpoints out of their zones.

### Steps for Testing

Verified against `nginx:1.31.3-alpine-slim` with the real config files and a stub upstream that answers like Artemis (`Cache-Control`, `Vary: Accept-Encoding`):

1. `nginx -t` passes; nginx starts a cache manager and cache loader process.
2. Repeat request for a bundle file → `X-Cache-Status: MISS` then `HIT`.
3. All four common browser `Accept-Encoding` strings share **one** entry; an `identity` client correctly gets its own.
4. `styles-*.css`, `media/*`, `i18n/en.json?_=aaa` all cache; `?_=bbb` is a separate entry, so a new build busts it.
5. **50 simultaneous requests for one uncached file → 1 MISS, 49 HIT.** This is `proxy_cache_lock` doing its job.
6. `/api/core/public/authenticate`, `/api/core/public/account/reset-password/init`, `/git/.../info/refs`, `/api/nested/path/file.js` and `/websocket` are all still routed as before and uncached.

Behaviour on the rate-limited endpoints was compared against unmodified `develop` in the same harness and is identical. (The harness could not make the login limiter fire from a single source address in a short burst, on either version, so that check establishes "no change", not "the limiter works".)

The same change for the VM deployment is in artemis-ansible-collection, where it is behind a `proxy_cache_client_bundle` flag with the size, lifetime and path as variables.

### Related

Composes with #13601, **already merged**, which fixed `Cache-Control: max-age` on these same paths — it was being emitted in milliseconds, so a configured 7 days went out as 19 years. That ordering mattered: nginx honours the upstream `Cache-Control` for its own TTL, so landing this cache first would have baked a 19-year TTL into nginx's store. With #13601 in, the store inherits the intended 30 days. This branch is based on a `develop` that contains it.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

### Checklist

#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) and too complex database calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved loading times for JavaScript, CSS, and media assets through server-side caching.
  - Added separate cached responses for compressed and uncompressed content.
  - Enabled cached assets to remain available during upstream service interruptions, with background refreshes.
  - Added cache status information to asset responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->