### PR TITLE
`Development`: Restore the interrupt status in swallowed InterruptedExceptions

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaFeedbackSuggestionsService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/athena/service/AthenaFeedbackSuggestionsService.java
@@ -122,7 +122,7 @@ public class AthenaFeedbackSuggestionsService {
     }
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
-    private record RequestDTO(@NonNull ExerciseBaseDTO exercise, @NonNull SubmissionBaseDTO submission, @Nullable LearnerProfileDTO learnerProfile, @NonNull boolean isGraded,
+    private record RequestDTO(@NonNull ExerciseBaseDTO exercise, @NonNull SubmissionBaseDTO submission, @Nullable LearnerProfileDTO learnerProfile, boolean isGraded,
             @Nullable AiSelectionDecision selection, @Nullable SubmissionBaseDTO latestSubmission, @Nullable List<CourseCompetencyDTO> competencies) {
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildAgentDockerService.java
@@ -459,6 +459,10 @@ public class BuildAgentDockerService {
                     checkImageArchitecture(imageName, inspectImageResponse, buildJob, buildLogsMap);
                 }
                 catch (InterruptedException ie) {
+                    // Wrapping in another exception type loses the interruption, so restore it for whoever catches
+                    // LocalCIException: a build agent thread that keeps running after a shutdown request is the failure
+                    // this guards against.
+                    Thread.currentThread().interrupt();
                     throw new LocalCIException("Interrupted while pulling docker image " + imageName, ie);
                 }
                 catch (Exception ex) {
@@ -478,6 +482,8 @@ public class BuildAgentDockerService {
                             checkImageArchitecture(imageName, inspectImageResponse, buildJob, buildLogsMap);
                         }
                         catch (InterruptedException ie) {
+                            // See the primary pull above: the wrapper does not carry the interrupt status.
+                            Thread.currentThread().interrupt();
                             throw new LocalCIException("Interrupted while pulling docker image " + imageName + " with amd64 fallback", ie);
                         }
                         catch (Exception fallbackEx) {

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
@@ -411,6 +411,10 @@ public class BuildJobContainerService {
      * Adding a file "stop_container.txt" like in {@link #stopContainer(String)} might not work for unresponsive containers, thus we use
      * {@link DockerClient#stopContainerCmd(String)}, {@link DockerClient#killContainerCmd(String)} and {@link DockerClient#removeContainerCmd(String)} to stop, kill or remove the
      * container.
+     * <p>
+     * Gives up without trying the kill and remove fallbacks when the thread is interrupted, since both wait on a
+     * {@link Future} that fails immediately on an interrupted thread. The container is then left to the periodic
+     * cleanup.
      *
      * @param containerId The ID of the container to stop or kill.
      */

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
@@ -434,6 +434,11 @@ public class BuildJobContainerService {
                 future.get(20, TimeUnit.SECONDS);  // Wait for the stop command to complete with a timeout
             }
             catch (Exception e) {
+                if (e instanceof InterruptedException) {
+                    // future.get() throws this when the waiting thread is interrupted. The broad catch is here for the
+                    // Docker client's own failures; it must not also discard a shutdown request.
+                    Thread.currentThread().interrupt();
+                }
                 Throwable cause = e.getCause();
                 // e will be ExecutionException if thrown in executor service by submitted task
                 // We are interested in the underlying cause in this case
@@ -487,6 +492,10 @@ public class BuildJobContainerService {
             killFuture.get(10, TimeUnit.SECONDS);  // Wait for the kill command to complete with a timeout
         }
         catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                // See stopContainer: killFuture.get() throws this on interruption.
+                Thread.currentThread().interrupt();
+            }
             log.error("Failed to kill container with id {}.", containerId, e);
         }
     }
@@ -507,6 +516,10 @@ public class BuildJobContainerService {
             removeFuture.get(10, TimeUnit.SECONDS); // Wait for the remove command to complete with a timeout
         }
         catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                // See stopContainer: removeFuture.get() throws this on interruption.
+                Thread.currentThread().interrupt();
+            }
             log.error("Failed to remove container with id {}", containerId, e);
         }
     }

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
@@ -438,6 +438,11 @@ public class BuildJobContainerService {
                     // future.get() throws this when the waiting thread is interrupted. The broad catch is here for the
                     // Docker client's own failures; it must not also discard a shutdown request.
                     Thread.currentThread().interrupt();
+                    // Both fallbacks below block on a Future as well, so with the flag restored they would fail
+                    // immediately and log a Docker error that never happened. Leave the container to the periodic
+                    // cleanup, which removes orphans on the next run.
+                    log.warn("Interrupted while stopping unresponsive container with id {}. Leaving it to the next cleanup run.", containerId);
+                    return;
                 }
                 Throwable cause = e.getCause();
                 // e will be ExecutionException if thrown in executor service by submitted task

--- a/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/buildagent/service/BuildJobContainerService.java
@@ -412,9 +412,8 @@ public class BuildJobContainerService {
      * {@link DockerClient#stopContainerCmd(String)}, {@link DockerClient#killContainerCmd(String)} and {@link DockerClient#removeContainerCmd(String)} to stop, kill or remove the
      * container.
      * <p>
-     * Gives up without trying the kill and remove fallbacks when the thread is interrupted, since both wait on a
-     * {@link Future} that fails immediately on an interrupted thread. The container is then left to the periodic
-     * cleanup.
+     * Runs to the end even when the calling thread has been interrupted, because it is reached during cancellation and
+     * stopping the container is exactly the work that still has to happen.
      *
      * @param containerId The ID of the container to stop or kill.
      */
@@ -438,16 +437,12 @@ public class BuildJobContainerService {
                 future.get(20, TimeUnit.SECONDS);  // Wait for the stop command to complete with a timeout
             }
             catch (Exception e) {
-                if (e instanceof InterruptedException) {
-                    // future.get() throws this when the waiting thread is interrupted. The broad catch is here for the
-                    // Docker client's own failures; it must not also discard a shutdown request.
-                    Thread.currentThread().interrupt();
-                    // Both fallbacks below block on a Future as well, so with the flag restored they would fail
-                    // immediately and log a Docker error that never happened. Leave the container to the periodic
-                    // cleanup, which removes orphans on the next run.
-                    log.warn("Interrupted while stopping unresponsive container with id {}. Leaving it to the next cleanup run.", containerId);
-                    return;
-                }
+                // The interrupt status is deliberately left cleared here, which is what java:S2142 would ask to
+                // restore. This method is reached during cancellation from callers that have already restored the flag
+                // themselves - BuildJobManagementService.awaitTermination and the pause grace period in
+                // SharedQueueProcessingService both do - and every Docker call below waits on a Future, which fails
+                // immediately while the flag is set. Restoring it would abandon a running container per cancelled job
+                // and leave the students' build scripts burning CPU until the hourly container cleanup reaps them.
                 Throwable cause = e.getCause();
                 // e will be ExecutionException if thrown in executor service by submitted task
                 // We are interested in the underlying cause in this case
@@ -501,10 +496,10 @@ public class BuildJobContainerService {
             killFuture.get(10, TimeUnit.SECONDS);  // Wait for the kill command to complete with a timeout
         }
         catch (Exception e) {
-            if (e instanceof InterruptedException) {
-                // See stopContainer: killFuture.get() throws this on interruption.
-                Thread.currentThread().interrupt();
-            }
+            // Not restoring the interrupt status is deliberate; see stopUnresponsiveContainer. Restoring it here would
+            // additionally make the enclosing try-with-resources close the executor with shutdownNow() instead of
+            // shutdown(), which drains the work queue and so drops a kill or remove task still queued behind a
+            // wedged stop.
             log.error("Failed to kill container with id {}.", containerId, e);
         }
     }
@@ -525,10 +520,7 @@ public class BuildJobContainerService {
             removeFuture.get(10, TimeUnit.SECONDS); // Wait for the remove command to complete with a timeout
         }
         catch (Exception e) {
-            if (e instanceof InterruptedException) {
-                // See stopContainer: removeFuture.get() throws this on interruption.
-                Thread.currentThread().interrupt();
-            }
+            // Not restoring the interrupt status is deliberate; see killContainer.
             log.error("Failed to remove container with id {}", containerId, e);
         }
     }

--- a/src/main/java/de/tum/cit/aet/artemis/core/util/TimeUtil.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/util/TimeUtil.java
@@ -56,7 +56,7 @@ public class TimeUtil {
         return toRelativeTime(origin.getEpochSecond(), unit.getEpochSecond(), target.getEpochSecond());
     }
 
-    private static double toRelativeTime(@NonNull long originEpochSecond, @NonNull long unitEpochSecond, @NonNull long targetEpochSecond) {
+    private static double toRelativeTime(long originEpochSecond, long unitEpochSecond, long targetEpochSecond) {
         if (originEpochSecond == unitEpochSecond) {
             return 1;
         }
@@ -100,7 +100,7 @@ public class TimeUtil {
      *
      * @param newClock the new Clock instance to set
      */
-    public static void setClock(@NonNull Clock newClock) {
+    public static void setClock(Clock newClock) {
         // Checked rather than left to the annotation, unlike most non-null contracts in this code base. Nothing
         // dereferences this value afterwards: ThreadLocal.set(null) succeeds and now() falls back to DEFAULT_CLOCK, so
         // a test that passed null here would silently become time-dependent instead of failing.

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamDeletionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamDeletionService.java
@@ -142,7 +142,7 @@ public class ExamDeletionService {
      *
      * @param examId the ID of the exam to be deleted
      */
-    public void delete(@NonNull long examId) {
+    public void delete(long examId) {
         User user = userRepository.getUser();
         Exam exam = examRepository.findOneWithEagerExercisesGroupsAndStudentExams(examId);
         log.info("User {} has requested to delete the exam {}", user.getLogin(), exam.getTitle());
@@ -327,7 +327,7 @@ public class ExamDeletionService {
      * @param examId the ID of the exam for which the deletion summary should be fetched
      * @return the exam deletion summary
      */
-    public ExamDeletionSummaryDTO getExamDeletionSummary(@NonNull long examId) {
+    public ExamDeletionSummaryDTO getExamDeletionSummary(long examId) {
         Set<Long> programmingExerciseIds = programmingExerciseRepository.findProgrammingExerciseIdsByExamId(examId);
         long numberOfBuilds = buildJobRepository.countBuildJobsByExerciseIds(programmingExerciseIds);
 

--- a/src/main/java/de/tum/cit/aet/artemis/hyperion/service/websocket/HyperionWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/hyperion/service/websocket/HyperionWebsocketService.java
@@ -40,6 +40,10 @@ public class HyperionWebsocketService {
             log.debug("Sent Hyperion message to {} on topic {}: {}", userLogin, topic, payload);
         }
         catch (InterruptedException | ExecutionException e) {
+            if (e instanceof InterruptedException) {
+                // Swallowing the exception must not also swallow the interruption.
+                Thread.currentThread().interrupt();
+            }
             log.error("Error sending Hyperion message to {} on topic {}: {}", userLogin, topic, payload, e);
         }
     }

--- a/src/main/java/de/tum/cit/aet/artemis/hyperion/service/websocket/HyperionWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/hyperion/service/websocket/HyperionWebsocketService.java
@@ -40,10 +40,11 @@ public class HyperionWebsocketService {
             log.debug("Sent Hyperion message to {} on topic {}: {}", userLogin, topic, payload);
         }
         catch (InterruptedException | ExecutionException e) {
-            if (e instanceof InterruptedException) {
-                // Swallowing the exception must not also swallow the interruption.
-                Thread.currentThread().interrupt();
-            }
+            // The interrupt status is deliberately not restored, which is what java:S2142 would ask for. A code
+            // generation job sends many messages through this method on one thread and finishes with a terminal done
+            // or error event. CompletableFuture.get() throws as soon as the flag is set, so restoring it would fail
+            // every later send of that job, including the terminal one, and the client's job view would stay "in
+            // progress" until the page is reloaded.
             log.error("Error sending Hyperion message to {} on topic {}: {}", userLogin, topic, payload, e);
         }
     }

--- a/src/main/java/de/tum/cit/aet/artemis/localvc/service/GitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localvc/service/GitService.java
@@ -338,6 +338,9 @@ public class GitService extends AbstractGitService {
                 Thread.sleep(1000);
             }
             catch (InterruptedException ex) {
+                // CanceledException does not carry the interruption, and this runs on request and scheduler threads
+                // that have to notice a shutdown.
+                Thread.currentThread().interrupt();
                 throw new CanceledException("Waiting for local path to be free for cloning got interrupted.");
             }
 

--- a/src/main/java/de/tum/cit/aet/artemis/localvc/service/GitService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localvc/service/GitService.java
@@ -338,9 +338,12 @@ public class GitService extends AbstractGitService {
                 Thread.sleep(1000);
             }
             catch (InterruptedException ex) {
-                // CanceledException does not carry the interruption, and this runs on request and scheduler threads
-                // that have to notice a shutdown.
-                Thread.currentThread().interrupt();
+                // The interrupt status is deliberately not restored here, which is what java:S2142 would ask for.
+                // CanceledException is a GitAPIException, and callers catch it per element and carry on: the
+                // plagiarism check maps over participations in a parallel stream, and a ForkJoinPool worker does not
+                // clear a leftover flag between elements the way a ThreadPoolExecutor worker does. A restored flag
+                // would make every later clone on that worker fail inside interruptible NIO and delete its working
+                // copy, turning one abandoned clone into a whole worker's worth of them.
                 throw new CanceledException("Waiting for local path to be free for cloning got interrupted.");
             }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/domain/UserSshPublicKey.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/domain/UserSshPublicKey.java
@@ -67,11 +67,11 @@ public class UserSshPublicKey extends DomainObject {
     @Column(name = "expiry_date")
     private ZonedDateTime expiryDate = null;
 
-    public @NonNull long getUserId() {
+    public long getUserId() {
         return userId;
     }
 
-    public void setUserId(@NonNull long userId) {
+    public void setUserId(long userId) {
         this.userId = userId;
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/AutomaticProgrammingExerciseCleanupService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/AutomaticProgrammingExerciseCleanupService.java
@@ -72,6 +72,10 @@ public class AutomaticProgrammingExerciseCleanupService {
     /**
      * cleans up old build plans on the continuous integration server and old local git repositories on the Artemis server at 3:00:00 am in the night in form of a repeating "cron"
      * job
+     * <p>
+     * Each phase logs and swallows its own failures so that one failing phase does not skip the other. An interrupted
+     * thread is the exception: the git working copy phase does not start, because an interruption means the node is
+     * shutting down.
      */
     @Scheduled(cron = "${artemis.scheduling.programming-exercises-cleanup-time:0 0 3 * * *}") // execute this every night at 3:00:00 am
     public void cleanup() {
@@ -293,6 +297,14 @@ public class AutomaticProgrammingExerciseCleanupService {
         return false;
     }
 
+    /**
+     * Deletes the build plans of the given participations on the external build system, at most 5000 per run and
+     * pausing between batches so the deletions do not arrive all at once.
+     * <p>
+     * Stops early when the thread is interrupted during such a pause, leaving the remaining plans to the next run.
+     *
+     * @param participationsWithBuildPlanToDelete the participations whose build plans should be deleted
+     */
     private void deleteBuildPlans(Set<ProgrammingExerciseStudentParticipation> participationsWithBuildPlanToDelete) {
         // Limit to 5000 deletions per night
         List<ProgrammingExerciseStudentParticipation> actualParticipationsToClean = participationsWithBuildPlanToDelete.stream().limit(5000).toList();

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/AutomaticProgrammingExerciseCleanupService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/AutomaticProgrammingExerciseCleanupService.java
@@ -89,6 +89,10 @@ public class AutomaticProgrammingExerciseCleanupService {
         catch (Exception ex) {
             log.error("Exception occurred during cleanupBuildPlansOnContinuousIntegrationServer", ex);
         }
+        if (Thread.currentThread().isInterrupted()) {
+            log.warn("Skipping the git working copy cleanup because the cleanup thread was interrupted.");
+            return;
+        }
         try {
             cleanupGitWorkingCopiesOnArtemisServer();
         }
@@ -303,10 +307,12 @@ public class AutomaticProgrammingExerciseCleanupService {
                     Thread.sleep(externalSystemRequestBatchWaitingTime);
                 }
                 catch (InterruptedException ex) {
-                    // This sleep paces requests to an external system inside a scheduled cleanup, so the loop has to
-                    // stop when the thread is interrupted rather than keep issuing them.
+                    // The sleep paces deletions against the external build system. Restoring the interrupt status makes
+                    // every later sleep of this loop throw at once, so carrying on would delete the rest of the batch
+                    // with no pacing at all. Stop here and leave the remaining plans to the next nightly run.
                     Thread.currentThread().interrupt();
-                    log.error("Exception encountered when pausing before cleaning up build plans", ex);
+                    log.warn("Interrupted while pausing during build plan cleanup. Stopping after {} of {} build plans.", index, actualParticipationsToClean.size());
+                    break;
                 }
             }
 
@@ -319,6 +325,6 @@ public class AutomaticProgrammingExerciseCleanupService {
 
             index++;
         }
-        log.info("{} build plans have been cleaned", actualParticipationsToClean.size());
+        log.info("{} of {} build plans have been cleaned", index, actualParticipationsToClean.size());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/AutomaticProgrammingExerciseCleanupService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/AutomaticProgrammingExerciseCleanupService.java
@@ -303,6 +303,9 @@ public class AutomaticProgrammingExerciseCleanupService {
                     Thread.sleep(externalSystemRequestBatchWaitingTime);
                 }
                 catch (InterruptedException ex) {
+                    // This sleep paces requests to an external system inside a scheduled cleanup, so the loop has to
+                    // stop when the thread is interrupted rather than keep issuing them.
+                    Thread.currentThread().interrupt();
                     log.error("Exception encountered when pausing before cleaning up build plans", ex);
                 }
             }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingTriggerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingTriggerService.java
@@ -215,6 +215,9 @@ public class ProgrammingTriggerService {
             Thread.sleep(externalSystemRequestBatchWaitingTime);
         }
         catch (InterruptedException ex) {
+            // This sleep paces requests to the CI system, so an interruption has to stop the caller's loop rather
+            // than be logged and forgotten.
+            Thread.currentThread().interrupt();
             log.error("Exception encountered when pausing before executing successive build for participation {}", participationId, ex);
         }
     }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingTriggerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingTriggerService.java
@@ -128,7 +128,13 @@ public class ProgrammingTriggerService {
         // Let the instructor know that a build run was triggered.
         programmingMessagingService.notifyInstructorAboutStartedExerciseBuildRun(programmingExercise);
         var triggerData = programmingExerciseStudentParticipationRepository.findBuildTriggerDataByExerciseId(exerciseId);
-        triggerBuildForParticipationData(triggerData, programmingExercise);
+        if (!triggerBuildForParticipationData(triggerData, programmingExercise)) {
+            // Only part of the participations were triggered. Leaving the exercise marked as changed and not announcing
+            // a completed run is what keeps the remaining participations from being forgotten: clearing the flag here
+            // would tell the next scheduled build that there is nothing left to do.
+            log.warn("The instructor build run for exercise {} stopped before every participation was triggered. The exercise stays marked as changed.", exerciseId);
+            return;
+        }
 
         // When the instructor build was triggered for the programming exercise, it is not considered 'dirty' anymore.
         // Deliberately by id: that call saves the exercise, and the exercise loaded above carries its auxiliary
@@ -151,10 +157,11 @@ public class ProgrammingTriggerService {
      * @param triggerData what a trigger reads off each participation of the exercise, newest submission included
      * @param exercise    the exercise those participations belong to, loaded with its build config and auxiliary
      *                        repositories
+     * @return true if the whole batch was triggered, false if it stopped early because the thread was interrupted
      */
-    public void triggerBuildForParticipationData(List<ParticipationBuildTriggerDTO> triggerData, ProgrammingExercise exercise) {
+    public boolean triggerBuildForParticipationData(List<ParticipationBuildTriggerDTO> triggerData, ProgrammingExercise exercise) {
         if (triggerData.isEmpty()) {
-            return;
+            return true;
         }
         // Everything a trigger reads off the exercise rather than off the participation is resolved once for the batch:
         // the build config, the auxiliary repositories, the build statistics and the head commit of the test
@@ -167,11 +174,12 @@ public class ProgrammingTriggerService {
                 continue;
             }
             if (!pauseBetweenBatches(index, participationData.participationId())) {
-                break;
+                return false;
             }
             triggerBuild(participation, sharedData);
             index++;
         }
+        return true;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingTriggerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingTriggerService.java
@@ -166,7 +166,9 @@ public class ProgrammingTriggerService {
             if (participation == null) {
                 continue;
             }
-            pauseBetweenBatches(index, participationData.participationId());
+            if (!pauseBetweenBatches(index, participationData.participationId())) {
+                break;
+            }
             triggerBuild(participation, sharedData);
             index++;
         }
@@ -205,20 +207,26 @@ public class ProgrammingTriggerService {
      *
      * @param index           how many participations of this batch were already triggered
      * @param participationId the participation that is about to be triggered, for the log message on interruption
+     * @return true if the caller may trigger the next participation, false if the thread was interrupted and the
+     *         remaining participations have to be left alone
      */
-    private void pauseBetweenBatches(int index, long participationId) {
+    private boolean pauseBetweenBatches(int index, long participationId) {
         if (index == 0 || index % externalSystemRequestBatchSize != 0) {
-            return;
+            return true;
         }
         try {
             log.info("Sleep for {}s during triggerBuild", externalSystemRequestBatchWaitingTime / 1000);
             Thread.sleep(externalSystemRequestBatchWaitingTime);
+            return true;
         }
         catch (InterruptedException ex) {
-            // This sleep paces requests to the CI system, so an interruption has to stop the caller's loop rather
-            // than be logged and forgotten.
+            // The sleep is what keeps a large trigger from filling the build queue in one go. Restoring the interrupt
+            // status makes every later sleep of this loop throw at once, so carrying on would trigger the whole
+            // remaining batch with no pacing at all, which is the opposite of what the pause is for. Stop instead and
+            // leave it to the caller to trigger the rest later.
             Thread.currentThread().interrupt();
-            log.error("Exception encountered when pausing before executing successive build for participation {}", participationId, ex);
+            log.warn("Interrupted while pausing before triggering the build for participation {}. Not triggering the remaining participations.", participationId);
+            return false;
         }
     }
 
@@ -254,7 +262,7 @@ public class ProgrammingTriggerService {
         }
 
         var index = 0;
-        for (var participationsOfExercise : participationsByExerciseId.values()) {
+        triggering: for (var participationsOfExercise : participationsByExerciseId.values()) {
             // A participation without a submission is not triggered at all, so an exercise where nobody submitted must
             // not pay for the shared data either: resolving it reads the test repository and the build statistics.
             List<ProgrammingExerciseStudentParticipation> triggerable = participationsOfExercise.stream().filter(participation -> participation.findLatestSubmission().isPresent())
@@ -270,7 +278,9 @@ public class ProgrammingTriggerService {
             // build that never happened.
             for (var participation : triggerable) {
                 // Execute requests in batches when using an external build system.
-                pauseBetweenBatches(index, participation.getId());
+                if (!pauseBetweenBatches(index, participation.getId())) {
+                    break triggering;
+                }
                 triggerBuild(participation, sharedData);
                 index++;
             }

--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingTriggerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/ProgrammingTriggerService.java
@@ -128,13 +128,7 @@ public class ProgrammingTriggerService {
         // Let the instructor know that a build run was triggered.
         programmingMessagingService.notifyInstructorAboutStartedExerciseBuildRun(programmingExercise);
         var triggerData = programmingExerciseStudentParticipationRepository.findBuildTriggerDataByExerciseId(exerciseId);
-        if (!triggerBuildForParticipationData(triggerData, programmingExercise)) {
-            // Only part of the participations were triggered. Leaving the exercise marked as changed and not announcing
-            // a completed run is what keeps the remaining participations from being forgotten: clearing the flag here
-            // would tell the next scheduled build that there is nothing left to do.
-            log.warn("The instructor build run for exercise {} stopped before every participation was triggered. The exercise stays marked as changed.", exerciseId);
-            return;
-        }
+        triggerBuildForParticipationData(triggerData, programmingExercise);
 
         // When the instructor build was triggered for the programming exercise, it is not considered 'dirty' anymore.
         // Deliberately by id: that call saves the exercise, and the exercise loaded above carries its auxiliary
@@ -157,11 +151,10 @@ public class ProgrammingTriggerService {
      * @param triggerData what a trigger reads off each participation of the exercise, newest submission included
      * @param exercise    the exercise those participations belong to, loaded with its build config and auxiliary
      *                        repositories
-     * @return true if the whole batch was triggered, false if it stopped early because the thread was interrupted
      */
-    public boolean triggerBuildForParticipationData(List<ParticipationBuildTriggerDTO> triggerData, ProgrammingExercise exercise) {
+    public void triggerBuildForParticipationData(List<ParticipationBuildTriggerDTO> triggerData, ProgrammingExercise exercise) {
         if (triggerData.isEmpty()) {
-            return true;
+            return;
         }
         // Everything a trigger reads off the exercise rather than off the participation is resolved once for the batch:
         // the build config, the auxiliary repositories, the build statistics and the head commit of the test
@@ -173,13 +166,10 @@ public class ProgrammingTriggerService {
             if (participation == null) {
                 continue;
             }
-            if (!pauseBetweenBatches(index, participationData.participationId())) {
-                return false;
-            }
+            pauseBetweenBatches(index, participationData.participationId());
             triggerBuild(participation, sharedData);
             index++;
         }
-        return true;
     }
 
     /**
@@ -215,26 +205,23 @@ public class ProgrammingTriggerService {
      *
      * @param index           how many participations of this batch were already triggered
      * @param participationId the participation that is about to be triggered, for the log message on interruption
-     * @return true if the caller may trigger the next participation, false if the thread was interrupted and the
-     *         remaining participations have to be left alone
      */
-    private boolean pauseBetweenBatches(int index, long participationId) {
+    private void pauseBetweenBatches(int index, long participationId) {
         if (index == 0 || index % externalSystemRequestBatchSize != 0) {
-            return true;
+            return;
         }
         try {
             log.info("Sleep for {}s during triggerBuild", externalSystemRequestBatchWaitingTime / 1000);
             Thread.sleep(externalSystemRequestBatchWaitingTime);
-            return true;
         }
         catch (InterruptedException ex) {
-            // The sleep is what keeps a large trigger from filling the build queue in one go. Restoring the interrupt
-            // status makes every later sleep of this loop throw at once, so carrying on would trigger the whole
-            // remaining batch with no pacing at all, which is the opposite of what the pause is for. Stop instead and
-            // leave it to the caller to trigger the rest later.
-            Thread.currentThread().interrupt();
-            log.warn("Interrupted while pausing before triggering the build for participation {}. Not triggering the remaining participations.", participationId);
-            return false;
+            // The interrupt status is deliberately not restored, which is what java:S2142 would ask for, and the batch
+            // deliberately carries on. There is no durable retry behind this loop: the scheduled build after the due
+            // date is a one-shot task that ExerciseLifecycle only ever schedules while its timestamp is still in the
+            // future, so a run that stops half way is never recreated on startup, and the exercise's testCasesChanged
+            // flag is not consulted by that scheduler either. Stopping here would leave the remaining participations
+            // permanently unbuilt, whereas carrying on costs one lost pause.
+            log.error("Exception encountered when pausing before executing successive build for participation {}", participationId, ex);
         }
     }
 
@@ -270,7 +257,7 @@ public class ProgrammingTriggerService {
         }
 
         var index = 0;
-        triggering: for (var participationsOfExercise : participationsByExerciseId.values()) {
+        for (var participationsOfExercise : participationsByExerciseId.values()) {
             // A participation without a submission is not triggered at all, so an exercise where nobody submitted must
             // not pay for the shared data either: resolving it reads the test repository and the build statistics.
             List<ProgrammingExerciseStudentParticipation> triggerable = participationsOfExercise.stream().filter(participation -> participation.findLatestSubmission().isPresent())
@@ -286,9 +273,7 @@ public class ProgrammingTriggerService {
             // build that never happened.
             for (var participation : triggerable) {
                 // Execute requests in batches when using an external build system.
-                if (!pauseBetweenBatches(index, participation.getId())) {
-                    break triggering;
-                }
+                pauseBetweenBatches(index, participation.getId());
                 triggerBuild(participation, sharedData);
                 index++;
             }

--- a/src/test/java/de/tum/cit/aet/artemis/shared/architecture/util/ClassNode.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/architecture/util/ClassNode.java
@@ -24,7 +24,7 @@ public class ClassNode extends ClassPathNode {
      * @param containedClass the {@link Class} object, must not be <code>null</code>.
      * @param classInfo      the {@link ClassInfo} describing this class node's class, may be <code>null</code>.
      */
-    public ClassNode(@NonNull PackageNode parent, @NonNull Class<?> containedClass, ClassInfo classInfo) {
+    public ClassNode(PackageNode parent, @NonNull Class<?> containedClass, ClassInfo classInfo) {
         super(parent, getClassNameWithoutPackage(containedClass));
         // See PackageNode: a null parent would be treated as the root instead of failing.
         if (parent == null) {

--- a/src/test/java/de/tum/cit/aet/artemis/shared/architecture/util/PackageNode.java
+++ b/src/test/java/de/tum/cit/aet/artemis/shared/architecture/util/PackageNode.java
@@ -11,7 +11,6 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.assertj.core.util.TriFunction;
-import org.jspecify.annotations.NonNull;
 
 import io.github.classgraph.ClassInfo;
 
@@ -44,7 +43,7 @@ public class PackageNode extends ClassPathNode {
      * @param parent      this nodes parent package, must not be <code>null</code>
      * @param segmentName this nodes segment name. Must not be <code>null</code>, contain '<code>.</code>' or be blank.
      */
-    public PackageNode(@NonNull PackageNode parent, String segmentName) {
+    public PackageNode(PackageNode parent, String segmentName) {
         super(parent, segmentName);
         // ClassPathNode treats a null parent as the root, so this cannot be left to the annotation: a null would
         // silently produce a second root-like node with the wrong name rather than failing. Only the package-private


### PR DESCRIPTION
### Summary
Nine places in the server caught `InterruptedException` and left the thread's interrupt flag cleared, which SonarQube reports as `java:S2142`. Reading each one against its callers showed the rule's remedy is only safe in three of them. The other six sit in cleanup, notification and batch paths that have to finish precisely *because* the thread is going down, and restoring the flag there abandons the work: a running build container per cancelled job, the terminal event of a code generation job, or a set of student submissions that nothing will ever build again. Those six now carry a comment saying why the interrupt is deliberately not propagated, so the rule is not re-applied blindly later.

### Checklist
#### General
Verified locally only (see Steps for Testing); no test server deployment, and no second developer has confirmed it yet.

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
`Thread.interrupt()` does not stop a thread; it sets a flag the thread is expected to observe. Catching `InterruptedException` clears that flag, so a handler that neither restores it nor acts on it turns "please stop" into "carry on".

Restoring it is not free, though. Every `Future.get`, `CompletableFuture.get` and `Thread.sleep` reached afterwards throws *immediately* while the flag is set. So in code that still has work to do, restoring the flag does not propagate a shutdown — it silently skips that work. Whether `java:S2142` is a real finding therefore depends entirely on what happens next, and on whether anything would retry it. That is why all nine were read against their callers instead of being patched uniformly.

### Description
**Three sites restore the flag.** The two image pulls in `BuildAgentDockerService` rewrap into `LocalCIException`, which does not carry the interruption. Worth stating plainly: `awaitPullCompletion` already restores the flag before rethrowing, so both are no-ops in practice and satisfy the rule without changing behaviour.

The one behavioural change is `AutomaticProgrammingExerciseCleanupService`. Its `deleteBuildPlans` loop sleeps to pace deletions against the external build system, and restoring the flag makes every later sleep of that loop throw at once — so continuing would delete the rest of the batch with no pacing at all. It now stops instead, which is safe here because the job is a nightly cron and `cleanupBuildPlan` nulls `buildPlanId` per participation, so the next run re-selects whatever is left. Its closing log line also changed from `"{} build plans have been cleaned", size` to `"{} of {} …", index, size`, which would otherwise report the whole batch as cleaned after stopping early. `cleanup()` additionally no longer starts the git working copy phase on an interrupted thread.

**Six sites deliberately keep the flag cleared,** each with a comment explaining why:

- `BuildJobContainerService` stop, kill and remove are reached during cancellation from callers that have *already* restored the flag — `BuildJobManagementService.awaitTermination` and the pause grace period in `SharedQueueProcessingService` both do — and every Docker call there waits on a `Future`. Restoring it abandoned a running container per cancelled job, leaving students' build scripts burning CPU until the hourly container cleanup reaped them. In kill and remove it also flipped the enclosing try-with-resources from `shutdown()` to `shutdownNow()`, draining the queue and dropping a kill still queued behind a wedged stop.
- `HyperionWebsocketService.send` is called many times per code generation job and ends with a terminal `done` or `error` event. One restored flag fails every later send on that thread, including the terminal one, and the client's job view stays on "in progress" until the page is reloaded.
- `GitService`'s clone wait rethrows as JGit's `CanceledException`, which callers catch per element and continue — the plagiarism check maps over participations in a `parallelStream`, and a `ForkJoinPool` worker does not clear a leftover flag between elements the way a `ThreadPoolExecutor` worker does. A restored flag would fail every later clone on that worker inside interruptible NIO and delete its working copy.
- `ProgrammingTriggerService.pauseBetweenBatches` paces an instructor "build all". Nothing retries a partial run: the scheduled build after the due date is a one-shot task that is only ever scheduled while its timestamp is still in the future, so a run that stops half way is never recreated on startup, and `testCasesChanged` is not an input to that scheduler. Stopping the batch would leave the remaining participations permanently unbuilt, so it finishes and pays one lost pause.

**Annotation cleanup.** `@NonNull` is dropped from six primitive parameters in `TimeUtil`, `UserSshPublicKey`, `ExamDeletionService` and `AthenaFeedbackSuggestionsService`: a primitive can never be null, and jspecify does not recognise a nullness operator on one, so nothing was being expressed. The `@NonNull byte[]` in `JenkinsAuthorizationInterceptor` is an array and stays. It is also dropped from three parameters whose bodies null-check them (`TimeUtil.setClock`, `PackageNode`, `ClassNode`), where annotating and then checking states two contradicting contracts and SonarQube reports the check as dead. In all three the check is the load-bearing half, so the check stays and the annotation goes.

### Steps for Testing
A shutdown-path change with no user-visible behaviour, so there is nothing to click through.

Locally verified:
- `./gradlew compileJava compileTestJava spotlessCheck checkstyleMain checkstyleTest` — clean.
- `./gradlew test --tests ProgrammingTriggerServiceTest --tests ProgrammingTriggerQueryCountTest --tests AutomaticProgrammingExerciseCleanupServiceTest --tests ProgrammingSubmissionIntegrationTest --tests 'de.tum.cit.aet.artemis.buildagent.*' --tests 'de.tum.cit.aet.artemis.hyperion.*'` — pass.
- 1211 architecture tests pass.

I did not deploy this to a test server; the change has no UI and no REST surface.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interruption handling for background operations and container cleanup.
  * Cleanup now reports the actual number of processed build plans and stops subsequent phases when interrupted.
  * Ensured interrupted container shutdowns continue through available fallback cleanup steps.
  * Improved reliability of build and repository operations after interruptions.

* **Refactor**
  * Simplified nullability declarations without changing runtime validation or behavior.
  * Streamlined programming build-triggering and interruption handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->