### PR TITLE
`Development`: Honor the configured Sentry traces sample rate

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/SentryConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/SentryConfiguration.java
@@ -47,6 +47,16 @@ public class SentryConfiguration {
     private Optional<String> environment;
 
     /**
+     * The configured performance-trace sampling rate, if the deployment sets one.
+     * <p>
+     * Empty falls back to {@link #environmentTracesSampleRate()}. The property existed and was rendered into every
+     * deployment's configuration long before it was read here, so a deployment that had set it was silently getting
+     * the hard-coded rate instead.
+     */
+    @Value("${sentry.traces-sample-rate:#{null}}")
+    private Optional<Double> configuredTracesSampleRate;
+
+    /**
      * init sentry with the correct package name and Artemis version
      * EventListener cannot be used here, as the bean is lazy
      * <a href="https://docs.spring.io/spring-framework/reference/core/beans/context-introduction.html#context-functionality-events-annotation">Spring Docs</a>
@@ -238,11 +248,25 @@ public class SentryConfiguration {
     }
 
     /**
-     * Get the traces sample rate based on the environment.
+     * The rate at which whole requests are traced for Sentry Performance.
+     * <p>
+     * A deployment that configures {@code sentry.traces-sample-rate} gets exactly that; otherwise the environment
+     * decides. Honouring the property matters because the cost is not small: a benchmark of 1000 simulated students
+     * against a staging server spent 14% of the Artemis nodes' on-CPU samples in Sentry's sender threads, nearly all
+     * of it in the TLS handshake each envelope opens, and there was no way to turn that down from the deployment.
+     *
+     * @return the configured rate, or the environment's default when none is configured
+     */
+    private double getTracesSampleRate() {
+        return configuredTracesSampleRate.orElseGet(this::environmentTracesSampleRate);
+    }
+
+    /**
+     * The default traces sample rate for a deployment that does not configure one.
      *
      * @return 0% for local, 100% for test and staging, 5% for production environments
      */
-    private double getTracesSampleRate() {
+    private double environmentTracesSampleRate() {
         String env = getEnvironment();
         // All test/staging environments get 1.0 sample rate
         if (env.contains("test") || env.contains("staging")) {

--- a/src/test/java/de/tum/cit/aet/artemis/core/config/SentryTracesSampleRateTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/config/SentryTracesSampleRateTest.java
@@ -1,0 +1,52 @@
+package de.tum.cit.aet.artemis.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * The traces sample rate has to come from configuration when a deployment sets one.
+ * <p>
+ * It did not: {@code sentry.traces-sample-rate} was rendered into every deployment's configuration and read by
+ * nobody, because the rate was derived from the environment name alone. Every environment whose name contains
+ * "staging" or "test" therefore traced 100% of requests no matter what its configuration said, and production traced
+ * 5% rather than the 0.2 its inventory asked for.
+ */
+class SentryTracesSampleRateTest {
+
+    private double rateFor(String environment, Double configured) {
+        SentryConfiguration configuration = new SentryConfiguration();
+        ReflectionTestUtils.setField(configuration, "environment", Optional.of(environment));
+        ReflectionTestUtils.setField(configuration, "isTestServer", Optional.empty());
+        ReflectionTestUtils.setField(configuration, "configuredTracesSampleRate", Optional.ofNullable(configured));
+        return (double) ReflectionTestUtils.invokeMethod(configuration, "getTracesSampleRate");
+    }
+
+    @Test
+    @DisplayName("A configured rate wins over the environment default")
+    void configuredRateWins() {
+        assertThat(rateFor("staging2", 0.05)).isEqualTo(0.05);
+        assertThat(rateFor("prod", 0.2)).isEqualTo(0.2);
+    }
+
+    @Test
+    @DisplayName("Turning tracing off entirely is possible from configuration")
+    void configuredZeroIsHonoured() {
+        // Zero must not be mistaken for "unset" and fall back to the environment default, which is what makes the
+        // setting usable for a benchmark run that does not want to pay for tracing at all.
+        assertThat(rateFor("staging2", 0.0)).isZero();
+    }
+
+    @Test
+    @DisplayName("Without configuration the environment still decides")
+    void environmentDefaultsAreUnchanged() {
+        assertThat(rateFor("staging2", null)).isEqualTo(1.0);
+        assertThat(rateFor("test5", null)).isEqualTo(1.0);
+        assertThat(rateFor("prod", null)).isEqualTo(0.05);
+        assertThat(rateFor("local", null)).isZero();
+    }
+}


### PR DESCRIPTION
### Motivation

`sentry.traces-sample-rate` is rendered into every deployment's configuration by the Ansible collection — and read by nobody.

`getTracesSampleRate()` derived the rate from the environment name alone, and the custom `tracesSampler` overrides `setTracesSampleRate`, so the configured value never had any effect:

| environment | configured | actually used |
|---|---|---|
| `staging` | 0.05 | **1.0** |
| `test5` | 1.0 | 1.0 |
| production | 0.2 | **0.05** |

Any environment whose name contains `staging` or `test` traced **100%** of requests regardless of its configuration.

That is not free. Profiling a 1000-simulated-student benchmark against the test cluster with JFR:

| phase | share of Artemis nodes' on-CPU samples in Sentry sender threads |
|---|---|
| exam / git | 14.4% |
| client bundle | 18.9% |

Almost all of it is TLS, not payload: the SDK opens a fresh HTTPS connection per envelope, so the profile is dominated by `SSLSocketImpl.startHandshake` and the X25519 key generation beneath it (`IntegerPolynomial25519`, `MontgomeryIntegerPolynomialP256` also show up as 8.1% of leaf frames overall).

The dead property is how this was found: lowering it on a test cluster and restarting changed the profile by ~2 points, which is noise.

### Description

`getTracesSampleRate()` now returns the configured `sentry.traces-sample-rate` when the deployment sets one, and falls back to the existing environment-based values otherwise. Those defaults are unchanged, so a deployment that configures nothing behaves exactly as before.

### Steps for testing

1. Set `sentry.traces-sample-rate: 0.05` on a staging server and restart.
2. Confirm transaction volume in Sentry Performance drops roughly twentyfold while error events keep arriving (they are governed by `sentry.sample-rate`, untouched).
3. Remove the property and confirm the environment default (1.0 for staging) returns.

### Test coverage

`SentryTracesSampleRateTest` covers a configured rate winning over the environment default, a configured `0.0` not being mistaken for "unset", and the environment defaults staying intact when nothing is configured. Reverting the one-line change makes the first two fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration setting for customizing Sentry trace sampling rates.
  * Explicitly configured values, including `0`, now take precedence over environment-based defaults.

* **Tests**
  * Added coverage for configured sampling rates and existing defaults across local, test, staging, and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->