### PR TITLE
`Development`: Send connection only for websocket handshakes

### DIFF
--- a/docker/nginx/artemis-nginx.conf
+++ b/docker/nginx/artemis-nginx.conf
@@ -3,6 +3,17 @@ upstream artemis {
     include includes/artemis-upstream.conf;
 }
 
+# The value for the upstream `Connection` header, per request.
+#
+# A websocket handshake has to reach Artemis as `Connection: upgrade`; nothing else may. This config
+# used to set the literal 'upgrade' on every proxied request, so each ordinary REST call, git request
+# and cache miss announced itself to Tomcat as an upgrade attempt. Browsers send `Upgrade: websocket`
+# only on the handshake, so keying off $http_upgrade tells the two apart.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      "";
+}
+
 # Remove nginx version from HTTP response
 server_tokens off;
 

--- a/docker/nginx/artemis-server.conf
+++ b/docker/nginx/artemis-server.conf
@@ -24,7 +24,7 @@ location / {
     proxy_pass http://artemis;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection 'upgrade';
+    proxy_set_header Connection $connection_upgrade;
     proxy_set_header Host $host;
 #   proxy_set_header Early-Data $ssl_early_data;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -145,7 +145,7 @@ location /git/ {
 
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection 'upgrade';
+    proxy_set_header Connection $connection_upgrade;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
### Motivation

`docker/nginx/artemis-server.conf` set `proxy_set_header Connection 'upgrade'` unconditionally in `location /` and `location /git/`. Every proxied request — each REST call, each git request, each cache miss — therefore reached Tomcat announcing itself as a protocol upgrade attempt, when only the websocket handshake is one.

Found while profiling a benchmark run against the test cluster. Worth being explicit about what this is **not**: I originally expected the missing upstream `keepalive` directive to mean a new TCP connection per proxied request, and measured that instead of assuming it. It does not — nginx 1.31.3 pools upstream connections here regardless:

| location config | 1,131 requests at concurrency 40 |
|---|---|
| no keepalive directive, nginx defaults | 26 upstream connections |
| current config (`Connection: 'upgrade'`) | 31 upstream connections |
| explicit `keepalive 16` + `Connection ""` | 33 upstream connections |

So this PR carries no throughput claim. It is a correctness fix for a header that was simply wrong on every non-websocket request.

### Description

Adds the standard map and uses it on both proxying locations:

```nginx
map $http_upgrade $connection_upgrade {
    default upgrade;
    ''      "";
}
```

Browsers send `Upgrade: websocket` only on the handshake, so the two cases are cleanly distinguished. `default upgrade` means any other protocol upgrade keeps working too.

### Steps for testing

Verified against a real nginx 1.31.3 container running this exact config, with an upstream that logs the headers it receives:

```
REQ GET /api/plain      HTTP/1.1 connection=None      upgrade=None
REQ GET /websocket/info HTTP/1.1 connection='upgrade' upgrade='websocket'
```

1. Start the docker stack, open Artemis, confirm the websocket connects and live updates still arrive.
2. Perform a git clone and push over HTTPS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebSocket connection handling for application and Git proxy requests.
  - Standard requests now avoid unnecessary connection upgrade headers, improving compatibility with regular HTTP traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->