### PR TITLE
`Development`: Stop rendering every websocket payload to a string to test it for emptiness

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/communication/service/WebsocketMessagingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/service/WebsocketMessagingService.java
@@ -128,21 +128,45 @@ public class WebsocketMessagingService {
 
     /**
      * Determine if a message for a specific topic should be compressed.
+     * <p>
+     * The topic is matched first because it rejects almost everything: only the build queue and build agent topics are
+     * compressible, and every other message the server sends - submissions, results, exam events, notifications - is
+     * decided by the regex alone. Asking about the payload first made every one of those pay for a question whose
+     * answer could not matter.
      */
     private static boolean shouldCompress(String topic, Object payload) {
         // Only compress messages for specific topics
         if (topic == null) {
             return false;
         }
-        if (isEmpty(payload)) {
+        // Match the topic against the regex
+        if (!COMPRESSIBLE_TOPICS.matcher(topic).matches()) {
             return false;
         }
-        // Match the topic against the regex
-        return COMPRESSIBLE_TOPICS.matcher(topic).matches();
+        return !isEmpty(payload);
     }
 
+    /**
+     * Whether there is nothing worth compressing.
+     * <p>
+     * Deliberately does not call {@code toString()} on an arbitrary payload. Doing so rendered whole DTO graphs to a
+     * String only to ask whether the String was empty and then discard it: profiling a 1000-student exam found 4.3% of
+     * the Artemis nodes' on-CPU samples inside this method, almost all of it in {@code StringBuilder.append} and
+     * integer-to-text conversion under {@code BuildJobQueueItem.toString} and {@code BuildConfig.toString}.
+     * <p>
+     * A DTO's {@code toString()} is never empty, so the check only ever meant anything for a text payload, and that is
+     * what it now asks about.
+     *
+     * @param payload the message payload
+     * @return true if the payload carries nothing
+     */
     private static boolean isEmpty(Object payload) {
-        return payload == null || payload.toString().isEmpty() || (payload instanceof Collection<?> collection && collection.isEmpty())
-                || (payload instanceof Map<?, ?> map && map.isEmpty());
+        return switch (payload) {
+            case null -> true;
+            case CharSequence text -> text.isEmpty();
+            case Collection<?> collection -> collection.isEmpty();
+            case Map<?, ?> map -> map.isEmpty();
+            default -> false;
+        };
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/communication/service/WebsocketMessagingServiceCompressionTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/service/WebsocketMessagingServiceCompressionTest.java
@@ -1,0 +1,87 @@
+package de.tum.cit.aet.artemis.communication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Which messages are compressed, and what deciding that is allowed to cost.
+ * <p>
+ * The cost is the point of most of this. Emptiness used to be established by rendering the payload with
+ * {@code toString()} and asking whether the result was empty, for every message on every topic, and the string was
+ * then discarded. A 1000-student exam spent 4.3% of the Artemis nodes' on-CPU samples doing it.
+ */
+class WebsocketMessagingServiceCompressionTest {
+
+    private static final String COMPRESSIBLE = "/topic/admin/queued-jobs";
+
+    private static final String ORDINARY = "/topic/exercise/42/newSubmissions";
+
+    private boolean shouldCompress(String topic, Object payload) {
+        return (boolean) ReflectionTestUtils.invokeMethod(WebsocketMessagingService.class, "shouldCompress", topic, payload);
+    }
+
+    /** A payload that records every time something renders it. */
+    private static final class CountingPayload {
+
+        private final AtomicInteger renders = new AtomicInteger();
+
+        @Override
+        public String toString() {
+            renders.incrementAndGet();
+            return "rendered";
+        }
+    }
+
+    @Test
+    @DisplayName("An ordinary message is never rendered to a String just to decide against compressing it")
+    void ordinaryTopicDoesNotRenderThePayload() {
+        CountingPayload payload = new CountingPayload();
+
+        assertThat(shouldCompress(ORDINARY, payload)).isFalse();
+        assertThat(payload.renders).hasValue(0);
+    }
+
+    @Test
+    @DisplayName("A compressible message is not rendered either")
+    void compressibleTopicDoesNotRenderThePayload() {
+        CountingPayload payload = new CountingPayload();
+
+        assertThat(shouldCompress(COMPRESSIBLE, payload)).isTrue();
+        assertThat(payload.renders).hasValue(0);
+    }
+
+    @Test
+    @DisplayName("Only the build queue and build agent topics are compressed")
+    void onlyTheBuildTopicsAreCompressed() {
+        Object payload = new CountingPayload();
+
+        assertThat(shouldCompress("/topic/courses/7/queued-jobs", payload)).isTrue();
+        assertThat(shouldCompress("/topic/courses/7/running-jobs", payload)).isTrue();
+        assertThat(shouldCompress("/topic/admin/build-agents", payload)).isTrue();
+        assertThat(shouldCompress("/topic/admin/build-agent/agent-1", payload)).isTrue();
+
+        assertThat(shouldCompress(ORDINARY, payload)).isFalse();
+        assertThat(shouldCompress("/topic/courses/7/exercises", payload)).isFalse();
+        assertThat(shouldCompress(null, payload)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Nothing worth compressing is still not compressed")
+    void emptyPayloadsAreNotCompressed() {
+        assertThat(shouldCompress(COMPRESSIBLE, null)).isFalse();
+        assertThat(shouldCompress(COMPRESSIBLE, "")).isFalse();
+        assertThat(shouldCompress(COMPRESSIBLE, List.of())).isFalse();
+        assertThat(shouldCompress(COMPRESSIBLE, Map.of())).isFalse();
+
+        assertThat(shouldCompress(COMPRESSIBLE, "queued")).isTrue();
+        assertThat(shouldCompress(COMPRESSIBLE, List.of("a"))).isTrue();
+        assertThat(shouldCompress(COMPRESSIBLE, Map.of("a", 1))).isTrue();
+    }
+}


### PR DESCRIPTION
### Motivation

You asked whether websocket gzip is only done for larger messages. It is not size-based at all — compression is decided by topic:

```java
private static final Pattern COMPRESSIBLE_TOPICS = Pattern.compile(
    "^/topic/courses/\\d+/(queued-jobs|running-jobs)|^/topic/admin/(queued-jobs|running-jobs|build-agents)|^/topic/admin/build-agent/[^/]+$");
```

That turns out to be fine, and **gzip itself is not the cost**. Splitting the JFR samples under `GzipMessageConverter.convertToInternal` during a 1000-student exam:

| | share |
|---|---|
| Jackson serialization (`super.convertToInternal`) | **97.3%** |
| actual gzip + base64 | 0.9% |
| the emptiness check | 1.4% |

So the ~11% of Artemis-attributed CPU I had labelled "websocket gzip" is really websocket *serialization*, which every message pays regardless. Raising a size threshold would have achieved nothing.

The real problem was next door. `shouldCompress` asked two questions in the wrong order:

```java
if (isEmpty(payload)) { return false; }              // payload.toString().isEmpty()
return COMPRESSIBLE_TOPICS.matcher(topic).matches();
```

Emptiness was established by rendering the payload with `toString()` — for **every** websocket message on **every** topic, including all the submissions, results, exam events and notifications that can never be compressed anyway — and the string was then discarded.

A JFR recording of a 1000-student exam put **4.3% of the Artemis nodes' on-CPU samples inside `isEmpty`**, almost all of it in `StringBuilder.append` and integer-to-text conversion beneath `BuildJobQueueItem.toString`, `BuildConfig.toString` and `JobTimingInfo.toString`.

### Description

- The topic is matched first, so a regex rejects nearly everything before the payload is considered at all.
- `isEmpty` no longer calls `toString()` on an arbitrary object. A DTO's `toString()` is never empty, so that test only ever meant anything for a text payload, which is what it now asks about.

No message changes its compression: the topics and the empty cases behave exactly as before.

### Steps for testing

1. Open the build queue / build agents admin views and confirm live updates still arrive (those are the compressed topics).
2. Work through an exam and confirm submissions, results and notifications still arrive over websocket.

### Test coverage

`WebsocketMessagingServiceCompressionTest` uses a payload that counts how often it is rendered, and asserts it is never rendered — on both a compressible and an ordinary topic. Reverting either half of the change makes those two tests fail. It also pins the topic list and the empty-payload cases so the behaviour is held still while the cost is removed.