### PR TITLE
`Programming exercises`: Fix after due date not being shown in the UI when requirements are met

### DIFF
--- a/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.html
@@ -37,7 +37,7 @@
                 <hr class="mb-5" />
             }
             <jhi-programming-exercise-language
-                [programmingExercise]="programmingExercise"
+                [(programmingExercise)]="programmingExercise"
                 [programmingExerciseCreationConfig]="getProgrammingExerciseCreationConfig()"
                 [isEditFieldDisplayedRecord]="isEditFieldDisplayedRecord()"
             />

--- a/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.spec.ts
+++ b/src/main/webapp/app/programming/manage/update/programming-exercise-update.component.spec.ts
@@ -1850,6 +1850,30 @@ describe('ProgrammingExerciseUpdateComponent', () => {
         }
     });
 
+    it('should propagate customizeBuildPlan changes from custom build plan component through language component to update component', () => {
+        vi.spyOn(profileService, 'isProfileActive').mockImplementation((profile) => profile === PROFILE_LOCALCI);
+        comp.ngOnInit();
+        fixture.detectChanges();
+
+        const languageComp = comp.exerciseLanguageComponent();
+        expect(languageComp).toBeDefined();
+
+        const customBuildPlanComp = languageComp?.programmingExerciseCustomBuildPlanComponent();
+        expect(customBuildPlanComp).toBeDefined();
+
+        expect(comp.programmingExercise.customizeBuildPlan).toBeFalsy();
+
+        customBuildPlanComp!.onCustomizeBuildPlanChange(true);
+        fixture.detectChanges();
+
+        expect(comp.programmingExercise.customizeBuildPlan).toBe(true);
+
+        customBuildPlanComp!.onCustomizeBuildPlanChange(false);
+        fixture.detectChanges();
+
+        expect(comp.programmingExercise.customizeBuildPlan).toBe(false);
+    });
+
     function verifyImport(importedProgrammingExercise: ProgrammingExercise) {
         expect(comp.programmingExercise.projectKey).toBeUndefined();
         expect(comp.programmingExercise.id).toBeUndefined();

--- a/src/main/webapp/app/programming/manage/update/update-components/custom-build-plans/programming-exercise-custom-build-plan.component.html
+++ b/src/main/webapp/app/programming/manage/update/update-components/custom-build-plans/programming-exercise-custom-build-plan.component.html
@@ -1,6 +1,13 @@
 <div class="form-group">
     <div class="form-check custom-checkbox">
-        <input class="form-check-input" type="checkbox" name="customizeBuildPlan" id="field_customizeBuildPlan" [(ngModel)]="programmingExercise().customizeBuildPlan" />
+        <input
+            class="form-check-input"
+            type="checkbox"
+            name="customizeBuildPlan"
+            id="field_customizeBuildPlan"
+            [ngModel]="programmingExercise().customizeBuildPlan"
+            (ngModelChange)="onCustomizeBuildPlanChange($event)"
+        />
         <label class="form-check-label custom-control-label" for="field_customizeBuildPlan" jhiTranslate="artemisApp.programmingExercise.customizeBuildPlan"></label>
         <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.customizeBuildPlanTooltip" />
     </div>

--- a/src/main/webapp/app/programming/manage/update/update-components/custom-build-plans/programming-exercise-custom-build-plan.component.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/custom-build-plans/programming-exercise-custom-build-plan.component.ts
@@ -1,4 +1,4 @@
-import { Component, DoCheck, OnInit, computed, inject, input, viewChild } from '@angular/core';
+import { Component, DoCheck, OnInit, computed, inject, input, model, viewChild } from '@angular/core';
 import { ProgrammingExercise, ProgrammingLanguage, ProjectType } from 'app/programming/shared/entities/programming-exercise.model';
 import { ProgrammingExerciseCreationConfig } from 'app/programming/manage/update/programming-exercise-creation-config';
 import { BuildPhasesTemplateService } from 'app/programming/shared/services/build-phases-template.service';
@@ -21,7 +21,8 @@ export class ProgrammingExerciseCustomBuildPlanComponent implements DoCheck, OnI
     private buildPhasesTemplateService = inject(BuildPhasesTemplateService);
     private legacyBuildPlanConverterService = inject(LegacyBuildPlanConverterService);
 
-    readonly programmingExercise = input.required<ProgrammingExercise>();
+    readonly programmingExercise = model.required<ProgrammingExercise>();
+
     readonly programmingExerciseCreationConfig = input.required<ProgrammingExerciseCreationConfig>();
     readonly isExamMode = input(false);
 
@@ -70,6 +71,10 @@ export class ProgrammingExerciseCustomBuildPlanComponent implements DoCheck, OnI
         if (this.shouldReloadTemplate()) {
             this.loadBuildPhasesTemplate(this.programmingExerciseCreationConfig().isImportFromFile);
         }
+    }
+
+    onCustomizeBuildPlanChange(customizeBuildPlan: boolean) {
+        this.programmingExercise.update((exercise) => cloneWith(exercise, { customizeBuildPlan }));
     }
 
     shouldReloadTemplate(): boolean {

--- a/src/main/webapp/app/programming/manage/update/update-components/language/programming-exercise-language.component.html
+++ b/src/main/webapp/app/programming/manage/update/update-components/language/programming-exercise-language.component.html
@@ -231,7 +231,7 @@
     }
     @if (isEditFieldDisplayedRecord().customizeBuildScript && programmingExerciseCreationConfig().customBuildPlansSupported === PROFILE_LOCALCI) {
         <jhi-programming-exercise-custom-build-plan
-            [programmingExercise]="programmingExercise()"
+            [(programmingExercise)]="programmingExercise"
             [programmingExerciseCreationConfig]="this.programmingExerciseCreationConfig()"
             [isExamMode]="programmingExerciseCreationConfig().isExamMode"
         />

--- a/src/main/webapp/app/programming/manage/update/update-components/language/programming-exercise-language.component.ts
+++ b/src/main/webapp/app/programming/manage/update/update-components/language/programming-exercise-language.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, AfterViewInit, Component, EventEmitter, OnDestroy, input, viewChild } from '@angular/core';
+import { AfterViewChecked, AfterViewInit, Component, EventEmitter, OnDestroy, input, model, viewChild } from '@angular/core';
 import { ProgrammingExercise, ProgrammingLanguage, ProjectType } from 'app/programming/shared/entities/programming-exercise.model';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { ProgrammingExerciseCreationConfig } from 'app/programming/manage/update/programming-exercise-creation-config';
@@ -36,7 +36,7 @@ export class ProgrammingExerciseLanguageComponent implements AfterViewChecked, A
     readonly ProgrammingLanguage = ProgrammingLanguage;
     readonly ProjectType = ProjectType;
 
-    readonly programmingExercise = input.required<ProgrammingExercise>();
+    readonly programmingExercise = model.required<ProgrammingExercise>();
     readonly programmingExerciseCreationConfig = input.required<ProgrammingExerciseCreationConfig>();
     isEditFieldDisplayedRecord = input.required<Record<ProgrammingExerciseInputField, boolean>>();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
When editing/creating a programming exercise and the requirements are met for after due date being shown it was not shown because of an in-place update of the programming exercise signal.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix a bug.

### Description
<!-- Describe your changes in detail -->
A component was mutating an input signal in place, causing a higher up component to not know when the build is being customized.

Introduces in #12872.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! Below is an example that you can refine. -->
Prerequisites:
- 1 Instructor

1. Create a programming exercise
2. Switch to advanced mode (bottom left)
3. Check "Customize build configuration"
4. Scroll down a bit, and set the last phase to "After due date"
5. Fill in the package name and all other requirements to create the exercise
6. Set a due date at the end.
7. Notice a new date pops up "Date for running tests after due date".
8. Done.


#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2
#### Manual Tests
- [ ] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Client

| Class/File | Line Coverage | Lines | Expects | Ratio |
|------------|-------------:|------:|--------:|------:|
| programming-exercise-custom-build-plan.component.ts | 98.38% | 131 | 34 | 26.0 |
| programming-exercise-language.component.ts | 93.02% | 103 | 7 | 6.8 |

_Last updated: 2026-09-09 19:53:48 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="707" height="427" alt="image" src="https://github.com/user-attachments/assets/eb3bc47f-f3ee-4e20-80da-c47a4c825c29" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom build plan settings so changes made in the programming exercise editor are correctly reflected throughout the update form.
  * Updated the customization checkbox to reliably propagate enabled and disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->