### PR TITLE
`Development`: Allow admin to receive websockets it should be able to

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/core/config/websocket/WebsocketConfiguration.java
+++ b/src/main/java/de/tum/cit/aet/artemis/core/config/websocket/WebsocketConfiguration.java
@@ -64,13 +64,13 @@ import org.springframework.web.socket.sockjs.transport.handler.WebSocketTranspor
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import de.tum.cit.aet.artemis.account.repository.UserRepository;
 import de.tum.cit.aet.artemis.core.config.InetSocketAddressValidator;
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
 import de.tum.cit.aet.artemis.core.security.Role;
 import de.tum.cit.aet.artemis.core.security.jwt.JWTFilter;
 import de.tum.cit.aet.artemis.core.security.jwt.JwtWithSource;
 import de.tum.cit.aet.artemis.core.security.jwt.TokenProvider;
-import de.tum.cit.aet.artemis.core.service.AuthorizationCheckService;
 import de.tum.cit.aet.artemis.core.service.ElevatedAccessService;
 import de.tum.cit.aet.artemis.exam.api.ExamRepositoryApi;
 import de.tum.cit.aet.artemis.exam.config.ExamApiNotPresentException;
@@ -101,7 +101,7 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
 
     private final StudentParticipationRepository studentParticipationRepository;
 
-    private final AuthorizationCheckService authorizationCheckService;
+    private final UserRepository userRepository;
 
     /**
      * Resolved when a subscription arrives rather than injected: this class is eager, so reaching for the service
@@ -125,13 +125,13 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
     private String brokerPassword;
 
     public WebsocketConfiguration(MappingJackson2HttpMessageConverter springMvcJacksonConverter, TaskScheduler messageBrokerTaskScheduler, TokenProvider tokenProvider,
-            StudentParticipationRepository studentParticipationRepository, AuthorizationCheckService authorizationCheckService,
-            ObjectProvider<ElevatedAccessService> elevatedAccessService, ExerciseRepository exerciseRepository, Optional<ExamRepositoryApi> examRepositoryApi) {
+            StudentParticipationRepository studentParticipationRepository, UserRepository userRepository, ObjectProvider<ElevatedAccessService> elevatedAccessService,
+            ExerciseRepository exerciseRepository, Optional<ExamRepositoryApi> examRepositoryApi) {
         this.objectMapper = springMvcJacksonConverter.getObjectMapper();
         this.messageBrokerTaskScheduler = messageBrokerTaskScheduler;
         this.tokenProvider = tokenProvider;
         this.studentParticipationRepository = studentParticipationRepository;
-        this.authorizationCheckService = authorizationCheckService;
+        this.userRepository = userRepository;
         this.elevatedAccessService = elevatedAccessService;
         this.exerciseRepository = exerciseRepository;
         this.examRepositoryApi = examRepositoryApi;
@@ -397,17 +397,17 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
                 // Request-bound elevation rather than account classification: the session the handshake established
                 // has to prove the configured passkey requirement, so an administrator who signed in with a password
                 // must not reach the admin build queue, job and agent topics on their persisted role alone.
-                return principal instanceof Authentication authentication && elevatedAccessService.getObject().isAdminElevationActive(authentication);
+                return hasAdministratorAccess(principal);
             }
 
             Optional<Long> courseId = isBuildQueueCourseDestination(destination);
             if (courseId.isPresent()) {
-                return authorizationCheckService.isAtLeastInstructorInCourse(login, courseId.get());
+                return userRepository.isAtLeastInstructorInCourse(login, courseId.get()) || hasAdministratorAccess(principal);
             }
 
             Optional<Long> buildJobCourseId = isBuildJobCourseDestination(destination);
             if (buildJobCourseId.isPresent()) {
-                return authorizationCheckService.isAtLeastInstructorInCourse(login, buildJobCourseId.get());
+                return userRepository.isAtLeastInstructorInCourse(login, buildJobCourseId.get()) || hasAdministratorAccess(principal);
             }
 
             if (isParticipationTeamDestination(destination)) {
@@ -419,10 +419,10 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
 
                 // TODO: Is it right that TAs are not allowed to subscribe to exam exercises?
                 if (exerciseRepository.isExamExercise(exerciseId)) {
-                    return authorizationCheckService.isAtLeastInstructorInExercise(login, exerciseId);
+                    return userRepository.isAtLeastInstructorInExercise(login, exerciseId) || hasAdministratorAccess(principal);
                 }
                 else {
-                    return authorizationCheckService.isAtLeastTeachingAssistantInExercise(login, exerciseId);
+                    return userRepository.isAtLeastTeachingAssistantInExercise(login, exerciseId) || hasAdministratorAccess(principal);
                 }
             }
 
@@ -430,15 +430,20 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
             if (examId.isPresent()) {
                 ExamRepositoryApi api = examRepositoryApi.orElseThrow(() -> new ExamApiNotPresentException(ExamRepositoryApi.class));
                 var exam = api.findByIdElseThrow(examId.get());
-                return authorizationCheckService.isAtLeastInstructorInCourse(login, exam.getCourse().getId());
+                return userRepository.isAtLeastInstructorInCourse(login, exam.getCourse().getId()) || hasAdministratorAccess(principal);
             }
 
             var synchronizationExerciseId = getExerciseIdFromSynchronizationDestination(destination);
             if (synchronizationExerciseId.isPresent()) {
-                return authorizationCheckService.isAtLeastEditorInExercise(login, synchronizationExerciseId.get());
+                return userRepository.isAtLeastEditorInExercise(login, synchronizationExerciseId.get()) || hasAdministratorAccess(principal);
             }
 
             return true;
+        }
+
+        private boolean hasAdministratorAccess(Principal principal) {
+            // Use the WebSocket session's authentication, never an unrelated or absent thread SecurityContext.
+            return principal instanceof Authentication authentication && elevatedAccessService.getObject().isAdminElevationActive(authentication);
         }
 
         private void logUnauthorizedDestinationAccess(Principal principal, String destination) {

--- a/src/test/java/de/tum/cit/aet/artemis/core/config/TopicSubscriptionInterceptorTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/core/config/TopicSubscriptionInterceptorTest.java
@@ -14,9 +14,11 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import de.tum.cit.aet.artemis.account.util.UserUtilService;
 import de.tum.cit.aet.artemis.core.config.websocket.WebsocketConfiguration;
@@ -83,6 +85,60 @@ class TopicSubscriptionInterceptorTest extends AbstractSpringIntegrationIndepend
 
     private static Authentication authenticationFor(String login, Role role) {
         return new UsernamePasswordAuthenticationToken(login, "irrelevant", List.of(new SimpleGrantedAuthority(role.getAuthority())));
+    }
+
+    @Test
+    void testRoleProtectedSubscriptionsUseWebsocketAuthentication() {
+        userUtilService.addAdmin(TEST_PREFIX);
+        String adminLogin = TEST_PREFIX + "admin";
+        userUtilService.addUsers(TEST_PREFIX, 1, 1, 1, 1);
+        var course = courseUtilService.createCourseWithAllExerciseTypesAndParticipationsAndSubmissionsAndResults(TEST_PREFIX, false);
+        var exercise = course.getExercises().stream().findFirst().orElseThrow();
+        var participation = exercise.getStudentParticipations().stream().findFirst().orElseThrow();
+        var exam = examUtilService.addExerciseGroupsAndExercisesToExam(examUtilService.addExam(course), false);
+        var examExercise = exam.getExerciseGroups().getFirst().getExercises().stream().findFirst().orElseThrow();
+        var interceptor = websocketConfiguration.new TopicSubscriptionInterceptor();
+        var channel = mock(MessageChannel.class);
+        var previousContext = SecurityContextHolder.getContext();
+        SecurityContextHolder.clearContext();
+        try {
+            for (String destination : List.of("/topic/courses/" + course.getId() + "/queued-jobs", "/topic/courses/" + course.getId() + "/running-jobs",
+                    "/topic/courses/" + course.getId() + "/build-job/test-job", "/topic/exercise/" + exercise.getId() + "/newResults",
+                    "/topic/exercise/" + examExercise.getId() + "/newResults", "/topic/exams/" + exam.getId() + "/exercise-start-status",
+                    "/topic/exercises/" + exercise.getId() + "/synchronization")) {
+                SecurityContextHolder.clearContext();
+                var headers = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+                headers.setLeaveMutable(true);
+                headers.setDestination(destination);
+                headers.setUser(authenticationFor(adminLogin, Role.ADMIN));
+                var message = MessageBuilder.createMessage(new byte[0], headers.getMessageHeaders());
+                assertThat(interceptor.preSend(message, channel)).as("elevated administrator: %s", destination).isSameAs(message);
+                assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+
+                // Even an elevated thread context must not override the WebSocket session's permissions.
+                SecurityContextHolder.getContext().setAuthentication(authenticationFor(adminLogin, Role.ADMIN));
+                headers.setUser(authenticationFor(adminLogin, Role.STUDENT));
+                message = MessageBuilder.createMessage(new byte[0], headers.getMessageHeaders());
+                assertThat(interceptor.preSend(message, channel)).as("non-elevated session: %s", destination).isNull();
+
+                headers.setUser(() -> adminLogin);
+                message = MessageBuilder.createMessage(new byte[0], headers.getMessageHeaders());
+                assertThat(interceptor.preSend(message, channel)).as("principal without authentication: %s", destination).isNull();
+
+                headers.setUser(authenticationFor(TEST_PREFIX + "instructor1", Role.INSTRUCTOR));
+                message = MessageBuilder.createMessage(new byte[0], headers.getMessageHeaders());
+                assertThat(interceptor.preSend(message, channel)).as("explicit instructor: %s", destination).isSameAs(message);
+            }
+
+            var headers = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+            headers.setDestination("/topic/participations/" + participation.getId() + "/team");
+            headers.setUser(authenticationFor(adminLogin, Role.ADMIN));
+            var message = MessageBuilder.createMessage(new byte[0], headers.getMessageHeaders());
+            assertThat(interceptor.preSend(message, channel)).as("administrator override must not bypass ownership").isNull();
+        }
+        finally {
+            SecurityContextHolder.setContext(previousContext);
+        }
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary 
I noticed a but where the "Prepare exercise start" was not showing progress. Turns out the messages were not being sent from the server. This fixes it.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix a bug.

### Description
<!-- Describe your changes in detail -->
I noticed a but where the "Prepare exercise start" was not showing progress. Turns out the messages were not being sent from the server. The issue was that the info that the user is an admin was not in the security context on different threads. It was only in the principal. Therefore the security check said: Ok, no instructor in the course, and also no admin even though the user may be one.

Introduced in #13632 

### Steps for Testing


#### Exam Mode Testing
<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->


Prerequisites:
- 1 Administrator but NOT registered instructor in relevant course (will still have instructor rights)
- 1 Student User

Steps as Admin:
1. Create an exam (dates in the future) with number of exercises set to one.
2. Create an exercise group with one text exercise in it (simple to create, exercise type irrelevant) with one point.
3. Go to students page.
4. Register at lease on student.
5. Generate the individual exams.
6. Prepare the exercise start.
7. Notice the loading bar and that the info text turns green live, without needing to refresh the page.
8. Done.

### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2
#### Manual Tests
- [x] Test 1

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| WebsocketConfiguration.java | 73.89% | 340 |

_Last updated: 2026-09-09 20:30:06 UTC_


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="641" height="307" alt="Screenshot 2026-09-09 at 21 37 32" src="https://github.com/user-attachments/assets/7744260f-f2c5-47b0-8b96-a3cc1ef9b4f6" />
