### PR TITLE
`Development`: Reduce the data read when preparing exam exercises

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exam/dto/StudentExamExerciseStartDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/dto/StudentExamExerciseStartDTO.java
@@ -1,0 +1,22 @@
+package de.tum.cit.aet.artemis.exam.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * One (student exam, exercise) pair whose participation the exam preparation has to set up.
+ * <p>
+ * Setting an exercise up needs nothing from the student exam but its id, and nothing from the student but the id and
+ * the login their repository is named after, so this projection is read instead of the student exam graph. That graph
+ * repeats the exam row and the full exercise row once per student exam: for 2000 students and four exercises it
+ * transfers megabytes to convey a few kilobytes of distinct data, and it grows with the length of every problem
+ * statement. The login is still repeated once per exercise here, but a login is orders of magnitude smaller than an
+ * exercise row.
+ *
+ * @param studentExamId the id of the student exam
+ * @param userId        the id of the student the student exam belongs to
+ * @param userLogin     the login of that student, which their exercise repository is named after
+ * @param exerciseId    the id of one exercise of that student exam
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record StudentExamExerciseStartDTO(long studentExamId, long userId, String userLogin, long exerciseId) {
+}

--- a/src/main/java/de/tum/cit/aet/artemis/exam/repository/ExamRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/repository/ExamRepository.java
@@ -282,8 +282,19 @@ public interface ExamRepository extends ArtemisJpaRepository<Exam, Long> {
     @EntityGraph(type = LOAD, attributePaths = { "examUsers", "exerciseGroups", "exerciseGroups.exercises" })
     Optional<Exam> findWithExamUsersAndExerciseGroupsAndExercisesById(long examId);
 
-    @EntityGraph(type = LOAD, attributePaths = { "studentExams", "studentExams.exercises" })
-    Optional<Exam> findWithStudentExamsExercisesById(long id);
+    /**
+     * Reads the single flag the exam preparation needs off the exam, rather than the whole row: the exam texts are
+     * unbounded in length and none of them is read there.
+     *
+     * @param examId the id of the exam
+     * @return whether the exam is a test exam, empty if no exam with that id exists
+     */
+    @Query("""
+            SELECT exam.testExam
+            FROM Exam exam
+            WHERE exam.id = :examId
+            """)
+    Optional<Boolean> findIsTestExamById(@Param("examId") long examId);
 
     @Query("""
             SELECT DISTINCT e

--- a/src/main/java/de/tum/cit/aet/artemis/exam/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/repository/StudentExamRepository.java
@@ -33,6 +33,7 @@ import de.tum.cit.aet.artemis.exam.domain.Exam;
 import de.tum.cit.aet.artemis.exam.domain.ExerciseGroup;
 import de.tum.cit.aet.artemis.exam.domain.StudentExam;
 import de.tum.cit.aet.artemis.exam.dto.ExamStudentDTO;
+import de.tum.cit.aet.artemis.exam.dto.StudentExamExerciseStartDTO;
 import de.tum.cit.aet.artemis.exam.dto.StudentExamSubmissionGateDTO;
 import de.tum.cit.aet.artemis.exam.dto.StudentExamWorkingTimeDTO;
 import de.tum.cit.aet.artemis.exercise.domain.Exercise;
@@ -287,6 +288,46 @@ public interface StudentExamRepository extends ArtemisJpaRepository<StudentExam,
                 AND se.user.id = :userId
             """)
     Optional<StudentExamWorkingTimeDTO> findWorkingTimeByExamIdAndUserId(@Param("examId") long examId, @Param("userId") long userId);
+
+    /**
+     * Reads everything the exam preparation needs to set up the participations of an exam: one row per
+     * (student exam, exercise) pair, carrying only identifiers and the student's login.
+     * <p>
+     * This deliberately replaces loading the exam with its student exams and their exercises. That entity graph repeats
+     * the exam row and the full exercise row - problem statement included - once per student exam, so its size grows
+     * with students times exercises even though the distinct data does not.
+     *
+     * @param examId the id of the exam
+     * @return one row per exercise of every student exam of the exam, test runs included
+     */
+    @Query("""
+            SELECT new de.tum.cit.aet.artemis.exam.dto.StudentExamExerciseStartDTO(studentExam.id, student.id, student.login, exercise.id)
+            FROM StudentExam studentExam
+                JOIN studentExam.user student
+                JOIN studentExam.exercises exercise
+            WHERE studentExam.exam.id = :examId
+            ORDER BY studentExam.id, exercise.id
+            """)
+    List<StudentExamExerciseStartDTO> findExerciseStartDataByExamId(@Param("examId") long examId);
+
+    /**
+     * The same rows as {@link #findExerciseStartDataByExamId}, restricted to the given student exams. Ids that do not
+     * belong to the exam simply do not match, so callers cannot prepare exercises across exams.
+     *
+     * @param examId         the id of the exam
+     * @param studentExamIds the ids of the student exams to read
+     * @return one row per exercise of every requested student exam that belongs to the exam
+     */
+    @Query("""
+            SELECT new de.tum.cit.aet.artemis.exam.dto.StudentExamExerciseStartDTO(studentExam.id, student.id, student.login, exercise.id)
+            FROM StudentExam studentExam
+                JOIN studentExam.user student
+                JOIN studentExam.exercises exercise
+            WHERE studentExam.exam.id = :examId
+                AND studentExam.id IN :studentExamIds
+            ORDER BY studentExam.id, exercise.id
+            """)
+    List<StudentExamExerciseStartDTO> findExerciseStartDataByExamIdAndStudentExamIds(@Param("examId") long examId, @Param("studentExamIds") Collection<Long> studentExamIds);
 
     Optional<StudentExam> findFirstByExamIdAndUserIdOrderByCreatedDateDesc(long examId, long userId);
 

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamService.java
@@ -9,6 +9,8 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -34,7 +36,6 @@ import org.springframework.stereotype.Service;
 import de.tum.cit.aet.artemis.account.domain.User;
 import de.tum.cit.aet.artemis.account.repository.UserRepository;
 import de.tum.cit.aet.artemis.communication.service.WebsocketMessagingService;
-import de.tum.cit.aet.artemis.core.domain.DomainObject;
 import de.tum.cit.aet.artemis.core.exception.AccessForbiddenException;
 import de.tum.cit.aet.artemis.core.exception.ConflictException;
 import de.tum.cit.aet.artemis.core.exception.EntityNotFoundException;
@@ -43,6 +44,7 @@ import de.tum.cit.aet.artemis.core.util.ExamExerciseStartPreparationStatus;
 import de.tum.cit.aet.artemis.exam.config.ExamEnabled;
 import de.tum.cit.aet.artemis.exam.domain.Exam;
 import de.tum.cit.aet.artemis.exam.domain.StudentExam;
+import de.tum.cit.aet.artemis.exam.dto.StudentExamExerciseStartDTO;
 import de.tum.cit.aet.artemis.exam.dto.StudentExamWithGradeDTO;
 import de.tum.cit.aet.artemis.exam.dto.submit.SubmitStudentExamDTO;
 import de.tum.cit.aet.artemis.exam.repository.ExamRepository;
@@ -599,9 +601,26 @@ public class StudentExamService {
      * @param generatedParticipations List of generated participations to track how many participations have been generated
      */
     private void setUpExerciseParticipationsAndSubmissions(StudentExam studentExam, List<StudentParticipation> generatedParticipations, boolean failFast) {
-        User student = studentExam.getUser();
+        setUpExerciseParticipationsAndSubmissions(studentExam.getId(), studentExam.getUser(), studentExam.getExercises(), studentExam.isTestExam(), generatedParticipations,
+                failFast);
+    }
 
-        for (Exercise exercise : studentExam.getExercises()) {
+    /**
+     * Sets up the participations and submissions for the given exercises of one student exam.
+     * <p>
+     * Takes the few values it reads rather than the student exam entity, so that the bulk preparation in
+     * {@link #startExercises(Long, List)} can feed it from a projection instead of loading the whole exam graph.
+     *
+     * @param studentExamId           the id of the student exam the participations belong to, used for logging only
+     * @param student                 the student to create the participations for
+     * @param exercises               the exercises of that student exam
+     * @param testExam                whether the student exam belongs to a test exam, in which case a new participation is always created
+     * @param generatedParticipations List of generated participations to track how many participations have been generated
+     * @param failFast                whether to rethrow the first failure instead of continuing with the next exercise
+     */
+    private void setUpExerciseParticipationsAndSubmissions(long studentExamId, User student, List<Exercise> exercises, boolean testExam,
+            List<StudentParticipation> generatedParticipations, boolean failFast) {
+        for (Exercise exercise : exercises) {
             // Stands in only if no caller context reached this thread; a real user's identity is kept.
             SecurityUtils.setAuthorizationObject();
             // NOTE: it's not ideal to invoke the next line several times (2000 student exams with 10 exercises would lead to 20.000 database calls to find all participations).
@@ -610,7 +629,7 @@ public class StudentExamService {
             // TODO: directly check in the database if the entry exists for the student, exercise and InitializationState.INITIALIZED
             var studentParticipations = studentParticipationRepository.findByExerciseIdAndStudentId(exercise.getId(), student.getId());
             // we start the exercise if no participation was found that was already fully initialized
-            if (studentExam.isTestExam() || studentParticipations.stream().noneMatch(studentParticipation -> studentParticipation.getParticipant().equals(student)
+            if (testExam || studentParticipations.stream().noneMatch(studentParticipation -> studentParticipation.getParticipant().equals(student)
                     && studentParticipation.getInitializationState() != null && studentParticipation.getInitializationState().hasCompletedState(InitializationState.INITIALIZED))) {
                 try {
                     // Load lazy property
@@ -625,14 +644,13 @@ public class StudentExamService {
 
                     if (!participation.isAtLeastInitialized()) {
                         throw new IllegalStateException("Participation " + participation.getId() + " was not initialized after starting exercise " + exercise.getId()
-                                + " for student exam " + studentExam.getId() + " and student " + student.getParticipantIdentifier());
+                                + " for student exam " + studentExamId + " and student " + student.getParticipantIdentifier());
                     }
 
-                    log.info("SUCCESS: Start exercise for student exam {} and exercise {} and student {}", studentExam.getId(), exercise.getId(),
-                            student.getParticipantIdentifier());
+                    log.info("SUCCESS: Start exercise for student exam {} and exercise {} and student {}", studentExamId, exercise.getId(), student.getParticipantIdentifier());
                 }
                 catch (Exception ex) {
-                    log.warn("FAILED: Start exercise for student exam {} and exercise {} and student {} with exception: {}", studentExam.getId(), exercise.getId(),
+                    log.warn("FAILED: Start exercise for student exam {} and exercise {} and student {} with exception: {}", studentExamId, exercise.getId(),
                             student.getParticipantIdentifier(), ex.getMessage(), ex);
                     if (failFast) {
                         throw ex;
@@ -664,16 +682,17 @@ public class StudentExamService {
     }
 
     private CompletableFuture<Integer> startExercises(Long examId, List<Long> studentExamIds) {
-        var exam = examRepository.findWithStudentExamsExercisesById(examId).orElseThrow(() -> new EntityNotFoundException("Exam", examId));
+        boolean testExam = examRepository.findIsTestExamById(examId).orElseThrow(() -> new EntityNotFoundException("Exam", examId));
 
-        Set<StudentExam> studentExams;
-        if (studentExamIds == null) {
-            studentExams = exam.getStudentExams();
-        }
-        else {
-            var studentExamsInExam = exam.getStudentExams().stream().collect(Collectors.toMap(DomainObject::getId, Function.identity()));
-            studentExams = studentExamIds.stream().map(studentExamsInExam::get).filter(Objects::nonNull).collect(Collectors.toSet());
-        }
+        // One row per (student exam, exercise) pair, carrying ids and the student's login only. Loading the exam with its
+        // student exams and their exercises instead would repeat the exam row and the full exercise row once per student
+        // exam, which for a large exam transfers megabytes to convey a few kilobytes of distinct data.
+        var exerciseStartData = studentExamIds == null ? studentExamRepository.findExerciseStartDataByExamId(examId)
+                : studentExamRepository.findExerciseStartDataByExamIdAndStudentExamIds(examId, studentExamIds);
+        var exercisesById = loadExercisesForPreparation(exerciseStartData);
+        // LinkedHashMap so the student exams are prepared in the order the query returned them
+        var rowsByStudentExamId = exerciseStartData.stream().collect(Collectors.groupingBy(StudentExamExerciseStartDTO::studentExamId, LinkedHashMap::new, Collectors.toList()));
+        int studentExamCount = rowsByStudentExamId.size();
 
         List<StudentParticipation> generatedParticipations = Collections.synchronizedList(new ArrayList<>());
 
@@ -683,27 +702,59 @@ public class StudentExamService {
         var failedExamsCounter = new AtomicInteger(0);
         var startedAt = ZonedDateTime.now();
         var lock = new ReentrantLock();
-        sendAndCacheExercisePreparationStatus(examId, 0, 0, studentExams.size(), 0, startedAt, lock);
+        sendAndCacheExercisePreparationStatus(examId, 0, 0, studentExamCount, 0, startedAt, lock);
 
         try (var threadPool = Executors.newFixedThreadPool(10)) {
-            var futures = studentExams.stream()
-                    .map(studentExam -> CompletableFuture.runAsync(() -> setUpExerciseParticipationsAndSubmissions(studentExam, generatedParticipations, true), threadPool)
-                            .thenRun(() -> sendAndCacheExercisePreparationStatus(examId, finishedExamsCounter.incrementAndGet(), failedExamsCounter.get(), studentExams.size(),
-                                    generatedParticipations.size(), startedAt, lock))
-                            .exceptionally(throwable -> {
-                                log.error("Exception while preparing exercises for student exam {}", studentExam.getId(), throwable);
-                                sendAndCacheExercisePreparationStatus(examId, finishedExamsCounter.get(), failedExamsCounter.incrementAndGet(), studentExams.size(),
-                                        generatedParticipations.size(), startedAt, lock);
-                                return null;
-                            }))
-                    .toArray(CompletableFuture[]::new);
+            var futures = rowsByStudentExamId.entrySet().stream().map(entry -> {
+                long studentExamId = entry.getKey();
+                var rows = entry.getValue();
+                var student = new User(rows.getFirst().userId());
+                student.setLogin(rows.getFirst().userLogin());
+                var exercises = rows.stream().map(row -> exercisesById.get(row.exerciseId())).filter(Objects::nonNull).toList();
+                return CompletableFuture
+                        .runAsync(() -> setUpExerciseParticipationsAndSubmissions(studentExamId, student, exercises, testExam, generatedParticipations, true), threadPool)
+                        .thenRun(() -> sendAndCacheExercisePreparationStatus(examId, finishedExamsCounter.incrementAndGet(), failedExamsCounter.get(), studentExamCount,
+                                generatedParticipations.size(), startedAt, lock))
+                        .exceptionally(throwable -> {
+                            log.error("Exception while preparing exercises for student exam {}", studentExamId, throwable);
+                            sendAndCacheExercisePreparationStatus(examId, finishedExamsCounter.get(), failedExamsCounter.incrementAndGet(), studentExamCount,
+                                    generatedParticipations.size(), startedAt, lock);
+                            return null;
+                        });
+            }).toArray(CompletableFuture[]::new);
             return CompletableFuture.allOf(futures).thenApply((emtpy) -> {
                 threadPool.shutdown();
-                sendAndCacheExercisePreparationStatus(examId, finishedExamsCounter.get(), failedExamsCounter.get(), studentExams.size(), generatedParticipations.size(), startedAt,
+                sendAndCacheExercisePreparationStatus(examId, finishedExamsCounter.get(), failedExamsCounter.get(), studentExamCount, generatedParticipations.size(), startedAt,
                         lock);
                 return generatedParticipations.size();
             });
         }
+    }
+
+    /**
+     * Loads every distinct exercise the given student exams reference, once, rather than once per student exam.
+     * <p>
+     * Programming exercises are loaded with their template participation right away: the preparation would otherwise
+     * fetch it lazily from inside the worker threads, which all share the same exercise instance.
+     *
+     * @param exerciseStartData the rows read for the exam
+     * @return the exercises by id
+     */
+    private Map<Long, Exercise> loadExercisesForPreparation(List<StudentExamExerciseStartDTO> exerciseStartData) {
+        var exerciseIds = exerciseStartData.stream().map(StudentExamExerciseStartDTO::exerciseId).collect(Collectors.toSet());
+        Map<Long, Exercise> exercisesById = new HashMap<>();
+        for (Exercise exercise : exerciseRepository.findAllById(exerciseIds)) {
+            var loadedExercise = exercise instanceof ProgrammingExercise ? programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationElseThrow(exercise.getId())
+                    : exercise;
+            exercisesById.put(loadedExercise.getId(), loadedExercise);
+        }
+        if (exercisesById.size() < exerciseIds.size()) {
+            // Cannot happen while the foreign key holds, but the student exams that reference a missing exercise would
+            // otherwise be prepared one exercise short without anything saying so.
+            exerciseIds.removeAll(exercisesById.keySet());
+            log.error("Exercises {} are referenced by student exams but no longer exist, their participations are not prepared", exerciseIds);
+        }
+        return exercisesById;
     }
 
     private void sendAndCacheExercisePreparationStatus(Long examId, int finished, int failed, int overall, int participations, ZonedDateTime startTime, ReentrantLock lock) {

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamService.java
@@ -601,8 +601,25 @@ public class StudentExamService {
      * @param generatedParticipations List of generated participations to track how many participations have been generated
      */
     private void setUpExerciseParticipationsAndSubmissions(StudentExam studentExam, List<StudentParticipation> generatedParticipations, boolean failFast) {
-        setUpExerciseParticipationsAndSubmissions(studentExam.getId(), studentExam.getUser(), studentExam.getExercises(), studentExam.isTestExam(), generatedParticipations,
-                failFast);
+        User student = studentExam.getUser();
+        List<Exercise> exercises = studentExam.getExercises();
+        // A single student exam is a handful of exercises, so asking per exercise is cheap here. The bulk preparation in
+        // startExercises asks for a whole cohort at once instead.
+        Set<Long> startedExerciseIds = studentExam.isTestExam() ? Set.of()
+                : exercises.stream().filter(exercise -> hasInitializedParticipation(exercise.getId(), student)).map(Exercise::getId).collect(Collectors.toSet());
+        setUpExerciseParticipationsAndSubmissions(studentExam.getId(), student, exercises, studentExam.isTestExam(), startedExerciseIds, generatedParticipations, failFast);
+    }
+
+    /**
+     * Whether the student already has a participation for the exercise that reached {@link InitializationState#INITIALIZED}.
+     *
+     * @param exerciseId the id of the exercise
+     * @param student    the student
+     * @return true if such a participation exists
+     */
+    private boolean hasInitializedParticipation(long exerciseId, User student) {
+        return studentParticipationRepository.findByExerciseIdAndStudentId(exerciseId, student.getId()).stream().anyMatch(
+                participation -> participation.getInitializationState() != null && participation.getInitializationState().hasCompletedState(InitializationState.INITIALIZED));
     }
 
     /**
@@ -615,22 +632,17 @@ public class StudentExamService {
      * @param student                 the student to create the participations for
      * @param exercises               the exercises of that student exam
      * @param testExam                whether the student exam belongs to a test exam, in which case a new participation is always created
+     * @param startedExerciseIds      the ids of those exercises the student already has a fully initialized participation for
      * @param generatedParticipations List of generated participations to track how many participations have been generated
      * @param failFast                whether to rethrow the first failure instead of continuing with the next exercise
      */
-    private void setUpExerciseParticipationsAndSubmissions(long studentExamId, User student, List<Exercise> exercises, boolean testExam,
+    private void setUpExerciseParticipationsAndSubmissions(long studentExamId, User student, List<Exercise> exercises, boolean testExam, Set<Long> startedExerciseIds,
             List<StudentParticipation> generatedParticipations, boolean failFast) {
         for (Exercise exercise : exercises) {
             // Stands in only if no caller context reached this thread; a real user's identity is kept.
             SecurityUtils.setAuthorizationObject();
-            // NOTE: it's not ideal to invoke the next line several times (2000 student exams with 10 exercises would lead to 20.000 database calls to find all participations).
-            // One optimization could be that we load all participations per exercise once (or per exercise) into a large list (10 * 2000 = 20.000 participations) and then check if
-            // those participations exist in Java, however this might lead to memory issues and might be more difficult to program (and more difficult to understand)
-            // TODO: directly check in the database if the entry exists for the student, exercise and InitializationState.INITIALIZED
-            var studentParticipations = studentParticipationRepository.findByExerciseIdAndStudentId(exercise.getId(), student.getId());
             // we start the exercise if no participation was found that was already fully initialized
-            if (testExam || studentParticipations.stream().noneMatch(studentParticipation -> studentParticipation.getParticipant().equals(student)
-                    && studentParticipation.getInitializationState() != null && studentParticipation.getInitializationState().hasCompletedState(InitializationState.INITIALIZED))) {
+            if (testExam || !startedExerciseIds.contains(exercise.getId())) {
                 try {
                     // Load lazy property
                     if (exercise instanceof ProgrammingExercise programmingExercise && !Hibernate.isInitialized(programmingExercise.getTemplateParticipation())) {
@@ -690,6 +702,8 @@ public class StudentExamService {
         var exerciseStartData = studentExamIds == null ? studentExamRepository.findExerciseStartDataByExamId(examId)
                 : studentExamRepository.findExerciseStartDataByExamIdAndStudentExamIds(examId, studentExamIds);
         var exercisesById = loadExercisesForPreparation(exerciseStartData);
+        // Which students are already set up, asked once per exercise rather than once per student and exercise
+        var startedStudentIdsByExerciseId = testExam ? Map.<Long, Set<Long>>of() : loadStartedStudentIds(exercisesById.keySet());
         // LinkedHashMap so the student exams are prepared in the order the query returned them
         var rowsByStudentExamId = exerciseStartData.stream().collect(Collectors.groupingBy(StudentExamExerciseStartDTO::studentExamId, LinkedHashMap::new, Collectors.toList()));
         int studentExamCount = rowsByStudentExamId.size();
@@ -711,8 +725,11 @@ public class StudentExamService {
                 var student = new User(rows.getFirst().userId());
                 student.setLogin(rows.getFirst().userLogin());
                 var exercises = rows.stream().map(row -> exercisesById.get(row.exerciseId())).filter(Objects::nonNull).toList();
+                var startedExerciseIds = exercises.stream().filter(exercise -> startedStudentIdsByExerciseId.getOrDefault(exercise.getId(), Set.of()).contains(student.getId()))
+                        .map(Exercise::getId).collect(Collectors.toSet());
                 return CompletableFuture
-                        .runAsync(() -> setUpExerciseParticipationsAndSubmissions(studentExamId, student, exercises, testExam, generatedParticipations, true), threadPool)
+                        .runAsync(() -> setUpExerciseParticipationsAndSubmissions(studentExamId, student, exercises, testExam, startedExerciseIds, generatedParticipations, true),
+                                threadPool)
                         .thenRun(() -> sendAndCacheExercisePreparationStatus(examId, finishedExamsCounter.incrementAndGet(), failedExamsCounter.get(), studentExamCount,
                                 generatedParticipations.size(), startedAt, lock))
                         .exceptionally(throwable -> {
@@ -755,6 +772,22 @@ public class StudentExamService {
             log.error("Exercises {} are referenced by student exams but no longer exist, their participations are not prepared", exerciseIds);
         }
         return exercisesById;
+    }
+
+    /**
+     * Reads which students already have a fully initialized participation, one query per exercise instead of one per
+     * student and exercise, and ids instead of whole participation rows.
+     *
+     * @param exerciseIds the ids of the exercises of the exam
+     * @return the ids of the students already set up, by exercise id
+     */
+    private Map<Long, Set<Long>> loadStartedStudentIds(Set<Long> exerciseIds) {
+        var startedStates = InitializationState.statesThatCompleted(InitializationState.INITIALIZED);
+        Map<Long, Set<Long>> startedStudentIdsByExerciseId = new HashMap<>();
+        for (Long exerciseId : exerciseIds) {
+            startedStudentIdsByExerciseId.put(exerciseId, studentParticipationRepository.findStudentIdsWithParticipationInStateByExerciseId(exerciseId, startedStates));
+        }
+        return startedStudentIdsByExerciseId;
     }
 
     private void sendAndCacheExercisePreparationStatus(Long examId, int finished, int failed, int overall, int participations, ZonedDateTime startTime, ReentrantLock lock) {

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamService.java
@@ -705,7 +705,8 @@ public class StudentExamService {
         // Which students are already set up, asked once per exercise rather than once per student and exercise
         var startedStudentIdsByExerciseId = testExam ? Map.<Long, Set<Long>>of() : loadStartedStudentIds(exercisesById.keySet());
         // LinkedHashMap so the student exams are prepared in the order the query returned them
-        var rowsByStudentExamId = exerciseStartData.stream().collect(Collectors.groupingBy(StudentExamExerciseStartDTO::studentExamId, LinkedHashMap::new, Collectors.toList()));
+        var rowsByStudentExamId = exerciseStartData.stream()
+                .collect(Collectors.groupingBy(StudentExamExerciseStartDTO::studentExamId, LinkedHashMap::new, Collectors.toCollection(ArrayList::new)));
         int studentExamCount = rowsByStudentExamId.size();
 
         List<StudentParticipation> generatedParticipations = Collections.synchronizedList(new ArrayList<>());

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/domain/InitializationState.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/domain/InitializationState.java
@@ -1,5 +1,9 @@
 package de.tum.cit.aet.artemis.exercise.domain;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * Describes the state of a participation.
  */
@@ -46,5 +50,16 @@ public enum InitializationState {
 
     public boolean hasCompletedState(InitializationState state) {
         return this.stateNumber >= state.stateNumber;
+    }
+
+    /**
+     * All states for which {@link #hasCompletedState} returns true for the given state. Lets a query filter on
+     * completion without spelling the states out, so it cannot drift apart from the check above when a state is added.
+     *
+     * @param state the state that must have been completed
+     * @return the states that have completed it, including the state itself
+     */
+    public static Set<InitializationState> statesThatCompleted(InitializationState state) {
+        return Arrays.stream(values()).filter(candidate -> candidate.hasCompletedState(state)).collect(Collectors.toUnmodifiableSet());
     }
 }

--- a/src/main/java/de/tum/cit/aet/artemis/exercise/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exercise/repository/StudentParticipationRepository.java
@@ -672,6 +672,28 @@ public interface StudentParticipationRepository extends ArtemisJpaRepository<Stu
             """)
     List<StudentParticipation> findByExerciseIdAndStudentId(@Param("exerciseId") long exerciseId, @Param("studentId") long studentId);
 
+    /**
+     * Reads which students already have a participation in one of the given states for an exercise, as ids only.
+     * <p>
+     * Answers for a whole cohort at once what {@link #findByExerciseIdAndStudentId} answers for one student, so that
+     * preparing an exam does not need one query and one full participation row per student and exercise. Pass
+     * {@link InitializationState#statesThatCompleted} to ask for a state having been reached rather than matched
+     * exactly.
+     *
+     * @param exerciseId           the id of the exercise
+     * @param initializationStates the states that count
+     * @return the ids of the students with such a participation, empty for team exercises
+     */
+    @Query("""
+            SELECT participation.student.id
+            FROM StudentParticipation participation
+            WHERE participation.exercise.id = :exerciseId
+                AND participation.student.id IS NOT NULL
+                AND participation.initializationState IN :initializationStates
+            """)
+    Set<Long> findStudentIdsWithParticipationInStateByExerciseId(@Param("exerciseId") long exerciseId,
+            @Param("initializationStates") Collection<InitializationState> initializationStates);
+
     @Query("""
             SELECT DISTINCT p
             FROM StudentParticipation p


### PR DESCRIPTION
### Summary

Preparing the exercises of an exam read the whole exam graph and then went back to the database twice per student and exercise. For an exam with 2000 students and four exercises that is a 3.5 MB result set conveying about 600 kB of distinct data, plus 10,000 further queries. This PR replaces both with projections: one row of ids per (student exam, exercise) pair, the distinct exercises once, and one query per exercise for the students who already started it.

### Motivation and Context

Measured on the test cluster against an exam with 2000 student exams and four exercises:

| read | before | after |
|---|---|---|
| the student exams and their exercises | `findWithStudentExamsExercisesById`: 8000 rows, width 5468, **3547 kB**, 15.2 ms | one projection: 8000 rows, width 46, **563 kB**, 9.4 ms |
| the exam | one of those 8000 copies | `SELECT test_exam`: 1 buffer, 0.05 ms |
| the exercises | 2000 copies of each of the four | **4 rows, 796 bytes** |
| the students | 2000 lazy `jhi_user` selects | none, the login is in the projection |
| who already started | 8000 `SELECT DISTINCT` over nine joined tables | **4 queries** returning student ids |

The exam row and every exercise row were repeated once per student exam, so the result set grew with students × exercises even though the distinct data did not. The exercises carry the problem statements: with a realistic 10 kB problem statement the same query moves roughly 80 MB to convey 40 kB.

None of that data was used. The loop reads exactly the student exam id, the student id and login, and the exercise — and the exercise is only passed on to `ParticipationService#startExercise`.

### Description

**Read the pairs, not the graph.** `StudentExamRepository#findExerciseStartDataByExamId` returns one `StudentExamExerciseStartDTO(studentExamId, userId, userLogin, exerciseId)` per pair. A second method restricts it to given student exam ids for the "prepare these student exams again" path; ids that do not belong to the exam do not match, which is the same filtering the caller did in Java before. `ExamRepository#findWithStudentExamsExercisesById` had this one caller and is gone; the test-exam flag it was loaded for now comes from `findIsTestExamById`.

**Load each exercise once.** `loadExercisesForPreparation` reads the distinct exercises and gives programming exercises their template participation up front. Before, the template participation was faulted in lazily from inside the worker threads, which all share the same exercise instance.

**Ask per exercise, not per student and exercise.** `StudentParticipationRepository#findStudentIdsWithParticipationInStateByExerciseId` answers for a whole cohort what `findByExerciseIdAndStudentId` answered for one student, and returns student ids rather than participation rows. The states that count come from `InitializationState#statesThatCompleted`, so the query cannot drift from `hasCompletedState`. Single student exams (test runs, test exams) keep asking per exercise — a handful of queries there is cheaper than reading a cohort.

`setUpExerciseParticipationsAndSubmissions` now takes the values it reads instead of the entity, so both paths share it.

### Steps for Testing

Prerequisites:
- 1 Instructor
- Several students
- 1 Exam with at least one programming exercise and one text or modeling exercise

1. Log in as the instructor and generate the student exams.
2. Prepare the exercises. All participations are created, and the progress indicator counts up to the number of student exams as before.
3. Prepare them a second time. Nothing is created twice.
4. Delete one student's participation and prepare again for that student exam only. Only the missing participation comes back.
5. Log in as a student and open the exam. All exercises are ready.

#### Exam Mode Testing

Prerequisites:
- 1 Instructor
- Several students
- 1 Test exam with a programming exercise

1. As the instructor, create a test run and confirm its participations are set up.
2. As a student, start the test exam twice and confirm a new participation is created each time.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [x] Test 1
- [x] Test 2

#### Exam Mode Test
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved exam exercise startup by loading only the information needed to prepare exercises.
  * Reduced repeated data retrieval when initializing exercise participations and submissions.
  * Improved handling of students who have already started exercises during exam preparation.

* **Reliability Improvements**
  * Improved tracking of completed exercise initialization states.
  * Added more targeted retrieval of participation and exercise-start information for smoother exam preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->