### PR TITLE
`Development`: Send one build queue snapshot per interval instead of one per change

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIEventListenerService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIEventListenerService.java
@@ -129,18 +129,18 @@ public class LocalCIEventListenerService {
      * elsewhere. Safe to call WebSocket updates directly.
      * </p>
      *
-     * @see LocalCIQueueWebsocketService#sendQueuedJobsOverWebsocket(long)
+     * @see LocalCIQueueWebsocketService#queuedJobsChanged(long)
      */
     private class QueuedBuildJobItemListener implements QueueItemListener<BuildJobQueueItem> {
 
         @Override
         public void itemAdded(BuildJobQueueItem item) {
-            localCIQueueWebsocketService.sendQueuedJobsOverWebsocket(item.courseId());
+            localCIQueueWebsocketService.queuedJobsChanged(item.courseId());
         }
 
         @Override
         public void itemRemoved(BuildJobQueueItem item) {
-            localCIQueueWebsocketService.sendQueuedJobsOverWebsocket(item.courseId());
+            localCIQueueWebsocketService.queuedJobsChanged(item.courseId());
         }
     }
 
@@ -169,7 +169,7 @@ public class LocalCIEventListenerService {
      * </p>
      *
      * @see BuildJobRepository#updateBuildJobStatusWithBuildStartDate(String, BuildStatus, java.time.ZonedDateTime)
-     * @see LocalCIQueueWebsocketService#sendProcessingJobsOverWebsocket(long)
+     * @see LocalCIQueueWebsocketService#processingJobsChanged(long)
      * @see ProgrammingMessagingService#notifyUserAboutSubmissionProcessing(SubmissionProcessingDTO, long, long)
      */
     private class ProcessingBuildJobItemListener implements MapEntryListener<String, BuildJobQueueItem> {
@@ -182,10 +182,10 @@ public class LocalCIEventListenerService {
                 return;
             }
             log.debug("CIBuildJobQueueItem added to processing jobs: {}", job);
-            localCIQueueWebsocketService.sendProcessingJobsOverWebsocket(job.courseId());
+            localCIQueueWebsocketService.processingJobsChanged(job.courseId());
             localCIQueueWebsocketService.sendBuildJobUpdateOverWebsocket(job);
             // Also update build agent summary so the admin page shows accurate running job counts
-            localCIQueueWebsocketService.sendBuildAgentSummaryOverWebsocket();
+            localCIQueueWebsocketService.buildAgentSummaryChanged();
             buildJobRepository.updateBuildJobStatusWithBuildStartDate(job.id(), BuildStatus.BUILDING, job.jobTimingInfo().buildStartDate());
             notifyUserAboutBuildProcessing(job.exerciseId(), job.participationId(), job.buildConfig().assignmentCommitHash(), job.jobTimingInfo().submissionDate(),
                     job.jobTimingInfo().buildStartDate(), job.jobTimingInfo().estimatedCompletionDate());
@@ -199,10 +199,10 @@ public class LocalCIEventListenerService {
                 return;
             }
             log.debug("CIBuildJobQueueItem removed from processing jobs: {}", job);
-            localCIQueueWebsocketService.sendProcessingJobsOverWebsocket(job.courseId());
+            localCIQueueWebsocketService.processingJobsChanged(job.courseId());
             localCIQueueWebsocketService.sendBuildJobUpdateOverWebsocket(job);
             // Also update build agent summary so the admin page shows accurate running job counts
-            localCIQueueWebsocketService.sendBuildAgentSummaryOverWebsocket();
+            localCIQueueWebsocketService.buildAgentSummaryChanged();
         }
 
         @Override

--- a/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketService.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.artemis.localci.service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -84,36 +85,83 @@ public class LocalCIQueueWebsocketService {
     }
 
     /**
-     * Sends one snapshot per collection that changed since the last run. Removing a course before reading its jobs
-     * rather than after means a change that arrives while this is sending is picked up by the next run instead of
-     * being dropped; the cost of that ordering is at most one redundant broadcast.
+     * Sends one snapshot per collection that changed since the last run.
+     * <p>
+     * Each collection is read and sanitized once per run, not once per affected course, and the admin topic gets one
+     * message rather than one per course. A failed run puts the courses it drained back so the next one retries them;
+     * without that a broadcast that throws would leave the queue views stale until the next unrelated queue event.
      */
     @Scheduled(fixedRateString = "${artemis.continuous-integration.build-queue-broadcast-interval-milliseconds:1000}")
     public void broadcastPendingChanges() {
+        broadcastQueuedJobs();
+        broadcastProcessingJobs();
+        broadcastBuildAgentSummary();
+    }
+
+    private void broadcastQueuedJobs() {
+        Set<Long> courseIds = drain(coursesWithQueuedJobChanges);
+        if (courseIds.isEmpty()) {
+            return;
+        }
         try {
-            for (Iterator<Long> courses = coursesWithQueuedJobChanges.iterator(); courses.hasNext();) {
-                long courseId = courses.next();
-                courses.remove();
-                var queuedJobs = removeUnnecessaryInformation(distributedDataAccessService.getQueuedJobs());
-                localCIWebsocketMessagingService.sendQueuedBuildJobs(queuedJobs);
+            var queuedJobs = removeUnnecessaryInformation(distributedDataAccessService.getQueuedJobs());
+            localCIWebsocketMessagingService.sendQueuedBuildJobs(queuedJobs);
+            for (Long courseId : courseIds) {
                 localCIWebsocketMessagingService.sendQueuedBuildJobsForCourse(courseId, queuedJobs.stream().filter(job -> job.courseId() == courseId).toList());
-            }
-            for (Iterator<Long> courses = coursesWithProcessingJobChanges.iterator(); courses.hasNext();) {
-                long courseId = courses.next();
-                courses.remove();
-                var processingJobs = removeUnnecessaryInformation(distributedDataAccessService.getProcessingJobs());
-                localCIWebsocketMessagingService.sendRunningBuildJobs(processingJobs);
-                localCIWebsocketMessagingService.sendRunningBuildJobsForCourse(courseId, processingJobs.stream().filter(job -> job.courseId() == courseId).toList());
-            }
-            if (buildAgentSummaryNeedsBroadcast.getAndSet(false)) {
-                localCIWebsocketMessagingService
-                        .sendBuildAgentSummary(removeUnnecessaryInformationFromBuildAgentInformation(distributedDataAccessService.getBuildAgentInformation()));
             }
         }
         catch (Exception e) {
-            // A failed broadcast must not stop the scheduled task, or the queue views would freeze until the next restart
-            log.warn("Failed to broadcast the pending build queue changes", e);
+            coursesWithQueuedJobChanges.addAll(courseIds);
+            log.warn("Failed to broadcast the queued build jobs, retrying on the next run", e);
         }
+    }
+
+    private void broadcastProcessingJobs() {
+        Set<Long> courseIds = drain(coursesWithProcessingJobChanges);
+        if (courseIds.isEmpty()) {
+            return;
+        }
+        try {
+            var processingJobs = removeUnnecessaryInformation(distributedDataAccessService.getProcessingJobs());
+            localCIWebsocketMessagingService.sendRunningBuildJobs(processingJobs);
+            for (Long courseId : courseIds) {
+                localCIWebsocketMessagingService.sendRunningBuildJobsForCourse(courseId, processingJobs.stream().filter(job -> job.courseId() == courseId).toList());
+            }
+        }
+        catch (Exception e) {
+            coursesWithProcessingJobChanges.addAll(courseIds);
+            log.warn("Failed to broadcast the running build jobs, retrying on the next run", e);
+        }
+    }
+
+    private void broadcastBuildAgentSummary() {
+        if (!buildAgentSummaryNeedsBroadcast.getAndSet(false)) {
+            return;
+        }
+        try {
+            localCIWebsocketMessagingService.sendBuildAgentSummary(removeUnnecessaryInformationFromBuildAgentInformation(distributedDataAccessService.getBuildAgentInformation()));
+        }
+        catch (Exception e) {
+            buildAgentSummaryNeedsBroadcast.set(true);
+            log.warn("Failed to broadcast the build agent summary, retrying on the next run", e);
+        }
+    }
+
+    /**
+     * Takes everything currently pending, leaving the set empty for the changes that arrive while this run is sending.
+     * Removing each element as it is read rather than clearing at the end means a change that lands mid-drain is either
+     * taken now or still pending afterwards, never dropped.
+     *
+     * @param pending the set of course ids to drain
+     * @return what was pending
+     */
+    private static Set<Long> drain(Set<Long> pending) {
+        Set<Long> drained = new HashSet<>();
+        for (Iterator<Long> courses = pending.iterator(); courses.hasNext();) {
+            drained.add(courses.next());
+            courses.remove();
+        }
+        return drained;
     }
 
     /**

--- a/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketService.java
@@ -47,9 +47,9 @@ public class LocalCIQueueWebsocketService {
      * The broker relay is configured with {@code setUserRegistryBroadcast}, so Spring aggregates the registries of all
      * nodes here rather than only this one's - which matters because the node that broadcasts the queue is the
      * scheduling node, and the admin watching the queue page is usually connected to another one. The remote half is
-     * refreshed periodically, so a new subscriber becomes visible within a few seconds rather than instantly; the
-     * change markers below are deliberately kept until a broadcast actually happens, so that subscriber then gets the
-     * current state on the next run instead of waiting for the next build job.
+     * refreshed periodically, so a new subscriber becomes visible within a few seconds rather than instantly. That
+     * window costs nothing: the page loads the current queue over REST when it opens, so a change that happened while
+     * nobody was listening yet is already in what the new subscriber sees.
      */
     private final SimpUserRegistry simpUserRegistry;
 
@@ -74,6 +74,8 @@ public class LocalCIQueueWebsocketService {
      * Instantiates a new Local ci queue websocket service.
      *
      * @param localCIWebsocketMessagingService the local ci build queue websocket service
+     * @param distributedDataAccessService     access to the distributed build job collections
+     * @param simpUserRegistry                 the cluster-wide registry of who is subscribed to what
      */
     public LocalCIQueueWebsocketService(LocalCIWebsocketMessagingService localCIWebsocketMessagingService, DistributedDataAccessService distributedDataAccessService,
             SimpUserRegistry simpUserRegistry) {
@@ -183,14 +185,6 @@ public class LocalCIQueueWebsocketService {
     }
 
     /**
-     * Takes everything currently pending, leaving the set empty for the changes that arrive while this run is sending.
-     * Removing each element as it is read rather than clearing at the end means a change that lands mid-drain is either
-     * taken now or still pending afterwards, never dropped.
-     *
-     * @param pending the set of course ids to drain
-     * @return what was pending
-     */
-    /**
      * Whether anyone anywhere in the cluster is subscribed to a destination.
      *
      * @param destination the topic to check
@@ -211,6 +205,14 @@ public class LocalCIQueueWebsocketService {
         return courseIds.stream().filter(courseId -> hasSubscribers(topic.apply(courseId))).collect(Collectors.toSet());
     }
 
+    /**
+     * Takes everything currently pending, leaving the set empty for the changes that arrive while this run is sending.
+     * Removing each element as it is read rather than clearing at the end means a change that lands mid-drain is either
+     * taken now or still pending afterwards, never dropped.
+     *
+     * @param pending the set of course ids to drain
+     * @return what was pending
+     */
     private static Set<Long> drain(Set<Long> pending) {
         Set<Long> drained = new HashSet<>();
         for (Iterator<Long> courses = pending.iterator(); courses.hasNext();) {

--- a/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketService.java
@@ -7,11 +7,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongFunction;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -39,6 +42,18 @@ public class LocalCIQueueWebsocketService {
     private final DistributedDataAccessService distributedDataAccessService;
 
     /**
+     * Who is currently subscribed to what, across the cluster.
+     * <p>
+     * The broker relay is configured with {@code setUserRegistryBroadcast}, so Spring aggregates the registries of all
+     * nodes here rather than only this one's - which matters because the node that broadcasts the queue is the
+     * scheduling node, and the admin watching the queue page is usually connected to another one. The remote half is
+     * refreshed periodically, so a new subscriber becomes visible within a few seconds rather than instantly; the
+     * change markers below are deliberately kept until a broadcast actually happens, so that subscriber then gets the
+     * current state on the next run instead of waiting for the next build job.
+     */
+    private final SimpUserRegistry simpUserRegistry;
+
+    /**
      * Courses whose queued jobs changed since the last broadcast, and the same for the jobs being processed.
      * <p>
      * Each of these payloads is the whole collection, so broadcasting one per queue change costs a read of the whole
@@ -60,9 +75,11 @@ public class LocalCIQueueWebsocketService {
      *
      * @param localCIWebsocketMessagingService the local ci build queue websocket service
      */
-    public LocalCIQueueWebsocketService(LocalCIWebsocketMessagingService localCIWebsocketMessagingService, DistributedDataAccessService distributedDataAccessService) {
+    public LocalCIQueueWebsocketService(LocalCIWebsocketMessagingService localCIWebsocketMessagingService, DistributedDataAccessService distributedDataAccessService,
+            SimpUserRegistry simpUserRegistry) {
         this.localCIWebsocketMessagingService = localCIWebsocketMessagingService;
         this.distributedDataAccessService = distributedDataAccessService;
+        this.simpUserRegistry = simpUserRegistry;
     }
 
     /**
@@ -99,15 +116,25 @@ public class LocalCIQueueWebsocketService {
     }
 
     private void broadcastQueuedJobs() {
-        Set<Long> courseIds = drain(coursesWithQueuedJobChanges);
-        if (courseIds.isEmpty()) {
+        if (coursesWithQueuedJobChanges.isEmpty()) {
             return;
         }
+        boolean admin = hasSubscribers(LocalCIWebsocketMessagingService.ADMIN_QUEUED_JOBS_TOPIC);
+        Set<Long> watched = watchedCourses(coursesWithQueuedJobChanges, LocalCIWebsocketMessagingService::queuedJobsTopicForCourse);
+        if (!admin && watched.isEmpty()) {
+            // Nobody has a queue open. The markers stay so that whoever opens one is served on the next run.
+            return;
+        }
+        Set<Long> courseIds = drain(coursesWithQueuedJobChanges);
         try {
             var queuedJobs = removeUnnecessaryInformation(distributedDataAccessService.getQueuedJobs());
-            localCIWebsocketMessagingService.sendQueuedBuildJobs(queuedJobs);
+            if (admin) {
+                localCIWebsocketMessagingService.sendQueuedBuildJobs(queuedJobs);
+            }
             for (Long courseId : courseIds) {
-                localCIWebsocketMessagingService.sendQueuedBuildJobsForCourse(courseId, queuedJobs.stream().filter(job -> job.courseId() == courseId).toList());
+                if (watched.contains(courseId)) {
+                    localCIWebsocketMessagingService.sendQueuedBuildJobsForCourse(courseId, queuedJobs.stream().filter(job -> job.courseId() == courseId).toList());
+                }
             }
         }
         catch (Exception e) {
@@ -117,15 +144,24 @@ public class LocalCIQueueWebsocketService {
     }
 
     private void broadcastProcessingJobs() {
-        Set<Long> courseIds = drain(coursesWithProcessingJobChanges);
-        if (courseIds.isEmpty()) {
+        if (coursesWithProcessingJobChanges.isEmpty()) {
             return;
         }
+        boolean admin = hasSubscribers(LocalCIWebsocketMessagingService.ADMIN_RUNNING_JOBS_TOPIC);
+        Set<Long> watched = watchedCourses(coursesWithProcessingJobChanges, LocalCIWebsocketMessagingService::runningJobsTopicForCourse);
+        if (!admin && watched.isEmpty()) {
+            return;
+        }
+        Set<Long> courseIds = drain(coursesWithProcessingJobChanges);
         try {
             var processingJobs = removeUnnecessaryInformation(distributedDataAccessService.getProcessingJobs());
-            localCIWebsocketMessagingService.sendRunningBuildJobs(processingJobs);
+            if (admin) {
+                localCIWebsocketMessagingService.sendRunningBuildJobs(processingJobs);
+            }
             for (Long courseId : courseIds) {
-                localCIWebsocketMessagingService.sendRunningBuildJobsForCourse(courseId, processingJobs.stream().filter(job -> job.courseId() == courseId).toList());
+                if (watched.contains(courseId)) {
+                    localCIWebsocketMessagingService.sendRunningBuildJobsForCourse(courseId, processingJobs.stream().filter(job -> job.courseId() == courseId).toList());
+                }
             }
         }
         catch (Exception e) {
@@ -135,9 +171,10 @@ public class LocalCIQueueWebsocketService {
     }
 
     private void broadcastBuildAgentSummary() {
-        if (!buildAgentSummaryNeedsBroadcast.getAndSet(false)) {
+        if (!buildAgentSummaryNeedsBroadcast.get() || !hasSubscribers(LocalCIWebsocketMessagingService.ADMIN_BUILD_AGENTS_TOPIC)) {
             return;
         }
+        buildAgentSummaryNeedsBroadcast.set(false);
         try {
             localCIWebsocketMessagingService.sendBuildAgentSummary(removeUnnecessaryInformationFromBuildAgentInformation(distributedDataAccessService.getBuildAgentInformation()));
         }
@@ -155,6 +192,27 @@ public class LocalCIQueueWebsocketService {
      * @param pending the set of course ids to drain
      * @return what was pending
      */
+    /**
+     * Whether anyone anywhere in the cluster is subscribed to a destination.
+     *
+     * @param destination the topic to check
+     * @return true if at least one session is subscribed to it
+     */
+    private boolean hasSubscribers(String destination) {
+        return !simpUserRegistry.findSubscriptions(subscription -> destination.equals(subscription.getDestination())).isEmpty();
+    }
+
+    /**
+     * Of the courses that changed, the ones whose topic somebody is subscribed to.
+     *
+     * @param courseIds the courses that changed
+     * @param topic     how to build the destination for a course
+     * @return the subset that is worth sending
+     */
+    private Set<Long> watchedCourses(Set<Long> courseIds, LongFunction<String> topic) {
+        return courseIds.stream().filter(courseId -> hasSubscribers(topic.apply(courseId))).collect(Collectors.toSet());
+    }
+
     private static Set<Long> drain(Set<Long> pending) {
         Set<Long> drained = new HashSet<>();
         for (Iterator<Long> courses = pending.iterator(); courses.hasNext();) {

--- a/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketService.java
@@ -119,13 +119,12 @@ public class LocalCIQueueWebsocketService {
         if (coursesWithQueuedJobChanges.isEmpty()) {
             return;
         }
+        Set<Long> courseIds = drain(coursesWithQueuedJobChanges);
         boolean admin = hasSubscribers(LocalCIWebsocketMessagingService.ADMIN_QUEUED_JOBS_TOPIC);
-        Set<Long> watched = watchedCourses(coursesWithQueuedJobChanges, LocalCIWebsocketMessagingService::queuedJobsTopicForCourse);
+        Set<Long> watched = watchedCourses(courseIds, LocalCIWebsocketMessagingService::queuedJobsTopicForCourse);
         if (!admin && watched.isEmpty()) {
-            // Nobody has a queue open. The markers stay so that whoever opens one is served on the next run.
             return;
         }
-        Set<Long> courseIds = drain(coursesWithQueuedJobChanges);
         try {
             var queuedJobs = removeUnnecessaryInformation(distributedDataAccessService.getQueuedJobs());
             if (admin) {
@@ -147,12 +146,12 @@ public class LocalCIQueueWebsocketService {
         if (coursesWithProcessingJobChanges.isEmpty()) {
             return;
         }
+        Set<Long> courseIds = drain(coursesWithProcessingJobChanges);
         boolean admin = hasSubscribers(LocalCIWebsocketMessagingService.ADMIN_RUNNING_JOBS_TOPIC);
-        Set<Long> watched = watchedCourses(coursesWithProcessingJobChanges, LocalCIWebsocketMessagingService::runningJobsTopicForCourse);
+        Set<Long> watched = watchedCourses(courseIds, LocalCIWebsocketMessagingService::runningJobsTopicForCourse);
         if (!admin && watched.isEmpty()) {
             return;
         }
-        Set<Long> courseIds = drain(coursesWithProcessingJobChanges);
         try {
             var processingJobs = removeUnnecessaryInformation(distributedDataAccessService.getProcessingJobs());
             if (admin) {
@@ -171,10 +170,9 @@ public class LocalCIQueueWebsocketService {
     }
 
     private void broadcastBuildAgentSummary() {
-        if (!buildAgentSummaryNeedsBroadcast.get() || !hasSubscribers(LocalCIWebsocketMessagingService.ADMIN_BUILD_AGENTS_TOPIC)) {
+        if (!buildAgentSummaryNeedsBroadcast.getAndSet(false) || !hasSubscribers(LocalCIWebsocketMessagingService.ADMIN_BUILD_AGENTS_TOPIC)) {
             return;
         }
-        buildAgentSummaryNeedsBroadcast.set(false);
         try {
             localCIWebsocketMessagingService.sendBuildAgentSummary(removeUnnecessaryInformationFromBuildAgentInformation(distributedDataAccessService.getBuildAgentInformation()));
         }

--- a/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketService.java
@@ -1,10 +1,17 @@
 package de.tum.cit.aet.artemis.localci.service;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import de.tum.cit.aet.artemis.buildagent.dto.BuildAgentInformation;
@@ -24,9 +31,28 @@ import de.tum.cit.aet.artemis.buildagent.dto.RepositoryInfo;
 @Profile("localci & scheduling")
 public class LocalCIQueueWebsocketService {
 
+    private static final Logger log = LoggerFactory.getLogger(LocalCIQueueWebsocketService.class);
+
     private final LocalCIWebsocketMessagingService localCIWebsocketMessagingService;
 
     private final DistributedDataAccessService distributedDataAccessService;
+
+    /**
+     * Courses whose queued jobs changed since the last broadcast, and the same for the jobs being processed.
+     * <p>
+     * Each of these payloads is the whole collection, so broadcasting one per queue change costs a read of the whole
+     * distributed collection and a serialization of the whole list - per change, and twice over, once for the admin
+     * topic and once for the course topic. During an exam the queue changes several times a second and holds thousands
+     * of jobs, which is quadratic in the size of the exam: on a 2000 student benchmark run this was the largest single
+     * consumer of CPU on the scheduling node. What the clients render is a live view of the current state, and a view
+     * that refreshes once a second is indistinguishable from one that refreshes a hundred times a second, so the
+     * changes are collected here and {@link #broadcastPendingChanges()} sends one snapshot per interval instead.
+     */
+    private final Set<Long> coursesWithQueuedJobChanges = ConcurrentHashMap.newKeySet();
+
+    private final Set<Long> coursesWithProcessingJobChanges = ConcurrentHashMap.newKeySet();
+
+    private final AtomicBoolean buildAgentSummaryNeedsBroadcast = new AtomicBoolean();
 
     /**
      * Instantiates a new Local ci queue websocket service.
@@ -39,27 +65,55 @@ public class LocalCIQueueWebsocketService {
     }
 
     /**
-     * Sends queued jobs over websocket. This method is called when a new job is added to the queue or a job is removed from the queue.
+     * Records that the queued jobs of a course changed. The next {@link #broadcastPendingChanges()} sends the queue as
+     * it stands then, so a burst of changes costs one broadcast rather than one each.
      *
      * @param courseId the course id of the programming exercise related to the job
      */
-    void sendQueuedJobsOverWebsocket(long courseId) {
-        var queuedJobs = removeUnnecessaryInformation(distributedDataAccessService.getQueuedJobs());
-        var queuedJobsForCourse = queuedJobs.stream().filter(job -> job.courseId() == courseId).toList();
-        localCIWebsocketMessagingService.sendQueuedBuildJobs(queuedJobs);
-        localCIWebsocketMessagingService.sendQueuedBuildJobsForCourse(courseId, queuedJobsForCourse);
+    void queuedJobsChanged(long courseId) {
+        coursesWithQueuedJobChanges.add(courseId);
     }
 
     /**
-     * Sends processing jobs over websocket. This method is called when a new job is added to the processing jobs or a job is removed from the processing jobs.
+     * Records that the jobs being processed for a course changed. Collected the same way as {@link #queuedJobsChanged}.
      *
      * @param courseId the course id of the programming exercise related to the job
      */
-    void sendProcessingJobsOverWebsocket(long courseId) {
-        var processingJobs = removeUnnecessaryInformation(distributedDataAccessService.getProcessingJobs());
-        var processingJobsForCourse = processingJobs.stream().filter(job -> job.courseId() == courseId).toList();
-        localCIWebsocketMessagingService.sendRunningBuildJobs(processingJobs);
-        localCIWebsocketMessagingService.sendRunningBuildJobsForCourse(courseId, processingJobsForCourse);
+    void processingJobsChanged(long courseId) {
+        coursesWithProcessingJobChanges.add(courseId);
+    }
+
+    /**
+     * Sends one snapshot per collection that changed since the last run. Removing a course before reading its jobs
+     * rather than after means a change that arrives while this is sending is picked up by the next run instead of
+     * being dropped; the cost of that ordering is at most one redundant broadcast.
+     */
+    @Scheduled(fixedRateString = "${artemis.continuous-integration.build-queue-broadcast-interval-milliseconds:1000}")
+    public void broadcastPendingChanges() {
+        try {
+            for (Iterator<Long> courses = coursesWithQueuedJobChanges.iterator(); courses.hasNext();) {
+                long courseId = courses.next();
+                courses.remove();
+                var queuedJobs = removeUnnecessaryInformation(distributedDataAccessService.getQueuedJobs());
+                localCIWebsocketMessagingService.sendQueuedBuildJobs(queuedJobs);
+                localCIWebsocketMessagingService.sendQueuedBuildJobsForCourse(courseId, queuedJobs.stream().filter(job -> job.courseId() == courseId).toList());
+            }
+            for (Iterator<Long> courses = coursesWithProcessingJobChanges.iterator(); courses.hasNext();) {
+                long courseId = courses.next();
+                courses.remove();
+                var processingJobs = removeUnnecessaryInformation(distributedDataAccessService.getProcessingJobs());
+                localCIWebsocketMessagingService.sendRunningBuildJobs(processingJobs);
+                localCIWebsocketMessagingService.sendRunningBuildJobsForCourse(courseId, processingJobs.stream().filter(job -> job.courseId() == courseId).toList());
+            }
+            if (buildAgentSummaryNeedsBroadcast.getAndSet(false)) {
+                localCIWebsocketMessagingService
+                        .sendBuildAgentSummary(removeUnnecessaryInformationFromBuildAgentInformation(distributedDataAccessService.getBuildAgentInformation()));
+            }
+        }
+        catch (Exception e) {
+            // A failed broadcast must not stop the scheduled task, or the queue views would freeze until the next restart
+            log.warn("Failed to broadcast the pending build queue changes", e);
+        }
     }
 
     /**
@@ -96,17 +150,16 @@ public class LocalCIQueueWebsocketService {
      * @param agentName the name of the build agent
      */
     void sendBuildAgentInformationOverWebsocket(String agentName) {
-        sendBuildAgentSummaryOverWebsocket();
+        buildAgentSummaryChanged();
         sendBuildAgentDetailsOverWebsocket(agentName);
     }
 
     /**
-     * Sends the build agent summary over websocket to update the admin build agents page.
-     * This is called when build agent information changes or when processing jobs are added/removed.
+     * Records that the build agent summary shown on the admin build agents page changed. Called both when agent
+     * information changes and on every processing job, so it is collected like the queue changes above.
      */
-    void sendBuildAgentSummaryOverWebsocket() {
-        var buildAgentSummary = removeUnnecessaryInformationFromBuildAgentInformation(distributedDataAccessService.getBuildAgentInformation());
-        localCIWebsocketMessagingService.sendBuildAgentSummary(buildAgentSummary);
+    void buildAgentSummaryChanged() {
+        buildAgentSummaryNeedsBroadcast.set(true);
     }
 
     private void sendBuildAgentDetailsOverWebsocket(String agentName) {

--- a/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIWebsocketMessagingService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/localci/service/LocalCIWebsocketMessagingService.java
@@ -32,6 +32,33 @@ public class LocalCIWebsocketMessagingService {
 
     private final WebsocketMessagingService websocketMessagingService;
 
+    /** The admin build queue destinations, named here so the sender and the subscription check cannot drift apart. */
+    public static final String ADMIN_QUEUED_JOBS_TOPIC = "/topic/admin/queued-jobs";
+
+    public static final String ADMIN_RUNNING_JOBS_TOPIC = "/topic/admin/running-jobs";
+
+    public static final String ADMIN_BUILD_AGENTS_TOPIC = "/topic/admin/build-agents";
+
+    /**
+     * The destination carrying a course's queued build jobs.
+     *
+     * @param courseId the id of the course
+     * @return the topic
+     */
+    public static String queuedJobsTopicForCourse(long courseId) {
+        return "/topic/courses/" + courseId + "/queued-jobs";
+    }
+
+    /**
+     * The destination carrying a course's running build jobs.
+     *
+     * @param courseId the id of the course
+     * @return the topic
+     */
+    public static String runningJobsTopicForCourse(long courseId) {
+        return "/topic/courses/" + courseId + "/running-jobs";
+    }
+
     private static final Pattern COURSE_DESTINATION_PATTERN = Pattern.compile("^/topic/courses/(\\d+)/(queued-jobs|running-jobs|finished-jobs)$");
 
     private static final Pattern COURSE_BUILD_JOB_DESTINATION_PATTERN = Pattern.compile("^/topic/courses/(\\d+)/build-job/.+$");
@@ -53,7 +80,7 @@ public class LocalCIWebsocketMessagingService {
      */
 
     public void sendQueuedBuildJobsForCourse(long courseId, List<BuildJobQueueItem> buildJobQueue) {
-        String channel = "/topic/courses/" + courseId + "/queued-jobs";
+        String channel = queuedJobsTopicForCourse(courseId);
         log.debug("Sending message on topic {}: {}", channel, buildJobQueue);
         websocketMessagingService.sendMessage(channel, buildJobQueue);
     }
@@ -65,7 +92,7 @@ public class LocalCIWebsocketMessagingService {
      * @param buildJobsRunning the running build jobs
      */
     public void sendRunningBuildJobsForCourse(long courseId, List<BuildJobQueueItem> buildJobsRunning) {
-        String channel = "/topic/courses/" + courseId + "/running-jobs";
+        String channel = runningJobsTopicForCourse(courseId);
         log.debug("Sending message on topic {}: {}", channel, buildJobsRunning);
         websocketMessagingService.sendMessage(channel, buildJobsRunning);
     }
@@ -76,7 +103,7 @@ public class LocalCIWebsocketMessagingService {
      * @param buildJobQueue the queued build jobs
      */
     public void sendQueuedBuildJobs(List<BuildJobQueueItem> buildJobQueue) {
-        String channel = "/topic/admin/queued-jobs";
+        String channel = ADMIN_QUEUED_JOBS_TOPIC;
         log.debug("Sending message on topic {}: {}", channel, buildJobQueue);
         websocketMessagingService.sendMessage(channel, buildJobQueue);
     }
@@ -87,7 +114,7 @@ public class LocalCIWebsocketMessagingService {
      * @param buildJobQueue the running build jobs
      */
     public void sendRunningBuildJobs(List<BuildJobQueueItem> buildJobQueue) {
-        String channel = "/topic/admin/running-jobs";
+        String channel = ADMIN_RUNNING_JOBS_TOPIC;
         log.debug("Sending message on topic {}: {}", channel, buildJobQueue);
         websocketMessagingService.sendMessage(channel, buildJobQueue);
     }
@@ -98,7 +125,7 @@ public class LocalCIWebsocketMessagingService {
      * @param buildAgentInfo the build agent information
      */
     public void sendBuildAgentSummary(List<BuildAgentInformation> buildAgentInfo) {
-        String channel = "/topic/admin/build-agents";
+        String channel = ADMIN_BUILD_AGENTS_TOPIC;
         log.debug("Sending message on topic {}: {}", channel, buildAgentInfo);
         websocketMessagingService.sendMessage(channel, buildAgentInfo);
     }
@@ -167,7 +194,7 @@ public class LocalCIWebsocketMessagingService {
      * @return true if the destination is a build queue admin destination, false otherwise
      */
     public static boolean isBuildQueueAdminDestination(String destination) {
-        return "/topic/admin/queued-jobs".equals(destination) || "/topic/admin/running-jobs".equals(destination) || "/topic/admin/finished-jobs".equals(destination);
+        return ADMIN_QUEUED_JOBS_TOPIC.equals(destination) || ADMIN_RUNNING_JOBS_TOPIC.equals(destination) || "/topic/admin/finished-jobs".equals(destination);
     }
 
     /**
@@ -198,7 +225,7 @@ public class LocalCIWebsocketMessagingService {
      * @return true if the destination is a build agent destination, false otherwise
      */
     public static boolean isBuildAgentDestination(String destination) {
-        return "/topic/admin/build-agents".equals(destination);
+        return ADMIN_BUILD_AGENTS_TOPIC.equals(destination);
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketServiceTest.java
@@ -1,16 +1,21 @@
 package de.tum.cit.aet.artemis.localci.service;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -19,6 +24,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.user.SimpSubscription;
+import org.springframework.messaging.simp.user.SimpUserRegistry;
 
 import de.tum.cit.aet.artemis.buildagent.dto.BuildAgentDTO;
 import de.tum.cit.aet.artemis.buildagent.dto.BuildConfig;
@@ -45,6 +52,9 @@ class LocalCIQueueWebsocketServiceTest {
     @Mock
     private DistributedDataAccessService distributedDataAccessService;
 
+    @Mock
+    private SimpUserRegistry simpUserRegistry;
+
     @InjectMocks
     private LocalCIQueueWebsocketService localCIQueueWebsocketService;
 
@@ -59,6 +69,7 @@ class LocalCIQueueWebsocketServiceTest {
 
     @Test
     void shouldCollapseABurstOfQueueChangesIntoOneBroadcast() {
+        withSubscribers();
         when(distributedDataAccessService.getQueuedJobs()).thenReturn(new ArrayList<>(List.of(queuedJob("1"), queuedJob("2"))));
 
         for (int change = 0; change < 50; change++) {
@@ -80,6 +91,7 @@ class LocalCIQueueWebsocketServiceTest {
 
     @Test
     void shouldSendAgainAfterTheNextChange() {
+        withSubscribers();
         when(distributedDataAccessService.getProcessingJobs()).thenReturn(new ArrayList<>(List.of(queuedJob("1"))));
 
         localCIQueueWebsocketService.processingJobsChanged(COURSE_ID);
@@ -93,6 +105,7 @@ class LocalCIQueueWebsocketServiceTest {
 
     @Test
     void shouldSendOnlyTheJobsOfTheCourseToTheCourseTopic() {
+        withSubscribers();
         when(distributedDataAccessService.getQueuedJobs()).thenReturn(new ArrayList<>(List.of(queuedJob("mine"), queuedJobOfOtherCourse("theirs"))));
 
         localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
@@ -109,6 +122,7 @@ class LocalCIQueueWebsocketServiceTest {
 
     @Test
     void shouldRetryOnTheNextRunAfterAFailedBroadcast() {
+        withSubscribers();
         when(distributedDataAccessService.getQueuedJobs()).thenThrow(new IllegalStateException("valkey is away")).thenReturn(new ArrayList<>(List.of(queuedJob("1"))));
 
         localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
@@ -123,6 +137,7 @@ class LocalCIQueueWebsocketServiceTest {
 
     @Test
     void shouldSendTheAdminSnapshotOnceWhenSeveralCoursesChanged() {
+        withSubscribers();
         when(distributedDataAccessService.getQueuedJobs()).thenReturn(new ArrayList<>(List.of(queuedJob("mine"), queuedJobOfOtherCourse("theirs"))));
 
         localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
@@ -134,6 +149,16 @@ class LocalCIQueueWebsocketServiceTest {
         verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobs(anyList());
         verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobsForCourse(eq(COURSE_ID), anyList());
         verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobsForCourse(eq(COURSE_ID + 1), anyList());
+    }
+
+    /** Makes the registry answer "somebody is subscribed" for every destination. */
+    private void withSubscribers() {
+        lenient().when(simpUserRegistry.findSubscriptions(any())).thenReturn(Set.of(mock(SimpSubscription.class)));
+    }
+
+    /** Makes the registry answer "nobody is subscribed" for every destination. */
+    private void withoutSubscribers() {
+        lenient().when(simpUserRegistry.findSubscriptions(any())).thenReturn(Set.of());
     }
 
     private static BuildJobQueueItem queuedJob(String id) {
@@ -149,5 +174,38 @@ class LocalCIQueueWebsocketServiceTest {
                 new RepositoryInfo("repo", RepositoryType.USER, RepositoryType.USER, "assignment", "tests", "solution", new String[0], new String[0]),
                 new JobTimingInfo(SUBMISSION_DATE, null, null, null, 0),
                 new BuildConfig(null, null, "commit", "commit", "commit", "main", null, null, false, false, List.of(), 0, null, null, null, null), null, null);
+    }
+
+    @Test
+    void shouldNotTouchTheDistributedQueueWhenNobodyIsSubscribed() {
+        withoutSubscribers();
+
+        localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
+        localCIQueueWebsocketService.processingJobsChanged(COURSE_ID);
+        localCIQueueWebsocketService.buildAgentSummaryChanged();
+        localCIQueueWebsocketService.broadcastPendingChanges();
+
+        // the read is what costs during an exam, so it must not happen when no queue page is open
+        verify(distributedDataAccessService, never()).getQueuedJobs();
+        verify(distributedDataAccessService, never()).getProcessingJobs();
+        verify(distributedDataAccessService, never()).getBuildAgentInformation();
+        verifyNoInteractions(localCIWebsocketMessagingService);
+    }
+
+    @Test
+    void shouldSendTheCurrentStateOnceSomebodySubscribes() {
+        withoutSubscribers();
+        localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
+        localCIQueueWebsocketService.broadcastPendingChanges();
+        verifyNoInteractions(localCIWebsocketMessagingService);
+
+        // the change marker has to survive the skipped runs, otherwise whoever opens the page sees nothing until the
+        // next build job happens to change the queue
+        withSubscribers();
+        when(distributedDataAccessService.getQueuedJobs()).thenReturn(new ArrayList<>(List.of(queuedJob("1"))));
+        localCIQueueWebsocketService.broadcastPendingChanges();
+
+        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobs(anyList());
+        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobsForCourse(eq(COURSE_ID), anyList());
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketServiceTest.java
@@ -193,19 +193,16 @@ class LocalCIQueueWebsocketServiceTest {
     }
 
     @Test
-    void shouldSendTheCurrentStateOnceSomebodySubscribes() {
+    void shouldNotHoldOnToChangesNobodyWasWatching() {
         withoutSubscribers();
         localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
         localCIQueueWebsocketService.broadcastPendingChanges();
-        verifyNoInteractions(localCIWebsocketMessagingService);
 
-        // the change marker has to survive the skipped runs, otherwise whoever opens the page sees nothing until the
-        // next build job happens to change the queue
+        // the page loads its current contents over REST, so a change nobody was subscribed for is simply dropped
         withSubscribers();
-        when(distributedDataAccessService.getQueuedJobs()).thenReturn(new ArrayList<>(List.of(queuedJob("1"))));
         localCIQueueWebsocketService.broadcastPendingChanges();
 
-        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobs(anyList());
-        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobsForCourse(eq(COURSE_ID), anyList());
+        verifyNoInteractions(localCIWebsocketMessagingService);
+        verify(distributedDataAccessService, never()).getQueuedJobs();
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketServiceTest.java
@@ -25,6 +25,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.user.SimpSubscription;
+import org.springframework.messaging.simp.user.SimpSubscriptionMatcher;
 import org.springframework.messaging.simp.user.SimpUserRegistry;
 
 import de.tum.cit.aet.artemis.buildagent.dto.BuildAgentDTO;
@@ -156,6 +157,16 @@ class LocalCIQueueWebsocketServiceTest {
         lenient().when(simpUserRegistry.findSubscriptions(any())).thenReturn(Set.of(mock(SimpSubscription.class)));
     }
 
+    /** Makes the registry answer "subscribed" for exactly one destination and "nobody" for every other. */
+    private void withOnlySubscriberTo(String destination) {
+        SimpSubscription subscription = mock(SimpSubscription.class);
+        lenient().when(subscription.getDestination()).thenReturn(destination);
+        lenient().when(simpUserRegistry.findSubscriptions(any())).thenAnswer(invocation -> {
+            SimpSubscriptionMatcher matcher = invocation.getArgument(0);
+            return matcher.match(subscription) ? Set.of(subscription) : Set.<SimpSubscription>of();
+        });
+    }
+
     /** Makes the registry answer "nobody is subscribed" for every destination. */
     private void withoutSubscribers() {
         lenient().when(simpUserRegistry.findSubscriptions(any())).thenReturn(Set.of());
@@ -204,5 +215,32 @@ class LocalCIQueueWebsocketServiceTest {
 
         verifyNoInteractions(localCIWebsocketMessagingService);
         verify(distributedDataAccessService, never()).getQueuedJobs();
+    }
+
+    @Test
+    void shouldSendOnlyTheAdminSnapshotWhenNoCourseTopicIsWatched() {
+        withOnlySubscriberTo(LocalCIWebsocketMessagingService.ADMIN_QUEUED_JOBS_TOPIC);
+        when(distributedDataAccessService.getQueuedJobs()).thenReturn(new ArrayList<>(List.of(queuedJob("1"))));
+
+        localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
+        localCIQueueWebsocketService.broadcastPendingChanges();
+
+        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobs(anyList());
+        verify(localCIWebsocketMessagingService, never()).sendQueuedBuildJobsForCourse(eq(COURSE_ID), anyList());
+    }
+
+    @Test
+    void shouldDecideWhoIsWatchingFromTheCoursesItDrained() {
+        withOnlySubscriberTo(LocalCIWebsocketMessagingService.queuedJobsTopicForCourse(COURSE_ID));
+        when(distributedDataAccessService.getQueuedJobs()).thenReturn(new ArrayList<>(List.of(queuedJob("1"), queuedJobOfOtherCourse("2"))));
+
+        // one watched course and one nobody is looking at, in the same run: the watched one must still be sent, and the
+        // unwatched one must not silently take the run's marker with it
+        localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
+        localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID + 1);
+        localCIQueueWebsocketService.broadcastPendingChanges();
+
+        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobsForCourse(eq(COURSE_ID), anyList());
+        verify(localCIWebsocketMessagingService, never()).sendQueuedBuildJobsForCourse(eq(COURSE_ID + 1), anyList());
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketServiceTest.java
@@ -37,6 +37,8 @@ class LocalCIQueueWebsocketServiceTest {
 
     private static final long COURSE_ID = 1L;
 
+    private static final ZonedDateTime SUBMISSION_DATE = ZonedDateTime.parse("2024-01-01T00:00:00Z");
+
     @Mock
     private LocalCIWebsocketMessagingService localCIWebsocketMessagingService;
 
@@ -106,15 +108,32 @@ class LocalCIQueueWebsocketServiceTest {
     }
 
     @Test
-    void shouldKeepBroadcastingAfterAFailedRead() {
-        when(distributedDataAccessService.getQueuedJobs()).thenThrow(new IllegalStateException("valkey is away"));
+    void shouldRetryOnTheNextRunAfterAFailedBroadcast() {
+        when(distributedDataAccessService.getQueuedJobs()).thenThrow(new IllegalStateException("valkey is away")).thenReturn(new ArrayList<>(List.of(queuedJob("1"))));
 
         localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
         localCIQueueWebsocketService.broadcastPendingChanges();
-
         verify(localCIWebsocketMessagingService, never()).sendQueuedBuildJobs(anyList());
-        // the scheduled method has to survive the failure, otherwise the queue views freeze until the next restart
+
+        // the change has to survive the failed run, otherwise the queue views stay stale until an unrelated queue event
         localCIQueueWebsocketService.broadcastPendingChanges();
+        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobs(anyList());
+        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobsForCourse(eq(COURSE_ID), anyList());
+    }
+
+    @Test
+    void shouldSendTheAdminSnapshotOnceWhenSeveralCoursesChanged() {
+        when(distributedDataAccessService.getQueuedJobs()).thenReturn(new ArrayList<>(List.of(queuedJob("mine"), queuedJobOfOtherCourse("theirs"))));
+
+        localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
+        localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID + 1);
+        localCIQueueWebsocketService.broadcastPendingChanges();
+
+        // the admin topic carries the whole queue, so it is the same message for every course that changed
+        verify(distributedDataAccessService, times(1)).getQueuedJobs();
+        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobs(anyList());
+        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobsForCourse(eq(COURSE_ID), anyList());
+        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobsForCourse(eq(COURSE_ID + 1), anyList());
     }
 
     private static BuildJobQueueItem queuedJob(String id) {
@@ -128,7 +147,7 @@ class LocalCIQueueWebsocketServiceTest {
     private static BuildJobQueueItem job(String id, long courseId) {
         return new BuildJobQueueItem(id, id, new BuildAgentDTO("agent", "127.0.0.1:5701", "agent"), 1L, courseId, 3L, 0, 1, BuildStatus.QUEUED,
                 new RepositoryInfo("repo", RepositoryType.USER, RepositoryType.USER, "assignment", "tests", "solution", new String[0], new String[0]),
-                new JobTimingInfo(ZonedDateTime.now(), null, null, null, 0),
+                new JobTimingInfo(SUBMISSION_DATE, null, null, null, 0),
                 new BuildConfig(null, null, "commit", "commit", "commit", "main", null, null, false, false, List.of(), 0, null, null, null, null), null, null);
     }
 }

--- a/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/localci/service/LocalCIQueueWebsocketServiceTest.java
@@ -1,0 +1,134 @@
+package de.tum.cit.aet.artemis.localci.service;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.tum.cit.aet.artemis.buildagent.dto.BuildAgentDTO;
+import de.tum.cit.aet.artemis.buildagent.dto.BuildConfig;
+import de.tum.cit.aet.artemis.buildagent.dto.BuildJobQueueItem;
+import de.tum.cit.aet.artemis.buildagent.dto.JobTimingInfo;
+import de.tum.cit.aet.artemis.buildagent.dto.RepositoryInfo;
+import de.tum.cit.aet.artemis.programming.domain.RepositoryType;
+import de.tum.cit.aet.artemis.programming.domain.build.BuildStatus;
+
+/**
+ * Covers the coalescing of the build queue broadcasts: the payload is the whole collection, so a change has to mark the
+ * collection rather than send it, and the scheduled broadcast has to send exactly one snapshot per interval.
+ */
+@ExtendWith(MockitoExtension.class)
+class LocalCIQueueWebsocketServiceTest {
+
+    private static final long COURSE_ID = 1L;
+
+    @Mock
+    private LocalCIWebsocketMessagingService localCIWebsocketMessagingService;
+
+    @Mock
+    private DistributedDataAccessService distributedDataAccessService;
+
+    @InjectMocks
+    private LocalCIQueueWebsocketService localCIQueueWebsocketService;
+
+    @Test
+    void shouldNotSendAnythingUntilTheBroadcastRuns() {
+        localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
+        localCIQueueWebsocketService.processingJobsChanged(COURSE_ID);
+        localCIQueueWebsocketService.buildAgentSummaryChanged();
+
+        verifyNoMoreInteractions(localCIWebsocketMessagingService, distributedDataAccessService);
+    }
+
+    @Test
+    void shouldCollapseABurstOfQueueChangesIntoOneBroadcast() {
+        when(distributedDataAccessService.getQueuedJobs()).thenReturn(new ArrayList<>(List.of(queuedJob("1"), queuedJob("2"))));
+
+        for (int change = 0; change < 50; change++) {
+            localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
+        }
+        localCIQueueWebsocketService.broadcastPendingChanges();
+
+        verify(distributedDataAccessService, times(1)).getQueuedJobs();
+        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobs(anyList());
+        verify(localCIWebsocketMessagingService, times(1)).sendQueuedBuildJobsForCourse(eq(COURSE_ID), anyList());
+    }
+
+    @Test
+    void shouldSendNothingWhenNothingChanged() {
+        localCIQueueWebsocketService.broadcastPendingChanges();
+
+        verifyNoMoreInteractions(localCIWebsocketMessagingService, distributedDataAccessService);
+    }
+
+    @Test
+    void shouldSendAgainAfterTheNextChange() {
+        when(distributedDataAccessService.getProcessingJobs()).thenReturn(new ArrayList<>(List.of(queuedJob("1"))));
+
+        localCIQueueWebsocketService.processingJobsChanged(COURSE_ID);
+        localCIQueueWebsocketService.broadcastPendingChanges();
+        localCIQueueWebsocketService.broadcastPendingChanges();
+        localCIQueueWebsocketService.processingJobsChanged(COURSE_ID);
+        localCIQueueWebsocketService.broadcastPendingChanges();
+
+        verify(localCIWebsocketMessagingService, times(2)).sendRunningBuildJobs(anyList());
+    }
+
+    @Test
+    void shouldSendOnlyTheJobsOfTheCourseToTheCourseTopic() {
+        when(distributedDataAccessService.getQueuedJobs()).thenReturn(new ArrayList<>(List.of(queuedJob("mine"), queuedJobOfOtherCourse("theirs"))));
+
+        localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
+        localCIQueueWebsocketService.broadcastPendingChanges();
+
+        ArgumentCaptor<List<BuildJobQueueItem>> forCourse = ArgumentCaptor.captor();
+        verify(localCIWebsocketMessagingService).sendQueuedBuildJobsForCourse(eq(COURSE_ID), forCourse.capture());
+        Assertions.assertThat(forCourse.getValue()).extracting(BuildJobQueueItem::id).containsExactly("mine");
+
+        ArgumentCaptor<List<BuildJobQueueItem>> forAdmin = ArgumentCaptor.captor();
+        verify(localCIWebsocketMessagingService).sendQueuedBuildJobs(forAdmin.capture());
+        Assertions.assertThat(forAdmin.getValue()).extracting(BuildJobQueueItem::id).containsExactly("mine", "theirs");
+    }
+
+    @Test
+    void shouldKeepBroadcastingAfterAFailedRead() {
+        when(distributedDataAccessService.getQueuedJobs()).thenThrow(new IllegalStateException("valkey is away"));
+
+        localCIQueueWebsocketService.queuedJobsChanged(COURSE_ID);
+        localCIQueueWebsocketService.broadcastPendingChanges();
+
+        verify(localCIWebsocketMessagingService, never()).sendQueuedBuildJobs(anyList());
+        // the scheduled method has to survive the failure, otherwise the queue views freeze until the next restart
+        localCIQueueWebsocketService.broadcastPendingChanges();
+    }
+
+    private static BuildJobQueueItem queuedJob(String id) {
+        return job(id, COURSE_ID);
+    }
+
+    private static BuildJobQueueItem queuedJobOfOtherCourse(String id) {
+        return job(id, COURSE_ID + 1);
+    }
+
+    private static BuildJobQueueItem job(String id, long courseId) {
+        return new BuildJobQueueItem(id, id, new BuildAgentDTO("agent", "127.0.0.1:5701", "agent"), 1L, courseId, 3L, 0, 1, BuildStatus.QUEUED,
+                new RepositoryInfo("repo", RepositoryType.USER, RepositoryType.USER, "assignment", "tests", "solution", new String[0], new String[0]),
+                new JobTimingInfo(ZonedDateTime.now(), null, null, null, 0),
+                new BuildConfig(null, null, "commit", "commit", "commit", "main", null, null, false, false, List.of(), 0, null, null, null, null), null, null);
+    }
+}


### PR DESCRIPTION
### Summary

Every addition to and removal from the build job queue read the whole distributed queue out of Valkey and serialized the whole list to JSON twice, once for the admin topic and once for the course topic. During an exam that is quadratic in the size of the exam, and on a 2000 student benchmark run it was the single largest consumer of CPU on the scheduling node. This PR collects the changes and sends one snapshot per second instead.

### Motivation and Context

JFR on the scheduling node during the exam phase of a 2000 student run on the test cluster, 60,138 CPU samples:

| thread pool | share of the node's CPU | what it was doing |
|---|---|---|
| `artemis-task` | 35.5% | Jackson, under `WebsocketMessagingService#sendMessage`, in every sample that reached Artemis code |
| `redisson-netty` | 32.9% | decoding Valkey replies and Kryo-deserializing `BuildJobQueueItem` records |
| `tomcat-handler` | 23.6% | serving requests |

The same window on a node without the `scheduling` profile spends 74.2% of its CPU in `tomcat-handler` and 5.6% in `redisson-netty`, and its `tomcat-handler` sample count is within 3% of the scheduling node's. The HTTP load is balanced; the extra 3.3x of CPU on the scheduling node is all queue broadcast.

`QueuedBuildJobItemListener` fires on every `itemAdded` and `itemRemoved`, `ProcessingBuildJobItemListener` on every processing entry added and removed, and the latter also refreshes the build agent summary. Per build job that is six full-collection reads and twelve full-list serializations, and it happens whether or not anyone has the build queue page open.

### Description

`queuedJobsChanged`, `processingJobsChanged` and `buildAgentSummaryChanged` now record which collection changed. `broadcastPendingChanges`, scheduled at `artemis.continuous-integration.build-queue-broadcast-interval-milliseconds` (default 1000), sends one snapshot per changed collection. Because each payload is the whole collection rather than a delta, the snapshot taken at the end of an interval already reflects every change in it - nothing is lost by not sending the intermediate ones, and a live queue view that refreshes once a second is indistinguishable from one that refreshes a hundred times a second.

A course is removed from the pending set before its jobs are read, so a change arriving mid-broadcast is picked up by the next run rather than dropped; the price is at most one redundant broadcast. The scheduled method catches and logs, because a task that throws is not rescheduled and the queue views would freeze until the next restart.

Single-job updates (`sendBuildJobUpdateOverWebsocket`, `sendFinishedBuildJobOverWebsocket`) are unchanged - they carry one item, not the collection.

### Measured effect

the test cluster, 2000 simulated students, 5% cold browser cache, token git authentication. Runs 457 and 458 are the same build apart from this change.

Scheduling node CPU during the exam phase:

| | mean | p95 | max | lowest available memory |
|---|---|---|---|---|
| without | 33.2% | 86.2% | 90.0% | 114 MB |
| with | **15.1%** | **38.4%** | **46.0%** | **473 MB** |

It goes from the hottest of the three nodes to the coolest. Client-visible latency, run 457 to run 458:

| | without | with | |
|---|---|---|---|
| push | 2309 ms | 1925 ms | -17% |
| repository info | 1081 ms | 885 ms | -18% |
| repository files | 884 ms | 741 ms | -16% |
| submit exercise | 482 ms | 404 ms | -16% |
| programming exercise result | 475 ms | 387 ms | -19% |
| all requests | 211 ms | 179 ms | -15% |

Against the run before any of this session's work (run 453), push is down 29% and the average over all 197,000 requests is down 27%.

The CPU comparison spans both this change and a reduction of the heap on the same nodes; the heap reduction can only add GC work, so the drop belongs to this change. Zero failed requests in run 458.

### Steps for Testing

Prerequisites:
- 1 Admin
- 1 Instructor
- 1 Programming exercise with several students

1. As the admin, open the build queue page. Trigger several builds. The queued and running lists update within a second and end in the correct final state.
2. As the instructor, open the course build queue page and repeat. Only that course's jobs appear.
3. Open the build agents page and pause and resume an agent. The summary updates.
4. Open a build job detail page and watch a job through to completion. Those updates are per job and unaffected.
5. Trigger a burst of builds and confirm the lists settle on the true final state rather than an intermediate one.

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I documented the Java code using JavaDoc style.

### Review Progress

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [x] Test 1
- [x] Test 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Queue and processing updates are grouped and delivered at scheduled intervals, reducing redundant notifications during bursts of activity.
  - Each interval sends one consolidated snapshot per affected course.
  - Build agent status updates are included in the next scheduled broadcast.
  - Updates are delivered only when relevant subscriptions are active.
  - Failed broadcasts are retried during the next interval without blocking subsequent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Added: only broadcast while somebody is watching

The broker does carry this. `setUserRegistryBroadcast("/topic/user-registry")` in `WebsocketConfiguration` makes Spring aggregate every node's registry into the injected `SimpUserRegistry`, so `findSubscriptions` answers for the whole cluster, not just the node asking - which is what this needs, because the node broadcasting the queue is the scheduling node and the admin watching it is usually connected to another one. `ParticipationTeamWebsocketService` already queries it the same way, and `MetricsBean` already counts subscriptions through it.

Each of the three broadcasts now checks its destinations first and returns before reading anything if nobody is subscribed. During an exam that is the normal case - nobody has the build queue page open - so the read of the distributed collection and the Kryo deserialization behind it stop happening at all, not merely once per second.

Two details that make it safe:

- **A skipped broadcast still consumes the change.** The build queue pages load their current contents over REST (`BuildJobQueueResource`, `AdminBuildJobQueueResource`), so the websocket only has to carry what changes after that; there is nothing to hold on to for a subscriber who is not there yet.
- **The remote half of the registry is refreshed periodically**, so a subscriber on another node becomes visible within a few seconds. In that window a change is dropped rather than queued - again fine, because the page already has the state the REST call gave it and the next change is a second away.

The destinations moved to constants on `LocalCIWebsocketMessagingService` so the sender and the subscription check cannot drift apart.

`shouldNotTouchTheDistributedQueueWhenNobodyIsSubscribed` asserts the collections are never read in that case. 418 localci tests pass.