### PR TITLE
`Development`: Keep the e2e exercise dates in a strict sequence

### DIFF
--- a/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseRepositoryExport.spec.ts
+++ b/src/test/playwright/e2e/exercise/programming/ProgrammingExerciseRepositoryExport.spec.ts
@@ -347,6 +347,9 @@ test.describe('Programming exercise example solution export', { tag: '@slow' }, 
             projectType: ProjectType.GRADLE_GRADLE,
             releaseDate: dayjs().subtract(2, 'hours'),
             dueDate: dayjs().subtract(1, 'hour'),
+            // The server requires the example solution to be published after the assessment is due, so both dates are
+            // set here rather than leaving the assessment due date at its default a day after the due date
+            assessmentDate: dayjs().subtract(45, 'minutes'),
             exampleSolutionPublicationDate: dayjs().subtract(30, 'minutes'),
         });
     });

--- a/src/test/playwright/support/requests/ExerciseAPIRequests.ts
+++ b/src/test/playwright/support/requests/ExerciseAPIRequests.ts
@@ -86,7 +86,7 @@ export class ExerciseAPIRequests {
      *   - programmingShortName: The short name of the programming exercise
      *   - programmingLanguage: The programming language for the exercise
      *   - packageName: The package name of the programming exercise
-     *   - assessmentDate: The due date of the assessment
+     *   - assessmentDate: The due date of the assessment, which the server requires to be strictly after the due date
      *   - assessmentType: The assessment type of the exercise
      *   - buildPlanConfiguration: Serialized LocalCI build phases used when the exercise is created
      * @returns Promise<ProgrammingExercise> representing the programming exercise created.
@@ -125,7 +125,9 @@ export class ExerciseAPIRequests {
             programmingLanguage = ProgrammingLanguage.JAVA,
             projectType,
             packageName = 'de.test',
-            assessmentDate = dayjs().add(2, 'days'),
+            // Derived from the due date rather than from now: the server requires a strictly increasing date sequence, and a
+            // caller passing a due date two days out would otherwise land in the same millisecond as an absolute default
+            assessmentDate = dueDate.add(1, 'day'),
             exampleSolutionPublicationDate,
             assessmentType = ProgrammingExerciseAssessmentType.AUTOMATIC,
             mode = ExerciseMode.INDIVIDUAL,
@@ -185,6 +187,11 @@ export class ExerciseAPIRequests {
         }
 
         const response = await this.page.request.post(`${PROGRAMMING_EXERCISE_BASE}/setup`, { data: exercise });
+        // Asserted so a rejected setup throws loudly here, instead of cascading into an undefined exercise id and a
+        // test that waits three minutes for a page it was never going to reach
+        if (!response.ok()) {
+            throw new Error(`Failed to create programming exercise: ${response.status()} ${await response.text()}`);
+        }
         return this.withKnownExerciseGroup(await response.json(), exerciseGroup);
     }
 


### PR DESCRIPTION
### Summary
Two Playwright specs have failed in every `develop` run since #13540, because their programming exercise setup is now rejected with `400 The exercise dates are not valid`. This adjusts the two fixtures that no longer satisfy the stricter date rules, and makes a rejected setup fail where it happens.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
`E2E / Run All E2E Tests (Non-PR)` on `develop` has been red since the merge run of #13540, and every open pull request inherits the same two failures:

- `e2e/course/CourseTabs.spec.ts` › `Exercises tab loads when a programming exercise was started and never submitted`
- `e2e/exercise/programming/ProgrammingExerciseRepositoryExport.spec.ts` › `Lets a student download the published example solution`

#13540 replaced the exercise date checks with one strictly increasing sequence (`release < start < due < assessment due < example solution publication`). Two of the test fixtures were only valid under the previous rules:

- The `createProgrammingExercise` default assessment due date was computed from the current time (`dayjs().add(2, 'days')`). A caller passing `dueDate: dayjs().add(2, 'day')` lands in the same millisecond, which used to be accepted and is now rejected.
- The example solution export fixture published its example solution 30 minutes ago while leaving the assessment due date two days out. The example solution publication date now has to follow the assessment due date.

The second failure was hard to read, because the rejected setup left an exercise without an id and the test then waited out its full three-minute timeout on a page it was never going to reach.

### Description
- `createProgrammingExercise` derives its default assessment due date from the effective due date instead of from the current time, so it can never coincide with a caller-supplied due date. With no due date passed the resulting default is unchanged (a day after the default due date, so two days out).
- The example solution export fixture sets the assessment due date explicitly, between its due date and its example solution publication date.
- A rejected `programming-exercises/setup` response now throws, mirroring `postTextExercise`, so the next such regression names itself instead of surfacing as a locator timeout.

No production code changes, so the strict validation from #13540 stays exactly as it is.

### Steps for Testing
The change is test infrastructure only; CI is the test. `Detect Changed Areas` classifies this as Playwright infrastructure, so the whole suite runs (`RUN_ALL_TESTS=true`) rather than a selected subset.

Locally:

1. `./run-e2e-tests-local-fast.sh --specs "e2e/course/CourseTabs.spec.ts e2e/exercise/programming/ProgrammingExerciseRepositoryExport.spec.ts e2e/course/CourseArchive.spec.ts"`
2. Both previously failing tests pass, and `CourseArchive` (which also relies on the default assessment due date) still passes.

### Testserver States
Not applicable, no deployment needed.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved programming exercise setup reliability by ensuring assessment dates are scheduled after due dates.
  - Added clearer error handling when exercise creation fails, including the server response details.
- **Tests**
  - Updated programming exercise export test setup to use a valid assessment date for example-solution publication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->