### PR TITLE
`Development`: Fix sonarqube issues

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/calendar/service/CalendarSubscriptionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/calendar/service/CalendarSubscriptionService.java
@@ -38,6 +38,12 @@ import net.fortuna.ical4j.model.property.immutable.ImmutableVersion;
 @Profile(PROFILE_CORE)
 public class CalendarSubscriptionService {
 
+    /**
+     * Shared deliberately: {@link SecureRandom} is thread-safe, and constructing one re-seeds from the system
+     * entropy source on every call.
+     */
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     private final UserRepository userRepository;
 
     private final CalendarSubscriptionTokenStoreRepository calendarSubscriptionTokenStoreRepository;
@@ -97,9 +103,8 @@ public class CalendarSubscriptionService {
     }
 
     private byte[] generateSubscriptionTokenBytes() {
-        SecureRandom random = new SecureRandom();
         byte[] bytes = new byte[16];
-        random.nextBytes(bytes);
+        SECURE_RANDOM.nextBytes(bytes);
         return bytes;
     }
 

--- a/src/main/java/de/tum/cit/aet/artemis/communication/dto/ForwardedMessageDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/dto/ForwardedMessageDTO.java
@@ -32,10 +32,10 @@ public record ForwardedMessageDTO(Long id, Long sourceId, PostingType sourceType
      * @return the ForwardedMessage entity
      */
     public ForwardedMessage toEntity() {
-        // A forwarded message points at exactly one destination, and both ways of getting that wrong come from the
-        // client. Two ids set makes the second setter below throw IllegalStateException, which surfaces as a 500.
-        // Neither id set is not rejected anywhere, so it persists a row that the retrieval endpoint can never return,
-        // because that groups messages by their destination. Both are reported here as the one malformed request.
+        // A forwarded message points at exactly one destination, which ForwardedMessage states twice: its setters
+        // reject a second destination with an IllegalStateException, and its @Check constraint requires exactly one.
+        // So two ids set trips the setter and neither id set trips the constraint, and both answer 500 for what is
+        // the client naming the wrong number of destinations. Both are rejected here instead.
         if ((this.destinationPostId == null) == (this.destinationAnswerPostId == null)) {
             throw new BadRequestAlertException("A forwarded message must have exactly one destination, either a destination post or a destination answer post", "forwardedMessage",
                     "forwardedMessageNeedsExactlyOneDestination");

--- a/src/main/java/de/tum/cit/aet/artemis/communication/dto/ForwardedMessageDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/dto/ForwardedMessageDTO.java
@@ -8,6 +8,7 @@ import de.tum.cit.aet.artemis.communication.domain.AnswerPost;
 import de.tum.cit.aet.artemis.communication.domain.ForwardedMessage;
 import de.tum.cit.aet.artemis.communication.domain.Post;
 import de.tum.cit.aet.artemis.communication.domain.PostingType;
+import de.tum.cit.aet.artemis.core.exception.BadRequestAlertException;
 
 /**
  * Data Transfer Object for ForwardedMessage.
@@ -31,6 +32,13 @@ public record ForwardedMessageDTO(Long id, Long sourceId, PostingType sourceType
      * @return the ForwardedMessage entity
      */
     public ForwardedMessage toEntity() {
+        // A forwarded message points at exactly one destination. Both setters below reject the second one with an
+        // IllegalStateException to keep that invariant, which would leave a request carrying both ids as a 500.
+        // Rejecting it here reports it as what it is: a malformed request.
+        if (this.destinationPostId != null && this.destinationAnswerPostId != null) {
+            throw new BadRequestAlertException("A forwarded message must have either a destination post or a destination answer post, not both", "forwardedMessage",
+                    "forwardedMessageHasTwoDestinations");
+        }
         ForwardedMessage message = new ForwardedMessage();
         message.setId(this.id);
         message.setSourceId(this.sourceId);

--- a/src/main/java/de/tum/cit/aet/artemis/communication/dto/ForwardedMessageDTO.java
+++ b/src/main/java/de/tum/cit/aet/artemis/communication/dto/ForwardedMessageDTO.java
@@ -32,12 +32,13 @@ public record ForwardedMessageDTO(Long id, Long sourceId, PostingType sourceType
      * @return the ForwardedMessage entity
      */
     public ForwardedMessage toEntity() {
-        // A forwarded message points at exactly one destination. Both setters below reject the second one with an
-        // IllegalStateException to keep that invariant, which would leave a request carrying both ids as a 500.
-        // Rejecting it here reports it as what it is: a malformed request.
-        if (this.destinationPostId != null && this.destinationAnswerPostId != null) {
-            throw new BadRequestAlertException("A forwarded message must have either a destination post or a destination answer post, not both", "forwardedMessage",
-                    "forwardedMessageHasTwoDestinations");
+        // A forwarded message points at exactly one destination, and both ways of getting that wrong come from the
+        // client. Two ids set makes the second setter below throw IllegalStateException, which surfaces as a 500.
+        // Neither id set is not rejected anywhere, so it persists a row that the retrieval endpoint can never return,
+        // because that groups messages by their destination. Both are reported here as the one malformed request.
+        if ((this.destinationPostId == null) == (this.destinationAnswerPostId == null)) {
+            throw new BadRequestAlertException("A forwarded message must have exactly one destination, either a destination post or a destination answer post", "forwardedMessage",
+                    "forwardedMessageNeedsExactlyOneDestination");
         }
         ForwardedMessage message = new ForwardedMessage();
         message.setId(this.id);

--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamSessionService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/ExamSessionService.java
@@ -43,6 +43,12 @@ public class ExamSessionService {
 
     private static final Logger log = LoggerFactory.getLogger(ExamSessionService.class);
 
+    /**
+     * Shared deliberately: {@link SecureRandom} is thread-safe, and constructing one re-seeds from the system
+     * entropy source on every call.
+     */
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     private final ExamSessionRepository examSessionRepository;
 
     private final StudentExamRepository studentExamRepository;
@@ -94,9 +100,8 @@ public class ExamSessionService {
     }
 
     private String generateSafeToken() {
-        SecureRandom random = new SecureRandom();
         byte[] bytes = new byte[16];
-        random.nextBytes(bytes);
+        SECURE_RANDOM.nextBytes(bytes);
         Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
         String token = encoder.encodeToString(bytes);
         return token.substring(0, 16);

--- a/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisJobService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/iris/service/pyris/PyrisJobService.java
@@ -39,6 +39,12 @@ import de.tum.cit.aet.artemis.iris.service.pyris.job.TutorSuggestionJob;
 @Conditional(IrisEnabled.class)
 public class PyrisJobService {
 
+    /**
+     * Shared deliberately: {@link SecureRandom} is thread-safe, and constructing one re-seeds from the system
+     * entropy source on every call.
+     */
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     private final DistributedDataProvider distributedDataProvider;
 
     @Nullable
@@ -262,9 +268,8 @@ public class PyrisJobService {
         randomStringBuilder.append('-');
         randomStringBuilder.append(System.currentTimeMillis());
         randomStringBuilder.append('-');
-        var secureRandom = new SecureRandom();
         for (int i = 0; i < 10; i++) {
-            var randomChar = secureRandom.nextInt(62);
+            var randomChar = SECURE_RANDOM.nextInt(62);
             if (randomChar < 10) {
                 randomStringBuilder.append(randomChar);
             }

--- a/src/main/webapp/app/account/user/settings/learner-profile/insights-learner-profile/iris-learner-profile/memiris-memories-list.component.ts
+++ b/src/main/webapp/app/account/user/settings/learner-profile/insights-learner-profile/iris-learner-profile/memiris-memories-list.component.ts
@@ -55,7 +55,7 @@ export class MemirisMemoriesListComponent implements OnInit {
             const ids = (c.memories ?? []).filter((id) => validIds.has(id));
             if (ids.length >= 2 && !seen.has(c.id)) {
                 seen.add(c.id);
-                groups.push(Array.from(new Set(ids)).sort());
+                groups.push(Array.from(new Set(ids)).sort((a, b) => a.localeCompare(b)));
             }
         }
         return groups;

--- a/src/main/webapp/app/lecture/manage/pdf-preview/pdf-preview-date-box/pdf-preview-date-box.component.ts
+++ b/src/main/webapp/app/lecture/manage/pdf-preview/pdf-preview-date-box/pdf-preview-date-box.component.ts
@@ -51,10 +51,14 @@ export class PdfPreviewDateBoxComponent implements OnInit {
             return `${pages[0].order}`;
         }
 
-        return pages
-            .map((p) => p.order)
-            .sort()
-            .join(', ');
+        return (
+            pages
+                .map((p) => p.order)
+                // Page orders are numbers, so they need a numeric comparator: the default sort compares them as
+                // strings, which listed page 10 before page 2.
+                .sort((a, b) => a - b)
+                .join(', ')
+        );
     });
     isMultiplePages = computed(() => this.selectedPages().length > 1);
     isSubmitDisabled = computed(() => {

--- a/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
@@ -338,7 +338,7 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
                             const sortedTestCaseNames = testCases
                                 .filter((testCase) => testCase.active)
                                 .map((testCase) => testCase.testName!)
-                                .sort();
+                                .sort((a, b) => a.localeCompare(b));
                             return of(sortedTestCaseNames);
                         } else if (this.exercise().templateParticipation) {
                             // Legacy case: If there are no test cases, but a template participation, use its feedbacks for generating test names.
@@ -376,7 +376,7 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
                 feedbacks!
                     .map((feedback) => feedback.text ?? feedback.testCase?.testName)
                     .filter((name): name is string => name != undefined)
-                    .sort(),
+                    .sort((a, b) => a.localeCompare(b)),
             ),
             catchError(() => of([])),
         );

--- a/src/main/webapp/app/programming/manage/services/programming-exercise.service.ts
+++ b/src/main/webapp/app/programming/manage/services/programming-exercise.service.ts
@@ -324,8 +324,10 @@ export class ProgrammingExerciseService {
 
         // important: sort to get the latest submission (the order of the server can be random)
         this.sortService.sortByProperty(submissions, 'submissionDate', true);
+        // No second sort here: sortByProperty above established the order, and calling sort() without a comparator
+        // on the submissions would compare them as strings, where every element is equal and nothing is reordered.
         // By id, not by position: the server holds a submission's results in a set, so the response order is arbitrary.
-        return getNewestResult(submissions.sort().last()?.results);
+        return getNewestResult(submissions.last()?.results);
     }
 
     /**

--- a/src/test/java/de/tum/cit/aet/artemis/communication/ForwardedMessageResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/ForwardedMessageResourceIntegrationTest.java
@@ -115,6 +115,32 @@ class ForwardedMessageResourceIntegrationTest extends AbstractConversationTest {
     }
 
     /**
+     * A forwarded message points at exactly one destination, so naming both is malformed input rather than a server
+     * fault: without this the second setter on the entity throws IllegalStateException and the request answers 500.
+     */
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void shouldRejectForwardedMessageWithTwoDestinations() throws Exception {
+        ForwardedMessageDTO dto = new ForwardedMessageDTO(null, testPost.getId(), PostingType.POST, testPost.getId(), testAnswerPost.getId());
+
+        request.performMvcRequest(MockMvcRequestBuilders.post(new URI("/api/communication/forwarded-messages")).param("courseId", exampleCourseId.toString())
+                .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(dto))).andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    /**
+     * The other half of the same invariant: a message with no destination would be stored but never returned, because
+     * retrieval groups messages by their destination.
+     */
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
+    void shouldRejectForwardedMessageWithoutDestination() throws Exception {
+        ForwardedMessageDTO dto = new ForwardedMessageDTO(null, testPost.getId(), PostingType.POST, null, null);
+
+        request.performMvcRequest(MockMvcRequestBuilders.post(new URI("/api/communication/forwarded-messages")).param("courseId", exampleCourseId.toString())
+                .contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(dto))).andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    /**
      * Test retrieving forwarded messages for destination IDs of type 'post'.
      */
     @Test

--- a/src/test/java/de/tum/cit/aet/artemis/communication/ForwardedMessageResourceIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/communication/ForwardedMessageResourceIntegrationTest.java
@@ -128,8 +128,8 @@ class ForwardedMessageResourceIntegrationTest extends AbstractConversationTest {
     }
 
     /**
-     * The other half of the same invariant: a message with no destination would be stored but never returned, because
-     * retrieval groups messages by their destination.
+     * The other half of the same invariant. Nothing rejects a message with no destination before the insert, so
+     * without this validation it reaches the check constraint that ForwardedMessage declares and fails there.
      */
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")


### PR DESCRIPTION
### Summary
SonarQube reported twelve critical-severity bugs, which is what holds the project's reliability rating at D. Reading all twelve found nine that are real and three that are not: one false positive and two deliberate design decisions. This fixes the nine; the other three are resolved in SonarCloud with their reasoning recorded. One of the nine is user visible — the PDF preview listed page 10 before page 2.

### Checklist
#### General
Verified locally only (see Steps for Testing); no test server deployment, and no second developer has confirmed it yet.

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).

### Motivation and Context
`reliability_rating` is a worst-offender metric, so the twelve critical bugs are what keep it at D regardless of the other 860. They are worth reading individually rather than patching uniformly, because a third of them turn out not to be defects at all.

### Description
**A sort with no comparator, five times (`typescript:S2871`).** `Array.prototype.sort` compares elements as strings unless given a comparator, which means three different problems here:

- `pdf-preview-date-box.component.ts` sorted `OrderedPage.order`, which is a `number`, so the hidden-pages label listed `1, 10, 2` instead of `1, 2, 10`. This is the one users could see. It now uses a numeric comparator.
- `programming-exercise-editable-instruction.component.ts` (twice) and `memiris-memories-list.component.ts` sort strings — test case names shown to instructors, and memory ids. They now compare with `localeCompare`.
- `programming-exercise.service.ts` was the interesting one: `submissions.sort()` sorts the submission objects themselves, so every element stringifies to the same value, every comparison is equal and nothing is reordered. It was dead code that also obscured the `sortByProperty` call directly above it, which is what actually establishes the order. Removed rather than given a comparator.

**A malformed request returning 500 (`javabugs:S6416`).** `ForwardedMessage` enforces "exactly one destination" in both setters by throwing `IllegalStateException`. `ForwardedMessageDTO.toEntity` sets the destination post and then the destination answer post, so a request carrying both ids set the first and threw on the second — an unhandled `IllegalStateException`, so a 500 for what is a client error. SonarQube's dataflow spelled the path out exactly. The DTO now rejects that combination as a bad request, and the entity keeps its invariant.

**One `SecureRandom` per call (`java:S2119`).** `SecureRandom` is thread-safe, and constructing one re-seeds from the system entropy source, so `CalendarSubscriptionService`, `ExamSessionService` and `PyrisJobService` now share a single instance. Worth stating plainly: all four reported sites already used `SecureRandom` rather than `java.util.Random`, so none of these was a weak-randomness problem — the rule is only about reuse.

### Resolved in SonarCloud instead of changed here
- **`java:S2222`, `RedissonDistributedDataMigrator:97` — false positive.** The lock is released on every path that holds it. `tryLock`'s result is checked and the not-acquired branch throws *before* the `try` is entered, so no lock is held there; the acquired path unlocks in a `finally` guarded by `isHeldByCurrentThread`, which is the correct idiom for a watchdog-renewed Redisson lock.
- **`java:S8947`, `Exercise:854` — won't fix.** The `final` on `validateBaseDates` is deliberate and documented at the method: `ExerciseVariantGroupService` calls it non-polymorphically so it stays callable on a `QuizExercise` whose lazy `quizBatches` are uninitialized, and removing `final` would let a subclass override that away. The rule's proxying concern does not bite, because the method reads through ordinary non-final date getters, which are proxied and do trigger initialization.
- **`java:S2119`, `StudentExamRepository:637` — won't fix.** The other three share a `private static final` instance, but this method is on a repository *interface*, where any field is implicitly `public static final`. Satisfying the rule would mean publishing a constant on the repository's API, and `createRandomStudentExams` runs once per exam generation, so re-seeding costs nothing worth that.

### Steps for Testing
The only user-visible change is the page list in the PDF preview.

1. Log in as an instructor and open a lecture with a PDF attachment.
2. Open the PDF preview and select more than ten pages to hide.
3. Check the page list in the date box reads `1, 2, 10` rather than `1, 10, 2`.

Locally verified:
- `./gradlew compileJava spotlessCheck checkstyleMain` — clean.
- `pnpm run compile:tests` — clean.
- `pnpm exec vitest run` over the PDF preview and programming exercise service specs — 132 tests pass.
- `./gradlew test --tests '*ForwardedMessage*' --tests '*ExamSession*' --tests '*CalendarSubscription*' --tests '*PyrisJob*'` — pass.

### Review Progress
#### Code Review
- [ ] Code Review 1
- [ ] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid forwarded messages with multiple destinations or no destination now return a clear bad-request error.
  * Page numbers in PDF previews are displayed in the correct numerical order.
  * Memory groups and test cases now use consistent, locale-aware sorting.
  * Programming exercise results use the intended submission order when selecting the latest result.
* **Reliability**
  * Token generation for calendar subscriptions, exams, and jobs is more consistent and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->