### PR TITLE
`Development`: Address the LTI close message to the platform

### DIFF
--- a/src/main/webapp/app/lti/overview/lti13-dynamic-registration/lti13-dynamic-registration.component.spec.ts
+++ b/src/main/webapp/app/lti/overview/lti13-dynamic-registration/lti13-dynamic-registration.component.spec.ts
@@ -117,6 +117,25 @@ describe('Lti13DynamicRegistrationComponentTest', () => {
         window.opener = originalOpener;
     });
 
+    it.each([
+        ['is not a URL at all', 'not a url'],
+        ['parses but has an opaque origin', 'data:text/html,x'],
+    ])('should not post a message when the platform configuration %s', (_description, openIdConfiguration) => {
+        const mockPostMessage = vi.fn();
+        const originalOpener = window.opener;
+        window.opener = { postMessage: mockPostMessage };
+        route.snapshot = { queryParamMap: convertToParamMap({ openid_configuration: openIdConfiguration, registration_token: 'token' }) } as ActivatedRouteSnapshot;
+
+        vi.spyOn(http, 'post').mockReturnValue(of({ body: {} }));
+
+        comp.ngOnInit();
+
+        // There is no origin to address the close signal to, and postMessage would reject 'null' outright.
+        expect(mockPostMessage).not.toHaveBeenCalled();
+
+        window.opener = originalOpener;
+    });
+
     it('should post message to parent window after registration fails', () => {
         const mockPostMessage = vi.fn();
         const originalParent = window.parent;

--- a/src/main/webapp/app/lti/overview/lti13-dynamic-registration/lti13-dynamic-registration.component.spec.ts
+++ b/src/main/webapp/app/lti/overview/lti13-dynamic-registration/lti13-dynamic-registration.component.spec.ts
@@ -9,6 +9,9 @@ import { of, throwError } from 'rxjs';
 import { MockTranslateService } from 'test/helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
 
+const PLATFORM_CONFIGURATION_URL = 'https://platform.example.com/.well-known/openid-configuration';
+const PLATFORM_ORIGIN = 'https://platform.example.com';
+
 describe('Lti13DynamicRegistrationComponentTest', () => {
     let fixture: ComponentFixture<Lti13DynamicRegistrationComponent>;
     let comp: Lti13DynamicRegistrationComponent;
@@ -18,7 +21,7 @@ describe('Lti13DynamicRegistrationComponentTest', () => {
     beforeEach(async () => {
         route = {
             params: of({ courseId: 1 }) as Params,
-            snapshot: { queryParamMap: convertToParamMap({ openid_configuration: 'config', registration_token: 'token' }) },
+            snapshot: { queryParamMap: convertToParamMap({ openid_configuration: PLATFORM_CONFIGURATION_URL, registration_token: 'token' }) },
         } as ActivatedRoute;
 
         await TestBed.configureTestingModule({
@@ -109,7 +112,7 @@ describe('Lti13DynamicRegistrationComponentTest', () => {
 
         comp.ngOnInit();
 
-        expect(mockPostMessage).toHaveBeenCalledWith({ subject: 'org.imsglobal.lti.close' }, '*');
+        expect(mockPostMessage).toHaveBeenCalledWith({ subject: 'org.imsglobal.lti.close' }, PLATFORM_ORIGIN);
 
         window.opener = originalOpener;
     });
@@ -129,7 +132,7 @@ describe('Lti13DynamicRegistrationComponentTest', () => {
 
         comp.ngOnInit();
 
-        expect(mockPostMessage).toHaveBeenCalledWith({ subject: 'org.imsglobal.lti.close' }, '*');
+        expect(mockPostMessage).toHaveBeenCalledWith({ subject: 'org.imsglobal.lti.close' }, PLATFORM_ORIGIN);
 
         Object.defineProperty(window, 'parent', { value: originalParent, writable: true });
     });

--- a/src/main/webapp/app/lti/overview/lti13-dynamic-registration/lti13-dynamic-registration.component.ts
+++ b/src/main/webapp/app/lti/overview/lti13-dynamic-registration/lti13-dynamic-registration.component.ts
@@ -73,6 +73,12 @@ export class Lti13DynamicRegistrationComponent implements OnInit {
             // persisted by the request above, so the only cost is that the window does not close by itself.
             return;
         }
+        // A URL with an opaque origin, such as a data: or blob: configuration URL, parses but serializes its origin
+        // as the string 'null', which postMessage rejects as a target with a SyntaxError. Since the parameter comes
+        // from the query string, that would let a crafted link throw inside this callback.
+        if (platformOrigin === 'null') {
+            return;
+        }
         (window.opener || window.parent).postMessage({ subject: 'org.imsglobal.lti.close' }, platformOrigin);
     }
 }

--- a/src/main/webapp/app/lti/overview/lti13-dynamic-registration/lti13-dynamic-registration.component.ts
+++ b/src/main/webapp/app/lti/overview/lti13-dynamic-registration/lti13-dynamic-registration.component.ts
@@ -50,7 +50,29 @@ export class Lti13DynamicRegistrationComponent implements OnInit {
             })
             .add(() => {
                 this.isRegistering.set(false);
-                (window.opener || window.parent).postMessage({ subject: 'org.imsglobal.lti.close' }, '*');
+                this.notifyPlatformToClose(openIdConfiguration);
             });
+    }
+
+    /**
+     * Sends the LTI close signal to the platform that opened this page.
+     *
+     * The target origin is derived from the platform's OpenID configuration URL rather than left as a wildcard.
+     * Dynamic registration is always started by the platform, and that URL is the platform's own issuer endpoint, so
+     * it identifies where this message belongs. The payload is only the close constant the specification defines and
+     * says nothing about the course or the registration.
+     *
+     * @param openIdConfiguration the platform's OpenID configuration URL, as the platform passed it
+     */
+    private notifyPlatformToClose(openIdConfiguration: string): void {
+        let platformOrigin: string;
+        try {
+            platformOrigin = new URL(openIdConfiguration).origin;
+        } catch {
+            // Without a parseable platform URL there is no origin to address. The registration has already been
+            // persisted by the request above, so the only cost is that the window does not close by itself.
+            return;
+        }
+        (window.opener || window.parent).postMessage({ subject: 'org.imsglobal.lti.close' }, platformOrigin);
     }
 }


### PR DESCRIPTION
### Summary
The LTI 1.3 dynamic registration page told the platform to close its registration window with `postMessage(..., '*')`, so any document embedding the page received that message. It is now addressed to the platform's own origin, derived from the OpenID configuration URL the platform passes when it starts the flow. This is the last SonarQube critical security finding that was a code change rather than a triage decision.

### Checklist
#### General
Verified locally only (see Steps for Testing); no test server deployment, and no second developer has confirmed it yet.

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Client
- [x] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
`postMessage` with a wildcard target origin delivers to whatever document happens to be on the other side, which is why SonarQube reports it (`typescript:S2819`).

Being straight about the size of this one, because it affects how much risk is worth taking for it: the payload is `{ subject: 'org.imsglobal.lti.close' }`, the constant the LTI specification defines for this purpose. It carries no course id, no registration token and no user data. So the information a wildcard leaks is that an LTI registration finished, to a document that already knew it had opened the registration page. The change is worth making because addressing a message correctly is the right default and the rule is right in general, not because a specific attack is being closed.

### Description
`notifyPlatformToClose` derives the target from the `openid_configuration` query parameter, which the platform supplies to start dynamic registration and which is the platform's own issuer endpoint. That is the document the close signal belongs to.

Two consequences worth stating rather than leaving to be discovered:

- A platform that serves its OpenID configuration from a different host than the window it opened will have the message dropped by the browser. The registration itself is already persisted by the request that precedes this, so the only visible effect is that the window no longer closes by itself and the administrator closes it. If that turns out to affect a platform in practice, reverting to a wildcard here is a one-line change, and the payload makes that an acceptable place to end up.
- If `openid_configuration` cannot be parsed as a URL, no message is sent at all, for the same reason: there is no origin to address it to. The parameter is required by the specification and the registration request would already have failed without it.

The two component specs asserting the wildcard now assert the derived origin, and the fixture uses a realistic configuration URL (`https://platform.example.com/.well-known/openid-configuration`) instead of the placeholder string `config`, so the derivation is actually exercised.

### Steps for Testing
Needs a platform that performs LTI 1.3 dynamic registration, so it is not reproducible from Artemis alone.

1. From an LTI platform (for example Moodle), start dynamic registration against `/lti/dynamic-registration/:courseId`.
2. Confirm the registration completes and the platform's registration window closes by itself.

Locally verified:
- `pnpm exec vitest run` over the component's spec — 7 tests pass.
- `pnpm run compile:tests` — clean.
- `pnpm exec prettier --check` on the touched directory — clean.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LTI dynamic registration now sends completion messages only to the platform’s verified origin instead of a wildcard destination.
  * Invalid or opaque platform configuration URLs no longer trigger failed completion messaging after registration.
  * Improved reliability when completing registration with unsupported or malformed platform configurations.

* **Tests**
  * Added coverage for origin-specific messaging and cases where no message should be sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->