### PR TITLE
`Development`: Fix an issue in the test exam feedback generation

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamAthenaFeedbackService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/exam/service/StudentExamAthenaFeedbackService.java
@@ -125,6 +125,10 @@ public class StudentExamAthenaFeedbackService {
             throw new BadRequestAlertException("No exam exercises with course-level Athena formative feedback enabled", "StudentExam", "noCourseLevelAthenaFormativeEnabled", true);
         }
 
+        // The participations are loaded separately from the student exam and therefore contain different exercise
+        // instances. Attach the lazy Athena configuration to the instances passed to the asynchronous generators.
+        eligibleParticipations.forEach(participation -> courseAthenaConfigRepository.attachToCourseOf(participation.getExercise()));
+
         for (StudentParticipation participation : eligibleParticipations) {
             Exercise exercise = participation.getExercise();
             if (exercise instanceof TextExercise && textFeedbackApi.isEmpty()) {

--- a/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamAthenaFeedbackIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/exam/StudentExamAthenaFeedbackIntegrationTest.java
@@ -2,11 +2,13 @@ package de.tum.cit.aet.artemis.exam;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Optional;
@@ -200,6 +202,7 @@ class StudentExamAthenaFeedbackIntegrationTest extends AbstractAthenaTest {
 
             studentExamAthenaFeedbackService.requestAthenaFeedbackForTestExam(studentExam, student);
 
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(athenaRequestMockProvider::verify);
             verify(resultWebsocketService, timeout(5000).times(2)).broadcastNewResult(eq(textParticipation), any(Result.class));
         }
 
@@ -234,6 +237,7 @@ class StudentExamAthenaFeedbackIntegrationTest extends AbstractAthenaTest {
 
             studentExamAthenaFeedbackService.requestAthenaFeedbackForTestExam(studentExam, student);
 
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(athenaRequestMockProvider::verify);
             verify(resultWebsocketService, timeout(5000).times(2)).broadcastNewResult(eq(modelingParticipation), any(Result.class));
         }
 
@@ -278,6 +282,7 @@ class StudentExamAthenaFeedbackIntegrationTest extends AbstractAthenaTest {
 
             studentExamAthenaFeedbackService.requestAthenaFeedbackForTestExam(studentExam, student);
 
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(athenaRequestMockProvider::verify);
             verify(resultWebsocketService, timeout(5000).times(2)).broadcastNewResult(eq(modelingParticipation), any(Result.class));
         }
     }
@@ -713,6 +718,7 @@ class StudentExamAthenaFeedbackIntegrationTest extends AbstractAthenaTest {
             String url = "/api/exam/courses/" + course.getId() + "/exams/" + testExam.getId() + "/student-exams/" + studentExam.getId() + "/request-feedback";
             request.postWithoutResponseBody(url, null, HttpStatus.OK);
 
+            await().atMost(Duration.ofSeconds(5)).untilAsserted(athenaRequestMockProvider::verify);
             verify(resultWebsocketService, timeout(5000).times(2)).broadcastNewResult(eq(textParticipation), any(Result.class));
         }
 


### PR DESCRIPTION
### Summary
Fix test-exam Athena feedback generation after the course configuration became lazy.

### Checklist
#### General
- [x] This is a small issue tested locally.
- [x] Language follows the inclusive-language guidelines.
- [x] The title follows the pull request naming conventions.

#### Server
- [x] The change avoids eager loading and only resolves configuration for eligible participations.
- [x] Database access follows data-economy and performance guidelines.
- [x] Server coding and design guidelines are followed.
- [x] Existing integration tests now verify the actual Athena request.

#### Client
Not applicable; there are no client changes.

#### Changes affecting Programming Exercises
Not applicable; only text and modeling test-exam feedback are affected.

### Motivation and Context
Follow-up to #13771. Participation exercises are loaded separately from student-exam exercises, so their lazy Athena configuration was unavailable in asynchronous feedback generation.

### Description
Attach the Athena configuration to the exact exercise instances passed to the asynchronous generators. Verify outbound Athena calls in all affected happy-path integration tests.

### Steps for Testing
1. Enable formative Athena feedback for a course.
2. Submit a test exam with a text or modeling answer.
3. Request feedback and confirm Athena is called and feedback generation succeeds.

Automated checks:
- ./gradlew test -x webapp --tests StudentExamAthenaFeedbackIntegrationTest
- ./gradlew test -DincludeTags=ArchitectureTest -x webapp
- ./gradlew spotlessCheck

#### Exam Mode Testing
Covered by the test-exam text, modeling, mixed-participation, and REST integration paths.

### Testserver States
Not deployed; this small follow-up was validated locally.

### Review Progress
#### Performance Review
Pending reviewer verification.

#### Code Review
Pending two code reviews.

#### Manual Tests
Local automated integration testing completed.

#### Exam Mode Test
Local automated test-exam verification completed; reviewer verification is pending.

#### Performance Tests
Not applicable; work is bounded to eligible exercises in one test-exam attempt.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| StudentExamAthenaFeedbackService.java | 94.64% | 117 |

_Last updated: 2026-09-10 18:11:08 UTC_


### Screenshots
Not applicable; there are no user-interface changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Athena feedback generation for exam exercises by ensuring the required configuration is available when feedback requests are processed.
  - Increased reliability of feedback dispatch verification for text, modeling, mixed-participation, and REST-based exam workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->