### PR TITLE
`Development`: Add the forwarded message destination constraint to Liquibase

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20260910212533_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20260910212533_changelog.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!--
+    Gives forwarded_message the check constraint its entity already declares.
+
+    ForwardedMessage carries @Check(constraints = "((destination_post_id IS NOT NULL AND
+    destination_answer_id IS NULL) OR (destination_post_id IS NULL AND destination_answer_id IS NOT
+    NULL))"), but ddl-auto is none in every profile, so Hibernate never emits it and no changeset
+    ever created it. The TUM production database has it as CHECK_DESTINATION_POST_OR_ANSWER, applied
+    outside Liquibase in the same way as the reconciliations in 20260728220917_changelog.xml. A
+    database built from these changelogs does not, so the invariant is enforced in production and
+    unenforced everywhere else, including every test environment.
+
+    Liquibase's addCheckConstraint is a Pro change type, so the DDL is raw SQL. It is the same
+    statement on both engines and was checked against MySQL 26.7.0 and PostgreSQL 18.6: a row with
+    one destination is accepted and a row with neither is rejected on both.
+    -->
+
+    <!--
+    information_schema is portable but the "current schema" function is not, following
+    20260728220917_changelog.xml. Every changeset interpolating ${lbSchema} must carry
+    dbms="mysql,postgresql" so the placeholder does not reach another engine verbatim.
+    -->
+    <property name="lbSchema" value="DATABASE()" dbms="mysql"/>
+    <property name="lbSchema" value="current_schema()" dbms="postgresql"/>
+
+    <!--
+    A forwarded message with no destination is unreachable: the retrieval endpoint groups messages by
+    their destination id, so nothing can ever return one. Until ForwardedMessageDTO started rejecting
+    the combination (#13776) an installation without the constraint accepted them, so they are
+    deleted here rather than allowed to abort the constraint below. Rows with both destinations set
+    are not cleaned up because they cannot be created: both setters on the entity have always
+    rejected the second destination.
+    -->
+    <changeSet id="20260910212533-01-delete-destinationless-forwarded-messages" author="krusche">
+        <comment>Remove forwarded messages that point at neither a post nor an answer post.</comment>
+        <sql>
+            DELETE FROM forwarded_message WHERE destination_post_id IS NULL AND destination_answer_id IS NULL;
+        </sql>
+        <!-- The deleted rows are unreachable through the API, so there is nothing to restore. -->
+        <rollback/>
+    </changeSet>
+
+    <!--
+    MARK_RAN rather than the CONTINUE this project normally prefers: the condition guarded here is
+    "the constraint already exists", which is a permanent and correct end state, not a transient one
+    worth retrying. CONTINUE would log a warning on every startup of the production database for
+    good. The changeset above removes the only violation an installation can have accumulated, so
+    the constraint cannot be skipped for want of clean data.
+
+    UPPER() on the name because PostgreSQL folds an unquoted identifier to lower case while MySQL
+    keeps it as written, so the same constraint is stored under two spellings.
+    -->
+    <changeSet id="20260910212533-02-forwarded-message-exactly-one-destination" author="krusche" dbms="mysql,postgresql">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM information_schema.table_constraints
+                WHERE table_schema = ${lbSchema} AND table_name = 'forwarded_message'
+                  AND UPPER(constraint_name) = 'CHECK_DESTINATION_POST_OR_ANSWER'
+            </sqlCheck>
+        </preConditions>
+        <comment>Enforce the one-destination invariant that ForwardedMessage declares with @Check.</comment>
+        <sql>
+            ALTER TABLE forwarded_message ADD CONSTRAINT CHECK_DESTINATION_POST_OR_ANSWER
+            CHECK ((destination_post_id IS NOT NULL AND destination_answer_id IS NULL)
+                OR (destination_post_id IS NULL AND destination_answer_id IS NOT NULL));
+        </sql>
+        <rollback>
+            <sql>ALTER TABLE forwarded_message DROP CONSTRAINT CHECK_DESTINATION_POST_OR_ANSWER;</sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -68,6 +68,7 @@
     <include file="classpath:config/liquibase/changelog/20260907100622_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260827174007_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20260910120000_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20260910212533_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
     <!-- you can use the command "date '+%Y%m%d%H%M%S'" to get the current date and time in the correct format -->


### PR DESCRIPTION
### Summary
`ForwardedMessage` declares a check constraint requiring exactly one destination, and long-lived installations enforce it, but no changeset ever created it. A database built from these changelogs therefore does not have it, so the invariant holds in those installations and nowhere else, including every test environment. This adds the constraint to Liquibase, guarded so it is a no-op where the constraint already exists.

### Checklist
#### General
Verified locally only (see Steps for Testing), including a read-only inspection of the production schema; no test server deployment, and no second developer has confirmed it yet.

- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

#### Server
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).

### Motivation and Context
`ForwardedMessage` carries

```java
@Check(constraints = "((destination_post_id IS NOT NULL AND destination_answer_id IS NULL) OR (destination_post_id IS NULL AND destination_answer_id IS NOT NULL))")
```

but `ddl-auto` is `none` in every profile, so Hibernate never emits that constraint, and no changeset creates it either. The result is measured rather than assumed:

| Database | Constraint present |
| --- | --- |
| Production, MySQL 8.0.46 | `CHECK_DESTINATION_POST_OR_ANSWER` |
| Built from these changelogs, PostgreSQL 18.6 | none on the table |

This is the same class of gap that `20260728220917_changelog.xml` reconciles, and that changelog names the cause: consolidating the initial schema dropped changesets, and the equivalent DDL was applied outside Liquibase. This constraint looks like one more of those.

The practical consequence is that the invariant behaves differently by environment. `ForwardedMessageDTO` now rejects a request naming the wrong number of destinations (#13776), so the application no longer depends on the constraint to catch it, but a database that does not enforce it can still be written to by anything else, and a test environment cannot reproduce the production failure.

### Description
Two changesets in `20260910212533_changelog.xml`.

**Delete destination-less rows first.** A forwarded message with no destination cannot be returned by `GET /forwarded-messages`, which groups messages by their destination id, so it is unreachable rather than merely wrong. Before the DTO validation an installation without the constraint accepted such rows, and any that exist would abort the constraint below and with it the application startup. Rows with *both* destinations set are deliberately not cleaned up, because they cannot be created: both setters on the entity have always rejected a second destination.

**Then add the constraint, only where it is missing.** `addCheckConstraint` is a Liquibase Pro change type, so the DDL is raw `<sql>`. The statement is the same on both engines. Three details are deliberate:

- The precondition queries `information_schema.table_constraints`, which is portable, and takes the one part that is not — the current-schema function — from the `${lbSchema}` property that `20260728220917_changelog.xml` introduced for exactly this. The changeset carries `dbms="mysql,postgresql"` so the placeholder cannot reach another engine verbatim, as that file warns.
- The constraint name is compared with `UPPER(...)`, because PostgreSQL folds an unquoted identifier to lower case while MySQL keeps it as written, so the same constraint is stored under two spellings.
- `onFail="MARK_RAN"`, which is against this project's usual preference for `CONTINUE`. That preference exists for a blocker you expect to clear, so that the changeset retries. Here the blocker is "the constraint is already present", which is a permanent and correct end state, and `CONTINUE` would log a warning on every startup indefinitely. The preceding changeset removes the only violation an installation can have accumulated, so the constraint cannot be marked as run for want of clean data.

### Steps for Testing
No user-visible behaviour changes. The invariant it enforces is already enforced by the DTO on the way in.

Verified locally:
- The precondition query, run read-only against both engines: returns `1` on the MySQL database that has the constraint, so the changeset is skipped, and `0` on the Liquibase-built PostgreSQL, so it runs.
- The DDL, applied to a throwaway table on both MySQL 26.7.0 and PostgreSQL 18.6 and then dropped: a row with one destination is accepted and a row with neither is rejected on both.
- `./gradlew test --tests ForwardedMessageResourceIntegrationTest` with Liquibase logging raised, which boots the application against a fresh PostgreSQL and confirms both changesets **ran** rather than being skipped by their precondition:

```
ChangeSet ...20260910212533-01-delete-destinationless-forwarded-messages::krusche ran successfully
ChangeSet ...20260910212533-02-forwarded-message-exactly-one-destination::krusche ran successfully
```

- Existing data was checked read-only before proposing the constraint: no row has both destinations null and none has both set, so it applies without the cleanup changeset having anything to delete.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2