### PR TITLE
`Development`: Read the Athena wire contract responses with Jackson 3

### DIFF
--- a/src/test/java/de/tum/cit/aet/artemis/course/AthenaConfigWireContractTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/course/AthenaConfigWireContractTest.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.util.LinkedMultiValueMap;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import de.tum.cit.aet.artemis.assessment.domain.AssessmentType;
 import de.tum.cit.aet.artemis.core.domain.Language;


### PR DESCRIPTION
### Summary
`AthenaConfigWireContractTest` asks for its responses as a Jackson 2 `JsonNode`, but the request helper it uses deserializes with Jackson 3. Every one of its ten tests fails on `develop`, and because they sit in the `Independent` server test shard, that shard is red on every pull request. This is a one-line import fix.

### Checklist
#### General
- [x] This is a small issue that I tested locally.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).

### Motivation and Context
`RequestUtilService` reads responses through Jackson 3:

```java
import tools.jackson.core.type.TypeReference;
import tools.jackson.databind.json.JsonMapper;
```

`AthenaConfigWireContractTest` passes `JsonNode.class` to it while importing the Jackson 2 type, so the Jackson 3 mapper is handed an abstract class it does not know how to instantiate:

```
tools.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of
`com.fasterxml.jackson.databind.JsonNode` (no Creators, like default constructor, exist)
```

The test arrived in #13771 and this is the only test file in the repository still importing the Jackson 2 `JsonNode`, so it looks like one file missed by the Jackson 3 migration rather than a deliberate mix.

The effect reaches past that one test. The failure is in `Test / Server Tests (Independent)`, which feeds the `All required CI Passed` gate, so it blocks merging on any branch that runs it until the import is corrected.

### Description
The import changes from `com.fasterxml.jackson.databind.JsonNode` to `tools.jackson.databind.JsonNode`. Nothing else changes: the assertions already use only `get`, `has` and `asBoolean`, which both versions provide with the same names.

### Steps for Testing
No production code is touched, so there is nothing to exercise in the application.

Locally verified:
- `./gradlew test --tests AthenaConfigWireContractTest` — passes. On `develop` the same command fails all ten tests with the exception above.
- `./gradlew spotlessCheck` — clean.

### Review Progress
#### Code Review
- [x] Code Review 1
- [x] Code Review 2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test compatibility with the Jackson 3 API without changing test behavior or coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->