### PR TITLE
`Athena`: Document why the course entity graph must keep athenaConfig

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/course/repository/CourseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/course/repository/CourseRepository.java
@@ -308,8 +308,11 @@ public interface CourseRepository extends ArtemisJpaRepository<Course, Long>, Jp
     Optional<Course> findWithEagerOrganizationsAndCompetenciesAndPrerequisitesAndLearningPaths(@Param("courseId") long courseId);
 
     // courseConfiguration is fetched here so the (instructor) course management view exposes grade-relevance and the
-    // per-course Atlas auto-orchestration settings for editing.
-    @EntityGraph(type = LOAD, attributePaths = { "onlineCourseConfiguration", "tutorialGroupsConfiguration", "courseConfiguration" })
+    // per-course Atlas auto-orchestration settings for editing. athenaConfig is fetched here because CourseOverviewResource
+    // returns this query's result as a raw Course, and Course#isAthenaGradingFeedbackEnabled()/isAthenaFormativeFeedbackEnabled()
+    // read it via Hibernate.isInitialized() rather than triggering a lazy load - leaving it out of this entity graph makes
+    // both JSON fields silently report false to the client regardless of the persisted value.
+    @EntityGraph(type = LOAD, attributePaths = { "onlineCourseConfiguration", "tutorialGroupsConfiguration", "courseConfiguration", "athenaConfig" })
     Course findWithEagerOnlineCourseConfigurationAndTutorialGroupConfigurationById(long courseId);
 
     @EntityGraph(type = LOAD, attributePaths = { "onlineCourseConfiguration" })

--- a/src/main/java/de/tum/cit/aet/artemis/course/repository/CourseRepository.java
+++ b/src/main/java/de/tum/cit/aet/artemis/course/repository/CourseRepository.java
@@ -309,7 +309,7 @@ public interface CourseRepository extends ArtemisJpaRepository<Course, Long>, Jp
 
     // courseConfiguration is fetched here so the (instructor) course management view exposes grade-relevance and the
     // per-course Atlas auto-orchestration settings for editing.
-    @EntityGraph(type = LOAD, attributePaths = { "onlineCourseConfiguration", "tutorialGroupsConfiguration", "athenaConfig", "courseConfiguration" })
+    @EntityGraph(type = LOAD, attributePaths = { "onlineCourseConfiguration", "tutorialGroupsConfiguration", "courseConfiguration" })
     Course findWithEagerOnlineCourseConfigurationAndTutorialGroupConfigurationById(long courseId);
 
     @EntityGraph(type = LOAD, attributePaths = { "onlineCourseConfiguration" })

--- a/src/main/java/de/tum/cit/aet/artemis/course/web/CourseUpdateResource.java
+++ b/src/main/java/de/tum/cit/aet/artemis/course/web/CourseUpdateResource.java
@@ -41,6 +41,7 @@ import de.tum.cit.aet.artemis.core.util.FileUtil;
 import de.tum.cit.aet.artemis.course.config.CourseLegacyRestPaths;
 import de.tum.cit.aet.artemis.course.domain.Course;
 import de.tum.cit.aet.artemis.course.dto.CourseUpdateDTO;
+import de.tum.cit.aet.artemis.course.repository.CourseAthenaConfigRepository;
 import de.tum.cit.aet.artemis.course.repository.CourseConfigurationRepository;
 import de.tum.cit.aet.artemis.course.repository.CourseRepository;
 import de.tum.cit.aet.artemis.course.service.CourseValidator;
@@ -88,6 +89,8 @@ public class CourseUpdateResource {
 
     private final CourseConfigurationRepository courseConfigurationRepository;
 
+    private final CourseAthenaConfigRepository courseAthenaConfigRepository;
+
     private final ExerciseRepository exerciseRepository;
 
     private final UserRepository userRepository;
@@ -99,8 +102,9 @@ public class CourseUpdateResource {
     public CourseUpdateResource(Optional<LtiApi> ltiApi, AuthorizationCheckService authCheckService, FileService fileService,
             Optional<TutorialGroupChannelManagementApi> tutorialGroupChannelManagementApi, Optional<LearningPathApi> learningPathApi,
             ConductAgreementService conductAgreementService, Optional<LearnerProfileApi> learnerProfileApi, Optional<CourseAutoOrchestrationApi> autoOrchestrationApi,
-            CourseRepository courseRepository, CourseConfigurationRepository courseConfigurationRepository, ExerciseRepository exerciseRepository, UserRepository userRepository,
-            Optional<SearchableEntityWeaviateService> searchableEntityWeaviateService, InstanceMessageSendService instanceMessageSendService) {
+            CourseRepository courseRepository, CourseConfigurationRepository courseConfigurationRepository, CourseAthenaConfigRepository courseAthenaConfigRepository,
+            ExerciseRepository exerciseRepository, UserRepository userRepository, Optional<SearchableEntityWeaviateService> searchableEntityWeaviateService,
+            InstanceMessageSendService instanceMessageSendService) {
         this.ltiApi = ltiApi;
         this.authCheckService = authCheckService;
         this.fileService = fileService;
@@ -111,6 +115,7 @@ public class CourseUpdateResource {
         this.learnerProfileApi = learnerProfileApi;
         this.courseRepository = courseRepository;
         this.courseConfigurationRepository = courseConfigurationRepository;
+        this.courseAthenaConfigRepository = courseAthenaConfigRepository;
         this.exerciseRepository = exerciseRepository;
         this.userRepository = userRepository;
         this.searchableEntityWeaviateService = searchableEntityWeaviateService;
@@ -135,8 +140,8 @@ public class CourseUpdateResource {
         // Always use the path variable for lookups to prevent a DTO with a mismatched id
         // from loading (and potentially modifying) a different course than the URL indicates
         var existingCourse = courseRepository.findByIdForUpdateElseThrow(courseId);
-        // athenaConfig is not included in the findForUpdateById EntityGraph; load it separately to avoid LazyInitializationException in courseUpdateDTO.applyTo()
-        existingCourse.setAthenaConfig(courseRepository.findByIdWithEagerOnlineCourseConfigurationAndTutorialGroupConfigurationElseThrow(courseId).getAthenaConfig());
+        // Lazy, like the course configuration below; read it through its own repository rather than a second full course fetch
+        courseAthenaConfigRepository.attachTo(existingCourse);
 
         // Attach the (lazily-stored) course configuration so applyTo updates it in place instead of creating a duplicate,
         // and so the admin-only auto-orchestration change detection below compares against the persisted values. Fetched


### PR DESCRIPTION
### Summary
This started as an efficiency fix: `CourseUpdateResource.updateCourse` did a second full course fetch just to read `athenaConfig`. While it was in review, [#13704](https://github.com/ls1intum/Artemis/pull/13704) landed on `develop` and refactored that exact code path — Athena grading/formative feedback is now edited through its own `CourseAthenaConfigService`/`CourseAthenaConfigResource`, and `CourseUpdateResource` no longer reads `athenaConfig` mid-method at all, only attaching it once at the end for the response. That already solves the problem this PR set out to fix, more thoroughly than this PR did.

So after merging `develop`, this PR's `CourseUpdateResource.java` change dropped out entirely (it's now identical to `develop`). What's left is the one genuinely independent finding from review: `CourseRepository.findWithEagerOnlineCourseConfigurationAndTutorialGroupConfigurationById`'s `@EntityGraph` needs a comment explaining why `athenaConfig` must stay in it, so nobody removes it again for the same "looks unused" reason this PR originally did.

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

#### Server
- [x] **Important**: I implemented the changes with a very good performance and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the server coding and design guidelines and the REST API guidelines.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
`CourseOverviewResource.getCourse()` returns this query's result as a raw `Course` for the instructor response. `Course#isAthenaGradingFeedbackEnabled()`/`isAthenaFormativeFeedbackEnabled()` check `Hibernate.isInitialized(athenaConfig)` rather than triggering a lazy load, so if `athenaConfig` is ever dropped from this entity graph again, both JSON fields silently report `false` regardless of the persisted value — an enabled Athena configuration would appear disabled to instructors. That's exactly what happened earlier in this PR's own review cycle (caught by a reviewer, fixed in 6eebbd8a117). The comment documents it so the next person doesn't repeat it.

### Description
- `CourseRepository.findWithEagerOnlineCourseConfigurationAndTutorialGroupConfigurationById`: no functional change, `athenaConfig` was already in the `@EntityGraph` on `develop`. Added a comment explaining why it has to stay, next to the existing comment about `courseConfiguration`.
- `CourseUpdateResource.java`: no change remains after merging `develop` — the second-fetch inefficiency this PR targeted was independently fixed by #13704's refactor.

### Steps for Testing
No behavior change; nothing to test manually. `CourseAthenaSchedulingUpdateIntegrationTest` and the new tests from #13704 already cover the Athena course-update paths.

### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| CourseRepository.java | 100.00% | 486 |

_Last updated: 2026-09-14 16:33:29 UTC_

