### PR TITLE
`Programming exercises`: Fix submission policy replacement when changing type

### DIFF
--- a/src/main/java/de/tum/cit/aet/artemis/programming/service/SubmissionPolicyService.java
+++ b/src/main/java/de/tum/cit/aet/artemis/programming/service/SubmissionPolicyService.java
@@ -212,10 +212,10 @@ public class SubmissionPolicyService {
             updateSubmissionPenaltyPolicy((SubmissionPenaltyPolicy) originalPolicy, (SubmissionPenaltyPolicy) newPolicy);
         }
 
-        // Case 3: The original and new submission policies have different types. In this case we want to remove
-        // all effects of the original policy and enforce the effects of the new policy.
+        // Case 3: A policy type change replaces the @OneToOne entity. Clearing the old id makes JPA insert the
+        // replacement instead of merging the previous policy.
         else {
-            removeSubmissionPolicyFromProgrammingExercise(programmingExercise);
+            newPolicy.setId(null);
             newPolicy = addSubmissionPolicyToProgrammingExercise(newPolicy, programmingExercise);
             return enableSubmissionPolicy(newPolicy);
         }

--- a/src/test/java/de/tum/cit/aet/artemis/programming/SubmissionPolicyIntegrationTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/SubmissionPolicyIntegrationTest.java
@@ -377,14 +377,46 @@ class SubmissionPolicyIntegrationTest extends AbstractProgrammingIntegrationLoca
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    void test_updateSubmissionPolicy_typeChangeWithPreviousId_conflict() throws Exception {
+    void test_updateSubmissionPolicy_ok_typeChangeWithPreviousId_replacesPolicyRow() throws Exception {
         addSubmissionPolicyToExercise(SubmissionPolicyBuilder.lockRepo().active(true).limit(10).policy());
         Long oldPolicyId = updatedExercise().getSubmissionPolicy().getId();
 
-        // Pre-existing behaviour, unchanged by the DTO migration: the update form keeps the id of the previously
-        // loaded policy when the type changes. The old row is deleted first, so re-saving the same id fails with an
-        // optimistic-locking conflict. The DTO carries the id through exactly as the entity binding did before.
-        request.patch(requestUrl(), new SubmissionPolicyDTO(oldPolicyId, "submission_penalty", 10, 5.0, true), HttpStatus.CONFLICT);
+        String response = request.patchWithResponseBody(requestUrl(), new SubmissionPolicyDTO(oldPolicyId, "submission_penalty", 4, 2.0, true), String.class, HttpStatus.OK);
+        Map<String, Object> body = asJsonMap(response);
+
+        assertThat(body).containsEntry("type", "submission_penalty").containsEntry("submissionLimit", 4).containsEntry("exceedingPenalty", 2.0).containsEntry("active", true);
+        assertThat(((Number) body.get("id")).longValue()).isNotEqualTo(oldPolicyId);
+
+        var storedPolicies = submissionPolicyRepository.findAllByProgrammingExerciseIds(Set.of(programmingExerciseId));
+        assertThat(storedPolicies).hasSize(1);
+        SubmissionPolicy storedPolicy = storedPolicies.iterator().next();
+        assertThat(storedPolicy).isInstanceOf(SubmissionPenaltyPolicy.class);
+        assertThat(storedPolicy.getSubmissionLimit()).isEqualTo(4);
+        assertThat(((SubmissionPenaltyPolicy) storedPolicy).getExceedingPenalty()).isEqualTo(2.0);
+        assertThat(submissionPolicyRepository.findById(oldPolicyId)).isEmpty();
+        assertThat(updatedExercise().getSubmissionPolicy().getId()).isEqualTo(storedPolicy.getId());
+    }
+
+    @Test
+    @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
+    void test_updateSubmissionPolicy_ok_typeChangeWithPreviousId_penaltyToLockRepository() throws Exception {
+        addSubmissionPolicyToExercise(SubmissionPolicyBuilder.submissionPenalty().active(true).limit(10).penalty(5.0).policy());
+        Long oldPolicyId = updatedExercise().getSubmissionPolicy().getId();
+
+        String response = request.patchWithResponseBody(requestUrl(), new SubmissionPolicyDTO(oldPolicyId, "lock_repository", 3, null, true), String.class, HttpStatus.OK);
+        Map<String, Object> body = asJsonMap(response);
+
+        assertThat(body).containsOnlyKeys("id", "type", "submissionLimit", "active");
+        assertThat(body).containsEntry("type", "lock_repository").containsEntry("submissionLimit", 3).containsEntry("active", true);
+        assertThat(((Number) body.get("id")).longValue()).isNotEqualTo(oldPolicyId);
+
+        var storedPolicies = submissionPolicyRepository.findAllByProgrammingExerciseIds(Set.of(programmingExerciseId));
+        assertThat(storedPolicies).hasSize(1);
+        SubmissionPolicy storedPolicy = storedPolicies.iterator().next();
+        assertThat(storedPolicy).isInstanceOf(LockRepositoryPolicy.class);
+        assertThat(storedPolicy.getSubmissionLimit()).isEqualTo(3);
+        assertThat(submissionPolicyRepository.findById(oldPolicyId)).isEmpty();
+        assertThat(updatedExercise().getSubmissionPolicy().getId()).isEqualTo(storedPolicy.getId());
     }
 
     // Beginning of toggleSubmissionPolicy tests

--- a/src/test/java/de/tum/cit/aet/artemis/programming/service/SubmissionPolicyServiceTest.java
+++ b/src/test/java/de/tum/cit/aet/artemis/programming/service/SubmissionPolicyServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -199,6 +200,52 @@ class SubmissionPolicyServiceTest {
         assertThat(policy.isActive()).as("the policy is disabled on the way out").isFalse();
         assertThat(exercise.getSubmissionPolicy()).as("the exercise no longer has a policy").isNull();
         verify(programmingExerciseRepository).save(exercise);
+    }
+
+    @Test
+    void updateSubmissionPolicy_forATypeChange_insertsTheReplacementWithoutThePreviousPolicyId() {
+        ProgrammingExercise exercise = new ProgrammingExercise();
+        LockRepositoryPolicy originalPolicy = lockRepositoryPolicy(10, true);
+        originalPolicy.setId(1L);
+        exercise.setSubmissionPolicy(originalPolicy);
+        SubmissionPenaltyPolicy newPolicy = penaltyPolicy(4, 2.0, true);
+        newPolicy.setId(1L);
+        List<Long> idsOnSave = new ArrayList<>();
+        when(submissionPolicyRepository.save(any(SubmissionPolicy.class))).thenAnswer(invocation -> {
+            SubmissionPolicy savedPolicy = invocation.getArgument(0);
+            idsOnSave.add(savedPolicy.getId());
+            if (savedPolicy.getId() == null) {
+                savedPolicy.setId(2L);
+            }
+            return savedPolicy;
+        });
+
+        SubmissionPolicy replacementPolicy = submissionPolicyService.updateSubmissionPolicy(exercise, newPolicy);
+
+        assertThat(idsOnSave).as("the replacement is inserted without an id and enabled afterwards").containsExactly(null, 2L);
+        assertThat(replacementPolicy).isSameAs(newPolicy);
+        assertThat(replacementPolicy.isActive()).isTrue();
+        assertThat(exercise.getSubmissionPolicy()).as("the exercise points at the replacement").isSameAs(newPolicy);
+        assertThat(originalPolicy.isActive()).as("the policy that is replaced is not written to").isTrue();
+        verify(submissionPolicyRepository, never()).save(originalPolicy);
+        verify(programmingExerciseRepository).save(exercise);
+    }
+
+    @Test
+    void updateSubmissionPolicy_forATypeChange_whenTheInsertFails_leavesTheExercisePolicyUntouched() {
+        ProgrammingExercise exercise = new ProgrammingExercise();
+        LockRepositoryPolicy originalPolicy = lockRepositoryPolicy(10, true);
+        originalPolicy.setId(1L);
+        exercise.setSubmissionPolicy(originalPolicy);
+        SubmissionPenaltyPolicy newPolicy = penaltyPolicy(4, 2.0, true);
+        newPolicy.setId(1L);
+        when(submissionPolicyRepository.save(any(SubmissionPolicy.class))).thenThrow(new IllegalStateException("insert failed"));
+
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> submissionPolicyService.updateSubmissionPolicy(exercise, newPolicy));
+
+        assertThat(exercise.getSubmissionPolicy()).as("the exercise keeps its policy when the replacement cannot be inserted").isSameAs(originalPolicy);
+        assertThat(originalPolicy.isActive()).isTrue();
+        verifyNoInteractions(programmingExerciseRepository);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->

### Summary
<!-- Add a short, but convincing summary (abstract) of the PR changes here. -->

Fixes submission policy type changes so that replacing a policy no longer reuses the previous policy entity ID. This prevents the update from failing with a concurrency error and avoids deleting the existing policy before the replacement has been persisted.

### Checklist
#### General
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review if all relevant tasks are checked! -->
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable, and you may remove the first checkmark. If you are unsure, please test on the test servers. -->

<!--
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
-->

- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.tum.de/developer/guidelines/language).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://docs.artemis.tum.de/developer/development-process#pr-naming-conventions).


#### Server
- [x] **Important**: I implemented the changes with a [very good performance](https://docs.artemis.tum.de/developer/guidelines/performance) and prevented too many (unnecessary) and too complex database calls.
- [x] I **strictly** followed the principle of **data economy** for all database calls.
- [x] I **strictly** followed the [server coding and design guidelines](https://docs.artemis.tum.de/developer/guidelines/server-development) and the [REST API guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

<!--
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.tum.de/developer/guidelines/rest-api#authorization) and checked the course groups for all new REST Calls (security).
- [ ] I documented the Java code using JavaDoc style.
-->


<!--
#### Client
- [ ] **Important**: I implemented the changes with a very good performance, prevented too many (unnecessary) REST calls and made sure the UI is responsive, even with large data (e.g. using paging).
- [ ] I **strictly** followed the principle of **data economy** for all client-server REST calls.
- [ ] I **strictly** followed the [client coding guidelines](https://docs.artemis.tum.de/developer/guidelines/client-development).
- [ ] I **strictly** followed the [AET UI-UX guidelines](https://ls1intum.github.io/ui-ux-guidelines/).
- [ ] Following the [theming guidelines](https://docs.artemis.tum.de/developer/guidelines/client-theming), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Vitest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.tum.de/developer/guidelines/client-tests).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.
-->


#### Changes affecting Programming Exercises
- [x] **High priority**: I tested **all** changes and their related features with **all** corresponding user types on a test server configured with the **integrated lifecycle setup** (LocalVC and LocalCI).
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server configured with **LocalVC** and **Jenkins**.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #13448.

Changing the type of an existing submission policy while keeping the previous policy ID caused the server to remove the existing policy and then attempt to merge the replacement using the deleted entity ID. This resulted in a concurrency failure and left the programming exercise without a submission policy.

### Description
<!-- Describe your changes in detail -->

- Clear the previous policy ID when the submission policy type changes so that the replacement is inserted as a new entity.
- Attach the replacement before the previous policy is removed through the existing one-to-one orphan-removal semantics.
- Avoid modifying or disabling the existing policy before the replacement has been persisted.
- Add integration tests for changing submission policy types in both directions.
- Add service tests for the replacement behavior and for failures while inserting the replacement.

### Steps for Testing
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->

Prerequisites:
- 1 Instructor
- 1 Editor
- 1 Tutor
- 1 Programming Exercise with a submission policy

1. Log in as an instructor.
2. Navigate to the programming exercise and open **Grading → Submission Policy**.
3. Configure a **Lock Repository** policy and save it.
4. Change the policy type to **Submission Penalty**, configure its values, and save it.
5. Verify that the update succeeds without a concurrency error.
6. Reload the page and verify that the Submission Penalty policy and its values are still present.
7. Change the policy back to **Lock Repository** and save it.
8. Reload the page and verify that the Lock Repository policy is still present.
9. Verify with an Editor account that modifying the submission policy is not permitted.
10. Verify with a Tutor account that modifying the submission policy is not permitted.

<!--
#### Exam Mode Testing
If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected.
If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out.

Prerequisites:
- 1 Instructor
- 1 Student
- 1 Exam with a Programming Exercise

1. Log in as an instructor and verify that the programming exercise can still be configured normally.
2. Participate in the exam as a student.
3. Verify that the programming exercise and its submission policy behavior remain unchanged during the exam.
-->


### Testserver States
You can manage test servers using [Helios](https://helios.aet.cit.tum.de/). Check environment statuses in the [environment list](https://helios.aet.cit.tum.de/repo/69562331/environment/list). To deploy to a test server, go to the [CI/CD](https://helios.aet.cit.tum.de/repo/69562331/ci-cd) page, find your PR or branch, and trigger the deployment.

### Review Progress
<!-- Each PR should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Performance Review
<!-- See [Large Course Setup](https://github.com/ls1intum/Artemis/tree/develop/supporting_scripts/course-scripts/quick-course-setup) for the automation script that handles large course setup. -->

<!--
- [ ] I (as a reviewer) confirm that the client changes (in particular related to REST calls and UI responsiveness) are implemented with a very good performance even for very large courses with more than 2000 students.

- [ ] I (as a reviewer) confirm that the server changes (in particular related to database calls) are implemented with a very good performance even for very large courses with more than 2000 students.
-->

#### Code Review
- [x] Code Review 1
- [x] Code Review 2

#### Manual Tests
- [x] Test 1
- [x] Test 2

<!--
#### Exam Mode Test
- [ ] Test 1
- [ ] Test 2
-->

<!--
#### Performance Tests
- [ ] Test 1
- [ ] Test 2
-->


### Test Coverage
<!-- Please add the test coverages for all changed files modified in this PR here. You can generate the coverage table using one of these options: -->
<!-- 1. Run `pnpm run coverage:pr` to generate coverage locally by running only the affected module tests (see supporting_scripts/code-coverage/local-pr-coverage/README.md) -->
<!-- 2. Use `supporting_scripts/code-coverage/generate_code_cov_table/generate_code_cov_table.py` to generate the table from CI artifacts (requires GitHub token, follow the README for setup) -->
<!-- The line coverage must be above 90% for changed files, and you must use extensive and useful assertions for server tests and expect statements for client tests. -->
<!-- Note: Confirm in the last column that you have implemented extensive assertions for server tests and expect statements for client tests. -->
<!--       Remove rows with only trivial changes from the table. -->

#### Server

| Class/File | Line Coverage | Lines |
|------------|-------------:|------:|
| SubmissionPolicyService.java | 100.00% | 188 |

_Last updated: 2026-09-14 14:17:01 UTC_


### Screenshots
Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI.
Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed policy updates where changing the policy type could result in a conflict.
  * Changing between repository locks and submission penalties now succeeds and correctly replaces the previous policy with the selected type.
  * Policy updates now preserve the exercise’s original configuration if creating the replacement policy fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->