### PR TITLE
`Development`: Keep documentation deployment current

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,7 +19,7 @@ ci.yml                                                            (single entry 
 ├── test            ── uses ci-test.yml           (server + client test suites)
 ├── quality         ── uses ci-quality.yml        (server + client style/lint/type-check, Java analyses)
 ├── gradle-wrapper  ── uses ci-gradle-wrapper.yml (if has_gradle; wrapper-jar integrity)
-├── docs            ── uses ci-docs.yml           (if has_docs)
+├── docs            ── uses ci-docs.yml           (if has_docs, or on every develop push)
 ├── translation     ── uses ci-translation.yml    (if has_i18n)
 ├── workflows       ── uses ci-workflows.yml      (if .github changed; actionlint)
 ├── version-consistency ─ uses ci-version-consistency.yml (if has_version; build.gradle/openapi/README in sync)
@@ -178,6 +178,12 @@ Concurrency lives only on the umbrella. Reusables share the umbrella's `run_id`,
 parent's concurrency lock applies transitively. **Never** add a `concurrency:` block to a
 `ci-*.yml` reusable — it creates a second lock that can deadlock the parent
 ([actions/runner#3205](https://github.com/actions/runner/issues/3205)).
+
+GitHub keeps only one pending run in a concurrency group by default, even when
+`cancel-in-progress` is false. A newer `develop` push can therefore replace an older pending push.
+The documentation build runs on every `develop` push so that a replacement run deploys the full
+current documentation tree instead of losing documentation changes that belonged to the evicted
+run. Pull requests still use `has_docs`, so this recovery guarantee adds no unrelated PR work.
 
 The one exception is the `deploy-docs` **job** in `ci.yml`, which carries a job-level
 `concurrency: { group: pages, cancel-in-progress: false }`. Job-level concurrency is safe (it is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,12 @@ jobs:
   docs:
     name: Build Documentation
     needs: detect-changes
-    if: needs.detect-changes.outputs.has_docs == 'true'
+    # Every develop push builds the current tree, even when its immediate diff has no docs changes.
+    # GitHub concurrency keeps only one pending run: a newer push can evict a queued docs-changing
+    # run, so relying only on the per-commit path filter can otherwise leave Pages permanently stale.
+    if: >-
+      needs.detect-changes.outputs.has_docs == 'true'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/develop')
     uses: ./.github/workflows/ci-docs.yml
     permissions:
       contents: read
@@ -387,7 +392,7 @@ jobs:
   deploy-docs:
     name: Deploy Documentation
     needs: [detect-changes, docs]
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.detect-changes.outputs.has_docs == 'true' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
### Summary

Ensures that the GitHub Pages documentation is built and deployed from every completed `develop` push. Pull requests remain path-filtered and only build documentation when relevant files change.

### Checklist

#### General

- [x] This is a small CI workflow change tested locally and through a successful documentation deployment.
- [x] Language: I followed the guidelines for inclusive, diversity-sensitive, and appreciative language.
- [x] I chose a title conforming to the naming conventions for pull requests.

### Motivation and Context

A documentation-changing `develop` run for commit `7ac8e36` was pending behind an earlier run. GitHub concurrency keeps only one pending run per group, so the next push replaced it even though `cancel-in-progress` was false. The replacement commit did not change documentation and therefore skipped the documentation build and deploy jobs, leaving GitHub Pages at `5e76f94`.

A manual recovery deployment has already published current `develop` (`e1fe2933`): https://github.com/ls1intum/Artemis/actions/runs/34740379000

### Description

- Run the documentation build on every `develop` push so a replacement run always builds the complete current documentation tree.
- Deploy that artifact on every `develop` push after the documentation build succeeds.
- Keep path-based documentation checks unchanged for pull requests and other events.
- Document why this is required by the concurrency model.

### Steps for Testing

1. Run `actionlint -color -shellcheck=`.
2. Confirm that a pull request without documentation changes skips the documentation job.
3. Confirm that every `develop` push runs `Build Documentation` and then `Deploy Documentation`, regardless of its immediate file diff.
4. Confirm that the deployed Pages SHA matches the latest completed `develop` push.

The recovery workflow passed documentation lint, type-checking, the production build, Playwright integration tests, artifact upload, and GitHub Pages deployment.

### Review Progress

#### Code Review

- [x] Code Review 1
- [x] Code Review 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated CI documentation to clarify how documentation builds run for changes pushed to the development branch.
  - Added guidance explaining concurrency behavior and how the latest documentation changes are preserved when multiple updates are queued.
  - Pull request documentation builds continue to run only when documentation files are affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->